### PR TITLE
CODE-2754

### DIFF
--- a/code/src/java/pcgen/core/term/PCMaxLevelTermEvaluator.java
+++ b/code/src/java/pcgen/core/term/PCMaxLevelTermEvaluator.java
@@ -42,6 +42,11 @@ public class PCMaxLevelTermEvaluator extends BasePCTermEvaluator implements
 			return 0.0f;
 		}
 		PCClass aClass = pc.getClassKeyed(classKey);
+		if (aClass == null)
+		{
+			//PC Doesn't have class
+			return 0.0f;
+		}
 		int level =
 				pc.getSpellSupport(aClass).getMaxSpellLevelForClassLevel(
 					pc.getDisplay().getLevel(aClass));


### PR DESCRIPTION
- Fix: feat glitch for spell knowledge
- MAXLEVEL was dumping stack when called on a class not possessed by a
PC.  Should default to zero