### PR TITLE
Fix bug: CODE-2848 - Template removal - CDOMObject cannot be null

### DIFF
--- a/code/src/java/pcgen/cdom/facet/base/AbstractAssociationFacet.java
+++ b/code/src/java/pcgen/cdom/facet/base/AbstractAssociationFacet.java
@@ -123,7 +123,11 @@ public abstract class AbstractAssociationFacet<S, A> extends
 		if (map != null)
 		{
 			A old = map.remove(obj);
-			fireScopeFacetChangeEvent(id, obj, old, DataFacetChangeEvent.DATA_REMOVED);
+			if (old != null)
+			{
+				// Only send out notifications if we really removed something.
+				fireScopeFacetChangeEvent(id, obj, old, DataFacetChangeEvent.DATA_REMOVED);
+			}
 		}
 	}
 


### PR DESCRIPTION
Template w/ SIZE:L is breaking the character sheets - java.lang.IllegalArgumentException: CDOMObject cannot be null