### PR TITLE
DATA-2441

### DIFF
--- a/data/pathfinder/paizo/roleplaying_game/advanced_players_guide/apg_abilities_class.lst
+++ b/data/pathfinder/paizo/roleplaying_game/advanced_players_guide/apg_abilities_class.lst
@@ -2,7 +2,9 @@
 SOURCELONG:Advanced Player's Guide	SOURCESHORT:APG	SOURCEWEB:http://paizo.com/store/downloads/pathfinder/pathfinderRPG/v5748btpy8fo1	SOURCEDATE:2010-08
 # Original Entry by: Stefan Radermacher & Andrew Maitland
 
-Antipaladin	CATEGORY:Class		DEFINE:BypassClassAlignment_Antipaladin|0		BONUS:VAR|BypassClassAlignment_Antipaladin|BypassClassAlignment_All_Class|TYPE=Bypass
+CATEGORY=Internal|Default.MOD		DEFINE:BypassClassAlignment_Antipaladin|0		BONUS:VAR|BypassClassAlignment_Antipaladin|BypassClassAlignment_All_Class|TYPE=Bypass
+
+Antipaladin	CATEGORY:Class	
 
 ###Block: Wizard Cantrips
 # Ability Name						List of Known Class Spells by Level

--- a/data/pathfinder/paizo/roleplaying_game/core_rulebook/cr_abilities_class.lst
+++ b/data/pathfinder/paizo/roleplaying_game/core_rulebook/cr_abilities_class.lst
@@ -37,6 +37,16 @@ CATEGORY=Internal|Default.MOD	DEFINE:Caster_Level_BL_Stripped_Sorcerer|0
 CATEGORY=Internal|Default.MOD	DEFINE:Caster_Level_BL_Stripped_Wizard|0
 CATEGORY=Internal|Default.MOD	DEFINE:Caster_Level_BL_Stripped_Adept|0
 
+
+CATEGORY=Internal|Default.MOD		DEFINE:BypassClassAlignment_Barbarian|0		BONUS:VAR|BypassClassAlignment_Barbarian|BypassClassAlignment_All_Class|TYPE=Bypass		
+CATEGORY=Internal|Default.MOD		DEFINE:BypassClassAlignment_Druid|0			BONUS:VAR|BypassClassAlignment_Druid|BypassClassAlignment_All_Class|TYPE=Bypass
+CATEGORY=Internal|Default.MOD		DEFINE:BypassClassAlignment_Monk|0			BONUS:VAR|BypassClassAlignment_Monk|BypassClassAlignment_All_Class|TYPE=Bypass	BONUS:VAR|BypassClassAlignment_Monk|1|TYPE=Bypass|PREABILITY:1,CATEGORY=Archetype,TYPE.MonkAlignment
+CATEGORY=Internal|Default.MOD		DEFINE:BypassClassAlignment_Paladin|0		BONUS:VAR|BypassClassAlignment_Paladin|BypassClassAlignment_All_Class|TYPE=Bypass
+
+CATEGORY=Internal|Default.MOD		DEFINE:BypassClassAlignment_Arcane_Trickster|0	BONUS:VAR|BypassClassAlignment_Arcane_Trickster|BypassClassAlignment_All_Class|TYPE=Bypass	
+CATEGORY=Internal|Default.MOD		DEFINE:BypassClassAlignment_Assassin|0		BONUS:VAR|BypassClassAlignment_Assassin|BypassClassAlignment_All_Class|TYPE=Bypass
+
+
 ###Block: Favored Classes
 # Ability Name	Category of Ability		Type			Visible		Stackable?	Multiple?	Bonus Ability Pool
 Barbarian		CATEGORY:Special Ability	TYPE:FavoredClass	VISIBLE:DISPLAY	STACK:NO	MULT:NO	BONUS:ABILITYPOOL|Favored Class Bonus|BarbarianLVL
@@ -63,22 +73,23 @@ Warrior		CATEGORY:Special Ability	TYPE:FavoredClass	VISIBLE:DISPLAY	STACK:NO	MUL
 Bonus Hit Point			KEY:Favored Class Bonus ~ Hit Point		CATEGORY:Special Ability	TYPE:FavoredClassBonus												VISIBLE:DISPLAY																																																																																																																																																																																																																																																																									STACK:YES	MULT:YES	CHOOSE:NOCHOICE																																						BONUS:HP|CURRENTMAX|1
 Bonus Skill Rank			KEY:Favored Class Bonus ~ Skill Rank	CATEGORY:Special Ability	TYPE:FavoredClassBonus												VISIBLE:DISPLAY																																																																																																																																																																																																																																																																									STACK:YES	MULT:YES	CHOOSE:SKILL|TYPE=Charisma|TYPE=Dexterity|TYPE=Intelligence|TYPE=Strength|TYPE=Wisdom																																					BONUS:SKILLRANK|LIST|1
 
+
+
 ###Block: Actual Base Class	These will eventually become FLAG in the new system
-Barbarian		CATEGORY:Class	DEFINE:BypassClassAlignment_Barbarian|0		BONUS:VAR|BypassClassAlignment_Barbarian|BypassClassAlignment_All_Class|TYPE=Bypass
+Barbarian		CATEGORY:Class
 Bard			CATEGORY:Class	
 Cleric		CATEGORY:Class	
-Druid			CATEGORY:Class	DEFINE:BypassClassAlignment_Druid|0		BONUS:VAR|BypassClassAlignment_Druid|BypassClassAlignment_All_Class|TYPE=Bypass
+Druid			CATEGORY:Class
 Fighter		CATEGORY:Class	
-Monk			CATEGORY:Class	DEFINE:BypassClassAlignment_Monk|0			BONUS:VAR|BypassClassAlignment_Monk|BypassClassAlignment_All_Class|TYPE=Bypass	BONUS:VAR|BypassClassAlignment_Monk|1|TYPE=Bypass|PREABILITY:1,CATEGORY=Archetype,TYPE.MonkAlignment
-Paladin		CATEGORY:Class	DEFINE:BypassClassAlignment_Paladin|0		BONUS:VAR|BypassClassAlignment_Paladin|BypassClassAlignment_All_Class|TYPE=Bypass
+Monk			CATEGORY:Class	
+Paladin		CATEGORY:Class	
 Ranger		CATEGORY:Class	
 Rogue			CATEGORY:Class	
 Sorcerer		CATEGORY:Class	
 Wizard		CATEGORY:Class	
 
-
-Arcane Trickster	CATEGORY:Class	DEFINE:BypassClassAlignment_Arcane_Trickster|0	BONUS:VAR|BypassClassAlignment_Arcane_Trickster|BypassClassAlignment_All_Class|TYPE=Bypass
-Assassin		CATEGORY:Class	DEFINE:BypassClassAlignment_Assassin|0		BONUS:VAR|BypassClassAlignment_Assassin|BypassClassAlignment_All_Class|TYPE=Bypass
+Arcane Trickster	CATEGORY:Class	
+Assassin		CATEGORY:Class
 
 
 ###Block: Homebrew and expansion support

--- a/data/pathfinder/paizo/roleplaying_game/core_rulebook/cr_classes.lst
+++ b/data/pathfinder/paizo/roleplaying_game/core_rulebook/cr_classes.lst
@@ -96,6 +96,7 @@ CLASS:Cleric	SPELLSTAT:WIS	SPELLTYPE:Divine	KNOWNSPELLS:LEVEL=0|LEVEL=1|LEVEL=2|
 1	PROHIBITSPELL:ALIGNMENT.Lawful|PREVAREQ:ProhibitSpell_Alignment_Lawful,1	
 1	PROHIBITSPELL:ALIGNMENT.Chaotic|PREVAREQ:ProhibitSpell_Alignment_Chaotic,1	
 ###Block:Proficiencies
+1	ABILITY:Class|AUTOMATIC|Cleric
 1	ABILITY:Special Ability|AUTOMATIC|Cleric ~ Weapon and Armor Proficiency
 1	ABILITY:Cleric Class Feature|AUTOMATIC|Cleric ~ Aura
 1	ABILITY:Cleric Class Feature|AUTOMATIC|Cleric ~ Channel Energy|!PREABILITY:1,CATEGORY=Archetype,TYPE.ClericChannelEnergy
@@ -201,6 +202,7 @@ CLASS:Fighter	HD:10		TYPE:Base.PC	CLASSTYPE:PC	ABB:Ftr		MAXLEVEL:20	SOURCEPAGE:p
 # Class Name	Skill Pts/Lvl
 CLASS:Fighter	STARTSKILLPTS:2
 ###Block:Proficiencies
+1	ABILITY:Class|AUTOMATIC|Fighter
 1	ABILITY:Fighter Class Feature|AUTOMATIC|Weapon and Armor Proficiency ~ Fighter|!PREABILITY:1,CATEGORY=Archetype,TYPE.FighterWeaponProficiencies,TYPE.FighterArmorProficiencies,TYPE.FighterHeavyArmorProficiency,TYPE.FighterMediumArmorProficiency,TYPE.FighterLightArmorProficiency,TYPE.FighterShieldProficiency,TYPE.FighterTowerShieldProficiency
 1	ABILITY:Internal|AUTOMATIC|Weapon Prof ~ Martial|Weapon Prof ~ Simple|!PREABILITY:1,CATEGORY=Archetype,TYPE.FighterWeaponProficiencies
 1	ABILITY:Internal|AUTOMATIC|Armor Prof ~ Heavy|!PREABILITY:1,CATEGORY=Archetype,TYPE.FighterArmorProficiencies,TYPE.FighterHeavyArmorProficiency


### PR DESCRIPTION
[Paizo] MA - Mythic Character with "Beyond Morality" cannot choose alignment-conflict classes
Allow bypass to happen without the base class being taken.