### PR TITLE
Fix bug: CODE-2858 - infinite loop in ability prereq tree view

### DIFF
--- a/code/src/java/pcgen/core/DataSet.java
+++ b/code/src/java/pcgen/core/DataSet.java
@@ -63,6 +63,7 @@ import pcgen.facade.util.DefaultListFacade;
 import pcgen.facade.util.ListFacade;
 import pcgen.facade.util.MapFacade;
 import pcgen.core.prereq.Prerequisite;
+import pcgen.core.prereq.PrerequisiteOperator;
 import pcgen.rules.context.LoadContext;
 import pcgen.util.enumeration.View;
 
@@ -316,7 +317,8 @@ public class DataSet implements DataSetFacade
 	private List<AbilityFacade> getAbilitiesFromPrereq(Prerequisite prereq, Category<Ability> cat)
 	{
 		List<AbilityFacade> prereqList = new ArrayList<AbilityFacade>();
-		if (prereq == null)
+		// Exclude negated prereqs
+		if (prereq == null || (prereq.getOperator() == PrerequisiteOperator.LT && "1".equals(prereq.getOperand())))
 		{
 			return prereqList;
 		}

--- a/code/src/java/pcgen/gui2/tabs/ability/AbilityTreeViews.java
+++ b/code/src/java/pcgen/gui2/tabs/ability/AbilityTreeViews.java
@@ -158,6 +158,7 @@ public class AbilityTreeViews
 		{
 			if (path.size() > 20)
 			{
+				
 				Logging.errorPrint("Found probable ability prereq cycle ["
 					+ StringUtils.join(path, ",") + "] with prereqs ["
 					+ StringUtils.join(preAbilities, ",") + "]. Skipping.");
@@ -171,6 +172,7 @@ public class AbilityTreeViews
 				List<AbilityFacade> preAbilities2 = dataset.getPrereqAbilities(preAbility);
 				// Don't include self references in the path
 				preAbilities2.remove(preAbility);
+				preAbilities2.removeAll(pathclone);
 				if (preAbilities2.isEmpty())
 				{
 					abilityPaths.add(pathclone);


### PR DESCRIPTION
Exclude negative (i.e. must not have) prereqs from the prereq tree for abilities.