### PR TITLE
Add new page to FAQ - "Community"

### DIFF
--- a/docs/faqpages/faqcommunity.html
+++ b/docs/faqpages/faqcommunity.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="Content-Style-Type" content="text/css" />
+  <meta name="generator" content="pandoc" />
+  <title></title>
+  <style type="text/css">code{white-space: pre;}</style>
+  <link rel="stylesheet" href="../pcgen.css" type="text/css" />
+</head>
+<body>
+<div id="TOC">
+<ul class="incremental">
+<li><a href="#community">Community</a><ul class="incremental">
+<li><a href="#main-website">Main website</a></li>
+<li><a href="#documentation">Documentation</a></li>
+<li><a href="#forums">Forums</a></li>
+<li><a href="#bug-reports-and-feature-requests">Bug reports and feature requests</a></li>
+<li><a href="#mailing-lists">Mailing lists</a></li>
+<li><a href="#email">Email</a></li>
+<li><a href="#live-chat">Live chat</a><ul class="incremental">
+<li><a href="#new-hipchat">New: HipChat</a></li>
+<li><a href="#old-irc">Old: IRC</a></li>
+</ul></li>
+<li><a href="#contributing-to-the-project">Contributing to the project</a></li>
+<li><a href="#development">Development</a></li>
+</ul></li>
+</ul>
+</div>
+<h1 id="community">Community</h1>
+<p><em>Last updated: 2015-07-19.</em></p>
+<p>There are many places where you can:</p>
+<ul class="incremental">
+<li>Find out more about PCGen</li>
+<li>Talk to the PCGen developers and other users</li>
+<li>Participate in PCGen development</li>
+</ul>
+<h2 id="main-website">Main website</h2>
+<p>The main website for PCGen is at <a href="http://pcgen.org">pcgen.org</a>.</p>
+<h2 id="documentation">Documentation</h2>
+<p>You are currently reading the documentation.</p>
+<p>The documentation is updated frequently. In case you are reading an old version of the documentation, you can find the latest documentation at the <a href="http://pcgen.sourceforge.net/autobuilds/pcgen-docs/index.html">SourceForge <code>autobuild</code></a>.</p>
+<p>If you see any errors in the documentation, please <a href="./faqsubmittingabugreport.html">file a bug report</a>. If you would like to improve the documentation yourself, <a href="https://github.com/PCGen/pcgen">GitHub pull requests</a> are welcome.</p>
+<p>There is also some documentation available at the <a href="http://wiki.pcgen.org">PCGen wiki</a>.</p>
+<h2 id="forums">Forums</h2>
+<p>All aspects of PCGen can be discussed at the new <a href="http://groups.pcgen.org">PCGen forums</a>.</p>
+<p>Subforums include:</p>
+<ul class="incremental">
+<li>General
+<ul class="incremental">
+<li>Question &amp; Issues</li>
+</ul></li>
+<li>Community Support
+<ul class="incremental">
+<li>Homebrew LST File Support</li>
+<li>Publisher Permission and Book Requests</li>
+</ul></li>
+<li>Development
+<ul class="incremental">
+<li>Developers - Code Monkeys</li>
+<li>Experimental</li>
+<li>New Sources</li>
+<li>Output Sheets</li>
+<li>Internationalization</li>
+</ul></li>
+</ul>
+<h2 id="bug-reports-and-feature-requests">Bug reports and feature requests</h2>
+<p>If you have noticed something wrong with PCGen, or you would like to request a feature, bug reports and feature requests are welcome at the <a href="../faqsubmittingabugreport.html">JIRA issue tracker</a>.</p>
+<h2 id="mailing-lists">Mailing lists</h2>
+<p>PCGen discussion occurs at multiple Yahoo! Groups mailing lists.</p>
+<p>Note: The Yahoo! Groups mailing lists are being phased out in favour of the <a href="#forums">new forums</a>.</p>
+<p><strong>Main discussion:</strong> <code>pcgen@yahoogroups.com</code> <a href="https://groups.yahoo.com/neo/groups/pcgen/info">(website / archives)</a></p>
+<blockquote>
+<p>PCGen related news (release notices, press releases) is posted here. This is <em>the</em> place to discuss bugs and feature requests. Users can post their files (their own material and material of publishers who have given us their permission) here to share with others.</p>
+</blockquote>
+<p><strong>Tag discussion:</strong> <code>pcgen_experimental@yahoogroups.com</code> <a href="https://groups.yahoo.com/neo/groups/pcgen_experimental/info">(website / archives)</a></p>
+<blockquote>
+<p>The PCGen Experimental group is the place for new data source development for PCGen, the RPG character generator. Requests for new data, experimental data, drafts for code feature requests and the future direction of PCGen's development are also discussed.</p>
+</blockquote>
+<p><strong>List file coding help:</strong> <code>pcgenlistfilehelp@yahoogroups.com</code> <a href="https://groups.yahoo.com/neo/groups/PCGenListFileHelp/info">(website / archives)</a></p>
+<blockquote>
+<p>To aid in the creation/editing/understanding of PCGen list files and documentation</p>
+</blockquote>
+<p><strong>International translation / development: </strong> Inactive. <code>pcgen_international@yahoogroups.com</code> <a href="https://groups.yahoo.com/neo/groups/pcgen_international/info">(website / archives)</a></p>
+<blockquote>
+<p>The PCGen International group is the place for the development of non-English language content for PCGen, the RPG character generator. Requests for translations, problems with translations and drafts of translated data sets or other translated content, as well as anything coming up with the Internationalization of PCGen are the topic of this list.</p>
+</blockquote>
+<p><strong>List file classes:</strong> Inactive. <a href="https://groups.yahoo.com/neo/groups/LSTfileclass/info">(website / archives)</a></p>
+<h2 id="email">Email</h2>
+<p>Direct email messages to the PCGen team are welcome at <code>help@pcgen.org</code>.</p>
+<h2 id="live-chat">Live chat</h2>
+<h3 id="new-hipchat">New: HipChat</h3>
+<p>New (July 2015): You can talk to the PCGen developers using <a href="https://www.hipchat.com/gmiCjELbV">HipChat</a>.</p>
+<h3 id="old-irc">Old: IRC</h3>
+<p>A small number of PCGen users and developers are present in the Freenode <code>#pcgen</code> IRC channel.</p>
+<p>You can connect using any IRC client, or the <a href="https://webchat.freenode.net/">Freenode web chat client.</a></p>
+<h2 id="contributing-to-the-project">Contributing to the project</h2>
+<p>We warmly welcome contributors to all parts of the PCGen project, no matter their level of experience.</p>
+<ul class="incremental">
+<li>Java programming</li>
+<li>List file coding (data set coding)</li>
+<li>Documentation</li>
+<li>Public relations (website, social media)</li>
+<li>User support</li>
+<li>Checking game material licenses</li>
+<li>General administration</li>
+</ul>
+<p>If you want to contribute, but don't know how, post a message like <em>&quot;I want to help!&quot;</em> to the <a href="#forums">PCGen forums</a> or <code>help@pcgen.org</code>.</p>
+<h2 id="development">Development</h2>
+<p>Code development occurs at the Github repositories for the project, mainly <a href="https://github.com/PCGen/pcgen"><code>PCGen/pcgen</code></a>. Pull requests are welcome for all parts of the project.</p>
+<p>Issue tracking is via the <a href="http://jira.pcgen.org">PCGen JIRA tracker</a>.</p>
+</body>
+</html>

--- a/docs/faqpages/faqcommunity.md
+++ b/docs/faqpages/faqcommunity.md
@@ -1,0 +1,105 @@
+# Community
+
+*Last updated: 2015-07-19.*
+
+There are many places where you can:
+
+* Find out more about PCGen
+* Talk to the PCGen developers and other users
+* Participate in PCGen development
+
+## Main website
+
+The main website for PCGen is at [pcgen.org](http://pcgen.org).
+
+## Documentation
+
+You are currently reading the documentation.
+
+The documentation is updated frequently. In case you are reading an old version of the documentation, you can find the latest documentation at the [SourceForge `autobuild`](http://pcgen.sourceforge.net/autobuilds/pcgen-docs/index.html).
+
+If you see any errors in the documentation, please [file a bug report](./faqsubmittingabugreport.html). If you would like to improve the documentation yourself, [GitHub pull requests](https://github.com/PCGen/pcgen) are welcome.
+
+There is also some documentation available at the [PCGen wiki](http://wiki.pcgen.org).
+
+## Forums
+
+All aspects of PCGen can be discussed at the new [PCGen forums](http://groups.pcgen.org).
+
+Subforums include:
+
+* General
+	* Question & Issues
+* Community Support
+	* Homebrew LST File Support
+	* Publisher Permission and Book Requests
+* Development
+	* Developers - Code Monkeys
+	* Experimental
+	* New Sources
+	* Output Sheets
+	* Internationalization
+
+## Bug reports and feature requests
+
+If you have noticed something wrong with PCGen, or you would like to request a feature, bug reports and feature requests are welcome at the [JIRA issue tracker](../faqsubmittingabugreport.html).
+
+## Mailing lists
+
+PCGen discussion occurs at multiple Yahoo! Groups mailing lists.
+
+Note: The Yahoo! Groups mailing lists are being phased out in favour of the [new forums](#forums).
+
+**Main discussion:** `pcgen@yahoogroups.com` [(website / archives)](https://groups.yahoo.com/neo/groups/pcgen/info)
+
+> PCGen related news (release notices, press releases) is posted here. This is *the* place to discuss bugs and feature requests. Users can post their files (their own material and material of publishers who have given us their permission) here to share with others.
+
+**Tag discussion:** `pcgen_experimental@yahoogroups.com` [(website / archives)](https://groups.yahoo.com/neo/groups/pcgen_experimental/info)
+
+> The PCGen Experimental group is the place for new data source development for PCGen, the RPG character generator. Requests for new data, experimental data, drafts for code feature requests and the future direction of PCGen's development are also discussed.
+
+**List file coding help:** `pcgenlistfilehelp@yahoogroups.com` [(website / archives)](https://groups.yahoo.com/neo/groups/PCGenListFileHelp/info)
+
+> To aid in the creation/editing/understanding of PCGen list files and documentation
+
+**International translation / development: **  Inactive. `pcgen_international@yahoogroups.com` [(website / archives)](https://groups.yahoo.com/neo/groups/pcgen_international/info)
+
+> The PCGen International group is the place for the development of non-English language content for PCGen, the RPG character generator. Requests for translations, problems with translations and drafts of translated data sets or other translated content, as well as anything coming up with the Internationalization of PCGen are the topic of this list.
+
+**List file classes:** Inactive. [(website / archives)](https://groups.yahoo.com/neo/groups/LSTfileclass/info)
+
+## Email
+
+Direct email messages to the PCGen team are welcome at `help@pcgen.org`.
+
+## Live chat
+
+### New: HipChat
+
+New (July 2015): You can talk to the PCGen developers using [HipChat](https://www.hipchat.com/gmiCjELbV).
+
+### Old: IRC
+
+A small number of PCGen users and developers are present in the Freenode `#pcgen` IRC channel.
+
+You can connect using any IRC client, or the [Freenode web chat client.](https://webchat.freenode.net/)
+
+## Contributing to the project
+
+We warmly welcome contributors to all parts of the PCGen project, no matter their level of experience.
+
+* Java programming
+* List file coding (data set coding)
+* Documentation
+* Public relations (website, social media)
+* User support
+* Checking game material licenses
+* General administration
+
+If you want to contribute, but don't know how, post a message like *"I want to help!"* to the [PCGen forums](#forums) or `help@pcgen.org`.
+
+## Development
+
+Code development occurs at the Github repositories for the project, mainly [`PCGen/pcgen`](https://github.com/PCGen/pcgen). Pull requests are welcome for all parts of the project.
+
+Issue tracking is via the [PCGen JIRA tracker](http://jira.pcgen.org).

--- a/docs/navtree.html
+++ b/docs/navtree.html
@@ -714,6 +714,9 @@ FreeMarker Functions</a></li>
 <li><a href="faqpages/faqsectionheading.html">Frequently Asked
 Questions</a>
 <ul>
+<li><a href="./faqpages/faqcommunity.html">Community - help,
+support; contributing</a>
+</li>
 <li><a href="faqpages/faqstartupinstallissues.html">Startup and
 Installation Issues</a></li>
 <li><a href="faqpages/faqoutofmemoryandjavaissues.html">Out of


### PR DESCRIPTION
This is a new page detailing where to find PCGen help, resources, and community discussion.

It is meant to improve on the information currently duplicated across pcgen.org, wiki.pcgen.org, and pcgen.sf.net.

1. http://pcgen.org/get-help/
2. http://pcgen.org/get-involved/
3. http://wiki.pcgen.org/Users
4. http://pcgen.sourceforge.net/04_support.php
5. http://pcgen.sourceforge.net/05_email_lists.php
6. http://pcgen.sourceforge.net/06_trackers.php

Points open to discussion;

* Whether it's more appropriate to have this in the HTML documentation, on the pcgen.org website, or the wiki
* the relative importance of Yahoo Groups vs. the new phpBB forums
* sections I probably haven't included like Donations

Whatever is decided, I think it is important for there to be exactly one place for this information. Currently there are multiple pages about the PCGen community, all of which link to different things, and none of which agree.