### PR TITLE
CODE-2829 Make Ability Tokens editor friendly

### DIFF
--- a/code/src/java/pcgen/cdom/base/CategorizedAbilitySelectionChooseInformation.java
+++ b/code/src/java/pcgen/cdom/base/CategorizedAbilitySelectionChooseInformation.java
@@ -24,7 +24,8 @@ package pcgen.cdom.base;
 
 import pcgen.cdom.choiceset.CollectionToAbilitySelection;
 import pcgen.cdom.content.AbilitySelection;
-import pcgen.core.Ability;
+import pcgen.cdom.reference.CDOMSingleRef;
+import pcgen.core.AbilityCategory;
 
 /**
  * CategorizedAbilitySelectionChooseInformation
@@ -60,7 +61,7 @@ public class CategorizedAbilitySelectionChooseInformation extends
 	/**
 	 * @return The ability category of the choices. 
 	 */
-	public Category<Ability> getCategory()
+	public CDOMSingleRef<AbilityCategory> getCategory()
 	{
 		return casChoiceSet.getCategory();
 	}

--- a/code/src/java/pcgen/cdom/base/CategorizedChooseInformation.java
+++ b/code/src/java/pcgen/cdom/base/CategorizedChooseInformation.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.Collections;
 
 import pcgen.cdom.enumeration.GroupingState;
+import pcgen.cdom.reference.CDOMSingleRef;
 import pcgen.core.PlayerCharacter;
 import pcgen.core.chooser.CDOMChoiceManager;
 import pcgen.core.chooser.ChoiceManagerList;
@@ -47,7 +48,7 @@ public class CategorizedChooseInformation<T extends Loadable & CategorizedCDOMOb
 	 */
 	private final PrimitiveChoiceSet<T> pcs;
 
-	private final Category<T> category;
+	private final CDOMSingleRef<? extends Category<T>> category;
 
 	/**
 	 * The name of this ChoiceSet
@@ -79,8 +80,9 @@ public class CategorizedChooseInformation<T extends Loadable & CategorizedCDOMOb
 	 * @throws IllegalArgumentException
 	 *             if the given name or PrimitiveChoiceSet is null
 	 */
-	public CategorizedChooseInformation(String name, Category<T> cat,
-			PrimitiveChoiceSet<T> choice, Class<T> objClass)
+	public CategorizedChooseInformation(String name,
+		CDOMSingleRef<? extends Category<T>> cat, PrimitiveChoiceSet<T> choice,
+		Class<T> objClass)
 	{
 		if (name == null)
 		{
@@ -161,7 +163,7 @@ public class CategorizedChooseInformation<T extends Loadable & CategorizedCDOMOb
 		if (choiceActor instanceof CategorizedChooser)
 		{
 			return ((CategorizedChooser<T>) choiceActor).decodeChoice(context,
-				choiceStr, category);
+				choiceStr, category.resolvesTo());
 		}
 		return choiceActor.decodeChoice(context, choiceStr);
 	}
@@ -230,7 +232,7 @@ public class CategorizedChooseInformation<T extends Loadable & CategorizedCDOMOb
 	@Override
 	public ClassIdentity<T> getClassIdentity()
 	{
-		return CategorizedClassIdentity.getInstance(underlyingClass, category);
+		return CategorizedClassIdentity.getInstance(underlyingClass, category.resolvesTo());
 	}
 
 	/**
@@ -296,7 +298,7 @@ public class CategorizedChooseInformation<T extends Loadable & CategorizedCDOMOb
 		return pcs.getGroupingState();
 	}
 
-	public Category<T> getCategory()
+	public CDOMSingleRef<? extends Category<T>> getCategory()
 	{
 		return category;
 	}

--- a/code/src/java/pcgen/cdom/base/ChoiceSet.java
+++ b/code/src/java/pcgen/cdom/base/ChoiceSet.java
@@ -28,7 +28,8 @@ import pcgen.cdom.choiceset.AbilityRefChoiceSet;
 import pcgen.cdom.enumeration.GroupingState;
 import pcgen.cdom.enumeration.Nature;
 import pcgen.cdom.helper.CNAbilitySelection;
-import pcgen.core.Ability;
+import pcgen.cdom.reference.CDOMSingleRef;
+import pcgen.core.AbilityCategory;
 import pcgen.core.PlayerCharacter;
 
 /**
@@ -249,7 +250,7 @@ public class ChoiceSet<T> extends ConcretePrereqObject implements PrereqObject,
 			arcs = choice;
 		}
 
-		public Category<Ability> getCategory()
+		public CDOMSingleRef<AbilityCategory> getCategory()
 		{
 			return arcs.getCategory();
 		}

--- a/code/src/java/pcgen/cdom/choiceset/AbilityRefChoiceSet.java
+++ b/code/src/java/pcgen/cdom/choiceset/AbilityRefChoiceSet.java
@@ -30,7 +30,6 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import pcgen.cdom.base.CDOMReference;
-import pcgen.cdom.base.Category;
 import pcgen.cdom.base.ChooseInformation;
 import pcgen.cdom.base.Constants;
 import pcgen.cdom.base.PrimitiveChoiceSet;
@@ -40,8 +39,10 @@ import pcgen.cdom.enumeration.ListKey;
 import pcgen.cdom.enumeration.Nature;
 import pcgen.cdom.enumeration.ObjectKey;
 import pcgen.cdom.helper.CNAbilitySelection;
+import pcgen.cdom.reference.CDOMSingleRef;
 import pcgen.cdom.reference.ReferenceUtilities;
 import pcgen.core.Ability;
+import pcgen.core.AbilityCategory;
 import pcgen.core.Deity;
 import pcgen.core.PlayerCharacter;
 import pcgen.core.WeaponProf;
@@ -66,7 +67,7 @@ public class AbilityRefChoiceSet implements
 	/**
 	 * The underlying Ability Category for this AbilityRefChoiceSet.
 	 */
-	private final Category<Ability> category;
+	private final CDOMSingleRef<AbilityCategory> category;
 
 	/**
 	 * The underlying Ability Nature for this AbilityRefChoiceSet.
@@ -98,7 +99,7 @@ public class AbilityRefChoiceSet implements
 	 * @throws IllegalArgumentException
 	 *             if the given Collection is null or empty.
 	 */
-	public AbilityRefChoiceSet(Category<Ability> cat,
+	public AbilityRefChoiceSet(CDOMSingleRef<AbilityCategory> cat,
 			Collection<? extends CDOMReference<Ability>> arCollection, Nature nat)
 	{
 		super();
@@ -199,7 +200,7 @@ public class AbilityRefChoiceSet implements
 				else
 				{
 					returnSet.add(new CNAbilitySelection(CNAbilityFactory.getCNAbility(
-						category, nature, a)));
+						category.resolvesTo(), nature, a)));
 				}
 			}
 		}
@@ -288,7 +289,7 @@ public class AbilityRefChoiceSet implements
 				availableList.size());
 		for (String s : availableList)
 		{
-			returnList.add(new CNAbilitySelection(CNAbilityFactory.getCNAbility(category,
+			returnList.add(new CNAbilitySelection(CNAbilityFactory.getCNAbility(category.resolvesTo(),
 				nature, ability), s));
 		}
 		return returnList;
@@ -346,7 +347,7 @@ public class AbilityRefChoiceSet implements
 	 * 
 	 * @return The underlying Ability Category for this AbilityRefChoiceSet
 	 */
-	public Category<Ability> getCategory()
+	public CDOMSingleRef<AbilityCategory> getCategory()
 	{
 		return category;
 	}

--- a/code/src/java/pcgen/cdom/choiceset/CollectionToAbilitySelection.java
+++ b/code/src/java/pcgen/cdom/choiceset/CollectionToAbilitySelection.java
@@ -26,7 +26,6 @@ import java.util.Stack;
 
 import pcgen.base.util.ObjectContainer;
 import pcgen.cdom.base.CDOMReference;
-import pcgen.cdom.base.Category;
 import pcgen.cdom.base.ChooseInformation;
 import pcgen.cdom.base.Converter;
 import pcgen.cdom.base.PrimitiveChoiceSet;
@@ -35,7 +34,9 @@ import pcgen.cdom.base.PrimitiveFilter;
 import pcgen.cdom.content.AbilitySelection;
 import pcgen.cdom.enumeration.GroupingState;
 import pcgen.cdom.enumeration.ObjectKey;
+import pcgen.cdom.reference.CDOMSingleRef;
 import pcgen.core.Ability;
+import pcgen.core.AbilityCategory;
 import pcgen.core.PlayerCharacter;
 import pcgen.util.Logging;
 
@@ -44,11 +45,11 @@ public class CollectionToAbilitySelection implements
 {
 	private final PrimitiveCollection<Ability> collection;
 	
-	private final Category<Ability> category;
+	private final CDOMSingleRef<AbilityCategory> category;
 
 	private static Stack<Ability> infiniteLoopDetectionStack = new Stack<Ability>();
 
-	public CollectionToAbilitySelection(Category<Ability> cat, PrimitiveCollection<Ability> coll)
+	public CollectionToAbilitySelection(CDOMSingleRef<AbilityCategory> cat, PrimitiveCollection<Ability> coll)
 	{
 		if (cat == null)
 		{
@@ -223,7 +224,7 @@ public class CollectionToAbilitySelection implements
 		sb.append('\n');
 	}
 
-	public Category<Ability> getCategory()
+	public CDOMSingleRef<AbilityCategory> getCategory()
 	{
 		return category;
 	}

--- a/code/src/java/pcgen/cdom/enumeration/AssociationKey.java
+++ b/code/src/java/pcgen/cdom/enumeration/AssociationKey.java
@@ -32,8 +32,8 @@ import pcgen.base.formula.Formula;
 import pcgen.base.lang.UnreachableError;
 import pcgen.base.util.CaseInsensitiveMap;
 import pcgen.cdom.base.CDOMObject;
-import pcgen.cdom.base.Category;
-import pcgen.core.Ability;
+import pcgen.cdom.reference.CDOMSingleRef;
+import pcgen.core.AbilityCategory;
 
 /**
  * @author Tom Parker <thpr@users.sourceforge.net>
@@ -82,7 +82,7 @@ public final class AssociationKey<T>
 
 	public static final AssociationKey<Nature> NATURE = new AssociationKey<Nature>();
 
-	public static final AssociationKey<Category<Ability>> CATEGORY = new AssociationKey<Category<Ability>>();
+	public static final AssociationKey<CDOMSingleRef<AbilityCategory>> CATEGORY = new AssociationKey<CDOMSingleRef<AbilityCategory>>();
 
 	public static final AssociationKey<String> CASTER_LEVEL = new AssociationKey<String>();
 

--- a/code/src/java/pcgen/cdom/helper/AbilitySelector.java
+++ b/code/src/java/pcgen/cdom/helper/AbilitySelector.java
@@ -17,7 +17,6 @@
  */
 package pcgen.cdom.helper;
 
-import pcgen.cdom.base.Category;
 import pcgen.cdom.base.ChooseDriver;
 import pcgen.cdom.base.ChooseSelectionActor;
 import pcgen.cdom.base.ConcretePrereqObject;
@@ -26,7 +25,8 @@ import pcgen.cdom.content.AbilitySelection;
 import pcgen.cdom.content.CNAbility;
 import pcgen.cdom.content.CNAbilityFactory;
 import pcgen.cdom.enumeration.Nature;
-import pcgen.core.Ability;
+import pcgen.cdom.reference.CDOMSingleRef;
+import pcgen.core.AbilityCategory;
 import pcgen.core.PlayerCharacter;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.util.Logging;
@@ -44,7 +44,7 @@ public class AbilitySelector extends ConcretePrereqObject implements
 
 	private final String source;
 
-	private final Category<Ability> category;
+	private final CDOMSingleRef<AbilityCategory> category;
 
 	/**
 	 * The Nature of the Ability as it should be applied to a PlayerCharacter
@@ -63,7 +63,7 @@ public class AbilitySelector extends ConcretePrereqObject implements
 	 *            The Nature of the given Ability as it should be applied to a
 	 *            PlayerCharacter
 	 */
-	public AbilitySelector(String token, Category<Ability> cat, Nature nat)
+	public AbilitySelector(String token, CDOMSingleRef<AbilityCategory> cat, Nature nat)
 	{
 		category = cat;
 		nature = nat;
@@ -75,7 +75,7 @@ public class AbilitySelector extends ConcretePrereqObject implements
 	 * 
 	 * @return The Category for the Ability in this AbilitySelection.
 	 */
-	public Category<Ability> getAbilityCategory()
+	public CDOMSingleRef<AbilityCategory> getAbilityCategory()
 	{
 		return category;
 	}
@@ -96,7 +96,7 @@ public class AbilitySelector extends ConcretePrereqObject implements
 	public void applyChoice(ChooseDriver obj, AbilitySelection as,
 		PlayerCharacter pc)
 	{
-		CNAbility cna = CNAbilityFactory.getCNAbility(category, nature, as.getObject());
+		CNAbility cna = CNAbilityFactory.getCNAbility(category.resolvesTo(), nature, as.getObject());
 		CNAbilitySelection cnas = new CNAbilitySelection(cna, as.getSelection());
 		pc.associateSelection(as, cnas);
 		pc.addAbility(cnas, obj, this);

--- a/code/src/java/pcgen/cdom/helper/AbilityTargetSelector.java
+++ b/code/src/java/pcgen/cdom/helper/AbilityTargetSelector.java
@@ -17,7 +17,6 @@
  */
 package pcgen.cdom.helper;
 
-import pcgen.cdom.base.Category;
 import pcgen.cdom.base.ChooseDriver;
 import pcgen.cdom.base.ChooseInformation;
 import pcgen.cdom.base.ChooseSelectionActor;
@@ -29,6 +28,7 @@ import pcgen.cdom.enumeration.Nature;
 import pcgen.cdom.enumeration.ObjectKey;
 import pcgen.cdom.reference.CDOMSingleRef;
 import pcgen.core.Ability;
+import pcgen.core.AbilityCategory;
 import pcgen.core.PlayerCharacter;
 import pcgen.persistence.PersistenceLayerException;
 
@@ -47,7 +47,7 @@ public class AbilityTargetSelector<T> extends ConcretePrereqObject implements
 
 	private final String source;
 
-	private final Category<Ability> category;
+	private final CDOMSingleRef<AbilityCategory> category;
 
 	/**
 	 * The Ability that this AbilitySelection represents
@@ -69,7 +69,7 @@ public class AbilityTargetSelector<T> extends ConcretePrereqObject implements
 	 *            The Nature of the given Ability as it should be applied to a
 	 *            PlayerCharacter
 	 */
-	public AbilityTargetSelector(String token, Category<Ability> cat,
+	public AbilityTargetSelector(String token, CDOMSingleRef<AbilityCategory> cat,
 			CDOMSingleRef<Ability> abil, Nature nat)
 	{
 		category = cat;
@@ -93,7 +93,7 @@ public class AbilityTargetSelector<T> extends ConcretePrereqObject implements
 	 * 
 	 * @return The Category for the Ability in this AbilitySelection.
 	 */
-	public Category<Ability> getAbilityCategory()
+	public CDOMSingleRef<AbilityCategory> getAbilityCategory()
 	{
 		return category;
 	}
@@ -176,7 +176,7 @@ public class AbilityTargetSelector<T> extends ConcretePrereqObject implements
 	{
 		String string = ci.encodeChoice(choice);
 		CNAbilitySelection appliedSelection = new CNAbilitySelection(
-				CNAbilityFactory.getCNAbility(category, nature, ability.resolvesTo()), string);
+				CNAbilityFactory.getCNAbility(category.resolvesTo(), nature, ability.resolvesTo()), string);
 		appliedSelection.addAllPrerequisites(getPrerequisiteList());
 		pc.addAbility(appliedSelection, obj, this);
 	}
@@ -206,7 +206,7 @@ public class AbilityTargetSelector<T> extends ConcretePrereqObject implements
 	{
 		String string = ci.encodeChoice(choice);
 		CNAbilitySelection appliedSelection = new CNAbilitySelection(
-				CNAbilityFactory.getCNAbility(category, nature, ability.resolvesTo()), string);
+				CNAbilityFactory.getCNAbility(category.resolvesTo(), nature, ability.resolvesTo()), string);
 		pc.removeAbility(appliedSelection, obj, this);
 	}
 

--- a/code/src/java/pcgen/cdom/list/AbilityList.java
+++ b/code/src/java/pcgen/cdom/list/AbilityList.java
@@ -24,10 +24,11 @@ import java.util.List;
 import pcgen.base.util.DoubleKeyMap;
 import pcgen.cdom.base.CDOMListObject;
 import pcgen.cdom.base.CDOMReference;
-import pcgen.cdom.base.Category;
 import pcgen.cdom.enumeration.Nature;
 import pcgen.cdom.reference.CDOMDirectSingleRef;
+import pcgen.cdom.reference.CDOMSingleRef;
 import pcgen.core.Ability;
+import pcgen.core.AbilityCategory;
 
 /**
  * AbilityList is a CDOMListObject designed to reference a List of Ability
@@ -36,15 +37,15 @@ import pcgen.core.Ability;
 public class AbilityList extends CDOMListObject<Ability>
 {
 
-	private Category<Ability> category;
+	private CDOMSingleRef<AbilityCategory> category;
 	private Nature nature;
 
 	/**
 	 * Stores references to the "master" set of lists that are unique for a
 	 * given Category/Nature combination.
 	 */
-	public static final DoubleKeyMap<Category<Ability>, Nature, CDOMReference<AbilityList>> MASTER_MAP =
-			new DoubleKeyMap<Category<Ability>, Nature, CDOMReference<AbilityList>>();
+	public static final DoubleKeyMap<CDOMSingleRef<AbilityCategory>, Nature, CDOMReference<AbilityList>> MASTER_MAP =
+			new DoubleKeyMap<CDOMSingleRef<AbilityCategory>, Nature, CDOMReference<AbilityList>>();
 
 	/**
 	 * Returns the Ability Class object (Ability.class)
@@ -81,7 +82,7 @@ public class AbilityList extends CDOMListObject<Ability>
 	 *         combination.
 	 */
 	public static CDOMReference<AbilityList> getAbilityListReference(
-			Category<Ability> category, Nature nature)
+		CDOMSingleRef<AbilityCategory> category, Nature nature)
 	{
 		CDOMReference<AbilityList> ref = MASTER_MAP.get(category, nature);
 		if (ref == null)
@@ -116,14 +117,14 @@ public class AbilityList extends CDOMListObject<Ability>
 	public static Collection<CDOMReference<AbilityList>> getAbilityLists()
 	{
 		List<CDOMReference<AbilityList>> list = new ArrayList<CDOMReference<AbilityList>>();
-		for (Category<Ability> cat : MASTER_MAP.getKeySet())
+		for (CDOMSingleRef<AbilityCategory> cat : MASTER_MAP.getKeySet())
 		{
 			list.addAll(MASTER_MAP.values(cat));
 		}
 		return list;
 	}
 
-	public Category<Ability> getCategory()
+	public CDOMSingleRef<AbilityCategory> getCategory()
 	{
 		return category;
 	}

--- a/code/src/java/pcgen/core/PlayerCharacter.java
+++ b/code/src/java/pcgen/core/PlayerCharacter.java
@@ -8601,7 +8601,8 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 				for (AssociatedPrereqObject apo : assoc)
 				{
 					Nature nature = apo.getAssociation(AssociationKey.NATURE);
-					Category<Ability> cat = apo.getAssociation(AssociationKey.CATEGORY);
+					CDOMSingleRef<AbilityCategory> acRef = apo.getAssociation(AssociationKey.CATEGORY);
+					AbilityCategory cat = acRef.resolvesTo();
 					if (ab.getSafe(ObjectKey.MULTIPLE_ALLOWED))
 					{
 						List<String> choices = apo.getAssociation(AssociationKey.ASSOC_CHOICES);

--- a/code/src/java/pcgen/core/kit/KitAbilities.java
+++ b/code/src/java/pcgen/core/kit/KitAbilities.java
@@ -36,6 +36,7 @@ import pcgen.cdom.content.CNAbilityFactory;
 import pcgen.cdom.enumeration.Nature;
 import pcgen.cdom.enumeration.ObjectKey;
 import pcgen.cdom.helper.CNAbilitySelection;
+import pcgen.cdom.reference.CDOMSingleRef;
 import pcgen.cdom.reference.ReferenceUtilities;
 import pcgen.core.Ability;
 import pcgen.core.AbilityCategory;
@@ -59,7 +60,7 @@ public final class KitAbilities extends BaseKit
 	// These members store the state of an instance of this class.  They are
 	// not cloned.
 	private transient List<CNAbilitySelection> abilitiesToAdd = null;
-	private AbilityCategory category;
+	private CDOMSingleRef<AbilityCategory> catRef;
 
 	/**
 	 * Set whether the kit is free.
@@ -169,6 +170,7 @@ public final class KitAbilities extends BaseKit
 		 * the new Ability Pools are going to work
 		 */
 
+		AbilityCategory category = catRef.resolvesTo();
 		boolean tooManyAbilities = false;
 		// Don't allow choosing of more than allotted number of abilities
 		int maxChoices =
@@ -256,6 +258,7 @@ public final class KitAbilities extends BaseKit
 			
 			if (isFree())
 			{
+				AbilityCategory category = catRef.resolvesTo();
 				aPC.adjustAbilities(category, new BigDecimal(1));
 			}
 		}
@@ -349,13 +352,13 @@ public final class KitAbilities extends BaseKit
 		}
 	}
 
-	public void setCategory(AbilityCategory ac)
+	public void setCategory(CDOMSingleRef<AbilityCategory> ac)
 	{
-		category = ac;
+		catRef = ac;
 	}
 
-	public AbilityCategory getCategory()
+	public CDOMSingleRef<AbilityCategory> getCategory()
 	{
-		return category;
+		return catRef;
 	}
 }

--- a/code/src/java/plugin/lsttokens/AbilityLst.java
+++ b/code/src/java/plugin/lsttokens/AbilityLst.java
@@ -36,7 +36,6 @@ import pcgen.cdom.base.AssociatedPrereqObject;
 import pcgen.cdom.base.CDOMList;
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.base.CDOMReference;
-import pcgen.cdom.base.Category;
 import pcgen.cdom.base.ChooseSelectionActor;
 import pcgen.cdom.base.Constants;
 import pcgen.cdom.base.PrereqObject;
@@ -187,7 +186,7 @@ public class AbilityLst extends AbstractTokenWithSeparator<CDOMObject>
 		ArrayList<PrereqObject> edgeList = new ArrayList<PrereqObject>();
 
 		CDOMReference<AbilityList> abilList =
-				AbilityList.getAbilityListReference(category, nature);
+				AbilityList.getAbilityListReference(acRef, nature);
 
 		boolean first = true;
 		boolean removed = false;
@@ -372,7 +371,7 @@ public class AbilityLst extends AbstractTokenWithSeparator<CDOMObject>
 				CDOMDirectSingleRef<AbilityList> dr = (CDOMDirectSingleRef<AbilityList>) ref;
 				AbilityList al = dr.resolvesTo();
 				StringBuilder sb = new StringBuilder();
-				sb.append(al.getCategory().getLSTformat()).append(Constants.PIPE);
+				sb.append(al.getCategory().getLSTformat(false)).append(Constants.PIPE);
 				sb.append(al.getNature()).append(Constants.PIPE);
 				sb.append(Constants.LST_DOT_CLEAR);
 				returnSet.add(sb.toString());

--- a/code/src/java/plugin/lsttokens/AbilityLst.java
+++ b/code/src/java/plugin/lsttokens/AbilityLst.java
@@ -193,6 +193,12 @@ public class AbilityLst extends AbstractTokenWithSeparator<CDOMObject>
 
 		ReferenceManufacturer<Ability> rm = context.getReferenceContext().getManufacturer(
 				ABILITY_CLASS, ABILITY_CATEGORY_CLASS, cat);
+		if (rm == null)
+		{
+			return new ParseResult.Fail(
+				"Could not get Reference Manufacturer for Category: " + cat,
+				context);
+		}
 
 		boolean prereqsAllowed = true;
 

--- a/code/src/java/plugin/lsttokens/add/AbilityToken.java
+++ b/code/src/java/plugin/lsttokens/add/AbilityToken.java
@@ -202,6 +202,12 @@ public class AbilityToken extends AbstractNonEmptyToken<CDOMObject> implements
 
 		ReferenceManufacturer<Ability> rm = context.getReferenceContext().getManufacturer(
 				ABILITY_CLASS, ABILITY_CATEGORY_CLASS, first);
+		if (rm == null)
+		{
+			return new ParseResult.Fail(
+				"Could not get Reference Manufacturer for Category: " + first,
+				context);
+		}
 
 		while (tok.hasNext())
 		{

--- a/code/src/java/plugin/lsttokens/add/AbilityToken.java
+++ b/code/src/java/plugin/lsttokens/add/AbilityToken.java
@@ -32,7 +32,6 @@ import java.util.List;
 import pcgen.base.formula.Formula;
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.base.CDOMReference;
-import pcgen.cdom.base.Category;
 import pcgen.cdom.base.ChoiceSet.AbilityChoiceSet;
 import pcgen.cdom.base.ConcretePersistentTransitionChoice;
 import pcgen.cdom.base.Constants;
@@ -48,6 +47,7 @@ import pcgen.cdom.enumeration.ListKey;
 import pcgen.cdom.enumeration.Nature;
 import pcgen.cdom.enumeration.ObjectKey;
 import pcgen.cdom.helper.CNAbilitySelection;
+import pcgen.cdom.reference.CDOMSingleRef;
 import pcgen.cdom.reference.ReferenceManufacturer;
 import pcgen.core.Ability;
 import pcgen.core.AbilityCategory;
@@ -167,13 +167,8 @@ public class AbilityToken extends AbstractNonEmptyToken<CDOMObject> implements
 					+ value, context);
 		}
 
-		Category<Ability> category = context.getReferenceContext()
-				.silentlyGetConstructedCDOMObject(ABILITY_CATEGORY_CLASS, first);
-		if (category == null)
-		{
-			return new ParseResult.Fail(getFullName() + ": Invalid ability category: "
-					+ first, context);
-		}
+		CDOMSingleRef<AbilityCategory> acRef = context.getReferenceContext()
+				.getCDOMReference(ABILITY_CATEGORY_CLASS, first);
 
 		Nature nature = Nature.valueOf(second);
 		if (nature == null)
@@ -206,7 +201,7 @@ public class AbilityToken extends AbstractNonEmptyToken<CDOMObject> implements
 		int dupChoices = 0;
 
 		ReferenceManufacturer<Ability> rm = context.getReferenceContext().getManufacturer(
-				ABILITY_CLASS, category);
+				ABILITY_CLASS, ABILITY_CATEGORY_CLASS, first);
 
 		while (tok.hasNext())
 		{
@@ -274,7 +269,7 @@ public class AbilityToken extends AbstractNonEmptyToken<CDOMObject> implements
 					+ ": Contains no ability reference: " + value, context);
 		}
 
-		AbilityRefChoiceSet rcs = new AbilityRefChoiceSet(category, refs,
+		AbilityRefChoiceSet rcs = new AbilityRefChoiceSet(acRef, refs,
 				nature);
 		if (!rcs.getGroupingState().isValid())
 		{
@@ -288,7 +283,7 @@ public class AbilityToken extends AbstractNonEmptyToken<CDOMObject> implements
 			title.append(nature.toString());
 			title.append(' ');
 		}
-		title.append(category.getDisplayName());
+		title.append(first);
 		title.append(" Choice");
 		cs.setTitle(title.toString());
 		PersistentTransitionChoice<CNAbilitySelection> tc =
@@ -349,7 +344,7 @@ public class AbilityToken extends AbstractNonEmptyToken<CDOMObject> implements
 				{
 					sb.append(f).append(Constants.PIPE);
 				}
-				sb.append(ascs.getCategory().getKeyName());
+				sb.append(ascs.getCategory().getLSTformat(false));
 				sb.append(Constants.PIPE);
 				sb.append(ascs.getNature());
 				sb.append(Constants.PIPE);

--- a/code/src/java/plugin/lsttokens/choose/AbilitySelectionToken.java
+++ b/code/src/java/plugin/lsttokens/choose/AbilitySelectionToken.java
@@ -163,7 +163,7 @@ public class AbilitySelectionToken extends AbstractTokenWithSeparator<CDOMObject
 		}
 
 		StringBuilder sb = new StringBuilder();
-		sb.append(((CategorizedAbilitySelectionChooseInformation) tc).getCategory());
+		sb.append(((CategorizedAbilitySelectionChooseInformation) tc).getCategory().getLSTformat(false));
 		sb.append('|');
 		sb.append(tc.getLSTformat());
 		String title = tc.getTitle();
@@ -255,6 +255,12 @@ public class AbilitySelectionToken extends AbstractTokenWithSeparator<CDOMObject
 		ReferenceManufacturer<Ability> rm =
 				context.getReferenceContext().getManufacturer(ABILITY_CLASS,
 					ABILITY_CATEGORY_CLASS, cat);
+		if (rm == null)
+		{
+			return new ParseResult.Fail(
+				"Could not get Reference Manufacturer for Category: " + cat,
+				context);
+		}
 		return parseTokenWithSeparator(context, rm, acRef, obj, abilities);
 	}
 

--- a/code/src/java/plugin/lsttokens/choose/AbilitySelectionToken.java
+++ b/code/src/java/plugin/lsttokens/choose/AbilitySelectionToken.java
@@ -26,7 +26,6 @@ import java.util.List;
 
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.base.CategorizedAbilitySelectionChooseInformation;
-import pcgen.cdom.base.Category;
 import pcgen.cdom.base.ChooseDriver;
 import pcgen.cdom.base.ChooseInformation;
 import pcgen.cdom.base.ChooseSelectionActor;
@@ -37,6 +36,7 @@ import pcgen.cdom.choiceset.CollectionToAbilitySelection;
 import pcgen.cdom.content.AbilitySelection;
 import pcgen.cdom.enumeration.AssociationListKey;
 import pcgen.cdom.enumeration.ObjectKey;
+import pcgen.cdom.reference.CDOMSingleRef;
 import pcgen.cdom.reference.ReferenceManufacturer;
 import pcgen.core.Ability;
 import pcgen.core.AbilityCategory;
@@ -73,7 +73,7 @@ public class AbilitySelectionToken extends AbstractTokenWithSeparator<CDOMObject
 	}
 	
 	protected ParseResult parseTokenWithSeparator(LoadContext context,
-		ReferenceManufacturer<Ability> rm, Category<Ability> category,
+		ReferenceManufacturer<Ability> rm, CDOMSingleRef<AbilityCategory> acRef,
 		CDOMObject obj, String value)
 	{
 		int pipeLoc = value.lastIndexOf('|');
@@ -119,7 +119,7 @@ public class AbilitySelectionToken extends AbstractTokenWithSeparator<CDOMObject
 				+ ": Contains ANY and a specific reference: " + value, context);
 		}
 		CollectionToAbilitySelection pcs =
-				new CollectionToAbilitySelection(category, prim);
+				new CollectionToAbilitySelection(acRef, prim);
 		CategorizedAbilitySelectionChooseInformation tc =
 				new CategorizedAbilitySelectionChooseInformation(
 					getTokenName(), pcs);
@@ -248,19 +248,14 @@ public class AbilitySelectionToken extends AbstractTokenWithSeparator<CDOMObject
 				+ " requires a CATEGORY and arguments : " + value, context);
 		}
 		String cat = value.substring(0, barLoc);
-		Category<Ability> category =
-				context.getReferenceContext().silentlyGetConstructedCDOMObject(
+		CDOMSingleRef<AbilityCategory> acRef =
+				context.getReferenceContext().getCDOMReference(
 					ABILITY_CATEGORY_CLASS, cat);
-		if (category == null)
-		{
-			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-				+ " found invalid CATEGORY: " + cat + " in value: " + value,
-				context);
-		}
 		String abilities = value.substring(barLoc + 1);
-		return parseTokenWithSeparator(context,
-			context.getReferenceContext().getManufacturer(ABILITY_CLASS, category), category,
-			obj, abilities);
+		ReferenceManufacturer<Ability> rm =
+				context.getReferenceContext().getManufacturer(ABILITY_CLASS,
+					ABILITY_CATEGORY_CLASS, cat);
+		return parseTokenWithSeparator(context, rm, acRef, obj, abilities);
 	}
 
 	@Override

--- a/code/src/java/plugin/lsttokens/choose/AbilityToken.java
+++ b/code/src/java/plugin/lsttokens/choose/AbilityToken.java
@@ -33,6 +33,7 @@ import pcgen.cdom.base.PrimitiveCollection;
 import pcgen.cdom.choiceset.CollectionToChoiceSet;
 import pcgen.cdom.enumeration.AssociationListKey;
 import pcgen.cdom.enumeration.ObjectKey;
+import pcgen.cdom.reference.CDOMSingleRef;
 import pcgen.cdom.reference.ReferenceManufacturer;
 import pcgen.core.Ability;
 import pcgen.core.AbilityCategory;
@@ -67,7 +68,7 @@ public class AbilityToken extends AbstractTokenWithSeparator<CDOMObject>
 	}
 
 	protected ParseResult parseTokenWithSeparator(LoadContext context,
-		ReferenceManufacturer<Ability> rm, Category<Ability> category,
+		ReferenceManufacturer<Ability> rm, CDOMSingleRef<AbilityCategory> acRef,
 		CDOMObject obj, String value)
 	{
 		int pipeLoc = value.lastIndexOf('|');
@@ -121,7 +122,7 @@ public class AbilityToken extends AbstractTokenWithSeparator<CDOMObject>
 				new CollectionToChoiceSet<Ability>(coll);
 		CategorizedChooseInformation<Ability> tc =
 				new CategorizedChooseInformation<Ability>(getTokenName(),
-					category, pcs, Ability.class);
+					acRef, pcs, Ability.class);
 		tc.setTitle(title);
 		tc.setChoiceActor(this);
 		context.getObjectContext().put(obj, ObjectKey.CHOOSE_INFO, tc);
@@ -240,19 +241,14 @@ public class AbilityToken extends AbstractTokenWithSeparator<CDOMObject>
 				+ " requires a CATEGORY and arguments : " + value, context);
 		}
 		String cat = value.substring(0, barLoc);
-		Category<Ability> category =
-				context.getReferenceContext().silentlyGetConstructedCDOMObject(
+		CDOMSingleRef<AbilityCategory> acRef =
+				context.getReferenceContext().getCDOMReference(
 					ABILITY_CATEGORY_CLASS, cat);
-		if (category == null)
-		{
-			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-				+ " found invalid CATEGORY: " + cat + " in value: " + value,
-				context);
-		}
 		String abilities = value.substring(barLoc + 1);
-		return parseTokenWithSeparator(context,
-			context.getReferenceContext().getManufacturer(ABILITY_CLASS, category), category,
-			obj, abilities);
+		ReferenceManufacturer<Ability> rm =
+				context.getReferenceContext().getManufacturer(ABILITY_CLASS,
+					ABILITY_CATEGORY_CLASS, cat);
+		return parseTokenWithSeparator(context, rm, acRef, obj, abilities);
 	}
 
 	@Override

--- a/code/src/java/plugin/lsttokens/choose/AbilityToken.java
+++ b/code/src/java/plugin/lsttokens/choose/AbilityToken.java
@@ -157,7 +157,7 @@ public class AbilityToken extends AbstractTokenWithSeparator<CDOMObject>
 			return null;
 		}
 		StringBuilder sb = new StringBuilder();
-		sb.append(((CategorizedChooseInformation<?>) tc).getCategory());
+		sb.append(((CategorizedChooseInformation<?>) tc).getCategory().getLSTformat(false));
 		sb.append('|');
 		sb.append(tc.getLSTformat());
 		String title = tc.getTitle();
@@ -248,6 +248,12 @@ public class AbilityToken extends AbstractTokenWithSeparator<CDOMObject>
 		ReferenceManufacturer<Ability> rm =
 				context.getReferenceContext().getManufacturer(ABILITY_CLASS,
 					ABILITY_CATEGORY_CLASS, cat);
+		if (rm == null)
+		{
+			return new ParseResult.Fail(
+				"Could not get Reference Manufacturer for Category: " + cat,
+				context);
+		}
 		return parseTokenWithSeparator(context, rm, acRef, obj, abilities);
 	}
 

--- a/code/src/java/plugin/lsttokens/deprecated/ChooseFeatSelectionToken.java
+++ b/code/src/java/plugin/lsttokens/deprecated/ChooseFeatSelectionToken.java
@@ -32,6 +32,7 @@ import pcgen.cdom.choiceset.CollectionToAbilitySelection;
 import pcgen.cdom.content.AbilitySelection;
 import pcgen.cdom.enumeration.AssociationListKey;
 import pcgen.cdom.enumeration.ObjectKey;
+import pcgen.cdom.reference.CDOMDirectSingleRef;
 import pcgen.cdom.reference.ReferenceManufacturer;
 import pcgen.core.Ability;
 import pcgen.core.AbilityCategory;
@@ -110,7 +111,7 @@ public class ChooseFeatSelectionToken extends AbstractTokenWithSeparator<CDOMObj
 				+ ": Contains ANY and a specific reference: " + value, context);
 		}
 		PrimitiveChoiceSet<AbilitySelection> pcs =
-				new CollectionToAbilitySelection(AbilityCategory.FEAT, prim);
+				new CollectionToAbilitySelection(CDOMDirectSingleRef.getRef(AbilityCategory.FEAT), prim);
 		//be tricky for compatibility
 		BasicChooseInformation<AbilitySelection> tc =
 				new BasicChooseInformation<AbilitySelection>(

--- a/code/src/java/plugin/lsttokens/deprecated/ChooseFeatToken.java
+++ b/code/src/java/plugin/lsttokens/deprecated/ChooseFeatToken.java
@@ -30,6 +30,7 @@ import pcgen.cdom.base.PrimitiveCollection;
 import pcgen.cdom.choiceset.CollectionToChoiceSet;
 import pcgen.cdom.enumeration.AssociationListKey;
 import pcgen.cdom.enumeration.ObjectKey;
+import pcgen.cdom.reference.CDOMDirectSingleRef;
 import pcgen.cdom.reference.ReferenceManufacturer;
 import pcgen.core.Ability;
 import pcgen.core.AbilityCategory;
@@ -112,7 +113,7 @@ public class ChooseFeatToken extends AbstractTokenWithSeparator<CDOMObject> impl
 		//Tricky for compatibility...
 		CategorizedChooseInformation<Ability> tc =
 				new CategorizedChooseInformation<Ability>("ABILITY",
-					AbilityCategory.FEAT, pcs, Ability.class);
+						CDOMDirectSingleRef.getRef(AbilityCategory.FEAT), pcs, Ability.class);
 		tc.setTitle(title);
 		tc.setChoiceActor(this);
 		context.getObjectContext().put(obj, ObjectKey.CHOOSE_INFO, tc);

--- a/code/src/java/plugin/lsttokens/deprecated/KitFeatToken.java
+++ b/code/src/java/plugin/lsttokens/deprecated/KitFeatToken.java
@@ -31,6 +31,7 @@ import java.util.StringTokenizer;
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.base.CDOMReference;
 import pcgen.cdom.base.Constants;
+import pcgen.cdom.reference.CDOMDirectSingleRef;
 import pcgen.cdom.reference.ReferenceManufacturer;
 import pcgen.cdom.reference.ReferenceUtilities;
 import pcgen.core.Ability;
@@ -80,7 +81,7 @@ public class KitFeatToken extends AbstractTokenWithSeparator<KitAbilities>
 	{
 		StringTokenizer st = new StringTokenizer(value, Constants.PIPE);
 
-		kitAbil.setCategory(AbilityCategory.FEAT);
+		kitAbil.setCategory(CDOMDirectSingleRef.getRef(AbilityCategory.FEAT));
 
 		ReferenceManufacturer<Ability> rm = context.getReferenceContext().getManufacturer(
 				ABILITY_CLASS, AbilityCategory.FEAT);

--- a/code/src/java/plugin/lsttokens/deprecated/RemoveFeatToken.java
+++ b/code/src/java/plugin/lsttokens/deprecated/RemoveFeatToken.java
@@ -45,6 +45,7 @@ import pcgen.cdom.enumeration.ListKey;
 import pcgen.cdom.enumeration.Nature;
 import pcgen.cdom.enumeration.ObjectKey;
 import pcgen.cdom.helper.CNAbilitySelection;
+import pcgen.cdom.reference.CDOMDirectSingleRef;
 import pcgen.cdom.reference.CDOMSingleRef;
 import pcgen.cdom.reference.ReferenceManufacturer;
 import pcgen.core.Ability;
@@ -194,7 +195,7 @@ public class RemoveFeatToken extends AbstractNonEmptyToken<CDOMObject> implement
 
 		if (!refs.isEmpty())
 		{
-			AbilityRefChoiceSet rcs = new AbilityRefChoiceSet(category, refs,
+			AbilityRefChoiceSet rcs = new AbilityRefChoiceSet(CDOMDirectSingleRef.getRef(category), refs,
 					nature);
 			pcs.add(rcs);
 		}

--- a/code/src/java/plugin/lsttokens/deprecated/TemplateFeatToken.java
+++ b/code/src/java/plugin/lsttokens/deprecated/TemplateFeatToken.java
@@ -37,6 +37,7 @@ import pcgen.cdom.enumeration.ListKey;
 import pcgen.cdom.enumeration.Nature;
 import pcgen.cdom.enumeration.ObjectKey;
 import pcgen.cdom.helper.CNAbilitySelection;
+import pcgen.cdom.reference.CDOMDirectSingleRef;
 import pcgen.cdom.reference.ReferenceManufacturer;
 import pcgen.cdom.reference.ReferenceUtilities;
 import pcgen.core.Ability;
@@ -243,7 +244,7 @@ public class TemplateFeatToken extends AbstractTokenWithSeparator<PCTemplate> im
 		if (list != null && !list.isEmpty())
 		{
 			AbilityRefChoiceSet rcs = new AbilityRefChoiceSet(
-					AbilityCategory.FEAT, list, Nature.NORMAL);
+				CDOMDirectSingleRef.getRef(AbilityCategory.FEAT), list, Nature.NORMAL);
 			ChoiceSet<CNAbilitySelection> cs = new ChoiceSet<CNAbilitySelection>(
 					getTokenName(), rcs);
 			cs.setTitle("Feat Choice");

--- a/code/src/java/plugin/lsttokens/kit/ability/AbilityToken.java
+++ b/code/src/java/plugin/lsttokens/kit/ability/AbilityToken.java
@@ -115,6 +115,12 @@ public class AbilityToken extends AbstractNonEmptyToken<KitAbilities> implements
 
 		ReferenceManufacturer<Ability> rm = context.getReferenceContext().getManufacturer(
 				ABILITY_CLASS, ABILITY_CATEGORY_CLASS, acName);
+		if (rm == null)
+		{
+			return new ParseResult.Fail(
+				"Could not get Reference Manufacturer for Category: " + acName,
+				context);
+		}
 
 		while (st.hasMoreTokens())
 		{

--- a/code/src/java/plugin/lsttokens/kit/ability/AbilityToken.java
+++ b/code/src/java/plugin/lsttokens/kit/ability/AbilityToken.java
@@ -29,8 +29,8 @@ import java.util.Collection;
 import java.util.StringTokenizer;
 
 import pcgen.cdom.base.CDOMReference;
-import pcgen.cdom.base.Category;
 import pcgen.cdom.base.Constants;
+import pcgen.cdom.reference.CDOMSingleRef;
 import pcgen.cdom.reference.ReferenceManufacturer;
 import pcgen.core.Ability;
 import pcgen.core.AbilityCategory;
@@ -91,20 +91,18 @@ public class AbilityToken extends AbstractNonEmptyToken<KitAbilities> implements
 				"No category found.  ABILITY token "
 					+ "in a Kit requires CATEGORY=<cat>|<abilities>", context);
 		}
-		Category<Ability> ac = context.getReferenceContext().silentlyGetConstructedCDOMObject(
-				ABILITY_CATEGORY_CLASS, catString.substring(9));
-		if (ac == null)
-		{
-			return new ParseResult.Fail(
-					"Ability Category " + catString.substring(9) + " not found", context);
-		}
+		String acName = catString.substring(9);
+		
+		CDOMSingleRef<AbilityCategory> acRef =
+				context.getReferenceContext().getCDOMReference(
+					ABILITY_CATEGORY_CLASS, acName);
 		/*
 		 * CONSIDER In the future it would be nice to not have to do this cast,
 		 * but that should be reserved for the time when the Pool nature of
 		 * AbilityCategory is separated from the Organizational nature of
 		 * AbilityCategory
 		 */
-		kitAbil.setCategory((AbilityCategory) ac);
+		kitAbil.setCategory(acRef);
 
 		String rest = value.substring(pipeLoc + 1);
 		if (isEmpty(rest) || hasIllegalSeparator('|', rest))
@@ -116,7 +114,7 @@ public class AbilityToken extends AbstractNonEmptyToken<KitAbilities> implements
 		StringTokenizer st = new StringTokenizer(rest, Constants.PIPE);
 
 		ReferenceManufacturer<Ability> rm = context.getReferenceContext().getManufacturer(
-				ABILITY_CLASS, ac);
+				ABILITY_CLASS, ABILITY_CATEGORY_CLASS, acName);
 
 		while (st.hasMoreTokens())
 		{
@@ -149,7 +147,7 @@ public class AbilityToken extends AbstractNonEmptyToken<KitAbilities> implements
 		}
 		StringBuilder result = new StringBuilder();
 		result.append("CATEGORY=");
-		result.append(kitAbil.getCategory().getKeyName());
+		result.append(kitAbil.getCategory().getLSTformat(false));
 		for (CDOMReference<Ability> ref : references)
 		{
 			result.append(Constants.PIPE);

--- a/code/src/test/pcgen/core/PCClassTest.java
+++ b/code/src/test/pcgen/core/PCClassTest.java
@@ -56,6 +56,7 @@ import pcgen.cdom.formula.FixedSizeFormula;
 import pcgen.cdom.inst.PCClassLevel;
 import pcgen.cdom.list.AbilityList;
 import pcgen.cdom.reference.CDOMDirectSingleRef;
+import pcgen.cdom.reference.CDOMSingleRef;
 import pcgen.cdom.reference.Qualifier;
 import pcgen.core.analysis.PCClassKeyChange;
 import pcgen.core.bonus.Bonus;
@@ -757,8 +758,11 @@ public class PCClassTest extends AbstractCharacterTestCase
 		ab2.setCDOMCategory(cat);
 		context.getReferenceContext().importObject(ab1);
 		context.getReferenceContext().importObject(ab2);
+		CDOMSingleRef<AbilityCategory> acRef =
+				context.getReferenceContext().getCDOMReference(
+					AbilityCategory.class, "TestCat");
 		assertTrue(context.getReferenceContext().resolveReferences(null));
-		CDOMReference<AbilityList> autoList = AbilityList.getAbilityListReference(cat, Nature.AUTOMATIC);
+		CDOMReference<AbilityList> autoList = AbilityList.getAbilityListReference(acRef, Nature.AUTOMATIC);
 		Collection<CDOMReference<Ability>> mods = pcclass.getListMods(autoList);
 		assertEquals(1, mods.size());
 		CDOMReference<Ability> ref = mods.iterator().next();

--- a/code/src/test/pcgen/core/PCTemplateTest.java
+++ b/code/src/test/pcgen/core/PCTemplateTest.java
@@ -41,6 +41,7 @@ import pcgen.cdom.enumeration.ListKey;
 import pcgen.cdom.enumeration.Nature;
 import pcgen.cdom.enumeration.StringKey;
 import pcgen.cdom.list.AbilityList;
+import pcgen.cdom.reference.CDOMSingleRef;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.CampaignSourceEntry;
 import pcgen.persistence.lst.GenericLoader;
@@ -139,8 +140,11 @@ public class PCTemplateTest extends AbstractCharacterTestCase
 		PCTemplate template = context.getReferenceContext().silentlyGetConstructedCDOMObject(PCTemplate.class, "Template1");
 		context.getReferenceContext().importObject(ab1);
 		context.getReferenceContext().importObject(ab2);
+		CDOMSingleRef<AbilityCategory> acRef =
+				context.getReferenceContext().getCDOMReference(
+					AbilityCategory.class, "TestCat");
 		assertTrue(context.getReferenceContext().resolveReferences(null));
-		CDOMReference<AbilityList> autoList = AbilityList.getAbilityListReference(cat, Nature.AUTOMATIC);
+		CDOMReference<AbilityList> autoList = AbilityList.getAbilityListReference(acRef, Nature.AUTOMATIC);
 		Collection<CDOMReference<Ability>> listMods = template.getListMods(autoList);
 		assertEquals(2, listMods.size());
 		Iterator<CDOMReference<Ability>> iterator = listMods.iterator();
@@ -198,8 +202,11 @@ public class PCTemplateTest extends AbstractCharacterTestCase
 		PCTemplate template = context.getReferenceContext().silentlyGetConstructedCDOMObject(PCTemplate.class, "Template1");
 		context.getReferenceContext().importObject(ab1);
 		context.getReferenceContext().importObject(ab2);
+		CDOMSingleRef<AbilityCategory> acRef =
+				context.getReferenceContext().getCDOMReference(
+					AbilityCategory.class, "Feat");
 		assertTrue(context.getReferenceContext().resolveReferences(null));
-		CDOMReference<AbilityList> autoList = AbilityList.getAbilityListReference(AbilityCategory.FEAT, Nature.AUTOMATIC);
+		CDOMReference<AbilityList> autoList = AbilityList.getAbilityListReference(acRef, Nature.AUTOMATIC);
 		Collection<CDOMReference<Ability>> listMods = template.getListMods(autoList);
 		assertEquals(2, listMods.size());
 		Iterator<CDOMReference<Ability>> iterator = listMods.iterator();
@@ -262,8 +269,11 @@ public class PCTemplateTest extends AbstractCharacterTestCase
 		PCTemplate template = context.getReferenceContext().silentlyGetConstructedCDOMObject(PCTemplate.class, "Template1");
 		context.getReferenceContext().importObject(ab1);
 		context.getReferenceContext().importObject(ab2);
+		CDOMSingleRef<AbilityCategory> acRef =
+				context.getReferenceContext().getCDOMReference(
+					AbilityCategory.class, "TestCat");
 		assertTrue(context.getReferenceContext().resolveReferences(null));
-		CDOMReference<AbilityList> autoList = AbilityList.getAbilityListReference(cat, Nature.AUTOMATIC);
+		CDOMReference<AbilityList> autoList = AbilityList.getAbilityListReference(acRef, Nature.AUTOMATIC);
 		Collection<CDOMReference<Ability>> listMods = template.getListMods(autoList);
 		assertEquals(1, listMods.size());
 		Iterator<CDOMReference<Ability>> iterator = listMods.iterator();
@@ -342,8 +352,11 @@ public class PCTemplateTest extends AbstractCharacterTestCase
 		PCTemplate template = context.getReferenceContext().silentlyGetConstructedCDOMObject(PCTemplate.class, "Template1");
 		context.getReferenceContext().importObject(ab1);
 		context.getReferenceContext().importObject(ab2);
+		CDOMSingleRef<AbilityCategory> acRef =
+				context.getReferenceContext().getCDOMReference(
+					AbilityCategory.class, "Feat");
 		assertTrue(context.getReferenceContext().resolveReferences(null));
-		CDOMReference<AbilityList> autoList = AbilityList.getAbilityListReference(AbilityCategory.FEAT, Nature.AUTOMATIC);
+		CDOMReference<AbilityList> autoList = AbilityList.getAbilityListReference(acRef, Nature.AUTOMATIC);
 		Collection<CDOMReference<Ability>> listMods = template.getListMods(autoList);
 		assertEquals(1, listMods.size());
 		Iterator<CDOMReference<Ability>> iterator = listMods.iterator();

--- a/code/src/test/pcgen/core/PObjectTest.java
+++ b/code/src/test/pcgen/core/PObjectTest.java
@@ -43,6 +43,7 @@ import pcgen.cdom.enumeration.ListKey;
 import pcgen.cdom.enumeration.Nature;
 import pcgen.cdom.enumeration.ObjectKey;
 import pcgen.cdom.list.AbilityList;
+import pcgen.cdom.reference.CDOMSingleRef;
 import pcgen.core.analysis.BonusAddition;
 import pcgen.core.bonus.Bonus;
 import pcgen.core.bonus.BonusObj;
@@ -384,8 +385,11 @@ public class PObjectTest extends AbstractCharacterTestCase
 				"Race1	ABILITY:TestCat|AUTOMATIC|Ability1	ABILITY:TestCat|AUTOMATIC|Ability2", source);
 		context.getReferenceContext().importObject(ab1);
 		context.getReferenceContext().importObject(ab2);
+		CDOMSingleRef<AbilityCategory> acRef =
+				context.getReferenceContext().getCDOMReference(
+					AbilityCategory.class, "TestCat");
 		assertTrue(context.getReferenceContext().resolveReferences(null));
-		CDOMReference<AbilityList> autoList = AbilityList.getAbilityListReference(cat, Nature.AUTOMATIC);
+		CDOMReference<AbilityList> autoList = AbilityList.getAbilityListReference(acRef, Nature.AUTOMATIC);
 		Collection<CDOMReference<Ability>> listMods = race.getListMods(autoList);
 		assertEquals(2, listMods.size());
 		Iterator<CDOMReference<Ability>> iterator = listMods.iterator();

--- a/code/src/utest/plugin/lsttokens/add/AbilityTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/add/AbilityTokenTest.java
@@ -858,7 +858,7 @@ public class AbilityTokenTest extends AbstractTokenTestCase<CDOMObject>
 
 	private void createTC(List<CDOMReference<Ability>> refs, Formula count)
 	{
-		AbilityRefChoiceSet rcs = new AbilityRefChoiceSet(AbilityCategory.FEAT,
+		AbilityRefChoiceSet rcs = new AbilityRefChoiceSet(CDOMDirectSingleRef.getRef(AbilityCategory.FEAT),
 				refs, Nature.NORMAL);
 		// TODO: Should this be present for the unit tests?
 		//assertTrue("Invalid grouping state " + rcs.getGroupingState(), rcs.getGroupingState().isValid());
@@ -961,7 +961,7 @@ public class AbilityTokenTest extends AbstractTokenTestCase<CDOMObject>
 	public void testUnparseComplex() throws PersistenceLayerException
 	{
 		List<CDOMReference<Ability>> refs = createSingle("TestWP1");
-		AbilityRefChoiceSet rcs = new AbilityRefChoiceSet(AbilityCategory.FEAT,
+		AbilityRefChoiceSet rcs = new AbilityRefChoiceSet(CDOMDirectSingleRef.getRef(AbilityCategory.FEAT),
 				refs, Nature.VIRTUAL);
 		assert (rcs.getGroupingState().isValid());
 		AbilityChoiceSet cs = new AbilityChoiceSet(


### PR DESCRIPTION
Note this is not a complete fix for CODE-2829 since the converter still doesn't leverage this new function, but this is a separately usable unit of work, so I'm proposing as its own PR.

Should be noted for future editor work - note that the responsibility for converting:
AbilityCategory.class "SomeCat" is now transferred from the token into the Reference Context (by using a different method on the Context).  

This does not change (materially) runtime behavior, since it still checks if the returned reference manufacturer is null

However, this allows an editor/converter to unconditionally return a Reference Manufacturer (or otherwise check an external perhaps unloaded in memory list) and decide whether to return null or not in order to indicate an error to the token (the editor may have an external list, a converter would probably do unconditional return of a manufacturer)

