### PR TITLE
NEWTAG-480 Implement SIZENUM token for Size Sorting

### DIFF
--- a/code/pluginbuild.xml
+++ b/code/pluginbuild.xml
@@ -6298,6 +6298,13 @@ jar-all-plugins - Generate the plugin jar files
 				</patternset>
 			</fileset>
 		</jar>
+		<jar jarfile="${systemlstplugins.dir}/SizeAdjustmentLstToken-SIZENUM.jar" manifest="${src.java.dir}/plugin/lsttokens/manifest.mf">
+			<fileset dir="${build.classes.dir}">
+				<patternset>
+					<include name="plugin/lsttokens/sizeadjustment/SizeNumToken.class" />
+				</patternset>
+			</fileset>
+		</jar>
 		<!-- StatsAndChecks tokens-->
 		<!-- StatsAndChecks: Alignment tokens-->
 		<jar jarfile="${systemlstplugins.dir}/StatsAndChecks-AlignmentLstToken-ABB.jar" manifest="${src.java.dir}/plugin/lsttokens/manifest.mf">

--- a/code/src/itest/pcgen/io/testsupport/AbstractSaveRestoreTest.java
+++ b/code/src/itest/pcgen/io/testsupport/AbstractSaveRestoreTest.java
@@ -168,6 +168,7 @@ public abstract class AbstractSaveRestoreTest extends TestCase
 		context.getReferenceContext().buildDerivedObjects();
 		context.resolveDeferredTokens();
 		assertTrue(context.getReferenceContext().resolveReferences(null));
+		context.resolvePostValidationTokens();
 		context.resolvePostDeferredTokens();
 		context.loadCampaignFacets();
 		pc = new PlayerCharacter();
@@ -305,16 +306,16 @@ public abstract class AbstractSaveRestoreTest extends TestCase
 		ref.importObject(wis);
 		ref.importObject(cha);
 
-		fine = BuildUtilities.createSize("Fine");
-		diminutive = BuildUtilities.createSize("Diminutive");
-		tiny = BuildUtilities.createSize("Tiny");
-		small = BuildUtilities.createSize("Small");
-		medium = BuildUtilities.createSize("Medium");
+		fine = BuildUtilities.createSize("Fine", 0);
+		diminutive = BuildUtilities.createSize("Diminutive", 1);
+		tiny = BuildUtilities.createSize("Tiny", 2);
+		small = BuildUtilities.createSize("Small", 3);
+		medium = BuildUtilities.createSize("Medium", 4);
 		medium.put(ObjectKey.IS_DEFAULT_SIZE, true);
-		large = BuildUtilities.createSize("Large");
-		huge = BuildUtilities.createSize("Huge");
-		gargantuan = BuildUtilities.createSize("Gargantuan");
-		colossal = BuildUtilities.createSize("Colossal");
+		large = BuildUtilities.createSize("Large", 5);
+		huge = BuildUtilities.createSize("Huge", 6);
+		gargantuan = BuildUtilities.createSize("Gargantuan", 7);
+		colossal = BuildUtilities.createSize("Colossal", 8);
 
 		context = Globals.getContext();
 		create(Language.class, "Common");

--- a/code/src/itest/plugin/lsttokens/editcontext/equipment/SizeIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/equipment/SizeIntegrationTest.java
@@ -62,13 +62,13 @@ public class SizeIntegrationTest extends AbstractIntegrationTestCase<Equipment>
 	public void setUp() throws PersistenceLayerException, URISyntaxException
 	{
 		super.setUp();
-		SizeAdjustment ps = BuildUtilities.createSize("Small");
+		SizeAdjustment ps = BuildUtilities.createSize("Small", 0);
 		primaryContext.getReferenceContext().importObject(ps);
-		SizeAdjustment pm = BuildUtilities.createSize("Medium");
+		SizeAdjustment pm = BuildUtilities.createSize("Medium", 1);
 		primaryContext.getReferenceContext().importObject(pm);
-		SizeAdjustment ss = BuildUtilities.createSize("Small");
+		SizeAdjustment ss = BuildUtilities.createSize("Small", 0);
 		secondaryContext.getReferenceContext().importObject(ss);
-		SizeAdjustment sm = BuildUtilities.createSize("Medium");
+		SizeAdjustment sm = BuildUtilities.createSize("Medium", 1);
 		secondaryContext.getReferenceContext().importObject(sm);
 	}
 

--- a/code/src/itest/plugin/lsttokens/editcontext/race/SizeIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/race/SizeIntegrationTest.java
@@ -62,13 +62,13 @@ public class SizeIntegrationTest extends AbstractIntegrationTestCase<Race>
 	public void setUp() throws PersistenceLayerException, URISyntaxException
 	{
 		super.setUp();
-		SizeAdjustment ps = BuildUtilities.createSize("Small");
+		SizeAdjustment ps = BuildUtilities.createSize("Small", 0);
 		primaryContext.getReferenceContext().importObject(ps);
-		SizeAdjustment pm = BuildUtilities.createSize("Medium");
+		SizeAdjustment pm = BuildUtilities.createSize("Medium", 1);
 		primaryContext.getReferenceContext().importObject(pm);
-		SizeAdjustment ss = BuildUtilities.createSize("Small");
+		SizeAdjustment ss = BuildUtilities.createSize("Small", 0);
 		secondaryContext.getReferenceContext().importObject(ss);
-		SizeAdjustment sm = BuildUtilities.createSize("Medium");
+		SizeAdjustment sm = BuildUtilities.createSize("Medium", 1);
 		secondaryContext.getReferenceContext().importObject(sm);
 	}
 

--- a/code/src/itest/plugin/lsttokens/editcontext/template/SizeIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/template/SizeIntegrationTest.java
@@ -63,13 +63,13 @@ public class SizeIntegrationTest extends
 	public void setUp() throws PersistenceLayerException, URISyntaxException
 	{
 		super.setUp();
-		SizeAdjustment ps = BuildUtilities.createSize("S");
+		SizeAdjustment ps = BuildUtilities.createSize("Small", 0);
 		primaryContext.getReferenceContext().importObject(ps);
-		SizeAdjustment pm = BuildUtilities.createSize("M");
+		SizeAdjustment pm = BuildUtilities.createSize("Medium", 1);
 		primaryContext.getReferenceContext().importObject(pm);
-		SizeAdjustment ss = BuildUtilities.createSize("S");
+		SizeAdjustment ss = BuildUtilities.createSize("Small", 0);
 		secondaryContext.getReferenceContext().importObject(ss);
-		SizeAdjustment sm = BuildUtilities.createSize("M");
+		SizeAdjustment sm = BuildUtilities.createSize("Medium", 1);
 		secondaryContext.getReferenceContext().importObject(sm);
 	}
 

--- a/code/src/itest/tokenmodel/testsupport/AbstractTokenModelTest.java
+++ b/code/src/itest/tokenmodel/testsupport/AbstractTokenModelTest.java
@@ -138,6 +138,7 @@ public abstract class AbstractTokenModelTest extends TestCase
 		context.getReferenceContext().buildDerivedObjects();
 		context.resolveDeferredTokens();
 		assertTrue(context.getReferenceContext().resolveReferences(null));
+		context.resolvePostValidationTokens();
 		context.resolvePostDeferredTokens();
 		context.loadCampaignFacets();
 		pc = new PlayerCharacter();
@@ -276,16 +277,16 @@ public abstract class AbstractTokenModelTest extends TestCase
 		ref.importObject(wis);
 		ref.importObject(cha);
 
-		fine = BuildUtilities.createSize("Fine");
-		diminutive = BuildUtilities.createSize("Diminutive");
-		tiny = BuildUtilities.createSize("Tiny");
-		small = BuildUtilities.createSize("Small");
-		medium = BuildUtilities.createSize("Medium");
-		medium.put(ObjectKey.IS_DEFAULT_SIZE, Boolean.TRUE);
-		large = BuildUtilities.createSize("Large");
-		huge = BuildUtilities.createSize("Huge");
-		gargantuan = BuildUtilities.createSize("Gargantuan");
-		colossal = BuildUtilities.createSize("Colossal");
+		fine = BuildUtilities.createSize("Fine", 0);
+		diminutive = BuildUtilities.createSize("Diminutive", 1);
+		tiny = BuildUtilities.createSize("Tiny", 2);
+		small = BuildUtilities.createSize("Small", 3);
+		medium = BuildUtilities.createSize("Medium", 4);
+		medium.put(ObjectKey.IS_DEFAULT_SIZE, true);
+		large = BuildUtilities.createSize("Large", 5);
+		huge = BuildUtilities.createSize("Huge", 6);
+		gargantuan = BuildUtilities.createSize("Gargantuan", 7);
+		colossal = BuildUtilities.createSize("Colossal", 8);
 
 		context = Globals.getContext();
 		create(Language.class, "Common");

--- a/code/src/java/pcgen/cdom/enumeration/IntegerKey.java
+++ b/code/src/java/pcgen/cdom/enumeration/IntegerKey.java
@@ -139,6 +139,13 @@ public class IntegerKey
 
 	public static final IntegerKey MAX_VALUE = getConstant("MAX_VALUE", 1000);
 
+	//Input value for SizeAdjustment ordering (in LST file)
+	public static final IntegerKey SIZENUM = getConstant("SIZENUM");
+
+	//Derived value for SizeAdjustment ordering (derived to be sequential)
+	public static final IntegerKey SIZEORDER = getConstant("SIZEORDER");
+
+
 	/*
 	 * TODO Okay, this is a hack. This should probably be a FormulaKey rather
 	 * than an IntegerKey in order to properly handle this strange delegation.

--- a/code/src/java/pcgen/cdom/facet/analysis/UnarmedDamageFacet.java
+++ b/code/src/java/pcgen/cdom/facet/analysis/UnarmedDamageFacet.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.enumeration.CharID;
 import pcgen.cdom.enumeration.FormulaKey;
+import pcgen.cdom.enumeration.IntegerKey;
 import pcgen.cdom.enumeration.ListKey;
 import pcgen.cdom.facet.CDOMObjectConsolidationFacet;
 import pcgen.cdom.facet.FormulaResolvingFacet;
@@ -118,8 +119,10 @@ public class UnarmedDamageFacet extends AbstractSourcedListFacet<CharID, List<St
 		int iSize = formulaResolvingFacet.resolve(id, race.getSafe(FormulaKey.SIZE),
 				race.getQualifiedKey()).intValue();
 		SizeAdjustment defAdj = SizeUtilities.getDefaultSizeAdjustment();
-		SizeAdjustment sizAdj = Globals.getContext().getReferenceContext().getItemInOrder(
-				SizeAdjustment.class, iSize);
+		SizeAdjustment sizAdj =
+				Globals.getContext().getReferenceContext()
+					.getSortedList(SizeAdjustment.class, IntegerKey.SIZEORDER)
+					.get(iSize);
 		if (sizAdj != null)
 		{
 			return Globals.adjustDamage("1d3", defAdj, sizAdj);

--- a/code/src/java/pcgen/cdom/facet/model/SizeFacet.java
+++ b/code/src/java/pcgen/cdom/facet/model/SizeFacet.java
@@ -24,6 +24,7 @@ import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.base.ItemFacet;
 import pcgen.cdom.enumeration.CharID;
 import pcgen.cdom.enumeration.FormulaKey;
+import pcgen.cdom.enumeration.IntegerKey;
 import pcgen.cdom.enumeration.ListKey;
 import pcgen.cdom.facet.BonusChangeFacet.BonusChangeEvent;
 import pcgen.cdom.facet.BonusChangeFacet.BonusChangeListener;
@@ -75,15 +76,19 @@ public class SizeFacet extends AbstractDataFacet<CharID, SizeAdjustment> impleme
 	public int racialSizeInt(CharID id)
 	{
 		SizeFacetInfo info = getInfo(id);
-		return info == null ? SizeUtilities.getDefaultSizeInt()
-				: info.racialSizeInt;
+		if (info == null)
+		{
+			return SizeUtilities.getDefaultSizeAdjustment().get(
+				IntegerKey.SIZEORDER);
+		}
+		return info.racialSizeInt;
 	}
 
 	private int calcRacialSizeInt(CharID id)
 	{
 		SizeFacetInfo info = getConstructingInfo(id);
 
-		int iSize = SizeUtilities.getDefaultSizeInt();
+		int iSize = SizeUtilities.getDefaultSizeAdjustment().get(IntegerKey.SIZEORDER);
 		Race race = raceFacet.get(id);
 		if (race != null)
 		{
@@ -122,7 +127,12 @@ public class SizeFacet extends AbstractDataFacet<CharID, SizeAdjustment> impleme
 	public int sizeInt(CharID id)
 	{
 		SizeFacetInfo info = getInfo(id);
-		return info == null ? SizeUtilities.getDefaultSizeInt() : info.sizeInt;
+		if (info == null)
+		{
+			return SizeUtilities.getDefaultSizeAdjustment().get(
+				IntegerKey.SIZEORDER);
+		}
+		return info.sizeInt;
 	}
 
 	/**
@@ -160,8 +170,10 @@ public class SizeFacet extends AbstractDataFacet<CharID, SizeAdjustment> impleme
 
 		info.sizeInt = iSize;
 		SizeAdjustment oldSize = info.sizeAdj;
-		SizeAdjustment newSize = Globals.getContext().getReferenceContext().getItemInOrder(
-				SIZEADJUSTMENT_CLASS, sizeInt(id));
+		SizeAdjustment newSize =
+				Globals.getContext().getReferenceContext()
+					.getSortedList(SizeAdjustment.class, IntegerKey.SIZEORDER)
+					.get(sizeInt(id));
 		info.sizeAdj = newSize;
 		if (oldSize != newSize)
 		{

--- a/code/src/java/pcgen/cdom/formula/FixedSizeFormula.java
+++ b/code/src/java/pcgen/cdom/formula/FixedSizeFormula.java
@@ -18,11 +18,11 @@
 package pcgen.cdom.formula;
 
 import pcgen.base.formula.Formula;
+import pcgen.cdom.enumeration.IntegerKey;
 import pcgen.cdom.reference.CDOMSingleRef;
 import pcgen.core.Equipment;
 import pcgen.core.PlayerCharacter;
 import pcgen.core.SizeAdjustment;
-import pcgen.core.analysis.SizeUtilities;
 
 /**
  * A FixedSizeFormula is a Formula that returns a deterministic value, used to
@@ -172,6 +172,6 @@ public class FixedSizeFormula implements Formula
 	@Override
 	public Integer resolveStatic()
 	{
-		return SizeUtilities.sizeInt(size.resolvesTo().getKeyName());
+		return size.resolvesTo().get(IntegerKey.SIZEORDER);
 	}
 }

--- a/code/src/java/pcgen/cdom/util/IntegerKeyComparator.java
+++ b/code/src/java/pcgen/cdom/util/IntegerKeyComparator.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2015 (C) Tom Parker <thpr@sourceforge.net>
+ * 
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 59 Temple Place,
+ * Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.cdom.util;
+
+import java.util.Comparator;
+
+import pcgen.cdom.base.CDOMObject;
+import pcgen.cdom.enumeration.IntegerKey;
+
+/**
+ * Provides a Comparator that is capable of sorting CDOMObjects based on the
+ * value in a specific IntegerKey.
+ * 
+ * Limitations: (1) Neither IntegerKey can be null. (2) No value stored for the
+ * IntegerKey can be identical (or the comparison will return a false positive -
+ * this will NOT fall back on [for example] the key of the object to keep
+ * objects distinguished)
+ */
+public class IntegerKeyComparator implements Comparator<CDOMObject>
+{
+	/**
+	 * The IntegerKey for sorting. Specifically, the value stored in the
+	 * CDOMObject with this IntegerKey will be used to determine the order of
+	 * the objects.
+	 */
+	private IntegerKey ik;
+
+	/**
+	 * Constructs a new IntegerKeyComparator that will use the given IntegerKey
+	 * 
+	 * @param key
+	 *            The IntegerKey for sorting
+	 * @throws IllegalArgumentException
+	 *             if the given IntegerKey is null
+	 */
+	public IntegerKeyComparator(IntegerKey key)
+	{
+		if (key == null)
+		{
+			throw new IllegalArgumentException("IntegerKey cannot be null");
+		}
+		ik = key;
+	}
+
+	/**
+	 * @see java.util.Comparator#compare(java.lang.Object, java.lang.Object)
+	 */
+	@Override
+	public int compare(CDOMObject cdo1, CDOMObject cdo2)
+	{
+		return Integer.compare(cdo1.getSafe(ik), cdo2.getSafe(ik));
+	}
+}

--- a/code/src/java/pcgen/core/DataSet.java
+++ b/code/src/java/pcgen/core/DataSet.java
@@ -36,10 +36,12 @@ import java.util.TreeMap;
 import pcgen.cdom.base.Category;
 import pcgen.cdom.base.ChooseInformation;
 import pcgen.cdom.base.Constants;
+import pcgen.cdom.enumeration.IntegerKey;
 import pcgen.cdom.enumeration.ObjectKey;
 import pcgen.cdom.enumeration.StringKey;
 import pcgen.cdom.enumeration.Type;
 import pcgen.core.character.EquipSlot;
+import pcgen.core.prereq.Prerequisite;
 import pcgen.facade.core.AbilityCategoryFacade;
 import pcgen.facade.core.AbilityFacade;
 import pcgen.facade.core.AlignmentFacade;
@@ -62,7 +64,6 @@ import pcgen.facade.util.AbstractMapFacade;
 import pcgen.facade.util.DefaultListFacade;
 import pcgen.facade.util.ListFacade;
 import pcgen.facade.util.MapFacade;
-import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteOperator;
 import pcgen.rules.context.LoadContext;
 import pcgen.util.enumeration.View;
@@ -244,7 +245,8 @@ public class DataSet implements DataSetFacade
 		{
 			characterTypes.addElement(characterType);
 		}
-		for (SizeAdjustment size : context.getReferenceContext().getOrderSortedCDOMObjects(SizeAdjustment.class))
+		for (SizeAdjustment size : context.getReferenceContext().getSortedList(
+			SizeAdjustment.class, IntegerKey.SIZEORDER))
 		{
 			sizes.addElement(size);
 		}

--- a/code/src/java/pcgen/core/Equipment.java
+++ b/code/src/java/pcgen/core/Equipment.java
@@ -79,13 +79,14 @@ import pcgen.core.bonus.BonusObj;
 import pcgen.core.bonus.BonusUtilities;
 import pcgen.core.character.EquipSlot;
 import pcgen.core.character.WieldCategory;
-import pcgen.facade.core.EquipmentFacade;
 import pcgen.core.prereq.PrereqHandler;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.utils.CoreUtility;
 import pcgen.core.utils.MessageType;
 import pcgen.core.utils.ShowMessageDelegate;
+import pcgen.facade.core.EquipmentFacade;
 import pcgen.io.FileAccess;
+import pcgen.rules.context.AbstractReferenceContext;
 import pcgen.util.BigDecimalHelper;
 import pcgen.util.JEPResourceChecker;
 import pcgen.util.Logging;
@@ -3718,7 +3719,7 @@ public final class Equipment extends PObject implements Serializable,
 		setBase();
 
 		final int iOldSize = sizeInt();
-		int iNewSize = SizeUtilities.sizeInt(newSize);
+		int iNewSize = newSize.get(IntegerKey.SIZEORDER);
 
 		if (iNewSize != iOldSize)
 		{
@@ -3796,15 +3797,16 @@ public final class Equipment extends PObject implements Serializable,
 		//
 		if (hasPrerequisites())
 		{
-			int maxIndex =
-					Globals.getContext().getReferenceContext()
-						.getConstructedObjectCount(SizeAdjustment.class);
+			AbstractReferenceContext ref = Globals.getContext().getReferenceContext();
+			int maxIndex = ref.getConstructedObjectCount(SizeAdjustment.class);
 			for (Prerequisite aBonus : getPrerequisiteList())
 			{
 				if ("SIZE".equalsIgnoreCase(aBonus.getKind()))
 				{
-					final int iOldPre =
-							SizeUtilities.sizeInt(aBonus.getOperand());
+					SizeAdjustment sa =
+							ref.silentlyGetConstructedCDOMObject(
+								SizeAdjustment.class, aBonus.getOperand());
+					final int iOldPre = sa.get(IntegerKey.SIZEORDER);
 					iNewSize += (iOldPre - iOldSize);
 
 					if ((iNewSize >= 0) && (iNewSize <= maxIndex))
@@ -3813,9 +3815,10 @@ public final class Equipment extends PObject implements Serializable,
 						// Equipment, since it is returned
 						// by reference from the get above ... thus no need to
 						// perform a set
-						aBonus.setOperand(Globals.getContext().getReferenceContext()
-							.getItemInOrder(SizeAdjustment.class, iNewSize)
-							.getKeyName());
+						SizeAdjustment size =
+								ref.getSortedList(SizeAdjustment.class,
+									IntegerKey.SIZEORDER).get(iNewSize);
+						aBonus.setOperand(size.getKeyName());
 					}
 				}
 			}
@@ -3829,7 +3832,8 @@ public final class Equipment extends PObject implements Serializable,
 	 */
 	public int sizeInt()
 	{
-		return SizeUtilities.sizeInt(getSafe(ObjectKey.SIZE).resolvesTo());
+		SizeAdjustment size = getSafe(ObjectKey.SIZE).resolvesTo();
+		return size.get(IntegerKey.SIZEORDER);
 	}
 
 	/**
@@ -5806,6 +5810,7 @@ public final class Equipment extends PObject implements Serializable,
 				iSize + (int) bonusTo(apc, "EQMWEAPON", "DAMAGESIZE", bPrimary);
 		iMod += (int) bonusTo(apc, "WEAPON", "DAMAGESIZE", bPrimary);
 
+		AbstractReferenceContext ref = Globals.getContext().getReferenceContext();
 		if (iMod < 0)
 		{
 			iMod = 0;
@@ -5813,16 +5818,15 @@ public final class Equipment extends PObject implements Serializable,
 		else
 		{
 			int maxIndex =
-					Globals.getContext().getReferenceContext()
-						.getConstructedObjectCount(SizeAdjustment.class) - 1;
+					ref.getConstructedObjectCount(SizeAdjustment.class) - 1;
 			if (iMod > maxIndex)
 			{
 				iMod = maxIndex;
 			}
 		}
 		SizeAdjustment sa =
-				Globals.getContext().getReferenceContext().getItemInOrder(SizeAdjustment.class,
-					iMod);
+				ref.getSortedList(SizeAdjustment.class, IntegerKey.SIZEORDER)
+					.get(iMod);
 		return adjustDamage(dam, sa);
 	}
 

--- a/code/src/java/pcgen/core/EquipmentList.java
+++ b/code/src/java/pcgen/core/EquipmentList.java
@@ -33,12 +33,14 @@ import java.util.Set;
 import java.util.StringTokenizer;
 
 import pcgen.cdom.enumeration.FormulaKey;
+import pcgen.cdom.enumeration.IntegerKey;
 import pcgen.cdom.enumeration.ObjectKey;
 import pcgen.cdom.enumeration.Type;
 import pcgen.core.analysis.EquipmentChoiceDriver;
 import pcgen.core.analysis.SizeUtilities;
 import pcgen.core.prereq.PrereqHandler;
 import pcgen.core.utils.CoreUtility;
+import pcgen.rules.context.AbstractReferenceContext;
 import pcgen.util.Delta;
 import pcgen.util.Logging;
 
@@ -520,7 +522,8 @@ public class EquipmentList {
 			// creatures weren't being catered for (and therefore an OutOfBounds exception
 			// was being thrown) - Bug 937586
 			//
-			for ( final Race race : Globals.getContext().getReferenceContext().getConstructedCDOMObjects(Race.class) )
+			AbstractReferenceContext ref = Globals.getContext().getReferenceContext();
+			for (final Race race : ref.getConstructedCDOMObjects(Race.class))
 			{
 				/*
 				 * SIZE: in Race LST files enforces that the formula is fixed,
@@ -536,13 +539,14 @@ public class EquipmentList {
 			Set<SizeAdjustment> gensizes = new HashSet<SizeAdjustment>();
 			for (Integer i : gensizesid)
 			{
-				gensizes.add(Globals.getContext().getReferenceContext().getItemInOrder(SizeAdjustment.class, i));
+				gensizes.add(ref.getSortedList(SizeAdjustment.class,
+					IntegerKey.SIZEORDER).get(i));
 			}
 			// skip over default size
 			gensizes.remove(defaultSize);
 
 			PlayerCharacter dummyPc = new PlayerCharacter();
-			for (Equipment eq : Globals.getContext().getReferenceContext().getConstructedCDOMObjects(Equipment.class))
+			for (Equipment eq : ref.getConstructedCDOMObjects(Equipment.class))
 			{
 				//
 				// Only apply to Armor, Shield and resizable items

--- a/code/src/java/pcgen/core/Globals.java
+++ b/code/src/java/pcgen/core/Globals.java
@@ -49,12 +49,12 @@ import pcgen.cdom.base.Constants;
 import pcgen.cdom.base.MasterListInterface;
 import pcgen.cdom.content.BaseDice;
 import pcgen.cdom.content.CNAbilityFactory;
+import pcgen.cdom.enumeration.IntegerKey;
 import pcgen.cdom.enumeration.ListKey;
 import pcgen.cdom.enumeration.RaceType;
 import pcgen.cdom.enumeration.SourceFormat;
 import pcgen.cdom.enumeration.StringKey;
 import pcgen.cdom.enumeration.Type;
-import pcgen.core.analysis.SizeUtilities;
 import pcgen.core.character.EquipSlot;
 import pcgen.core.chooser.CDOMChooserFacadeImpl;
 import pcgen.core.spell.Spell;
@@ -138,7 +138,7 @@ public final class Globals
 			}
 		};
 
-	private static final Comparator<CDOMObject> pObjectNameComp = new Comparator<CDOMObject>()
+	public static final Comparator<CDOMObject> pObjectNameComp = new Comparator<CDOMObject>()
 		{
         @Override
 			public int compare(final CDOMObject o1, final CDOMObject o2)
@@ -1502,8 +1502,8 @@ public final class Globals
 		{
 			return aDamage;
 		}
-		int baseIndex = SizeUtilities.sizeInt(baseSize);
-		int newIndex =  SizeUtilities.sizeInt(newSize);
+		int baseIndex = baseSize.get(IntegerKey.SIZEORDER);
+		int newIndex =  newSize.get(IntegerKey.SIZEORDER);
 		return adjustDamage(aDamage, baseIndex, newIndex);
 	}
 

--- a/code/src/java/pcgen/core/PCClass.java
+++ b/code/src/java/pcgen/core/PCClass.java
@@ -825,8 +825,10 @@ public class PCClass extends PObject implements ClassFacade
 		// resize the damage as if it were a weapon
 		if (adjustForPCSize)
 		{
-			aDamage = Globals.adjustDamage(aDamage, SizeUtilities
-					.getDefaultSizeInt(), pcSize);
+			int defSize =
+					SizeUtilities.getDefaultSizeAdjustment().get(
+						IntegerKey.SIZEORDER);
+			aDamage = Globals.adjustDamage(aDamage, defSize, pcSize);
 		}
 
 		//

--- a/code/src/java/pcgen/core/analysis/SizeUtilities.java
+++ b/code/src/java/pcgen/core/analysis/SizeUtilities.java
@@ -17,61 +17,12 @@
  */
 package pcgen.core.analysis;
 
-import java.util.List;
-
 import pcgen.cdom.enumeration.ObjectKey;
 import pcgen.core.Globals;
 import pcgen.core.SizeAdjustment;
 
 public class SizeUtilities
 {
-
-	/**
-	 * Get size as an integer
-	 * @param aSize
-	 * @param defaultValue
-	 * @return size as an int
-	 */
-	public static int sizeInt(final String aSize, final int defaultValue)
-	{
-		List<SizeAdjustment> list = Globals.getContext().getReferenceContext()
-				.getOrderSortedCDOMObjects(SizeAdjustment.class);
-		for (int i = 0; i < list.size(); i++)
-		{
-			if (aSize.equals(list.get(i).getKeyName()))
-			{
-				return i;
-			}
-		}
-	
-		return defaultValue;
-	}
-
-	public static int sizeInt(final SizeAdjustment aSize)
-	{
-		List<SizeAdjustment> list = Globals.getContext().getReferenceContext()
-				.getOrderSortedCDOMObjects(SizeAdjustment.class);
-		for (int i = 0; i < list.size(); i++)
-		{
-			if (aSize.equals(list.get(i)))
-			{
-				return i;
-			}
-		}
-	
-		return -1;
-	}
-
-	/**
-	 * Get size as an int
-	 * @param aSize
-	 * @return size as an int
-	 */
-	public static int sizeInt(final String aSize)
-	{
-		return sizeInt(aSize, 0);
-	}
-
 	/**
 	 * Get the default size adjustment
 	 * @return the default size adjustment
@@ -79,7 +30,7 @@ public class SizeUtilities
 	public static SizeAdjustment getDefaultSizeAdjustment()
 	{
 		for (SizeAdjustment s : Globals.getContext().getReferenceContext()
-				.getOrderSortedCDOMObjects(SizeAdjustment.class))
+			.getConstructedCDOMObjects(SizeAdjustment.class))
 		{
 			if (s.getSafe(ObjectKey.IS_DEFAULT_SIZE))
 			{
@@ -88,21 +39,5 @@ public class SizeUtilities
 		}
 	
 		return null;
-	}
-
-	public static int getDefaultSizeInt()
-	{
-		List<SizeAdjustment> list = Globals.getContext().getReferenceContext()
-				.getOrderSortedCDOMObjects(SizeAdjustment.class);
-		for (int i = 0; i < list.size(); i++)
-		{
-			SizeAdjustment s = list.get(i);
-			if (s.getSafe(ObjectKey.IS_DEFAULT_SIZE))
-			{
-				return i;
-			}
-		}
-
-		return -1;
 	}
 }

--- a/code/src/java/pcgen/core/character/WieldCategory.java
+++ b/code/src/java/pcgen/core/character/WieldCategory.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 
 import pcgen.cdom.base.Loadable;
+import pcgen.cdom.enumeration.IntegerKey;
 import pcgen.cdom.enumeration.ObjectKey;
 import pcgen.cdom.reference.CDOMDirectSingleRef;
 import pcgen.cdom.reference.CDOMSingleRef;
@@ -42,6 +43,7 @@ import pcgen.core.PlayerCharacter;
 import pcgen.core.QualifiedObject;
 import pcgen.core.SizeAdjustment;
 import pcgen.core.prereq.PrereqHandler;
+import pcgen.rules.context.AbstractReferenceContext;
 
 public final class WieldCategory implements Loadable
 {
@@ -217,8 +219,11 @@ public final class WieldCategory implements Loadable
 			if (aBump != 0)
 			{
 				final int newSizeInt = eq.sizeInt() + aBump;
-				final SizeAdjustment sadj = Globals.getContext().getReferenceContext()
-						.getItemInOrder(SizeAdjustment.class, newSizeInt);
+				AbstractReferenceContext ref =
+						Globals.getContext().getReferenceContext();
+				SizeAdjustment sadj =
+						ref.getSortedList(SizeAdjustment.class,
+							IntegerKey.SIZEORDER).get(newSizeInt);
 				eq.put(ObjectKey.SIZE, CDOMDirectSingleRef.getRef(sadj));
 			}
 		}

--- a/code/src/java/pcgen/io/exporttoken/WeaponToken.java
+++ b/code/src/java/pcgen/io/exporttoken/WeaponToken.java
@@ -34,6 +34,7 @@ import pcgen.cdom.base.Constants;
 import pcgen.cdom.enumeration.EquipmentLocation;
 import pcgen.cdom.enumeration.FactKey;
 import pcgen.cdom.enumeration.FormulaKey;
+import pcgen.cdom.enumeration.IntegerKey;
 import pcgen.cdom.enumeration.ObjectKey;
 import pcgen.cdom.reference.CDOMSingleRef;
 import pcgen.core.Equipment;
@@ -691,11 +692,11 @@ public class WeaponToken extends Token
 	public static String getHeft(PlayerCharacter pc, Equipment eq)
 	{
 		String retString = "";
-		if (pc.getDisplay().sizeInt() > SizeUtilities.sizeInt(eq.getSize()))
+		if (pc.getDisplay().sizeInt() > eq.sizeInt())
 		{
 			retString = "LIGHT";
 		}
-		else if (pc.getDisplay().sizeInt() == SizeUtilities.sizeInt(eq.getSize()))
+		else if (pc.getDisplay().sizeInt() == eq.sizeInt())
 		{
 			retString = "MEDIUM";
 		}
@@ -2688,7 +2689,7 @@ public class WeaponToken extends Token
 				final SizeAdjustment defAdj = SizeUtilities.getDefaultSizeAdjustment();
 				if (defAdj != null)
 				{
-					eqSize = SizeUtilities.sizeInt(defAdj.getKeyName());
+					eqSize = defAdj.get(IntegerKey.SIZEORDER);
 				}
 			}
 

--- a/code/src/java/pcgen/persistence/SourceFileLoader.java
+++ b/code/src/java/pcgen/persistence/SourceFileLoader.java
@@ -68,7 +68,6 @@ import pcgen.core.PCTemplate;
 import pcgen.core.Race;
 import pcgen.core.SettingsHandler;
 import pcgen.core.ShieldProf;
-import pcgen.core.SizeAdjustment;
 import pcgen.core.Skill;
 import pcgen.core.SystemCollections;
 import pcgen.core.WeaponProf;
@@ -687,30 +686,13 @@ public class SourceFileLoader extends PCGenTask implements Observer
 		LoadValidator validator = new LoadValidator(aSelectedCampaignsList);
 		refContext.validate(validator);
 		refContext.resolveReferences(validator);
+		context.resolvePostValidationTokens();
 		context.resolvePostDeferredTokens();
 		ReferenceContextUtilities.validateAssociations(refContext, validator);
 		for (Equipment eq : refContext.getConstructedCDOMObjects(Equipment.class))
 		{
 			eq.setToCustomSize(null);
 			EqModAttachment.finishEquipment(eq);
-		}
-		validateSingleDefaultSize(context);
-	}
-
-	private void validateSingleDefaultSize(LoadContext context)
-	{
-		int defaults = getDefaultSizeAdjustmentCount(context);
-		if (defaults == 0)
-		{
-			Logging.log(Logging.LST_WARNING,
-						"Did not find a default size in Game Mode: " +
-					SettingsHandler.getGame().getName());
-		}
-		else if (defaults > 1)
-		{
-			Logging.log(Logging.LST_WARNING,
-						"Found more than one size claiming to be default in Game Mode: " +
-					SettingsHandler.getGame().getName());
 		}
 	}
 
@@ -1175,21 +1157,6 @@ public class SourceFileLoader extends PCGenTask implements Observer
 		{
 			sendErrorMessage((Exception) arg);
 		}
-	}
-
-	public int getDefaultSizeAdjustmentCount(LoadContext context)
-	{
-		int i = 0;
-		for (SizeAdjustment s : context.getReferenceContext()
-				.getOrderSortedCDOMObjects(SizeAdjustment.class))
-		{
-			if (s.getSafe(ObjectKey.IS_DEFAULT_SIZE))
-			{
-				i++;
-			}
-		}
-	
-		return i;
 	}
 
 	private class LoadHandler extends Handler

--- a/code/src/java/pcgen/rules/context/LoadContext.java
+++ b/code/src/java/pcgen/rules/context/LoadContext.java
@@ -74,6 +74,8 @@ public interface LoadContext
 
 	public void resolvePostDeferredTokens();
 
+	public void resolvePostValidationTokens();
+
 	public <T extends CDOMObject> PrimitiveCollection<T> getChoiceSet(
 		SelectionCreator<T> sc, String value);
 

--- a/code/src/java/pcgen/rules/context/LoadContextInst.java
+++ b/code/src/java/pcgen/rules/context/LoadContextInst.java
@@ -54,6 +54,7 @@ import pcgen.rules.persistence.TokenSupport;
 import pcgen.rules.persistence.token.DeferredToken;
 import pcgen.rules.persistence.token.ParseResult;
 import pcgen.rules.persistence.token.PostDeferredToken;
+import pcgen.rules.persistence.token.PostValidationToken;
 import pcgen.util.Logging;
 import freemarker.template.ObjectWrapper;
 
@@ -257,6 +258,31 @@ public abstract class LoadContextInst implements LoadContext
 					this.setSourceURI(po.getSourceURI());
 					token.process(this, po);
 				}
+			}
+		}
+	}
+
+	@Override
+	public void resolvePostValidationTokens()
+	{
+		Collection<? extends ReferenceManufacturer> mfgs = getReferenceContext()
+				.getAllManufacturers();
+		for (PostValidationToken<? extends Loadable> token : TokenLibrary.getPostValidationTokens())
+		{
+			processPostVal(token, mfgs);
+		}
+	}
+
+	private <T extends Loadable> void processPostVal(PostValidationToken<T> token,
+			Collection<? extends ReferenceManufacturer> mfgs)
+	{
+		Class<T> cl = token.getValidationTokenClass();
+		for (ReferenceManufacturer<? extends T> rm : mfgs)
+		{
+			if (cl.isAssignableFrom(rm.getReferenceClass()))
+			{
+				setSourceURI(null);
+				token.process(this, rm.getAllObjects());
 			}
 		}
 	}

--- a/code/src/java/pcgen/rules/persistence/TokenLibrary.java
+++ b/code/src/java/pcgen/rules/persistence/TokenLibrary.java
@@ -45,6 +45,7 @@ import pcgen.rules.persistence.token.CDOMToken;
 import pcgen.rules.persistence.token.ClassWrappedToken;
 import pcgen.rules.persistence.token.DeferredToken;
 import pcgen.rules.persistence.token.PostDeferredToken;
+import pcgen.rules.persistence.token.PostValidationToken;
 import pcgen.rules.persistence.token.PreCompatibilityToken;
 import pcgen.rules.persistence.token.PrimitiveToken;
 import pcgen.rules.persistence.token.QualifierToken;
@@ -61,6 +62,8 @@ public final class TokenLibrary implements PluginLoader
 	private static final Class<CDOMObject> CDOMOBJECT_CLASS = CDOMObject.class;
 	private static final TreeMapToList<Integer, PostDeferredToken<? extends Loadable>> POST_DEFERRED_TOKENS =
 			new TreeMapToList<Integer, PostDeferredToken<? extends Loadable>>();
+	private static final TreeMapToList<Integer, PostValidationToken<? extends Loadable>> POST_VALIDATION_TOKENS =
+			new TreeMapToList<Integer, PostValidationToken<? extends Loadable>>();
 	private static final DoubleKeyMap<Class<?>, String, Class<? extends QualifierToken>> QUALIFIER_MAP =
 			new DoubleKeyMap<Class<?>, String, Class<? extends QualifierToken>>();
 	private static final DoubleKeyMap<Class<?>, String, Class<PrimitiveToken<?>>> PRIMITIVE_MAP =
@@ -117,6 +120,17 @@ public final class TokenLibrary implements PluginLoader
 		return list;
 	}
 
+	public static Collection<PostValidationToken<? extends Loadable>> getPostValidationTokens()
+	{
+		List<PostValidationToken<? extends Loadable>> list =
+				new ArrayList<PostValidationToken<? extends Loadable>>();
+		for (Integer key : POST_VALIDATION_TOKENS.getKeySet())
+		{
+			list.addAll(POST_VALIDATION_TOKENS.getListFor(key));
+		}
+		return list;
+	}
+
 	public static void addToPrimitiveMap(PrimitiveToken<?> p)
 	{
 		Class<? extends PrimitiveToken> newTokClass = p.getClass();
@@ -151,6 +165,11 @@ public final class TokenLibrary implements PluginLoader
 		{
 			PostDeferredToken<?> pdt = (PostDeferredToken<?>) newToken;
 			POST_DEFERRED_TOKENS.addToListFor(pdt.getPriority(), pdt);
+		}
+		if (newToken instanceof PostValidationToken)
+		{
+			PostValidationToken<?> pdt = (PostValidationToken<?>) newToken;
+			POST_VALIDATION_TOKENS.addToListFor(pdt.getPriority(), pdt);
 		}
 		if (newToken instanceof CDOMCompatibilityToken)
 		{

--- a/code/src/java/pcgen/rules/persistence/token/PostValidationToken.java
+++ b/code/src/java/pcgen/rules/persistence/token/PostValidationToken.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2015 (C) Tom Parker <thpr@users.sourceforge.net>
+ * 
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.rules.persistence.token;
+
+import java.util.Collection;
+
+import pcgen.cdom.base.Loadable;
+import pcgen.rules.context.LoadContext;
+
+/**
+ * A PostValidationToken is a token that is processed after LST file load is
+ * complete, AFTER references are resolved. It is used when processing across
+ * ALL objects of a given type are required.
+ * 
+ * @param <T>
+ *            The type of object upon which the PostValidationToken operates
+ */
+public interface PostValidationToken<T extends Loadable>
+{
+	/**
+	 * Processes the PostValidationToken with the given LoadContext and
+	 * collection of objects. Returns true if the processing was successful,
+	 * false if the processing indicates an LST load error.
+	 * 
+	 * @param context
+	 *            The LoadContext around which this PostValidationToken is
+	 *            evaluated
+	 * @param c
+	 *            The collection of objects to be processed in this
+	 *            PostValidationToken
+	 * @return true if the processing was successful; false otherwise
+	 */
+	public boolean process(LoadContext context, Collection<? extends T> c);
+
+	/**
+	 * Returns the class of the object upon which this PostValidationToken
+	 * operates.
+	 * 
+	 * @return The class of the object upon which this PostValidationToken
+	 *         operates
+	 */
+	public Class<T> getValidationTokenClass();
+
+	/**
+	 * Returns the priority of this PostValidationToken. PostValidationTokens
+	 * are supposed to be processed in the order in which they are required
+	 * (lowest first).
+	 * 
+	 * @return The priority of this PostValidationToken
+	 */
+	public int getPriority();
+}

--- a/code/src/java/plugin/lsttokens/NaturalattacksLst.java
+++ b/code/src/java/plugin/lsttokens/NaturalattacksLst.java
@@ -40,10 +40,10 @@ import pcgen.cdom.inst.EquipmentHead;
 import pcgen.cdom.reference.CDOMDirectSingleRef;
 import pcgen.cdom.reference.CDOMSingleRef;
 import pcgen.core.Equipment;
+import pcgen.core.Globals;
 import pcgen.core.SizeAdjustment;
 import pcgen.core.SpecialProperty;
 import pcgen.core.WeaponProf;
-import pcgen.core.analysis.SizeUtilities;
 import pcgen.core.bonus.Bonus;
 import pcgen.core.bonus.BonusObj;
 import pcgen.core.prereq.Prerequisite;
@@ -427,8 +427,11 @@ public class NaturalattacksLst extends AbstractTokenWithSeparator<CDOMObject>
 			{
 				int isize =
 						sizeFormula.resolveStatic().intValue();
-				SizeAdjustment size = context.getReferenceContext().getItemInOrder(
-						SizeAdjustment.class, isize);
+				SizeAdjustment size =
+						context
+							.getReferenceContext()
+							.getSortedList(SizeAdjustment.class,
+								IntegerKey.SIZEORDER).get(isize);
 				for (Equipment e : natWeapons)
 				{
 					CDOMDirectSingleRef<SizeAdjustment> sizeRef = CDOMDirectSingleRef.getRef(size);
@@ -463,7 +466,13 @@ public class NaturalattacksLst extends AbstractTokenWithSeparator<CDOMObject>
 		Integer requiredSize = null;
 		for (Prerequisite prereq : sizePrereqs)
 		{
-			final int targetSize = SizeUtilities.sizeInt(prereq.getOperand());
+			SizeAdjustment sa =
+					Globals
+						.getContext()
+						.getReferenceContext()
+						.silentlyGetConstructedCDOMObject(SizeAdjustment.class,
+							prereq.getOperand());
+			final int targetSize = sa.get(IntegerKey.SIZEORDER);
 			if (requiredSize != null && requiredSize != targetSize)
 			{
 				return null;

--- a/code/src/java/plugin/lsttokens/sizeadjustment/SizeNumToken.java
+++ b/code/src/java/plugin/lsttokens/sizeadjustment/SizeNumToken.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2008 Tom Parker <thpr@users.sourceforge.net>
+ * 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+package plugin.lsttokens.sizeadjustment;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.TreeMap;
+
+import pcgen.cdom.enumeration.IntegerKey;
+import pcgen.core.SizeAdjustment;
+import pcgen.rules.context.LoadContext;
+import pcgen.rules.persistence.token.AbstractIntToken;
+import pcgen.rules.persistence.token.CDOMPrimaryToken;
+import pcgen.rules.persistence.token.PostValidationToken;
+import pcgen.util.Logging;
+
+/**
+ * Class deals with LEGS Token
+ */
+public class SizeNumToken extends AbstractIntToken<SizeAdjustment> implements
+		CDOMPrimaryToken<SizeAdjustment>, PostValidationToken<SizeAdjustment>
+{
+
+	@Override
+	public String getTokenName()
+	{
+		return "SIZENUM";
+	}
+
+	@Override
+	protected IntegerKey integerKey()
+	{
+		return IntegerKey.SIZENUM;
+	}
+
+	@Override
+	protected int minValue()
+	{
+		return 0;
+	}
+
+	@Override
+	public Class<SizeAdjustment> getTokenClass()
+	{
+		return SizeAdjustment.class;
+	}
+
+	@Override
+	public boolean process(LoadContext context,
+		Collection<? extends SizeAdjustment> obj)
+	{
+		boolean returnValue = true;
+		Collection<SizeAdjustment> ordered;
+		boolean hasAny = false;
+		//First loop to detect deprecated case, remove in 6.7
+		for (SizeAdjustment sa : obj)
+		{
+			if (sa.get(IntegerKey.SIZENUM) != null)
+			{
+				hasAny = true;
+			}
+		}
+		if (hasAny)
+		{
+			Map<Integer, SizeAdjustment> map =
+					new TreeMap<Integer, SizeAdjustment>();
+			for (SizeAdjustment sa : obj)
+			{
+				Integer sizenum = sa.get(IntegerKey.SIZENUM);
+				if (sizenum == null)
+				{
+					Logging.errorPrint("Size: " + sa.getKeyName()
+						+ " did not have a SIZENUM (cannot be assumed)");
+					returnValue = false;
+					continue;
+				}
+				SizeAdjustment previous = map.put(sizenum, sa);
+				if (previous != null)
+				{
+					Logging.errorPrint("Size: " + sa.getKeyName()
+						+ " and size: " + previous.getKeyName()
+						+ " had identical SIZENUM: " + sizenum);
+					returnValue = false;
+				}
+			}
+			ordered = map.values();
+		}
+		else
+		{
+			//Provide a fall back to avoid immediate failure
+			Logging.deprecationPrint(
+				"SizeAdjustment items must have a SIZENUM", context);
+			ordered =
+					context.getReferenceContext().getOrderSortedCDOMObjects(
+						SizeAdjustment.class);
+		}
+		int order = 0;
+		for (SizeAdjustment sa : ordered)
+		{
+			sa.put(IntegerKey.SIZEORDER, order++);
+		}
+		return returnValue;
+	}
+
+	@Override
+	public Class<SizeAdjustment> getValidationTokenClass()
+	{
+		return SizeAdjustment.class;
+	}
+
+	@Override
+	public int getPriority()
+	{
+		return 1;
+	}
+}

--- a/code/src/java/plugin/pretokens/parser/PreBaseSizeParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreBaseSizeParser.java
@@ -31,14 +31,12 @@ package plugin.pretokens.parser;
 import pcgen.cdom.reference.CDOMSingleRef;
 import pcgen.core.Globals;
 import pcgen.core.SizeAdjustment;
-import pcgen.core.analysis.SizeUtilities;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteException;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteParser;
 import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 import pcgen.rules.context.LoadContext;
-import pcgen.util.Logging;
 
 /**
  * A prerequisite parser class that handles the parsing of pre base size tokens.
@@ -90,19 +88,13 @@ public class PreBaseSizeParser extends AbstractPrerequisiteParser implements
 			prereq.setOperator(compType);
 
 			String abb = formula.substring(0,1);
-			if (SizeUtilities.sizeInt(abb, -1) < 0)
-			{
-				LoadContext context = Globals.getContext();
-				CDOMSingleRef<SizeAdjustment> ref =
-						context.getReferenceContext().getCDOMReference(
-							SizeAdjustment.class, abb);
-				context.forgetMeNot(ref);
-			}
-			else if (formula.length() > 1)
-			{
-				Logging.deprecationPrint("Use of a non-key (" + formula
-					+ ") in PREBASESIZE is deprecated, use the KEY of the Size");
-			}
+
+			LoadContext context = Globals.getContext();
+			CDOMSingleRef<SizeAdjustment> ref =
+					context.getReferenceContext().getCDOMReference(
+						SizeAdjustment.class, abb);
+			context.forgetMeNot(ref);
+
 			prereq.setOperand(abb);
 			if (invertResult)
 			{

--- a/code/src/java/plugin/pretokens/parser/PreSizeParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreSizeParser.java
@@ -31,14 +31,12 @@ package plugin.pretokens.parser;
 import pcgen.cdom.reference.CDOMSingleRef;
 import pcgen.core.Globals;
 import pcgen.core.SizeAdjustment;
-import pcgen.core.analysis.SizeUtilities;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteException;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteParser;
 import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 import pcgen.rules.context.LoadContext;
-import pcgen.util.Logging;
 
 /**
  * A prerequisite parser class that handles the parsing of pre size tokens.
@@ -90,19 +88,13 @@ public class PreSizeParser extends AbstractPrerequisiteParser implements
 			prereq.setOperator(compType);
 
 			String abb = formula.substring(0,1);
-			if (SizeUtilities.sizeInt(abb, -1) < 0)
-			{
-				LoadContext context = Globals.getContext();
-				CDOMSingleRef<SizeAdjustment> ref =
-						context.getReferenceContext().getCDOMReference(
-							SizeAdjustment.class, abb);
-				context.forgetMeNot(ref);
-			}
-			else if (formula.length() > 1)
-			{
-				Logging.deprecationPrint("Use of a non-key (" + formula
-					+ ") in PRESIZE is deprecated, use the KEY of the Size");
-			}
+
+			LoadContext context = Globals.getContext();
+			CDOMSingleRef<SizeAdjustment> ref =
+					context.getReferenceContext().getCDOMReference(
+						SizeAdjustment.class, abb);
+			context.forgetMeNot(ref);
+
 			prereq.setOperand(formula);
 			if (invertResult)
 			{

--- a/code/src/java/plugin/pretokens/test/PreBaseSizeTester.java
+++ b/code/src/java/plugin/pretokens/test/PreBaseSizeTester.java
@@ -27,14 +27,15 @@
 package plugin.pretokens.test;
 
 import pcgen.cdom.base.CDOMObject;
+import pcgen.cdom.enumeration.IntegerKey;
 import pcgen.core.Globals;
-import pcgen.core.analysis.SizeUtilities;
+import pcgen.core.SizeAdjustment;
 import pcgen.core.display.CharacterDisplay;
 import pcgen.core.prereq.AbstractDisplayPrereqTest;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteException;
 import pcgen.core.prereq.PrerequisiteTest;
-import pcgen.system.LanguageBundle;
+import pcgen.rules.context.AbstractReferenceContext;
 
 /**
  * @author wardc
@@ -55,13 +56,12 @@ public class PreBaseSizeTester extends AbstractDisplayPrereqTest implements Prer
 		if ((display.getRace() != null)
 			&& !display.getRace().equals(Globals.s_EMPTYRACE))
 		{
-			final int targetSize = SizeUtilities.sizeInt(prereq.getOperand(), -1);
-			if (targetSize < 0)
-			{
-				throw new PrerequisiteException(LanguageBundle
-					.getFormattedString(
-						"PreBaseSize.error.bad_size", prereq.getOperand())); //$NON-NLS-1$
-			}
+			AbstractReferenceContext ref =
+					Globals.getContext().getReferenceContext();
+			SizeAdjustment sa =
+					ref.silentlyGetConstructedCDOMObject(SizeAdjustment.class,
+						prereq.getOperand());
+			int targetSize = sa.get(IntegerKey.SIZEORDER);
 			runningTotal =
 					prereq.getOperator().compare(display.racialSizeInt(),
 						targetSize);

--- a/code/src/java/plugin/pretokens/test/PreSizeTester.java
+++ b/code/src/java/plugin/pretokens/test/PreSizeTester.java
@@ -27,13 +27,16 @@
 package plugin.pretokens.test;
 
 import pcgen.cdom.base.CDOMObject;
+import pcgen.cdom.enumeration.IntegerKey;
 import pcgen.core.Equipment;
-import pcgen.core.analysis.SizeUtilities;
+import pcgen.core.Globals;
+import pcgen.core.SizeAdjustment;
 import pcgen.core.display.CharacterDisplay;
 import pcgen.core.prereq.AbstractDisplayPrereqTest;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteException;
 import pcgen.core.prereq.PrerequisiteTest;
+import pcgen.rules.context.AbstractReferenceContext;
 
 /**
  * @author wardc
@@ -48,7 +51,7 @@ public class PreSizeTester extends AbstractDisplayPrereqTest implements Prerequi
 	@Override
 	public int passes(final Prerequisite prereq, final CharacterDisplay display, CDOMObject source)
 	{
-		final int targetSize = SizeUtilities.sizeInt(prereq.getOperand());
+		final int targetSize = getTargetSizeInt(prereq.getOperand());
 
 		final int runningTotal =
 				prereq.getOperator().compare(display.sizeInt(), targetSize);
@@ -60,7 +63,7 @@ public class PreSizeTester extends AbstractDisplayPrereqTest implements Prerequi
 	public int passes(final Prerequisite prereq, final Equipment equipment,
 		CharacterDisplay display) throws PrerequisiteException
 	{
-		final int targetSize = SizeUtilities.sizeInt(prereq.getOperand());
+		final int targetSize = getTargetSizeInt(prereq.getOperand());
 
 		final int runningTotal =
 				prereq.getOperator().compare(equipment.sizeInt(), targetSize);
@@ -78,4 +81,12 @@ public class PreSizeTester extends AbstractDisplayPrereqTest implements Prerequi
 		return "SIZE"; //$NON-NLS-1$
 	}
 
+	private int getTargetSizeInt(String size)
+	{
+		AbstractReferenceContext ref =
+				Globals.getContext().getReferenceContext();
+		SizeAdjustment sa =
+				ref.silentlyGetConstructedCDOMObject(SizeAdjustment.class, size);
+		return sa.get(IntegerKey.SIZEORDER);
+	}
 }

--- a/code/src/test/pcgen/AbstractCharacterTestCase.java
+++ b/code/src/test/pcgen/AbstractCharacterTestCase.java
@@ -162,16 +162,16 @@ abstract public class AbstractCharacterTestCase extends PCGenTestCase
 		fd.setSelectable(true);
 		SourceFileLoader.processFactDefinitions(context);
 
-		fine = BuildUtilities.createSize("Fine");
-		diminutive = BuildUtilities.createSize("Diminutive");
-		tiny = BuildUtilities.createSize("Tiny");
-		small = BuildUtilities.createSize("Small");
-		medium = BuildUtilities.createSize("Medium");
+		fine = BuildUtilities.createSize("Fine", 0);
+		diminutive = BuildUtilities.createSize("Diminutive", 1);
+		tiny = BuildUtilities.createSize("Tiny", 2);
+		small = BuildUtilities.createSize("Small", 3);
+		medium = BuildUtilities.createSize("Medium", 4);
 		medium.put(ObjectKey.IS_DEFAULT_SIZE, true);
-		large = BuildUtilities.createSize("Large");
-		huge = BuildUtilities.createSize("Huge");
-		gargantuan = BuildUtilities.createSize("Gargantuan");
-		colossal = BuildUtilities.createSize("Colossal");
+		large = BuildUtilities.createSize("Large", 5);
+		huge = BuildUtilities.createSize("Huge", 6);
+		gargantuan = BuildUtilities.createSize("Gargantuan", 7);
+		colossal = BuildUtilities.createSize("Colossal", 8);
 
 		SourceFileLoader.createLangBonusObject(context);
 		GameModeFileLoader.addDefaultUnitSet(SettingsHandler.getGame());

--- a/code/src/test/pcgen/AbstractJunit4CharacterTestCase.java
+++ b/code/src/test/pcgen/AbstractJunit4CharacterTestCase.java
@@ -201,16 +201,16 @@ abstract public class AbstractJunit4CharacterTestCase
 				BuildUtilities.createFact(context, "SpellType", PCClass.class);
 		fd.setSelectable(true);
 
-		fine = BuildUtilities.createSize("Fine");
-		diminutive = BuildUtilities.createSize("Diminutive");
-		tiny = BuildUtilities.createSize("Tiny");
-		small = BuildUtilities.createSize("Small");
-		medium = BuildUtilities.createSize("Medium");
+		fine = BuildUtilities.createSize("Fine", 0);
+		diminutive = BuildUtilities.createSize("Diminutive", 1);
+		tiny = BuildUtilities.createSize("Tiny", 2);
+		small = BuildUtilities.createSize("Small", 3);
+		medium = BuildUtilities.createSize("Medium", 4);
 		medium.put(ObjectKey.IS_DEFAULT_SIZE, true);
-		large = BuildUtilities.createSize("Large");
-		huge = BuildUtilities.createSize("Huge");
-		gargantuan = BuildUtilities.createSize("Gargantuan");
-		colossal = BuildUtilities.createSize("Colossal");
+		large = BuildUtilities.createSize("Large", 5);
+		huge = BuildUtilities.createSize("Huge", 6);
+		gargantuan = BuildUtilities.createSize("Gargantuan", 7);
+		colossal = BuildUtilities.createSize("Colossal", 8);
 
 		SourceFileLoader.createLangBonusObject(context);
 		GameModeFileLoader.addDefaultUnitSet(SettingsHandler.getGame());
@@ -222,6 +222,9 @@ abstract public class AbstractJunit4CharacterTestCase
 		{
 			fail("Unconstructed References");
 		}
+		context.resolvePostValidationTokens();
+		context.resolvePostDeferredTokens();
+		context.loadCampaignFacets();
 
 		character = new PlayerCharacter();
 	}

--- a/code/src/test/pcgen/util/TestHelper.java
+++ b/code/src/test/pcgen/util/TestHelper.java
@@ -114,9 +114,10 @@ public class TestHelper
 			GameModeFileLoader.addDefaultTabInfo(gamemode);
 		}
 		SettingsHandler.setGame("3.5");
+		int count = 0;
 		while (aTok.hasMoreTokens())
 		{
-			SizeAdjustment sa = BuildUtilities.createSize(aTok.nextToken());
+			SizeAdjustment sa = BuildUtilities.createSize(aTok.nextToken(), count++);
 			Globals.getContext().getReferenceContext().importObject(sa);
 		}
 		Globals.getContext().getReferenceContext()

--- a/code/src/testcommon/plugin/lsttokens/testsupport/BuildUtilities.java
+++ b/code/src/testcommon/plugin/lsttokens/testsupport/BuildUtilities.java
@@ -10,6 +10,7 @@ import pcgen.cdom.content.factset.FactSetDefinition;
 import pcgen.cdom.enumeration.FactKey;
 import pcgen.cdom.enumeration.FactSetKey;
 import pcgen.cdom.enumeration.FormulaKey;
+import pcgen.cdom.enumeration.IntegerKey;
 import pcgen.cdom.enumeration.VariableKey;
 import pcgen.core.Globals;
 import pcgen.core.PCAlignment;
@@ -32,7 +33,7 @@ public class BuildUtilities
 		return align;
 	}
 
-	public static SizeAdjustment createSize(String name)
+	public static SizeAdjustment createSize(String name, int order)
 	{
 		final String abb  = name.substring(0, 1);
 	
@@ -40,6 +41,7 @@ public class BuildUtilities
 	
 		sa.setName(name);
 		sa.setKeyName(abb);
+		sa.put(IntegerKey.SIZEORDER, order);
 	
 		Globals.getContext().getReferenceContext().importObject(sa);
 		return sa;

--- a/code/src/utest/pcgen/cdom/facet/model/SizeFacetTest.java
+++ b/code/src/utest/pcgen/cdom/facet/model/SizeFacetTest.java
@@ -82,16 +82,16 @@ public class SizeFacetTest extends TestCase
 		{
 			SettingsHandler.getGame().clearLoadContext();
 			AbstractReferenceContext ref = Globals.getContext().getReferenceContext();
-			t = BuildUtilities.createSize("Tiny");
+			t = BuildUtilities.createSize("Tiny", 0);
 			ref.importObject(t);
-			s = BuildUtilities.createSize("Small");
+			s = BuildUtilities.createSize("Small", 1);
 			ref.importObject(s);
-			m = BuildUtilities.createSize("Medium");
+			m = BuildUtilities.createSize("Medium", 2);
 			m.put(ObjectKey.IS_DEFAULT_SIZE, true);
 			ref.importObject(m);
-			l = BuildUtilities.createSize("Large");
+			l = BuildUtilities.createSize("Large", 3);
 			ref.importObject(l);
-			h = BuildUtilities.createSize("Huge");
+			h = BuildUtilities.createSize("Huge", 4);
 			ref.importObject(h);
 			staticDone = true;
 		}

--- a/code/src/utest/pcgen/testsupport/AbstractCharacterUsingTestCase.java
+++ b/code/src/utest/pcgen/testsupport/AbstractCharacterUsingTestCase.java
@@ -96,6 +96,7 @@ public abstract class AbstractCharacterUsingTestCase extends TestCase {
 		context.getReferenceContext().buildDerivedObjects();
 		context.resolveDeferredTokens();
 		assertTrue(context.getReferenceContext().resolveReferences(null));
+		context.resolvePostValidationTokens();
 		context.resolvePostDeferredTokens();
 		context.loadCampaignFacets();
 	}
@@ -162,16 +163,16 @@ public abstract class AbstractCharacterUsingTestCase extends TestCase {
 		ref.importObject(wis);
 		ref.importObject(cha);
 
-		fine = BuildUtilities.createSize("Fine");
-		diminutive = BuildUtilities.createSize("Diminutive");
-		tiny = BuildUtilities.createSize("Tiny");
-		small = BuildUtilities.createSize("Small");
-		medium = BuildUtilities.createSize("Medium");
+		fine = BuildUtilities.createSize("Fine", 0);
+		diminutive = BuildUtilities.createSize("Diminutive", 1);
+		tiny = BuildUtilities.createSize("Tiny", 2);
+		small = BuildUtilities.createSize("Small", 3);
+		medium = BuildUtilities.createSize("Medium", 4);
 		medium.put(ObjectKey.IS_DEFAULT_SIZE, true);
-		large = BuildUtilities.createSize("Large");
-		huge = BuildUtilities.createSize("Huge");
-		gargantuan = BuildUtilities.createSize("Gargantuan");
-		colossal = BuildUtilities.createSize("Colossal");
+		large = BuildUtilities.createSize("Large", 5);
+		huge = BuildUtilities.createSize("Huge", 6);
+		gargantuan = BuildUtilities.createSize("Gargantuan", 7);
+		colossal = BuildUtilities.createSize("Colossal", 8);
 
 		universal = ref.constructCDOMObject(Language.class, "Universal");
 		other = ref.constructCDOMObject(Language.class, "Other");

--- a/code/src/utest/plugin/lsttokens/UdamLstTest.java
+++ b/code/src/utest/plugin/lsttokens/UdamLstTest.java
@@ -52,40 +52,40 @@ public class UdamLstTest extends AbstractGlobalTokenTestCase
 	public void setUp() throws PersistenceLayerException, URISyntaxException
 	{
 		super.setUp();
-		fine = BuildUtilities.createSize("Fine");
+		fine = BuildUtilities.createSize("Fine", 0);
 		primaryContext.getReferenceContext().importObject(fine);
 		secondaryContext.getReferenceContext().importObject(fine);
 
-		diminutive = BuildUtilities.createSize("Diminutive");
+		diminutive = BuildUtilities.createSize("Diminutive", 1);
 		primaryContext.getReferenceContext().importObject(diminutive);
 		secondaryContext.getReferenceContext().importObject(diminutive);
 		
-		tiny = BuildUtilities.createSize("Tiny");
+		tiny = BuildUtilities.createSize("Tiny", 2);
 		primaryContext.getReferenceContext().importObject(tiny);
 		secondaryContext.getReferenceContext().importObject(tiny);
 		
-		small = BuildUtilities.createSize("Small");
+		small = BuildUtilities.createSize("Small", 3);
 		primaryContext.getReferenceContext().importObject(small);
 		secondaryContext.getReferenceContext().importObject(small);
 		
-		medium = BuildUtilities.createSize("Medium");		
+		medium = BuildUtilities.createSize("Medium", 4);		
 		medium.put(ObjectKey.IS_DEFAULT_SIZE, true);
 		primaryContext.getReferenceContext().importObject(medium);
 		secondaryContext.getReferenceContext().importObject(medium);
 		
-		large = BuildUtilities.createSize("Large");
+		large = BuildUtilities.createSize("Large", 5);
 		primaryContext.getReferenceContext().importObject(large);
 		secondaryContext.getReferenceContext().importObject(large);
 		
-		huge = BuildUtilities.createSize("Huge");
+		huge = BuildUtilities.createSize("Huge", 6);
 		primaryContext.getReferenceContext().importObject(huge);
 		secondaryContext.getReferenceContext().importObject(huge);
 		
-		gargantuan = BuildUtilities.createSize("Gargantuan");
+		gargantuan = BuildUtilities.createSize("Gargantuan", 7);
 		primaryContext.getReferenceContext().importObject(gargantuan);
 		secondaryContext.getReferenceContext().importObject(gargantuan);
 		
-		colossal = BuildUtilities.createSize("Colossal");
+		colossal = BuildUtilities.createSize("Colossal", 8);
 		primaryContext.getReferenceContext().importObject(colossal);
 		secondaryContext.getReferenceContext().importObject(colossal);
 	}

--- a/code/src/utest/plugin/lsttokens/equipment/SizeTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/equipment/SizeTokenTest.java
@@ -64,13 +64,13 @@ public class SizeTokenTest extends AbstractTokenTestCase<Equipment>
 	public void setUp() throws PersistenceLayerException, URISyntaxException
 	{
 		super.setUp();
-		ps = BuildUtilities.createSize("Small");
+		ps = BuildUtilities.createSize("Small", 0);
 		primaryContext.getReferenceContext().importObject(ps);
-		SizeAdjustment pm = BuildUtilities.createSize("Medium");
+		SizeAdjustment pm = BuildUtilities.createSize("Medium", 1);
 		primaryContext.getReferenceContext().importObject(pm);
-		SizeAdjustment ss = BuildUtilities.createSize("Small");
+		SizeAdjustment ss = BuildUtilities.createSize("Small", 0);
 		secondaryContext.getReferenceContext().importObject(ss);
-		SizeAdjustment sm = BuildUtilities.createSize("Medium");
+		SizeAdjustment sm = BuildUtilities.createSize("Medium", 1);
 		secondaryContext.getReferenceContext().importObject(sm);
 	}
 

--- a/code/src/utest/plugin/lsttokens/kit/gear/SizeTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/kit/gear/SizeTokenTest.java
@@ -60,13 +60,13 @@ public class SizeTokenTest extends AbstractKitTokenTestCase<KitGear>
 	public void setUp() throws PersistenceLayerException, URISyntaxException
 	{
 		super.setUp();
-		SizeAdjustment ps = BuildUtilities.createSize("S");
+		SizeAdjustment ps = BuildUtilities.createSize("S", 0);
 		primaryContext.getReferenceContext().importObject(ps);
-		SizeAdjustment pm = BuildUtilities.createSize("M");
+		SizeAdjustment pm = BuildUtilities.createSize("M", 1);
 		primaryContext.getReferenceContext().importObject(pm);
-		SizeAdjustment ss = BuildUtilities.createSize("S");
+		SizeAdjustment ss = BuildUtilities.createSize("S", 0);
 		secondaryContext.getReferenceContext().importObject(ss);
-		SizeAdjustment sm = BuildUtilities.createSize("M");
+		SizeAdjustment sm = BuildUtilities.createSize("M", 1);
 		secondaryContext.getReferenceContext().importObject(sm);
 	}
 

--- a/code/src/utest/plugin/lsttokens/race/SizeTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/race/SizeTokenTest.java
@@ -66,13 +66,13 @@ public class SizeTokenTest extends AbstractTokenTestCase<Race>
 	public void setUp() throws PersistenceLayerException, URISyntaxException
 	{
 		super.setUp();
-		ps = BuildUtilities.createSize("S");
+		ps = BuildUtilities.createSize("S", 0);
 		primaryContext.getReferenceContext().importObject(ps);
-		SizeAdjustment pm = BuildUtilities.createSize("M");
+		SizeAdjustment pm = BuildUtilities.createSize("M", 1);
 		primaryContext.getReferenceContext().importObject(pm);
-		SizeAdjustment ss = BuildUtilities.createSize("S");
+		SizeAdjustment ss = BuildUtilities.createSize("S", 0);
 		secondaryContext.getReferenceContext().importObject(ss);
-		SizeAdjustment sm = BuildUtilities.createSize("M");
+		SizeAdjustment sm = BuildUtilities.createSize("M", 1);
 		secondaryContext.getReferenceContext().importObject(sm);
 	}
 

--- a/code/src/utest/plugin/lsttokens/template/SizeTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/template/SizeTokenTest.java
@@ -64,14 +64,15 @@ public class SizeTokenTest extends AbstractTokenTestCase<PCTemplate>
 	public void setUp() throws PersistenceLayerException, URISyntaxException
 	{
 		super.setUp();
-		SizeAdjustment ps = BuildUtilities.createSize("Small");
+		SizeAdjustment ps = BuildUtilities.createSize("Small", 0);
 		primaryContext.getReferenceContext().importObject(ps);
-		SizeAdjustment pm = BuildUtilities.createSize("Medium");
+		SizeAdjustment pm = BuildUtilities.createSize("Medium", 1);
 		primaryContext.getReferenceContext().importObject(pm);
-		SizeAdjustment ss = BuildUtilities.createSize("Small");
+		SizeAdjustment ss = BuildUtilities.createSize("Small", 0);
 		secondaryContext.getReferenceContext().importObject(ss);
-		SizeAdjustment sm = BuildUtilities.createSize("Medium");
+		SizeAdjustment sm = BuildUtilities.createSize("Medium", 1);
 		secondaryContext.getReferenceContext().importObject(sm);
+
 	}
 
 	@Override

--- a/code/src/utest/plugin/lsttokens/testsupport/AbstractQualifierTokenTestCase.java
+++ b/code/src/utest/plugin/lsttokens/testsupport/AbstractQualifierTokenTestCase.java
@@ -1912,6 +1912,7 @@ public abstract class AbstractQualifierTokenTestCase<T extends CDOMObject, TC ex
 		primaryContext.getReferenceContext().buildDerivedObjects();
 		primaryContext.resolveDeferredTokens();
 		assertTrue(primaryContext.getReferenceContext().resolveReferences(null));
+		primaryContext.resolvePostValidationTokens();
 		primaryContext.resolvePostDeferredTokens();
 		primaryContext.loadCampaignFacets();
 	}
@@ -2001,16 +2002,16 @@ public abstract class AbstractQualifierTokenTestCase<T extends CDOMObject, TC ex
 		ref.importObject(wis);
 		ref.importObject(cha);
 
-		fine = BuildUtilities.createSize("Fine");
-		diminutive = BuildUtilities.createSize("Diminutive");
-		tiny = BuildUtilities.createSize("Tiny");
-		small = BuildUtilities.createSize("Small");
-		medium = BuildUtilities.createSize("Medium");
+		fine = BuildUtilities.createSize("Fine", 0);
+		diminutive = BuildUtilities.createSize("Diminutive", 1);
+		tiny = BuildUtilities.createSize("Tiny", 2);
+		small = BuildUtilities.createSize("Small", 3);
+		medium = BuildUtilities.createSize("Medium", 4);
 		medium.put(ObjectKey.IS_DEFAULT_SIZE, true);
-		large = BuildUtilities.createSize("Large");
-		huge = BuildUtilities.createSize("Huge");
-		gargantuan = BuildUtilities.createSize("Gargantuan");
-		colossal = BuildUtilities.createSize("Colossal");
+		large = BuildUtilities.createSize("Large", 5);
+		huge = BuildUtilities.createSize("Huge", 6);
+		gargantuan = BuildUtilities.createSize("Gargantuan", 7);
+		colossal = BuildUtilities.createSize("Colossal", 8);
 
 		SourceFileLoader.createLangBonusObject(Globals.getContext());
 	}

--- a/code/src/utest/plugin/pretokens/PreBaseSizeRoundRobin.java
+++ b/code/src/utest/plugin/pretokens/PreBaseSizeRoundRobin.java
@@ -46,7 +46,7 @@ public class PreBaseSizeRoundRobin extends AbstractComparatorRoundRobin
 		super.setUp();
 		TokenRegistration.register(new PreBaseSizeParser());
 		TokenRegistration.register(new PreBaseSizeWriter());
-		BuildUtilities.createSize("Fine");
+		BuildUtilities.createSize("Fine", 0);
 	}
 
 	public void testSimpleString()

--- a/code/src/utest/plugin/pretokens/PreSizeRoundRobin.java
+++ b/code/src/utest/plugin/pretokens/PreSizeRoundRobin.java
@@ -50,7 +50,7 @@ public class PreSizeRoundRobin extends AbstractComparatorRoundRobin
 		super.setUp();
 		TokenRegistration.register(new PreSizeParser());
 		TokenRegistration.register(new PreSizeWriter());
-		medium = BuildUtilities.createSize("Medium");
+		medium = BuildUtilities.createSize("Medium", 1);
 		medium.put(ObjectKey.IS_DEFAULT_SIZE, true);
 	}
 

--- a/code/src/utest/plugin/primitive/race/BaseSizeTokenTest.java
+++ b/code/src/utest/plugin/primitive/race/BaseSizeTokenTest.java
@@ -52,9 +52,9 @@ public class BaseSizeTokenTest extends
 	{
 		super.setUp();
 		TokenRegistration.register(BASESIZE_TOKEN);
-		SizeAdjustment ps = BuildUtilities.createSize("Small");
+		SizeAdjustment ps = BuildUtilities.createSize("Small", 0);
 		primaryContext.getReferenceContext().importObject(ps);
-		SizeAdjustment ss = BuildUtilities.createSize("Small");
+		SizeAdjustment ss = BuildUtilities.createSize("Small", 0);
 		secondaryContext.getReferenceContext().importObject(ss);
 	}
 


### PR DESCRIPTION
- Make "cross-object" processing (used in the past for ensuring only one
default size) a reusable behavior
- Implement SIZENUM and the "cross-object" validation/post-load
renumbering
- Default behavior (order) exists when no SIZENUM is present
- Cache sorted lists of objects from the ReferenceContext