### PR TITLE
Fix munted newlines inside code blocks.

### DIFF
--- a/docs/faqpages/faqcommunity.html
+++ b/docs/faqpages/faqcommunity.html
@@ -122,9 +122,7 @@
    The documentation is updated frequently. In case you are reading an old version of the documentation, you can find the latest documentation at the
    <a href="http://pcgen.sourceforge.net/autobuilds/pcgen-docs/index.html">
     SourceForge
-    <code>
-     autobuild
-    </code>
+    <code>autobuild</code>
    </a>
    .
   </p>
@@ -227,9 +225,7 @@
    <strong>
     Main discussion:
    </strong>
-   <code>
-    pcgen@yahoogroups.com
-   </code>
+   <code>pcgen@yahoogroups.com</code>
    <a href="https://groups.yahoo.com/neo/groups/pcgen/info">
     (website / archives)
    </a>
@@ -247,9 +243,7 @@
    <strong>
     Tag discussion:
    </strong>
-   <code>
-    pcgen_experimental@yahoogroups.com
-   </code>
+   <code>pcgen_experimental@yahoogroups.com</code>
    <a href="https://groups.yahoo.com/neo/groups/pcgen_experimental/info">
     (website / archives)
    </a>
@@ -263,9 +257,7 @@
    <strong>
     List file coding help:
    </strong>
-   <code>
-    pcgenlistfilehelp@yahoogroups.com
-   </code>
+   <code>pcgenlistfilehelp@yahoogroups.com</code>
    <a href="https://groups.yahoo.com/neo/groups/PCGenListFileHelp/info">
     (website / archives)
    </a>
@@ -280,9 +272,7 @@
     International translation / development:
    </strong>
    Inactive.
-   <code>
-    pcgen_international@yahoogroups.com
-   </code>
+   <code>pcgen_international@yahoogroups.com</code>
    <a href="https://groups.yahoo.com/neo/groups/pcgen_international/info">
     (website / archives)
    </a>
@@ -306,9 +296,7 @@
   </h2>
   <p>
    Direct email messages to the PCGen team are welcome at
-   <code>
-    help@pcgen.org
-   </code>
+   <code>help@pcgen.org</code>
    .
   </p>
   <h2 id="live-chat">
@@ -329,9 +317,7 @@
   </h3>
   <p>
    A small number of PCGen users and developers are present in the Freenode
-   <code>
-    #pcgen
-   </code>
+   <code>#pcgen</code>
    IRC channel.
   </p>
   <p>
@@ -379,9 +365,7 @@
     PCGen forums
    </a>
    or
-   <code>
-    help@pcgen.org
-   </code>
+   <code>help@pcgen.org</code>
    .
   </p>
   <h2 id="development">
@@ -390,9 +374,7 @@
   <p>
    Code development occurs at the Github repositories for the project, mainly
    <a href="https://github.com/PCGen/pcgen">
-    <code>
-     PCGen/pcgen
-    </code>
+    <code>PCGen/pcgen</code>
    </a>
    . Pull requests are welcome for all parts of the project.
   </p>

--- a/docs/faqpages/faqoutofmemoryandjavaissues.html
+++ b/docs/faqpages/faqoutofmemoryandjavaissues.html
@@ -59,19 +59,15 @@
       <strong>
        From:
       </strong>
-      <code>
-       java -Dswing.aatext=true -Xms128m
--Xmx256m -jar pcgen.jar
-      </code>
+      <code>java -Dswing.aatext=true -Xms128m
+-Xmx256m -jar pcgen.jar</code>
      </li>
      <li>
       <strong>
        To:
       </strong>
-      <code>
-       java -Dswing.aatext=true -Xms256m
--Xmx512m -jar pcgen.jar
-      </code>
+      <code>java -Dswing.aatext=true -Xms256m
+-Xmx512m -jar pcgen.jar</code>
      </li>
     </ul>
    </li>
@@ -79,9 +75,7 @@
     <strong>
      Note:
     </strong>
-    <code>
-     -Xms256
-    </code>
+    <code>-Xms256</code>
     assigns starting
 memory for PCGen to 256Mb of RAM and should be enough memory for
 pcgen to run with lots of sources loaded.
@@ -90,9 +84,7 @@ pcgen to run with lots of sources loaded.
     <strong>
      Note:
     </strong>
-    <code>
-     -Xmx512
-    </code>
+    <code>-Xmx512</code>
     assigns a maximum
 of 512Mb of RAM to PCGen and should be enough memory for pcgen to
 run with lots more sources and characters loaded.
@@ -126,23 +118,17 @@ will work out better.
    </li>
    <li>
     Look for the following text:
-    <code>
-     -Xms128m -Xmx256m
-    </code>
+    <code>-Xms128m -Xmx256m</code>
     <ol style="list-style-type: lower-alpha">
      <li>
       If you have 512MB of ram, you can change the text to the
 following:
-      <code>
-       -Xms256m -Xmx512m
-      </code>
+      <code>-Xms256m -Xmx512m</code>
      </li>
      <li>
       If you have 1GB of ram, you can change the text to the
 following:
-      <code>
-       -Xms512m -Xmx1024m
-      </code>
+      <code>-Xms512m -Xmx1024m</code>
      </li>
     </ol>
    </li>
@@ -170,18 +156,14 @@ following:
    </li>
    <li>
     Find the following line:
-    <code>
-     java -jar ./pcgen.jar
-    </code>
+    <code>java -jar ./pcgen.jar</code>
     . .
 .
    </li>
    <li>
     Replace it with the following line:
-    <code>
-     java -Xms256m
--Xmx512m -jar ./pcgen.jar
-    </code>
+    <code>java -Xms256m
+-Xmx512m -jar ./pcgen.jar</code>
     . . .
    </li>
    <li>
@@ -260,29 +242,21 @@ for PCGen (by PCGen version)
    Go the command prompt and type:
   </p>
   <p class="indent2">
-   <code>
-    java -version
-   </code>
+   <code>java -version</code>
   </p>
   <p class="indent1">
    You should get some kind of a response like:
   </p>
   <p class="indent2">
-   <code>
-    java version "1.5.0_06"
-   </code>
+   <code>java version "1.5.0_06"</code>
   </p>
   <p class="indent2">
-   <code>
-    Java(TM) 2 Runtime Environment, Standard
-Edition (build 1.5.0_06-b05)
-   </code>
+   <code>Java(TM) 2 Runtime Environment, Standard
+Edition (build 1.5.0_06-b05)</code>
   </p>
   <p class="indent2">
-   <code>
-    Java HotSpot(TM) Client VM (build
-1.5.0_06-b05, mixed mode, sharing)
-   </code>
+   <code>Java HotSpot(TM) Client VM (build
+1.5.0_06-b05, mixed mode, sharing)</code>
   </p>
   <h4>
    For Windows Vista Users:
@@ -322,29 +296,21 @@ other than 1.6.0_00
    Open a terminal window and enter:
   </p>
   <p class="indent2">
-   <code>
-    java -version
-   </code>
+   <code>java -version</code>
   </p>
   <p class="indent1">
    You should get some kind of a response like:
   </p>
   <p class="indent2">
-   <code>
-    java version "1.5.0_06"
-   </code>
+   <code>java version "1.5.0_06"</code>
   </p>
   <p class="indent2">
-   <code>
-    Java(TM) 2 Runtime Environment, Standard
-Edition (build 1.5.0_06-b05)
-   </code>
+   <code>Java(TM) 2 Runtime Environment, Standard
+Edition (build 1.5.0_06-b05)</code>
   </p>
   <p class="indent2">
-   <code>
-    Java HotSpot(TM) Client VM (build
-1.5.0_06-b05, mixed mode, sharing)
-   </code>
+   <code>Java HotSpot(TM) Client VM (build
+1.5.0_06-b05, mixed mode, sharing)</code>
   </p>
   <h4>
    For Unix Users:
@@ -409,18 +375,14 @@ problem is that Windows is not pointing the command "java" to the
   </p>
   <ol class="indent2">
    <li>
-    <code>
-     &lt;Path to Java&gt; -Dswing.aatext=true -Xms&lt;Minimum
+    <code>&lt;Path to Java&gt; -Dswing.aatext=true -Xms&lt;Minimum
 Memory&gt;m -Xmx&lt;Maximum Memory&gt;m -jar &lt;Path to
-PcGen&gt;
-    </code>
+PcGen&gt;</code>
     <div style="margin-left: 2em">
-     <code>
-      Example Vista: "C:\Program
+     <code>Example Vista: "C:\Program
 Files (x86)\Java\jre1.6.0_01\bin\java.exe" -Dswing.aatext=true
 -Xms256m -Xmx512m -jar "C:\Program Files
-(x86)\PCGen\PCGen5102\pcgen.jar"
-     </code>
+(x86)\PCGen\PCGen5102\pcgen.jar"</code>
     </div>
    </li>
    <li>
@@ -537,10 +499,8 @@ default that ships with Ubuntu.
   <ul>
    <li>
     Check the version of Java being used:
-    <code>
-     $ java
--version
-    </code>
+    <code>$ java
+-version</code>
    </li>
    <li>
     If not using Sun's JRE, you will need to install it. (see the
@@ -551,17 +511,13 @@ Ubuntu wiki for help)
 java by using:
     <ul>
      <li>
-      <code>
-       $ sudo update-alternatives --config java
-      </code>
+      <code>$ sudo update-alternatives --config java</code>
       <br/>
       or
      </li>
      <li>
-      <code>
-       $ sudo update-alternatives --set \java
-/usr/lib/jvm/java-1.5.0-sun/jre/bin/java
-      </code>
+      <code>$ sudo update-alternatives --set \java
+/usr/lib/jvm/java-1.5.0-sun/jre/bin/java</code>
       <br/>
       Note: Both command do the same thing (with the first command you
 get a list of possible java's and are asked to choose).

--- a/docs/faqpages/faqprintingissues.html
+++ b/docs/faqpages/faqprintingissues.html
@@ -95,24 +95,16 @@ following:
     </p>
     <blockquote>
      <p class="indent2">
-      <code>
-       Bite
-      </code>
+      <code>Bite</code>
      </p>
      <p class="indent2">
-      <code>
-       CATEGORY:Natural Attack
-      </code>
+      <code>CATEGORY:Natural Attack</code>
      </p>
      <p class="indent2">
-      <code>
-       TYPE:NaturalAttack
-      </code>
+      <code>TYPE:NaturalAttack</code>
      </p>
      <p class="indent2">
-      <code>
-       ASPECT:NaturalAttackName|Bite
-      </code>
+      <code>ASPECT:NaturalAttackName|Bite</code>
      </p>
      <p class="indent3">
       <i>
@@ -121,9 +113,7 @@ displayed.
       </i>
      </p>
      <p class="indent2">
-      <code>
-       ASPECT:NaturalAttackToHit|%1|BAB+STR+BiteAdditional
-      </code>
+      <code>ASPECT:NaturalAttackToHit|%1|BAB+STR+BiteAdditional</code>
      </p>
      <p class="indent3">
       <i>
@@ -135,9 +125,7 @@ to work, there is NO proficiency associated with this
      </p>
      <p class="indent2">
       <i>
-       <code>
-        ASPECT:NaturalAttackDamage|%1d%2|BiteDamageDice|BiteDamageSize
-       </code>
+       <code>ASPECT:NaturalAttackDamage|%1d%2|BiteDamageDice|BiteDamageSize</code>
       </i>
      </p>
      <p class="indent3">
@@ -148,9 +136,7 @@ the damage
       </i>
      </p>
      <p class="indent2">
-      <code>
-       ASPECT:NaturalAttackDamageBonus|%1|STR
-      </code>
+      <code>ASPECT:NaturalAttackDamageBonus|%1|STR</code>
      </p>
      <p class="indent3">
       <i>
@@ -158,9 +144,7 @@ the damage
       </i>
      </p>
      <p class="indent2">
-      <code>
-       ASPECT:NaturalAttackReach|%1|REACH.VAL
-      </code>
+      <code>ASPECT:NaturalAttackReach|%1|REACH.VAL</code>
      </p>
      <p class="indent3">
       <i>
@@ -169,9 +153,7 @@ natural Reach value
       </i>
      </p>
      <p class="indent2">
-      <code>
-       ASPECT:NaturalAttackType|Bludgeoning
-      </code>
+      <code>ASPECT:NaturalAttackType|Bludgeoning</code>
      </p>
      <p class="indent3">
       <i>
@@ -180,9 +162,7 @@ Slashing, Piercing, Energy Type, Element Type
       </i>
      </p>
      <p class="indent2">
-      <code>
-       ASPECT:NaturalAttackThreatRange|%1|BiteThreatRange
-      </code>
+      <code>ASPECT:NaturalAttackThreatRange|%1|BiteThreatRange</code>
      </p>
      <p class="indent3">
       <i>
@@ -191,9 +171,7 @@ typically '20'
       </i>
      </p>
      <p class="indent2">
-      <code>
-       ASPECT:NaturalAttackThreatRange|x%1|BiteCritMult
-      </code>
+      <code>ASPECT:NaturalAttackThreatRange|x%1|BiteCritMult</code>
      </p>
      <p class="indent3">
       <i>
@@ -201,9 +179,7 @@ typically '20'
       </i>
      </p>
      <p class="indent2">
-      <code>
-       ASPECT:NaturalAttackNotes|x
-      </code>
+      <code>ASPECT:NaturalAttackNotes|x</code>
      </p>
      <p class="indent3">
       <i>
@@ -212,9 +188,7 @@ attack
       </i>
      </p>
      <p class="indent2">
-      <code>
-       DESC:x
-      </code>
+      <code>DESC:x</code>
      </p>
      <p class="indent3">
       <i>
@@ -229,63 +203,39 @@ variables and you may alter however you wish.
       </i>
      </p>
      <p class="indent2">
-      <code>
-       DEFINE:BiteDamageDice|0
-      </code>
+      <code>DEFINE:BiteDamageDice|0</code>
      </p>
      <p class="indent2">
-      <code>
-       DEFINE:BiteDamageSize|0
-      </code>
+      <code>DEFINE:BiteDamageSize|0</code>
      </p>
      <p class="indent2">
-      <code>
-       DEFINE:BiteCritMult|2
-      </code>
+      <code>DEFINE:BiteCritMult|2</code>
      </p>
      <p class="indent2">
-      <code>
-       BONUS:VAR|BiteDamageDice|1
-      </code>
+      <code>BONUS:VAR|BiteDamageDice|1</code>
      </p>
      <p class="indent2">
-      <code>
-       BONUS:VAR|BiteDamageSize|6
-      </code>
+      <code>BONUS:VAR|BiteDamageSize|6</code>
      </p>
      <p class="indent2">
-      <code>
-       DEFINE:BiteAdditional|0
-      </code>
+      <code>DEFINE:BiteAdditional|0</code>
      </p>
      <p class="indent2">
-      <code>
-       DEFINE:BiteThreatRange|0
-      </code>
+      <code>DEFINE:BiteThreatRange|0</code>
      </p>
      <p class="indent2">
-      <code>
-       BONUS:VAR|BiteThreatRange|20
-      </code>
+      <code>BONUS:VAR|BiteThreatRange|20</code>
      </p>
     </blockquote>
     <p class="indent0">
      For Special Attack Notes, you may either use
-     <code>
-      DESC:x
-     </code>
+     <code>DESC:x</code>
      , or
-     <code>
-      ASPECT:NaturalAttackNotes|x
-     </code>
+     <code>ASPECT:NaturalAttackNotes|x</code>
      .
-     <code>
-      ASPECT
-     </code>
+     <code>ASPECT</code>
      is used for just one note while
-     <code>
-      DESC
-     </code>
+     <code>DESC</code>
      can take PRExxx tags and are ideal if your attack
 can be given to other creatures whose attacks vary by level based
 increases.
@@ -293,9 +243,7 @@ increases.
     <p class="indent0">
      What this solution will not do is handle
 iterative attacks unless you set up the ability with an
-     <code>
-      ASPECT
-     </code>
+     <code>ASPECT</code>
      with all the iterative attacks. Unfortunately,
 ASPECT needs work in order to fully support any Alternative
 Iterative Attacks, or partial Iterative Attacks.
@@ -303,10 +251,8 @@ Iterative Attacks, or partial Iterative Attacks.
     <p class="indent0">
      Suggested Method to add Bonus to Hit by
 proficiency would be to do
-     <code>
-      BONUS:VAR|BiteAdditional|1|PREFEAT:1,Weapon
-Focus(Bite)
-     </code>
+     <code>BONUS:VAR|BiteAdditional|1|PREFEAT:1,Weapon
+Focus(Bite)</code>
      <i>
       and make sure you add
       <b>
@@ -317,9 +263,7 @@ Focus(Bite)
        weaponprof.lst
       </u>
       file and append
-      <code>
-       AUTO:WEAPONPROF|Bite
-      </code>
+      <code>AUTO:WEAPONPROF|Bite</code>
       to the ability. This will allow
 the character to take the Proficiency in Weapon Focus. Repeat for
 other methods you desire.
@@ -350,39 +294,29 @@ include the following in your ability:
        <strong>
         Example:
        </strong>
-       <code>
-        TYPE:SpecialAttack.Supernatural.Checklist
-       </code>
+       <code>TYPE:SpecialAttack.Supernatural.Checklist</code>
       </i>
      </li>
      <li>
       <i>
        Include the following
-       <code>
-        ASPECT
-       </code>
+       <code>ASPECT</code>
        tags:
       </i>
       <p class="indent2">
        <i>
-        <code>
-         ASPECT:CheckList|Yes
-        </code>
+        <code>ASPECT:CheckList|Yes</code>
        </i>
       </p>
       <p class="indent2">
        <i>
-        <code>
-         ASPECT:CheckCount|x
-        </code>
+        <code>ASPECT:CheckCount|x</code>
         [x can be a
 number, variable or formula.]
        </i>
       </p>
       <p class="indent2">
-       <code>
-        ASPECT:CheckType|y
-       </code>
+       <code>ASPECT:CheckType|y</code>
        [
        <i>
         y is simple
@@ -411,19 +345,13 @@ feat with the following included in it:
       <strong>
        Example:
       </strong>
-      <code>
-       TYPE:SpecialQuality.RacialBonus.SkillBonus
-      </code>
+      <code>TYPE:SpecialQuality.RacialBonus.SkillBonus</code>
      </li>
      <li>
-      <code>
-       ASPECT:SkillBonus|x
-      </code>
+      <code>ASPECT:SkillBonus|x</code>
       tag must be included in the
 granted ability or feat. The quot;xquot; is simple text as per the
-      <code>
-       DESC
-      </code>
+      <code>DESC</code>
       tag.
      </li>
     </ol>

--- a/docs/faqpages/faqsectionheading.html
+++ b/docs/faqpages/faqsectionheading.html
@@ -37,9 +37,7 @@ most often from PCGen users!
    </strong>
    This FAQ is
 Tongue in Cheek, complaints about the style can go to
-   <code>
-    /dev/null
-   </code>
+   <code>/dev/null</code>
    , or go talk to Karianna, same diff ;-)
   </p>
   <p class="indent1">

--- a/docs/faqpages/faqskinningpcgen.html
+++ b/docs/faqpages/faqskinningpcgen.html
@@ -47,9 +47,7 @@ PCGen team or Code Monkey Publishing.
      </a>
      <br/>
      Unzip the file into the
-     <code>
-      \pcgen\lib directory.
-     </code>
+     <code>\pcgen\lib directory.</code>
     </p>
    </li>
    <li>
@@ -75,9 +73,7 @@ page:
     </p>
     <p>
      The easiest is in the
-     <code>
-      \pcgen\lib\
-     </code>
+     <code>\pcgen\lib\</code>
      directory however
 you can use your own directory format as you will. There is no need
 to unzip the themes/skins as they are applied from the zip

--- a/docs/faqpages/faqstartupinstallissues.html
+++ b/docs/faqpages/faqstartupinstallissues.html
@@ -84,9 +84,7 @@ sample instructions for WinZip. After WinZip has been installed,
 double-click the file. This will open the file in WinZip. On the
 menu-bar, click the "Extract to..." button, and enter the location
 where you want to have PCGen (Example:
-     <code>
-      c:\tools\pcgen
-     </code>
+     <code>c:\tools\pcgen</code>
      ). Make sure you have the "Include
 Subfolders" option checked!!
     </p>
@@ -156,10 +154,8 @@ hard-drive.
        Unix/Linux
       </strong>
       , you need to execute
-      <code>
-       java
--jar pcgen.jar
-      </code>
+      <code>java
+-jar pcgen.jar</code>
       .
       <br/>
      </li>
@@ -418,33 +414,23 @@ never is). There are machine-specific releases of PCGen available,
 but unless you choose to use one of these, you'll have to manually
 change the addressing in the files you're to access. Normally this
 is a case of changing a
-     <code>
-      /
-     </code>
+     <code>/</code>
      to a
-     <code>
-      \
-     </code>
+     <code>\</code>
      or the
 other way round. Also make sure that you don't try to access
 something like
-     <code>
-      c:/program files/pcgen/
-     </code>
+     <code>c:/program files/pcgen/</code>
      when you should
 be accessing
-     <code>
-      c:/program~1/pcgen/
-     </code>
+     <code>c:/program~1/pcgen/</code>
      , or vice versa.
     </p>
     <p>
      Note that on Windows, enclosing the entire path in double
 quotation marks is an acceptable way to accessing the directory,
 i.e.
-     <code>
-      "c:\program files\pcgen\"
-     </code>
+     <code>"c:\program files\pcgen\"</code>
      .
     </p>
    </li>

--- a/docs/faqpages/faqsubmittingabugreport.html
+++ b/docs/faqpages/faqsubmittingabugreport.html
@@ -48,9 +48,7 @@
   </h1>
   <p>
    The PCGen project uses a system named
-   <code>
-    JIRA
-   </code>
+   <code>JIRA</code>
    , located at
    <a href="http://jira.pcgen.org">
     jira.pcgen.org
@@ -368,9 +366,7 @@
   </p>
   <ul>
    <li>
-    <code>
-     CODE
-    </code>
+    <code>CODE</code>
     : PCGen program including the user interface, parsing of data, rules engine, output tags etc.
     <ul>
      <li>
@@ -379,9 +375,7 @@
     </ul>
    </li>
    <li>
-    <code>
-     DATA
-    </code>
+    <code>DATA</code>
     : LST/Data issues and requests.
     <ul>
      <li>
@@ -390,9 +384,7 @@
     </ul>
    </li>
    <li>
-    <code>
-     DOCS
-    </code>
+    <code>DOCS</code>
     : The user manual, which you are reading now.
     <ul>
      <li>
@@ -407,24 +399,18 @@
     </ul>
    </li>
    <li>
-    <code>
-     NEWSOURCE
-    </code>
+    <code>NEWSOURCE</code>
     : This is where new books are entered that have permission to be included in PCGen.
    </li>
    <li>
-    <code>
-     NEWTAG
-    </code>
+    <code>NEWTAG</code>
     :
     <em>
      (Ed: What is this?)
     </em>
    </li>
    <li>
-    <code>
-     OS
-    </code>
+    <code>OS</code>
     : Output sheets.
     <ul>
      <li>
@@ -436,32 +422,22 @@
     </ul>
    </li>
    <li>
-    <code>
-     PLAYTEST
-    </code>
+    <code>PLAYTEST</code>
     : Non-versioned sets.
     <em>
      (Ed: What is this for?)
     </em>
    </li>
    <li>
-    <code>
-     PRET
-    </code>
+    <code>PRET</code>
     : The
-    <code>
-     prettylst.pl
-    </code>
+    <code>prettylst.pl</code>
     Perl program, used to pretty-print
-    <code>
-     LST
-    </code>
+    <code>LST</code>
     files and update them to the latest tag formats.
    </li>
    <li>
-    <code>
-     HELP
-    </code>
+    <code>HELP</code>
     : For general user support requests, such as
     <em>
      "How do I?..."
@@ -477,9 +453,7 @@
      </li>
      <li>
       The Yahoo!
-      <code>
-       pcgen
-      </code>
+      <code>pcgen</code>
       mailing list. (Old; being phased out.)
      </li>
     </ul>

--- a/docs/listfilepages/datafilestagpages/datafilesability.html
+++ b/docs/listfilepages/datafilestagpages/datafilesability.html
@@ -125,17 +125,11 @@ higher the spell levelslot requires.
     </strong>
     When modifying an ability with
 the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     ADDSPELLLEVEL
-    </code>
+    <code>ADDSPELLLEVEL</code>
     tag, the data included in a new
-    <code>
-     ADDSPELLLEVEL
-    </code>
+    <code>ADDSPELLLEVEL</code>
     tag will overwrite the existing tag
 data.
    </li>
@@ -146,9 +140,7 @@ data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ADDSPELLLEVEL:2
-   </code>
+   <code>ADDSPELLLEVEL:2</code>
   </p>
   <p class="indent3">
    A spell with this metamagic ability applied to
@@ -161,27 +153,21 @@ it takes up a slot two levels higher than the normal spell.
   </p>
   <p class="indent2">
    Initial Ability:
-   <code>
-    CATEGORY=&lt;category
+   <code>CATEGORY=&lt;category
 name&gt;|&lt;ability name&gt; &lt;tab&gt;
-ADDSPELLLEVEL:1
-   </code>
+ADDSPELLLEVEL:1</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    CATEGORY=&lt;category
+   <code>CATEGORY=&lt;category
 name&gt;|&lt;ability name&gt; &lt;tab&gt;
-ADDSPELLLEVEL:2
-   </code>
+ADDSPELLLEVEL:2</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    CATEGORY=&lt;category
+   <code>CATEGORY=&lt;category
 name&gt;|&lt;ability name&gt; &lt;tab&gt;
-ADDSPELLLEVEL:2
-   </code>
+ADDSPELLLEVEL:2</code>
   </p>
   <p class="indent3">
    Modified ability applied to a spell will cause
@@ -223,9 +209,7 @@ an addribute that can modify the spell name./p&gt;
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    APPLIEDNAME:Empowered
-   </code>
+   <code>APPLIEDNAME:Empowered</code>
   </p>
   <p class="indent3">
    A spell with this metamagic ability applied to
@@ -279,30 +263,22 @@ and sets its value.
    </li>
    <li>
     PRExxx tags can be used with the
-    <code>
-     ASPECT
-    </code>
+    <code>ASPECT</code>
     tag.
    </li>
    <li>
     This tag can be used multiple times within an ability but each
 time it must identify a new aspect unless the
-    <code>
-     ASPECT
-    </code>
+    <code>ASPECT</code>
     tag includes a PRExxx tag appended to the end.
    </li>
    <li>
     When using multiple
-    <code>
-     ASPECT
-    </code>
+    <code>ASPECT</code>
     tags for the same
 "aspect" and PRExxx tags appended to the end of each, the final
 value for that aspect will be set by the physically last
-    <code>
-     ASPECT
-    </code>
+    <code>ASPECT</code>
     tag in the ability line that passes the
 prerequisite.
    </li>
@@ -314,38 +290,26 @@ first (z), %2 is replaced by the second (z), etc..
    <li>
     The (y) parameter can also use other special variables as is
 done in the
-    <code>
-     DESC
-    </code>
+    <code>DESC</code>
     tag:
     <ul>
      <li>
-      <code>
-       %CHOICE
-      </code>
+      <code>%CHOICE</code>
       - Will replace the first associated choice
 in the object.
      </li>
      <li>
-      <code>
-       %LIST
-      </code>
+      <code>%LIST</code>
       - Will substitute all choices comma
 separated into that parameter.
      </li>
      <li>
-      <code>
-       %NAME
-      </code>
+      <code>%NAME</code>
       - The
-      <code>
-       OUTPUTNAME
-      </code>
+      <code>OUTPUTNAME</code>
       or name of the
 object this
-      <code>
-       DESC
-      </code>
+      <code>DESC</code>
       tag is in.
      </li>
     </ul>
@@ -356,30 +320,20 @@ object this
     </strong>
     When modifying an ability with
 the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     ASPECT
-    </code>
+    <code>ASPECT</code>
     tag, the data included in a new
-    <code>
-     ASPECT
-    </code>
+    <code>ASPECT</code>
     tag will
 selectively overwrite the existing tag data or include the separate
 tags. Since each aspect name can hold only one value per ability,
 modifying an existing
-    <code>
-     ASPECT
-    </code>
+    <code>ASPECT</code>
     tag will overwrite only
 the value of the aspect by that name in the ability, and will add a
 separate
-    <code>
-     ASPECT
-    </code>
+    <code>ASPECT</code>
     tag with a new name.
    </li>
   </ul>
@@ -389,10 +343,8 @@ separate
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ASPECT:Action Type|Standard
-Action
-   </code>
+   <code>ASPECT:Action Type|Standard
+Action</code>
   </p>
   <p class="indent3">
    Identifies the "Action Type" of an action
@@ -400,9 +352,7 @@ performed as part of the associated ability as a "Standard
 Action".
   </p>
   <p class="indent2">
-   <code>
-    ASPECT:Attack Type|Melee weapon
-   </code>
+   <code>ASPECT:Attack Type|Melee weapon</code>
   </p>
   <p class="indent3">
    Identifies the "Attack Type" of an attack
@@ -410,28 +360,22 @@ performed as part of the associated ability as a "Melee weapon"
 attack.
   </p>
   <p class="indent2">
-   <code>
-    ASPECT:Target|One creature
-   </code>
+   <code>ASPECT:Target|One creature</code>
   </p>
   <p class="indent3">
    Identifies the "Target" of an action performed
 as part of the associated ability as "One creature".
   </p>
   <p class="indent2">
-   <code>
-    ASPECT:Attack|Strength vs. AC
-   </code>
+   <code>ASPECT:Attack|Strength vs. AC</code>
   </p>
   <p class="indent3">
    Identifies an "Attack" performed as part of the
 associated ability as "Strength vs. AC".
   </p>
   <p class="indent2">
-   <code>
-    ASPECT:Attack Type|Ranged
-%1|PowerRange
-   </code>
+   <code>ASPECT:Attack Type|Ranged
+%1|PowerRange</code>
   </p>
   <p class="indent3">
    Identifies the "Attack Type" of an attack
@@ -439,10 +383,8 @@ performed as part of the associated ability as a "Ranged" attack
 with a range equivalent to the "PowerRange" variable.
   </p>
   <p class="indent2">
-   <code>
-    ASPECT:Effect|Double damage to %CHOICE
-creatures
-   </code>
+   <code>ASPECT:Effect|Double damage to %CHOICE
+creatures</code>
   </p>
   <p class="indent3">
    Identifies the "Effect" of an action performed
@@ -450,11 +392,9 @@ as part of the associated ability as "Double damage" to the
 creature chosen by the associated chooser.
   </p>
   <p class="indent2">
-   <code>
-    ASPECT:Target|One creature &lt;tab&gt;
+   <code>ASPECT:Target|One creature &lt;tab&gt;
 ASPECT:Target|Two creatures|PREPCLEVEL:MIN=7,MAX=12 &lt;tab&gt;
-ASPECT:Target|Three creatures|PREPCLEVEL:MIN=13
-   </code>
+ASPECT:Target|Three creatures|PREPCLEVEL:MIN=13</code>
   </p>
   <p class="indent3">
    Identifies the "Target" of an action performed
@@ -469,24 +409,18 @@ that are level 1-6, "Two creatures"' for characters level 7-12, and
   </p>
   <p class="indent2">
    Initial Ability:
-   <code>
-    CATEGORY=&lt;category
-name&gt;|&lt;ability name&gt; &lt;tab&gt; ASPECT:A1|A2
-   </code>
+   <code>CATEGORY=&lt;category
+name&gt;|&lt;ability name&gt; &lt;tab&gt; ASPECT:A1|A2</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    CATEGORY=&lt;category
-name&gt;|&lt;ability name&gt; &lt;tab&gt; ASPECT:A1|A3
-   </code>
+   <code>CATEGORY=&lt;category
+name&gt;|&lt;ability name&gt; &lt;tab&gt; ASPECT:A1|A3</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    CATEGORY=&lt;category
-name&gt;|&lt;ability name&gt; &lt;tab&gt; ASPECT:A1|A3
-   </code>
+   <code>CATEGORY=&lt;category
+name&gt;|&lt;ability name&gt; &lt;tab&gt; ASPECT:A1|A3</code>
   </p>
   <p class="indent1">
    <strong>
@@ -496,25 +430,19 @@ Separately):
   </p>
   <p class="indent2">
    Initial Ability:
-   <code>
-    CATEGORY=&lt;category
-name&gt;|&lt;ability name&gt; &lt;tab&gt; ASPECT:A1|A2
-   </code>
+   <code>CATEGORY=&lt;category
+name&gt;|&lt;ability name&gt; &lt;tab&gt; ASPECT:A1|A2</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    CATEGORY=&lt;category
-name&gt;|&lt;ability name&gt; &lt;tab&gt; ASPECT:B1|B2
-   </code>
+   <code>CATEGORY=&lt;category
+name&gt;|&lt;ability name&gt; &lt;tab&gt; ASPECT:B1|B2</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    CATEGORY=&lt;category
+   <code>CATEGORY=&lt;category
 name&gt;|&lt;ability name&gt; &lt;tab&gt; ASPECT:A1|A2 &lt;tab&gt;
-ASPECT:B1|B2
-   </code>
+ASPECT:B1|B2</code>
   </p>
   <hr/>
   <p class="lstnew">
@@ -575,53 +503,37 @@ Preference window is unchecked. Otherwise the text from the
    </li>
    <li>
     PRExxx tags can be used with the
-    <code>
-     BENEFIT
-    </code>
+    <code>BENEFIT</code>
     tag.
    </li>
    <li>
     Multiple
-    <code>
-     BENEFIT
-    </code>
+    <code>BENEFIT</code>
     tags per line are allowed with
 all qualifying
-    <code>
-     BENEFIT
-    </code>
+    <code>BENEFIT</code>
     tags being concatonated for
 output and separated by spaces.
    </li>
    <li>
-    <code>
-     .CLEAR
-    </code>
+    <code>.CLEAR</code>
     will clear all
-    <code>
-     BENEFIT
-    </code>
+    <code>BENEFIT</code>
     tags.
    </li>
    <li>
-    <code>
-     .CLEAR.(regular expression match)
-    </code>
+    <code>.CLEAR.(regular expression match)</code>
     will clear
 specific instances.
    </li>
    <li>
-    <code>
-     BENEFIT
-    </code>
+    <code>BENEFIT</code>
     tags will take variable substitution.
     <ul>
      <li>
       Within the text a % followed by a number will substitute the
 #th variable from the variable list associated with the
-      <code>
-       BENEFIT
-      </code>
+      <code>BENEFIT</code>
       .
      </li>
      <li>
@@ -644,33 +556,23 @@ number should be surrounded in curly brackets { }. For example,
 list:
     <ul>
      <li>
-      <code>
-       %NAME
-      </code>
+      <code>%NAME</code>
       - The name of the object this
-      <code>
-       BENEFIT
-      </code>
+      <code>BENEFIT</code>
       tag is in.
      </li>
      <li>
-      <code>
-       %FEAT
-      </code>
+      <code>%FEAT</code>
       - Will substitute the descriptions of feats
 within the object that match the associated preqrequisites.
      </li>
      <li>
-      <code>
-       %CHOICE
-      </code>
+      <code>%CHOICE</code>
       - Will replace the first associated choice
 in the object.
      </li>
      <li>
-      <code>
-       %LIST
-      </code>
+      <code>%LIST</code>
       - Will substitute all choices into that
 parameter as a comma-delimited list.
      </li>
@@ -706,19 +608,13 @@ You can create fairly powerful match structures using things like
 character groups "[a-zA-Z]" match any alphabetic character or
 groupings "(bat|super)man" match batman or superman and many many
 more. So, for example, you could clear all benefits by doing
-    <code>
-     BENEFIT:.CLEAR..*
-    </code>
+    <code>BENEFIT:.CLEAR..*</code>
     , or clear all exceptional abilities
 by doing
-    <code>
-     BENEFIT:.CLEAR.\(Ex\)
-    </code>
+    <code>BENEFIT:.CLEAR.\(Ex\)</code>
     , or clear everything
 that's non-numeric with
-    <code>
-     BENEFIT:.CLEAR.[A-Za-z]
-    </code>
+    <code>BENEFIT:.CLEAR.[A-Za-z]</code>
     .
    </li>
    <li>
@@ -727,17 +623,11 @@ that's non-numeric with
     </strong>
     When modifying an ability with
 the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     BENEFIT
-    </code>
+    <code>BENEFIT</code>
     tag, the data included in a new
-    <code>
-     BENEFIT
-    </code>
+    <code>BENEFIT</code>
     tag will be
 included as a separate tag.
    </li>
@@ -748,75 +638,61 @@ included as a separate tag.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BENEFIT:This is sample text for the
-example purposes
-   </code>
+   <code>BENEFIT:This is sample text for the
+example purposes</code>
   </p>
   <p class="indent3">
    Adds ability benefit.
   </p>
   <p class="indent2">
-   <code>
-    BENEFIT:Kick Butt (level
-3)|PRELEVEL:3
-   </code>
+   <code>BENEFIT:Kick Butt (level
+3)|PRELEVEL:3</code>
   </p>
   <p class="indent3">
    Adds ability description only if the PC is level
 3 or higher.
   </p>
   <p class="indent2">
-   <code>
-    BENEFIT:Assembly ~ 1
+   <code>BENEFIT:Assembly ~ 1
 table|PREVAREQ:AssemblyTables,1
     <br/>
     BENEFIT:Assembly ~ %1
-tables|AssemblyTables|PREVARGTEQ:AssemblyTables,2
-   </code>
+tables|AssemblyTables|PREVARGTEQ:AssemblyTables,2</code>
   </p>
   <p class="indent3">
    Adds an ability description which is dependent
 upon the value of the variable AssemblyTables.
   </p>
   <p class="indent2">
-   <code>
-    BENEFIT:You get a +2 bonus on all %1
-saving throws|%CHOICE
-   </code>
+   <code>BENEFIT:You get a +2 bonus on all %1
+saving throws|%CHOICE</code>
   </p>
   <p class="indent3">
    Adds ability description and replaces %1 with
 the first choice made.
   </p>
   <p class="indent2">
-   <code>
-    BENEFIT:You get a +3 bonus on all checks
-involving %1|%LIST.
-   </code>
+   <code>BENEFIT:You get a +3 bonus on all checks
+involving %1|%LIST.</code>
   </p>
   <p class="indent3">
    Adds ability description, replacing %LIST with
 all choices made.
   </p>
   <p class="indent2">
-   <code>
-    BENEFIT:%3 Sneak Attacks per day for
+   <code>BENEFIT:%3 Sneak Attacks per day for
 +%1d%2
-damage|SneakAttack|SneakAttackDie|SneakAttackTimes
-   </code>
+damage|SneakAttack|SneakAttackDie|SneakAttackTimes</code>
   </p>
   <p class="indent3">
    Adds ability description, substituting the
 variables from the positions specified.
   </p>
   <p class="indent2">
-   <code>
-    Advanced Combat Martial Arts.MOD
+   <code>Advanced Combat Martial Arts.MOD
 &lt;tab&gt; BENEFIT:.CLEAR &lt;tab&gt; BENEFIT:When the character
 scores a critical hit on an opponent with an unarmed strike, the
-character deals triple damage
-   </code>
+character deals triple damage</code>
   </p>
   <p class="indent3">
    Changes the ability description, substituting
@@ -830,27 +706,21 @@ Separately):
   </p>
   <p class="indent2">
    Initial Ability:
-   <code>
-    CATEGORY=&lt;category
+   <code>CATEGORY=&lt;category
 name&gt;|&lt;ability name&gt; &lt;tab&gt; BENEFIT:Initial benefit
-text.
-   </code>
+text.</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    CATEGORY=&lt;category
+   <code>CATEGORY=&lt;category
 name&gt;|&lt;ability name&gt; &lt;tab&gt; BENEFIT:New benefit
-text.
-   </code>
+text.</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    CATEGORY=&lt;category
+   <code>CATEGORY=&lt;category
 name&gt;|&lt;ability name&gt; &lt;tab&gt; BENEFIT:Initial benefit
-text. &lt;tab&gt; BENEFIT:New benefit text.
-   </code>
+text. &lt;tab&gt; BENEFIT:New benefit text.</code>
   </p>
   <p class="indent3">
    The output will show the following:
@@ -897,18 +767,14 @@ only be unique within its category.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CATEGORY:SpecialAttack
-   </code>
+   <code>CATEGORY:SpecialAttack</code>
   </p>
   <p class="indent3">
    This ability is part of the "SpecialAttack"
 ability category.
   </p>
   <p class="indent2">
-   <code>
-    CATEGORY:Feat
-   </code>
+   <code>CATEGORY:Feat</code>
   </p>
   <p class="indent3">
    This ability is part of the "Feat" ability
@@ -916,10 +782,8 @@ category, which is a special case of abilities that can be selected
 as feats.
   </p>
   <p class="indent2">
-   <code>
-    CATEGORY=Talent|Uncanny Dodge II.MOD
-&lt;tab&gt; PRE:.CLEAR
-   </code>
+   <code>CATEGORY=Talent|Uncanny Dodge II.MOD
+&lt;tab&gt; PRE:.CLEAR</code>
   </p>
   <p class="indent3">
    This ability is part of the "Talent" ability
@@ -962,18 +826,12 @@ ability point.
     </strong>
     When modifying an ability with
 the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     COST
-    </code>
+    <code>COST</code>
     tag,
 the data included in a new
-    <code>
-     COST
-    </code>
+    <code>COST</code>
     tag will overwrite the
 existing tag data.
    </li>
@@ -984,17 +842,13 @@ existing tag data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    COST:1
-   </code>
+   <code>COST:1</code>
   </p>
   <p class="indent3">
    Ability costs one ability point.
   </p>
   <p class="indent2">
-   <code>
-    COST:.5
-   </code>
+   <code>COST:.5</code>
   </p>
   <p class="indent3">
    Ability costs half a ability point.
@@ -1005,9 +859,7 @@ existing tag data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    1
-   </code>
+   <code>1</code>
   </p>
   <p class="indent1">
    <strong>
@@ -1016,24 +868,18 @@ existing tag data.
   </p>
   <p class="indent2">
    Initial Ability:
-   <code>
-    CATEGORY=&lt;category
-name&gt;|&lt;ability name&gt; &lt;tab&gt; COST:2
-   </code>
+   <code>CATEGORY=&lt;category
+name&gt;|&lt;ability name&gt; &lt;tab&gt; COST:2</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    CATEGORY=&lt;category
-name&gt;|&lt;ability name&gt; &lt;tab&gt; COST:1
-   </code>
+   <code>CATEGORY=&lt;category
+name&gt;|&lt;ability name&gt; &lt;tab&gt; COST:1</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    CATEGORY=&lt;category
-name&gt;|&lt;ability name&gt; &lt;tab&gt; COST:1
-   </code>
+   <code>CATEGORY=&lt;category
+name&gt;|&lt;ability name&gt; &lt;tab&gt; COST:1</code>
   </p>
   <p class="indent3">
    Ability costs one ability point.
@@ -1072,9 +918,7 @@ the value is set to 'YES', then you
     </strong>
     also use
 a
-    <code>
-     CHOOSE
-    </code>
+    <code>CHOOSE</code>
     tag.
    </li>
    <li>
@@ -1083,18 +927,12 @@ a
     </strong>
     When modifying an ability with
 the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     MULT
-    </code>
+    <code>MULT</code>
     tag,
 the data included in a new
-    <code>
-     MULT
-    </code>
+    <code>MULT</code>
     tag will overwrite the
 existing tag data.
    </li>
@@ -1105,9 +943,7 @@ existing tag data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    MULT:YES
-   </code>
+   <code>MULT:YES</code>
   </p>
   <p class="indent3">
    This Ability can be taken multiple times.
@@ -1118,9 +954,7 @@ existing tag data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    NO
-   </code>
+   <code>NO</code>
   </p>
   <p class="indent1">
    <strong>
@@ -1129,24 +963,18 @@ existing tag data.
   </p>
   <p class="indent2">
    Initial Ability:
-   <code>
-    CATEGORY=&lt;category
-name&gt;|&lt;ability name&gt; &lt;tab&gt; MULT:YES
-   </code>
+   <code>CATEGORY=&lt;category
+name&gt;|&lt;ability name&gt; &lt;tab&gt; MULT:YES</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    CATEGORY=&lt;category
-name&gt;|&lt;ability name&gt; &lt;tab&gt; MULT:NO
-   </code>
+   <code>CATEGORY=&lt;category
+name&gt;|&lt;ability name&gt; &lt;tab&gt; MULT:NO</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    CATEGORY=&lt;category
-name&gt;|&lt;ability name&gt; &lt;tab&gt; MULT:NO
-   </code>
+   <code>CATEGORY=&lt;category
+name&gt;|&lt;ability name&gt; &lt;tab&gt; MULT:NO</code>
   </p>
   <p class="indent3">
    Modified ability cannot be taken multiple
@@ -1188,17 +1016,11 @@ another.
     </strong>
     When modifying an ability with
 the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     STACK
-    </code>
+    <code>STACK</code>
     tag, the data included in a new
-    <code>
-     STACK
-    </code>
+    <code>STACK</code>
     tag will
 overwrite the existing tag data.
    </li>
@@ -1209,9 +1031,7 @@ overwrite the existing tag data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    STACK:YES
-   </code>
+   <code>STACK:YES</code>
   </p>
   <p class="indent3">
    The benefits for this ability stack with itself
@@ -1223,9 +1043,7 @@ if taken multiple times.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    NO
-   </code>
+   <code>NO</code>
   </p>
   <p class="indent1">
    <strong>
@@ -1234,24 +1052,18 @@ if taken multiple times.
   </p>
   <p class="indent2">
    Initial Ability:
-   <code>
-    CATEGORY=&lt;category
-name&gt;|&lt;ability name&gt; &lt;tab&gt; STACK:YES
-   </code>
+   <code>CATEGORY=&lt;category
+name&gt;|&lt;ability name&gt; &lt;tab&gt; STACK:YES</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    CATEGORY=&lt;category
-name&gt;|&lt;ability name&gt; &lt;tab&gt; STACK:NO
-   </code>
+   <code>CATEGORY=&lt;category
+name&gt;|&lt;ability name&gt; &lt;tab&gt; STACK:NO</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    CATEGORY=&lt;category
-name&gt;|&lt;ability name&gt; &lt;tab&gt; STACK:NO
-   </code>
+   <code>CATEGORY=&lt;category
+name&gt;|&lt;ability name&gt; &lt;tab&gt; STACK:NO</code>
   </p>
   <p class="indent3">
    The benefits for the modified ability will not
@@ -1289,13 +1101,9 @@ by the ability.
    </li>
    <li>
     Supports
-    <code>
-     %LIST
-    </code>
+    <code>%LIST</code>
     in conjunction with a
-    <code>
-     CHOOSE
-    </code>
+    <code>CHOOSE</code>
     tag.
    </li>
   </ul>
@@ -1305,9 +1113,7 @@ by the ability.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TEMPLATE:Incorporeal|Undead|Celestial
-   </code>
+   <code>TEMPLATE:Incorporeal|Undead|Celestial</code>
   </p>
   <p class="indent3">
    The ability applies the "Incorporeal", "Undead"
@@ -1338,28 +1144,18 @@ and "Celestial" templates.
    <li>
     This is a pipe-delimited list of template choices that are
 added to the list presented by the original
-    <code>
-     TEMPLATE:CHOOSE
-    </code>
+    <code>TEMPLATE:CHOOSE</code>
     tag.
    </li>
    <li>
     When using the
-    <code>
-     TEMPLATE:ADDCOICE
-    </code>
+    <code>TEMPLATE:ADDCOICE</code>
     tag as part of a
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     of a Race object that containes multiple
-    <code>
-     TEMPLATE:CHOOSE
-    </code>
+    <code>TEMPLATE:CHOOSE</code>
     tags, all instances of the
-    <code>
-     TEMPLATE:CHOOSE
-    </code>
+    <code>TEMPLATE:CHOOSE</code>
     tag will be modified.
    </li>
   </ul>
@@ -1369,9 +1165,7 @@ added to the list presented by the original
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TEMPLATE:ADDCHOICE:Demihuman|Beast
-   </code>
+   <code>TEMPLATE:ADDCHOICE:Demihuman|Beast</code>
   </p>
   <p class="indent3">
    The ability can choose previously defined
@@ -1406,18 +1200,14 @@ list.
    </li>
    <li>
     Multiple
-    <code>
-     TEMPLATE:CHOOSE
-    </code>
+    <code>TEMPLATE:CHOOSE</code>
     tags can be used in the
 same LST object but PCGen's current Data Standard is to include no
 more that one in each LST object.
    </li>
    <li>
     Though the
-    <code>
-     TEMPLATE:CHOOSE
-    </code>
+    <code>TEMPLATE:CHOOSE</code>
     tag is not a gobal tag
 it can be used in the
     <a href="datafilesclasses.html#templatechoose">
@@ -1440,9 +1230,7 @@ it can be used in the
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TEMPLATE:CHOOSE:Celestial|Outsider
-   </code>
+   <code>TEMPLATE:CHOOSE:Celestial|Outsider</code>
   </p>
   <p class="indent3">
    The ability allows the selection of either the
@@ -1493,30 +1281,22 @@ it can be used in the
   </p>
   <ul class="indent2">
    <li>
-    <code>
-     YES
-    </code>
+    <code>YES</code>
     - Shows the ability name in PCGen and on
 export to a character sheet.
    </li>
    <li>
-    <code>
-     NO
-    </code>
+    <code>NO</code>
     - Hides the ability name in PCGen and on export
 to a character sheet.
    </li>
    <li>
-    <code>
-     DISPLAY
-    </code>
+    <code>DISPLAY</code>
     - Displays the ability name in PCGen but
 not on the character sheet.
    </li>
    <li>
-    <code>
-     EXPORT
-    </code>
+    <code>EXPORT</code>
     - Hides the ability name from PCGen but
 displays it on the character sheet.
    </li>
@@ -1526,17 +1306,11 @@ displays it on the character sheet.
     </strong>
     When modifying an ability with
 the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     VISIBLE
-    </code>
+    <code>VISIBLE</code>
     tag, the data included in a new
-    <code>
-     VISIBLE
-    </code>
+    <code>VISIBLE</code>
     tag will
 overwrite the existing tag data.
    </li>
@@ -1547,9 +1321,7 @@ overwrite the existing tag data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    VISIBLE:YES
-   </code>
+   <code>VISIBLE:YES</code>
   </p>
   <p class="indent3">
    Shows the ability name in PCGen and on the
@@ -1562,26 +1334,20 @@ Output sheet.
   </p>
   <p class="indent2">
    Initial Ability:
-   <code>
-    CATEGORY=&lt;category
-name&gt;|&lt;ability name&gt; &lt;tab&gt; VISIBLEE:YES
-   </code>
+   <code>CATEGORY=&lt;category
+name&gt;|&lt;ability name&gt; &lt;tab&gt; VISIBLEE:YES</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    CATEGORY=&lt;category
+   <code>CATEGORY=&lt;category
 name&gt;|&lt;ability name&gt; &lt;tab&gt;
-VISIBLE:DISPLAY
-   </code>
+VISIBLE:DISPLAY</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    CATEGORY=&lt;category
+   <code>CATEGORY=&lt;category
 name&gt;|&lt;ability name&gt; &lt;tab&gt;
-VISIBLE:DISPLAY
-   </code>
+VISIBLE:DISPLAY</code>
   </p>
   <p class="indent3">
    Modified ability will appear in the GUI but will

--- a/docs/listfilepages/datafilestagpages/datafilesabilitycategory.html
+++ b/docs/listfilepages/datafilestagpages/datafilesabilitycategory.html
@@ -61,9 +61,7 @@ documentation.
      Warning:
     </span>
    </strong>
-   <code>
-    SOURCExxx
-   </code>
+   <code>SOURCExxx</code>
    tags must not
 be used in the abilitycategory list file, so source information
 must be listed in comments where required.
@@ -124,18 +122,14 @@ whole number only pool with a starting value of 0.
    <br/>
   </p>
   <p class="indent2">
-   <code>
-    ABILITYCATEGORY:Special Attack
-   </code>
+   <code>ABILITYCATEGORY:Special Attack</code>
   </p>
   <p class="indent3">
    Defines a category named Special Attack.
   </p>
   <p class="indent2">
-   <code>
-    Special Attack &lt;tab&gt;
-PLURAL=Ambush
-   </code>
+   <code>Special Attack &lt;tab&gt;
+PLURAL=Ambush</code>
   </p>
   <p class="indent3">
    Defines a category named Special Attack and sets

--- a/docs/listfilepages/datafilestagpages/datafilesarmorproficiencies.html
+++ b/docs/listfilepages/datafilestagpages/datafilesarmorproficiencies.html
@@ -40,15 +40,11 @@ the name of the armor proficiency.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    Studded Leather
-   </code>
+   <code>Studded Leather</code>
   </p>
   <p class="indent3">
    Defines
-   <code>
-    Studded Leather
-   </code>
+   <code>Studded Leather</code>
    as a
 category of armor to be used in the associated dataset.
   </p>

--- a/docs/listfilepages/datafilestagpages/datafilesclasses.html
+++ b/docs/listfilepages/datafilestagpages/datafilesclasses.html
@@ -81,9 +81,7 @@ classes.
   <ul>
    <li>
     Begins with the
-    <code>
-     CLASS:&lt;class name&gt;
-    </code>
+    <code>CLASS:&lt;class name&gt;</code>
     tag.
    </li>
    <li>
@@ -117,41 +115,23 @@ ths line.
   </p>
   <blockquote>
    <p>
-    <code>
-     CLASS:Rogue . . .
-    </code>
+    <code>CLASS:Rogue . . .</code>
     <br/>
-    <code>
-     CLASS:Rogue . . .
-    </code>
+    <code>CLASS:Rogue . . .</code>
     <br/>
-    <code>
-     1 . . .
-    </code>
+    <code>1 . . .</code>
     <br/>
-    <code>
-     2 . . .
-    </code>
+    <code>2 . . .</code>
     <br/>
-    <code>
-     .
-    </code>
+    <code>.</code>
     <br/>
-    <code>
-     .
-    </code>
+    <code>.</code>
     <br/>
-    <code>
-     .
-    </code>
+    <code>.</code>
     <br/>
-    <code>
-     19 . . .
-    </code>
+    <code>19 . . .</code>
     <br/>
-    <code>
-     20 . . .
-    </code>
+    <code>20 . . .</code>
    </p>
   </blockquote>
   <h3>
@@ -164,17 +144,13 @@ i.e. take the subclass and gain 'spell' related advantages and
 disadvantages in comparison to the base class. You pick a subclass
 and your characters abilities are changed throughout as defined by
 the subclass tags;
-   <code>
-    <a href="#subclass">
+   <code><a href="#subclass">
      SUBCLASS
-    </a>
-   </code>
+    </a></code>
    and
-   <code>
-    <a href="#subclasslevel">
+   <code><a href="#subclasslevel">
      SUBCLASSLEVEL
-    </a>
-   </code>
+    </a></code>
    tags.
   </p>
   <p>
@@ -187,17 +163,13 @@ the subclass tags;
     <strong>
      NOTE:
     </strong>
-    <code>
-     HASSUBCLASS
-    </code>
+    <code>HASSUBCLASS</code>
     is no longer
 required to create sub-classes.
    </li>
    <li>
     Begins with the
-    <code>
-     SUBCLASS:&lt;sub-class name&gt;
-    </code>
+    <code>SUBCLASS:&lt;sub-class name&gt;</code>
     tag.
    </li>
    <li>
@@ -217,9 +189,7 @@ should be used on this line.
   <ul>
    <li>
     Begins with the
-    <code>
-     SUBCLASSLEVEL:&lt;level number&gt;
-    </code>
+    <code>SUBCLASSLEVEL:&lt;level number&gt;</code>
     tag.
    </li>
    <li>
@@ -235,14 +205,10 @@ included.
 should be used on this line.
     <ul>
      <li>
-      <code>
-       SPELLLIST
-      </code>
+      <code>SPELLLIST</code>
       does not work on Class Line if a
 subclass or substitution class is present. In these cases, the
-      <code>
-       SPELLLIST
-      </code>
+      <code>SPELLLIST</code>
       tag must be placed on each SubClass or
 Substitution Class Line (Not the SubClass/Substitution Level
 Line).
@@ -257,60 +223,34 @@ Line).
   </p>
   <blockquote>
    <p>
-    <code>
-     CLASS:Wizard . . .
-    </code>
+    <code>CLASS:Wizard . . .</code>
     <br/>
-    <code>
-     CLASS:Wizard . . . ALLOWBASECLASS:NO
-    </code>
+    <code>CLASS:Wizard . . . ALLOWBASECLASS:NO</code>
     <br/>
-    <code>
-     CLASS:Wizard . . .
-    </code>
+    <code>CLASS:Wizard . . .</code>
     <br/>
-    <code>
-     SUBCLASS:Abjurer &lt;tab&gt; COST:2 &lt;tab&gt;
+    <code>SUBCLASS:Abjurer &lt;tab&gt; COST:2 &lt;tab&gt;
 CHOICE:SCHOOL|Abjuration &lt;tab&gt;
-KNOWNSPELLSFROMSPECIALTY:1
-    </code>
+KNOWNSPELLSFROMSPECIALTY:1</code>
     <br/>
-    <code>
-     SUBCLASSLEVEL:1 &lt;tab&gt; FEATAUTO:Abjurer Learning
-Bonus
-    </code>
+    <code>SUBCLASSLEVEL:1 &lt;tab&gt; FEATAUTO:Abjurer Learning
+Bonus</code>
     <br/>
-    <code>
-     SUBCLASSLEVEL:10 &lt;tab&gt; SA:Immune to Acid
-    </code>
+    <code>SUBCLASSLEVEL:10 &lt;tab&gt; SA:Immune to Acid</code>
     <br/>
-    <code>
-     1 . . .
-    </code>
+    <code>1 . . .</code>
     <br/>
-    <code>
-     2 . . .
-    </code>
+    <code>2 . . .</code>
     <br/>
-    <code>
-     .
-    </code>
+    <code>.</code>
     <br/>
-    <code>
-     .
-    </code>
+    <code>.</code>
     <br/>
-    <code>
-     .
-    </code>
+    <code>.</code>
     <br/>
-    <code>
-     19 . . .
-    </code>
+    <code>19 . . .</code>
     <br/>
-    <code>
-     20 . . .
-    </code>
+    <code>20 . . .</code>
    </p>
   </blockquote>
   <h3>
@@ -326,17 +266,13 @@ levels as you desire in your set and when your character reaches a
 level with a substitution level he/she will be able to select the
 substitution level or the standard level as he/she desires.
 Substitution levels can be implemented with the inclusion of the
-   <code>
-    <a href="#substitutionclass">
+   <code><a href="#substitutionclass">
      SUBSTITUTIONCLASS
-    </a>
-   </code>
+    </a></code>
    and
-   <code>
-    <a href="#substitutionlevel">
+   <code><a href="#substitutionlevel">
      SUBSTITUTIONLEVEL
-    </a>
-   </code>
+    </a></code>
    tags.
   </p>
   <p>
@@ -349,18 +285,14 @@ Substitution levels can be implemented with the inclusion of the
     <strong>
      NOTE:
     </strong>
-    <code>
-     HASSUBSTITUTIONLEVEL
-    </code>
+    <code>HASSUBSTITUTIONLEVEL</code>
     is no
 longer required to create a substitution level.
    </li>
    <li>
     Begins with the
-    <code>
-     SUBSTITUTIONCLASS:&lt;substitution class
-name&gt;
-    </code>
+    <code>SUBSTITUTIONCLASS:&lt;substitution class
+name&gt;</code>
     tag.
    </li>
    <li>
@@ -380,10 +312,8 @@ tags should be used on this line.
   <ul>
    <li>
     Begins with the
-    <code>
-     SUBSTITUTIONLEVEL:&lt;level
-number&gt;
-    </code>
+    <code>SUBSTITUTIONLEVEL:&lt;level
+number&gt;</code>
     tag.
    </li>
    <li>
@@ -424,54 +354,30 @@ Entry
   </p>
   <blockquote>
    <p>
-    <code>
-     CLASS:Ranger . . .
-    </code>
+    <code>CLASS:Ranger . . .</code>
     <br/>
-    <code>
-     CLASS:Ranger . . .
-    </code>
+    <code>CLASS:Ranger . . .</code>
     <br/>
-    <code>
-     SUBSTITUTIONCLASS:Orc Ranger
-    </code>
+    <code>SUBSTITUTIONCLASS:Orc Ranger</code>
     <br/>
-    <code>
-     SUBSTITUTIONLEVEL:4 &lt;tab&gt; HITDIE:12 &lt;tab&gt;
-SA:Goblin Slave (Ex)
-    </code>
+    <code>SUBSTITUTIONLEVEL:4 &lt;tab&gt; HITDIE:12 &lt;tab&gt;
+SA:Goblin Slave (Ex)</code>
     <br/>
-    <code>
-     SUBSTITUTIONLEVEL:10 &lt;tab&gt; HITDIE:12
-    </code>
+    <code>SUBSTITUTIONLEVEL:10 &lt;tab&gt; HITDIE:12</code>
     <br/>
-    <code>
-     1 . . .
-    </code>
+    <code>1 . . .</code>
     <br/>
-    <code>
-     2 . . .
-    </code>
+    <code>2 . . .</code>
     <br/>
-    <code>
-     .
-    </code>
+    <code>.</code>
     <br/>
-    <code>
-     .
-    </code>
+    <code>.</code>
     <br/>
-    <code>
-     .
-    </code>
+    <code>.</code>
     <br/>
-    <code>
-     19 . . .
-    </code>
+    <code>19 . . .</code>
     <br/>
-    <code>
-     20 . . .
-    </code>
+    <code>20 . . .</code>
    </p>
   </blockquote>
   <p>
@@ -482,22 +388,14 @@ Entry
   </p>
   <blockquote>
    <p>
-    <code>
-     CLASS:Ranger.MOD
-    </code>
+    <code>CLASS:Ranger.MOD</code>
     <br/>
-    <code>
-     SUBSTITUTIONCLASS:Orc Ranger
-    </code>
+    <code>SUBSTITUTIONCLASS:Orc Ranger</code>
     <br/>
-    <code>
-     SUBSTITUTIONLEVEL:4 &lt;tab&gt; HITDIE:12 &lt;tab&gt;
-SA:Goblin Slave (Ex)
-    </code>
+    <code>SUBSTITUTIONLEVEL:4 &lt;tab&gt; HITDIE:12 &lt;tab&gt;
+SA:Goblin Slave (Ex)</code>
     <br/>
-    <code>
-     SUBSTITUTIONLEVEL:10 &lt;tab&gt; HITDIE:12
-    </code>
+    <code>SUBSTITUTIONLEVEL:10 &lt;tab&gt; HITDIE:12</code>
     <br/>
    </p>
   </blockquote>
@@ -584,9 +482,7 @@ name.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ABB:Rgr
-   </code>
+   <code>ABB:Rgr</code>
   </p>
   <p class="indent3">
    The class abbreviation is "Rgr".
@@ -643,9 +539,7 @@ or UAB
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ATTACKCYCLE:UAB|3
-   </code>
+   <code>ATTACKCYCLE:UAB|3</code>
   </p>
   <p class="indent3">
    Grants another attack ever 3 bonus points of BAB
@@ -719,36 +613,28 @@ Class Name (Source)' ex. Cleric (Fey).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CLASS:Ranger
-   </code>
+   <code>CLASS:Ranger</code>
   </p>
   <p class="indent3">
    The full class name is "Ranger".
   </p>
   <p class="indent2">
-   <code>
-    CLASS:Defender.MOD &lt;tab&gt;
-TEMPLATE:Maximum Spell Level
-   </code>
+   <code>CLASS:Defender.MOD &lt;tab&gt;
+TEMPLATE:Maximum Spell Level</code>
   </p>
   <p class="indent3">
    Adds the TEMPLATE:Maximum Spell Level to the
 class "Defender".
   </p>
   <p class="indent2">
-   <code>
-    CLASS:Rogue.COPY=Rogueless
-   </code>
+   <code>CLASS:Rogue.COPY=Rogueless</code>
   </p>
   <p class="indent3">
    Copies the Class "Rogue" and renames to
 "Rogueless".
   </p>
   <p class="indent2">
-   <code>
-    CLASS:Fighter.FORGET
-   </code>
+   <code>CLASS:Fighter.FORGET</code>
   </p>
   <p class="indent3">
    Removes the Class "Fighter" from the
@@ -800,9 +686,7 @@ that is used to determine CR for creatures with this class.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CLASSTYPE:PC
-   </code>
+   <code>CLASSTYPE:PC</code>
   </p>
   <p class="indent3">
    The PC class type is used to determine the CR
@@ -840,9 +724,7 @@ at each level gained.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    HD:10
-   </code>
+   <code>HD:10</code>
   </p>
   <p class="indent3">
    The hit dice per level is 10.
@@ -904,27 +786,21 @@ menu to allow this to be overridden.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    MAXLEVEL:10
-   </code>
+   <code>MAXLEVEL:10</code>
   </p>
   <p class="indent3">
    The maximum class level is 10.
   </p>
   <p class="indent2">
-   <code>
-    CLASS:Barbarian.MOD &lt;tab&gt;
-MAXLEVEL:100
-   </code>
+   <code>CLASS:Barbarian.MOD &lt;tab&gt;
+MAXLEVEL:100</code>
   </p>
   <p class="indent3">
    The maximum class level is modified to 100.
   </p>
   <p class="indent2">
-   <code>
-    CLASS:Barbarian.MOD &lt;tab&gt;
-MAXLEVEL:NOLIMIT
-   </code>
+   <code>CLASS:Barbarian.MOD &lt;tab&gt;
+MAXLEVEL:NOLIMIT</code>
   </p>
   <p class="indent3">
    Remove the previously specified maximum class
@@ -971,41 +847,33 @@ per level.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    STARTSKILLPTS:4
-   </code>
+   <code>STARTSKILLPTS:4</code>
   </p>
   <p class="indent3">
    Class gets 4 skill points per level, before any
 modifiers.
   </p>
   <p class="indent2">
-   <code>
-    STARTSKILLPTS:4+INT
-   </code>
+   <code>STARTSKILLPTS:4+INT</code>
   </p>
   <p class="indent3">
    Class gets 4 skill points per level plus the INT
 Bonus points, before any modifiers.
   </p>
   <p class="indent2">
-   <code>
-    STARTSKILLPTS:4/CHA
-   </code>
+   <code>STARTSKILLPTS:4/CHA</code>
   </p>
   <p class="indent3">
    Class gets 4 skill points per level divided by
 the CHA Bonus points, before any modifiers.
   </p>
   <p class="indent2">
-   <code>
-    CLASS:Blackguard.MOD &lt;tab&gt;
+   <code>CLASS:Blackguard.MOD &lt;tab&gt;
 STARTSKILLPTS:2 &lt;tab&gt; CSKILL:.CLEAR|Handle Animal|Ride
 &lt;tab&gt;
 CSKILL:Concentration|TYPE.Craft|Diplomacy|Heal|Intimidate|Knowledge
 (Religion) |TYPE.Profession|Climb|Jump|Listen|Spot|Swim|Pilot
-&lt;tab&gt; CCSKILL:Handle Animal|Ride
-   </code>
+&lt;tab&gt; CCSKILL:Handle Animal|Ride</code>
   </p>
   <p class="indent3">
    Modified Class that changes all of these Tags
@@ -1050,9 +918,7 @@ the class will get at first level only.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    XTRAFEATS:1
-   </code>
+   <code>XTRAFEATS:1</code>
   </p>
   <p class="indent3">
    The class will gets 1 extra feat.
@@ -1125,38 +991,30 @@ after the domain name.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CLASS:Foo &lt;tab&gt;
+   <code>CLASS:Foo &lt;tab&gt;
 ADDDOMAINS:Travel|Sun &lt;tab&gt; SPELLSTAT:CHA &lt;tab&gt;
-SPELLTYPE:Arcane
-   </code>
+SPELLTYPE:Arcane</code>
   </p>
   <p class="indent3">
    The class gets the Travel and Sun domains as a
 choice regardless of the deity selected.
   </p>
   <p class="indent2">
-   <code>
-    ADDDOMAINS:Sun
-   </code>
+   <code>ADDDOMAINS:Sun</code>
   </p>
   <p class="indent3">
    The class gets the Sun domain as a choice
 regardless of the deity selected.
   </p>
   <p class="indent2">
-   <code>
-    ADDDOMAINS:Sun|Law
-   </code>
+   <code>ADDDOMAINS:Sun|Law</code>
   </p>
   <p class="indent3">
    The class gets the Sun &amp; Law domains as a
 choice regardless of the deity selected.
   </p>
   <p class="indent2">
-   <code>
-    ADDDOMAINS:Sun[PREDIETY:Ra]|Law
-   </code>
+   <code>ADDDOMAINS:Sun[PREDIETY:Ra]|Law</code>
   </p>
   <p class="indent3">
    The class gets to choose between the Sun domain,
@@ -1180,15 +1038,11 @@ regardless of the deity selected.
    </span>
   </p>
   <p class="indent2">
-   <code>
-    ADDDOMAINS:Travel.Sun
-   </code>
+   <code>ADDDOMAINS:Travel.Sun</code>
   </p>
   <p class="indent3">
    Becomes:
-   <code>
-    ADDDOMAINS:Travel|Sun
-   </code>
+   <code>ADDDOMAINS:Travel|Sun</code>
   </p>
   <hr/>
   <p class="status">
@@ -1247,18 +1101,14 @@ racial spells. See the
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:CASTERLEVEL|Wizard|CL
-   </code>
+   <code>BONUS:CASTERLEVEL|Wizard|CL</code>
   </p>
   <p class="indent3">
    Sets the Wizard's spell caster level to his
 class level.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:CASTERLEVEL|Paladin|CL/2|PRECLASSLEVEL:Paladin=4
-   </code>
+   <code>BONUS:CASTERLEVEL|Paladin|CL/2|PRECLASSLEVEL:Paladin=4</code>
   </p>
   <p class="indent3">
    Sets the Paladin's spell caster level to half
@@ -1317,22 +1167,18 @@ spells.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUSSPELLSTAT:STR
-   </code>
+   <code>BONUSSPELLSTAT:STR</code>
   </p>
   <p class="indent3">
    The class uses Strength to determine bonus
 spells.
   </p>
   <p class="indent2">
-   <code>
-    CLASS:Defender.MOD &lt;tab&gt;
+   <code>CLASS:Defender.MOD &lt;tab&gt;
 SPELLSTAT:INT &lt;tab&gt; BONUSSPELLSTAT:NONE &lt;tab&gt;
 SPELLTYPE:Arcane &lt;tab&gt; SPELLBOOK:NO &lt;tab&gt;
 BONUS:CASTERLEVEL|Defender|TL &lt;tab&gt;
-SPELLLIST:1|Channeler
-   </code>
+SPELLLIST:1|Channeler</code>
   </p>
   <p class="indent3">
    Modifying the class Defender changes all of
@@ -1394,9 +1240,7 @@ variable and use the variable in the CAST progression.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CAST:3,3,1
-   </code>
+   <code>CAST:3,3,1</code>
   </p>
   <p class="indent3">
    Class can cast 3 0th level spells, 3 1st level
@@ -1408,17 +1252,13 @@ spells and 1 2nd level spell.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DEFINE:CastLvl0|min(6,4+CL) &lt;tab&gt;
-CAST:CastLvl0
-   </code>
+   <code>DEFINE:CastLvl0|min(6,4+CL) &lt;tab&gt;
+CAST:CastLvl0</code>
   </p>
   <p class="indent3">
    Sets the cast progression to the value of the
 variable
-   <code>
-    CastLvl0
-   </code>
+   <code>CastLvl0</code>
    for 0 level spells.
   </p>
   <p class="indent1">
@@ -1460,17 +1300,13 @@ Name:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DEITY:Zeus
-   </code>
+   <code>DEITY:Zeus</code>
   </p>
   <p class="indent3">
    Class may only have "Zeus" as its Deity.
   </p>
   <p class="indent2">
-   <code>
-    DEITY:Zeus|Athena
-   </code>
+   <code>DEITY:Zeus|Athena</code>
   </p>
   <p class="indent3">
    Class may have "Zeus" or "Athena" as its
@@ -1519,24 +1355,18 @@ character.
    <li>
     If a domain is added on top of the character's other normal
 domains, it will need to be paired with a
-    <code>
-     BONUS:DOMAIN|NUMBER|x
-    </code>
+    <code>BONUS:DOMAIN|NUMBER|x</code>
     .
    </li>
    <li>
     This tag can use trailing PRExxx tags to provide prerequisites
 for the domains included in the associated
-    <code>
-     DOMAIN
-    </code>
+    <code>DOMAIN</code>
     tag.
    </li>
    <li>
     Multiple
-    <code>
-     DOMAIN
-    </code>
+    <code>DOMAIN</code>
     tags may be used in a class
 object, allowing access to some domains without prerequisites and
 some with.
@@ -1548,28 +1378,22 @@ some with.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    7 &lt;tab&gt; DOMAIN:Sun
-   </code>
+   <code>7 &lt;tab&gt; DOMAIN:Sun</code>
   </p>
   <p class="indent3">
    At the seventh level class gets the Sun domain
 added.
   </p>
   <p class="indent2">
-   <code>
-    15 &lt;tab&gt; DOMAIN:Sun|Law
-   </code>
+   <code>15 &lt;tab&gt; DOMAIN:Sun|Law</code>
   </p>
   <p class="indent3">
    At fifteenth level class gets the Sun or law
 domain added.
   </p>
   <p class="indent2">
-   <code>
-    11 &lt;tab&gt; DOMAIN:Sun|PREDEITY:Ra
-&lt;tab&gt; DOMAIN:Law
-   </code>
+   <code>11 &lt;tab&gt; DOMAIN:Sun|PREDEITY:Ra
+&lt;tab&gt; DOMAIN:Law</code>
   </p>
   <p class="indent3">
    At eleventh level class gets the Sun or Law
@@ -1623,18 +1447,14 @@ will default to a value of 1.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ITEMCREATE:2
-   </code>
+   <code>ITEMCREATE:2</code>
   </p>
   <p class="indent3">
    The class level is doubled when calculating
 potions, scrolls and wands.
   </p>
   <p class="indent2">
-   <code>
-    CLASS:Paladin ITEMCREATE:CL/3.3
-   </code>
+   <code>CLASS:Paladin ITEMCREATE:CL/3.3</code>
   </p>
   <p class="indent3">
    The class level is calculated to the following
@@ -1698,9 +1518,7 @@ variable and use the variable in the KNOWN progression.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    KNOWN:6,4,3
-   </code>
+   <code>KNOWN:6,4,3</code>
   </p>
   <p class="indent3">
    The class knows 6 0th level spells, 4 1st level
@@ -1712,17 +1530,13 @@ spells and 3 2nd level spells.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DEFINE:KnownLvl0|min(9,4+(CL/2))
-&lt;tab&gt; KNOWN:KnownLvl0
-   </code>
+   <code>DEFINE:KnownLvl0|min(9,4+(CL/2))
+&lt;tab&gt; KNOWN:KnownLvl0</code>
   </p>
   <p class="indent3">
    Sets the known progression to the value of the
 variable
-   <code>
-    KnownLvl0
-   </code>
+   <code>KnownLvl0</code>
    for 0 level spells.
   </p>
   <p class="indent1">
@@ -1793,9 +1607,7 @@ prerequisites. (e.g. class level and required spell-stat
 score.)
    </li>
    <li>
-    <code>
-     .CLEARALL
-    </code>
+    <code>.CLEARALL</code>
     will clear all spells awarded on Class
 or Class Level line 0.
    </li>
@@ -1810,30 +1622,24 @@ otherwise Class Level Lines are NOT allowed.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CLASS:Monkey Mage &lt;tab&gt;
-KNOWNSPELLS:Acid Fog
-   </code>
+   <code>CLASS:Monkey Mage &lt;tab&gt;
+KNOWNSPELLS:Acid Fog</code>
   </p>
   <p class="indent3">
    The class knows the spell "Acid Fog" at 6th
 Level.
   </p>
   <p class="indent2">
-   <code>
-    CLASS:Monkey Mage &lt;tab&gt;
-KNOWNSPELLS:Acid Fog|Alarm
-   </code>
+   <code>CLASS:Monkey Mage &lt;tab&gt;
+KNOWNSPELLS:Acid Fog|Alarm</code>
   </p>
   <p class="indent3">
    The class knows the spell "Acid Fog" at 6th
 Level; and "Alarm" at 1st Level.
   </p>
   <p class="indent2">
-   <code>
-    CLASS:Monkey Mage &lt;tab&gt;
-KNOWNSPELLS:LEVEL=3
-   </code>
+   <code>CLASS:Monkey Mage &lt;tab&gt;
+KNOWNSPELLS:LEVEL=3</code>
   </p>
   <p class="indent3">
    The class knows all level 3 spells
@@ -1848,19 +1654,15 @@ available.
         <p class="indent3">The class knows all level 3 spells available.</p>
 -->
   <p class="indent2">
-   <code>
-    CLASS:Monkey Cleric &lt;tab&gt;
-KNOWNSPELLS:TYPE=Divine
-   </code>
+   <code>CLASS:Monkey Cleric &lt;tab&gt;
+KNOWNSPELLS:TYPE=Divine</code>
   </p>
   <p class="indent3">
    The class knows all available divine spells.
   </p>
   <p class="indent2">
-   <code>
-    CLASS:Monkey Mage &lt;tab&gt;
-KNOWNSPELLS:LEVEL=3,TYPE=Arcane
-   </code>
+   <code>CLASS:Monkey Mage &lt;tab&gt;
+KNOWNSPELLS:LEVEL=3,TYPE=Arcane</code>
   </p>
   <p class="indent3">
    The class Monkey Mage knows all level 3 arcane
@@ -1912,9 +1714,7 @@ spells as a wizard does.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    MEMORIZE:YES
-   </code>
+   <code>MEMORIZE:YES</code>
   </p>
   <p class="indent3">
    The class memorizes spells as a wizard does.
@@ -1959,9 +1759,7 @@ taken).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PROHIBITED:Divination,Necromancy
-   </code>
+   <code>PROHIBITED:Divination,Necromancy</code>
   </p>
   <p class="indent3">
    The class cannot use Divination or
@@ -2052,45 +1850,35 @@ the PROHIBITSPELLS house rule preference.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PROHIBITSPELL:ALIGNMENT.Evil
-   </code>
+   <code>PROHIBITSPELL:ALIGNMENT.Evil</code>
   </p>
   <p class="indent3">
    Prohibits the character from taking spells with
 the "Evil" descriptor.
   </p>
   <p class="indent2">
-   <code>
-    PROHIBITSPELL:ALIGNMENT.Chaotic.Evil
-   </code>
+   <code>PROHIBITSPELL:ALIGNMENT.Chaotic.Evil</code>
   </p>
   <p class="indent3">
    Prohibits the character from taking spells that
 have both the "Chaotic" and the "Evil" descriptors.
   </p>
   <p class="indent2">
-   <code>
-    PROHIBITSPELL:DESCRIPTOR.Fear
-   </code>
+   <code>PROHIBITSPELL:DESCRIPTOR.Fear</code>
   </p>
   <p class="indent3">
    Prohibits the character from taking spells with
 the "Fear" descriptor.
   </p>
   <p class="indent2">
-   <code>
-    PROHIBITSPELL:SCHOOL.Illusion
-   </code>
+   <code>PROHIBITSPELL:SCHOOL.Illusion</code>
   </p>
   <p class="indent3">
    Prohibits the character from taking spells from
 the "Illusion" school.
   </p>
   <p class="indent2">
-   <code>
-    PROHIBITSPELL:SUBSCHOOL.Healing
-   </code>
+   <code>PROHIBITSPELL:SUBSCHOOL.Healing</code>
   </p>
   <p class="indent3">
    Prohibits the character from taking spells from
@@ -2098,8 +1886,7 @@ the "Healing" subschool.
   </p>
   <blockquote class="indent2">
    <p class="tagindent2">
-    <code>
-     1 &lt;tab&gt;
+    <code>1 &lt;tab&gt;
 PROHIBITSPELL:ALIGNMENT.Good|PREALIGN:LE,NE,CE &lt;tab&gt;
 PROHIBITSPELL:ALIGNMENT.Evil|PREALIGN:LG,NG,CG &lt;tab&gt;
 PROHIBITSPELL:ALIGNMENT.Lawful|PREALIGN:CG,CN,CE &lt;tab&gt;
@@ -2107,8 +1894,7 @@ PROHIBITSPELL:ALIGNMENT.Chaotic|PREALIGN:LG,LN,LE &lt;tab&gt;
 PROHIBITSPELL:ALIGNMENT.Good|PREDEITYALIGN:LE,NE,CE &lt;tab&gt;
 PROHIBITSPELL:ALIGNMENT.Evil|PREDEITYALIGN:LG,NG,CG &lt;tab&gt;
 PROHIBITSPELL:ALIGNMENT.Lawful|PREDEITYALIGN:CG,CN,CE &lt;tab&gt;
-PROHIBITSPELL:ALIGNMENT.Chaotic|PREDEITYALIGN:LG,LN,LE
-    </code>
+PROHIBITSPELL:ALIGNMENT.Chaotic|PREDEITYALIGN:LG,LN,LE</code>
    </p>
   </blockquote>
   <p class="indent3">
@@ -2122,10 +1908,8 @@ alignment is CG,CN,CE; taking "Chaotic" spells if Deity alignment
 is LG,LN,LE.
   </p>
   <p class="indent2">
-   <code>
-    PROHIBITSPELL:SPELL.Fireball,Lightning
-Bolt
-   </code>
+   <code>PROHIBITSPELL:SPELL.Fireball,Lightning
+Bolt</code>
   </p>
   <p class="indent3">
    Prohibits the character from taking either
@@ -2177,18 +1961,14 @@ both racial hit dice and class levels.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ROLE:Skill
-   </code>
+   <code>ROLE:Skill</code>
   </p>
   <p class="indent3">
    Character levels in this class are key levels
 for CR calculation purposes for creatures with the Skill role.
   </p>
   <p class="indent2">
-   <code>
-    ROLE:Combat.Skill
-   </code>
+   <code>ROLE:Combat.Skill</code>
   </p>
   <p class="indent3">
    Character levels in this class are key levels
@@ -2226,21 +2006,17 @@ spellbook as a wizard does.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SPELLBOOK:YES
-   </code>
+   <code>SPELLBOOK:YES</code>
   </p>
   <p class="indent3">
    The class uses a spellbook.
   </p>
   <p class="indent2">
-   <code>
-    CLASS:Defender.MOD &lt;tab&gt;
+   <code>CLASS:Defender.MOD &lt;tab&gt;
 SPELLSTAT:INT &lt;tab&gt; BONUSSPELLSTAT:NONE &lt;tab&gt;
 SPELLTYPE:Arcane &lt;tab&gt; SPELLBOOK:NO &lt;tab&gt;
 BONUS:CASTERLEVEL|Defender|TL &lt;tab&gt;
-SPELLLIST:1|Channeler
-   </code>
+SPELLLIST:1|Channeler</code>
   </p>
   <p class="indent3">
    Modifying the class Defender changes all of
@@ -2260,9 +2036,7 @@ these tags to determine bonus spells and maximum casting level.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    NO
-   </code>
+   <code>NO</code>
   </p>
   <hr/>
   <p class="status">
@@ -2319,9 +2093,7 @@ duplicate spell casting ability.
    <li>
     For a spellcasting class with subclasses that have separate
 spell lists, the
-    <code>
-     SPELLLIST
-    </code>
+    <code>SPELLLIST</code>
     tag should be included in
 the subclass line only.
    </li>
@@ -2332,61 +2104,49 @@ the subclass line only.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CLASS:Faemancer &lt;tab&gt;
-SPELLLIST:1|Ranger
-   </code>
+   <code>CLASS:Faemancer &lt;tab&gt;
+SPELLLIST:1|Ranger</code>
   </p>
   <p class="indent3">
    The class uses the ranger spell list.
   </p>
   <p class="indent2">
-   <code>
-    SUBCLASS:Egoist &lt;tab&gt;
-SPELLLIST:1|Ranger|Druid
-   </code>
+   <code>SUBCLASS:Egoist &lt;tab&gt;
+SPELLLIST:1|Ranger|Druid</code>
   </p>
   <p class="indent3">
    The subclass uses either the ranger or druid
 spell list.
   </p>
   <p class="indent2">
-   <code>
-    CLASS:War Mind &lt;tab&gt;
-SPELLLIST:2|Ranger|Druid|Barabarian
-   </code>
+   <code>CLASS:War Mind &lt;tab&gt;
+SPELLLIST:2|Ranger|Druid|Barabarian</code>
   </p>
   <p class="indent3">
    The class uses 2 of the ranger, Druid or
 Barbarian spell lists.
   </p>
   <p class="indent2">
-   <code>
-    CLASS:Blood Witch &lt;tab&gt;
-SPELLLIST:1|DOMAIN.Animal
-   </code>
+   <code>CLASS:Blood Witch &lt;tab&gt;
+SPELLLIST:1|DOMAIN.Animal</code>
   </p>
   <p class="indent3">
    The class uses the Animal Domain spell list.
   </p>
   <p class="indent2">
-   <code>
-    CLASS:Rogue.COPY=Blood Witch &lt;tab&gt;
-SPELLLIST:1|DOMAIN.Animal
-   </code>
+   <code>CLASS:Rogue.COPY=Blood Witch &lt;tab&gt;
+SPELLLIST:1|DOMAIN.Animal</code>
   </p>
   <p class="indent3">
    Copy class Rogue to Blood Witch useing the
 Animal Domain spell list.
   </p>
   <p class="indent2">
-   <code>
-    CLASS:Defender.MOD &lt;tab&gt;
+   <code>CLASS:Defender.MOD &lt;tab&gt;
 SPELLSTAT:INT &lt;tab&gt; BONUSSPELLSTAT:NONE &lt;tab&gt;
 SPELLTYPE:Arcane &lt;tab&gt; SPELLBOOK:NO &lt;tab&gt;
 BONUS:CASTERLEVEL|Defender|TL &lt;tab&gt;
-SPELLLIST:1|Channeler
-   </code>
+SPELLLIST:1|Channeler</code>
   </p>
   <p class="indent3">
    Modifying the class Defender changes all of
@@ -2442,9 +2202,7 @@ bonus spells and maximum level the character can cast
    </li>
    <li>
     Used in a Subclass Line this tag overwrites any
-    <code>
-     SPELLSTAT
-    </code>
+    <code>SPELLSTAT</code>
     tag in the main Class Line.
    </li>
    <li>
@@ -2456,22 +2214,16 @@ bonus spells and maximum level the character can cast
    </li>
    <li>
     Use of the
-    <code>
-     SPELL
-    </code>
+    <code>SPELL</code>
     subtag tells PCGen to use the
 stat specified in the
-    <code>
-     SPELLSTAT
-    </code>
+    <code>SPELLSTAT</code>
     tag located in the
 class' individual spells.
    </li>
    <li>
     Use of the
-    <code>
-     OTHER
-    </code>
+    <code>OTHER</code>
     subtag will result in no stat
 bonuses being granted.
    </li>
@@ -2482,45 +2234,35 @@ bonuses being granted.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SPELLSTAT:INT
-   </code>
+   <code>SPELLSTAT:INT</code>
   </p>
   <p class="indent3">
    This class/subclass uses Intelligence to
 determine maximum level of spells.
   </p>
   <p class="indent2">
-   <code>
-    SPELLSTAT:SPELL
-   </code>
+   <code>SPELLSTAT:SPELL</code>
   </p>
   <p class="indent3">
    This class/subclass uses the stat specified in
 the
-   <code>
-    STAT:x
-   </code>
+   <code>STAT:x</code>
    tag in the spells the class/subclass
 uses.
   </p>
   <p class="indent2">
-   <code>
-    SPELLSTAT:OTHER
-   </code>
+   <code>SPELLSTAT:OTHER</code>
   </p>
   <p class="indent3">
    Thia class/subclass does not recieve a stat
 bonus for spell casting.
   </p>
   <p class="indent2">
-   <code>
-    CLASS:Defender.MOD &lt;tab&gt;
+   <code>CLASS:Defender.MOD &lt;tab&gt;
 SPELLSTAT:INT &lt;tab&gt; BONUSSPELLSTAT:NONE &lt;tab&gt;
 SPELLTYPE:Arcane &lt;tab&gt; SPELLBOOK:NO &lt;tab&gt;
 BONUS:CASTERLEVEL|Defender|TL &lt;tab&gt;
-SPELLLIST:1|Channeler
-   </code>
+SPELLLIST:1|Channeler</code>
   </p>
   <p class="indent3">
    Modifies the
@@ -2572,21 +2314,17 @@ type)
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SPELLTYPE:Arcane
-   </code>
+   <code>SPELLTYPE:Arcane</code>
   </p>
   <p class="indent3">
    The class uses arcane spells.
   </p>
   <p class="indent2">
-   <code>
-    CLASS:Defender.MOD &lt;tab&gt;
+   <code>CLASS:Defender.MOD &lt;tab&gt;
 SPELLSTAT:INT &lt;tab&gt; BONUSSPELLSTAT:NONE &lt;tab&gt;
 SPELLTYPE:Arcane &lt;tab&gt; SPELLBOOK:NO &lt;tab&gt;
 BONUS:CASTERLEVEL|Defender|TL &lt;tab&gt;
-SPELLLIST:1|Channeler
-   </code>
+SPELLLIST:1|Channeler</code>
   </p>
   <p class="indent3">
    Modifying the class Defender changes all of
@@ -2635,10 +2373,8 @@ not listed, the default value is 0.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    19 &lt;tab&gt;
-SPECIALTYKNOWN:1,1,1,1,1,1,1,1,1,1
-   </code>
+   <code>19 &lt;tab&gt;
+SPECIALTYKNOWN:1,1,1,1,1,1,1,1,1,1</code>
   </p>
   <p class="indent3">
    At 19 level the specialist can prepare one
@@ -2646,10 +2382,8 @@ additional Zero thru ninth level spell (of the school selected as a
 specialty) per spell level each day.
   </p>
   <p class="indent2">
-   <code>
-    12 &lt;tab&gt;
-SPECIALTYKNOWN:1,1,1
-   </code>
+   <code>12 &lt;tab&gt;
+SPECIALTYKNOWN:1,1,1</code>
   </p>
   <p class="indent3">
    At 12 level the Paladin can prepare one third
@@ -2714,9 +2448,7 @@ when selecting a subclass.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ALLOWBASECLASS:NO
-   </code>
+   <code>ALLOWBASECLASS:NO</code>
   </p>
   <p class="indent3">
    The base class cannot be selected, only
@@ -2797,56 +2529,44 @@ subschools available.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SUBCLASS:Illusionist &lt;tab&gt;
-CHOICE:SCHOOL|Illusion
-   </code>
+   <code>SUBCLASS:Illusionist &lt;tab&gt;
+CHOICE:SCHOOL|Illusion</code>
   </p>
   <p class="indent3">
    For an Illusionist.
   </p>
   <p class="indent2">
-   <code>
-    SUBCLASS:Abjure &lt;tab&gt;
-CHOICE:SCHOOL|Abjuration
-   </code>
+   <code>SUBCLASS:Abjure &lt;tab&gt;
+CHOICE:SCHOOL|Abjuration</code>
   </p>
   <p class="indent3">
    For an Abjurer.
   </p>
   <p class="indent2">
-   <code>
-    SUBCLASS:Diviner &lt;tab&gt;
-CHOICE:SCHOOL|Divination
-   </code>
+   <code>SUBCLASS:Diviner &lt;tab&gt;
+CHOICE:SCHOOL|Divination</code>
   </p>
   <p class="indent3">
    For a Diviner.
   </p>
   <p class="indent2">
-   <code>
-    SUBCLASS:Savant &lt;tab&gt;
-CHOICE:SCHOOL|Psychokinesis
-   </code>
+   <code>SUBCLASS:Savant &lt;tab&gt;
+CHOICE:SCHOOL|Psychokinesis</code>
   </p>
   <p class="indent3">
    For a Psychokinesis.
   </p>
   <p class="indent2">
-   <code>
-    SUBCLASS:Shaper &lt;tab&gt;
-CHOICE:SCHOOL|Illusion.CLEAR
-   </code>
+   <code>SUBCLASS:Shaper &lt;tab&gt;
+CHOICE:SCHOOL|Illusion.CLEAR</code>
   </p>
   <p class="indent3">
    Removes the choice for an Illusionist.
   </p>
   <p class="indent2">
-   <code>
-    SUBCLASS:Nomad &lt;tab&gt;
+   <code>SUBCLASS:Nomad &lt;tab&gt;
 CHOICE:SCHOOL|Abjuration.MOD &lt;tab&gt;
-CHOICE:SCHOOL|Divination
-   </code>
+CHOICE:SCHOOL|Divination</code>
   </p>
   <p class="indent3">
    Replaces the choice for an Abjurer with
@@ -2895,9 +2615,7 @@ must be selected) of this specialty or subclass (0 is default).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    COST:2
-   </code>
+   <code>COST:2</code>
   </p>
   <p class="indent3">
    The subclass has a cost of 2.
@@ -2947,9 +2665,7 @@ allotment.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    KNOWNSPELLSFROMSPECIALTY:1
-   </code>
+   <code>KNOWNSPELLSFROMSPECIALTY:1</code>
   </p>
   <p class="indent3">
    The subclass has 1 spell from their specialty in
@@ -3003,9 +2719,7 @@ prevents this school from being prohibited.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PROHIBITCOST:2
-   </code>
+   <code>PROHIBITCOST:2</code>
   </p>
   <p class="indent3">
    The subclass has a prohibited cost of 2.
@@ -3056,9 +2770,7 @@ specialties.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SUBCLASS:Illusionist
-   </code>
+   <code>SUBCLASS:Illusionist</code>
   </p>
   <p class="indent3">
    The class has Illusionist as a subclass.
@@ -3115,10 +2827,8 @@ immediately above it.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SUBCLASSLEVEL:3 &lt;tab&gt;
-SA:Angelfire
-   </code>
+   <code>SUBCLASSLEVEL:3 &lt;tab&gt;
+SA:Angelfire</code>
   </p>
   <p class="indent3">
    would add SA:Angelfire at level 3
@@ -3177,9 +2887,7 @@ levels.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SUBSTITUTIONCLASS:Orc Ranger
-   </code>
+   <code>SUBSTITUTIONCLASS:Orc Ranger</code>
   </p>
   <p class="indent3">
    The class has Orc Ranger substitution
@@ -3236,10 +2944,8 @@ immediately above it.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SUBSTITUTIONLEVEL:4 &lt;tab&gt; SA:Goblin
-Slave (Ex)
-   </code>
+   <code>SUBSTITUTIONLEVEL:4 &lt;tab&gt; SA:Goblin
+Slave (Ex)</code>
   </p>
   <p class="indent3">
    would add SA:Goblin Slave (Ex) at level 4
@@ -3362,54 +3068,40 @@ skills.
    </li>
    <li>
     If
-    <code>
-     ANY
-    </code>
+    <code>ANY</code>
     or
-    <code>
-     ALL
-    </code>
+    <code>ALL</code>
     are used, the list of
 skills to select from will include all skills.
    </li>
    <li>
     If
-    <code>
-     CROSSCLASSSKILLS
-    </code>
+    <code>CROSSCLASSSKILLS</code>
     is used, the list of skills to
 select from will include all cross-class skills.
    </li>
    <li>
     If
-    <code>
-     UNTRAINED
-    </code>
+    <code>UNTRAINED</code>
     is used, the list of skills to select
 from will include all untrained skills.
    </li>
    <li>
     If
-    <code>
-     TRAINED
-    </code>
+    <code>TRAINED</code>
     is used, the list of skills to select
 from will include all trained skills.
    </li>
    <li>
     If
-    <code>
-     EXCLUSIVE
-    </code>
+    <code>EXCLUSIVE</code>
     is used, the list of skills to select
 from will include all skills exclusive to the associated
 class.
    </li>
    <li>
     If
-    <code>
-     NONEXCLUSIVE
-    </code>
+    <code>NONEXCLUSIVE</code>
     is used, the list of skills to
 select from will include all skills that are not exclusive to the
 assiciated class.
@@ -3424,20 +3116,16 @@ assiciated class.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ADD:CLASSSKILLS|Knowledge
-(Reverie)
-   </code>
+   <code>ADD:CLASSSKILLS|Knowledge
+(Reverie)</code>
   </p>
   <p class="indent3">
    Add "Knowledge (Reverie)" skill to the
 character's list of class skills.
   </p>
   <p class="indent2">
-   <code>
-    ADD:CLASSSKILLS|Knowledge
-(nature),Survival,AUTORANK=3
-   </code>
+   <code>ADD:CLASSSKILLS|Knowledge
+(nature),Survival,AUTORANK=3</code>
   </p>
   <p class="indent3">
    Add "Knowledge (nature)" and "Survival" skills
@@ -3445,72 +3133,56 @@ to the character's list of class skills and grant 2 free ranks in
 each.
   </p>
   <p class="indent2">
-   <code>
-    ADD:CLASSSKILLS|TYPE=Craft
-   </code>
+   <code>ADD:CLASSSKILLS|TYPE=Craft</code>
   </p>
   <p class="indent3">
    Add one skill from the list of "Craft" type
 skills to the character's list of class skills.
   </p>
   <p class="indent2">
-   <code>
-    ADD:CLASSSKILLS|3|ANY
-   </code>
+   <code>ADD:CLASSSKILLS|3|ANY</code>
   </p>
   <p class="indent3">
    Add three skills from the full list of skills to
 the character's list of class skills.
   </p>
   <p class="indent2">
-   <code>
-    ADD:CLASSSKILLS|3|ALL
-   </code>
+   <code>ADD:CLASSSKILLS|3|ALL</code>
   </p>
   <p class="indent3">
    Add three skills from the full list of skills to
 the character's list of class skills.
   </p>
   <p class="indent2">
-   <code>
-    ADD:CLASSSKILLS|CROSSCLASSSKILLS
-   </code>
+   <code>ADD:CLASSSKILLS|CROSSCLASSSKILLS</code>
   </p>
   <p class="indent3">
    Add one skill from the list of cross-class
 skills to the character's list of class skills.
   </p>
   <p class="indent2">
-   <code>
-    ADD:CLASSSKILLS|UNTRAINED
-   </code>
+   <code>ADD:CLASSSKILLS|UNTRAINED</code>
   </p>
   <p class="indent3">
    Add one skill from the list of skills that can
 be used untrained to the character's list of class skills.
   </p>
   <p class="indent2">
-   <code>
-    ADD:CLASSSKILLS|3|TRAINED
-   </code>
+   <code>ADD:CLASSSKILLS|3|TRAINED</code>
   </p>
   <p class="indent3">
    Add three skills from the list of skills that
 require training to the character's list of class skills.
   </p>
   <p class="indent2">
-   <code>
-    ADD:CLASSSKILLS|2|EXCLUSIVE
-   </code>
+   <code>ADD:CLASSSKILLS|2|EXCLUSIVE</code>
   </p>
   <p class="indent3">
    Add two skills from the list of exclusive skills
 to the character's list of class skills.
   </p>
   <p class="indent2">
-   <code>
-    ADD:CLASSSKILLS|2|NONEXCLUSIVE
-   </code>
+   <code>ADD:CLASSSKILLS|2|NONEXCLUSIVE</code>
   </p>
   <p class="indent3">
    Add two skills from the list of non-exclusive
@@ -3559,18 +3231,14 @@ that the bonus appears in
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SKILLPOOL|NUMBER|1
-   </code>
+   <code>BONUS:SKILLPOOL|NUMBER|1</code>
   </p>
   <p class="indent3">
    Adds one skill point to the skill pool.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SKILLPOOL|NUMBER|1|PREFEAT:1,Scribe
-Scroll
-   </code>
+   <code>BONUS:SKILLPOOL|NUMBER|1|PREFEAT:1,Scribe
+Scroll</code>
   </p>
   <p class="indent3">
    Adds one skill point to the skill pool if the
@@ -3624,9 +3292,7 @@ the associated level.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    5 &lt;tab&gt; DONOTADD:HITDIE
-   </code>
+   <code>5 &lt;tab&gt; DONOTADD:HITDIE</code>
   </p>
   <p class="indent3">
    The character will not receive an additional hit
@@ -3673,9 +3339,7 @@ met.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    EXCLASS:Ex Monk
-   </code>
+   <code>EXCLASS:Ex Monk</code>
   </p>
   <p class="indent3">
    If prerequisites are no longer met, the
@@ -3742,10 +3406,8 @@ class to the specified class.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    EXCHANGELEVEL:Ex
-Paladin|11|10|1
-   </code>
+   <code>EXCHANGELEVEL:Ex
+Paladin|11|10|1</code>
   </p>
   <p class="indent3">
    Up to 10 levels of Ex Paladin can be exchanged
@@ -3897,76 +3559,58 @@ sizes specified by the DIESIZES tag.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    HITDIE:12
-   </code>
+   <code>HITDIE:12</code>
   </p>
   <p class="indent3">
    The character now has a Hit Dice of 12.
   </p>
   <p class="indent2">
-   <code>
-    HITDIE:%+2
-   </code>
+   <code>HITDIE:%+2</code>
   </p>
   <p class="indent3">
    Adds 2 to the current Hit Dice size.
   </p>
   <p class="indent2">
-   <code>
-    HITDIE:%-4
-   </code>
+   <code>HITDIE:%-4</code>
   </p>
   <p class="indent3">
    Subtracts 4 from the current Hit Dice size.
   </p>
   <p class="indent2">
-   <code>
-    HITDIE:%*3
-   </code>
+   <code>HITDIE:%*3</code>
   </p>
   <p class="indent3">
    Multiplies the current Hit Dice size by 3.
   </p>
   <p class="indent2">
-   <code>
-    HITDIE:%/2
-   </code>
+   <code>HITDIE:%/2</code>
   </p>
   <p class="indent3">
    Divides the current Hit Dice size by 2.
   </p>
   <p class="indent2">
-   <code>
-    HITDIE:%up2
-   </code>
+   <code>HITDIE:%up2</code>
   </p>
   <p class="indent3">
    Steps up the Hit Dice size by two steps. If the
 class has a Hit Die of d6 it will be stepped up to d10.
   </p>
   <p class="indent2">
-   <code>
-    HITDIE:%down1
-   </code>
+   <code>HITDIE:%down1</code>
   </p>
   <p class="indent3">
    Steps down the Hit Dice size by one step. If the
 class has a Hit Die of d6 it will be stepped down to d4.
   </p>
   <p class="indent2">
-   <code>
-    HITDIE:%Hup4
-   </code>
+   <code>HITDIE:%Hup4</code>
   </p>
   <p class="indent3">
    Steps up the Hit Dice size by four steps. If the
 class has a Hit Die of d6 it will be stepped up to d20.
   </p>
   <p class="indent2">
-   <code>
-    HITDIE:%Hdown3
-   </code>
+   <code>HITDIE:%Hdown3</code>
   </p>
   <p class="indent3">
    Steps down the Hit Dice size by three step. If
@@ -4037,54 +3681,42 @@ is necessary.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    LANGBONUS:Draconic
-   </code>
+   <code>LANGBONUS:Draconic</code>
   </p>
   <p class="indent3">
    The class can choose "Draconic" as one of their
 languages.
   </p>
   <p class="indent2">
-   <code>
-    LANGBONUS:Draconic,Elven
-   </code>
+   <code>LANGBONUS:Draconic,Elven</code>
   </p>
   <p class="indent3">
    The class can choose "Draconic" or "Elven" as
 one of their languages.
   </p>
   <p class="indent2">
-   <code>
-    LANGBONUS:ALL
-   </code>
+   <code>LANGBONUS:ALL</code>
   </p>
   <p class="indent3">
    The class can choose any language loaded from
 sources as one of their languages.
   </p>
   <p class="indent2">
-   <code>
-    LANGBONUS:TYPE=Written
-   </code>
+   <code>LANGBONUS:TYPE=Written</code>
   </p>
   <p class="indent3">
    The class can choose any written language as one
 of their languages.
   </p>
   <p class="indent2">
-   <code>
-    LANGBONUS:TYPE=Spoken,Draconic
-   </code>
+   <code>LANGBONUS:TYPE=Spoken,Draconic</code>
   </p>
   <p class="indent3">
    The class can choose any written language or
 "Draconic" as one of their languages.
   </p>
   <p class="indent2">
-   <code>
-    LANGBONUS:.CLEAR,Dwarven,Gnomish,Orcish
-   </code>
+   <code>LANGBONUS:.CLEAR,Dwarven,Gnomish,Orcish</code>
   </p>
   <p class="indent3">
    The class has all bonus languages cleared then
@@ -4204,20 +3836,16 @@ SUBSTITUTIONLEVEL lines.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    5:REPEATLEVEL:5 &lt;tab&gt;
-ADD:FEAT(ABonusFeat)
-   </code>
+   <code>5:REPEATLEVEL:5 &lt;tab&gt;
+ADD:FEAT(ABonusFeat)</code>
   </p>
   <p class="indent3">
    Would add at levels 5,10,15,20,... up to the
 MAXLEVEL defined by class.
   </p>
   <p class="indent2">
-   <code>
-    1:REPEATLEVEL:1|SKIP=4 &lt;tab&gt;
-ADD:FEAT(ABonusFeat)
-   </code>
+   <code>1:REPEATLEVEL:1|SKIP=4 &lt;tab&gt;
+ADD:FEAT(ABonusFeat)</code>
   </p>
   <p class="indent3">
    Would add at levels
@@ -4225,10 +3853,8 @@ ADD:FEAT(ABonusFeat)
 class.
   </p>
   <p class="indent2">
-   <code>
-    2:REPEATLEVEL:2|SKIP=0|MAX=20 &lt;tab&gt;
-ADD:FEAT(ABonusFeat)
-   </code>
+   <code>2:REPEATLEVEL:2|SKIP=0|MAX=20 &lt;tab&gt;
+ADD:FEAT(ABonusFeat)</code>
   </p>
   <p class="indent3">
    Would add at levels 2,4,6,8,... up to level
@@ -4240,10 +3866,8 @@ ADD:FEAT(ABonusFeat)
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    5 &lt;tab&gt; REPEATLEVEL:5 &lt;tab&gt;
-ADD:FEAT(ABonusFeat)
-   </code>
+   <code>5 &lt;tab&gt; REPEATLEVEL:5 &lt;tab&gt;
+ADD:FEAT(ABonusFeat)</code>
   </p>
   <p class="indent1">
    <strong>
@@ -4293,27 +3917,21 @@ that the class can choose from to duplicate class skills.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SKILLLIST:1|Ranger
-   </code>
+   <code>SKILLLIST:1|Ranger</code>
   </p>
   <p class="indent3">
    The class can choose from Ranger class
 skills.
   </p>
   <p class="indent2">
-   <code>
-    SKILLLIST:1|Ranger|Druid
-   </code>
+   <code>SKILLLIST:1|Ranger|Druid</code>
   </p>
   <p class="indent3">
    The class can choose either from Ranger or Druid
 class skills.
   </p>
   <p class="indent2">
-   <code>
-    SKILLLIST:2|Ranger|Druid|Barabarian
-   </code>
+   <code>SKILLLIST:2|Ranger|Druid|Barabarian</code>
   </p>
   <p class="indent3">
    The class can choose from 2 of Ranger, Druid or
@@ -4359,9 +3977,7 @@ that are granted to the class.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TEMPLATE:Incorporeal|Undead|Celestial
-   </code>
+   <code>TEMPLATE:Incorporeal|Undead|Celestial</code>
   </p>
   <p class="indent3">
    The class uses the "Incorporeal", "Undead" and
@@ -4404,21 +4020,13 @@ tag.
    </li>
    <li>
     When using the
-    <code>
-     TEMPLATE:ADDCOICE
-    </code>
+    <code>TEMPLATE:ADDCOICE</code>
     tag as part of a
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     of a class that containes multiple
-    <code>
-     TEMPLATE:CHOOSE
-    </code>
+    <code>TEMPLATE:CHOOSE</code>
     tags, all instances of the
-    <code>
-     TEMPLATE:CHOOSE
-    </code>
+    <code>TEMPLATE:CHOOSE</code>
     tag will be modified.
    </li>
   </ul>
@@ -4428,9 +4036,7 @@ tag.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TEMPLATE:ADDCHOICE:Demihuman|Beast
-   </code>
+   <code>TEMPLATE:ADDCHOICE:Demihuman|Beast</code>
   </p>
   <p class="indent3">
    The class can choose previously defined
@@ -4473,18 +4079,14 @@ list.
    </li>
    <li>
     Multiple
-    <code>
-     TEMPLATE:CHOOSE
-    </code>
+    <code>TEMPLATE:CHOOSE</code>
     tags can be used in the
 same LST object but PCGen's current Data Standard is to include no
 more that one in each LST object.
    </li>
    <li>
     Though the
-    <code>
-     TEMPLATE:CHOOSE
-    </code>
+    <code>TEMPLATE:CHOOSE</code>
     tag is not a gobal tag
 it can be used in the
     <a href="datafilesability.html#templatechoose">
@@ -4507,9 +4109,7 @@ it can be used in the
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TEMPLATE:CHOOSE:Celestial|Outsider
-   </code>
+   <code>TEMPLATE:CHOOSE:Celestial|Outsider</code>
   </p>
   <p class="indent3">
    The class can choose either the "Celestial" or
@@ -4566,9 +4166,7 @@ Summary tabs as a valid choice for selection.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    VISIBLE:NO
-   </code>
+   <code>VISIBLE:NO</code>
   </p>
   <p class="indent3">
    The class is not visible for selection on the
@@ -4632,10 +4230,8 @@ tab.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    WEAPONBONUS:Dagger|Staff|Club|Mace|Sword
-(Short)|Shortbow (Composite)
-   </code>
+   <code>WEAPONBONUS:Dagger|Staff|Club|Mace|Sword
+(Short)|Shortbow (Composite)</code>
   </p>
   <p class="indent3">
    The class can choose from a weapon proficiency
@@ -4643,9 +4239,7 @@ from "Dagger", "Staff", "Club", "Mace", "Sword (Short)" or
 "Shortbow (Composite)".
   </p>
   <p class="indent2">
-   <code>
-    WEAPONBONUS:TYPE.Simple
-   </code>
+   <code>WEAPONBONUS:TYPE.Simple</code>
   </p>
   <p class="indent3">
    The class receives bonus proficiency in any one
@@ -4696,9 +4290,7 @@ monster to gain a new feat.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    LEVELSPERFEAT:2
-   </code>
+   <code>LEVELSPERFEAT:2</code>
   </p>
   <p class="indent3">
    The class gets 1 feat per 2 levels.
@@ -4743,9 +4335,7 @@ gaining hit dice
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    MODTOSKILLS:YES
-   </code>
+   <code>MODTOSKILLS:YES</code>
   </p>
   <p class="indent3">
    The class gets the intelligence modifier for
@@ -4765,9 +4355,7 @@ skills they get for gaining hit dice.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    YES
-   </code>
+   <code>YES</code>
   </p>
   <hr/>
   <p class="status">
@@ -4805,9 +4393,7 @@ tag is normally seen with a PRESIZE requirement.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    MONNONSKILLHD:32|PRESIZEEQ:C
-   </code>
+   <code>MONNONSKILLHD:32|PRESIZEEQ:C</code>
   </p>
   <p class="indent3">
    A colossal monster would not get skill points
@@ -4857,9 +4443,7 @@ a number.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    MONSKILL:6+INT
-   </code>
+   <code>MONSKILL:6+INT</code>
   </p>
   <p class="indent3">
    Each level the monster will receive 6 + int
@@ -4901,13 +4485,9 @@ Type)
   <ul class="indent2">
    <li>
     This tag checks both the
-    <code>
-     TYPE
-    </code>
+    <code>TYPE</code>
     and
-    <code>
-     RACETYPE
-    </code>
+    <code>RACETYPE</code>
     tags in the original race file entry,
 ignoring any race types aquired outside of the original race file
 entry.
@@ -4931,9 +4511,7 @@ not take the class.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRERACETYPE:Animal
-   </code>
+   <code>PRERACETYPE:Animal</code>
   </p>
   <p class="indent3">
    This class can only be taken by "Animal"

--- a/docs/listfilepages/datafilestagpages/datafilescompanionmodifiers.html
+++ b/docs/listfilepages/datafilestagpages/datafilescompanionmodifiers.html
@@ -190,9 +190,7 @@ granted)
 the value specified.
    </li>
    <li>
-    <code>
-     MASTER
-    </code>
+    <code>MASTER</code>
     is a special sub-tag which passes the value
 of the Master's BAB.
    </li>
@@ -203,9 +201,7 @@ of the Master's BAB.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    COPYMASTERBAB:MASTER
-   </code>
+   <code>COPYMASTERBAB:MASTER</code>
   </p>
   <p class="indent3">
    Uses the Master's BAB
@@ -249,9 +245,7 @@ master.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    COPYMASTERCHECK:MASTER
-   </code>
+   <code>COPYMASTERCHECK:MASTER</code>
   </p>
   <p class="indent3">
    Uses the base master checks
@@ -299,9 +293,7 @@ master.
 value specified.
    </li>
    <li>
-    <code>
-     MASTER
-    </code>
+    <code>MASTER</code>
     is a special sub-tag which passes the value
 of the Master's HP.
    </li>
@@ -312,18 +304,14 @@ of the Master's HP.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    COPYMASTERHP:MASTER/2
-   </code>
+   <code>COPYMASTERHP:MASTER/2</code>
   </p>
   <p class="indent3">
    Gives the creature half the master's hit
 points
   </p>
   <p class="indent2">
-   <code>
-    COPYMASTERHP:max(1,MASTER/2)
-   </code>
+   <code>COPYMASTERHP:max(1,MASTER/2)</code>
   </p>
   <p class="indent3">
    Gives the creature half the master's hit points
@@ -382,27 +370,21 @@ tags in the line.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    FOLLOWER:Paladin=5
-   </code>
+   <code>FOLLOWER:Paladin=5</code>
   </p>
   <p class="indent3">
    True if PC is a Level 5 or greater
 "Paladin".
   </p>
   <p class="indent2">
-   <code>
-    FOLLOWER:Sorcerer,Wizard=1
-   </code>
+   <code>FOLLOWER:Sorcerer,Wizard=1</code>
   </p>
   <p class="indent3">
    True if PC is a Level 1 or greater "Sorcerer" or
 "Wizard".
   </p>
   <p class="indent2">
-   <code>
-    FOLLOWER:CompanionLevel=5
-   </code>
+   <code>FOLLOWER:CompanionLevel=5</code>
   </p>
   <p class="indent3">
    True if the CompanionLevel variable is 5 or
@@ -440,9 +422,7 @@ creature type.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    HD:2
-   </code>
+   <code>HD:2</code>
   </p>
   <p class="indent3">
    Defines the creature having two Hit Dice.
@@ -479,9 +459,7 @@ Name)
   <ul class="indent2">
    <li>
     The
-    <code>
-     MASTERBONUSRACE
-    </code>
+    <code>MASTERBONUSRACE</code>
     tag is the first tag on a
 MASTERBONUSRACE line.
    </li>
@@ -492,29 +470,19 @@ of companion.
    </li>
    <li>
     The tags following the
-    <code>
-     MASTERBONUSRACE
-    </code>
+    <code>MASTERBONUSRACE</code>
     tag on the
 MASTERBONUSRACE line are granted to the master.
    </li>
    <li>
     Valid tags on this line are
-    <code>
-     TYPE
-    </code>
+    <code>TYPE</code>
     ,
-    <code>
-     BONUS
-    </code>
+    <code>BONUS</code>
     ,
-    <code>
-     VFEAT
-    </code>
+    <code>VFEAT</code>
     and the
-    <code>
-     ABILITY
-    </code>
+    <code>ABILITY</code>
     tags.
    </li>
   </ul>
@@ -525,9 +493,7 @@ MASTERBONUSRACE line are granted to the master.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    MASTERBONUSRACE:Bat
-   </code>
+   <code>MASTERBONUSRACE:Bat</code>
   </p>
   <p class="indent3">
    Specifies what race the master has chosen (Bat)
@@ -588,9 +554,7 @@ Plant, Shapechanger, Undead, and Vermin
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    RACETYPE:Undead
-   </code>
+   <code>RACETYPE:Undead</code>
   </p>
   <p class="indent3">
    The Creature is now of the "Undead" type.
@@ -634,16 +598,12 @@ skill ranks of its master or not.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    USEMASTERSKILL:YES
-   </code>
+   <code>USEMASTERSKILL:YES</code>
   </p>
   <p class="indent3">
    Defines the creature as using the skill ranks of
 its master, including those granted by the
-   <code>
-    BONUS:SKILLRANK
-   </code>
+   <code>BONUS:SKILLRANK</code>
    tag.
   </p>
   <p class="indent1">
@@ -660,9 +620,7 @@ its master, including those granted by the
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    NO
-   </code>
+   <code>NO</code>
   </p>
   <hr/>
   <p>

--- a/docs/listfilepages/datafilestagpages/datafilesdeities.html
+++ b/docs/listfilepages/datafilestagpages/datafilesdeities.html
@@ -83,9 +83,7 @@ the deity itself.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ALIGN:LG
-   </code>
+   <code>ALIGN:LG</code>
   </p>
   <p class="indent3">
    The deity's alignment is Lawful Good.
@@ -97,24 +95,18 @@ the deity itself.
   </p>
   <p class="indent2">
    Initial Deity:
-   <code>
-    &lt;deity name&gt;
-&lt;tab&gt; ALIGN:LG
-   </code>
+   <code>&lt;deity name&gt;
+&lt;tab&gt; ALIGN:LG</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;deity name&gt;.MOD
-&lt;tab&gt; ALIGN:NG
-   </code>
+   <code>&lt;deity name&gt;.MOD
+&lt;tab&gt; ALIGN:NG</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;deity name&gt;
-&lt;tab&gt; ALIGN:NG
-   </code>
+   <code>&lt;deity name&gt;
+&lt;tab&gt; ALIGN:NG</code>
   </p>
   <hr/>
   <p class="lstdep">
@@ -151,10 +143,8 @@ looks like.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    APPEARANCE:Tall human with dark
-hair
-   </code>
+   <code>APPEARANCE:Tall human with dark
+hair</code>
   </p>
   <p class="indent3">
    The deity's description of appearance.
@@ -166,24 +156,18 @@ hair
   </p>
   <p class="indent2">
    Initial Deity:
-   <code>
-    &lt;deity name&gt;
-&lt;tab&gt; APPEARANCE:Tall human with dark hair
-   </code>
+   <code>&lt;deity name&gt;
+&lt;tab&gt; APPEARANCE:Tall human with dark hair</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;deity name&gt;.MOD
-&lt;tab&gt; APPEARANCE:Tall human with white hair
-   </code>
+   <code>&lt;deity name&gt;.MOD
+&lt;tab&gt; APPEARANCE:Tall human with white hair</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;deity name&gt;
-&lt;tab&gt; APPEARANCE:Tall human with white hair
-   </code>
+   <code>&lt;deity name&gt;
+&lt;tab&gt; APPEARANCE:Tall human with white hair</code>
   </p>
   <hr/>
   <p class="lstnew">
@@ -238,9 +222,7 @@ proficiencies list file.
    </li>
    <li>
     Using
-    <code>
-     .CLEAR
-    </code>
+    <code>.CLEAR</code>
     will clear all deity weapons from the
 associated deity.
    </li>
@@ -251,27 +233,21 @@ associated deity.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DEITYWEAP:Sword (Long)
-   </code>
+   <code>DEITYWEAP:Sword (Long)</code>
   </p>
   <p class="indent3">
    The deity's favored weapon is a "Long
 Sword".
   </p>
   <p class="indent2">
-   <code>
-    DEITYWEAP:Longspear|Shortspear|Halfspear
-   </code>
+   <code>DEITYWEAP:Longspear|Shortspear|Halfspear</code>
   </p>
   <p class="indent3">
    The deity's favored weapon is either a
 "Longspear", "Shortspear" or "Halfspear".
   </p>
   <p class="indent2">
-   <code>
-    DEITYWEAP:ANY
-   </code>
+   <code>DEITYWEAP:ANY</code>
   </p>
   <p class="indent3">
    The deity's favored weapon can be any
@@ -284,24 +260,18 @@ weapon.
   </p>
   <p class="indent2">
    Initial Deity:
-   <code>
-    &lt;deity name&gt;
-&lt;tab&gt; DEITYWEAP:Longsword
-   </code>
+   <code>&lt;deity name&gt;
+&lt;tab&gt; DEITYWEAP:Longsword</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;deity name&gt;.MOD
-&lt;tab&gt; DEITYWEAP:Scimitar
-   </code>
+   <code>&lt;deity name&gt;.MOD
+&lt;tab&gt; DEITYWEAP:Scimitar</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;deity name&gt;
-&lt;tab&gt; DEITYWEAP:Longsword|Scimitar
-   </code>
+   <code>&lt;deity name&gt;
+&lt;tab&gt; DEITYWEAP:Longsword|Scimitar</code>
   </p>
   <hr/>
   <p class="indent0">
@@ -383,9 +353,7 @@ domain.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DOMAINS:War,Law,Protection|PREALIGN:LG,NG,TN,CG
-   </code>
+   <code>DOMAINS:War,Law,Protection|PREALIGN:LG,NG,TN,CG</code>
   </p>
   <p class="indent3">
    The deity grants two of either the "War", "Law"
@@ -393,9 +361,7 @@ or "Protection" domains, but only if the cleric has one of the
 listed alignments.
   </p>
   <p class="indent2">
-   <code>
-    DOMAINS:ALL
-   </code>
+   <code>DOMAINS:ALL</code>
   </p>
   <p class="indent3">
    The deity grants two of any domains.
@@ -407,24 +373,18 @@ listed alignments.
   </p>
   <p class="indent2">
    Initial Deity:
-   <code>
-    &lt;deity name&gt;
-&lt;tab&gt; DOMAINS:Law
-   </code>
+   <code>&lt;deity name&gt;
+&lt;tab&gt; DOMAINS:Law</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;deity name&gt;.MOD
-&lt;tab&gt; DOMAINS:Evil
-   </code>
+   <code>&lt;deity name&gt;.MOD
+&lt;tab&gt; DOMAINS:Evil</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;deity name&gt;
-&lt;tab&gt; DOMAINS:Law,Evil
-   </code>
+   <code>&lt;deity name&gt;
+&lt;tab&gt; DOMAINS:Law,Evil</code>
   </p>
   <hr/>
   <p class="lstdep">
@@ -470,9 +430,7 @@ present.
    </li>
    <li>
     Using
-    <code>
-     .CLEAR
-    </code>
+    <code>.CLEAR</code>
     will clear the pantheon from the
 deities profile.
    </li>
@@ -483,17 +441,13 @@ deities profile.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PANTHEON:Celtic
-   </code>
+   <code>PANTHEON:Celtic</code>
   </p>
   <p class="indent3">
    The deity belongs to the "Celtic" pantheon.
   </p>
   <p class="indent2">
-   <code>
-    PANTHEON:Celtic|Elf (Sun)
-   </code>
+   <code>PANTHEON:Celtic|Elf (Sun)</code>
   </p>
   <p class="indent3">
    The deity belongs to the "Celtic" or "Sun Elf"
@@ -506,24 +460,18 @@ pantheon.
   </p>
   <p class="indent2">
    Initial Deity:
-   <code>
-    &lt;deity name&gt;
-&lt;tab&gt; PANTHEON:Celtic
-   </code>
+   <code>&lt;deity name&gt;
+&lt;tab&gt; PANTHEON:Celtic</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;deity name&gt;.MOD
-&lt;tab&gt; PANTHEON:Elf
-   </code>
+   <code>&lt;deity name&gt;.MOD
+&lt;tab&gt; PANTHEON:Elf</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;deity name&gt;
-&lt;tab&gt; PANTHEON:Celtic|Elf
-   </code>
+   <code>&lt;deity name&gt;
+&lt;tab&gt; PANTHEON:Celtic|Elf</code>
   </p>
   <hr/>
   <p class="lstdep">
@@ -560,9 +508,7 @@ worshippers of a Deity.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    RACE:Dwarf|Gnome
-   </code>
+   <code>RACE:Dwarf|Gnome</code>
   </p>
   <p class="indent3">
    The deity's typical worshippers are Dwarves and
@@ -575,24 +521,18 @@ Gnomes.
   </p>
   <p class="indent2">
    Initial Deity:
-   <code>
-    &lt;deity name&gt;
-&lt;tab&gt; RACE:Elf
-   </code>
+   <code>&lt;deity name&gt;
+&lt;tab&gt; RACE:Elf</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;deity name&gt;.MOD
-&lt;tab&gt; RACE:Halfling
-   </code>
+   <code>&lt;deity name&gt;.MOD
+&lt;tab&gt; RACE:Halfling</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;deity name&gt;
-&lt;tab&gt; RACE:Elf|Halfling
-   </code>
+   <code>&lt;deity name&gt;
+&lt;tab&gt; RACE:Elf|Halfling</code>
   </p>
   <hr/>
   <p class="lstdep">
@@ -629,9 +569,7 @@ holy symbol is for this deity.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SYMBOL:A small wooden cross
-   </code>
+   <code>SYMBOL:A small wooden cross</code>
   </p>
   <p class="indent3">
    The deity's symbol is a small wooden cross.
@@ -643,24 +581,18 @@ holy symbol is for this deity.
   </p>
   <p class="indent2">
    Initial Deity:
-   <code>
-    &lt;deity name&gt;
-&lt;tab&gt; SYMBOL:Knowed Snake
-   </code>
+   <code>&lt;deity name&gt;
+&lt;tab&gt; SYMBOL:Knowed Snake</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;deity name&gt;.MOD
-&lt;tab&gt; SYMBOL:Frayed Knot
-   </code>
+   <code>&lt;deity name&gt;.MOD
+&lt;tab&gt; SYMBOL:Frayed Knot</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;deity name&gt;
-&lt;tab&gt; SYMBOL:Frayed Knot
-   </code>
+   <code>&lt;deity name&gt;
+&lt;tab&gt; SYMBOL:Frayed Knot</code>
   </p>
   <hr/>
   <p class="lstdep">
@@ -696,9 +628,7 @@ Deity's title)
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TITLE:Lord of the Morning
-   </code>
+   <code>TITLE:Lord of the Morning</code>
   </p>
   <p class="indent3">
    The deity's title.
@@ -710,24 +640,18 @@ Deity's title)
   </p>
   <p class="indent2">
    Initial Deity:
-   <code>
-    &lt;deity name&gt;
-&lt;tab&gt; TITLE:War Bringer
-   </code>
+   <code>&lt;deity name&gt;
+&lt;tab&gt; TITLE:War Bringer</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;deity name&gt;.MOD
-&lt;tab&gt; TITLE:The Storm Crow
-   </code>
+   <code>&lt;deity name&gt;.MOD
+&lt;tab&gt; TITLE:The Storm Crow</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;deity name&gt;
-&lt;tab&gt; TITLE:The Storm Crow
-   </code>
+   <code>&lt;deity name&gt;
+&lt;tab&gt; TITLE:The Storm Crow</code>
   </p>
   <hr/>
   <p class="lstdep">
@@ -764,9 +688,7 @@ worshippers.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    WORSHIPPERS:Fighters and Monks
-   </code>
+   <code>WORSHIPPERS:Fighters and Monks</code>
   </p>
   <p class="indent3">
    The deity's typical worshippers.
@@ -778,24 +700,18 @@ worshippers.
   </p>
   <p class="indent2">
    Initial Deity:
-   <code>
-    &lt;deity name&gt;
-&lt;tab&gt; WORSHIPPERS:Fighters and Monks
-   </code>
+   <code>&lt;deity name&gt;
+&lt;tab&gt; WORSHIPPERS:Fighters and Monks</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;deity name&gt;.MOD
-&lt;tab&gt; WORSHIPPERS:Rogues and Ninjas
-   </code>
+   <code>&lt;deity name&gt;.MOD
+&lt;tab&gt; WORSHIPPERS:Rogues and Ninjas</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;deity name&gt;
-&lt;tab&gt; WORSHIPPERS:Ronues and Ninjas
-   </code>
+   <code>&lt;deity name&gt;
+&lt;tab&gt; WORSHIPPERS:Ronues and Ninjas</code>
   </p>
   <hr/>
   <p>

--- a/docs/listfilepages/datafilestagpages/datafilesdomains.html
+++ b/docs/listfilepages/datafilestagpages/datafilesdomains.html
@@ -56,17 +56,13 @@ tag.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    Holy
-   </code>
+   <code>Holy</code>
   </p>
   <p class="indent3">
    The domain named "Holy" is to be created.
   </p>
   <p class="indent2">
-   <code>
-    Travel.MOD
-   </code>
+   <code>Travel.MOD</code>
   </p>
   <p class="indent3">
    The domain named "Travel" is to be modified.
@@ -107,34 +103,24 @@ Dictionary
       <ul class="incremental">
        <li>
         The
-        <code>
-         FEAT
-        </code>
+        <code>FEAT</code>
         tag is deprecated. Use
         <a href="../globalfilestagpages/globalfilesother.html#ability">
-         <code>
-          ABILITY
-         </code>
+         <code>ABILITY</code>
         </a>
         instead.
        </li>
        <li>
         All
-        <code>
-         FEAT
-        </code>
+        <code>FEAT</code>
         tags have been
         <strong>
          deprecated
         </strong>
         and replaced by the
-        <code>
-         ABILITY
-        </code>
+        <code>ABILITY</code>
         system, which is more general. The
-        <code>
-         ABILITY
-        </code>
+        <code>ABILITY</code>
         system can model feats, racial features, class
 features, traits, flaws, temporary bonuses, and so on, all using a
 common format.
@@ -174,9 +160,7 @@ character.
       </li>
       <li>
        The hyphen (-) is used only in the
-       <code>
-        OUTPUTNAME
-       </code>
+       <code>OUTPUTNAME</code>
        of
 feats and should NOT be used in the feat list for this tag. (See
 example below.)
@@ -195,13 +179,9 @@ be handled one of two ways.
         </li>
         <li>
          Used in conjunction with the
-         <code>
-          CHOOSE
-         </code>
+         <code>CHOOSE</code>
          tag,
-         <code>
-          %LIST
-         </code>
+         <code>%LIST</code>
          can be used with this tag to provide the
 required choice.
         </li>
@@ -211,18 +191,12 @@ required choice.
          </strong>
          When modifying a domain with
 the
-         <code>
-          .MOD
-         </code>
+         <code>.MOD</code>
          tag, given an existing
-         <code>
-          FEAT
-         </code>
+         <code>FEAT</code>
          tag,
 the data included in a new
-         <code>
-          FEAT
-         </code>
+         <code>FEAT</code>
          tag will be appended
 to the existing tag data.
         </li>
@@ -235,26 +209,20 @@ to the existing tag data.
       </strong>
      </p>
      <p class="indent2">
-      <code>
-       FEAT:Blind Fight,Alertness
-      </code>
+      <code>FEAT:Blind Fight,Alertness</code>
      </p>
      <p class="indent3">
       The "Blind-Fight" &amp; "Alertness" bonus feats
 are granted to clerics with this domain.
      </p>
      <p class="indent2">
-      <code>
-       CHOOSE:WEAPONPROFS|LIST &lt;tab&gt;
-FEAT:Weapon Focus (%LIST)
-      </code>
+      <code>CHOOSE:WEAPONPROFS|LIST &lt;tab&gt;
+FEAT:Weapon Focus (%LIST)</code>
      </p>
      <p class="indent3">
       The feat "Weapon Focus" is granted as an
 automatic feat with the weapon chosen with the
-      <code>
-       CHOOSE
-      </code>
+      <code>CHOOSE</code>
       tag.
      </p>
      <p class="indent1">
@@ -264,24 +232,18 @@ automatic feat with the weapon chosen with the
      </p>
      <p class="indent2">
       Initial Domain:
-      <code>
-       Space Monkey &lt;tab&gt;
-FEAT:Alertness
-      </code>
+      <code>Space Monkey &lt;tab&gt;
+FEAT:Alertness</code>
      </p>
      <p class="indent2">
       Modified By:
-      <code>
-       Space Monkey.MOD &lt;tab&gt;
-FEAT:Blind Fight
-      </code>
+      <code>Space Monkey.MOD &lt;tab&gt;
+FEAT:Blind Fight</code>
      </p>
      <p class="indent2">
       Is Equivalent To:
-      <code>
-       Space Monkey &lt;tab&gt;
-FEAT:Alertness,Blind Fight
-      </code>
+      <code>Space Monkey &lt;tab&gt;
+FEAT:Alertness,Blind Fight</code>
       .
      </p>
      <p class="indent3">

--- a/docs/listfilepages/datafilestagpages/datafilesequipment.html
+++ b/docs/listfilepages/datafilestagpages/datafilesequipment.html
@@ -61,27 +61,21 @@ piece of equipment.
 This first list of tags is relevant to all equipment
   </p>
   <p class="indent2">
-   <code>
-    Clothing Outfit (Business)
-   </code>
+   <code>Clothing Outfit (Business)</code>
   </p>
   <p class="indent3">
    The item named "Clothing Outfit (Business)" is
 to be created.
   </p>
   <p class="indent2">
-   <code>
-    Handbag.MOD
-   </code>
+   <code>Handbag.MOD</code>
   </p>
   <p class="indent3">
    The item named "Handbag" is to be modified.
   </p>
   <p class="indent2">
-   <code>
-    Light-Duty Vest.COPY=Vest
-(Concealable/w.Outershell)
-   </code>
+   <code>Light-Duty Vest.COPY=Vest
+(Concealable/w.Outershell)</code>
   </p>
   <p class="indent3">
    Copy the equipment "Light-Duty Vest" and rename
@@ -146,20 +140,14 @@ of base item)
 an existing item.
    </li>
    <li>
-    <code>
-     BASEITEM
-    </code>
+    <code>BASEITEM</code>
     must be used in conjunction with the
-    <code>
-     EQMOD
-    </code>
+    <code>EQMOD</code>
     tag.
    </li>
    <li>
     Eqmods listed in the
-    <code>
-     EQMOD
-    </code>
+    <code>EQMOD</code>
     tag are applied to the
 base item prior to the application of any other included tags.
    </li>
@@ -167,9 +155,7 @@ base item prior to the application of any other included tags.
   <p class="sidebar1">
    NOTE: This tag will not copy any of the base
 item's existing tags so you will need to add them yourself. The
-   <code>
-    .COPY
-   </code>
+   <code>.COPY</code>
    tag will perform this same function but will
 copy all tags to the new item, verbatim, prior to adding any new
 tags. (See
@@ -185,11 +171,9 @@ tags. (See
   </p>
   <blockquote class="indent2">
    <p class="tagindent1">
-    <code>
-     Davril's Longsword &lt;tab&gt;
+    <code>Davril's Longsword &lt;tab&gt;
 BONUS:COMBAT|DAMAGE,TOHIT|2 &lt;tab&gt; BASEITEM:Longsword
-&lt;tab&gt; EQMOD:BANE_M|Undead.HOLY_M.KEEN
-    </code>
+&lt;tab&gt; EQMOD:BANE_M|Undead.HOLY_M.KEEN</code>
    </p>
   </blockquote>
   <p class="indent3">
@@ -230,9 +214,7 @@ items in this bundle. ie. Arrows (20) should have.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BASEQTY:20
-   </code>
+   <code>BASEQTY:20</code>
   </p>
   <p class="indent3">
    20 items in a bundle (e.g. Arrows).
@@ -290,17 +272,11 @@ object, a container can hold.
    </li>
    <li>
     Any object with
-    <code>
-     CONTAINS
-    </code>
+    <code>CONTAINS</code>
     must also include a
-    <code>
-     TYPE:Container
-    </code>
+    <code>TYPE:Container</code>
     tag for the
-    <code>
-     CONTAINS
-    </code>
+    <code>CONTAINS</code>
     tag
 to be activated.
    </li>
@@ -325,9 +301,7 @@ files in the
       </span>
       file with
 the tag
-      <code>
-       WEIGHTUNITABBREV
-      </code>
+      <code>WEIGHTUNITABBREV</code>
       .
      </li>
     </ul>
@@ -364,21 +338,15 @@ associated type of items.
    <strong>
     Note:
    </strong>
-   <code>
-    UNLIM
-   </code>
+   <code>UNLIM</code>
    may
 be used, in either (x) or (z), to indicate an unlimited weight
 allowance for the container or the item type quantity. If no value
 is provided for (z),
-   <code>
-    UNLIM
-   </code>
+   <code>UNLIM</code>
    is assumed. PCGen's Data
 Converter will remove
-   <code>
-    UNLIM
-   </code>
+   <code>UNLIM</code>
    when converting a data
 file.
   </p>
@@ -388,71 +356,55 @@ file.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CONTAINS:500
-   </code>
+   <code>CONTAINS:500</code>
   </p>
   <p class="indent3">
    500 units of weight can fit in this
 container.
   </p>
   <p class="indent2">
-   <code>
-    CONTAINS:*500
-   </code>
+   <code>CONTAINS:*500</code>
   </p>
   <p class="indent3">
    500 units of weight can fit in this container
 and this is not added to the PCs carried weight.
   </p>
   <p class="indent2">
-   <code>
-    CONTAINS:50%50|Any=25
-   </code>
+   <code>CONTAINS:50%50|Any=25</code>
   </p>
   <p class="indent3">
    Holds up to 25 items of up to 50 units of
 weight, but the total weight contained is reduced 50%.
   </p>
   <p class="indent2">
-   <code>
-    CONTAINS:25%UNLIM|Any=100
-   </code>
+   <code>CONTAINS:25%UNLIM|Any=100</code>
   </p>
   <p class="indent3">
    Holds up to 100 items no matter the weight, but
 total weight contained is reduced 25%.
   </p>
   <p class="indent2">
-   <code>
-    CONTAINS:500|Potions=100
-   </code>
+   <code>CONTAINS:500|Potions=100</code>
   </p>
   <p class="indent3">
    500 units of weight can fit in this container,
 but only 100 potions fit.
   </p>
   <p class="indent2">
-   <code>
-    CONTAINS:UNLIM
-   </code>
+   <code>CONTAINS:UNLIM</code>
   </p>
   <p class="indent3">
    This container has an unlimited weight
 allowance.
   </p>
   <p class="indent2">
-   <code>
-    CONTAINS:UNLIM|Any=100
-   </code>
+   <code>CONTAINS:UNLIM|Any=100</code>
   </p>
   <p class="indent3">
    Holds 100 things, no matter what the weight.
   </p>
   <p class="indent2">
-   <code>
-    CONTAINS:UNLIM|Total=10|Paper=10|Scroll=10
-   </code>
+   <code>CONTAINS:UNLIM|Total=10|Paper=10|Scroll=10</code>
   </p>
   <p class="indent3">
    Holds 10 papers or 10 scrolls, or any
@@ -489,9 +441,7 @@ Name:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    COST:5
-   </code>
+   <code>COST:5</code>
   </p>
   <p class="indent3">
    Item costs 5 gold pieces.
@@ -530,9 +480,7 @@ item.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    EDR:5
-   </code>
+   <code>EDR:5</code>
   </p>
   <p class="indent3">
    Item takes 5 points to destroy.
@@ -592,9 +540,7 @@ variables or choosers of the eqmod itself. See
    </li>
    <li>
     When used in conjunction with
-    <code>
-     BASEITEM
-    </code>
+    <code>BASEITEM</code>
     , the eqmod
 is automatically applied to the base item and is applied before
 looking at other tags.
@@ -606,28 +552,22 @@ looking at other tags.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    EQMOD:KEEN.BANE|Undead
-   </code>
+   <code>EQMOD:KEEN.BANE|Undead</code>
   </p>
   <p class="indent3">
    Creates a sword that is keen and also has Bane
 Undead.
   </p>
   <p class="indent2">
-   <code>
-    EQMOD:ABILITYPLUS|STR+2
-   </code>
+   <code>EQMOD:ABILITYPLUS|STR+2</code>
   </p>
   <p class="indent3">
    Applies a +2 strength bonus to the character
 when using the item.
   </p>
   <p class="indent2">
-   <code>
-    Leather Armor.MOD &lt;tab&gt;
-EQMOD:DR_CONVERSION_ARCHAIC|2
-   </code>
+   <code>Leather Armor.MOD &lt;tab&gt;
+EQMOD:DR_CONVERSION_ARCHAIC|2</code>
   </p>
   <p class="indent3">
    Applies a damage reduction bonus of 2 to the
@@ -635,13 +575,11 @@ character when using the item.
   </p>
   <blockquote class="indent2">
    <p class="tagindent1">
-    <code>
-     Rod (Absorption) &lt;TAB&gt;
+    <code>Rod (Absorption) &lt;TAB&gt;
 OUTPUTNAME:Rod of [NAME] &lt;TAB&gt; TYPE:Magic.Rod &lt;TAB&gt;
 COST:50000 &lt;TAB&gt; WT:5 &lt;TAB&gt; BASEITEM:Rod &lt;TAB&gt;
 EQMOD:CHARGED_ITEM_50|CHARGES[50] &lt;TAB&gt;
-SOURCEPAGE:MagicItemsIII.rtf
-    </code>
+SOURCEPAGE:MagicItemsIII.rtf</code>
    </p>
   </blockquote>
   <p class="indent3">
@@ -686,9 +624,7 @@ specify where the path is relative to.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ICON:@/d20ogl/srd35/icons/backpack.png
-   </code>
+   <code>ICON:@/d20ogl/srd35/icons/backpack.png</code>
   </p>
   <p class="indent3">
    The icon for this item will be
@@ -739,9 +675,7 @@ order to purchase the item.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    MODS:YES
-   </code>
+   <code>MODS:YES</code>
   </p>
   <p class="indent3">
    Item can have equipment modifiers added.
@@ -782,9 +716,7 @@ sub-tab of the Spells Tab.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    NUMPAGES:100
-   </code>
+   <code>NUMPAGES:100</code>
   </p>
   <p class="indent3">
    Spell book with 100 pages.
@@ -827,18 +759,14 @@ Tab.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PAGEUSAGE:max(SPELLLEVEL*2,1)
-   </code>
+   <code>PAGEUSAGE:max(SPELLLEVEL*2,1)</code>
   </p>
   <p class="indent3">
    Each spell will use 2 pages per level (3.0
 standard spellbook).
   </p>
   <p class="indent2">
-   <code>
-    PAGEUSAGE:1
-   </code>
+   <code>PAGEUSAGE:1</code>
   </p>
   <p class="indent3">
    Each spell will use a single page (Blessed
@@ -891,9 +819,7 @@ number of types that must match the specified requirements).
     Make specific Types or Equipment Modifiers a prerequisite.
    </li>
    <li>
-    <code>
-     EQMODTYPE
-    </code>
+    <code>EQMODTYPE</code>
     checks for the
     <strong>
      TYPE
@@ -902,9 +828,7 @@ number of types that must match the specified requirements).
 the applied Equipment Modifiers, not Equipment type.
    </li>
    <li>
-    <code>
-     EQMOD
-    </code>
+    <code>EQMOD</code>
     checks for the specified
     <strong>
      EQMOD
@@ -912,13 +836,9 @@ the applied Equipment Modifiers, not Equipment type.
     by name or key.
    </li>
    <li>
-    <code>
-     EQMOD
-    </code>
+    <code>EQMOD</code>
     can take an optional parameter of the form
-    <code>
-     EQMOD=&lt;key&gt;(&lt;choice&gt;)
-    </code>
+    <code>EQMOD=&lt;key&gt;(&lt;choice&gt;)</code>
     , where the "choice"
 represents an item previously selected by an internal chooser for
 the specified
@@ -933,9 +853,7 @@ the specified
     Note
    </span>
    :
-   <code>
-    PRETYPE
-   </code>
+   <code>PRETYPE</code>
    has a different use outside of Equipment and
 Equipment Modifier files, it checks for race types. See the
    <a href="../globalfilestagpages/globalfilesprexxx.html#pretype">
@@ -951,18 +869,14 @@ Modifier files.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRETYPE:1,Magic &lt;tab&gt;
-PRETYPE:1,Piercing,Slashing
-   </code>
+   <code>PRETYPE:1,Magic &lt;tab&gt;
+PRETYPE:1,Piercing,Slashing</code>
   </p>
   <p class="indent3">
    Type must be magic and piercing or slashing
   </p>
   <p class="indent2">
-   <code>
-    PREMULT:2,[PRETYPE:1,Magic],[PRETYPE:1,Piercing,Slashing]
-   </code>
+   <code>PREMULT:2,[PRETYPE:1,Magic],[PRETYPE:1,Piercing,Slashing]</code>
   </p>
   <p class="indent3">
    This example, utilizing the PREMULT tag,
@@ -970,26 +884,20 @@ accomplishes the same thing as the example above it but as it is
 one statement it can be attached to a BONUS statement.
   </p>
   <p class="indent2">
-   <code>
-    !PRETYPE:1,Heavy
-   </code>
+   <code>!PRETYPE:1,Heavy</code>
   </p>
   <p class="indent3">
    Type must NOT be Heavy
   </p>
   <p class="indent2">
-   <code>
-    PRETYPE:1,EQMODTYPE=Mundane
-   </code>
+   <code>PRETYPE:1,EQMODTYPE=Mundane</code>
   </p>
   <p class="indent3">
    Use to test for any modifier with "Mundane"
 type.
   </p>
   <p class="indent2">
-   <code>
-    PRETYPE:1,EQMOD=IRONWOOD
-   </code>
+   <code>PRETYPE:1,EQMOD=IRONWOOD</code>
   </p>
   <p class="indent3">
    Use to test for the "Ironwood" Equipment
@@ -1044,9 +952,7 @@ to pass.
      AND
     </strong>
     . As an example,
-    <code>
-     PRETYPE:Heavy,Armor|Shield
-    </code>
+    <code>PRETYPE:Heavy,Armor|Shield</code>
     translates to: Must have
 "Heavy" AND either "Armor" OR "Shield" types.
    </li>
@@ -1058,17 +964,13 @@ syntax:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRETYPE:Magic,Piercing,Slashing
-   </code>
+   <code>PRETYPE:Magic,Piercing,Slashing</code>
   </p>
   <p class="indent3">
    Type must be Magic, Piercing and Slashing.
   </p>
   <p class="indent2">
-   <code>
-    PRETYPE:Magic,Armor|Shield,Piercing,Slashing
-   </code>
+   <code>PRETYPE:Magic,Armor|Shield,Piercing,Slashing</code>
   </p>
   <p class="indent3">
    Type must be Magic, Piercing, Slashing and
@@ -1109,11 +1011,9 @@ string value of the quality)
   <p class="indent2">
    Sets the name and value of a quality which will
 be attached to the equipment. Qualities can be output by the
-   <code>
-    <a href="../../outputsheetpages/tokens/outputsheettokensequip.html#eq.quality">
+   <code><a href="../../outputsheetpages/tokens/outputsheettokensequip.html#eq.quality">
      EQ.0.QUALITY
-    </a>
-   </code>
+    </a></code>
    tag
   </p>
   <p class="indent1">
@@ -1122,18 +1022,14 @@ be attached to the equipment. Qualities can be output by the
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    QUALITY:Restriction|Licensed
-   </code>
+   <code>QUALITY:Restriction|Licensed</code>
   </p>
   <p class="indent3">
    The equipment has the "Restriction" quality
 which has a value of "Licensed".
   </p>
   <p class="indent2">
-   <code>
-    QUALITY:Black Market DC|(+1)
-   </code>
+   <code>QUALITY:Black Market DC|(+1)</code>
   </p>
   <p class="indent3">
    The equipment has the "Black Market DC" quality
@@ -1196,9 +1092,7 @@ abilities for weapons.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SIZE:M
-   </code>
+   <code>SIZE:M</code>
   </p>
   <p class="indent3">
    Item is medium size.
@@ -1236,9 +1130,7 @@ default is one.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SLOTS:2
-   </code>
+   <code>SLOTS:2</code>
   </p>
   <p class="indent3">
    Weapon requires two hands to wield it.
@@ -1315,40 +1207,32 @@ one SPROP tag.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SPROP:Shines with an inner
-light
-   </code>
+   <code>SPROP:Shines with an inner
+light</code>
   </p>
   <p class="indent3">
    Output sheet reads "Shines with an inner light"
 under the item.
   </p>
   <p class="indent2">
-   <code>
-    SPROP:Squash code bugs % times per
-day|TL
-   </code>
+   <code>SPROP:Squash code bugs % times per
+day|TL</code>
   </p>
   <p class="indent3">
    For a 5th level character the output sheet would
 read "Squash code bugs 5 times per day" under the item.
   </p>
   <p class="indent2">
-   <code>
-    SPROP:+2 against
-undead|PRECLASS:1,Paladin=1
-   </code>
+   <code>SPROP:+2 against
+undead|PRECLASS:1,Paladin=1</code>
   </p>
   <p class="indent3">
    Outputs the text if the character has at least 1
 level of Paladin.
   </p>
   <p class="indent2">
-   <code>
-    SPROP:+% vs. code
-bugs|ColaIntake|PRESKILL:1,Programming=10
-   </code>
+   <code>SPROP:+% vs. code
+bugs|ColaIntake|PRESKILL:1,Programming=10</code>
   </p>
   <p class="indent3">
    If the character has the Programming skill of at
@@ -1356,12 +1240,10 @@ least 10 and the variable "ColaIntake" is defined as equal to 4
 then the output sheet reads "+4 vs. code bugs".
   </p>
   <p class="indent2">
-   <code>
-    SPROP:+1 luck bonus to saves vs. %|%CHOICE
+   <code>SPROP:+1 luck bonus to saves vs. %|%CHOICE
 &lt;tab&gt; CHOOSE:Abjuration|Conjuration|
     <br/>
-    Divination|Evocation|Necromancy|Enchantment|Transmutation|Universal
-   </code>
+    Divination|Evocation|Necromancy|Enchantment|Transmutation|Universal</code>
   </p>
   <p class="indent3">
    Allows for the selection of the type of luck
@@ -1395,17 +1277,13 @@ Name:
    </li>
    <li>
     The
-    <code>
-     WT
-    </code>
+    <code>WT</code>
     tag will take a number greater than or
 equal to zero (0) for the weight.
    </li>
    <li>
     The units for the weight is set with the
-    <code>
-     WEIGHTUNIT
-    </code>
+    <code>WEIGHTUNIT</code>
     tag in the gameMode
     <span class="lstfile">
      miscinfo.lst
@@ -1419,9 +1297,7 @@ equal to zero (0) for the weight.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    WT:5
-   </code>
+   <code>WT:5</code>
   </p>
   <p class="indent3">
    Item weighs 5 lbs.
@@ -1484,9 +1360,7 @@ penalty applied to certain skills that have an Armor Check.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ACCHECK:-6
-   </code>
+   <code>ACCHECK:-6</code>
   </p>
   <p class="indent3">
    Item has an armor check penalty of -6.
@@ -1535,17 +1409,13 @@ multiplier for the secondary attack.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ALTCRITMULT:x3
-   </code>
+   <code>ALTCRITMULT:x3</code>
   </p>
   <p class="indent3">
    2nd head has a critical modifier of x3.
   </p>
   <p class="indent2">
-   <code>
-    ALTCRITMULT:-
-   </code>
+   <code>ALTCRITMULT:-</code>
   </p>
   <p class="indent3">
    2nd head has no critical modifier.
@@ -1588,9 +1458,7 @@ multiplier for the secondary attack.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ALTCRITRANGE:2
-   </code>
+   <code>ALTCRITRANGE:2</code>
   </p>
   <p class="indent3">
    2nd head criticals on roll of 19 or 20.
@@ -1631,9 +1499,7 @@ Name:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ALTDAMAGE:1d6-1
-   </code>
+   <code>ALTDAMAGE:1d6-1</code>
   </p>
   <p class="indent3">
    2nd head does 1d6-1 damage.
@@ -1698,9 +1564,7 @@ EQMOD on both heads.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ALTEQMOD:WOOD
-   </code>
+   <code>ALTEQMOD:WOOD</code>
   </p>
   <p class="indent3">
    2nd head has the WOOD EQMOD applied to it.
@@ -1749,9 +1613,7 @@ included.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ALTTYPE:Simple.Melee.Bludgeoning
-   </code>
+   <code>ALTTYPE:Simple.Melee.Bludgeoning</code>
   </p>
   <p class="indent3">
    2nd head is Simple Melee Bludgeoning.
@@ -1794,17 +1656,13 @@ multiplier for the equipment.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CRITMULT:x2
-   </code>
+   <code>CRITMULT:x2</code>
   </p>
   <p class="indent3">
    Item has a critical modifier of x2.
   </p>
   <p class="indent2">
-   <code>
-    CRITMULT:-
-   </code>
+   <code>CRITMULT:-</code>
   </p>
   <p class="indent3">
    Item has no critical modifier.
@@ -1845,9 +1703,7 @@ Name:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CRITRANGE:2
-   </code>
+   <code>CRITRANGE:2</code>
   </p>
   <p class="indent3">
    Item criticals on roll of 19 or 20.
@@ -1884,9 +1740,7 @@ the character sheet output.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DAMAGE:1d6
-   </code>
+   <code>DAMAGE:1d6</code>
   </p>
   <p class="indent3">
    Item damage is 1d6.
@@ -1930,17 +1784,13 @@ weapon head).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    FUMBLERANGE:1-3
-   </code>
+   <code>FUMBLERANGE:1-3</code>
   </p>
   <p class="indent3">
    Indicates and error range of 1-3.
   </p>
   <p class="indent2">
-   <code>
-    FUMBLERANGE:Natural 1
-   </code>
+   <code>FUMBLERANGE:Natural 1</code>
   </p>
   <p class="indent3">
    Indicates and error range of a natural 1.
@@ -1978,9 +1828,7 @@ the armor.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    MAXDEX:3
-   </code>
+   <code>MAXDEX:3</code>
   </p>
   <p class="indent3">
    Item allows a maximum dexterity bonus of three
@@ -2045,26 +1893,20 @@ from the appropriate
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PROFICIENCY:WEAPON|Sword (Long)
-   </code>
+   <code>PROFICIENCY:WEAPON|Sword (Long)</code>
   </p>
   <p class="indent3">
    Item uses the "Longsword" weapon
 proficiency.
   </p>
   <p class="indent2">
-   <code>
-    PROFICIENCY:ARMOR|Chainmail
-   </code>
+   <code>PROFICIENCY:ARMOR|Chainmail</code>
   </p>
   <p class="indent3">
    Item uses the "Chainmail" armor proficiency.
   </p>
   <p class="indent2">
-   <code>
-    PROFICIENCY:SHIELD|Buckler
-   </code>
+   <code>PROFICIENCY:SHIELD|Buckler</code>
   </p>
   <p class="indent3">
    Item uses the "Buckler" shield proficiency.
@@ -2101,9 +1943,7 @@ increment.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    RANGE:50
-   </code>
+   <code>RANGE:50</code>
   </p>
   <p class="indent3">
    One range increment for this weapon is 50
@@ -2145,34 +1985,26 @@ futuristic games.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    RATEOFFIRE:1
-   </code>
+   <code>RATEOFFIRE:1</code>
   </p>
   <p class="indent3">
    1 shot per round.
   </p>
   <p class="indent2">
-   <code>
-    RATEOFFIRE:0/10/20
-   </code>
+   <code>RATEOFFIRE:0/10/20</code>
   </p>
   <p class="indent3">
    0 shots first round, 10 shots second round and
 20 shots on the third.
   </p>
   <p class="indent2">
-   <code>
-    RATEOFFIRE:S,A
-   </code>
+   <code>RATEOFFIRE:S,A</code>
   </p>
   <p class="indent3">
    Single or Automatic.
   </p>
   <p class="indent2">
-   <code>
-    RATEOFFIRE:Single
-   </code>
+   <code>RATEOFFIRE:Single</code>
   </p>
   <p class="indent3">
    Single shot only.
@@ -2219,9 +2051,7 @@ have a reach of 15 with that weapon.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    REACH:10
-   </code>
+   <code>REACH:10</code>
   </p>
   <p class="indent3">
    Item reaches 10 feet.
@@ -2268,9 +2098,7 @@ weapon.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    REACHMULT:2
-   </code>
+   <code>REACHMULT:2</code>
   </p>
   <p class="indent3">
    Item reaches 2 times the character's normal
@@ -2308,9 +2136,7 @@ wearing/wielding this item (when item is equipped).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SPELLFAILURE:5
-   </code>
+   <code>SPELLFAILURE:5</code>
   </p>
   <p class="indent3">
    Item causes 5% of arcane spells to fail.
@@ -2371,9 +2197,7 @@ category 'TwoHanded' for a Medium sized PC.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    WIELD:TwoHanded
-   </code>
+   <code>WIELD:TwoHanded</code>
   </p>
   <p class="indent3">
    Weapon must be wielded with two hands.

--- a/docs/listfilepages/datafilestagpages/datafilesequipmentmodifiers.html
+++ b/docs/listfilepages/datafilestagpages/datafilesequipmentmodifiers.html
@@ -34,17 +34,13 @@ the modifier, after that, the tags do not need to be in any special
 order.
   </p>
   <p class="indent2">
-   <code>
-    SCP_STD.MOD
-   </code>
+   <code>SCP_STD.MOD</code>
   </p>
   <p class="indent3">
    The item named "SCP_STD" is to be modified.
   </p>
   <p class="indent2">
-   <code>
-    Autofire.FORGET
-   </code>
+   <code>Autofire.FORGET</code>
   </p>
   <p class="indent3">
    The item named "Autofire" is to be
@@ -89,9 +85,7 @@ delimited.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ARMORTYPE:Medium|Heavy
-   </code>
+   <code>ARMORTYPE:Medium|Heavy</code>
   </p>
   <p class="indent3">
    Changes the armor type from "Medium" to
@@ -128,9 +122,7 @@ present then the modifiers will be applied to both heads.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ASSIGNTOALL:YES
-   </code>
+   <code>ASSIGNTOALL:YES</code>
   </p>
   <p class="indent3">
    Assigns modifiers to both heads.
@@ -141,9 +133,7 @@ present then the modifiers will be applied to both heads.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    NO
-   </code>
+   <code>NO</code>
   </p>
   <hr/>
   <p class="indent0">
@@ -193,18 +183,14 @@ more information on bonus types.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:EQM|HANDS|1
-   </code>
+   <code>BONUS:EQM|HANDS|1</code>
   </p>
   <p class="indent3">
    Sets the number of hands required by the item to
 one.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:EQM|HANDS|-EQHANDS
-   </code>
+   <code>BONUS:EQM|HANDS|-EQHANDS</code>
   </p>
   <p class="indent3">
    Sets the number of hands required by the item to
@@ -257,18 +243,14 @@ more information on bonus types.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:EQM|WEIGHTADD|0.5
-   </code>
+   <code>BONUS:EQM|WEIGHTADD|0.5</code>
   </p>
   <p class="indent3">
    Adds half a weight unit to the item's
 weight.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:EQM|WEIGHTADD|-10|TYPE=Enhancement
-   </code>
+   <code>BONUS:EQM|WEIGHTADD|-10|TYPE=Enhancement</code>
   </p>
   <p class="indent3">
    Subtracts 10 from the item's weight due to
@@ -321,17 +303,13 @@ more information on bonus types.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:EQM|WEIGHTDIV|2
-   </code>
+   <code>BONUS:EQM|WEIGHTDIV|2</code>
   </p>
   <p class="indent3">
    Divides the weight of the item in half.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:EQM|WEIGHTDIV|2|TYPE=Enhancement.REPLACE
-   </code>
+   <code>BONUS:EQM|WEIGHTDIV|2|TYPE=Enhancement.REPLACE</code>
   </p>
   <p class="indent3">
    Divides the weight of the item in half, replaces
@@ -384,17 +362,13 @@ more information on bonus types.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:EQM|WEIGHTMULT|2
-   </code>
+   <code>BONUS:EQM|WEIGHTMULT|2</code>
   </p>
   <p class="indent3">
    Doubles the weight of the item.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:EQM|WEIGHTMULT|1.2|TYPE=Enhancement
-   </code>
+   <code>BONUS:EQM|WEIGHTMULT|1.2|TYPE=Enhancement</code>
   </p>
   <p class="indent3">
    Multiples the weight of the item by 1.2 by
@@ -447,17 +421,13 @@ more information on bonus types.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:EQMARMOR|ACCHECK|3
-   </code>
+   <code>BONUS:EQMARMOR|ACCHECK|3</code>
   </p>
   <p class="indent3">
    Decreases the armor check penalty by 3.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:EQMARMOR|ACCHECK|2|TYPE=Enhancement
-   </code>
+   <code>BONUS:EQMARMOR|ACCHECK|2|TYPE=Enhancement</code>
   </p>
   <p class="indent3">
    Decreases the armor check penalty by 2 by
@@ -511,9 +481,7 @@ more information on bonus types.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:EQMARMOR|EDR|1
-   </code>
+   <code>BONUS:EQMARMOR|EDR|1</code>
   </p>
   <p class="indent3">
    Makes the damage resistance for the armor 1
@@ -567,18 +535,14 @@ more information on bonus types.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:EQMARMOR|MAXDEX|2
-   </code>
+   <code>BONUS:EQMARMOR|MAXDEX|2</code>
   </p>
   <p class="indent3">
    Increases maximum dexterity bonus of the armor
 by 2.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:EQMARMOR|MAXDEX|2|TYPE=Enhancement
-   </code>
+   <code>BONUS:EQMARMOR|MAXDEX|2|TYPE=Enhancement</code>
   </p>
   <p class="indent3">
    Increases maximum dexterity bonus of the armor
@@ -632,18 +596,14 @@ more information on bonus types.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:EQMARMOR|SPELLFAILURE|-10
-   </code>
+   <code>BONUS:EQMARMOR|SPELLFAILURE|-10</code>
   </p>
   <p class="indent3">
    Decreases the spell failure chance of the armor
 by 10%.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:EQMARMOR|SPELLFAILURE|-10|TYPE=Enhancement
-   </code>
+   <code>BONUS:EQMARMOR|SPELLFAILURE|-10|TYPE=Enhancement</code>
   </p>
   <p class="indent3">
    Decreases the spell failure chance of the armor
@@ -696,9 +656,7 @@ more information on bonus types.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:EQMWEAPON|CRITRANGEADD|1
-   </code>
+   <code>BONUS:EQMWEAPON|CRITRANGEADD|1</code>
   </p>
   <p class="indent3">
    Increases the critical threat range of the
@@ -751,18 +709,14 @@ more information on bonus types.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:EQMWEAPON|CRITRANGEDOUBLE|1
-   </code>
+   <code>BONUS:EQMWEAPON|CRITRANGEDOUBLE|1</code>
   </p>
   <p class="indent3">
    Doubles the critical threat range of the
 weapon.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:EQMWEAPON|CRITRANGEDOUBLE|1|TYPE=NonStackingCrit
-   </code>
+   <code>BONUS:EQMWEAPON|CRITRANGEDOUBLE|1|TYPE=NonStackingCrit</code>
   </p>
   <p class="indent3">
    Adds one to the non-stacking-critical threat
@@ -815,9 +769,7 @@ more information on bonus types.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:EQMWEAPON|DAMAGESIZE|1
-   </code>
+   <code>BONUS:EQMWEAPON|DAMAGESIZE|1</code>
   </p>
   <p class="indent3">
    Modifies the weapon's damage as if it were 1
@@ -870,18 +822,14 @@ more information on bonus types.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:EQMWEAPON|RANGEADD|10
-   </code>
+   <code>BONUS:EQMWEAPON|RANGEADD|10</code>
   </p>
   <p class="indent3">
    Adds 10 distance units to the weapon's
 range.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:EQMWEAPON|RANGEADD|5|TYPE=CONVERSION
-   </code>
+   <code>BONUS:EQMWEAPON|RANGEADD|5|TYPE=CONVERSION</code>
   </p>
   <p class="indent3">
    Adds 5 distance units to the weapon's range by
@@ -934,9 +882,7 @@ more information on bonus types.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:EQMWEAPON|RANGEMULT|2
-   </code>
+   <code>BONUS:EQMWEAPON|RANGEMULT|2</code>
   </p>
   <p class="indent3">
    Doubles the range of the weapon.
@@ -979,9 +925,7 @@ Name:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHARGES:1|50
-   </code>
+   <code>CHARGES:1|50</code>
   </p>
   <p class="indent3">
    Sets the charges for a magic item at a minimum
@@ -1042,10 +986,8 @@ this tag to function properly.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:ABILITY|FEAT|TYPE=Rogue
-Abilities
-   </code>
+   <code>CHOOSE:ABILITY|FEAT|TYPE=Rogue
+Abilities</code>
   </p>
   <p class="indent3">
    A list of all "Rogue Abilities" type feats will
@@ -1136,53 +1078,41 @@ z.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:EQBUILDER.SPELL|SCHOOL.Enchantment;SUBSCHOOL.Compulsion
-   </code>
+   <code>CHOOSE:EQBUILDER.SPELL|SCHOOL.Enchantment;SUBSCHOOL.Compulsion</code>
   </p>
   <p class="indent3">
    Show all spells that are Evocation AND
 Compulsion.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:EQBUILDER.SPELL|SCHOOL.Enchantment|SCHOOL.Abjuration
-   </code>
+   <code>CHOOSE:EQBUILDER.SPELL|SCHOOL.Enchantment|SCHOOL.Abjuration</code>
   </p>
   <p class="indent3">
    Show all spells that are Evocation OR
 Abjuration.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:EQBUILDER.SPELL|Arcane,Divine|0|3
-   </code>
+   <code>CHOOSE:EQBUILDER.SPELL|Arcane,Divine|0|3</code>
   </p>
   <p class="indent3">
    Allows the user to quickly generate a minor
 scroll
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:EQBUILDER.SPELL|Arcane|SCHOOL.Evocation|0|3
-   </code>
+   <code>CHOOSE:EQBUILDER.SPELL|Arcane|SCHOOL.Evocation|0|3</code>
   </p>
   <p class="indent3">
    Allows the user to quickly generate a minor wand
 with only evocation spells
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:EQBUILDER.SPELL|Psionics|0|3
-   </code>
+   <code>CHOOSE:EQBUILDER.SPELL|Psionics|0|3</code>
   </p>
   <p class="indent3">
    Allows a minor powerstone
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:EQBUILDER.SPELL|Arcane|SCHOOL.Illusion,DESCRIPTOR.Fear|SCHOOL.Abjuration
-   </code>
+   <code>CHOOSE:EQBUILDER.SPELL|Arcane|SCHOOL.Illusion,DESCRIPTOR.Fear|SCHOOL.Abjuration</code>
   </p>
   <p class="indent3">
    Indicates Spells which are: (School Illusion AND
@@ -1237,35 +1167,27 @@ designated for this tag to function properly.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:EQUIPMENT|TYPE=Goods
-   </code>
+   <code>CHOOSE:EQUIPMENT|TYPE=Goods</code>
   </p>
   <p class="indent3">
    A list of all equipment of type 'Goods'.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:EQUIPMENT|TYPE=Martial|TYPE=Finessable
-   </code>
+   <code>CHOOSE:EQUIPMENT|TYPE=Martial|TYPE=Finessable</code>
   </p>
   <p class="indent3">
    A list of all equipment of types 'Martial' and
 'Finessable'.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:EQUIPMENT|TYPE=Natural|TYPE=Bludgeoning
-   </code>
+   <code>CHOOSE:EQUIPMENT|TYPE=Natural|TYPE=Bludgeoning</code>
   </p>
   <p class="indent3">
    A list of all equipment of types 'Natural' and
 'Bludgeoning'.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:EQUIPMENT|TYPE=Alchemical|TYPE=Consumable
-   </code>
+   <code>CHOOSE:EQUIPMENT|TYPE=Alchemical|TYPE=Consumable</code>
   </p>
   <p class="indent3">
    A list of all equipment of types 'Alchemical'
@@ -1315,9 +1237,7 @@ tag to function properly.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:FEAT|TYPE=Fighter
-   </code>
+   <code>CHOOSE:FEAT|TYPE=Fighter</code>
   </p>
   <p class="indent3">
    A list of all "Fighter" type feats will be
@@ -1351,9 +1271,7 @@ window.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:NOCHOICE
-   </code>
+   <code>CHOOSE:NOCHOICE</code>
   </p>
   <p class="indent3">
    The associated feat is added without a chooser
@@ -1431,10 +1349,8 @@ the chooser if invoked from the Temporary Bonus tab.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:NUMBER|MIN=2|MAX=5|TITLE=Roll 1d4+1
-and pick a number
-   </code>
+   <code>CHOOSE:NUMBER|MIN=2|MAX=5|TITLE=Roll 1d4+1
+and pick a number</code>
   </p>
   <p class="indent3">
    Will let you choose a number between 2 and 5.
@@ -1496,10 +1412,8 @@ the chooser if invoked from the Temporary Bonus tab.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:SKILL|Climb|Jump|Balance|Tumble|TITLE=Acrobatics Skill
-Bonus
-   </code>
+   <code>CHOOSE:SKILL|Climb|Jump|Balance|Tumble|TITLE=Acrobatics Skill
+Bonus</code>
   </p>
   <p class="indent3">
    Will let you select "Climb", "Jump", "Balance",
@@ -1575,10 +1489,8 @@ the chooser if invoked from the Temporary Bonus tab.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:SKILLBONUS|Climb|MIN=2|MAX=5|TITLE=Enhancement
-Bonus
-   </code>
+   <code>CHOOSE:SKILLBONUS|Climb|MIN=2|MAX=5|TITLE=Enhancement
+Bonus</code>
   </p>
   <p class="indent3">
    Will let you choose a number between 2 and 5 as
@@ -1647,10 +1559,8 @@ the chooser if invoked from the Temporary Bonus tab.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:STATBONUS|INT|MIN=2|MAX=5|TITLE=Enhancement
-Bonus
-   </code>
+   <code>CHOOSE:STATBONUS|INT|MIN=2|MAX=5|TITLE=Enhancement
+Bonus</code>
   </p>
   <p class="indent3">
    Will let you choose a number between 2 and 5 as
@@ -1698,20 +1608,16 @@ strings.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:STRING|+1|+2|TITLE=Enhancement
-Bonus
-   </code>
+   <code>CHOOSE:STRING|+1|+2|TITLE=Enhancement
+Bonus</code>
   </p>
   <p class="indent3">
    This will produce an "Enhancement Bonus" list
 consisting of "+1" and "+2".
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:STRING|Undead|Constructs|Monkeys|TITLE=Biggest
-Irritant
-   </code>
+   <code>CHOOSE:STRING|Undead|Constructs|Monkeys|TITLE=Biggest
+Irritant</code>
   </p>
   <p class="indent3">
    This will produce a list consisting of "Undead",
@@ -1810,35 +1716,27 @@ added by the modifier.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    COST:300
-   </code>
+   <code>COST:300</code>
   </p>
   <p class="indent3">
    Adds 300 gold to the equipments cost.
   </p>
   <p class="indent2">
-   <code>
-    COST:BASECOST/2
-   </code>
+   <code>COST:BASECOST/2</code>
   </p>
   <p class="indent3">
    Adds half the base cost of the equipment to the
 cost.
   </p>
   <p class="indent2">
-   <code>
-    COST:500*WT
-   </code>
+   <code>COST:500*WT</code>
   </p>
   <p class="indent3">
    Adds 500 gold per lb. to the equipments
 cost.
   </p>
   <p class="indent2">
-   <code>
-    COST:((BASECOST/50)*%CHARGES)-BASECOST
-   </code>
+   <code>COST:((BASECOST/50)*%CHARGES)-BASECOST</code>
   </p>
   <p class="indent3">
    Assuming this modifier adds 50 charges to the
@@ -1847,9 +1745,7 @@ basecost making the cost of the equipment proportional to the
 number of charges left in it.
   </p>
   <p class="indent2">
-   <code>
-    COST:(25*((%SPELLLEVEL)MAX(1/2))*%CASTERLEVEL)+%SPELLCOST+(5*%SPELLXPCOST)
-   </code>
+   <code>COST:(25*((%SPELLLEVEL)MAX(1/2))*%CASTERLEVEL)+%SPELLCOST+(5*%SPELLXPCOST)</code>
   </p>
   <p class="indent3">
    This is the cost formula from a scroll
@@ -1893,9 +1789,7 @@ as it's TYPE is not 'MANTLE', 'POTION', 'SCROLL', 'STAFF', or
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    COSTDOUBLE:YES
-   </code>
+   <code>COSTDOUBLE:YES</code>
   </p>
   <p class="indent3">
    Cost of item is doubled.
@@ -1932,9 +1826,7 @@ resizing an item occurs.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    COSTPRE:100
-   </code>
+   <code>COSTPRE:100</code>
   </p>
   <p class="indent3">
    Item cost is 100 gold before resizing.
@@ -2000,27 +1892,21 @@ after the base equipment item name.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    Masterwork[tab]FORMATCAT:PARENS[tab]NAMEOPT:TEXT=MW
-   </code>
+   <code>Masterwork[tab]FORMATCAT:PARENS[tab]NAMEOPT:TEXT=MW</code>
   </p>
   <p class="indent3">
    when applied to a battleaxe would give battleaxe
 (MW)
   </p>
   <p class="indent2">
-   <code>
-    MAGIC_PLUS_1[tab]FORMATCAT:FRONT[tab]NAMEOPT:TEXT=+1
-   </code>
+   <code>MAGIC_PLUS_1[tab]FORMATCAT:FRONT[tab]NAMEOPT:TEXT=+1</code>
   </p>
   <p class="indent3">
    when applied to a battleaxe would give +1
 battleaxe
   </p>
   <p class="indent2">
-   <code>
-    MAGIC_PLUS_1[tab]FORMATCAT:MIDDLE[tab]NAMEOPT:TEXT=+1
-   </code>
+   <code>MAGIC_PLUS_1[tab]FORMATCAT:MIDDLE[tab]NAMEOPT:TEXT=+1</code>
   </p>
   <p class="indent3">
    when applied to a battleaxe would give battleaxe
@@ -2065,17 +1951,13 @@ secondary weapon head).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    FUMBLERANGE:1-3
-   </code>
+   <code>FUMBLERANGE:1-3</code>
   </p>
   <p class="indent3">
    Indicates and error range of 1-3.
   </p>
   <p class="indent2">
-   <code>
-    FUMBLERANGE:Natural 1
-   </code>
+   <code>FUMBLERANGE:Natural 1</code>
   </p>
   <p class="indent3">
    Indicates and error range of a natural 1.
@@ -2113,9 +1995,7 @@ item being created.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ITYPE:Magic.Ranged.Thrown
-   </code>
+   <code>ITYPE:Magic.Ranged.Thrown</code>
   </p>
   <p class="indent3">
    The item gains the types "Magic", "Ranged" &amp;
@@ -2216,9 +2096,7 @@ equipment.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    Craft[tab]CHOOSE:SKILL|TYPE=CRAFT[tab]BONUS:SKILL|%CHOICE|2[tab]
-   </code>
+   <code>Craft[tab]CHOOSE:SKILL|TYPE=CRAFT[tab]BONUS:SKILL|%CHOICE|2[tab]</code>
   </p>
   <p class="indent3">
    selecting "Craft (Armorsmithing)" in the chooser
@@ -2243,9 +2121,7 @@ the name.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    NAMEOPT:SPELL
-   </code>
+   <code>NAMEOPT:SPELL</code>
   </p>
   <p class="indent3">
    Customizing boots with an invisibility spell
@@ -2282,9 +2158,7 @@ item.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PLUS:1
-   </code>
+   <code>PLUS:1</code>
   </p>
   <p class="indent3">
    Item is treated as +1.
@@ -2336,9 +2210,7 @@ number of types that must match the specified requirements).
     Make specific Types or Equipment Modifiers a prerequisite.
    </li>
    <li>
-    <code>
-     EQMODTYPE
-    </code>
+    <code>EQMODTYPE</code>
     checks for the
     <strong>
      TYPE
@@ -2347,9 +2219,7 @@ number of types that must match the specified requirements).
 the applied Equipment Modifiers, not Equipment type.
    </li>
    <li>
-    <code>
-     EQMOD
-    </code>
+    <code>EQMOD</code>
     checks for the specified
     <strong>
      EQMOD
@@ -2357,13 +2227,9 @@ the applied Equipment Modifiers, not Equipment type.
     by name or key.
    </li>
    <li>
-    <code>
-     EQMOD
-    </code>
+    <code>EQMOD</code>
     can take an optional parameter of the form
-    <code>
-     EQMOD=&lt;key&gt;(&lt;choice&gt;)
-    </code>
+    <code>EQMOD=&lt;key&gt;(&lt;choice&gt;)</code>
     , where the "choice"
 represents an item previously selected by an internal chooser for
 the specified
@@ -2378,9 +2244,7 @@ the specified
     Note
    </span>
    :
-   <code>
-    PRETYPE
-   </code>
+   <code>PRETYPE</code>
    has a different use outside of Equipment and
 Equipment Modifier files, it checks for race types. See the
    <a href="../globalfilestagpages/globalfilesprexxx.html#pretype">
@@ -2396,18 +2260,14 @@ Modifier files.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRETYPE:1,Magic &lt;tab&gt;
-PRETYPE:1,Piercing,Slashing
-   </code>
+   <code>PRETYPE:1,Magic &lt;tab&gt;
+PRETYPE:1,Piercing,Slashing</code>
   </p>
   <p class="indent3">
    Type must be magic and piercing or slashing
   </p>
   <p class="indent2">
-   <code>
-    PREMULT:2,[PRETYPE:1,Magic],[PRETYPE:1,Piercing,Slashing]
-   </code>
+   <code>PREMULT:2,[PRETYPE:1,Magic],[PRETYPE:1,Piercing,Slashing]</code>
   </p>
   <p class="indent3">
    This example, utilizing the PREMULT tag,
@@ -2415,26 +2275,20 @@ accomplishes the same thing as the example above it but as it is
 one statement it can be attached to a BONUS statement.
   </p>
   <p class="indent2">
-   <code>
-    !PRETYPE:1,Heavy
-   </code>
+   <code>!PRETYPE:1,Heavy</code>
   </p>
   <p class="indent3">
    Type must NOT be Heavy
   </p>
   <p class="indent2">
-   <code>
-    PRETYPE:1,EQMODTYPE=Mundane
-   </code>
+   <code>PRETYPE:1,EQMODTYPE=Mundane</code>
   </p>
   <p class="indent3">
    Use to test for any modifier with "Mundane"
 type.
   </p>
   <p class="indent2">
-   <code>
-    PRETYPE:1,EQMOD=IRONWOOD
-   </code>
+   <code>PRETYPE:1,EQMOD=IRONWOOD</code>
   </p>
   <p class="indent3">
    Use to test for the "Ironwood" Equipment
@@ -2489,9 +2343,7 @@ to pass.
      AND
     </strong>
     . As an example,
-    <code>
-     PRETYPE:Heavy,Armor|Shield
-    </code>
+    <code>PRETYPE:Heavy,Armor|Shield</code>
     translates to: Must have
 "Heavy" AND either "Armor" OR "Shield" types.
    </li>
@@ -2503,17 +2355,13 @@ syntax:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRETYPE:Magic,Piercing,Slashing
-   </code>
+   <code>PRETYPE:Magic,Piercing,Slashing</code>
   </p>
   <p class="indent3">
    Type must be Magic, Piercing and Slashing.
   </p>
   <p class="indent2">
-   <code>
-    PRETYPE:Magic,Armor|Shield,Piercing,Slashing
-   </code>
+   <code>PRETYPE:Magic,Armor|Shield,Piercing,Slashing</code>
   </p>
   <p class="indent3">
    Type must be Magic, Piercing, Slashing and
@@ -2574,17 +2422,13 @@ number of the wield categories that must match)
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PREWIELD:1,Light,OneHanded
-   </code>
+   <code>PREWIELD:1,Light,OneHanded</code>
   </p>
   <p class="indent3">
    Weapon must be either Light or OneHanded.
   </p>
   <p class="indent2">
-   <code>
-    PREWIELD:1,TwoHanded
-   </code>
+   <code>PREWIELD:1,TwoHanded</code>
   </p>
   <p class="indent3">
    Weapon must be TwoHanded.
@@ -2621,9 +2465,7 @@ in the existing item by the specified eqmod keys in this tag.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    REPLACES:WEAP+1,WEAP+2,WEAP+3,WEAP+4,WEAP+5
-   </code>
+   <code>REPLACES:WEAP+1,WEAP+2,WEAP+3,WEAP+4,WEAP+5</code>
   </p>
   <p class="indent3">
    Replaces keys "WEAP+1", "WEAP+2", "WEAP+3",
@@ -2705,40 +2547,32 @@ SPROP will pick up and display the selection from the CHOOSE.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SPROP:Shines with an inner
-light
-   </code>
+   <code>SPROP:Shines with an inner
+light</code>
   </p>
   <p class="indent3">
    Output sheet reads "Shines with an inner light"
 under the item.
   </p>
   <p class="indent2">
-   <code>
-    SPROP:Squash code bugs % times per
-day|TL
-   </code>
+   <code>SPROP:Squash code bugs % times per
+day|TL</code>
   </p>
   <p class="indent3">
    For a 5th level character the output sheet would
 read "Squash code bugs 5 times per day" under the item.
   </p>
   <p class="indent2">
-   <code>
-    SPROP:+2 against
-undead|PRECLASS:Paladin=1
-   </code>
+   <code>SPROP:+2 against
+undead|PRECLASS:Paladin=1</code>
   </p>
   <p class="indent3">
    Outputs the text if the character has at least 1
 level of Paladin.
   </p>
   <p class="indent2">
-   <code>
-    SPROP:+% vs. code
-bugs|ColaIntake|PRESKILL:1,Programming=10
-   </code>
+   <code>SPROP:+% vs. code
+bugs|ColaIntake|PRESKILL:1,Programming=10</code>
   </p>
   <p class="indent3">
    If the character has the Programming skill of at
@@ -2746,19 +2580,15 @@ least 10 and the variable "ColaIntake" is defined as equal to 4
 then the output sheet reads "+4 vs. code bugs".
   </p>
   <p class="indent2">
-   <code>
-    SPROP:+2 against %CHOICE
-   </code>
+   <code>SPROP:+2 against %CHOICE</code>
   </p>
   <p class="indent3">
    If one of the choices offered by the EQMOD were
 "Dragons" the SPROP might read "+2 against Dragons".
   </p>
   <p class="indent2">
-   <code>
-    SPROP:Unreliable (%CHOICE) &lt;tab&gt;
-CHOOSE:5%|10%|15%|20%|25%|30%|35%|40%|45%|50%|55%|60%|65%|70%|75%|80%|85%|90%|95%|100%
-   </code>
+   <code>SPROP:Unreliable (%CHOICE) &lt;tab&gt;
+CHOOSE:5%|10%|15%|20%|25%|30%|35%|40%|45%|50%|55%|60%|65%|70%|75%|80%|85%|90%|95%|100%</code>
   </p>
   <p class="indent3">
    Chooser to select the level of unreliablty.
@@ -2799,23 +2629,17 @@ Name:
   </p>
   <ul class="indent2">
    <li>
-    <code>
-     YES
-    </code>
+    <code>YES</code>
     - This will always show the modifier in the
 customizer window.
    </li>
    <li>
-    <code>
-     NO
-    </code>
+    <code>NO</code>
     - This will never show the modifier in the
 customizer window.
    </li>
    <li>
-    <code>
-     QUALIFY
-    </code>
+    <code>QUALIFY</code>
     - This will always show the modifier in
 the customizer window if the item meets the requirements to obtain
 this modifier.
@@ -2827,9 +2651,7 @@ this modifier.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    VISIBLE:YES
-   </code>
+   <code>VISIBLE:YES</code>
   </p>
   <p class="indent3">
    This will always show the modifier in the

--- a/docs/listfilepages/datafilestagpages/datafilesfeats.html
+++ b/docs/listfilepages/datafilestagpages/datafilesfeats.html
@@ -55,32 +55,22 @@
        ability
       </a>
       belonging to the
-      <code>
-       FEAT
-      </code>
+      <code>FEAT</code>
       <a href="file:///C:/Users/lws/gits/pcgen/docs/listfilepages/datafilestagpages/datafilesabilitycategory.html">
        ability category
       </a>
       , i.e.
-      <code>
-       CATEGORY:FEAT
-      </code>
+      <code>CATEGORY:FEAT</code>
       .
      </li>
      <li>
       The feats may still be contained in a file called
-      <code>
-       feats.lst
-      </code>
+      <code>feats.lst</code>
       (see
-      <code>
-       /data/35e/wizards_of_the_coast/rsrd/basics/feats.lst
-      </code>
+      <code>/data/35e/wizards_of_the_coast/rsrd/basics/feats.lst</code>
       for an example.) However this file must use the
       <a href="file:///C:/Users/lws/gits/pcgen/docs/listfilepages/datafilestagpages/datafilesability.html">
-       <code>
-        ability.lst
-       </code>
+       <code>ability.lst</code>
        format
       </a>
       , not the obsolete format
@@ -88,21 +78,15 @@ described below.
      </li>
      <li>
       All
-      <code>
-       FEAT
-      </code>
+      <code>FEAT</code>
       tags have been
       <strong>
        deprecated
       </strong>
       and replaced by the
-      <code>
-       ABILITY
-      </code>
+      <code>ABILITY</code>
       system, which is more general. The
-      <code>
-       ABILITY
-      </code>
+      <code>ABILITY</code>
       system can model feats, racial features, class
 features, traits, flaws, temporary bonuses, and so on, all using a
 common format
@@ -140,28 +124,22 @@ assumes that feat is an instance of the one without parentheses and
 does not display the one with parentheses.
    </p>
    <p class="indent2">
-    <code>
-     Improved Critical
-    </code>
+    <code>Improved Critical</code>
    </p>
    <p class="indent3">
     The feat named "Improved Critical" is to be
 created.
    </p>
    <p class="indent2">
-    <code>
-     Acrobatic.MOD
-    </code>
+    <code>Acrobatic.MOD</code>
    </p>
    <p class="indent3">
     The feat named "Acrobatic" is to be
 modified.
    </p>
    <p class="indent2">
-    <code>
-     Occupation (Emergency
-Services).FORGET
-    </code>
+    <code>Occupation (Emergency
+Services).FORGET</code>
    </p>
    <p class="indent3">
     The feat named "Occupation (Emergency Services)"
@@ -169,9 +147,7 @@ is to be forgotten.
    </p>
    <p class="indent1">
     When the
-    <code>
-     POINTPOOLNAME
-    </code>
+    <code>POINTPOOLNAME</code>
     trigger tag
 is present in the
     <span class="lstfile">
@@ -238,17 +214,11 @@ the spell level slot requires.
      </strong>
      When modifying a a feat with
 the
-     <code>
-      .MOD
-     </code>
+     <code>.MOD</code>
      tag, given an existing
-     <code>
-      ADDSPELLLEVEL
-     </code>
+     <code>ADDSPELLLEVEL</code>
      tag, the data included in a new
-     <code>
-      ADDSPELLLEVEL
-     </code>
+     <code>ADDSPELLLEVEL</code>
      tag will overwrite the existing tag
 data.
     </li>
@@ -259,9 +229,7 @@ data.
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     ADDSPELLLEVEL:2
-    </code>
+    <code>ADDSPELLLEVEL:2</code>
    </p>
    <p class="indent3">
     A spell with this metamagic feat applied to it
@@ -274,24 +242,18 @@ takes up a slot two levels higher than the normal spell.
    </p>
    <p class="indent2">
     Initial Feat:
-    <code>
-     &lt;feat name&gt;
-&lt;tab&gt; ADDSPELLLEVEL:1
-    </code>
+    <code>&lt;feat name&gt;
+&lt;tab&gt; ADDSPELLLEVEL:1</code>
    </p>
    <p class="indent2">
     Modified By:
-    <code>
-     &lt;feat name&gt; &lt;tab&gt;
-ADDSPELLLEVEL:2
-    </code>
+    <code>&lt;feat name&gt; &lt;tab&gt;
+ADDSPELLLEVEL:2</code>
    </p>
    <p class="indent2">
     Is Equivalent To:
-    <code>
-     &lt;feat name&gt;
-&lt;tab&gt; ADDSPELLLEVEL:2
-    </code>
+    <code>&lt;feat name&gt;
+&lt;tab&gt; ADDSPELLLEVEL:2</code>
    </p>
    <p class="indent3">
     Modified feat applied to a spell will causes the
@@ -333,9 +295,7 @@ addribute that can modify the spell name./p&gt;
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     APPLIEDNAME:Empowered
-    </code>
+    <code>APPLIEDNAME:Empowered</code>
    </p>
    <p class="indent3">
     A spell with this metamagic feat applied to it
@@ -397,38 +357,26 @@ replaced by the second z, etc..
     <li>
      The y text can also use other special variables, also usable in
 the
-     <code>
-      DESC
-     </code>
+     <code>DESC</code>
      tag:
      <ul>
       <li>
-       <code>
-        %CHOICE
-       </code>
+       <code>%CHOICE</code>
        - Will replace the first associated choice
 in the object.
       </li>
       <li>
-       <code>
-        %LIST
-       </code>
+       <code>%LIST</code>
        - Will substitute all choices comma
 separated into that parameter.
       </li>
       <li>
-       <code>
-        %NAME
-       </code>
+       <code>%NAME</code>
        - The
-       <code>
-        OUTPUTNAME
-       </code>
+       <code>OUTPUTNAME</code>
        or name of the
 object this
-       <code>
-        DESC
-       </code>
+       <code>DESC</code>
        tag is in.
       </li>
      </ul>
@@ -438,30 +386,20 @@ object this
       .MOD Behavior:
      </strong>
      When modifying a feat with the
-     <code>
-      .MOD
-     </code>
+     <code>.MOD</code>
      tag, given an existing
-     <code>
-      ASPECT
-     </code>
+     <code>ASPECT</code>
      tag,
 the data included in a new
-     <code>
-      ASPECT
-     </code>
+     <code>ASPECT</code>
      tag will selectively
 overwrite the existing tag data or include the separate tags. Since
 each aspect name can hold only one value per feat, modifying an
 existing
-     <code>
-      ASPECT
-     </code>
+     <code>ASPECT</code>
      tag will overwrite only the value of
 the aspect by that name in the feat, and will add a separate
-     <code>
-      ASPECT
-     </code>
+     <code>ASPECT</code>
      tag with a new name.
     </li>
    </ul>
@@ -471,10 +409,8 @@ the aspect by that name in the feat, and will add a separate
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     ASPECT:Action Type|Standard
-Action
-    </code>
+    <code>ASPECT:Action Type|Standard
+Action</code>
    </p>
    <p class="indent3">
     Identifies the "Action Type" of an action
@@ -482,9 +418,7 @@ performed as part of the associated feat as a "Standard
 Action".
    </p>
    <p class="indent2">
-    <code>
-     ASPECT:Attack Type|Melee weapon
-    </code>
+    <code>ASPECT:Attack Type|Melee weapon</code>
    </p>
    <p class="indent3">
     Identifies the "Attack Type" of an attack
@@ -492,28 +426,22 @@ performed as part of the associated feat as a "Melee weapon"
 attack.
    </p>
    <p class="indent2">
-    <code>
-     ASPECT:Target|One creature
-    </code>
+    <code>ASPECT:Target|One creature</code>
    </p>
    <p class="indent3">
     Identifies the "Target" of an action performed
 as part of the associated feat as "One creature".
    </p>
    <p class="indent2">
-    <code>
-     ASPECT:Attack|Strength vs. AC
-    </code>
+    <code>ASPECT:Attack|Strength vs. AC</code>
    </p>
    <p class="indent3">
     Identifies an "Attack" performed as part of the
 associated feat as "Strength vs. AC".
    </p>
    <p class="indent2">
-    <code>
-     ASPECT:Attack Type|Ranged
-%1|PowerRange
-    </code>
+    <code>ASPECT:Attack Type|Ranged
+%1|PowerRange</code>
    </p>
    <p class="indent3">
     Identifies the "Attack Type" of an attack
@@ -521,10 +449,8 @@ performed as part of the associated feat as a "Ranged" attack with
 a range equivalent to the "PowerRange" variable.
    </p>
    <p class="indent2">
-    <code>
-     ASPECT:Effect|Double damage to %CHOICE
-creatures
-    </code>
+    <code>ASPECT:Effect|Double damage to %CHOICE
+creatures</code>
    </p>
    <p class="indent3">
     Identifies the "Effect" of an action performed
@@ -538,24 +464,18 @@ chosen by the associated chooser.
    </p>
    <p class="indent2">
     Initial Feat:
-    <code>
-     &lt;feat name&gt;
-&lt;tab&gt; ASPECT:A1|A2
-    </code>
+    <code>&lt;feat name&gt;
+&lt;tab&gt; ASPECT:A1|A2</code>
    </p>
    <p class="indent2">
     Modified By:
-    <code>
-     &lt;feat name&gt; &lt;tab&gt;
-ASPECT:A1|A3
-    </code>
+    <code>&lt;feat name&gt; &lt;tab&gt;
+ASPECT:A1|A3</code>
    </p>
    <p class="indent2">
     Is Equivalent To:
-    <code>
-     &lt;feat name&gt;
-&lt;tab&gt; ASPECT:A1|A3
-    </code>
+    <code>&lt;feat name&gt;
+&lt;tab&gt; ASPECT:A1|A3</code>
    </p>
    <p class="indent1">
     <strong>
@@ -565,24 +485,18 @@ Separately):
    </p>
    <p class="indent2">
     Initial Feat:
-    <code>
-     &lt;feat name&gt;
-&lt;tab&gt; ASPECT:A1|A2
-    </code>
+    <code>&lt;feat name&gt;
+&lt;tab&gt; ASPECT:A1|A2</code>
    </p>
    <p class="indent2">
     Modified By:
-    <code>
-     &lt;feat name&gt; &lt;tab&gt;
-ASPECT:B1|B2
-    </code>
+    <code>&lt;feat name&gt; &lt;tab&gt;
+ASPECT:B1|B2</code>
    </p>
    <p class="indent2">
     Is Equivalent To:
-    <code>
-     &lt;feat name&gt;
-&lt;tab&gt; ASPECT:A1|A2 &lt;tab&gt; ASPECT:B1|B2
-    </code>
+    <code>&lt;feat name&gt;
+&lt;tab&gt; ASPECT:A1|A2 &lt;tab&gt; ASPECT:B1|B2</code>
    </p>
    <hr/>
    <p class="indent0">
@@ -627,53 +541,37 @@ Preference window is unchecked. Otherwise the text from the
     </li>
     <li>
      PRExxx tags can be used with the
-     <code>
-      BENEFIT
-     </code>
+     <code>BENEFIT</code>
      tag.
     </li>
     <li>
      Multiple
-     <code>
-      BENEFIT
-     </code>
+     <code>BENEFIT</code>
      tags per line are allowed with
 all qualifying
-     <code>
-      BENEFIT
-     </code>
+     <code>BENEFIT</code>
      tags being concatonated for
 output and separated by spaces.
     </li>
     <li>
-     <code>
-      .CLEAR
-     </code>
+     <code>.CLEAR</code>
      will clear all
-     <code>
-      BENEFIT
-     </code>
+     <code>BENEFIT</code>
      tags.
     </li>
     <li>
-     <code>
-      .CLEAR.(regular expression match)
-     </code>
+     <code>.CLEAR.(regular expression match)</code>
      will clear
 specific instances.
     </li>
     <li>
-     <code>
-      BENEFIT
-     </code>
+     <code>BENEFIT</code>
      tags will take variable substitution.
      <ul>
       <li>
        Within the text a % followed by a number will substitute the
 #th variable from the variable list associated with the
-       <code>
-        BENEFIT
-       </code>
+       <code>BENEFIT</code>
        .
       </li>
       <li>
@@ -696,33 +594,23 @@ number should be surrounded in curly brackets { }. For example,
 list:
      <ul>
       <li>
-       <code>
-        %NAME
-       </code>
+       <code>%NAME</code>
        - The name of the object this
-       <code>
-        BENEFIT
-       </code>
+       <code>BENEFIT</code>
        tag is in.
       </li>
       <li>
-       <code>
-        %FEAT
-       </code>
+       <code>%FEAT</code>
        - Will substitute the descriptions of feats
 within the object that match the associated preqrequisites.
       </li>
       <li>
-       <code>
-        %CHOICE
-       </code>
+       <code>%CHOICE</code>
        - Will replace the first associated choice
 in the object.
       </li>
       <li>
-       <code>
-        %LIST
-       </code>
+       <code>%LIST</code>
        - Will substitute all choices into that
 parameter as a comma-delimited list.
       </li>
@@ -758,19 +646,13 @@ You can create fairly powerful match structures using things like
 character groups "[a-zA-Z]" match any alphabetic character or
 groupings "(bat|super)man" match batman or superman and many many
 more. So, for example, you could clear all benefits by doing
-     <code>
-      BENEFIT:.CLEAR..*
-     </code>
+     <code>BENEFIT:.CLEAR..*</code>
      , or clear all exceptional abilities
 by doing
-     <code>
-      BENEFIT:.CLEAR.\(Ex\)
-     </code>
+     <code>BENEFIT:.CLEAR.\(Ex\)</code>
      , or clear everything
 that's non-numeric with
-     <code>
-      BENEFIT:.CLEAR.[A-Za-z]
-     </code>
+     <code>BENEFIT:.CLEAR.[A-Za-z]</code>
      .
     </li>
     <li>
@@ -778,18 +660,12 @@ that's non-numeric with
       .MOD Behavior:
      </strong>
      When modifying a feat with the
-     <code>
-      .MOD
-     </code>
+     <code>.MOD</code>
      tag, given an existing
-     <code>
-      BENEFIT
-     </code>
+     <code>BENEFIT</code>
      tag,
 the data included in a new
-     <code>
-      BENEFIT
-     </code>
+     <code>BENEFIT</code>
      tag will be
 included as a separate tag.
     </li>
@@ -800,10 +676,8 @@ included as a separate tag.
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     BENEFIT:This is sample text for the
-example purposes
-    </code>
+    <code>BENEFIT:This is sample text for the
+example purposes</code>
    </p>
    <p class="indent3">
     Adds feat benefit.
@@ -816,25 +690,19 @@ Separately):
    </p>
    <p class="indent2">
     Initial Feat:
-    <code>
-     &lt;feat name&gt;
-&lt;tab&gt; BENEFIT:Initial benefit text.
-    </code>
+    <code>&lt;feat name&gt;
+&lt;tab&gt; BENEFIT:Initial benefit text.</code>
    </p>
    <p class="indent2">
     Modified By:
-    <code>
-     &lt;feat name&gt; &lt;tab&gt;
-BENEFIT:New benefit text.
-    </code>
+    <code>&lt;feat name&gt; &lt;tab&gt;
+BENEFIT:New benefit text.</code>
    </p>
    <p class="indent2">
     Is Equivalent To:
-    <code>
-     &lt;feat name&gt;
+    <code>&lt;feat name&gt;
 &lt;tab&gt; BENEFIT:Initial benefit text. &lt;tab&gt; BENEFIT:New
-benefit text.
-    </code>
+benefit text.</code>
    </p>
    <p class="indent3">
     The output of the modified will show the
@@ -873,18 +741,12 @@ point.
       .MOD Behavior:
      </strong>
      When modifying a feat with the
-     <code>
-      .MOD
-     </code>
+     <code>.MOD</code>
      tag, given an existing
-     <code>
-      COST
-     </code>
+     <code>COST</code>
      tag, the
 data included in a new
-     <code>
-      COST
-     </code>
+     <code>COST</code>
      tag will overwrite the
 existing tag data.
     </li>
@@ -895,17 +757,13 @@ existing tag data.
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     COST:1
-    </code>
+    <code>COST:1</code>
    </p>
    <p class="indent3">
     Feat costs one feat point.
    </p>
    <p class="indent2">
-    <code>
-     COST:.5
-    </code>
+    <code>COST:.5</code>
    </p>
    <p class="indent3">
     Feat costs half a feat point.
@@ -916,9 +774,7 @@ existing tag data.
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     1
-    </code>
+    <code>1</code>
    </p>
    <p class="indent1">
     <strong>
@@ -927,24 +783,18 @@ existing tag data.
    </p>
    <p class="indent2">
     Initial Feat:
-    <code>
-     &lt;feat name&gt;
-&lt;tab&gt; COST:2
-    </code>
+    <code>&lt;feat name&gt;
+&lt;tab&gt; COST:2</code>
    </p>
    <p class="indent2">
     Modified By:
-    <code>
-     &lt;feat name&gt; &lt;tab&gt;
-COST:1
-    </code>
+    <code>&lt;feat name&gt; &lt;tab&gt;
+COST:1</code>
    </p>
    <p class="indent2">
     Is Equivalent To:
-    <code>
-     &lt;ability name&gt;
-&lt;tab&gt; COST:1
-    </code>
+    <code>&lt;ability name&gt;
+&lt;tab&gt; COST:1</code>
    </p>
    <p class="indent3">
     Modified Feat costs one feat point.
@@ -993,17 +843,11 @@ new one.
       .MOD Behavior:
      </strong>
      When modifying an feat with the
-     <code>
-      .MOD
-     </code>
+     <code>.MOD</code>
      tag, given an existing
-     <code>
-      MODIFYFEATCHOICE
-     </code>
+     <code>MODIFYFEATCHOICE</code>
      tag, the data included in a new
-     <code>
-      MODIFYFEATCHOICE
-     </code>
+     <code>MODIFYFEATCHOICE</code>
      tag will overwrite the existing tag
 data.
     </li>
@@ -1014,9 +858,7 @@ data.
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     MODIFYFEATCHOICE:TYPE=NinjaMonkeySchool
-    </code>
+    <code>MODIFYFEATCHOICE:TYPE=NinjaMonkeySchool</code>
    </p>
    <p class="indent3">
     Allows the selection of a new school from a list
@@ -1024,10 +866,8 @@ of schools of type 'NinjaMonkeySchool' to replace a previously
 selected one.
    </p>
    <p class="indent2">
-    <code>
-     MODIFYFEATCHOICE:Ninja Monkey Primary
-Weapon Reselection
-    </code>
+    <code>MODIFYFEATCHOICE:Ninja Monkey Primary
+Weapon Reselection</code>
    </p>
    <p class="indent3">
     Allows a ninja monkey to select a new primary
@@ -1040,25 +880,19 @@ weapon, replacing an earlier selected primary weapon.
    </p>
    <p class="indent2">
     Initial Feat:
-    <code>
-     &lt;feat name&gt;
-&lt;tab&gt; MODIFYFEATCHOICE:TYPE=NinjaMonkeyChimpSchool
-    </code>
+    <code>&lt;feat name&gt;
+&lt;tab&gt; MODIFYFEATCHOICE:TYPE=NinjaMonkeyChimpSchool</code>
    </p>
    <p class="indent2">
     Modified By:
-    <code>
-     &lt;feat name&gt; &lt;tab&gt;
-MODIFYFEATCHOICE:TYPE=NinjaMonkeySilverbackSchool
-    </code>
+    <code>&lt;feat name&gt; &lt;tab&gt;
+MODIFYFEATCHOICE:TYPE=NinjaMonkeySilverbackSchool</code>
    </p>
    <p class="indent2">
     Is Equivalent To:
-    <code>
-     &lt;feat name&gt;
+    <code>&lt;feat name&gt;
 &lt;tab&gt;
-MODIFYFEATCHOICE:TYPE=NinjaMonkeySilverbackSchool
-    </code>
+MODIFYFEATCHOICE:TYPE=NinjaMonkeySilverbackSchool</code>
    </p>
    <p class="indent3">
     Modified feat allows the selection of a new
@@ -1095,9 +929,7 @@ value is set to YES, then you
       MUST
      </strong>
      also use a
-     <code>
-      CHOOSE
-     </code>
+     <code>CHOOSE</code>
      tag.
     </li>
     <li>
@@ -1105,18 +937,12 @@ value is set to YES, then you
       .MOD Behavior:
      </strong>
      When modifying an feat with the
-     <code>
-      .MOD
-     </code>
+     <code>.MOD</code>
      tag, given an existing
-     <code>
-      MULT
-     </code>
+     <code>MULT</code>
      tag, the
 data included in a new
-     <code>
-      MULT
-     </code>
+     <code>MULT</code>
      tag will overwrite the
 existing tag data.
     </li>
@@ -1127,9 +953,7 @@ existing tag data.
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     MULT:YES
-    </code>
+    <code>MULT:YES</code>
    </p>
    <p class="indent3">
     This Feat can be taken multiple times.
@@ -1140,9 +964,7 @@ existing tag data.
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     NO
-    </code>
+    <code>NO</code>
    </p>
    <p class="indent1">
     <strong>
@@ -1151,24 +973,18 @@ existing tag data.
    </p>
    <p class="indent2">
     Initial Feat:
-    <code>
-     &lt;feat name&gt;
-&lt;tab&gt; MULT:YES
-    </code>
+    <code>&lt;feat name&gt;
+&lt;tab&gt; MULT:YES</code>
    </p>
    <p class="indent2">
     Modified By:
-    <code>
-     &lt;feat name&gt; &lt;tab&gt;
-MULT:NO
-    </code>
+    <code>&lt;feat name&gt; &lt;tab&gt;
+MULT:NO</code>
    </p>
    <p class="indent2">
     Is Equivalent To:
-    <code>
-     &lt;feat name&gt;
-&lt;tab&gt; MULT:NO
-    </code>
+    <code>&lt;feat name&gt;
+&lt;tab&gt; MULT:NO</code>
    </p>
    <p class="indent3">
     Modified feat cannot be taken multiple
@@ -1206,18 +1022,12 @@ another.
       .MOD Behavior:
      </strong>
      When modifying a feat with the
-     <code>
-      .MOD
-     </code>
+     <code>.MOD</code>
      tag, given an existing
-     <code>
-      STACK
-     </code>
+     <code>STACK</code>
      tag,
 the data included in a new
-     <code>
-      STACK
-     </code>
+     <code>STACK</code>
      tag will overwrite
 the existing tag data.
     </li>
@@ -1228,9 +1038,7 @@ the existing tag data.
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     STACK:YES
-    </code>
+    <code>STACK:YES</code>
    </p>
    <p class="indent3">
     This Feat may be stack on itself.
@@ -1241,9 +1049,7 @@ the existing tag data.
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     NO
-    </code>
+    <code>NO</code>
    </p>
    <p class="indent1">
     <strong>
@@ -1252,24 +1058,18 @@ the existing tag data.
    </p>
    <p class="indent2">
     Initial Feat:
-    <code>
-     &lt;feat name&gt;
-&lt;tab&gt; STACK:YES
-    </code>
+    <code>&lt;feat name&gt;
+&lt;tab&gt; STACK:YES</code>
    </p>
    <p class="indent2">
     Modified By:
-    <code>
-     &lt;feat name&gt; &lt;tab&gt;
-STACK:NO
-    </code>
+    <code>&lt;feat name&gt; &lt;tab&gt;
+STACK:NO</code>
    </p>
    <p class="indent2">
     Is Equivalent To:
-    <code>
-     &lt;feat name&gt;
-&lt;tab&gt; STACK:NO
-    </code>
+    <code>&lt;feat name&gt;
+&lt;tab&gt; STACK:NO</code>
    </p>
    <p class="indent3">
     The benefits for the modified feat will not
@@ -1307,13 +1107,9 @@ by the feat.
     </li>
     <li>
      Supports
-     <code>
-      %LIST
-     </code>
+     <code>%LIST</code>
      in conjunction with a
-     <code>
-      CHOOSE
-     </code>
+     <code>CHOOSE</code>
      tag.
     </li>
    </ul>
@@ -1323,19 +1119,15 @@ by the feat.
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     TEMPLATE:Celestial
-    </code>
+    <code>TEMPLATE:Celestial</code>
    </p>
    <p class="indent3">
     Adds the "Celestial" template to the
 character.
    </p>
    <p class="indent2">
-    <code>
-     TEMPLATE:Half Dragon
-(Red)|Zombie
-    </code>
+    <code>TEMPLATE:Half Dragon
+(Red)|Zombie</code>
    </p>
    <p class="indent3">
     Adds the templates "Half Dragon (Red)" and
@@ -1366,28 +1158,18 @@ character.
     <li>
      This is a pipe-delimited list of template choices that are
 added to the list presented by the original
-     <code>
-      TEMPLATE:CHOOSE
-     </code>
+     <code>TEMPLATE:CHOOSE</code>
      tag.
     </li>
     <li>
      When using the
-     <code>
-      TEMPLATE:ADDCOICE
-     </code>
+     <code>TEMPLATE:ADDCOICE</code>
      tag as part of a
-     <code>
-      .MOD
-     </code>
+     <code>.MOD</code>
      of a Feat that containes multiple
-     <code>
-      TEMPLATE:CHOOSE
-     </code>
+     <code>TEMPLATE:CHOOSE</code>
      tags, all instances of the
-     <code>
-      TEMPLATE:CHOOSE
-     </code>
+     <code>TEMPLATE:CHOOSE</code>
      tag will be modified.
     </li>
    </ul>
@@ -1397,9 +1179,7 @@ added to the list presented by the original
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     TEMPLATE:ADDCHOICE:Demihuman|Beast
-    </code>
+    <code>TEMPLATE:ADDCHOICE:Demihuman|Beast</code>
    </p>
    <p class="indent3">
     The feat allows the selection of previously
@@ -1434,9 +1214,7 @@ list.
     </li>
     <li>
      Multiple
-     <code>
-      TEMPLATE:CHOOSE
-     </code>
+     <code>TEMPLATE:CHOOSE</code>
      tags can be used in the
 same LST object but doing so can cause unintended results.
     </li>
@@ -1447,9 +1225,7 @@ same LST object but doing so can cause unintended results.
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     TEMPLATE:CHOOSE:Celestial|Outsider
-    </code>
+    <code>TEMPLATE:CHOOSE:Celestial|Outsider</code>
    </p>
    <p class="indent3">
     The feat allows the selections of either the
@@ -1497,30 +1273,22 @@ Name:
    </p>
    <ul class="indent2">
     <li>
-     <code>
-      YES
-     </code>
+     <code>YES</code>
      - Shows the feat name in PCGen and on export
 to a character sheet.
     </li>
     <li>
-     <code>
-      NO
-     </code>
+     <code>NO</code>
      - Hides the feat name in PCGen and on export to
 a character sheet.
     </li>
     <li>
-     <code>
-      DISPLAY
-     </code>
+     <code>DISPLAY</code>
      - Displays the feat name in PCGen but not
 on the character sheet.
     </li>
     <li>
-     <code>
-      EXPORT
-     </code>
+     <code>EXPORT</code>
      - Hides the feat name from PCGen but
 displays it on the character sheet.
     </li>
@@ -1529,18 +1297,12 @@ displays it on the character sheet.
       .MOD Behavior:
      </strong>
      When modifying a feat with the
-     <code>
-      .MOD
-     </code>
+     <code>.MOD</code>
      tag, given an existing
-     <code>
-      VISIBLE
-     </code>
+     <code>VISIBLE</code>
      tag,
 the data included in a new
-     <code>
-      VISIBLE
-     </code>
+     <code>VISIBLE</code>
      tag will overwrite
 the existing tag data.
     </li>
@@ -1551,9 +1313,7 @@ the existing tag data.
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     VISIBLE:YES
-    </code>
+    <code>VISIBLE:YES</code>
    </p>
    <p class="indent3">
     Shows the feat name in PCGen and on the Output
@@ -1566,24 +1326,18 @@ sheet.
    </p>
    <p class="indent2">
     Initial Feat:
-    <code>
-     &lt;feat name&gt;
-&lt;tab&gt; VISIBLEE:YES
-    </code>
+    <code>&lt;feat name&gt;
+&lt;tab&gt; VISIBLEE:YES</code>
    </p>
    <p class="indent2">
     Modified By:
-    <code>
-     &lt;feat name&gt; &lt;tab&gt;
-VISIBLE:DISPLAY
-    </code>
+    <code>&lt;feat name&gt; &lt;tab&gt;
+VISIBLE:DISPLAY</code>
    </p>
    <p class="indent2">
     Is Equivalent To:
-    <code>
-     &lt;feat name&gt;
-&lt;tab&gt; VISIBLE:DISPLAY
-    </code>
+    <code>&lt;feat name&gt;
+&lt;tab&gt; VISIBLE:DISPLAY</code>
    </p>
    <p class="indent3">
     Modified feat will appear in the GUI but will

--- a/docs/listfilepages/datafilestagpages/datafilesinstall.html
+++ b/docs/listfilepages/datafilestagpages/datafilesinstall.html
@@ -244,9 +244,7 @@ be installed by 5.14.0, but could be installed by 5.14.1 or
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    MINVER:5.14.1
-   </code>
+   <code>MINVER:5.14.1</code>
   </p>
   <p class="indent3">
    This dataset requires PCGen prodiction version
@@ -299,13 +297,9 @@ the MINDEVVER value.
      </li>
      <li>
       e.g. Given
-      <code>
-       MINVER:5.14.1
-      </code>
+      <code>MINVER:5.14.1</code>
       and
-      <code>
-       MINDEVVER:5.15.3
-      </code>
+      <code>MINDEVVER:5.15.3</code>
       , the source could not be installed by
 5.15.2, but could be installed by 5.14.1 or 5.15.3
      </li>
@@ -318,9 +312,7 @@ the MINDEVVER value.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    MINDEVVER:5.15.2
-   </code>
+   <code>MINDEVVER:5.15.2</code>
   </p>
   <p class="indent3">
    This dataset requires PCGen developer version
@@ -366,9 +358,7 @@ upgrade process.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DEST:DATA
-   </code>
+   <code>DEST:DATA</code>
   </p>
   <p class="indent3">
    The dataset will be installed within the DATA
@@ -403,10 +393,8 @@ file documentation.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CAMPAIGN:FGI - FooB Core Rulebook I -
-FHB
-   </code>
+   <code>CAMPAIGN:FGI - FooB Core Rulebook I -
+FHB</code>
   </p>
   <hr/>
   <p class="indent0">
@@ -423,11 +411,9 @@ FHB
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    COPYRIGHT:PCGen OGC dataset Copyright
+   <code>COPYRIGHT:PCGen OGC dataset Copyright
 2006, PCGen Data team (Including, but not limited to Eddy Anthony
-(MoSaT), Andrew McDougall (Tir Gwaith)).
-   </code>
+(MoSaT), Andrew McDougall (Tir Gwaith)).</code>
   </p>
   <hr/>
   <p class="indent0">
@@ -444,11 +430,9 @@ FHB
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    INFOTEXT:PCGen Open Gaming Content objects
+   <code>INFOTEXT:PCGen Open Gaming Content objects
 are detailed in the PCGen documentation under the Source Help
-section
-   </code>
+section</code>
   </p>
   <hr/>
   <p class="indent0">
@@ -465,10 +449,8 @@ section
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PUBNAMELONG:PCGen Open Source
-Team
-   </code>
+   <code>PUBNAMELONG:PCGen Open Source
+Team</code>
   </p>
   <hr/>
   <p class="indent0">
@@ -485,9 +467,7 @@ Team
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PUBNAMESHORT:PCGen
-   </code>
+   <code>PUBNAMESHORT:PCGen</code>
   </p>
   <hr/>
   <p class="indent0">
@@ -504,9 +484,7 @@ Team
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PUBNAMEWEB:http://pcgen.org/
-   </code>
+   <code>PUBNAMEWEB:http://pcgen.org/</code>
   </p>
   <hr/>
   <p class="indent0">
@@ -523,10 +501,8 @@ Team
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SOURCELONG:PCGen Test Out of Cycle
-Releases
-   </code>
+   <code>SOURCELONG:PCGen Test Out of Cycle
+Releases</code>
   </p>
   <hr/>
   <p class="indent0">
@@ -543,9 +519,7 @@ Releases
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SOURCESHORT:PCGen TOCC
-   </code>
+   <code>SOURCESHORT:PCGen TOCC</code>
   </p>
   <hr/>
   <p class="indent0">
@@ -562,9 +536,7 @@ Releases
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SOURCEWEB:http://pcgen.org/
-   </code>
+   <code>SOURCEWEB:http://pcgen.org/</code>
   </p>
   <hr/>
   <p class="indent0">
@@ -581,9 +553,7 @@ Releases
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SOURCEDATE:2007-12
-   </code>
+   <code>SOURCEDATE:2007-12</code>
   </p>
   <hr/>
   <a id="example" name="example">
@@ -600,91 +570,61 @@ Releases
   </p>
   <blockquote class="indent2">
    <p class="tagindent1">
-    <code>
-     CAMPAIGN:PCGen Test OCC
-    </code>
+    <code>CAMPAIGN:PCGen Test OCC</code>
    </p>
    <p class="tagindent1">
-    <code>
-     MINVER:5.14.1
-    </code>
+    <code>MINVER:5.14.1</code>
    </p>
    <p class="tagindent1">
-    <code>
-     MINDEVVER: 5.15.2
-    </code>
+    <code>MINDEVVER: 5.15.2</code>
    </p>
    <p class="tagindent1">
-    <code>
-     DEST:VENDORDATA
-    </code>
+    <code>DEST:VENDORDATA</code>
    </p>
    <p class="tagindent1">
-    <code>
-     COPYRIGHT:Open Game License v 1.0a
-Copyright 2000, Wizards of the Coast, Inc.
-    </code>
+    <code>COPYRIGHT:Open Game License v 1.0a
+Copyright 2000, Wizards of the Coast, Inc.</code>
    </p>
    <p class="tagindent1">
-    <code>
-     COPYRIGHT:System Reference Document
+    <code>COPYRIGHT:System Reference Document
 Copyright 2000-2003, Wizards of the Coast, Inc.; Authors Jonathan
 Tweet, Monte Cook, Skip Williams, Rich Baker, Andy Collins, David
 Noonan, Rich Redman, Bruce R. Cordell, John D. Rateliff, Thomas
 Reid, James Wyatt, based on original material by E. Gary Gygax and
-Dave Arneson.
-    </code>
+Dave Arneson.</code>
    </p>
    <p class="tagindent1">
-    <code>
-     COPYRIGHT:PCGen OGC dataset Copyright
+    <code>COPYRIGHT:PCGen OGC dataset Copyright
 2006, PCGen Data team (Including, but not limited to Eddy Anthony
-(MoSaT), Andrew McDougall (Tir Gwaith)).
-    </code>
+(MoSaT), Andrew McDougall (Tir Gwaith)).</code>
    </p>
    <p class="tagindent1">
-    <code>
-     INFOTEXT:PCGen Open Gaming Content
+    <code>INFOTEXT:PCGen Open Gaming Content
 objects are detailed in the PCGen documentation under the Source
-Help section
-    </code>
+Help section</code>
    </p>
    <p class="tagindent1">
-    <code>
-     SOURCELONG:PCGen Test Out of Cycle
-Releases
-    </code>
+    <code>SOURCELONG:PCGen Test Out of Cycle
+Releases</code>
    </p>
    <p class="tagindent1">
-    <code>
-     SOURCESHORT:PCGen TOCC
-    </code>
+    <code>SOURCESHORT:PCGen TOCC</code>
    </p>
    <p class="tagindent1">
-    <code>
-     SOURCEWEB:http://pcgen.org/
-    </code>
+    <code>SOURCEWEB:http://pcgen.org/</code>
    </p>
    <p class="tagindent1">
-    <code>
-     SOURCEDATE:2007-12
-    </code>
+    <code>SOURCEDATE:2007-12</code>
    </p>
    <p class="tagindent1">
-    <code>
-     PUBNAMELONG:PCGen Open Source
-Team
-    </code>
+    <code>PUBNAMELONG:PCGen Open Source
+Team</code>
    </p>
    <p class="tagindent1">
-    <code>
-     PUBNAMESHORT:PCGen
-    </code>
+    <code>PUBNAMESHORT:PCGen</code>
    </p>
    <p class="tagindent1">
-    <code>
-     PUBNAMEWEB:http://pcgen.org/
-    </code>
+    <code>PUBNAMEWEB:http://pcgen.org/</code>
    </p>
   </blockquote>
   <hr/>

--- a/docs/listfilepages/datafilestagpages/datafileslanguages.html
+++ b/docs/listfilepages/datafilestagpages/datafileslanguages.html
@@ -41,43 +41,33 @@ on their primary language stat (usually Intelligence). Languages,
 like many other objects in PCGen, can be qualified with PRExxx
 tags. For example the Druidic language may only be learned by
 Druids so the Druidic entry contains a
-   <code>
-    PREVARGTEQ:DruidicLanguage,1
-   </code>
+   <code>PREVARGTEQ:DruidicLanguage,1</code>
    tag which prevents the
 language from appearing in chooser lists for the language skill or
 bonus languages. Any Class or Race which grants Druidic as a bonus
 language must place a
-   <code>
-    DEFINE:DruidicLanguage|1
-   </code>
+   <code>DEFINE:DruidicLanguage|1</code>
    tag in
 it to meet the prerequisite. This is not needed if the language is
 granted automatically by the LANGAUTO tag because it bypasses any
 prerequisites on the language.
   </p>
   <p class="indent2">
-   <code>
-    Terran
-   </code>
+   <code>Terran</code>
   </p>
   <p class="indent3">
    The language named "Terran" is to be
 created.
   </p>
   <p class="indent2">
-   <code>
-    Celestial.MOD
-   </code>
+   <code>Celestial.MOD</code>
   </p>
   <p class="indent3">
    The language named "Celestial" is to be
 modified.
   </p>
   <p class="indent2">
-   <code>
-    Common.FORGET
-   </code>
+   <code>Common.FORGET</code>
   </p>
   <p class="indent3">
    The language named "Common" is to be

--- a/docs/listfilepages/datafilestagpages/datafilespcc.html
+++ b/docs/listfilepages/datafilestagpages/datafilespcc.html
@@ -160,9 +160,7 @@ Ability files.
   </h4>
   <p class="indent1">
    Global
-   <code>
-    BONUS
-   </code>
+   <code>BONUS</code>
    tags can be included
 within a PCC file and will apply the relevant bonus to every
 character created while that PCC file is loaded, but it should be
@@ -180,9 +178,7 @@ Bonuses contained within embedded PCC files will
    You cannot use a colon
 (:) in the PCC file anywhere other than immediately after LST tags,
 e.g.
-   <code>
-    CAMPAIGN:
-   </code>
+   <code>CAMPAIGN:</code>
    , etc. Doing so will cause PCGen to
 report errors and not load correctly.
   </p>
@@ -248,13 +244,9 @@ Information Tags
   </h3>
   <p class="indent0">
    The first two tags in the PCC file should be
-   <code>
-    CAMPAIGN
-   </code>
+   <code>CAMPAIGN</code>
    and
-   <code>
-    GAMEMODE
-   </code>
+   <code>GAMEMODE</code>
    . These are
 presented below out of alphabetical order to emphasize that they
 are required tags which must be the first two lines in a PCC
@@ -308,10 +300,8 @@ campaign names.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CAMPAIGN:FGI - FooB Core Rulebook I -
-FHB
-   </code>
+   <code>CAMPAIGN:FGI - FooB Core Rulebook I -
+FHB</code>
   </p>
   <hr/>
   <p class="indent0">
@@ -349,9 +339,7 @@ entered exactly as shown.
    </li>
    <li>
     The
-    <code>
-     GAMEMODE
-    </code>
+    <code>GAMEMODE</code>
     tag is case-sensitive.
    </li>
   </ul>
@@ -361,9 +349,7 @@ entered exactly as shown.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    GAMEMODE:3e
-   </code>
+   <code>GAMEMODE:3e</code>
   </p>
   <p class="indent3">
    This PCC file uses the Third Edition SRD
@@ -413,18 +399,14 @@ prerequisite for loading data sets. See the
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BOOKTYPE:Supplement
-   </code>
+   <code>BOOKTYPE:Supplement</code>
   </p>
   <p class="indent3">
    The source data set that this PCC file
 represents is a "Supplement".
   </p>
   <p class="indent2">
-   <code>
-    BOOKTYPE:Supplement|Traits
-   </code>
+   <code>BOOKTYPE:Supplement|Traits</code>
   </p>
   <p class="indent3">
    The source data set that this PCC file
@@ -474,11 +456,9 @@ the PCGen conversion in the format shown below.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    COPYRIGHT:PCGen dataset conversion for "X
+   <code>COPYRIGHT:PCGen dataset conversion for "X
 Book" Copyright XXXX-YYYY, PCgen Data Team including, but not
-limited to, "Original Author", "Any secondary authors".
-   </code>
+limited to, "Original Author", "Any secondary authors".</code>
   </p>
   <p class="indent3">
    This is the Sec. 15 that should be added to all
@@ -487,18 +467,14 @@ XXXX should be the year the dataset was created and YYYY is the
 current year. Please list all contributors to the dataset.
   </p>
   <p class="indent2">
-   <code>
-    COPYRIGHT:Foo Reference Document &amp;copy
-2003 Foo Games, Inc.
-   </code>
+   <code>COPYRIGHT:Foo Reference Document &amp;copy
+2003 Foo Games, Inc.</code>
   </p>
   <p class="indent3">
    <strong>
     Note(s):
    </strong>
-   <code>
-    &amp;copy
-   </code>
+   <code>&amp;copy</code>
    - This code coverts to a copyright symbol (©) when put in the
 text of a COPYRIGHT tag.
   </p>
@@ -554,10 +530,8 @@ appears in the Source Info panel.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DESC:This pcc loads all the Foo source
-materials minus the FooWorld races
-   </code>
+   <code>DESC:This pcc loads all the Foo source
+materials minus the FooWorld races</code>
   </p>
   <hr/>
   <p class="indent0">
@@ -594,9 +568,7 @@ sources.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    GENRE:Fantasy
-   </code>
+   <code>GENRE:Fantasy</code>
   </p>
   <hr/>
   <p class="indent0">
@@ -632,9 +604,7 @@ Help...".
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    HELP:http://www.foogames.com/producthelp.html
-   </code>
+   <code>HELP:http://www.foogames.com/producthelp.html</code>
   </p>
   <hr/>
   <p class="indent0">
@@ -665,17 +635,13 @@ Window on the Source Tab when the source material is selected.
    </li>
    <li>
     Multiple
-    <code>
-     INFOTEXT
-    </code>
+    <code>INFOTEXT</code>
     tags may be used in a
     <span class="lstfile">
      PCC
     </span>
     file with each
-    <code>
-     INFOTEXT
-    </code>
+    <code>INFOTEXT</code>
     tag starting a new line of text.
    </li>
   </ul>
@@ -685,10 +651,8 @@ Window on the Source Tab when the source material is selected.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    INFOTEXT:This pcc loads all the Foo source
-materials minus the FooWorld races
-   </code>
+   <code>INFOTEXT:This pcc loads all the Foo source
+materials minus the FooWorld races</code>
   </p>
   <p class="indent3">
    Displays the text "This pcc loads all the Foo
@@ -719,9 +683,7 @@ or NO)
   <p class="indent2">
    This tag is so that we have the ability to
 include datasets based upon sources of a more mature nature. If
-   <code>
-    ISMATURE:YES
-   </code>
+   <code>ISMATURE:YES</code>
    then the following info gets inserted
 into a pop-up window "This dataset contains content of a mature
 nature. User discretion is advised." This tag is optional.
@@ -732,9 +694,7 @@ nature. User discretion is advised." This tag is optional.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ISMATURE:YES
-   </code>
+   <code>ISMATURE:YES</code>
   </p>
   <p class="indent2">
    Causes a pop-up to fire saying "This dataset
@@ -742,9 +702,7 @@ contains content of a mature nature. User discretion is
 advised."
   </p>
   <p class="indent2">
-   <code>
-    ISMATURE:NO
-   </code>
+   <code>ISMATURE:NO</code>
   </p>
   <p class="indent2">
    Does not cause a pop-up to fire saying "This
@@ -757,9 +715,7 @@ advised."
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    NO
-   </code>
+   <code>NO</code>
   </p>
   <hr/>
   <p class="indent0">
@@ -786,9 +742,7 @@ or NO)
   <p class="indent2">
    Used to indicate if sources are OGL compliant.
 If
-   <code>
-    ISOGL:YES
-   </code>
+   <code>ISOGL:YES</code>
    then its COPYRIGHT info gets inserted
 into the OGL license. This tag is optional.
   </p>
@@ -798,14 +752,10 @@ into the OGL license. This tag is optional.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ISOGL:YES
-   </code>
+   <code>ISOGL:YES</code>
   </p>
   <p class="indent2">
-   <code>
-    ISOGL:NO
-   </code>
+   <code>ISOGL:NO</code>
   </p>
   <p class="indent1">
    <strong>
@@ -813,9 +763,7 @@ into the OGL license. This tag is optional.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    NO
-   </code>
+   <code>NO</code>
   </p>
   <hr/>
   <p class="status">
@@ -853,14 +801,10 @@ information about the license to the end-user.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ISLICENSED:YES
-   </code>
+   <code>ISLICENSED:YES</code>
   </p>
   <p class="indent2">
-   <code>
-    ISLICENSED:NO
-   </code>
+   <code>ISLICENSED:NO</code>
   </p>
   <p class="indent1">
    <strong>
@@ -868,9 +812,7 @@ information about the license to the end-user.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    NO
-   </code>
+   <code>NO</code>
   </p>
   <hr/>
   <p class="status">
@@ -907,9 +849,7 @@ information about the license to the end-user.
   <p class="indent2">
    Displays special license information in a pop-up
 at time of source load. Requires a
-   <code>
-    ISLICENSED:YES
-   </code>
+   <code>ISLICENSED:YES</code>
    tag
 to be active.
   </p>
@@ -919,25 +859,19 @@ to be active.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    LICENSE:This set included with special
-permission from Foo Games
-   </code>
+   <code>LICENSE:This set included with special
+permission from Foo Games</code>
   </p>
   <p class="indent3">
    Would display the text in a nice box with other
 licenses.
   </p>
   <p class="indent2">
-   <code>
-    LICENSE:FILE=foolicense.html
-   </code>
+   <code>LICENSE:FILE=foolicense.html</code>
   </p>
   <p class="indent3">
    Doing a
-   <code>
-    FILE=
-   </code>
+   <code>FILE=</code>
    allows PCC to point
 to an HTML formatted file, which will display in a box of its
 own.
@@ -1005,9 +939,7 @@ an appended tag on
     .
    </li>
    <li>
-    <code>
-     PRECAMPAIGN
-    </code>
+    <code>PRECAMPAIGN</code>
     sets specific data sets as required or
 prohibited for the associated data set to be loaded. In the Source
 tab a data set which requires another data set will appear in red
@@ -1027,9 +959,7 @@ you click the load button.
    </li>
    <li>
     Enclosing the data set name or
-    <code>
-     BOOKTYPE
-    </code>
+    <code>BOOKTYPE</code>
     sub-tag
 and text in square-brackets ([]) will exclude the relevant data
 sets from the prerequisite evaluation.
@@ -1051,38 +981,30 @@ PRExxx
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRECAMPAIGN:1,3.5 RSRD,3.5 RSRD
-Basics
-   </code>
+   <code>PRECAMPAIGN:1,3.5 RSRD,3.5 RSRD
+Basics</code>
   </p>
   <p class="indent3">
    Will cause a data set to be loaded only if the
 "3.5 RSRD" or the "3.5 RSRD Basics" data set is loaded.
   </p>
   <p class="indent2">
-   <code>
-    !PRECAMPAIGN:1,3.5 RSRD
-   </code>
+   <code>!PRECAMPAIGN:1,3.5 RSRD</code>
   </p>
   <p class="indent3">
    Will prohibit the loading of the associated data
 set if the "3.5 RSRD" data set is loaded.
   </p>
   <p class="indent2">
-   <code>
-    PRECAMPAIGN:1,3.5 RSRD Basics
-   </code>
+   <code>PRECAMPAIGN:1,3.5 RSRD Basics</code>
   </p>
   <p class="indent3">
    Will cause the associated data set to be loaded
 only if the "3.5 RSRD Basics" data set is loaded.
   </p>
   <p class="indent2">
-   <code>
-    PRECAMPAIGN:1,BOOKTYPE=Core,[3.5 RSRD
-Basics]
-   </code>
+   <code>PRECAMPAIGN:1,BOOKTYPE=Core,[3.5 RSRD
+Basics]</code>
   </p>
   <p class="indent3">
    Will cause the associated data set to be loaded
@@ -1090,10 +1012,8 @@ only if the a "Core" data set is loaded but does not include the
 "3.5 RSRD Basics" data set in the evaluation.
   </p>
   <p class="indent2">
-   <code>
-    !PRECAMPAIGN:1,BOOKTYPE=Core,[3.5 RSRD
-Basics]
-   </code>
+   <code>!PRECAMPAIGN:1,BOOKTYPE=Core,[3.5 RSRD
+Basics]</code>
   </p>
   <p class="indent3">
    Will cause the associated data set to be loaded
@@ -1101,10 +1021,8 @@ only if the a "Core" data set other than the "3.5 RSRD Basics" data
 set is loaded.
   </p>
   <p class="indent2">
-   <code>
-    PRECAMPAIGN:1,INCLUDES=3.5 RSRD
-Basics
-   </code>
+   <code>PRECAMPAIGN:1,INCLUDES=3.5 RSRD
+Basics</code>
   </p>
   <p class="indent3">
    Will cause a data set to be loaded only if the
@@ -1112,9 +1030,7 @@ Basics
 the "3.5 RSRD Basics" set is loaded.
   </p>
   <p class="indent2">
-   <code>
-    PRECAMPAIGN:1,INCLUDESBOOKTYPE=Core
-   </code>
+   <code>PRECAMPAIGN:1,INCLUDESBOOKTYPE=Core</code>
   </p>
   <p class="indent3">
    Will cause the associated data set to be loaded
@@ -1155,9 +1071,7 @@ name of publisher)
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PUBNAMELONG:Foo Games, Inc.
-   </code>
+   <code>PUBNAMELONG:Foo Games, Inc.</code>
   </p>
   <hr/>
   <p class="status">
@@ -1194,9 +1108,7 @@ initials).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PUBNAMESHORT:FGI
-   </code>
+   <code>PUBNAMESHORT:FGI</code>
   </p>
   <hr/>
   <p class="status">
@@ -1232,9 +1144,7 @@ link)
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PUBNAMEWEB:http://www.foogames.com/index.php
-   </code>
+   <code>PUBNAMEWEB:http://www.foogames.com/index.php</code>
   </p>
   <hr/>
   <p class="status">
@@ -1288,9 +1198,7 @@ file.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    RANK:1
-   </code>
+   <code>RANK:1</code>
   </p>
   <p class="indent3">
    This pcc file is given first priority when
@@ -1366,9 +1274,7 @@ sources.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SETTING:Ravenloft
-   </code>
+   <code>SETTING:Ravenloft</code>
   </p>
   <hr/>
   <p class="indent0">
@@ -1393,9 +1299,7 @@ or NO, TRUE or FALSE also accepted)
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SHOWINMENU:YES
-   </code>
+   <code>SHOWINMENU:YES</code>
   </p>
   <p class="indent1">
    <strong>
@@ -1447,10 +1351,8 @@ name of source)
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SOURCELONG:Core Rulebook I (Foo
-Handbook)
-   </code>
+   <code>SOURCELONG:Core Rulebook I (Foo
+Handbook)</code>
   </p>
   <p class="indent3">
    The long source name for this file is "Core
@@ -1490,9 +1392,7 @@ name of source)
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SOURCESHORT:FHB
-   </code>
+   <code>SOURCESHORT:FHB</code>
   </p>
   <p class="indent3">
    The short source name for this file is
@@ -1533,9 +1433,7 @@ product/book.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SOURCEWEB:http://www.foogames.com/product.php?products=654321
-   </code>
+   <code>SOURCEWEB:http://www.foogames.com/product.php?products=654321</code>
   </p>
   <p class="indent3">
    The web site for this source is
@@ -1580,9 +1478,7 @@ older sources".
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SOURCEDATE:2005-12
-   </code>
+   <code>SOURCEDATE:2005-12</code>
   </p>
   <p class="indent3">
    This source was published in December 2005.
@@ -1639,36 +1535,28 @@ older sources".
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    STATUS:RELEASE
-   </code>
+   <code>STATUS:RELEASE</code>
   </p>
   <p class="indent3">
    This dataset has been approved as release
 quality.
   </p>
   <p class="indent2">
-   <code>
-    STATUS:ALPHA
-   </code>
+   <code>STATUS:ALPHA</code>
   </p>
   <p class="indent3">
    This dataset is a work in progress, use it at
 your own risk.
   </p>
   <p class="indent2">
-   <code>
-    STATUS:BETA
-   </code>
+   <code>STATUS:BETA</code>
   </p>
   <p class="indent3">
    This dataset is finished, but not yet approved
 as release quality.
   </p>
   <p class="indent2">
-   <code>
-    STATUS:TESTONLY
-   </code>
+   <code>STATUS:TESTONLY</code>
   </p>
   <p class="indent3">
    This data is set of internal testing use
@@ -1757,10 +1645,8 @@ file.
   </p>
   <blockquote class="indent2">
    <p class="tagindent1">
-    <code>
-     URL:Barcommerce|http://www.barcommercesite.com/product_info.php?products_id=12345&amp;affiliate_id=54321|Support
-PCGen by buying this source now!
-    </code>
+    <code>URL:Barcommerce|http://www.barcommercesite.com/product_info.php?products_id=12345&amp;affiliate_id=54321|Support
+PCGen by buying this source now!</code>
    </p>
    <p class="tagindent2" style="text-indent: -25px">
     Displays the text
@@ -1769,10 +1655,8 @@ URL
 "http://www.foobarcommercesite.com/product_info.php?products_id=12345&amp;affiliate_\id=5432".
    </p>
    <p class="tagindent1">
-    <code>
-     URL:WEBSITE|http://www.foopublisher.com|Visit FooPublishers
-website.
-    </code>
+    <code>URL:WEBSITE|http://www.foopublisher.com|Visit FooPublishers
+website.</code>
    </p>
    <p class="tagindent2" style="text-indent: -25px">
     Displays the text
@@ -1780,11 +1664,9 @@ website.
 "http://www.foopublisher.com"
    </p>
    <p class="tagindent1">
-    <code>
-     URL:SURVEY|http://www.pcgenubersite.com|Help PCGen out by
+    <code>URL:SURVEY|http://www.pcgenubersite.com|Help PCGen out by
 visiting our user feedback page and letting us know what you
-think.
-    </code>
+think.</code>
    </p>
    <p class="tagindent2" style="text-indent: -25px">
     Displays the text
@@ -1833,9 +1715,7 @@ the name of the file.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CLASS:fhbclasses.lst
-   </code>
+   <code>CLASS:fhbclasses.lst</code>
   </p>
   <p class="indent3">
    Loads the file fhbclasses.lst which is in the
@@ -1888,27 +1768,21 @@ then will look in the
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SPELL:@/d20ogl/srd/srdspells.lst
-   </code>
+   <code>SPELL:@/d20ogl/srd/srdspells.lst</code>
   </p>
   <p class="indent3">
    Loads the file from a path relative to the data
 folder.
   </p>
   <p class="indent2">
-   <code>
-    CLASS:&amp;/complete_monkey/complete_monkey_classes.lst
-   </code>
+   <code>CLASS:&amp;/complete_monkey/complete_monkey_classes.lst</code>
   </p>
   <p class="indent3">
    Loads the file from a path relative to the
 vendor data folder.
   </p>
   <p class="indent2">
-   <code>
-    EQUIPMENT:*/d20ogl/srd35/basics/rsrd_equip.lst
-   </code>
+   <code>EQUIPMENT:*/d20ogl/srd35/basics/rsrd_equip.lst</code>
   </p>
   <p class="indent3">
    Loads the file from a path relative to the
@@ -1937,9 +1811,7 @@ web address instead of a file path to load source files.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CLASS:http://www.foogames.com/fhandbook/fhbclasses.lst
-   </code>
+   <code>CLASS:http://www.foogames.com/fhandbook/fhbclasses.lst</code>
   </p>
   <p class="indent3">
    Loads the source file from a web site.
@@ -1963,9 +1835,7 @@ recommended for equipment, have multiple lines. The names of the
 list files in the example column are also only suggestions. To
 include the same type of files from the same directory on the same
 line as a pipe-delimited (|) list of files, e.g.
-   <code>
-    fhbarmorshields.lst|fhbequip|etc
-   </code>
+   <code>fhbarmorshields.lst|fhbequip|etc</code>
    . Sometimes, not all
 of these tags are required by a source material. If a tag is not
 required, it cannot be left blank, it must be commented out or
@@ -1980,9 +1850,7 @@ one.
   </h4>
   <p class="indent1">
    The
-   <code>
-    PRECAMPAIGN
-   </code>
+   <code>PRECAMPAIGN</code>
    tag can be appended
 to the end of any main body tag to either include or exclude the
 loading of LST files, either in whole or in part.
@@ -1991,9 +1859,7 @@ loading of LST files, either in whole or in part.
    Examples:
   </p>
   <p class="indent2">
-   <code>
-    FEAT:source_feats_apg.lst|!PRECAMPAIGN:1,APG
-   </code>
+   <code>FEAT:source_feats_apg.lst|!PRECAMPAIGN:1,APG</code>
   </p>
   <p class="indent3">
    The
@@ -2004,9 +1870,7 @@ loading of LST files, either in whole or in part.
 the APG Campaign file is not loaded.
   </p>
   <p class="indent2">
-   <code>
-    FEAT:source_feats_um.lst|!PRECAMPAIGN:1,UM
-   </code>
+   <code>FEAT:source_feats_um.lst|!PRECAMPAIGN:1,UM</code>
   </p>
   <p class="indent3">
    The
@@ -2017,9 +1881,7 @@ the APG Campaign file is not loaded.
 the UM Campaign file is not loaded.
   </p>
   <p class="indent2">
-   <code>
-    FEAT:source_feats_apg.lst|(INCLUDE:foo|bar)|PRECAMPAIGN:1,APG
-   </code>
+   <code>FEAT:source_feats_apg.lst|(INCLUDE:foo|bar)|PRECAMPAIGN:1,APG</code>
   </p>
   <p class="indent3">
    The
@@ -2030,10 +1892,8 @@ the UM Campaign file is not loaded.
 the APG Campaign file is not loaded.
   </p>
   <p class="indent2">
-   <code>
-    EQUIPMENT:../ultimate_combat/pfuc_equip_armor.lst|!PRECAMPAIGN:1,INCLUDES=Paizo
-- Pathfinder Roleplaying Game Ultimate Combat
-   </code>
+   <code>EQUIPMENT:../ultimate_combat/pfuc_equip_armor.lst|!PRECAMPAIGN:1,INCLUDES=Paizo
+- Pathfinder Roleplaying Game Ultimate Combat</code>
   </p>
   <p class="indent3">
    The
@@ -2089,9 +1949,7 @@ path)
     </a>
     for more information on the use of these
 sub-tags with the
-    <code>
-     ABILITY
-    </code>
+    <code>ABILITY</code>
     tag.
    </li>
   </ul>
@@ -2101,9 +1959,7 @@ sub-tags with the
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ABILITY:specialabilities.lst
-   </code>
+   <code>ABILITY:specialabilities.lst</code>
   </p>
   <hr/>
   <p class="status">
@@ -2146,9 +2002,7 @@ categories.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ABILITYCATEGORY:myabilitycategories.lst
-   </code>
+   <code>ABILITYCATEGORY:myabilitycategories.lst</code>
   </p>
   <hr/>
   <p class="indent0">
@@ -2182,9 +2036,7 @@ file specified.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ARMORPROF:fooarmorproflight.lst
-   </code>
+   <code>ARMORPROF:fooarmorproflight.lst</code>
   </p>
   <p class="indent3">
    Load the armor proficiencies
@@ -2194,9 +2046,7 @@ file specified.
    file.
   </p>
   <p class="indent2">
-   <code>
-    ARMORPROF:fooarmorproflight.lst.FORGET
-   </code>
+   <code>ARMORPROF:fooarmorproflight.lst.FORGET</code>
   </p>
   <p class="indent3">
    Forgets to load the armor proficiencies
@@ -2237,9 +2087,7 @@ specified.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BIOSET:biosettings.lst
-   </code>
+   <code>BIOSET:biosettings.lst</code>
   </p>
   <hr/>
   <p class="indent0">
@@ -2273,9 +2121,7 @@ specified.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CLASS:fhbclasses.lst
-   </code>
+   <code>CLASS:fhbclasses.lst</code>
   </p>
   <hr/>
   <p class="indent0">
@@ -2308,9 +2154,7 @@ file specified.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    COMPANIONMOD:foocompanionmods.lst
-   </code>
+   <code>COMPANIONMOD:foocompanionmods.lst</code>
   </p>
   <hr/>
   <p class="status">
@@ -2347,9 +2191,7 @@ when the dataset is selected.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    COVER:foohandbookcover.jpg
-   </code>
+   <code>COVER:foohandbookcover.jpg</code>
   </p>
   <hr/>
   <p class="indent0">
@@ -2383,9 +2225,7 @@ specified.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DEITY:foodeities.lst
-   </code>
+   <code>DEITY:foodeities.lst</code>
   </p>
   <hr/>
   <p class="indent0">
@@ -2419,9 +2259,7 @@ specified.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DOMAIN:foodomains.lst
-   </code>
+   <code>DOMAIN:foodomains.lst</code>
   </p>
   <hr/>
   <p class="indent0">
@@ -2455,14 +2293,10 @@ specified.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    EQUIPMENT:fooallequip.lst
-   </code>
+   <code>EQUIPMENT:fooallequip.lst</code>
   </p>
   <p class="indent2">
-   <code>
-    EQUIPMENT:fooequiparmorsshields.lst
-   </code>
+   <code>EQUIPMENT:fooequiparmorsshields.lst</code>
   </p>
   <hr/>
   <p class="indent0">
@@ -2496,9 +2330,7 @@ file specified.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    EQUIPMOD:fooequipmods.lst
-   </code>
+   <code>EQUIPMOD:fooequipmods.lst</code>
   </p>
   <hr/>
   <h3 id="feat">
@@ -2517,34 +2349,24 @@ file specified.
     <ul class="incremental">
      <li>
       The
-      <code>
-       FEAT
-      </code>
+      <code>FEAT</code>
       file is deprecated. Use
       <a href="#abilitypcc">
-       <code>
-        ABILITY
-       </code>
+       <code>ABILITY</code>
       </a>
       instead.
      </li>
      <li>
       All
-      <code>
-       FEAT
-      </code>
+      <code>FEAT</code>
       tags have been
       <strong>
        deprecated
       </strong>
       and replaced by the
-      <code>
-       ABILITY
-      </code>
+      <code>ABILITY</code>
       system, which is more general. The
-      <code>
-       ABILITY
-      </code>
+      <code>ABILITY</code>
       system can model feats, racial features, class
 features, traits, flaws, temporary bonuses, and so on, all using a
 common format.
@@ -2581,9 +2403,7 @@ specified.
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     FEAT:foofeats.lst
-    </code>
+    <code>FEAT:foofeats.lst</code>
    </p>
   </div>
   <hr/>
@@ -2618,9 +2438,7 @@ specified.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    KIT:foostartingkits.lst
-   </code>
+   <code>KIT:foostartingkits.lst</code>
   </p>
   <hr/>
   <p class="indent0">
@@ -2654,9 +2472,7 @@ specified.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    LANGUAGE:foolanguages.lst
-   </code>
+   <code>LANGUAGE:foolanguages.lst</code>
   </p>
   <hr/>
   <p class="status">
@@ -2701,9 +2517,7 @@ datasets, from the same publisher, referencing the same image.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    LOGO:../barcompanylogo.jpg
-   </code>
+   <code>LOGO:../barcompanylogo.jpg</code>
   </p>
   <hr/>
   <p class="indent0">
@@ -2739,9 +2553,7 @@ included.
     <ul>
      <li>
       The
-      <code>
-       @
-      </code>
+      <code>@</code>
       symbol used at the beginning of the file
 path will set the
       <strong>
@@ -2752,9 +2564,7 @@ the path.
      </li>
      <li>
       The
-      <code>
-       &amp;
-      </code>
+      <code>&amp;</code>
       symbol used at the beginning of the file
 path will set the
       <strong>
@@ -2765,9 +2575,7 @@ in the path.
      </li>
      <li>
       The
-      <code>
-       $
-      </code>
+      <code>$</code>
       symbol used at the beginning of the file
 path will set the
       <strong>
@@ -2789,9 +2597,7 @@ load LST files.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PCC:@/d20ogl/paizo/pathfinder_rpg/pathfinder_rpg_for_players_advanced.pcc
-   </code>
+   <code>PCC:@/d20ogl/paizo/pathfinder_rpg/pathfinder_rpg_for_players_advanced.pcc</code>
   </p>
   <p class="indent3">
    Loads the campaign file
@@ -2806,9 +2612,7 @@ the
    folder.
   </p>
   <p class="indent2">
-   <code>
-    PCC:&amp;/foodir/foobook.pcc
-   </code>
+   <code>PCC:&amp;/foodir/foobook.pcc</code>
   </p>
   <p class="indent3">
    Loads the campaign file
@@ -2853,9 +2657,7 @@ specified.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    RACE:fooraces.lst
-   </code>
+   <code>RACE:fooraces.lst</code>
   </p>
   <hr/>
   <p class="indent0">
@@ -2889,9 +2691,7 @@ specified.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SKILL:fooskills.lst
-   </code>
+   <code>SKILL:fooskills.lst</code>
   </p>
   <hr/>
   <p class="indent0">
@@ -2925,9 +2725,7 @@ list file specified.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SHIELDPROF:fooshieldproflight.lst
-   </code>
+   <code>SHIELDPROF:fooshieldproflight.lst</code>
   </p>
   <p class="indent3">
    Load the shield proficiencies
@@ -2937,9 +2735,7 @@ list file specified.
    file.
   </p>
   <p class="indent2">
-   <code>
-    SHIELDPROF:fooshieldproflight.lst.FORGET
-   </code>
+   <code>SHIELDPROF:fooshieldproflight.lst.FORGET</code>
   </p>
   <p class="indent3">
    Forgets to load the shield proficiencies
@@ -2980,9 +2776,7 @@ specified.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SPELL:foospells.lst
-   </code>
+   <code>SPELL:foospells.lst</code>
   </p>
   <hr/>
   <p class="indent0">
@@ -3016,9 +2810,7 @@ specified.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TEMPLATE:footemplates.lst
-   </code>
+   <code>TEMPLATE:footemplates.lst</code>
   </p>
   <hr/>
   <p class="indent0">
@@ -3052,9 +2844,7 @@ list file specified.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    WEAPONPROF:fooweapprofsimple.lst
-   </code>
+   <code>WEAPONPROF:fooweapprofsimple.lst</code>
   </p>
   <p class="indent3">
    Load the weapons proficiencies
@@ -3113,19 +2903,13 @@ is in the same directory as the files to be excluded.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    LSTEXCLUDE:fooraces.lst
-   </code>
+   <code>LSTEXCLUDE:fooraces.lst</code>
   </p>
   <p class="indent2">
-   <code>
-    LSTEXCLUDE:fooraces.lst|foogods.lst
-   </code>
+   <code>LSTEXCLUDE:fooraces.lst|foogods.lst</code>
   </p>
   <p class="indent2">
-   <code>
-    LSTEXCLUDE:@d20ogl/foogames/foohandbook/fooclasses.lst
-   </code>
+   <code>LSTEXCLUDE:@d20ogl/foogames/foohandbook/fooclasses.lst</code>
   </p>
   <hr/>
   <p class="lststatus">
@@ -3173,9 +2957,7 @@ the exact PCC file selected by the user.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ALLOWDUPES:SPELL
-   </code>
+   <code>ALLOWDUPES:SPELL</code>
   </p>
   <p class="indent3">
    Duplicate spells loaded by the user selected PCC
@@ -3250,31 +3032,23 @@ INCLUDE to be processed.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    RACE:myrace.lst|(INCLUDE:Happy Elf|Dower
-Dwarf)
-   </code>
+   <code>RACE:myrace.lst|(INCLUDE:Happy Elf|Dower
+Dwarf)</code>
   </p>
   <p class="indent3">
    This loads only the "Happy Elf" and the "Dower
 Dward" from
-   <code>
-    myrace.lst
-   </code>
+   <code>myrace.lst</code>
    .
   </p>
   <p class="indent2">
-   <code>
-    ABILITY:myability.lst|(INCLUDE:CATEGORY=Class Ability,Monkey
-See,Monkey Do)
-   </code>
+   <code>ABILITY:myability.lst|(INCLUDE:CATEGORY=Class Ability,Monkey
+See,Monkey Do)</code>
   </p>
   <p class="indent3">
    This loads only the "Monkey See" and "Monkey Do"
 Class Abilities from
-   <code>
-    myability.lst
-   </code>
+   <code>myability.lst</code>
    .
   </p>
   <hr/>
@@ -3343,29 +3117,21 @@ LANGUAGE, RACE, SKILL, SPELL, TEMPLATE, WEAPONPROF
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    RACE:fhbrace.lst|(EXCLUDE:Fooman|Foowarf)
-   </code>
+   <code>RACE:fhbrace.lst|(EXCLUDE:Fooman|Foowarf)</code>
   </p>
   <p class="indent3">
    This loads all the races from the
-   <code>
-    fhbrace.lst
-   </code>
+   <code>fhbrace.lst</code>
    file except for the "Fooman" and "Foowarf"
 races.
   </p>
   <p class="indent2">
-   <code>
-    ABILITY:fhbability.lst|(EXCLUDE:CATEGORY=Class Ability,Monkey
-See,Monkey Do)
-   </code>
+   <code>ABILITY:fhbability.lst|(EXCLUDE:CATEGORY=Class Ability,Monkey
+See,Monkey Do)</code>
   </p>
   <p class="indent3">
    This loads all the abilities from the
-   <code>
-    fhbability.lst
-   </code>
+   <code>fhbability.lst</code>
    file except for the "Monkey See" and
 "Monkey Do" Class Abilities.
   </p>
@@ -3524,10 +3290,8 @@ it always needs to be intentionally placed.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    FORWARDREF:CLASSSPELLLIST|Assassin,Black
-Guard
-   </code>
+   <code>FORWARDREF:CLASSSPELLLIST|Assassin,Black
+Guard</code>
   </p>
   <p class="indent3">
    "Unconstructed Object" errors for the
@@ -3594,9 +3358,7 @@ the GUI. HIDETYPE will effect all sources loaded but only when the
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    HIDETYPE:EQUIP|Starting|SpecialTools
-   </code>
+   <code>HIDETYPE:EQUIP|Starting|SpecialTools</code>
   </p>
   <p class="indent3">
    The Types Starting and SpecialTools will not be
@@ -3629,18 +3391,12 @@ Name:
   <p class="indent2">
    Specifies an option which should be set when the
 campaign is loaded. The format is the same as in the
-   <code>
-    options.ini
-   </code>
+   <code>options.ini</code>
    or
-   <code>
-    legacy.ini
-   </code>
+   <code>legacy.ini</code>
    files. For
 options from
-   <code>
-    legacy.ini
-   </code>
+   <code>legacy.ini</code>
    only the
    <em>
     pcgen.options
@@ -3667,19 +3423,15 @@ be set by sources
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    OPTION:hpMaxAtFirstLevel=true
-   </code>
+   <code>OPTION:hpMaxAtFirstLevel=true</code>
   </p>
   <p class="indent3">
    Set the pcgen.options.hpMaxAtFirstLevel
 preference stored in legacy.ini to true.
   </p>
   <p class="indent2">
-   <code>
-    OPTION:gameMode.Pathfinder_RPG.purchaseMethodName=Epic
-Fantasy
-   </code>
+   <code>OPTION:gameMode.Pathfinder_RPG.purchaseMethodName=Epic
+Fantasy</code>
   </p>
   <p class="indent3">
    Set the selected stats purchase mode (stored in
@@ -3687,9 +3439,7 @@ options.ini) for the Pathfinder_RPG game mode to "Epic
 Fantasy".
   </p>
   <p class="indent2">
-   <code>
-    OPTION:pcgen.options.autoResizeEquip=true
-   </code>
+   <code>OPTION:pcgen.options.autoResizeEquip=true</code>
   </p>
   <p class="indent3">
    Set the auto resize equipment for PC option
@@ -3722,21 +3472,15 @@ REQSKILL:ALL or UNTRAINED or REQSKILL:UNTRAINED or Text
   </p>
   <ul class="indent2">
    <li>
-    <code>
-     UNTRAINED
-    </code>
+    <code>UNTRAINED</code>
     - all untrained skills will be
 automatically included on any character as if the skill had the REQ
 tag (see
-    <code>
-     skill.lst
-    </code>
+    <code>skill.lst</code>
     for details);
    </li>
    <li>
-    <code>
-     ALL
-    </code>
+    <code>ALL</code>
     - all skills will have the REQ tag, or;
    </li>
    <li>
@@ -3745,9 +3489,7 @@ tag (see
   </ul>
   <p class="indent2">
    If this tag is included it should be after the
-   <code>
-    SKILL:
-   </code>
+   <code>SKILL:</code>
    tag.
   </p>
   <p class="indent1">
@@ -3756,9 +3498,7 @@ tag (see
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    REQSKILL:Alchemy|Bluff|Diplomacy|etc
-   </code>
+   <code>REQSKILL:Alchemy|Bluff|Diplomacy|etc</code>
   </p>
   <hr/>
   <p>

--- a/docs/listfilepages/datafilestagpages/datafilesraces.html
+++ b/docs/listfilepages/datafilestagpages/datafilesraces.html
@@ -35,28 +35,22 @@
 remaining tags may be of any order.
   </p>
   <p class="indent2">
-   <code>
-    Boar (Wild Pig)
-   </code>
+   <code>Boar (Wild Pig)</code>
   </p>
   <p class="indent3">
    The race named "Boar (Wild Pig)" is to be
 created.
   </p>
   <p class="indent2">
-   <code>
-    Bugbear.COPY=Bugbear
-(Shadowkind)
-   </code>
+   <code>Bugbear.COPY=Bugbear
+(Shadowkind)</code>
   </p>
   <p class="indent3">
    Copies the race named "Bugbear" to a new race
 called "Bugbear (Shadowkind)".
   </p>
   <p class="indent2">
-   <code>
-    Shark (Huge).MOD
-   </code>
+   <code>Shark (Huge).MOD</code>
   </p>
   <p class="indent3">
    The race named "Shark (Huge)" is to be
@@ -69,12 +63,10 @@ modified.
    </strong>
    in your
 campaign, better put
-   <code>
-    racex.
+   <code>racex.
     <a href="../globalfilestagpages/globalfilesother.html#forget">
      FORGET
-    </a>
-   </code>
+    </a></code>
    in one of your
    <strong>
     RACE
@@ -96,9 +88,7 @@ your campaign. If you want to do so later you will need to use the
    tag.
   </p>
   <p class="indent2">
-   <code>
-    Shark (Huge).FORGET
-   </code>
+   <code>Shark (Huge).FORGET</code>
   </p>
   <p class="indent3">
    The race named "Shark (Huge)" is to be
@@ -141,9 +131,7 @@ Stat.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:LANGAUTO:Abyssal|Infernal
-   </code>
+   <code>CHOOSE:LANGAUTO:Abyssal|Infernal</code>
   </p>
   <p class="indent3">
    May choose between "Abyssal" or "Infernal" as a
@@ -181,18 +169,12 @@ Name:
      .MOD Behavior:
     </strong>
     When modifying a race with the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     CR
-    </code>
+    <code>CR</code>
     tag, the
 data included in a new
-    <code>
-     CR
-    </code>
+    <code>CR</code>
     tag will overwrite the
 existing tag data.
    </li>
@@ -211,9 +193,7 @@ not work.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CR:1/4
-   </code>
+   <code>CR:1/4</code>
   </p>
   <p class="indent3">
    Race is rated at a quarter challenge rating.
@@ -225,24 +205,18 @@ not work.
   </p>
   <p class="indent2">
    Initial Race:
-   <code>
-    Boar &lt;tab&gt;
-CR:2
-   </code>
+   <code>Boar &lt;tab&gt;
+CR:2</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    Boar.MOD &lt;tab&gt;
-CR:3
-   </code>
+   <code>Boar.MOD &lt;tab&gt;
+CR:3</code>
   </p>
   <p class="indent2">
    Results In:
-   <code>
-    Boar &lt;tab&gt;
-CR:3
-   </code>
+   <code>Boar &lt;tab&gt;
+CR:3</code>
   </p>
   <p class="indent3">
    The Boar's CR is set to 3.
@@ -292,18 +266,14 @@ class types specified as x
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CRMOD:PC.NPC|0
-   </code>
+   <code>CRMOD:PC.NPC|0</code>
   </p>
   <p class="indent3">
    In the Pathfinder RPG, a drow noble's CR is
 always equal to his character level.
   </p>
   <p class="indent2">
-   <code>
-    CRMOD:NPC|-3
-   </code>
+   <code>CRMOD:NPC|-3</code>
   </p>
   <p class="indent3">
    In the Pathfinder RPG, the CR of a kobold with
@@ -350,18 +320,12 @@ assumed to represent all sides.
      .MOD Behavior:
     </strong>
     When modifying a race with the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     FACE
-    </code>
+    <code>FACE</code>
     tag, the
 data included in a new
-    <code>
-     FACE
-    </code>
+    <code>FACE</code>
     tag will overwrite the
 existing tag data.
    </li>
@@ -372,17 +336,13 @@ existing tag data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    FACE:5,10
-   </code>
+   <code>FACE:5,10</code>
   </p>
   <p class="indent3">
    The race has a face of 5 by 10.
   </p>
   <p class="indent2">
-   <code>
-    FACE:10
-   </code>
+   <code>FACE:10</code>
   </p>
   <p class="indent3">
    The race has a face of 10.
@@ -394,24 +354,18 @@ existing tag data.
   </p>
   <p class="indent2">
    Initial Race:
-   <code>
-    &lt;race name&gt;
-&lt;tab&gt; FACE:10
-   </code>
+   <code>&lt;race name&gt;
+&lt;tab&gt; FACE:10</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;race name&gt;.MOD
-&lt;tab&gt; FACE:5,10
-   </code>
+   <code>&lt;race name&gt;.MOD
+&lt;tab&gt; FACE:5,10</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;race name&gt;
-&lt;tab&gt; FACE:5,10
-   </code>
+   <code>&lt;race name&gt;
+&lt;tab&gt; FACE:5,10</code>
   </p>
   <p class="indent3">
    The race now has a face of 5 by 10.
@@ -478,18 +432,12 @@ class as Favored.
      .MOD Behavior:
     </strong>
     When modifying a race with the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     FAVCLASS
-    </code>
+    <code>FAVCLASS</code>
     tag,
 the data included in a new
-    <code>
-     FAVCLASS
-    </code>
+    <code>FAVCLASS</code>
     tag will overwrite
 the existing tag data.
    </li>
@@ -500,27 +448,21 @@ the existing tag data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    FAVCLASS:Wizard|Fighter
-   </code>
+   <code>FAVCLASS:Wizard|Fighter</code>
   </p>
   <p class="indent3">
    The character's favored classes are "Wizard"
 (including any sub-class of wizard) and "Fighter".
   </p>
   <p class="indent2">
-   <code>
-    FAVCLASS:Wizard.Wizard
-   </code>
+   <code>FAVCLASS:Wizard.Wizard</code>
   </p>
   <p class="indent3">
    Race's favored class is "Wizard" (excluding any
 sub-class of wizard).
   </p>
   <p class="indent2">
-   <code>
-    FAVCLASS:Wizard.Illusionist
-   </code>
+   <code>FAVCLASS:Wizard.Illusionist</code>
   </p>
   <p class="indent3">
    Race's favored class is the "Wizard" sub-class,
@@ -533,24 +475,18 @@ the "Illusionist".
   </p>
   <p class="indent2">
    Initial Race:
-   <code>
-    &lt;race name&gt;
-&lt;tab&gt; FAVCLASS:Wizard|Fighter
-   </code>
+   <code>&lt;race name&gt;
+&lt;tab&gt; FAVCLASS:Wizard|Fighter</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;race name&gt;.MOD
-&lt;tab&gt; FAVCLASS:Wizard.Illusionist
-   </code>
+   <code>&lt;race name&gt;.MOD
+&lt;tab&gt; FAVCLASS:Wizard.Illusionist</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;race name&gt;
-&lt;tab&gt; FAVCLASS:Wizard.Illusionist
-   </code>
+   <code>&lt;race name&gt;
+&lt;tab&gt; FAVCLASS:Wizard.Illusionist</code>
   </p>
   <p class="indent3">
    Race's favored class is changed to "Wizard"
@@ -615,27 +551,21 @@ class as Favored.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    FAVCLASS:CHOOSE:Wizard
-   </code>
+   <code>FAVCLASS:CHOOSE:Wizard</code>
   </p>
   <p class="indent3">
    Race may select any sub-class of "Wizard" as the
 favored class.
   </p>
   <p class="indent2">
-   <code>
-    FAVCLASS:CHOOSE:Rogue|Wizard.Illusionist
-   </code>
+   <code>FAVCLASS:CHOOSE:Rogue|Wizard.Illusionist</code>
   </p>
   <p class="indent3">
    Race may select either "Rogue" or "Wizard"
 sub-class, "Illusionist", as the favored class.
   </p>
   <p class="indent2">
-   <code>
-    FAVCLASS:CHOOSE:Wizard
-   </code>
+   <code>FAVCLASS:CHOOSE:Wizard</code>
   </p>
   <p class="indent3">
    Race may select the "Wizard" base class or any
@@ -658,34 +588,24 @@ of its sub-classes as the favored class.
     <ul class="incremental">
      <li>
       The
-      <code>
-       FEAT
-      </code>
+      <code>FEAT</code>
       tag is deprecated. Use
       <a href="../globalfilestagpages/globalfilesother.html#ability">
-       <code>
-        ABILITY
-       </code>
+       <code>ABILITY</code>
       </a>
       instead.
      </li>
      <li>
       All
-      <code>
-       FEAT
-      </code>
+      <code>FEAT</code>
       tags have been
       <strong>
        deprecated
       </strong>
       and replaced by the
-      <code>
-       ABILITY
-      </code>
+      <code>ABILITY</code>
       system, which is more general. The
-      <code>
-       ABILITY
-      </code>
+      <code>ABILITY</code>
       system can model feats, racial features, class
 features, traits, flaws, temporary bonuses, and so on, all using a
 common format.
@@ -722,9 +642,7 @@ name)
     </li>
     <li>
      The hyphen (-) is used only in the
-     <code>
-      OUTPUTNAME
-     </code>
+     <code>OUTPUTNAME</code>
      of
 feats and should NOT be used in the feat list for this tag. (See
 example below.)
@@ -743,13 +661,9 @@ be handled one of two ways.
       </li>
       <li>
        Used in conjunction with the
-       <code>
-        CHOOSE
-       </code>
+       <code>CHOOSE</code>
        tag,
-       <code>
-        %LIST
-       </code>
+       <code>%LIST</code>
        can be used with this tag to provide the
 required choice.
       </li>
@@ -757,18 +671,12 @@ required choice.
     </li>
     <li>
      When modifying a race, with the
-     <code>
-      .MOD
-     </code>
+     <code>.MOD</code>
      tag, given an
 existing
-     <code>
-      FEAT
-     </code>
+     <code>FEAT</code>
      tag, the data included in a new
-     <code>
-      FEAT
-     </code>
+     <code>FEAT</code>
      tag will overwrite the existing tag data.
     </li>
    </ul>
@@ -778,26 +686,20 @@ existing
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     FEAT:Blind Fight|Alertness
-    </code>
+    <code>FEAT:Blind Fight|Alertness</code>
    </p>
    <p class="indent3">
     Race gets "Blind-Fight" and "Alertness" as bonus
 feats.
    </p>
    <p class="indent2">
-    <code>
-     CHOOSE:WEAPONPROFS|LIST &lt;tab&gt;
-FEAT:Weapon Focus (%LIST)
-    </code>
+    <code>CHOOSE:WEAPONPROFS|LIST &lt;tab&gt;
+FEAT:Weapon Focus (%LIST)</code>
    </p>
    <p class="indent3">
     The feat "Weapon Focus" is granted as an
 automatic feat with the weapon chosen with the
-    <code>
-     CHOOSE
-    </code>
+    <code>CHOOSE</code>
     tag.
    </p>
    <p class="indent1">
@@ -807,24 +709,18 @@ automatic feat with the weapon chosen with the
    </p>
    <p class="indent2">
     Initial Race:
-    <code>
-     Darkling &lt;tab&gt;
-FEAT:Blind Fight|Alertness
-    </code>
+    <code>Darkling &lt;tab&gt;
+FEAT:Blind Fight|Alertness</code>
    </p>
    <p class="indent2">
     Modified By:
-    <code>
-     Darkling.MOD &lt;tab&gt;
-FEAT:Blind Fight|Combat Reflexes
-    </code>
+    <code>Darkling.MOD &lt;tab&gt;
+FEAT:Blind Fight|Combat Reflexes</code>
    </p>
    <p class="indent2">
     Is Equivalent To:
-    <code>
-     Darkling &lt;tab&gt;
-FEAT:Blind Fight|Combat Reflexes
-    </code>
+    <code>Darkling &lt;tab&gt;
+FEAT:Blind Fight|Combat Reflexes</code>
    </p>
    <p class="indent3">
     Race gets the "Blind-Fight" and "Combat
@@ -863,18 +759,12 @@ Multiattack and Multidexterity.
      .MOD Behavior:
     </strong>
     When modifying a race with the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     HANDS
-    </code>
+    <code>HANDS</code>
     tag,
 the data included in a new
-    <code>
-     HANDS
-    </code>
+    <code>HANDS</code>
     tag will overwrite
 the existing tag data.
    </li>
@@ -885,9 +775,7 @@ the existing tag data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    HANDS:4
-   </code>
+   <code>HANDS:4</code>
   </p>
   <p class="indent3">
    Race has four hands.
@@ -899,24 +787,18 @@ the existing tag data.
   </p>
   <p class="indent2">
    Initial Race:
-   <code>
-    &lt;race name&gt;
-&lt;tab&gt; HANDS:2
-   </code>
+   <code>&lt;race name&gt;
+&lt;tab&gt; HANDS:2</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;race name&gt;.MOD
-&lt;tab&gt; HANDS:4
-   </code>
+   <code>&lt;race name&gt;.MOD
+&lt;tab&gt; HANDS:4</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;race name&gt;
-&lt;tab&gt; HANDS:4
-   </code>
+   <code>&lt;race name&gt;
+&lt;tab&gt; HANDS:4</code>
   </p>
   <p class="indent3">
    Race now has four hands.
@@ -959,17 +841,11 @@ increases by one category.
      .MOD Behavior:
     </strong>
     When modifying a race with the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     HITDICEADVANCMENT
-    </code>
+    <code>HITDICEADVANCMENT</code>
     tag, the data included in a new
-    <code>
-     HITDICEADVACEMENT
-    </code>
+    <code>HITDICEADVACEMENT</code>
     tag will overwrite the existing tag
 data.
    </li>
@@ -980,9 +856,7 @@ data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    HITDICEADVANCEMENT:4,6,8
-   </code>
+   <code>HITDICEADVANCEMENT:4,6,8</code>
   </p>
   <p class="indent3">
    Race starts out as Tiny, with 4 Hit Dice. 5-6 it
@@ -990,9 +864,7 @@ is Small, 7+ it is Medium. 8 Hit Dice is the maximum it can ever
 raise to.
   </p>
   <p class="indent2">
-   <code>
-    HITDICEADVANCEMENT:4,16,32,*
-   </code>
+   <code>HITDICEADVANCEMENT:4,16,32,*</code>
   </p>
   <p class="indent3">
    Assassin Vine: starts out as Large, with 4 HD.
@@ -1000,9 +872,7 @@ raise to.
 is no limit to the creature's hit dice.
   </p>
   <p class="indent2">
-   <code>
-    HITDICEADVANCEMENT:4,6,*
-   </code>
+   <code>HITDICEADVANCEMENT:4,6,*</code>
   </p>
   <p class="indent3">
    Race starts out as Tiny, with 4 Hit Dice. 5-6 it
@@ -1016,24 +886,18 @@ dice.
   </p>
   <p class="indent2">
    Initial Race:
-   <code>
-    &lt;race name&gt;
-&lt;tab&gt; HITDICEADVANCEMENT:4,6,8
-   </code>
+   <code>&lt;race name&gt;
+&lt;tab&gt; HITDICEADVANCEMENT:4,6,8</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;race name&gt;.MOD
-&lt;tab&gt; HITDICEADVANCEMENT:4,6,*
-   </code>
+   <code>&lt;race name&gt;.MOD
+&lt;tab&gt; HITDICEADVANCEMENT:4,6,*</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;race name&gt;
-&lt;tab&gt; HITDICEADVANCEMENT:4,6,*
-   </code>
+   <code>&lt;race name&gt;
+&lt;tab&gt; HITDICEADVANCEMENT:4,6,*</code>
   </p>
   <p class="indent3">
    Race starts out as Tiny, with 4 Hit Dice. 5-6 it
@@ -1185,18 +1049,12 @@ in which case it will only be applied to matching classes.
      .MOD Behavior:
     </strong>
     When modifying a race with the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     HITDIE
-    </code>
+    <code>HITDIE</code>
     tag,
 the data included in a new
-    <code>
-     HITDIE
-    </code>
+    <code>HITDIE</code>
     tag will overwrite
 the existing tag data.
    </li>
@@ -1207,67 +1065,51 @@ the existing tag data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    HITDIE:12
-   </code>
+   <code>HITDIE:12</code>
   </p>
   <p class="indent3">
    The character now has a Hit Dice of 12.
   </p>
   <p class="indent2">
-   <code>
-    HITDIE:%+2
-   </code>
+   <code>HITDIE:%+2</code>
   </p>
   <p class="indent3">
    Adds 2 to the current Hit Dice size.
   </p>
   <p class="indent2">
-   <code>
-    HITDIE:%-4
-   </code>
+   <code>HITDIE:%-4</code>
   </p>
   <p class="indent3">
    Subtracts 4 from the current Hit Dice size.
   </p>
   <p class="indent2">
-   <code>
-    HITDIE:%*3
-   </code>
+   <code>HITDIE:%*3</code>
   </p>
   <p class="indent3">
    Multiplies the current Hit Dice size by 3.
   </p>
   <p class="indent2">
-   <code>
-    HITDIE:%/2
-   </code>
+   <code>HITDIE:%/2</code>
   </p>
   <p class="indent3">
    Divides the current Hit Dice size by 2.
   </p>
   <p class="indent2">
-   <code>
-    HITDIE:%up2
-   </code>
+   <code>HITDIE:%up2</code>
   </p>
   <p class="indent3">
    Steps up the Hit Dice size by two steps. If the
 creature has a Hit Die of d6 it will be stepped up to d10.
   </p>
   <p class="indent2">
-   <code>
-    HITDIE:%down1
-   </code>
+   <code>HITDIE:%down1</code>
   </p>
   <p class="indent3">
    Steps down the Hit Dice size by one step. If the
 creature has a Hit Die of d6 it will be stepped down to d4.
   </p>
   <p class="indent2">
-   <code>
-    HITDIE:%up1|CLASS.TYPE=Monster
-   </code>
+   <code>HITDIE:%up1|CLASS.TYPE=Monster</code>
   </p>
   <p class="indent3">
    Steps up the Hit Dice size by one step for any
@@ -1275,18 +1117,14 @@ Monster class levels the creature has. If the creature has a
 Monster class Hit Die of d8 it will be stepped up to d10.
   </p>
   <p class="indent2">
-   <code>
-    HITDIE:%Hup4
-   </code>
+   <code>HITDIE:%Hup4</code>
   </p>
   <p class="indent3">
    Steps up the Hit Dice size by four steps. If the
 class has a Hit Die of d6 it will be stepped up to d20.
   </p>
   <p class="indent2">
-   <code>
-    HITDIE:%Hdown3
-   </code>
+   <code>HITDIE:%Hdown3</code>
   </p>
   <p class="indent3">
    Steps down the Hit Dice size by three steps. If
@@ -1299,24 +1137,18 @@ the class has a Hit Die of d6 it will be stepped down to d2.
   </p>
   <p class="indent2">
    Initial Race:
-   <code>
-    &lt;race name&gt;
-&lt;tab&gt; HITDIE:12
-   </code>
+   <code>&lt;race name&gt;
+&lt;tab&gt; HITDIE:12</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;race name&gt;.MOD
-&lt;tab&gt; HITDIE:%/2
-   </code>
+   <code>&lt;race name&gt;.MOD
+&lt;tab&gt; HITDIE:%/2</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;race name&gt;
-&lt;tab&gt; HITDIE:%/2
-   </code>
+   <code>&lt;race name&gt;
+&lt;tab&gt; HITDIE:%/2</code>
   </p>
   <p class="indent3">
    The creature's new hitdie size is a divided by
@@ -1371,9 +1203,7 @@ not effect languages granted from skills.
    </li>
    <li>
     When using
-    <code>
-     ALL
-    </code>
+    <code>ALL</code>
     , no other language designation is
 necessary.
    </li>
@@ -1382,17 +1212,11 @@ necessary.
      .MOD Behavior:
     </strong>
     When modifying a race with the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     LANGBONUS
-    </code>
+    <code>LANGBONUS</code>
     tag, the data included in a new
-    <code>
-     LANGBONUS
-    </code>
+    <code>LANGBONUS</code>
     tag will be
 appended to the existing tag data.
    </li>
@@ -1403,9 +1227,7 @@ appended to the existing tag data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    LANGBONUS:Dwarven,Elven,Gnome,Goblin,Orc
-   </code>
+   <code>LANGBONUS:Dwarven,Elven,Gnome,Goblin,Orc</code>
   </p>
   <p class="indent3">
    Race can choose starting languages from
@@ -1413,11 +1235,9 @@ appended to the existing tag data.
   </p>
   <blockquote class="indent2">
    <p class="tagindent1">
-    <code>
-     Hobgoblin.MOD &lt;tab&gt;
+    <code>Hobgoblin.MOD &lt;tab&gt;
 LANGAUTO:Gadohig &lt;tab&gt; LANGBONUS:.CLEAR &lt;tab&gt;
-LANGBONUS:Aeylamdyarian,Calisian,Desolati,Galkarnic,Homish,Launhymian
-    </code>
+LANGBONUS:Aeylamdyarian,Calisian,Desolati,Galkarnic,Homish,Launhymian</code>
    </p>
   </blockquote>
   <p class="indent3">
@@ -1426,10 +1246,8 @@ LANGBONUS:Aeylamdyarian,Calisian,Desolati,Galkarnic,Homish,Launhymian
 or "Launhymian", in addition to the Autoknown "Gadohig".
   </p>
   <p class="indent2">
-   <code>
-    LANGBONUS:Old
-Dwarven,Orcish,TYPE=ClanDialect,Trader's Tongue
-   </code>
+   <code>LANGBONUS:Old
+Dwarven,Orcish,TYPE=ClanDialect,Trader's Tongue</code>
   </p>
   <p class="indent3">
    Race can choose starting languages from "Old
@@ -1443,24 +1261,18 @@ Tongue".
   </p>
   <p class="indent2">
    Initial Race:
-   <code>
-    Space Monkey &lt;tab&gt;
-LANGBONUS:Simian
-   </code>
+   <code>Space Monkey &lt;tab&gt;
+LANGBONUS:Simian</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    Space Monkey.MOD &lt;tab&gt;
-LANGBONUS:Martian
-   </code>
+   <code>Space Monkey.MOD &lt;tab&gt;
+LANGBONUS:Martian</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    Space Monkey &lt;tab&gt;
-LANGBONUS:Simian,Martian
-   </code>
+   <code>Space Monkey &lt;tab&gt;
+LANGBONUS:Simian,Martian</code>
    .
   </p>
   <p class="indent3">
@@ -1500,18 +1312,12 @@ than/less than 2).
      .MOD Behavior:
     </strong>
     When modifying a race with the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     LEGS
-    </code>
+    <code>LEGS</code>
     tag, the
 data included in a new
-    <code>
-     LEGS
-    </code>
+    <code>LEGS</code>
     tag will overwrite the
 existing tag data.
    </li>
@@ -1522,17 +1328,13 @@ existing tag data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    LEGS:4
-   </code>
+   <code>LEGS:4</code>
   </p>
   <p class="indent3">
    A horse has 4 legs.
   </p>
   <p class="indent2">
-   <code>
-    LEGS:0
-   </code>
+   <code>LEGS:0</code>
   </p>
   <p class="indent3">
    Slime and ooze creatures/characters would have
@@ -1545,24 +1347,18 @@ no legs!
   </p>
   <p class="indent2">
    Initial Race:
-   <code>
-    &lt;race name&gt;
-&lt;tab&gt; LEGS:2
-   </code>
+   <code>&lt;race name&gt;
+&lt;tab&gt; LEGS:2</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;race name&gt;.MOD
-&lt;tab&gt; LEGS:4
-   </code>
+   <code>&lt;race name&gt;.MOD
+&lt;tab&gt; LEGS:4</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;race name&gt;
-&lt;tab&gt; LEGS:4
-   </code>
+   <code>&lt;race name&gt;
+&lt;tab&gt; LEGS:4</code>
   </p>
   <p class="indent3">
    The race now has 4 legs.
@@ -1613,17 +1409,11 @@ of the creature.
      .MOD Behavior:
     </strong>
     When modifying a race with the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     LEVELADJUSTMENT
-    </code>
+    <code>LEVELADJUSTMENT</code>
     tag, the data included in a new
-    <code>
-     LEVELADJUSTMENT
-    </code>
+    <code>LEVELADJUSTMENT</code>
     tag will overwrite the existing tag
 data.
    </li>
@@ -1634,20 +1424,16 @@ data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    LEVELADJUSTMENT:1
-   </code>
+   <code>LEVELADJUSTMENT:1</code>
   </p>
   <p class="indent3">
    Effective Character Level is raised by one.
   </p>
   <p class="indent2">
-   <code>
-    Bugbear (Shadowkind).MOD &lt;tab&gt;
+   <code>Bugbear (Shadowkind).MOD &lt;tab&gt;
 OUTPUTNAME:Bugbear &lt;tab&gt; RACETYPE:Humanoid &lt;tab&gt;
 RACESUBTYPE:Shadowkind &lt;tab&gt; TEMPLATE:Shadowkind &lt;tab&gt;
-LEVELADJUSTMENT:2
-   </code>
+LEVELADJUSTMENT:2</code>
   </p>
   <p class="indent3">
    This modification of the race Bugbear, changes
@@ -1660,24 +1446,18 @@ all of the indicated tags.
   </p>
   <p class="indent2">
    Initial Race:
-   <code>
-    &lt;race name&gt;
-&lt;tab&gt; LEVELADJUSTMENT:1
-   </code>
+   <code>&lt;race name&gt;
+&lt;tab&gt; LEVELADJUSTMENT:1</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;race name&gt;.MOD
-&lt;tab&gt; LEVELADJUSTMENT:2
-   </code>
+   <code>&lt;race name&gt;.MOD
+&lt;tab&gt; LEVELADJUSTMENT:2</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;race name&gt;
-&lt;tab&gt; LEVELADJUSTMENT:2
-   </code>
+   <code>&lt;race name&gt;
+&lt;tab&gt; LEVELADJUSTMENT:2</code>
   </p>
   <p class="indent3">
    Effective Character Level is now raised by
@@ -1738,17 +1518,11 @@ apply.
      .MOD Behavior:
     </strong>
     When modifying a race with the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     MONCCSKILL
-    </code>
+    <code>MONCCSKILL</code>
     tag, the data included in a new
-    <code>
-     MONCCSKILL
-    </code>
+    <code>MONCCSKILL</code>
     tag will be
 appended to the existing tag data.
    </li>
@@ -1759,19 +1533,15 @@ appended to the existing tag data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    MONCCSKILL:Alchemy|Wilderness
-Lore
-   </code>
+   <code>MONCCSKILL:Alchemy|Wilderness
+Lore</code>
   </p>
   <p class="indent3">
    The "Alchemy" and "Wilderness Lore" skills are
 made monster cross class skills.
   </p>
   <p class="indent2">
-   <code>
-    MONCCSKILL:Alchemy|TYPE.Knowledge
-   </code>
+   <code>MONCCSKILL:Alchemy|TYPE.Knowledge</code>
   </p>
   <p class="indent3">
    The "Alchemy" and "Knowledge" type skills are
@@ -1784,24 +1554,18 @@ made monster cross class skills.
   </p>
   <p class="indent2">
    Initial Race:
-   <code>
-    Ooze Monkey &lt;tab&gt;
-MONCCSKILL:Alchemy|Wilderness Lore
-   </code>
+   <code>Ooze Monkey &lt;tab&gt;
+MONCCSKILL:Alchemy|Wilderness Lore</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    Ooze Monkey.MOD &lt;tab&gt;
-MONCCSKILL:Acrobatics|Stealth
-   </code>
+   <code>Ooze Monkey.MOD &lt;tab&gt;
+MONCCSKILL:Acrobatics|Stealth</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    Ooze Monkey &lt;tab&gt;
-MONCCSKILL:Acrobatics|Alchemy|Stealth|Wilderness Lore
-   </code>
+   <code>Ooze Monkey &lt;tab&gt;
+MONCCSKILL:Acrobatics|Alchemy|Stealth|Wilderness Lore</code>
    .
   </p>
   <p class="indent3">
@@ -1862,17 +1626,11 @@ that level, the monster class skills will not apply.
      .MOD Behavior:
     </strong>
     When modifying a race with the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     MONCSKILL
-    </code>
+    <code>MONCSKILL</code>
     tag, the data included in a new
-    <code>
-     MONCSKILL
-    </code>
+    <code>MONCSKILL</code>
     tag will be
 appended to the existing tag data.
    </li>
@@ -1883,19 +1641,15 @@ appended to the existing tag data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    MONCSKILL:Alchemy|Wilderness
-Lore
-   </code>
+   <code>MONCSKILL:Alchemy|Wilderness
+Lore</code>
   </p>
   <p class="indent3">
    The "Alchemy" and "Wilderness Lore" skills are
 made monster class skills.
   </p>
   <p class="indent2">
-   <code>
-    MONCSKILL:Alchemy|TYPE.Knowledge
-   </code>
+   <code>MONCSKILL:Alchemy|TYPE.Knowledge</code>
   </p>
   <p class="indent3">
    The "Alchemy" and "Knowledge" type skills are
@@ -1908,24 +1662,18 @@ made monster class skills.
   </p>
   <p class="indent2">
    Initial Race:
-   <code>
-    Ooze Monkey &lt;tab&gt;
-MONCSKILL:Alchemy|Wilderness Lore
-   </code>
+   <code>Ooze Monkey &lt;tab&gt;
+MONCSKILL:Alchemy|Wilderness Lore</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    Ooze Monkey.MOD &lt;tab&gt;
-MONCSKILL:Acrobatics|Stealth
-   </code>
+   <code>Ooze Monkey.MOD &lt;tab&gt;
+MONCSKILL:Acrobatics|Stealth</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    Ooze Monkey &lt;tab&gt;
-MONCSKILL:Acrobatics|Alchemy|Stealth|Wilderness Lore
-   </code>
+   <code>Ooze Monkey &lt;tab&gt;
+MONCSKILL:Acrobatics|Alchemy|Stealth|Wilderness Lore</code>
    .
   </p>
   <p class="indent3">
@@ -1974,17 +1722,11 @@ the race.
      .MOD Behavior:
     </strong>
     When modifying a race with the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     MONSTERCLASS
-    </code>
+    <code>MONSTERCLASS</code>
     tag, the data included in a new
-    <code>
-     MONSTERCLASS
-    </code>
+    <code>MONSTERCLASS</code>
     tag will
 overwrite the existing tag data.
    </li>
@@ -1995,9 +1737,7 @@ overwrite the existing tag data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    MONSTERCLASS:Outsider:2
-   </code>
+   <code>MONSTERCLASS:Outsider:2</code>
   </p>
   <p class="indent3">
    The race has 2 levels of Outsider to start.
@@ -2009,24 +1749,18 @@ overwrite the existing tag data.
   </p>
   <p class="indent2">
    Initial Race:
-   <code>
-    &lt;race name&gt;
-&lt;tab&gt; MONSTERCLASS:2
-   </code>
+   <code>&lt;race name&gt;
+&lt;tab&gt; MONSTERCLASS:2</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;race name&gt;.MOD
-&lt;tab&gt; MONSTERCLASS:4
-   </code>
+   <code>&lt;race name&gt;.MOD
+&lt;tab&gt; MONSTERCLASS:4</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;race name&gt;
-&lt;tab&gt; MONSTERCLASS:4
-   </code>
+   <code>&lt;race name&gt;
+&lt;tab&gt; MONSTERCLASS:4</code>
   </p>
   <p class="indent3">
    The creature's new monster class is "Outsider"
@@ -2073,9 +1807,7 @@ as well as Humanoid subraces such as Elf, Orc, Dwarf, etc..
    </li>
    <li>
     The
-    <code>
-     .CLEAR
-    </code>
+    <code>.CLEAR</code>
     tag may be used with this tag.
    </li>
    <li>
@@ -2083,17 +1815,11 @@ as well as Humanoid subraces such as Elf, Orc, Dwarf, etc..
      .MOD Behavior:
     </strong>
     When modifying a race with the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     RACESUBTYPE
-    </code>
+    <code>RACESUBTYPE</code>
     tag, the data included in a new
-    <code>
-     RACESUBTYPE
-    </code>
+    <code>RACESUBTYPE</code>
     tag will
 be appended to the existing tag data.
    </li>
@@ -2104,31 +1830,25 @@ be appended to the existing tag data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    RACESUBTYPE:Lawful|Air
-   </code>
+   <code>RACESUBTYPE:Lawful|Air</code>
   </p>
   <p class="indent3">
    The race possesses the "Lawful" and "Air"
 subtypes.
   </p>
   <p class="indent2">
-   <code>
-    Bugbear (Shadowkind).MOD &lt;tab&gt;
+   <code>Bugbear (Shadowkind).MOD &lt;tab&gt;
 OUTPUTNAME:Bugbear &lt;tab&gt; RACETYPE:Humanoid &lt;tab&gt;
 RACESUBTYPE:Shadowkind &lt;tab&gt; TEMPLATE:Shadowkind &lt;tab&gt;
-LEVELADJUSTMENT:2
-   </code>
+LEVELADJUSTMENT:2</code>
   </p>
   <p class="indent3">
    This modification of the race Bugbear, changes
 all of the indicated tags.
   </p>
   <p class="indent2">
-   <code>
-    &lt;race&gt;.MOD &lt;tab&gt;
-RACESUBTYPE:.CLEAR &lt;tab&gt; RACESUBTYPE:Lawful|Air
-   </code>
+   <code>&lt;race&gt;.MOD &lt;tab&gt;
+RACESUBTYPE:.CLEAR &lt;tab&gt; RACESUBTYPE:Lawful|Air</code>
   </p>
   <p class="indent3">
    This modification clears a race's existing
@@ -2141,24 +1861,18 @@ subtypes and replaces it with the "Lawful" and "Air" subtypes.
   </p>
   <p class="indent2">
    Initial Race:
-   <code>
-    Ooze Monkey &lt;tab&gt;
-RACESUBTYPE:Simian
-   </code>
+   <code>Ooze Monkey &lt;tab&gt;
+RACESUBTYPE:Simian</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    Ooze Monkey.MOD &lt;tab&gt;
-RACESUBTYPE:Gooey
-   </code>
+   <code>Ooze Monkey.MOD &lt;tab&gt;
+RACESUBTYPE:Gooey</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    Ooze Monkey &lt;tab&gt;
-RACESUBTYPE:Simian|Gooey
-   </code>
+   <code>Ooze Monkey &lt;tab&gt;
+RACESUBTYPE:Simian|Gooey</code>
    .
   </p>
   <p class="indent3">
@@ -2212,18 +1926,12 @@ Plant, Shapechanger, Undead, and Vermin.
      .MOD Behavior:
     </strong>
     When modifying a race with the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     RACETYPE
-    </code>
+    <code>RACETYPE</code>
     tag,
 the data included in a new
-    <code>
-     RACETYPE
-    </code>
+    <code>RACETYPE</code>
     tag will overwrite
 the existing tag data.
    </li>
@@ -2234,20 +1942,16 @@ the existing tag data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    RACETYPE:Outsider
-   </code>
+   <code>RACETYPE:Outsider</code>
   </p>
   <p class="indent3">
    The race is of the "Outsider" type.
   </p>
   <p class="indent2">
-   <code>
-    Bugbear (Shadowkind).MOD &lt;tab&gt;
+   <code>Bugbear (Shadowkind).MOD &lt;tab&gt;
 OUTPUTNAME:Bugbear &lt;tab&gt; RACETYPE:Humanoid &lt;tab&gt;
 RACESUBTYPE:Shadowkind &lt;tab&gt; TEMPLATE:Shadowkind &lt;tab&gt;
-LEVELADJUSTMENT:2
-   </code>
+LEVELADJUSTMENT:2</code>
   </p>
   <p class="indent3">
    This modification of the race Bugbear, changes
@@ -2260,24 +1964,18 @@ all of the indicated tags.
   </p>
   <p class="indent2">
    Initial Race:
-   <code>
-    &lt;race name&gt;
-&lt;tab&gt; RACETYPE:Humanoid
-   </code>
+   <code>&lt;race name&gt;
+&lt;tab&gt; RACETYPE:Humanoid</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;race name&gt;.MOD
-&lt;tab&gt; RACETYPE:Outsider
-   </code>
+   <code>&lt;race name&gt;.MOD
+&lt;tab&gt; RACETYPE:Outsider</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;race name&gt;
-&lt;tab&gt; RACETYPE:Outsider
-   </code>
+   <code>&lt;race name&gt;
+&lt;tab&gt; RACETYPE:Outsider</code>
   </p>
   <p class="indent3">
    The race is now of the "Outsider" type.
@@ -2313,18 +2011,12 @@ Name:
      .MOD Behavior:
     </strong>
     When modifying a race with the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     REACH
-    </code>
+    <code>REACH</code>
     tag,
 the data included in a new
-    <code>
-     REACH
-    </code>
+    <code>REACH</code>
     tag will overwrite
 the existing tag data.
    </li>
@@ -2335,9 +2027,7 @@ the existing tag data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    REACH:10
-   </code>
+   <code>REACH:10</code>
   </p>
   <p class="indent3">
    The race has a reach of ten feet.
@@ -2349,24 +2039,18 @@ the existing tag data.
   </p>
   <p class="indent2">
    Initial Race:
-   <code>
-    &lt;race name&gt;
-&lt;tab&gt; REACH:5
-   </code>
+   <code>&lt;race name&gt;
+&lt;tab&gt; REACH:5</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;race name&gt;.MOD
-&lt;tab&gt; REACH:10
-   </code>
+   <code>&lt;race name&gt;.MOD
+&lt;tab&gt; REACH:10</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;race name&gt;
-&lt;tab&gt; REACH:10
-   </code>
+   <code>&lt;race name&gt;
+&lt;tab&gt; REACH:10</code>
   </p>
   <p class="indent3">
    The final reach is "10".
@@ -2409,9 +2093,7 @@ dice and class levels.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ROLE:Combat
-   </code>
+   <code>ROLE:Combat</code>
   </p>
   <p class="indent3">
    Character levels in classes associated with the
@@ -2419,9 +2101,7 @@ Combat role are key levels for CR calculation purposes for this
 creature.
   </p>
   <p class="indent2">
-   <code>
-    ROLE:Combat.Skill
-   </code>
+   <code>ROLE:Combat.Skill</code>
   </p>
   <p class="indent3">
    Character levels in classes associated with
@@ -2429,9 +2109,7 @@ either the Combat role or the Skill role are key levels for CR
 calculation purposes for this creature.
   </p>
   <p class="indent2">
-   <code>
-    ROLE:Cleric
-   </code>
+   <code>ROLE:Cleric</code>
   </p>
   <p class="indent3">
    Cleric levels are key levels for CR calculation
@@ -2478,18 +2156,12 @@ sizeadjustments.lst file.
      .MOD Behavior:
     </strong>
     When modifying a race with the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     SIZE
-    </code>
+    <code>SIZE</code>
     tag, the
 data included in a new
-    <code>
-     SIZE
-    </code>
+    <code>SIZE</code>
     tag will overwrite the
 existing tag data.
    </li>
@@ -2514,9 +2186,7 @@ dragons.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SIZE:M
-   </code>
+   <code>SIZE:M</code>
   </p>
   <p class="indent3">
    The race is of Medium size.
@@ -2528,24 +2198,18 @@ dragons.
   </p>
   <p class="indent2">
    Initial Race:
-   <code>
-    &lt;race name&gt;
-&lt;tab&gt; SIZE:M
-   </code>
+   <code>&lt;race name&gt;
+&lt;tab&gt; SIZE:M</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;race name&gt;.MOD
-&lt;tab&gt; SIZE:L
-   </code>
+   <code>&lt;race name&gt;.MOD
+&lt;tab&gt; SIZE:L</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;race name&gt;
-&lt;tab&gt; SIZE:L
-   </code>
+   <code>&lt;race name&gt;
+&lt;tab&gt; SIZE:L</code>
   </p>
   <p class="indent3">
    The creatue is "Large".
@@ -2589,17 +2253,11 @@ class levels is done as Multi-Classing.
      .MOD Behavior:
     </strong>
     When modifying a race with the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     SKILLMULT
-    </code>
+    <code>SKILLMULT</code>
     tag, the data included in a new
-    <code>
-     SKILLMULT
-    </code>
+    <code>SKILLMULT</code>
     tag will
 overwrite the existing tag data.
    </li>
@@ -2610,9 +2268,7 @@ overwrite the existing tag data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SKILLMULT:1
-   </code>
+   <code>SKILLMULT:1</code>
   </p>
   <p class="indent3">
    Monsters have x1 since adding class levels is
@@ -2625,24 +2281,18 @@ done as Multi-classing.
   </p>
   <p class="indent2">
    Initial Race:
-   <code>
-    &lt;race name&gt;
-&lt;tab&gt; SKILLMULT:1
-   </code>
+   <code>&lt;race name&gt;
+&lt;tab&gt; SKILLMULT:1</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;race name&gt;.MOD
-&lt;tab&gt; SKILLMULT:2
-   </code>
+   <code>&lt;race name&gt;.MOD
+&lt;tab&gt; SKILLMULT:2</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;race name&gt;
-&lt;tab&gt; SKILLMULT:2
-   </code>
+   <code>&lt;race name&gt;
+&lt;tab&gt; SKILLMULT:2</code>
   </p>
   <p class="indent3">
    The final skill multiplier is "2".
@@ -2684,17 +2334,11 @@ feats") use the global ADD:FEAT() tag.
     </strong>
     When modifying a template, with
 the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     STARTFEATS
-    </code>
+    <code>STARTFEATS</code>
     tag, the data included in a new
-    <code>
-     STARTFEATS
-    </code>
+    <code>STARTFEATS</code>
     tag will be included as if it were a
 separate tag.
    </li>
@@ -2705,9 +2349,7 @@ separate tag.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    STARTFEATS:2
-   </code>
+   <code>STARTFEATS:2</code>
   </p>
   <p class="indent3">
    The race starts with 2 free feats.
@@ -2719,24 +2361,18 @@ separate tag.
   </p>
   <p class="indent2">
    Initial Race:
-   <code>
-    Werewolf &lt;tab&gt;
-STARTFEATS:2
-   </code>
+   <code>Werewolf &lt;tab&gt;
+STARTFEATS:2</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    Werewolf.MOD &lt;tab&gt;
-STARTFEATS:2
-   </code>
+   <code>Werewolf.MOD &lt;tab&gt;
+STARTFEATS:2</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    Werewolf &lt;tab&gt;
-STARTFEATS:2 &lt;tab&gt; STARTFEATS:2
-   </code>
+   <code>Werewolf &lt;tab&gt;
+STARTFEATS:2 &lt;tab&gt; STARTFEATS:2</code>
   </p>
   <p class="indent3">
    The Werewolf now starts with 4 free feats.
@@ -2773,21 +2409,17 @@ that are granted to the race.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TEMPLATE:Incorporeal|Undead|Celestial
-   </code>
+   <code>TEMPLATE:Incorporeal|Undead|Celestial</code>
   </p>
   <p class="indent3">
    The race uses the "Incorporeal", "Undead" and
 "Celestial" templates.
   </p>
   <p class="indent2">
-   <code>
-    Bugbear (Shadowkind).MOD &lt;tab&gt;
+   <code>Bugbear (Shadowkind).MOD &lt;tab&gt;
 OUTPUTNAME:Bugbear &lt;tab&gt; RACETYPE:Humanoid &lt;tab&gt;
 RACESUBTYPE:Shadowkind &lt;tab&gt; TEMPLATE:Shadowkind &lt;tab&gt;
-LEVELADJUSTMENT:2
-   </code>
+LEVELADJUSTMENT:2</code>
   </p>
   <p class="indent3">
    This modification of the race Bugbear, changes
@@ -2822,21 +2454,13 @@ tag.
    </li>
    <li>
     When using the
-    <code>
-     TEMPLATE:ADDCOICE
-    </code>
+    <code>TEMPLATE:ADDCOICE</code>
     tag as part of a
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     of a Race object that containes multiple
-    <code>
-     TEMPLATE:CHOOSE
-    </code>
+    <code>TEMPLATE:CHOOSE</code>
     tags, all instances of the
-    <code>
-     TEMPLATE:CHOOSE
-    </code>
+    <code>TEMPLATE:CHOOSE</code>
     tag will be modified.
    </li>
   </ul>
@@ -2846,9 +2470,7 @@ tag.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TEMPLATE:ADDCHOICE:Demihuman|Beast
-   </code>
+   <code>TEMPLATE:ADDCHOICE:Demihuman|Beast</code>
   </p>
   <p class="indent3">
    The race can choose previously defined templates
@@ -2883,18 +2505,14 @@ list.
    </li>
    <li>
     Multiple
-    <code>
-     TEMPLATE:CHOOSE
-    </code>
+    <code>TEMPLATE:CHOOSE</code>
     tags can be used in the
 same LST object but PCGen's current Data Standard is to include no
 more that one in each LST object.
    </li>
    <li>
     Although the
-    <code>
-     TEMPLATE:CHOOSE
-    </code>
+    <code>TEMPLATE:CHOOSE</code>
     tag is not a gobal
 tag it can be used in the
     <a href="datafilesability.html#templatechoose">
@@ -2917,9 +2535,7 @@ tag it can be used in the
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TEMPLATE:CHOOSE:Celestial|Outsider
-   </code>
+   <code>TEMPLATE:CHOOSE:Celestial|Outsider</code>
   </p>
   <p class="indent3">
    The race can choose either the "Celestial" or
@@ -2969,18 +2585,14 @@ listed weapons.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    WEAPONBONUS:Rapier|Longbow
-   </code>
+   <code>WEAPONBONUS:Rapier|Longbow</code>
   </p>
   <p class="indent3">
    The race receives bonus proficiency in "Rapier"
 or "Longbow".
   </p>
   <p class="indent2">
-   <code>
-    WEAPONBONUS:TYPE.Simple
-   </code>
+   <code>WEAPONBONUS:TYPE.Simple</code>
   </p>
   <p class="indent3">
    The race receives bonus proficiency in any one
@@ -2993,24 +2605,18 @@ Simple weapon.
   </p>
   <p class="indent2">
    Initial Race:
-   <code>
-    Grunt &lt;tab&gt;
-WEAPONBONUS:TYPE.Simple
-   </code>
+   <code>Grunt &lt;tab&gt;
+WEAPONBONUS:TYPE.Simple</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    Grunt.MOD &lt;tab&gt;
-WEAPONBONUS:TYPE.Martial
-   </code>
+   <code>Grunt.MOD &lt;tab&gt;
+WEAPONBONUS:TYPE.Martial</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    Grunt &lt;tab&gt;
-WEAPONBONUS:TYPE.Simple|TYPE.Martial
-   </code>
+   <code>Grunt &lt;tab&gt;
+WEAPONBONUS:TYPE.Simple|TYPE.Martial</code>
    .
   </p>
   <p class="indent3">
@@ -3060,18 +2666,14 @@ behavior.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    XTRASKILLPTSPERLVL:1
-   </code>
+   <code>XTRASKILLPTSPERLVL:1</code>
   </p>
   <p class="indent3">
    Adds one to the skill points per level (before
 multiplication for the 1st level).
   </p>
   <p class="indent2">
-   <code>
-    XTRASKILLPTSPERLVL:HumanSkillBase
-   </code>
+   <code>XTRASKILLPTSPERLVL:HumanSkillBase</code>
   </p>
   <p class="indent3">
    Adds a number of skill points per level (before
@@ -3085,24 +2687,18 @@ variable "HumanSkillBase"".
   </p>
   <p class="indent2">
    Initial Race:
-   <code>
-    &lt;race name&gt;
-&lt;tab&gt; XTRASKILLPTSPERLVL:1
-   </code>
+   <code>&lt;race name&gt;
+&lt;tab&gt; XTRASKILLPTSPERLVL:1</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;race name&gt;.MOD
-&lt;tab&gt; XTRASKILLPTSPERLVL:2
-   </code>
+   <code>&lt;race name&gt;.MOD
+&lt;tab&gt; XTRASKILLPTSPERLVL:2</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;race name&gt;
-&lt;tab&gt; XTRASKILLPTSPERLVL:2
-   </code>
+   <code>&lt;race name&gt;
+&lt;tab&gt; XTRASKILLPTSPERLVL:2</code>
   </p>
   <p class="indent3">
    The final extra skill points per level are

--- a/docs/listfilepages/datafilestagpages/datafilesshieldproficiencies.html
+++ b/docs/listfilepages/datafilestagpages/datafilesshieldproficiencies.html
@@ -40,15 +40,11 @@ of the shield proficiency.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    Shield (Light)
-   </code>
+   <code>Shield (Light)</code>
   </p>
   <p class="indent3">
    Defines
-   <code>
-    Shield (Light)
-   </code>
+   <code>Shield (Light)</code>
    as a
 category of shield to be used in the associated dataset.
   </p>

--- a/docs/listfilepages/datafilestagpages/datafilesskills.html
+++ b/docs/listfilepages/datafilestagpages/datafilesskills.html
@@ -34,26 +34,20 @@
 the remaining tags may be of any order.
   </p>
   <p class="indent2">
-   <code>
-    Craft (Structural)
-   </code>
+   <code>Craft (Structural)</code>
   </p>
   <p class="indent3">
    The skill named "Craft (Structural)" is to be
 created.
   </p>
   <p class="indent2">
-   <code>
-    Forgery.MOD
-   </code>
+   <code>Forgery.MOD</code>
   </p>
   <p class="indent3">
    The skill named "Forgery" is to be modified.
   </p>
   <p class="indent2">
-   <code>
-    Computer Use.FORGET
-   </code>
+   <code>Computer Use.FORGET</code>
   </p>
   <p class="indent3">
    The skill named "Computer Use" is to be
@@ -157,18 +151,12 @@ check.
      .MOD Behavior:
     </strong>
     When modifying a skill with the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     ACHECK
-    </code>
+    <code>ACHECK</code>
     tag,
 the data included in a new
-    <code>
-     ACHECK
-    </code>
+    <code>ACHECK</code>
     tag will overwrite
 the existing tag data.
    </li>
@@ -179,9 +167,7 @@ the existing tag data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ACHECK:YES
-   </code>
+   <code>ACHECK:YES</code>
   </p>
   <p class="indent3">
    Armor check penalty applies to this skill.
@@ -193,24 +179,18 @@ the existing tag data.
   </p>
   <p class="indent2">
    Initial Skill:
-   <code>
-    Brachiation &lt;tab&gt;
-ACHECK:YES
-   </code>
+   <code>Brachiation &lt;tab&gt;
+ACHECK:YES</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    Brachiation.MOD &lt;tab&gt;
-ACHECK:DOUBLE
-   </code>
+   <code>Brachiation.MOD &lt;tab&gt;
+ACHECK:DOUBLE</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    Brachiation &lt;tab&gt;
-ACHECK:DOUBLE
-   </code>
+   <code>Brachiation &lt;tab&gt;
+ACHECK:DOUBLE</code>
   </p>
   <p class="indent3">
    The skill "Brachiation" receives a double
@@ -257,18 +237,12 @@ classes.
      .MOD Behavior:
     </strong>
     When modifying a skill with the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     CLASSES
-    </code>
+    <code>CLASSES</code>
     tag,
 the data included in a new
-    <code>
-     CLASSES
-    </code>
+    <code>CLASSES</code>
     tag will be
 appended to the existing tag data.
    </li>
@@ -279,27 +253,21 @@ appended to the existing tag data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CLASSES:Cleric|Paladin
-   </code>
+   <code>CLASSES:Cleric|Paladin</code>
   </p>
   <p class="indent3">
    The listed skill is class skill for "Cleric" or
 "Paladin" characters.
   </p>
   <p class="indent2">
-   <code>
-    CLASSES:ALL
-   </code>
+   <code>CLASSES:ALL</code>
   </p>
   <p class="indent3">
    The listed skill is class skill for all
 classes.
   </p>
   <p class="indent2">
-   <code>
-    CLASSES:ALL|!Wizard
-   </code>
+   <code>CLASSES:ALL|!Wizard</code>
   </p>
   <p class="indent3">
    The listed skill is a class skill for all
@@ -312,24 +280,18 @@ classes except for "Wizard" characters.
   </p>
   <p class="indent2">
    Initial Skill:
-   <code>
-    Brachiation &lt;tab&gt;
-CLASSES:Acrobat
-   </code>
+   <code>Brachiation &lt;tab&gt;
+CLASSES:Acrobat</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    Brachiation.MOD &lt;tab&gt;
-CLASSES:Ranger
-   </code>
+   <code>Brachiation.MOD &lt;tab&gt;
+CLASSES:Ranger</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    Brachiation &lt;tab&gt;
-CLASSES:Acrobat|Ranger
-   </code>
+   <code>Brachiation &lt;tab&gt;
+CLASSES:Acrobat|Ranger</code>
    .
   </p>
   <p class="indent3">
@@ -375,17 +337,11 @@ as a class skill can take it.
      .MOD Behavior:
     </strong>
     When modifying a skill with the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     EXCLUSIVE
-    </code>
+    <code>EXCLUSIVE</code>
     tag, the data included in a new
-    <code>
-     EXCLUSIVE
-    </code>
+    <code>EXCLUSIVE</code>
     tag will
 overwrite the existing tag data.
    </li>
@@ -396,9 +352,7 @@ overwrite the existing tag data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    EXCLUSIVE:YES
-   </code>
+   <code>EXCLUSIVE:YES</code>
   </p>
   <p class="indent3">
    This skill may only be taken if it is a class
@@ -411,24 +365,18 @@ skill.
   </p>
   <p class="indent2">
    Initial Skill:
-   <code>
-    Brachiation &lt;tab&gt;
-EXCLUSIVE:YES
-   </code>
+   <code>Brachiation &lt;tab&gt;
+EXCLUSIVE:YES</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    Brachiation.MOD &lt;tab&gt;
-EXCLUSIVE:NO
-   </code>
+   <code>Brachiation.MOD &lt;tab&gt;
+EXCLUSIVE:NO</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    Brachiation &lt;tab&gt;
-EXCLUSIVE:NO
-   </code>
+   <code>Brachiation &lt;tab&gt;
+EXCLUSIVE:NO</code>
   </p>
   <p class="indent3">
    The exclusive skill "Brachiation" is no longer
@@ -469,18 +417,12 @@ File) the skill draws bonuses from.
      .MOD Behavior:
     </strong>
     When modifying a skill with the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     KEYSTAT
-    </code>
+    <code>KEYSTAT</code>
     tag,
 the data included in a new
-    <code>
-     KEYSTAT
-    </code>
+    <code>KEYSTAT</code>
     tag will overwrite
 the existing tag data.
    </li>
@@ -491,9 +433,7 @@ the existing tag data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    KEYSTAT:INT
-   </code>
+   <code>KEYSTAT:INT</code>
   </p>
   <p class="indent3">
    Sets the Key stat for the skill to
@@ -506,24 +446,18 @@ Intelligence.
   </p>
   <p class="indent2">
    Initial Skill:
-   <code>
-    Brachiation &lt;tab&gt;
-KEYSTAT:DEX
-   </code>
+   <code>Brachiation &lt;tab&gt;
+KEYSTAT:DEX</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    Brachiation.MOD &lt;tab&gt;
-KEYSTAT:STR
-   </code>
+   <code>Brachiation.MOD &lt;tab&gt;
+KEYSTAT:STR</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    Brachiation &lt;tab&gt;
-KEYSTAT:STR
-   </code>
+   <code>Brachiation &lt;tab&gt;
+KEYSTAT:STR</code>
   </p>
   <p class="indent3">
    The keystat for the skill "Brachiation" is no
@@ -563,17 +497,11 @@ situation)
      .MOD Behavior:
     </strong>
     When modifying a skill with the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     SITUATION
-    </code>
+    <code>SITUATION</code>
     tag, the data included in a new
-    <code>
-     SITUATION
-    </code>
+    <code>SITUATION</code>
     tag will
 appended to the existing tag data.
    </li>
@@ -584,10 +512,8 @@ appended to the existing tag data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    Stealth &lt;tab&gt; SITUATION:In
-Darkness
-   </code>
+   <code>Stealth &lt;tab&gt; SITUATION:In
+Darkness</code>
   </p>
   <p class="indent3">
    Sets the situational skill "Stealth (In
@@ -600,24 +526,18 @@ Darkness)".
   </p>
   <p class="indent2">
    Initial Skill:
-   <code>
-    Stealth &lt;tab&gt;
-SITUATION:In Darkness
-   </code>
+   <code>Stealth &lt;tab&gt;
+SITUATION:In Darkness</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    Stealth.MOD &lt;tab&gt;
-SITUATION:In Caverns
-   </code>
+   <code>Stealth.MOD &lt;tab&gt;
+SITUATION:In Caverns</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    Stealth &lt;tab&gt;
-SITUATION:In Darkness|In Caverns
-   </code>
+   <code>Stealth &lt;tab&gt;
+SITUATION:In Darkness|In Caverns</code>
   </p>
   <p class="indent3">
    Creates the situational skills "Stealth (In
@@ -646,13 +566,9 @@ Darkness)" and "Stealth (In Caverns)".
   </p>
   <ul class="indent2">
    <li>
-    <code>
-     YES
-    </code>
+    <code>YES</code>
     or
-    <code>
-     NO
-    </code>
+    <code>NO</code>
     are used to indicate if
 this skill can be used untrained by the character.
    </li>
@@ -661,17 +577,11 @@ this skill can be used untrained by the character.
      .MOD Behavior:
     </strong>
     When modifying a skill with the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     USEUNTRAINED
-    </code>
+    <code>USEUNTRAINED</code>
     tag, the data included in a new
-    <code>
-     USEUNTRAINED
-    </code>
+    <code>USEUNTRAINED</code>
     tag will
 overwrite the existing tag data.
    </li>
@@ -682,9 +592,7 @@ overwrite the existing tag data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    USEUNTRAINED:NO
-   </code>
+   <code>USEUNTRAINED:NO</code>
   </p>
   <p class="indent3">
    This skill may not be used if untrained.
@@ -696,24 +604,18 @@ overwrite the existing tag data.
   </p>
   <p class="indent2">
    Initial Skill:
-   <code>
-    Brachiation &lt;tab&gt;
-USEUNTRAINED:NO
-   </code>
+   <code>Brachiation &lt;tab&gt;
+USEUNTRAINED:NO</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    Brachiation.MOD &lt;tab&gt;
-USEUNTRAINED:YES
-   </code>
+   <code>Brachiation.MOD &lt;tab&gt;
+USEUNTRAINED:YES</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    Brachiation &lt;tab&gt;
-USEUNTRAINED:YES
-   </code>
+   <code>Brachiation &lt;tab&gt;
+USEUNTRAINED:YES</code>
   </p>
   <p class="indent3">
    The modified "Brachiation" skill can be used
@@ -789,68 +691,44 @@ untrained.
   </p>
   <ul class="indent2">
    <li>
-    <code>
-     YES
-    </code>
+    <code>YES</code>
     ,
-    <code>
-     ALWAYS
-    </code>
+    <code>ALWAYS</code>
     - Shows the skill name in
 PCGen and on export to a character sheet.
    </li>
    <li>
-    <code>
-     NO
-    </code>
+    <code>NO</code>
     - Hides the skill completely.
    </li>
    <li>
-    <code>
-     DISPLAY
-    </code>
+    <code>DISPLAY</code>
     ,
-    <code>
-     GUI
-    </code>
+    <code>GUI</code>
     - Displays the skill
 name in PCGen but not on the character sheet.
    </li>
    <li>
-    <code>
-     EXPORT
-    </code>
+    <code>EXPORT</code>
     ,
-    <code>
-     CSHEET
-    </code>
+    <code>CSHEET</code>
     - Hides the skill name
 from PCGen but displays it on the character sheet.
    </li>
    <li>
-    <code>
-     READONLY
-    </code>
+    <code>READONLY</code>
     - This will block the user from adding
 Ranks to the skill in the Skill Tab.
    </li>
    <li>
-    <code>
-     READONLY
-    </code>
+    <code>READONLY</code>
     is not valid when
-    <code>
-     VISIBLE
-    </code>
+    <code>VISIBLE</code>
     is
 set to
-    <code>
-     EXPORT
-    </code>
+    <code>EXPORT</code>
     or
-    <code>
-     CSHEET
-    </code>
+    <code>CSHEET</code>
     .
    </li>
    <li>
@@ -858,18 +736,12 @@ set to
      .MOD Behavior:
     </strong>
     When modifying a skill with the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     VISIBLE
-    </code>
+    <code>VISIBLE</code>
     tag,
 the data included in a new
-    <code>
-     VISIBLE
-    </code>
+    <code>VISIBLE</code>
     tag will overwrite
 the existing tag data.
    </li>
@@ -880,54 +752,42 @@ the existing tag data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    VISIBLE:YES
-   </code>
+   <code>VISIBLE:YES</code>
   </p>
   <p class="indent3">
    Shows the skill name in PCGen and on the Output
 sheet.
   </p>
   <p class="indent2">
-   <code>
-    VISIBLE:ALWAYS
-   </code>
+   <code>VISIBLE:ALWAYS</code>
   </p>
   <p class="indent3">
    Shows the skill name in PCGen and on the Output
 sheet.
   </p>
   <p class="indent2">
-   <code>
-    VISIBLE:DISPLAY
-   </code>
+   <code>VISIBLE:DISPLAY</code>
   </p>
   <p class="indent3">
    Shows the skill name in PCGen but not on the
 Output sheet.
   </p>
   <p class="indent2">
-   <code>
-    VISIBLE:GUI
-   </code>
+   <code>VISIBLE:GUI</code>
   </p>
   <p class="indent3">
    Shows the skill name in PCGen but not on the
 Output sheet.
   </p>
   <p class="indent2">
-   <code>
-    VISIBLE:CSHEET
-   </code>
+   <code>VISIBLE:CSHEET</code>
   </p>
   <p class="indent3">
    Shows the skill name on the Output sheet but not
 in PCGen.
   </p>
   <p class="indent2">
-   <code>
-    VISIBLE:ALWAYS|READONLY
-   </code>
+   <code>VISIBLE:ALWAYS|READONLY</code>
   </p>
   <p class="indent3">
    Shows the skill name in PCGen and on the Output
@@ -940,24 +800,18 @@ sheet but prohibits the user from adding ranks to it.
   </p>
   <p class="indent2">
    Initial Skill:
-   <code>
-    Brachiation &lt;tab&gt;
-VISIBLE:EXPORT
-   </code>
+   <code>Brachiation &lt;tab&gt;
+VISIBLE:EXPORT</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    Brachiation.MOD &lt;tab&gt;
-VISIBLE:YES
-   </code>
+   <code>Brachiation.MOD &lt;tab&gt;
+VISIBLE:YES</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    Brachiation &lt;tab&gt;
-VISIBLE:YES
-   </code>
+   <code>Brachiation &lt;tab&gt;
+VISIBLE:YES</code>
   </p>
   <p class="indent3">
    The modified "Brachiation" skill can be seen

--- a/docs/listfilepages/datafilestagpages/datafilesspells.html
+++ b/docs/listfilepages/datafilestagpages/datafilesspells.html
@@ -54,37 +54,29 @@ Spell
    The first field is the name of the spell.
   </p>
   <p class="indent2">
-   <code>
-    Ghost Sound
-   </code>
+   <code>Ghost Sound</code>
   </p>
   <p class="indent3">
    The spell named "Ghost Sound" is to be
 created.
   </p>
   <p class="indent2">
-   <code>
-    Silent Image.MOD
-   </code>
+   <code>Silent Image.MOD</code>
   </p>
   <p class="indent3">
    The spell named "Silent Image" is to be
 modified.
   </p>
   <p class="indent2">
-   <code>
-    Magic Aura.COPY=Nystal's Undetectable
-Aura
-   </code>
+   <code>Magic Aura.COPY=Nystal's Undetectable
+Aura</code>
   </p>
   <p class="indent3">
    Copy the spell "Magic Aura" and rename to
 "Nystal's Undetectable Aura" in all aspects.
   </p>
   <p class="indent2">
-   <code>
-    Holy Smite.FORGET
-   </code>
+   <code>Holy Smite.FORGET</code>
   </p>
   <p class="indent3">
    The spell "Holy Smite" is to be forgotten.
@@ -199,9 +191,7 @@ applied is equal to the Caster's current level.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:PPCOST|Blade Barrier|3
-   </code>
+   <code>BONUS:PPCOST|Blade Barrier|3</code>
   </p>
   <p class="indent3">
    It costs a Clr9/Good9/War9 11 PP to launch a
@@ -211,9 +201,7 @@ extra PP is 3 for this example. Damage can not be raised over the
 Caster's actual level.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:PPCOST|Lightning Bolt|2
-   </code>
+   <code>BONUS:PPCOST|Lightning Bolt|2</code>
   </p>
   <p class="indent3">
    It costs a Sor/Wiz 9 5 PP to launch a Lightning
@@ -263,9 +251,7 @@ formula.
      </li>
      <li>
       When used inside parenthesis in these tags,
-      <code>
-       CASTERLEVEL
-      </code>
+      <code>CASTERLEVEL</code>
       returns the caster level of the class
 which grants the spell.
      </li>
@@ -273,17 +259,13 @@ which grants the spell.
    </li>
    <li>
     The value of
-    <code>
-     CASTERLEVEL
-    </code>
+    <code>CASTERLEVEL</code>
     depends mostly on the
 "Class" granting the spell, but can be affected by "Race" or by
 other attributes of the spell (e.g. School, Descriptor, etc.).
    </li>
    <li>
-    <code>
-     CASTERLEVEL
-    </code>
+    <code>CASTERLEVEL</code>
     can be adjusted using the
     <a href="../globalfilestagpages/globalfilesbonus.html#casterlevel">
      BONUS:CASTERLEVEL
@@ -302,29 +284,23 @@ recommended that the
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DESC:Electricity deals (CASTERLEVEL)d6
-damage
-   </code>
+   <code>DESC:Electricity deals (CASTERLEVEL)d6
+damage</code>
   </p>
   <p class="indent3">
    If the caster level is 2, the output
 reads:Electricity deals 2d6 damage.
   </p>
   <p class="indent2">
-   <code>
-    DURATION:((CASTERLEVEL/3)+1)
-rounds
-   </code>
+   <code>DURATION:((CASTERLEVEL/3)+1)
+rounds</code>
   </p>
   <p class="indent3">
    If the caster level is 6, the output
 reads:DURATION:3 rounds
   </p>
   <p class="indent2">
-   <code>
-    TARGETAREA:(floor((CASTERLEVEL/2)*5)+25)
-   </code>
+   <code>TARGETAREA:(floor((CASTERLEVEL/2)*5)+25)</code>
   </p>
   <p class="indent3">
    If the caster level is 7, the output
@@ -332,19 +308,15 @@ reads:TARGETAREA:40 (Note that if floor() were not used formula
 would return 42).
   </p>
   <p class="indent2">
-   <code>
-    DURATION:(CASTERLEVEL) rounds
-   </code>
+   <code>DURATION:(CASTERLEVEL) rounds</code>
   </p>
   <p class="indent3">
    If the caster level is 3, the output
 reads:DURATION:3 rounds
   </p>
   <p class="indent2">
-   <code>
-    DESC:Random damage in area during
-duration, plus (CASTERLEVEL)d4 damage
-   </code>
+   <code>DESC:Random damage in area during
+duration, plus (CASTERLEVEL)d4 damage</code>
   </p>
   <p class="indent3">
    If the caster level is 3, output
@@ -383,9 +355,7 @@ spell.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CASTTIME:1 Round
-   </code>
+   <code>CASTTIME:1 Round</code>
   </p>
   <p class="indent3">
    This spell takes 1 round to cast.
@@ -397,24 +367,18 @@ spell.
   </p>
   <p class="indent2">
    Initial Spell:
-   <code>
-    &lt;spell name&gt;
-&lt;tab&gt; CASTTIME:1 Round
-   </code>
+   <code>&lt;spell name&gt;
+&lt;tab&gt; CASTTIME:1 Round</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;spell name&gt;.MOD
-&lt;tab&gt; CASTTIME:10 Minute Ritual
-   </code>
+   <code>&lt;spell name&gt;.MOD
+&lt;tab&gt; CASTTIME:10 Minute Ritual</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;spell name&gt;
-&lt;tab&gt; CASTTIME:1 Round|10 Minute Ritual
-   </code>
+   <code>&lt;spell name&gt;
+&lt;tab&gt; CASTTIME:1 Round|10 Minute Ritual</code>
   </p>
   <p class="indent3">
    The output sheet will display "1 Round, 10
@@ -483,26 +447,18 @@ named class.
      MUST
     </strong>
     also be included in a
-    <code>
-     SPELLLIST
-    </code>
+    <code>SPELLLIST</code>
     tag in the appropriate class file object. For example, if the
 "Enchanter" subclass is included as part of a
-    <code>
-     CLASSES
-    </code>
+    <code>CLASSES</code>
     tag in a spell, there must be an "Enchanter" subclass defined in a
 loaded class file.
    </li>
    <li>
-    <code>
-     .CLEARALL
-    </code>
+    <code>.CLEARALL</code>
     will clear all classes or class/level
 pairs from the
-    <code>
-     CLASSES
-    </code>
+    <code>CLASSES</code>
     tag.
    </li>
    <li>
@@ -517,54 +473,42 @@ instead of the usual pipe-delineation (|).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CLASSES:Wizard=5|Enchanter=3|Druid=6
-   </code>
+   <code>CLASSES:Wizard=5|Enchanter=3|Druid=6</code>
   </p>
   <p class="indent3">
    Indicates this spell is 5th Lvl Wizard, 3rd Lvl
 Enchanter, and 6th Lvl Druid.
   </p>
   <p class="indent2">
-   <code>
-    CLASSES:Wizard,Sorcerer=5|Cleric=4
-   </code>
+   <code>CLASSES:Wizard,Sorcerer=5|Cleric=4</code>
   </p>
   <p class="indent3">
    Indicates this spell is 5th Lvl Wizard, 5th Lvl
 Sorcerer, and 4th Lvl Cleric.
   </p>
   <p class="indent2">
-   <code>
-    CLASSES:ALL=4
-   </code>
+   <code>CLASSES:ALL=4</code>
   </p>
   <p class="indent3">
    Indicates this spell is 4th Lvl for all
 classes.
   </p>
   <p class="indent2">
-   <code>
-    CLASSES:TYPE.Divine=3
-   </code>
+   <code>CLASSES:TYPE.Divine=3</code>
   </p>
   <p class="indent3">
    Indicates this spell is 3rd Lvl for divine
 classes.
   </p>
   <p class="indent2">
-   <code>
-    CLASSES:ALL=4[PREDEITY:Java]
-   </code>
+   <code>CLASSES:ALL=4[PREDEITY:Java]</code>
   </p>
   <p class="indent3">
    Indicates this spell is 4th Lvl for all classes,
 but is only available for followers of Java.
   </p>
   <p class="indent2">
-   <code>
-    CLASSES:Wizard,Sorcerer=5|Cleric=4[PRECLASS:1,Magician=1]
-   </code>
+   <code>CLASSES:Wizard,Sorcerer=5|Cleric=4[PRECLASS:1,Magician=1]</code>
   </p>
   <p class="indent3">
    Indicates this spell is 5th Lvl Wizard, 5th Lvl
@@ -575,10 +519,8 @@ add caster levels to existing levels but do not otherwise have a
 spell progression.
   </p>
   <p class="indent2">
-   <code>
-    Misdirection.MOD &lt;tab&gt;
-CLASSES:Circle Walker=2
-   </code>
+   <code>Misdirection.MOD &lt;tab&gt;
+CLASSES:Circle Walker=2</code>
   </p>
   <p class="indent3">
    Indicates this spell is modified to 2nd Level
@@ -591,24 +533,18 @@ for Circle Walker classes.
   </p>
   <p class="indent2">
    Initial Spell:
-   <code>
-    &lt;spell name&gt;
-&lt;tab&gt; CLASSES:Wizard=4
-   </code>
+   <code>&lt;spell name&gt;
+&lt;tab&gt; CLASSES:Wizard=4</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;spell name&gt;.MOD
-&lt;tab&gt; CLASSES:Cleris=3
-   </code>
+   <code>&lt;spell name&gt;.MOD
+&lt;tab&gt; CLASSES:Cleris=3</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;spell name&gt;
-&lt;tab&gt; CLASSES:Wizard=4|Cleric=3
-   </code>
+   <code>&lt;spell name&gt;
+&lt;tab&gt; CLASSES:Wizard=4|Cleric=3</code>
   </p>
   <p class="indent3">
    The associated spell is a 4th level Wizard spell
@@ -649,19 +585,15 @@ this spells (Verbal, Somatic, etc).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    COMPS:V S
-   </code>
+   <code>COMPS:V S</code>
   </p>
   <p class="indent3">
    This spell has "Verbal" and "Somatic"
 components.
   </p>
   <p class="indent2">
-   <code>
-    SpellFoo &lt;tab&gt; COMPS:.CLEAR
-&lt;tab&gt; COMPS:V &lt;tab&gt; COMPS:S
-   </code>
+   <code>SpellFoo &lt;tab&gt; COMPS:.CLEAR
+&lt;tab&gt; COMPS:V &lt;tab&gt; COMPS:S</code>
   </p>
   <p class="indent3">
    The spell SpellFoo has its COMPS cleared and
@@ -674,24 +606,18 @@ components.
   </p>
   <p class="indent2">
    Initial Spell:
-   <code>
-    &lt;spell name&gt;
-&lt;tab&gt; COMPS:V S
-   </code>
+   <code>&lt;spell name&gt;
+&lt;tab&gt; COMPS:V S</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;spell name&gt;.MOD
-&lt;tab&gt; COMPS:M
-   </code>
+   <code>&lt;spell name&gt;.MOD
+&lt;tab&gt; COMPS:M</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;spell name&gt;
-&lt;tab&gt; COMPS:V S|M
-   </code>
+   <code>&lt;spell name&gt;
+&lt;tab&gt; COMPS:V S|M</code>
   </p>
   <p class="indent3">
    The associated spell's spell components include
@@ -733,9 +659,7 @@ components.
     This tag identifies the cost of the spell's components.
    </li>
    <li>
-    <code>
-     .CLEAR
-    </code>
+    <code>.CLEAR</code>
     is used to clear the cost of a spell's
 components.
    </li>
@@ -746,9 +670,7 @@ components.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    COST:300
-   </code>
+   <code>COST:300</code>
   </p>
   <p class="indent1">
    <strong>
@@ -757,24 +679,18 @@ components.
   </p>
   <p class="indent2">
    Initial Spell:
-   <code>
-    &lt;spell name&gt;
-&lt;tab&gt; COST:300
-   </code>
+   <code>&lt;spell name&gt;
+&lt;tab&gt; COST:300</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;spell name&gt;.MOD
-&lt;tab&gt; COST:150
-   </code>
+   <code>&lt;spell name&gt;.MOD
+&lt;tab&gt; COST:150</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;spell name&gt;
-&lt;tab&gt; COST:150
-   </code>
+   <code>&lt;spell name&gt;
+&lt;tab&gt; COST:150</code>
   </p>
   <p class="indent3">
    The associated spell components cost 150 gp.
@@ -809,9 +725,7 @@ components.
 of the spell that the mage is casting.
    </li>
    <li>
-    <code>
-     CT
-    </code>
+    <code>CT</code>
     must be in integer &gt;= 0
    </li>
   </ul>
@@ -821,9 +735,7 @@ of the spell that the mage is casting.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CT:41
-   </code>
+   <code>CT:41</code>
   </p>
   <p class="indent3">
    This spell takes 41+ points to cast.
@@ -835,24 +747,18 @@ of the spell that the mage is casting.
   </p>
   <p class="indent2">
    Initial Spell:
-   <code>
-    &lt;spell name&gt;
-&lt;tab&gt; CT:25
-   </code>
+   <code>&lt;spell name&gt;
+&lt;tab&gt; CT:25</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;spell name&gt;.MOD
-&lt;tab&gt; CT:35
-   </code>
+   <code>&lt;spell name&gt;.MOD
+&lt;tab&gt; CT:35</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;spell name&gt;
-&lt;tab&gt; CT:35
-   </code>
+   <code>&lt;spell name&gt;
+&lt;tab&gt; CT:35</code>
   </p>
   <p class="indent3">
    The casting threshold of the associated spell is
@@ -895,9 +801,7 @@ type)
 wizards to determine their favored school's bonus spells.
    </li>
    <li>
-    <code>
-     .CLEAR
-    </code>
+    <code>.CLEAR</code>
     is used to clear all descriptors from a
 spell and can be followed by new descriptors to replace those
 cleared.
@@ -909,18 +813,14 @@ cleared.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DESCRIPTOR:Sonic|Acid|Evil
-   </code>
+   <code>DESCRIPTOR:Sonic|Acid|Evil</code>
   </p>
   <p class="indent3">
    This spell is of the "Sonic", "Acid" &amp;
 "Evil" types.
   </p>
   <p class="indent2">
-   <code>
-    DESCRIPTOR:.CLEAR|Fire
-   </code>
+   <code>DESCRIPTOR:.CLEAR|Fire</code>
   </p>
   <p class="indent3">
    This clears the spell list and replaces it with
@@ -933,24 +833,18 @@ the "Fire" type.
   </p>
   <p class="indent2">
    Initial Spell:
-   <code>
-    &lt;spell name&gt;
-&lt;tab&gt; DESCRIPTOR:Sonic|Acid
-   </code>
+   <code>&lt;spell name&gt;
+&lt;tab&gt; DESCRIPTOR:Sonic|Acid</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;spell name&gt;.MOD
-&lt;tab&gt; DESCRIPTOR:Evil
-   </code>
+   <code>&lt;spell name&gt;.MOD
+&lt;tab&gt; DESCRIPTOR:Evil</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;spell name&gt;
-&lt;tab&gt; DESCRIPTOR:Sonic|Acid|Evil
-   </code>
+   <code>&lt;spell name&gt;
+&lt;tab&gt; DESCRIPTOR:Sonic|Acid|Evil</code>
   </p>
   <p class="indent3">
    The associated spell has the descriptors "Acid",
@@ -1000,25 +894,17 @@ the "Fire" type.
 named domain.
    </li>
    <li>
-    <code>
-     .CLEARALL
-    </code>
+    <code>.CLEARALL</code>
     will clear all classes or class/level
 pairs from the
-    <code>
-     CLASSES
-    </code>
+    <code>CLASSES</code>
     tag.
    </li>
    <li>
     This tag can now be qualified with
-    <code>
-     PRExxx
-    </code>
+    <code>PRExxx</code>
     statements. Please note that you must enclose the
-    <code>
-     PRExxx
-    </code>
+    <code>PRExxx</code>
     statement with [ ] instead of the usual Pipe
 delineation.
    </li>
@@ -1029,18 +915,14 @@ delineation.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DOMAINS:Charm=2|Beauty=3
-   </code>
+   <code>DOMAINS:Charm=2|Beauty=3</code>
   </p>
   <p class="indent3">
    Indicates that this is a 2nd level spell for the
 Charm domain, and 3rd level for the Beauty domain.
   </p>
   <p class="indent2">
-   <code>
-    DOMAINS:Fire=3|Magic=4[PREALIGN:2,5,8]
-   </code>
+   <code>DOMAINS:Fire=3|Magic=4[PREALIGN:2,5,8]</code>
   </p>
   <p class="indent3">
    Indicates that this is a 3rd level spell for the
@@ -1048,9 +930,7 @@ Fire domain, and 4th level for the Magic domain, but is only
 available to evil characters.
   </p>
   <p class="indent2">
-   <code>
-    DOMAINS:Charm=2|Beauty=3[PRECLASS:Supermodel=1]
-   </code>
+   <code>DOMAINS:Charm=2|Beauty=3[PRECLASS:Supermodel=1]</code>
   </p>
   <p class="indent3">
    Indicates that this is a 2nd level spell for the
@@ -1059,10 +939,8 @@ added to the spell list of a character with a level of the
 Supermodel prestige class.
   </p>
   <p class="indent2">
-   <code>
-    Binding.MOD &lt;tab&gt;
-DOMAINS:Fate=8
-   </code>
+   <code>Binding.MOD &lt;tab&gt;
+DOMAINS:Fate=8</code>
   </p>
   <p class="indent3">
    Indicates that this is an 8th level spell for
@@ -1074,33 +952,21 @@ the Fate domain.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DOMAINS:.CLEAR
-   </code>
+   <code>DOMAINS:.CLEAR</code>
    replaced by
-   <code>
-    DOMAINS:.CLEARALL.
-   </code>
+   <code>DOMAINS:.CLEARALL.</code>
   </p>
   <p class="indent3">
    This is done due to the past side-effects
 between the
-   <code>
-    CLASSES
-   </code>
+   <code>CLASSES</code>
    and
-   <code>
-    DOMAINS
-   </code>
+   <code>DOMAINS</code>
    tags.
 Note that any single
-   <code>
-    .CLEAR
-   </code>
+   <code>.CLEAR</code>
    is equivalent to both
-   <code>
-    .CLEARALL
-   </code>
+   <code>.CLEARALL</code>
    tags due to this old interaction.
   </p>
   <p class="indent1">
@@ -1110,24 +976,18 @@ Note that any single
   </p>
   <p class="indent2">
    Initial Spell:
-   <code>
-    &lt;spell name&gt;
-&lt;tab&gt; DOMAINS:Charm=2
-   </code>
+   <code>&lt;spell name&gt;
+&lt;tab&gt; DOMAINS:Charm=2</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;spell name&gt;.MOD
-&lt;tab&gt; DOMAINS:Beauty=3
-   </code>
+   <code>&lt;spell name&gt;.MOD
+&lt;tab&gt; DOMAINS:Beauty=3</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;spell name&gt;
-&lt;tab&gt; DOMAINS:Charm=2|Beauty=3
-   </code>
+   <code>&lt;spell name&gt;
+&lt;tab&gt; DOMAINS:Charm=2|Beauty=3</code>
   </p>
   <p class="indent3">
    The associated spell is a 2nd level spell for
@@ -1183,17 +1043,13 @@ to be parsed, text containing parentheses must substitute brackets
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DURATION:1 Round/Level
-   </code>
+   <code>DURATION:1 Round/Level</code>
   </p>
   <p class="indent3">
    This spell lasts for one round per level.
   </p>
   <p class="indent2">
-   <code>
-    DURATION:(CASTERLEVEL) rounds
-   </code>
+   <code>DURATION:(CASTERLEVEL) rounds</code>
   </p>
   <p class="indent3">
    If CASTERLEVEL is equal to 3 then this outputs:
@@ -1206,24 +1062,18 @@ to be parsed, text containing parentheses must substitute brackets
   </p>
   <p class="indent2">
    Initial Spell:
-   <code>
-    &lt;spell name&gt;
-&lt;tab&gt; DURATION:1 Round/Level
-   </code>
+   <code>&lt;spell name&gt;
+&lt;tab&gt; DURATION:1 Round/Level</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;spell name&gt;.MOD
-&lt;tab&gt; DURATION:(CASTERLEVEL) rounds
-   </code>
+   <code>&lt;spell name&gt;.MOD
+&lt;tab&gt; DURATION:(CASTERLEVEL) rounds</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;spell name&gt;
-&lt;tab&gt; DURATION:1 Round/Level|(CASTERLEVEL) rounds
-   </code>
+   <code>&lt;spell name&gt;
+&lt;tab&gt; DURATION:1 Round/Level|(CASTERLEVEL) rounds</code>
   </p>
   <p class="indent3">
    For a 3rd level spellcaster the associated spell
@@ -1273,17 +1123,13 @@ being used in the specified item.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ITEM:Potion
-   </code>
+   <code>ITEM:Potion</code>
   </p>
   <p class="indent3">
    This spell can be used in a potion.
   </p>
   <p class="indent2">
-   <code>
-    ITEM:[Scroll]
-   </code>
+   <code>ITEM:[Scroll]</code>
   </p>
   <p class="indent3">
    This spell can NOT be used in a scroll.
@@ -1295,24 +1141,18 @@ being used in the specified item.
   </p>
   <p class="indent2">
    Initial Spell:
-   <code>
-    &lt;spell name&gt;
-&lt;tab&gt; ITEM:Scroll
-   </code>
+   <code>&lt;spell name&gt;
+&lt;tab&gt; ITEM:Scroll</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;spell name&gt;.MOD
-&lt;tab&gt; ITEM:Potion
-   </code>
+   <code>&lt;spell name&gt;.MOD
+&lt;tab&gt; ITEM:Potion</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;spell name&gt;
-&lt;tab&gt; ITEM:Scroll|Potion
-   </code>
+   <code>&lt;spell name&gt;
+&lt;tab&gt; ITEM:Scroll|Potion</code>
   </p>
   <p class="indent3">
    The associated spell can be used to make scrolls
@@ -1352,9 +1192,7 @@ spell works with SKILLTOTAL=&gt;skill name)
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PPCOST:9
-   </code>
+   <code>PPCOST:9</code>
   </p>
   <p class="indent3">
    This spell costs 9 points to use.
@@ -1366,24 +1204,18 @@ spell works with SKILLTOTAL=&gt;skill name)
   </p>
   <p class="indent2">
    Initial Spell:
-   <code>
-    &lt;spell name&gt;
-&lt;tab&gt; PPCOST:3
-   </code>
+   <code>&lt;spell name&gt;
+&lt;tab&gt; PPCOST:3</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;spell name&gt;.MOD
-&lt;tab&gt; PPCOST:6
-   </code>
+   <code>&lt;spell name&gt;.MOD
+&lt;tab&gt; PPCOST:6</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;spell name&gt;
-&lt;tab&gt; PPCOST:6
-   </code>
+   <code>&lt;spell name&gt;
+&lt;tab&gt; PPCOST:6</code>
   </p>
   <p class="indent3">
    The associated spells costs "6" power
@@ -1423,19 +1255,15 @@ range)
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    RANGE:Medium (100' + 5/lv)
-   </code>
+   <code>RANGE:Medium (100' + 5/lv)</code>
   </p>
   <p class="indent3">
    This spell has a range of 100 feet plus 5 feet
 per level.
   </p>
   <p class="indent2">
-   <code>
-    RANGE:.CLEAR &lt;tab&gt;
-RANGE:Personal
-   </code>
+   <code>RANGE:.CLEAR &lt;tab&gt;
+RANGE:Personal</code>
   </p>
   <p class="indent3">
    This clears the previous range and replaces with
@@ -1448,24 +1276,18 @@ RANGE:Personal
   </p>
   <p class="indent2">
    Initial Spell:
-   <code>
-    &lt;spell name&gt;
-&lt;tab&gt; RANGE:Personal
-   </code>
+   <code>&lt;spell name&gt;
+&lt;tab&gt; RANGE:Personal</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;spell name&gt;.MOD
-&lt;tab&gt; RANGE:Medium (100' + 5/lvl)
-   </code>
+   <code>&lt;spell name&gt;.MOD
+&lt;tab&gt; RANGE:Medium (100' + 5/lvl)</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;spell name&gt;
-&lt;tab&gt; RANGE:Personal|Medium (100' + 5/lvl)
-   </code>
+   <code>&lt;spell name&gt;
+&lt;tab&gt; RANGE:Personal|Medium (100' + 5/lvl)</code>
   </p>
   <p class="indent3">
    The associated spell can be used as a personal
@@ -1503,9 +1325,7 @@ spell, and if so what it is.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SAVEINFO:Will Negates
-   </code>
+   <code>SAVEINFO:Will Negates</code>
   </p>
   <p class="indent3">
    A successful Will save will negate the spell
@@ -1518,24 +1338,18 @@ effects.
   </p>
   <p class="indent2">
    Initial Spell:
-   <code>
-    &lt;spell name&gt;
-&lt;tab&gt; SAVEINFO:Will negates
-   </code>
+   <code>&lt;spell name&gt;
+&lt;tab&gt; SAVEINFO:Will negates</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;spell name&gt;.MOD
-&lt;tab&gt; SAVEINFO:Reflex for half
-   </code>
+   <code>&lt;spell name&gt;.MOD
+&lt;tab&gt; SAVEINFO:Reflex for half</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;spell name&gt;
-&lt;tab&gt; SAVEINFO:Will negates|Reflex for half
-   </code>
+   <code>&lt;spell name&gt;
+&lt;tab&gt; SAVEINFO:Will negates|Reflex for half</code>
   </p>
   <p class="indent3">
    A successful Reflex save will half the spell
@@ -1581,29 +1395,23 @@ SCHOOL:.CLEAR|x|x|.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SCHOOL:Divination
-   </code>
+   <code>SCHOOL:Divination</code>
   </p>
   <p class="indent3">
    This spell belongs to the "Divination"
 school.
   </p>
   <p class="indent2">
-   <code>
-    SCHOOL:Enchantment|Illusion
-   </code>
+   <code>SCHOOL:Enchantment|Illusion</code>
   </p>
   <p class="indent3">
    This spell belongs to the "Enchantment" and
 "Illusion" schools.
   </p>
   <p class="indent2">
-   <code>
-    Summon Monster VII.MOD &lt;tab&gt;
+   <code>Summon Monster VII.MOD &lt;tab&gt;
 CLASSES:Channeler=7 &lt;tab&gt; SCHOOL:.CLEAR &lt;tab&gt;
-SCHOOL:Greater Conjuration
-   </code>
+SCHOOL:Greater Conjuration</code>
   </p>
   <p class="indent3">
    For the Class Channeler of level 7 the spell
@@ -1611,10 +1419,8 @@ Summon Monster VII is modified, moving it from whatever schools it
 was in to just "Greater Conjuration".
   </p>
   <p class="indent2">
-   <code>
-    SCHOOL:.CLEAR &lt;tab&gt;
-SCHOOL:Illusion
-   </code>
+   <code>SCHOOL:.CLEAR &lt;tab&gt;
+SCHOOL:Illusion</code>
   </p>
   <p class="indent3">
    This clears the schools list and replaces it
@@ -1627,24 +1433,18 @@ with the "Illusion" school.
   </p>
   <p class="indent2">
    Initial Spell:
-   <code>
-    &lt;spell name&gt;
-&lt;tab&gt; SCHOOL:Enchantment
-   </code>
+   <code>&lt;spell name&gt;
+&lt;tab&gt; SCHOOL:Enchantment</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;spell name&gt;.MOD
-&lt;tab&gt; SCHOOL:Illusion
-   </code>
+   <code>&lt;spell name&gt;.MOD
+&lt;tab&gt; SCHOOL:Illusion</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;spell name&gt;
-&lt;tab&gt; SCHOOL:Enchantment|Illusion
-   </code>
+   <code>&lt;spell name&gt;
+&lt;tab&gt; SCHOOL:Enchantment|Illusion</code>
   </p>
   <p class="indent3">
    This spell belongs to the "Enchantment" and
@@ -1704,10 +1504,8 @@ effect costs.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SPELLPOINTCOST:Evoke Fire=4|Range=1|Area
-of Effect=1|Duration=1
-   </code>
+   <code>SPELLPOINTCOST:Evoke Fire=4|Range=1|Area
+of Effect=1|Duration=1</code>
   </p>
   <p class="indent3">
    Enhancing the "Evoke Fire" effect would cost 4
@@ -1715,9 +1513,7 @@ spell points, the "Range", "Area of Effect", and "Duration" one
 point each.
   </p>
   <p class="indent2">
-   <code>
-    SPELLPOINTCOST:4
-   </code>
+   <code>SPELLPOINTCOST:4</code>
   </p>
   <p class="indent3">
    Enhancing the spell costs a total of 4 spell
@@ -1730,24 +1526,18 @@ points.
   </p>
   <p class="indent2">
    Initial Spell:
-   <code>
-    &lt;spell name&gt;
-&lt;tab&gt; SPELLPOINTCOST:Evoke Fire=4
-   </code>
+   <code>&lt;spell name&gt;
+&lt;tab&gt; SPELLPOINTCOST:Evoke Fire=4</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;spell name&gt;.MOD
-&lt;tab&gt; SPELLPOINTCOST:Range=1
-   </code>
+   <code>&lt;spell name&gt;.MOD
+&lt;tab&gt; SPELLPOINTCOST:Range=1</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;spell name&gt;
-&lt;tab&gt; SPELLPOINTCOST:Evoke Fire=4|Range=1
-   </code>
+   <code>&lt;spell name&gt;
+&lt;tab&gt; SPELLPOINTCOST:Evoke Fire=4|Range=1</code>
   </p>
   <p class="indent3">
    Enhancing the "Evoke Fire" effect would cost 4
@@ -1795,26 +1585,20 @@ Creatures|Limited or SPELLRES:.CLEAR|No
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SPELLRES:Yes
-   </code>
+   <code>SPELLRES:Yes</code>
   </p>
   <p class="indent3">
    This spell is susceptible to spell
 resistance.
   </p>
   <p class="indent2">
-   <code>
-    SPELLRES:For Good Creatures
-   </code>
+   <code>SPELLRES:For Good Creatures</code>
   </p>
   <p class="indent3">
    This spell is susceptible to Good Creatures.
   </p>
   <p class="indent2">
-   <code>
-    SPELLRES:.CLEAR
-   </code>
+   <code>SPELLRES:.CLEAR</code>
   </p>
   <p class="indent3">
    This clears the Spell resistance setting.
@@ -1826,24 +1610,18 @@ resistance.
   </p>
   <p class="indent2">
    Initial Spell:
-   <code>
-    &lt;spell name&gt;
-&lt;tab&gt; SPELLRES:YES
-   </code>
+   <code>&lt;spell name&gt;
+&lt;tab&gt; SPELLRES:YES</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;spell name&gt;.MOD
-&lt;tab&gt; SPELLRES:
-   </code>
+   <code>&lt;spell name&gt;.MOD
+&lt;tab&gt; SPELLRES:</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;spell name&gt;
-&lt;tab&gt; SPELLRES:
-   </code>
+   <code>&lt;spell name&gt;
+&lt;tab&gt; SPELLRES:</code>
   </p>
   <p class="indent3">
   </p>
@@ -1876,9 +1654,7 @@ bonus spells and maximum level the character can cast.
    </li>
    <li>
     Used in conjunction with the
-    <code>
-     SPELLSTAT:SPELL
-    </code>
+    <code>SPELLSTAT:SPELL</code>
     tag
 in the
     <em>
@@ -1893,15 +1669,11 @@ in the
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    STAT:CHA
-   </code>
+   <code>STAT:CHA</code>
   </p>
   <p class="indent3">
    When used in conjunction with the
-   <code>
-    SPELLSTAT:SPELL
-   </code>
+   <code>SPELLSTAT:SPELL</code>
    tag in a class file, a spell with this
 tag will use the charisma modifier to determine bonus spells and
 maximum level the character can cast.
@@ -1913,24 +1685,18 @@ maximum level the character can cast.
   </p>
   <p class="indent2">
    Initial Spell:
-   <code>
-    &lt;spell name&gt;
-&lt;tab&gt; STAT:CHA
-   </code>
+   <code>&lt;spell name&gt;
+&lt;tab&gt; STAT:CHA</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;spell name&gt;.MOD
-&lt;tab&gt; STAT:INT
-   </code>
+   <code>&lt;spell name&gt;.MOD
+&lt;tab&gt; STAT:INT</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;spell name&gt;
-&lt;tab&gt; STAT:INT
-   </code>
+   <code>&lt;spell name&gt;
+&lt;tab&gt; STAT:INT</code>
   </p>
   <p class="indent3">
    This spell will now use the intelligence
@@ -1977,37 +1743,29 @@ SUBSCHOOL:.CLEAR|x|x|.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SUBSCHOOL:Charm
-   </code>
+   <code>SUBSCHOOL:Charm</code>
   </p>
   <p class="indent3">
    This spell belongs to the "Charm"
 sub-school.
   </p>
   <p class="indent2">
-   <code>
-    SUBSCHOOL:Creation|Calling
-   </code>
+   <code>SUBSCHOOL:Creation|Calling</code>
   </p>
   <p class="indent3">
    This spell belongs to the "Creation" and
 "Calling" subschools.
   </p>
   <p class="indent2">
-   <code>
-    Wall of Force.MOD &lt;tab&gt;
-SUBSCHOOL:Force
-   </code>
+   <code>Wall of Force.MOD &lt;tab&gt;
+SUBSCHOOL:Force</code>
   </p>
   <p class="indent3">
    This spell belongs to the "Force"
 sub-school.
   </p>
   <p class="indent2">
-   <code>
-    SUBSCHOOL:.CLEAR|Charm
-   </code>
+   <code>SUBSCHOOL:.CLEAR|Charm</code>
   </p>
   <p class="indent3">
    This clears the subschools list and replaces
@@ -2020,24 +1778,18 @@ with "Charm" sub-school.
   </p>
   <p class="indent2">
    Initial Spell:
-   <code>
-    &lt;spell name&gt;
-&lt;tab&gt; SUBSCHOOL:Creation
-   </code>
+   <code>&lt;spell name&gt;
+&lt;tab&gt; SUBSCHOOL:Creation</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;spell name&gt;.MOD
-&lt;tab&gt; SUBSCHOOL:Calling
-   </code>
+   <code>&lt;spell name&gt;.MOD
+&lt;tab&gt; SUBSCHOOL:Calling</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;spell name&gt;
-&lt;tab&gt; SUBSCHOOL:Creation|Calling
-   </code>
+   <code>&lt;spell name&gt;
+&lt;tab&gt; SUBSCHOOL:Creation|Calling</code>
   </p>
   <p class="indent3">
    This spell belongs to the "Creation" and
@@ -2096,9 +1848,7 @@ to be parsed, text containing parentheses must substitute brackets
 [ ] in place of parentheses.
    </li>
    <li>
-    <code>
-     .CLEAR
-    </code>
+    <code>.CLEAR</code>
     is used to clear the target, area, or
 effects that a spell has.
    </li>
@@ -2109,18 +1859,14 @@ effects that a spell has.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TARGETAREA:Cone
-   </code>
+   <code>TARGETAREA:Cone</code>
   </p>
   <p class="indent3">
    Spell has a cone area of effect.
   </p>
   <p class="indent2">
-   <code>
-    TARGETAREA:(CASTERLEVEL*10) ft.
-cube
-   </code>
+   <code>TARGETAREA:(CASTERLEVEL*10) ft.
+cube</code>
   </p>
   <p class="indent3">
    If CASTERLEVEL is equal to 3 then this outputs:
@@ -2133,24 +1879,18 @@ cube
   </p>
   <p class="indent2">
    Initial Spell:
-   <code>
-    &lt;spell name&gt;
-&lt;tab&gt; TARGETAREA:(CASTERLEVEL*5) ft. cube
-   </code>
+   <code>&lt;spell name&gt;
+&lt;tab&gt; TARGETAREA:(CASTERLEVEL*5) ft. cube</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;spell name&gt;.MOD
-&lt;tab&gt; TARGETAREA:(CASTERLEVEL*10) ft. cube
-   </code>
+   <code>&lt;spell name&gt;.MOD
+&lt;tab&gt; TARGETAREA:(CASTERLEVEL*10) ft. cube</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;spell name&gt;
-&lt;tab&gt; TARGETAREA:(CASTERLEVEL*10) ft. cube
-   </code>
+   <code>&lt;spell name&gt;
+&lt;tab&gt; TARGETAREA:(CASTERLEVEL*10) ft. cube</code>
   </p>
   <p class="indent3">
    The target area is now equal to cube 10 times
@@ -2205,36 +1945,28 @@ TAG:.CLEAR|x|x|.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    VARIANTS:Blast|Spell
-   </code>
+   <code>VARIANTS:Blast|Spell</code>
   </p>
   <p class="indent3">
    Names the two variations of the spell.
   </p>
   <p class="indent2">
-   <code>
-    VARIANTS:Acorn Grenades|Holly Berry
-Bombs
-   </code>
+   <code>VARIANTS:Acorn Grenades|Holly Berry
+Bombs</code>
   </p>
   <p class="indent3">
    Names the two variants of the spell Fire
 seeds.
   </p>
   <p class="indent2">
-   <code>
-    VARIANTS:.CLEAR
-   </code>
+   <code>VARIANTS:.CLEAR</code>
   </p>
   <p class="indent3">
    Removes all variants of the spell.
   </p>
   <p class="indent2">
-   <code>
-    VARIANTS:.CLEAR|Acorn Grenades|Holly Berry
-Bombs
-   </code>
+   <code>VARIANTS:.CLEAR|Acorn Grenades|Holly Berry
+Bombs</code>
   </p>
   <p class="indent3">
    Removes all variants of the spell Fire
@@ -2247,24 +1979,18 @@ seeds.
   </p>
   <p class="indent2">
    Initial Spell:
-   <code>
-    &lt;spell name&gt;
-&lt;tab&gt; VARIANTS:Acorn Grenades
-   </code>
+   <code>&lt;spell name&gt;
+&lt;tab&gt; VARIANTS:Acorn Grenades</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;spell name&gt;.MOD
-&lt;tab&gt; VARIANTS:Holly Berry Bombs
-   </code>
+   <code>&lt;spell name&gt;.MOD
+&lt;tab&gt; VARIANTS:Holly Berry Bombs</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;spell name&gt;
-&lt;tab&gt; VARIANTS:Acorn Grenades|Holly Berry Bombs
-   </code>
+   <code>&lt;spell name&gt;
+&lt;tab&gt; VARIANTS:Acorn Grenades|Holly Berry Bombs</code>
   </p>
   <p class="indent3">
    Names the two variants of the spell Fire
@@ -2305,9 +2031,7 @@ for determining potion, wand, etc costs.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    XPCOST:1250
-   </code>
+   <code>XPCOST:1250</code>
   </p>
   <p class="indent3">
    Spell costs 1250 Experience points to cast.
@@ -2319,24 +2043,18 @@ for determining potion, wand, etc costs.
   </p>
   <p class="indent2">
    Initial Spell:
-   <code>
-    &lt;spell name&gt;
-&lt;tab&gt; XPCOST:1250
-   </code>
+   <code>&lt;spell name&gt;
+&lt;tab&gt; XPCOST:1250</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;spell name&gt;.MOD
-&lt;tab&gt; XPCOST:750
-   </code>
+   <code>&lt;spell name&gt;.MOD
+&lt;tab&gt; XPCOST:750</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;spell name&gt;
-&lt;tab&gt; XPCOST:750
-   </code>
+   <code>&lt;spell name&gt;
+&lt;tab&gt; XPCOST:750</code>
   </p>
   <p class="indent3">
    Spell costs 750 Experience points to cast.

--- a/docs/listfilepages/datafilestagpages/datafilesstartingkits.html
+++ b/docs/listfilepages/datafilestagpages/datafilesstartingkits.html
@@ -88,9 +88,7 @@
    <p class="indent2">
     Region line using the
     <a href="#region">
-     <code>
-      REGION
-     </code>
+     <code>REGION</code>
     </a>
     tag.
    </p>
@@ -100,312 +98,228 @@
    <p class="indent3">
     STARTPACK line using the
     <a href="#startpack">
-     <code>
-      STARTPACK
-     </code>
+     <code>STARTPACK</code>
     </a>
     ,
     <a href="#apply">
-     <code>
-      APPLY
-     </code>
+     <code>APPLY</code>
     </a>
     ,
     <a href="#equipbuy">
-     <code>
-      EQUIPBUY
-     </code>
+     <code>EQUIPBUY</code>
     </a>
     ,
     <a href="#totalcost">
-     <code>
-      TOTALCOST
-     </code>
+     <code>TOTALCOST</code>
     </a>
     and
     <a href="#visible">
-     <code>
-      VISIBLE
-     </code>
+     <code>VISIBLE</code>
     </a>
     tags.
    </p>
    <p class="indent3">
     RACE line using the
     <a href="#race">
-     <code>
-      RACE
-     </code>
+     <code>RACE</code>
     </a>
     and TBD tags.
    </p>
    <p class="indent3">
     NAME line using the
     <a href="#name">
-     <code>
-      NAME
-     </code>
+     <code>NAME</code>
     </a>
     tag.
    </p>
    <p class="indent3">
     GENDER line using the
     <a href="#gender">
-     <code>
-      GENDER
-     </code>
+     <code>GENDER</code>
     </a>
     tag.
    </p>
    <p class="indent3">
     AGE line using the
     <a href="#age">
-     <code>
-      AGE
-     </code>
+     <code>AGE</code>
     </a>
     tag.
    </p>
    <p class="indent3">
     ALIGN line using the
     <a href="#align">
-     <code>
-      ALIGN
-     </code>
+     <code>ALIGN</code>
     </a>
     and TBD tags.
    </p>
    <p class="indent3">
     STAT line using the
     <a href="#stat">
-     <code>
-      STAT
-     </code>
+     <code>STAT</code>
     </a>
     and TBD tags.
    </p>
    <p class="indent3">
     CLASS line using the
     <a href="#class">
-     <code>
-      CLASS
-     </code>
+     <code>CLASS</code>
     </a>
     and
     <a href="#level">
-     <code>
-      LEVEL
-     </code>
+     <code>LEVEL</code>
     </a>
     tags.
    </p>
    <p class="indent3">
     SKILL line for Class using the
     <a href="#skill">
-     <code>
-      SKILL
-     </code>
+     <code>SKILL</code>
     </a>
     and
     <a href="#free">
-     <code>
-      FREE
-     </code>
+     <code>FREE</code>
     </a>
     ,
     <a href="#rank">
-     <code>
-      RANK
-     </code>
+     <code>RANK</code>
     </a>
     and
     <a href="#selection">
-     <code>
-      SELECTION
-     </code>
+     <code>SELECTION</code>
     </a>
     tags.
    </p>
    <p class="indent3">
     DEITY line using the
     <a href="#deity">
-     <code>
-      DEITY
-     </code>
+     <code>DEITY</code>
     </a>
     and TBD tags.
    </p>
    <p class="indent3">
     DOMAIN line using the
     <a href="#domain">
-     <code>
-      DOMAIN
-     </code>
+     <code>DOMAIN</code>
     </a>
     and
     <a href="#count">
-     <code>
-      COUNT
-     </code>
+     <code>COUNT</code>
     </a>
     tags.
    </p>
    <p class="indent3">
     PROF line using the
     <a href="#prof">
-     <code>
-      PROF
-     </code>
+     <code>PROF</code>
     </a>
     ,
     <a href="#count">
-     <code>
-      COUNT
-     </code>
+     <code>COUNT</code>
     </a>
     and
     <a href="#racial">
-     <code>
-      RACIAL
-     </code>
+     <code>RACIAL</code>
     </a>
     tags.
    </p>
    <p class="indent3">
     FEAT line using the
     <a href="#feat">
-     <code>
-      FEAT
-     </code>
+     <code>FEAT</code>
     </a>
     ,
     <a href="#free">
-     <code>
-      FREE
-     </code>
+     <code>FREE</code>
     </a>
     and
     <a href="#count">
-     <code>
-      COUNT
-     </code>
+     <code>COUNT</code>
     </a>
     tags.
    </p>
    <p class="indent3">
     ABILITY line using the
     <a href="#category">
-     <code>
-      ABILITY:CATEGORY
-     </code>
+     <code>ABILITY:CATEGORY</code>
     </a>
     and TBD tags.
    </p>
    <p class="indent3">
     LEVELABILITY line using the
     <a href="#levelability">
-     <code>
-      LEVELABILITY
-     </code>
+     <code>LEVELABILITY</code>
     </a>
     and
     <a href="#ability">
-     <code>
-      ABILITY:PROMPT
-     </code>
+     <code>ABILITY:PROMPT</code>
     </a>
     tags.
    </p>
    <p class="indent3">
     TEMPLATE line using the
     <a href="#template">
-     <code>
-      TEMPLATE
-     </code>
+     <code>TEMPLATE</code>
     </a>
     and TBD tags.
    </p>
    <p class="indent3">
     FUNDS line using the
     <a href="#funds">
-     <code>
-      FUNDS
-     </code>
+     <code>FUNDS</code>
     </a>
     and TBD tags.
    </p>
    <p class="indent3">
     GEAR line using the
     <a href="#gear">
-     <code>
-      GEAR
-     </code>
+     <code>GEAR</code>
     </a>
     ,
     <a href="#eqmod">
-     <code>
-      EQMOD
-     </code>
+     <code>EQMOD</code>
     </a>
     ,
     <a href="#location">
-     <code>
-      LOCATION
-     </code>
+     <code>LOCATION</code>
     </a>
     ,
     <a href="#lookup">
-     <code>
-      LOOKUP
-     </code>
+     <code>LOOKUP</code>
     </a>
     ,
     <a href="#maxcost">
-     <code>
-      MAXCOST
-     </code>
+     <code>MAXCOST</code>
     </a>
     and
     <a href="#qty">
-     <code>
-      QTY
-     </code>
+     <code>QTY</code>
     </a>
     tags.
    </p>
    <p class="indent3">
     TABLE line using the
     <a href="#table">
-     <code>
-      TABLE
-     </code>
+     <code>TABLE</code>
     </a>
     ,
     <a href="#lookup">
-     <code>
-      LOOKUP
-     </code>
+     <code>LOOKUP</code>
     </a>
     and
     <a href="#values">
-     <code>
-      VALUES
-     </code>
+     <code>VALUES</code>
     </a>
     tags.
    </p>
    <p class="indent3">
     SPELLS line using the
     <a href="#spells">
-     <code>
-      SPELLS
-     </code>
+     <code>SPELLS</code>
     </a>
     and
     <a href="#count">
-     <code>
-      COUNT
-     </code>
+     <code>COUNT</code>
     </a>
     tags.
    </p>
@@ -415,16 +329,12 @@
    <p class="indent3">
     SELECT line using the
     <a href="#select">
-     <code>
-      SELECT
-     </code>
+     <code>SELECT</code>
     </a>
     tag
 					in conjunction with any line listed above containing the
     <a href="#option">
-     <code>
-      OPTION
-     </code>
+     <code>OPTION</code>
     </a>
     tag.
    </p>
@@ -455,28 +365,20 @@
    <ol class="indent1">
     <li>
      The racial kit x contains a RACE:x tag, e.g.
-     <code>
-      RACE:Goblin
-     </code>
+     <code>RACE:Goblin</code>
     </li>
     <li>
      The race x object contains a KIT:x tag, e.g.
-     <code>
-      KIT:Goblin
-     </code>
+     <code>KIT:Goblin</code>
     </li>
    </ol>
    <p class="indent0">
     This combination of objects/tags will cause an infinite loop which in turn will
 			cause PCGen to crash. To prevent this you must use the
-    <code>
-     !PRERACE:1,x
-    </code>
+    <code>!PRERACE:1,x</code>
     tag. For the
 			example used above that would mean
-    <code>
-     !PRERACE:1,Goblin
-    </code>
+    <code>!PRERACE:1,Goblin</code>
     .
    </p>
    <p>
@@ -539,17 +441,13 @@
       </strong>
      </p>
      <p class="indent2">
-      <code>
-       REGION:Europa
-      </code>
+      <code>REGION:Europa</code>
      </p>
      <p class="indent3">
       Character must be from region Europa to apply any kits in the file.
      </p>
      <p class="indent2">
-      <code>
-       REGION:None
-      </code>
+      <code>REGION:None</code>
      </p>
      <p class="indent3">
       There is no region prerequisite for these kits.
@@ -603,9 +501,7 @@
         </strong>
        </p>
        <p class="indent2">
-        <code>
-         STARTPACK:Bar1
-        </code>
+        <code>STARTPACK:Bar1</code>
        </p>
        <p class="indent3">
         Would create a new available kit called "Bar1".
@@ -665,57 +561,43 @@
          </strong>
         </p>
         <p class="indent2">
-         <code>
-          ABILITY:CATEGORY=FEAT|Weapon Focus (Greataxe)
-         </code>
+         <code>ABILITY:CATEGORY=FEAT|Weapon Focus (Greataxe)</code>
         </p>
         <p class="indent3">
          Would grant the "Greataxe Weapon Focus" feat.
         </p>
         <p class="indent2">
-         <code>
-          ABILITY:CATEGORY=Fighter Feat|Dodge PRESTAT:1,DEX=13
-         </code>
+         <code>ABILITY:CATEGORY=Fighter Feat|Dodge PRESTAT:1,DEX=13</code>
         </p>
         <p class="indent3">
          Would grant "Dodge" if the character has a Dexterity of at least 13.
         </p>
         <p class="indent2">
-         <code>
-          ABILITY:CATEGORY=Fighter Feat|Dodge|Improved Initiative
-         </code>
+         <code>ABILITY:CATEGORY=Fighter Feat|Dodge|Improved Initiative</code>
         </p>
         <p class="indent3">
          Would grant the choice of Dodge or Improved Initiative.
         </p>
         <p class="indent2">
-         <code>
-          ABILITY:CATEGORY=Wizard Feat|TYPE=ItemCreation
-         </code>
+         <code>ABILITY:CATEGORY=Wizard Feat|TYPE=ItemCreation</code>
         </p>
         <p class="indent3">
          Would grant the choice of an ItemCreation type feat.
         </p>
         <p class="indent2">
-         <code>
-          ABILITY:CATEGORY=Salient Divine Ability|Alter Size
-         </code>
+         <code>ABILITY:CATEGORY=Salient Divine Ability|Alter Size</code>
         </p>
         <p class="indent3">
          Would grant the Alter Size salient divine ability.
         </p>
         <p class="indent2">
-         <code>
-          ABILITY:CATEGORY=Salient Divine Ability|Alter Size|Divine Blessing
-         </code>
+         <code>ABILITY:CATEGORY=Salient Divine Ability|Alter Size|Divine Blessing</code>
         </p>
         <p class="indent3">
          Would grant a choice of the Alter Size and Divine Blessing salient divine abilities.
         </p>
         <p class="indent2">
-         <code>
-          ABILITY:CATEGORY=Salient Divine Ability|Alter Form&lt;tab&gt;FREE:YES
-         </code>
+         <code>ABILITY:CATEGORY=Salient Divine Ability|Alter Form&lt;tab&gt;FREE:YES</code>
         </p>
         <p class="indent3">
          Would grant the Alter Form salient divine ability without charging the salient divine ability
@@ -755,9 +637,7 @@
           </strong>
          </p>
          <p class="indent2">
-          <code>
-           AGE:46
-          </code>
+          <code>AGE:46</code>
          </p>
          <p class="indent3">
           Sets the character's age to 46.
@@ -796,17 +676,13 @@
            </strong>
           </p>
           <p class="indent2">
-           <code>
-            ALIGN:LG|NG|CG
-           </code>
+           <code>ALIGN:LG|NG|CG</code>
           </p>
           <p class="indent3">
            Grants a choice of any good alignment.
           </p>
           <p class="indent2">
-           <code>
-            ALIGN:CE
-           </code>
+           <code>ALIGN:CE</code>
           </p>
           <p class="indent3">
            Sets the alignment to Chaotic Evil.
@@ -842,9 +718,7 @@
             </li>
             <li>
              Used in conjunction with the
-             <code>
-              LEVEL
-             </code>
+             <code>LEVEL</code>
              tag.
             </li>
            </ul>
@@ -854,17 +728,13 @@
             </strong>
            </p>
            <p class="indent2">
-            <code>
-             CLASS:Warrior &lt;tab&gt; LEVEL:2
-            </code>
+            <code>CLASS:Warrior &lt;tab&gt; LEVEL:2</code>
            </p>
            <p class="indent3">
             Would grant the character two levels of the Warrior class.
            </p>
            <p class="indent2">
-            <code>
-             CLASS:Fighter &lt;tab&gt; LEVEL:4 &lt;tab&gt; PRECLASS:1,Fighter=1
-            </code>
+            <code>CLASS:Fighter &lt;tab&gt; LEVEL:4 &lt;tab&gt; PRECLASS:1,Fighter=1</code>
            </p>
            <p class="indent3">
             Would grant four levels of Fighter if the character has at least one level in Fighter already.
@@ -903,9 +773,7 @@
              </strong>
             </p>
             <p class="indent2">
-             <code>
-              DEITY:Kong
-             </code>
+             <code>DEITY:Kong</code>
             </p>
             <p class="indent3">
              Sets character's Deity to "Kong".
@@ -954,9 +822,7 @@
               </strong>
              </p>
              <p class="indent2">
-              <code>
-               DOMAIN:Animal
-              </code>
+              <code>DOMAIN:Animal</code>
              </p>
              <p class="indent3">
               Sets the character's Domain to "Animal" if qualified.
@@ -981,35 +847,25 @@
                <ul class="incremental">
                 <li>
                  The
-                 <code>
-                  FEAT
-                 </code>
+                 <code>FEAT</code>
                  tag is deprecated. Use
                  <a href="#category">
-                  <code>
-                   ABILITY
-                  </code>
+                  <code>ABILITY</code>
                  </a>
                  instead.
                 </li>
                 <li>
                  All
-                 <code>
-                  FEAT
-                 </code>
+                 <code>FEAT</code>
                  tags have been
                  <strong>
                   deprecated
                  </strong>
                  and replaced by the
-                 <code>
-                  ABILITY
-                 </code>
+                 <code>ABILITY</code>
                  system, which is more
           general. The
-                 <code>
-                  ABILITY
-                 </code>
+                 <code>ABILITY</code>
                  system can model feats, racial
           features, class features, traits, flaws, temporary bonuses, and so on,
           all using a common format.
@@ -1058,33 +914,25 @@
                 </strong>
                </p>
                <p class="indent2">
-                <code>
-                 FEAT:Weapon Focus (Greataxe)
-                </code>
+                <code>FEAT:Weapon Focus (Greataxe)</code>
                </p>
                <p class="indent3">
                 Would grant the "Greataxe Weapon Focus" feat.
                </p>
                <p class="indent2">
-                <code>
-                 FEAT:Dodge PRESTAT:1,DEX=13
-                </code>
+                <code>FEAT:Dodge PRESTAT:1,DEX=13</code>
                </p>
                <p class="indent3">
                 Would grant "Dodge" if the character has a Dexterity of at least 13.
                </p>
                <p class="indent2">
-                <code>
-                 FEAT:Dodge|Improved Initiative
-                </code>
+                <code>FEAT:Dodge|Improved Initiative</code>
                </p>
                <p class="indent3">
                 Would grant the choice of Dodge or Improved Initiative.
                </p>
                <p class="indent2">
-                <code>
-                 FEAT:TYPE=ItemCreation
-                </code>
+                <code>FEAT:TYPE=ItemCreation</code>
                </p>
                <p class="indent3">
                 Would grant the choice of an ItemCreation type feat.
@@ -1125,9 +973,7 @@
 			 JEP operator
                 </a>
                 , for example
-                <code>
-                 roll("1d6")
-                </code>
+                <code>roll("1d6")</code>
                 simulates a 1d6.
                </p>
                <p class="indent1">
@@ -1136,25 +982,19 @@
                 </strong>
                </p>
                <p class="indent2">
-                <code>
-                 FUNDS:gp &lt;tab&gt; QTY:100
-                </code>
+                <code>FUNDS:gp &lt;tab&gt; QTY:100</code>
                </p>
                <p class="indent3">
                 Adds 100 gp to the Gold pool which the character may now spend on equipment.
                </p>
                <p class="indent2">
-                <code>
-                 FUNDS:gp &lt;tab&gt; QTY:10*TL
-                </code>
+                <code>FUNDS:gp &lt;tab&gt; QTY:10*TL</code>
                </p>
                <p class="indent3">
                 Adds 10 times the character's total level of gp to the Gold pool.
                </p>
                <p class="indent2">
-                <code>
-                 FUNDS:gp &lt;tab&gt; QTY:10*roll("2d4")
-                </code>
+                <code>FUNDS:gp &lt;tab&gt; QTY:10*roll("2d4")</code>
                </p>
                <p class="indent3">
                 Adds 2d4 times 10 gp to the Gold pool.
@@ -1190,9 +1030,7 @@
                  </strong>
                 </p>
                 <p class="indent2">
-                 <code>
-                  GEAR:Sack
-                 </code>
+                 <code>GEAR:Sack</code>
                 </p>
                 <p class="indent3">
                  Would put a "Sack" into the PC's equipment if they can afford it.
@@ -1241,9 +1079,7 @@
                   </strong>
                  </p>
                  <p class="indent2">
-                  <code>
-                   GENDER:Male
-                  </code>
+                  <code>GENDER:Male</code>
                  </p>
                  <p class="indent3">
                   The character's/creature's gender is "Male".
@@ -1275,16 +1111,12 @@
                   </p>
                   <ul class="indent2">
                    <li>
-                    <code>
-                     LANGBONUS
-                    </code>
+                    <code>LANGBONUS</code>
                     chooses from the Bonus Language Selections if there are enough language bonuses to be spent.
                    </li>
                    <li>
                     This tag requires that a
-                    <code>
-                     LANGBONUS
-                    </code>
+                    <code>LANGBONUS</code>
                     tag be included in the
                     <span class="lstfile">
                      race.lst
@@ -1307,9 +1139,7 @@
                    </strong>
                   </p>
                   <p class="indent2">
-                   <code>
-                    LANGBONUS:Dwarven|Elvish
-                   </code>
+                   <code>LANGBONUS:Dwarven|Elvish</code>
                   </p>
                   <p class="indent3">
                    Selects Dwarven and Elvish langauges.
@@ -1362,9 +1192,7 @@
                     </strong>
                    </p>
                    <p class="indent2">
-                    <code>
-                     LEVELABILITY:Ranger=1 &lt;tab&gt; ABILITY:PROMPT:FEAT(TYPE.Favored Enemy)|CHOICE:Favored Enemy (Humanoid (Elf))
-                    </code>
+                    <code>LEVELABILITY:Ranger=1 &lt;tab&gt; ABILITY:PROMPT:FEAT(TYPE.Favored Enemy)|CHOICE:Favored Enemy (Humanoid (Elf))</code>
                    </p>
                    <p class="indent3">
                     Selects Humanoid (Elf) as a ranger's first favored enemy selection.
@@ -1403,9 +1231,7 @@
                      </strong>
                     </p>
                     <p class="indent2">
-                     <code>
-                      NAME:Code Monkey
-                     </code>
+                     <code>NAME:Code Monkey</code>
                     </p>
                     <p class="indent3">
                      Sets the character's name to "Code Monkey".
@@ -1438,9 +1264,7 @@
                       </li>
                       <li>
                        If the
-                       <code>
-                        RACIAL:YES
-                       </code>
+                       <code>RACIAL:YES</code>
                        tag is included on the line, PCGen will fill any racial
 	  			bonus proficiency choices first, otherwise it will try to fill any class bonus proficiency
 	  			choices. If there are any choices left they will be granted as bonus proficiencies.
@@ -1452,25 +1276,19 @@
                       </strong>
                      </p>
                      <p class="indent2">
-                      <code>
-                       PROF:Greataxe
-                      </code>
+                      <code>PROF:Greataxe</code>
                      </p>
                      <p class="indent3">
                       Would give a proficiency in the use of "Greataxe" if the PC can afford it.
                      </p>
                      <p class="indent2">
-                      <code>
-                       PROF:Longsword &lt;tab&gt; RACIAL:YES
-                      </code>
+                      <code>PROF:Longsword &lt;tab&gt; RACIAL:YES</code>
                      </p>
                      <p class="indent3">
                       Would select Longsword as the bonus proficiency choice if the character can legally select that choice.
                      </p>
                      <p class="indent2">
-                      <code>
-                       PROF:Longbow|Shortbow
-                      </code>
+                      <code>PROF:Longbow|Shortbow</code>
                      </p>
                      <p class="indent3">
                       Would grant the choice of Longbow or Shortbow as a bonus proficiency.
@@ -1509,9 +1327,7 @@
                        </strong>
                       </p>
                       <p class="indent2">
-                       <code>
-                        RACE:Bugbear
-                       </code>
+                       <code>RACE:Bugbear</code>
                       </p>
                       <p class="indent3">
                        Sets the character's race to Bugbear.
@@ -1551,30 +1367,22 @@
                          tag.
                          <li>
                           This tag is used, in conjunction with the
-                          <code>
-                           OPTION
-                          </code>
+                          <code>OPTION</code>
                           tag, to
 				randomly determine if an item will be granted by the kit.
                          </li>
                          <li>
                           The
-                          <code>
-                           OPTION
-                          </code>
+                          <code>OPTION</code>
                           tag can be added to any kit line and the object will
 				only be granted if the range specified by the OPTION tag matches the number
 				generated by the
-                          <code>
-                           SELECT
-                          </code>
+                          <code>SELECT</code>
                           tag.
                          </li>
                          <li>
                           If more than one
-                          <code>
-                           SELECT
-                          </code>
+                          <code>SELECT</code>
                           tag is used in a kit, each use of
 				it will reset the value for the OPTION tags below it.
                          </li>
@@ -1586,9 +1394,7 @@
                         </strong>
                        </p>
                        <p class="indent2">
-                        <code>
-                         SELECT:roll("1d100")
-                        </code>
+                        <code>SELECT:roll("1d100")</code>
                        </p>
                        <p class="indent3">
                         Selects a number from 1 to 100 which can be checked by the OPTION tag.
@@ -1628,20 +1434,14 @@
                          </li>
                          <li>
                           The number of ranks granted are determined by the
-                          <code>
-                           RANK
-                          </code>
+                          <code>RANK</code>
                           tag
 				immediately following the
-                          <code>
-                           SKILL
-                          </code>
+                          <code>SKILL</code>
                           tag.
                          </li>
                          <li>
-                          <code>
-                           RANK
-                          </code>
+                          <code>RANK</code>
                           tag MUST be used on all SKILL lines.
                          </li>
                          <li>
@@ -1655,25 +1455,19 @@
                          </strong>
                         </p>
                         <p class="indent2">
-                         <code>
-                          SKILL:Climb RANK:4
-                         </code>
+                         <code>SKILL:Climb RANK:4</code>
                         </p>
                         <p class="indent3">
                          Gives four ranks of "Climb" skill if they can afford it.
                         </p>
                         <p class="indent2">
-                         <code>
-                          SKILL:TYPE=Knowledge RANK:4
-                         </code>
+                         <code>SKILL:TYPE=Knowledge RANK:4</code>
                         </p>
                         <p class="indent3">
                          Gives four ranks of "Knowledge" type skills if they can afford it.
                         </p>
                         <p class="indent2">
-                         <code>
-                          SKILL:Bluff|Concentration|Hide RANK:18 COUNT:2
-                         </code>
+                         <code>SKILL:Bluff|Concentration|Hide RANK:18 COUNT:2</code>
                         </p>
                         <p class="indent3">
                          This would offer a chooser and allow you to pick 2 of the three listed
@@ -1715,9 +1509,7 @@
                           </strong>
                          </p>
                          <p class="indent2">
-                          <code>
-                           SPELLS:Detect Magic|Ghost Sound|Light|Read Magic
-                          </code>
+                          <code>SPELLS:Detect Magic|Ghost Sound|Light|Read Magic</code>
                          </p>
                          <p class="indent3">
                           Would give the
@@ -1739,9 +1531,7 @@
                           spells if the PC has free spells.
                          </p>
                          <p class="indent2">
-                          <code>
-                           SPELLS:LEVEL=0
-                          </code>
+                          <code>SPELLS:LEVEL=0</code>
                          </p>
                          <p class="indent3">
                           Grants ALL 0-level spells.
@@ -1809,17 +1599,13 @@
                            </strong>
                           </p>
                           <p class="indent2">
-                           <code>
-                            SPELLS:SPELLBOOK=Prepared Spells|CLASS=Cleric|Aid=3|Align Weapon|Banishment
-                           </code>
+                           <code>SPELLS:SPELLBOOK=Prepared Spells|CLASS=Cleric|Aid=3|Align Weapon|Banishment</code>
                           </p>
                           <p class="indent3">
                            Would add Aid, Align Weapon and Banishment to the Prepared Spells spellbook, Aid appears three times.
                           </p>
                           <p class="indent2">
-                           <code>
-                            SPELLS:SPELLBOOK=Known Spells|CLASS=Sorcerer|Daze|Detect Magic|Ghost Sound
-                           </code>
+                           <code>SPELLS:SPELLBOOK=Known Spells|CLASS=Sorcerer|Daze|Detect Magic|Ghost Sound</code>
                           </p>
                           <p class="indent3">
                            Adds Daze, Detect Magic and Ghost Sound to the Sorcerer's Known Spells spellbook.
@@ -1866,9 +1652,7 @@
                             </strong>
                            </p>
                            <p class="indent2">
-                            <code>
-                             STAT:STR=15|DEX=14|WIS=10|CON=10|INT=10|CHA=18
-                            </code>
+                            <code>STAT:STR=15|DEX=14|WIS=10|CON=10|INT=10|CHA=18</code>
                            </p>
                            <p class="indent3">
                             Sets the editable scores to those specified.
@@ -1907,9 +1691,7 @@
                              </strong>
                             </p>
                             <p class="indent2">
-                             <code>
-                              SUBCLASS:Fast Hero
-                             </code>
+                             <code>SUBCLASS:Fast Hero</code>
                             </p>
                             <p class="indent3">
                              Sets a subclass choice to "Fast Hero".
@@ -1938,13 +1720,9 @@
                              </p>
                              <p class="indent2">
                               Identifies a table of values to be used in conjunction with the
-                              <code>
-                               VALUES
-                              </code>
+                              <code>VALUES</code>
                               tag and called by a
-                              <code>
-                               LOOKUP
-                              </code>
+                              <code>LOOKUP</code>
                               tag.
                              </p>
                              <p class="indent1">
@@ -1953,9 +1731,7 @@
                               </strong>
                              </p>
                              <p class="indent2">
-                              <code>
-                               TABLE:Minor Special Ability (P/S)
-                              </code>
+                              <code>TABLE:Minor Special Ability (P/S)</code>
                              </p>
                              <p class="indent3">
                               Would create a table called "Minor Special Ability (P/S)".
@@ -1994,9 +1770,7 @@
                                </strong>
                               </p>
                               <p class="indent2">
-                               <code>
-                                TEMPLATE:Celestial
-                               </code>
+                               <code>TEMPLATE:Celestial</code>
                               </p>
                               <p class="indent3">
                                Adds the "Celestial" template to the character.
@@ -2042,21 +1816,13 @@
                                 </p>
                                 <p class="indent2">
                                  The
-                                 <code>
-                                  ABILITY
-                                 </code>
+                                 <code>ABILITY</code>
                                  tag is used to select the choice presented by an
-                                 <code>
-                                  ADD:FEAT
-                                 </code>
+                                 <code>ADD:FEAT</code>
                                  chooser in a class level line.  The Feat choices parameter must match the choices used in the
-                                 <code>
-                                  ADD:FEAT
-                                 </code>
+                                 <code>ADD:FEAT</code>
                                  this
-                                 <code>
-                                  ABILITY
-                                 </code>
+                                 <code>ABILITY</code>
                                  is selecting for.  The Feat to select should be a valid selection but this is not checked by the kit.
                                 </p>
                                 <p class="indent1">
@@ -2065,9 +1831,7 @@
                                  </strong>
                                 </p>
                                 <p class="indent2">
-                                 <code>
-                                  LEVELABILITY:Ranger=1 &lt;tab&gt; ABILITY:PROMPT:FEAT(TYPE.Favored Enemy)|CHOICE:Favored Enemy (Humanoid (Elf))
-                                 </code>
+                                 <code>LEVELABILITY:Ranger=1 &lt;tab&gt; ABILITY:PROMPT:FEAT(TYPE.Favored Enemy)|CHOICE:Favored Enemy (Humanoid (Elf))</code>
                                 </p>
                                 <p class="indent3">
                                  Selects Humanoid (Elf) as a ranger's first favored enemy selection.
@@ -2123,9 +1887,7 @@
                                   </strong>
                                  </p>
                                  <p class="indent2">
-                                  <code>
-                                   APPLY:INSTANT
-                                  </code>
+                                  <code>APPLY:INSTANT</code>
                                  </p>
                                  <p class="indent3">
                                   Sets this kit to be usable multiple times.
@@ -2185,25 +1947,19 @@
                                    </strong>
                                   </p>
                                   <p class="indent2">
-                                   <code>
-                                    FEAT:Dodge|Improved Initiative|Alertness &lt;tab&gt; COUNT:2
-                                   </code>
+                                   <code>FEAT:Dodge|Improved Initiative|Alertness &lt;tab&gt; COUNT:2</code>
                                   </p>
                                   <p class="indent3">
                                    Would allow the choice of two of Dodge, Improved Initiative, and Alertness.
                                   </p>
                                   <p class="indent2">
-                                   <code>
-                                    PROF:Longsword|Rapier|Longbow|Shortbow &lt;tab&gt; COUNT:2
-                                   </code>
+                                   <code>PROF:Longsword|Rapier|Longbow|Shortbow &lt;tab&gt; COUNT:2</code>
                                   </p>
                                   <p class="indent3">
                                    Would allow the choice of two of Longsword, Rapier, Longbow, and Shortbow.
                                   </p>
                                   <p class="indent2">
-                                   <code>
-                                    SPELLS:LEVEL=1 &lt;tab&gt; COUNT:2
-                                   </code>
+                                   <code>SPELLS:LEVEL=1 &lt;tab&gt; COUNT:2</code>
                                   </p>
                                   <p class="indent3">
                                    Would allow the choice of two first level spells.
@@ -2269,30 +2025,22 @@
                                     </strong>
                                    </p>
                                    <p class="indent2">
-                                    <code>
-                                     EQMOD:Bane.Holy.Keen
-                                    </code>
+                                    <code>EQMOD:Bane.Holy.Keen</code>
                                    </p>
                                    <p class="indent3">
                                     The equipment modifiers "Bane", "Holy" and "Keen" (as seen in the item
 			customizer in PCGen) are added to the granted equipment item.
                                    </p>
                                    <p class="indent2">
-                                    <code>
-                                     EQMOD:KEEN.BANE|Undead
-                                    </code>
+                                    <code>EQMOD:KEEN.BANE|Undead</code>
                                     or
-                                    <code>
-                                     EQMOD:BANE|Undead.KEEN
-                                    </code>
+                                    <code>EQMOD:BANE|Undead.KEEN</code>
                                    </p>
                                    <p class="indent3">
                                     Bane Undead is added to the item.
                                    </p>
                                    <p class="indent2">
-                                    <code>
-                                     EQMOD:ABILITYPLUS|STR+2
-                                    </code>
+                                    <code>EQMOD:ABILITYPLUS|STR+2</code>
                                    </p>
                                    <p class="indent3">
                                     Applies a +2 STR bonus to the character when using the item.
@@ -2340,25 +2088,19 @@
                                      </strong>
                                     </p>
                                     <p class="indent2">
-                                     <code>
-                                      EQUIPBUY:0
-                                     </code>
+                                     <code>EQUIPBUY:0</code>
                                     </p>
                                     <p class="indent3">
                                      The gear granted by the KIT is free.
                                     </p>
                                     <p class="indent2">
-                                     <code>
-                                      EQUIPBUY:50
-                                     </code>
+                                     <code>EQUIPBUY:50</code>
                                     </p>
                                     <p class="indent3">
                                      The gear granted by the KIT is granted for half the normal cost.
                                     </p>
                                     <p class="indent2">
-                                     <code>
-                                      EQUIPBUY:200
-                                     </code>
+                                     <code>EQUIPBUY:200</code>
                                     </p>
                                     <p class="indent3">
                                      The gear granted by the KIT is granted for twice the normal cost.
@@ -2405,9 +2147,7 @@
                                       </strong>
                                      </p>
                                      <p class="indent2">
-                                      <code>
-                                       FREE:YES
-                                      </code>
+                                      <code>FREE:YES</code>
                                      </p>
                                      <p class="indent3">
                                       The item that appears on this line will be granted to the character
@@ -2452,9 +2192,7 @@
                                        </li>
                                        <li>
                                         Must be used with the
-                                        <code>
-                                         CLASS
-                                        </code>
+                                        <code>CLASS</code>
                                         tag.
                                        </li>
                                       </ul>
@@ -2464,17 +2202,13 @@
                                        </strong>
                                       </p>
                                       <p class="indent2">
-                                       <code>
-                                        CLASS:Warrior &lt;tab&gt; LEVEL:2
-                                       </code>
+                                       <code>CLASS:Warrior &lt;tab&gt; LEVEL:2</code>
                                       </p>
                                       <p class="indent3">
                                        Would grant the character two levels of the Warrior class.
                                       </p>
                                       <p class="indent2">
-                                       <code>
-                                        CLASS:Fighter &lt;tab&gt; LEVEL:4 &lt;tab&gt; PRECLASS:1,Fighter=1
-                                       </code>
+                                       <code>CLASS:Fighter &lt;tab&gt; LEVEL:4 &lt;tab&gt; PRECLASS:1,Fighter=1</code>
                                       </p>
                                       <p class="indent3">
                                        Would grant four levels of Fighter if the character has at least one level in Fighter already.
@@ -2563,33 +2297,25 @@
                                         </strong>
                                        </p>
                                        <p class="indent2">
-                                        <code>
-                                         GEAR:Morningstar &lt;tab&gt; LOCATION:Primary Hand
-                                        </code>
+                                        <code>GEAR:Morningstar &lt;tab&gt; LOCATION:Primary Hand</code>
                                        </p>
                                        <p class="indent3">
                                         Equips the Morningstar to the Primary Hand slot.
                                        </p>
                                        <p class="indent2">
-                                        <code>
-                                         GEAR:Leather &lt;tab&gt; LOCATION:Equipped
-                                        </code>
+                                        <code>GEAR:Leather &lt;tab&gt; LOCATION:Equipped</code>
                                        </p>
                                        <p class="indent3">
                                         Equips the Leather armor to the Armor slot.
                                        </p>
                                        <p class="indent2">
-                                        <code>
-                                         GEAR:Shield (Light/Wood) &lt;tab&gt; LOCATION:Equipped
-                                        </code>
+                                        <code>GEAR:Shield (Light/Wood) &lt;tab&gt; LOCATION:Equipped</code>
                                        </p>
                                        <p class="indent3">
                                         Equips the Shield to the Shield slot.
                                        </p>
                                        <p class="indent2">
-                                        <code>
-                                         GEAR:Javelin &lt;tab&gt; LOCATION:Carried
-                                        </code>
+                                        <code>GEAR:Javelin &lt;tab&gt; LOCATION:Carried</code>
                                        </p>
                                        <p class="indent3">
                                         Equips the Javelin to Carried.
@@ -2633,9 +2359,7 @@
                                         <p class="indent2">
                                          Matches the value of the JEP formula or VAR (y variable) with the
 			associated table's (x variable)
-                                         <code>
-                                          VALUES
-                                         </code>
+                                         <code>VALUES</code>
                                          tag's upper and lower selection
 			range and returns the relevant "value".
                                         </p>
@@ -2645,9 +2369,7 @@
                                          </strong>
                                         </p>
                                         <p class="indent2">
-                                         <code>
-                                          LOOKUP:Minor Special Ability (P/S),roll("1d100")
-                                         </code>
+                                         <code>LOOKUP:Minor Special Ability (P/S),roll("1d100")</code>
                                         </p>
                                         <p class="indent3">
                                          A random number is generated between 1 and 100 and the item corresponding to
@@ -2696,9 +2418,7 @@
                                           </strong>
                                          </p>
                                          <p class="indent2">
-                                          <code>
-                                           MAXCOST:10
-                                          </code>
+                                          <code>MAXCOST:10</code>
                                          </p>
                                          <p class="indent3">
                                           This equipment will only be purchased if it costs less than 10.
@@ -2747,9 +2467,7 @@
                                             This tag is used on a line to determine randomly if the line will be granted to the character.
                                            </li>
                                            <li>
-                                            <code>
-                                             OPTION
-                                            </code>
+                                            <code>OPTION</code>
                                             specifies a number range in which the line will be granted if it matches
 				the number generated by the last preceding
                                             <a href="#select">
@@ -2764,34 +2482,22 @@
                                            </strong>
                                           </p>
                                           <p class="indent2">
-                                           <code>
-                                            SELECT:roll("1d100")
-                                           </code>
+                                           <code>SELECT:roll("1d100")</code>
                                           </p>
                                           <p class="indent2">
-                                           <code>
-                                            GEAR:Scimitar &lt;tab&gt; OPTION:1,50
-                                           </code>
+                                           <code>GEAR:Scimitar &lt;tab&gt; OPTION:1,50</code>
                                           </p>
                                           <p class="indent2">
-                                           <code>
-                                            GEAR:Falchion &lt;tab&gt; OPTION:51,100
-                                           </code>
+                                           <code>GEAR:Falchion &lt;tab&gt; OPTION:51,100</code>
                                           </p>
                                           <p class="indent2">
-                                           <code>
-                                            GEAR:Full Plate &lt;tab&gt; OPTION:1,STR*5
-                                           </code>
+                                           <code>GEAR:Full Plate &lt;tab&gt; OPTION:1,STR*5</code>
                                           </p>
                                           <p class="indent2">
-                                           <code>
-                                            GEAR:Shield&lt;tab&gt; OPTION:1,10|75,100
-                                           </code>
+                                           <code>GEAR:Shield&lt;tab&gt; OPTION:1,10|75,100</code>
                                           </p>
                                           <p class="indent2">
-                                           <code>
-                                            GEAR:The One Ring &lt;tab&gt; OPTION:100
-                                           </code>
+                                           <code>GEAR:The One Ring &lt;tab&gt; OPTION:100</code>
                                           </p>
                                           <p class="indent3">
                                            The SELECT tag sets a value between 1 and 100. If that value
@@ -2848,9 +2554,7 @@
                                             </strong>
                                            </p>
                                            <p class="indent2">
-                                            <code>
-                                             QTY:3
-                                            </code>
+                                            <code>QTY:3</code>
                                            </p>
                                            <p class="indent3">
                                             Three items are given.
@@ -2906,9 +2610,7 @@
                                              </strong>
                                             </p>
                                             <p class="indent2">
-                                             <code>
-                                              RACIAL:YES
-                                             </code>
+                                             <code>RACIAL:YES</code>
                                             </p>
                                             <p class="indent3">
                                              Elves naturally have the ability, during creation, to have a
@@ -2947,16 +2649,12 @@
                                              <ul class="indent2">
                                               <li>
                                                Grants the number of ranks to the skill indicated, in the immediately preceeding
-                                               <code>
-                                                SKILL
-                                               </code>
+                                               <code>SKILL</code>
                                                tag, to the character if they can legally have that many
 				additional ranks of that skill.
                                               </li>
                                               <li>
-                                               <code>
-                                                RANK
-                                               </code>
+                                               <code>RANK</code>
                                                tag MUST be used on all SKILL lines.
                                               </li>
                                               <li>
@@ -2970,17 +2668,13 @@
                                               </strong>
                                              </p>
                                              <p class="indent2">
-                                              <code>
-                                               SKILL:Climb RANK:4
-                                              </code>
+                                              <code>SKILL:Climb RANK:4</code>
                                              </p>
                                              <p class="indent3">
                                               Gives four ranks of "Climb" skill if they can afford it.
                                              </p>
                                              <p class="indent2">
-                                              <code>
-                                               SKILL:TYPE=Knowledge RANK:4
-                                              </code>
+                                              <code>SKILL:TYPE=Knowledge RANK:4</code>
                                              </p>
                                              <p class="indent3">
                                               Gives four ranks of "Knowledge" type skills if they can afford it.
@@ -3024,13 +2718,9 @@
                                                </li>
                                                <li>
                                                 This tag is used, in conjunction with the
-                                                <code>
-                                                 SKILL
-                                                </code>
+                                                <code>SKILL</code>
                                                 and
-                                                <code>
-                                                 RANK
-                                                </code>
+                                                <code>RANK</code>
                                                 tags, to
 				select languages.
                                                </li>
@@ -3041,15 +2731,13 @@
                                                </strong>
                                               </p>
                                               <p class="indent2">
-                                               <code>
-                                                SKILL:Speak Language
+                                               <code>SKILL:Speak Language
                                                 <tab>
                                                  RANK:2
                                                  <tab>
                                                   SELECTION:Dwarven,Elven
                                                  </tab>
-                                                </tab>
-                                               </code>
+                                                </tab></code>
                                               </p>
                                               <p class="indent3">
                                                Selects Dwarven and Elven languages with the ranks bought.
@@ -3102,9 +2790,7 @@
                                                 </strong>
                                                </p>
                                                <p class="indent2">
-                                                <code>
-                                                 SIZE:S
-                                                </code>
+                                                <code>SIZE:S</code>
                                                </p>
                                                <p class="indent3">
                                                 The item is set to size small.
@@ -3154,17 +2840,13 @@
                                                  </strong>
                                                 </p>
                                                 <p class="indent2">
-                                                 <code>
-                                                  TOTALCOST:170
-                                                 </code>
+                                                 <code>TOTALCOST:170</code>
                                                 </p>
                                                 <p class="indent3">
                                                  The KIT costs 170gp for all gear.
                                                 </p>
                                                 <p class="indent2">
-                                                 <code>
-                                                  TOTALCOST:if(var("SIZE==3||SIZE==4"),5,10)
-                                                 </code>
+                                                 <code>TOTALCOST:if(var("SIZE==3||SIZE==4"),5,10)</code>
                                                 </p>
                                                 <p class="indent3">
                                                  The kit will cost 5 gp if the SIZE variable is 3 or 4, otherwise it will cost 10 gp.
@@ -3235,12 +2917,10 @@
                                                  </p>
                                                  <blockquote class="indent2">
                                                   <p class="tagindent1">
-                                                   <code>
-                                                    VALUES:EQMOD:BANE_M|1,10|EQMOD:DEFEND|11,17|EQMOD:FLM_M|18,27|EQMOD:FROST_M|28,37|
+                                                   <code>VALUES:EQMOD:BANE_M|1,10|EQMOD:DEFEND|11,17|EQMOD:FLM_M|18,27|EQMOD:FROST_M|28,37|
 				EQMOD:SHOCK_M|38,47|EQMOD:GHOST_M|48,67|EQMOD:KIFOC|68,71|EQMOD:MERC_M|72,75|
 				EQMOD:MI_CLE|76,82|EQMOD:SPL_STR|83,87|EQMOD:THROW|88,91|EQMOD:THNDR_M|92,95|
-				EQMOD:VICIOU|96,100
-                                                   </code>
+				EQMOD:VICIOU|96,100</code>
                                                   </p>
                                                  </blockquote>
                                                  <p class="indent3">
@@ -3397,21 +3077,15 @@
    This is an optional tag that determins whether the KIT appears in the KIT Selection window.
   </li>
   <li>
-   <code>
-    YES
-   </code>
+   <code>YES</code>
    - Displays the name of the KIT in the KIT selection window.
   </li>
   <li>
-   <code>
-    NO
-   </code>
+   <code>NO</code>
    - Hides the name of the KIT in the KIT selection window.
   </li>
   <li>
-   <code>
-    QUALIFY
-   </code>
+   <code>QUALIFY</code>
    - Displays the name of the KIT only if the character passes the prerequisites.
   </li>
  </ul>
@@ -3421,25 +3095,19 @@
   </strong>
  </p>
  <p class="indent2">
-  <code>
-   VISIBLE:YES
-  </code>
+  <code>VISIBLE:YES</code>
  </p>
  <p class="indent3">
   Shows the KIT name in PCGen.
  </p>
  <p class="indent2">
-  <code>
-   VISIBLE:NO
-  </code>
+  <code>VISIBLE:NO</code>
  </p>
  <p class="indent3">
   Hides the KIT name in PCGen.
  </p>
  <p class="indent2">
-  <code>
-   VISIBLE:QUALIFY
-  </code>
+  <code>VISIBLE:QUALIFY</code>
  </p>
  <p class="indent3">
   The KIT name will be displayed in PCGen if the character meets all prerequisites.

--- a/docs/listfilepages/datafilestagpages/datafilestemplates.html
+++ b/docs/listfilepages/datafilestagpages/datafilestemplates.html
@@ -106,17 +106,11 @@ character qualifies for the class in question.
     </strong>
     When modifying a template, with
 the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     ADDLEVEL
-    </code>
+    <code>ADDLEVEL</code>
     tag, the data included in a new
-    <code>
-     ADDLEVEL
-    </code>
+    <code>ADDLEVEL</code>
     tag will be
 included as if it were a separate tag.
    </li>
@@ -127,9 +121,7 @@ included as if it were a separate tag.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ADDLEVEL:Animal|6
-   </code>
+   <code>ADDLEVEL:Animal|6</code>
   </p>
   <p class="indent3">
    Adds six levels of the Animal class to the
@@ -143,24 +135,18 @@ Separately):
   </p>
   <p class="indent2">
    Initial Template:
-   <code>
-    Werewolf &lt;tab&gt;
-ADDLEVEL:Animal|2
-   </code>
+   <code>Werewolf &lt;tab&gt;
+ADDLEVEL:Animal|2</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    Werewolf.MOD &lt;tab&gt;
-ADDLEVEL:Animal|1
-   </code>
+   <code>Werewolf.MOD &lt;tab&gt;
+ADDLEVEL:Animal|1</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    Werewolf &lt;tab&gt;
-ADDLEVEL:Animal|2 &lt;tab&gt; ADDLEVEL:Animal|1
-   </code>
+   <code>Werewolf &lt;tab&gt;
+ADDLEVEL:Animal|2 &lt;tab&gt; ADDLEVEL:Animal|1</code>
    .
   </p>
   <p class="indent3">
@@ -201,17 +187,11 @@ additional skill points.
     </strong>
     When modifying a template, with
 the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     BONUSSKILLPOINTS
-    </code>
+    <code>BONUSSKILLPOINTS</code>
     tag, the data included in a new
-    <code>
-     BONUSSKILLPOINTS
-    </code>
+    <code>BONUSSKILLPOINTS</code>
     tag will overwrite the existing tag
 data.
    </li>
@@ -222,9 +202,7 @@ data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUSSKILLPOINTS:2
-   </code>
+   <code>BONUSSKILLPOINTS:2</code>
   </p>
   <p class="indent3">
    Two bonus skill points are given.
@@ -236,24 +214,18 @@ data.
   </p>
   <p class="indent2">
    Initial Template:
-   <code>
-    Sentient Construct
-&lt;tab&gt; BONUSSKILLPOINTS:2
-   </code>
+   <code>Sentient Construct
+&lt;tab&gt; BONUSSKILLPOINTS:2</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    Sentience Construct.MOD
-&lt;tab&gt; BONUSSKILLPOINTS:3
-   </code>
+   <code>Sentience Construct.MOD
+&lt;tab&gt; BONUSSKILLPOINTS:3</code>
   </p>
   <p class="indent2">
    Results In:
-   <code>
-    Sentient Construct &lt;tab&gt;
-BONUSSKILLPOINTS:3
-   </code>
+   <code>Sentient Construct &lt;tab&gt;
+BONUSSKILLPOINTS:3</code>
   </p>
   <p class="indent3">
    Twelve skill points are granted at first level
@@ -293,9 +265,7 @@ monster HD. This tag will work retroactively.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:MONSKILLPTS|LOCKNUMBER|6
-   </code>
+   <code>BONUS:MONSKILLPTS|LOCKNUMBER|6</code>
   </p>
   <p class="indent3">
    This template will set 6 as the base skill
@@ -335,14 +305,10 @@ score/stat.
     </strong>
     When modifying a template with
 the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, the data included in this tag will be
 overwritten by the new
-    <code>
-     CHOOSE:LANGAUTO
-    </code>
+    <code>CHOOSE:LANGAUTO</code>
     tag if one is
 included in the modification.
    </li>
@@ -353,9 +319,7 @@ included in the modification.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:LANGAUTO:Abyssal|Infernal
-   </code>
+   <code>CHOOSE:LANGAUTO:Abyssal|Infernal</code>
   </p>
   <p class="indent3">
    "Abyssal" &amp; "Infernal" are granted as bonus
@@ -368,24 +332,18 @@ languages.
   </p>
   <p class="indent2">
    Initial Template:
-   <code>
-    Darkling &lt;tab&gt;
-CHOOSE:LANGAUTO:Abyssal|Infernal
-   </code>
+   <code>Darkling &lt;tab&gt;
+CHOOSE:LANGAUTO:Abyssal|Infernal</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    Darkling.MOD &lt;tab&gt;
-CHOOSE:LANGAUTO:Ignan|Undercommon
-   </code>
+   <code>Darkling.MOD &lt;tab&gt;
+CHOOSE:LANGAUTO:Ignan|Undercommon</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    Darkling &lt;tab&gt;
-CHOOSE:LANGAUTO:Undercommon
-   </code>
+   <code>Darkling &lt;tab&gt;
+CHOOSE:LANGAUTO:Undercommon</code>
   </p>
   <p class="indent3">
    Darklings are allowed to choose either "Ignan"
@@ -424,18 +382,12 @@ increased by this template.
     </strong>
     When modifying a template, with
 the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     CR
-    </code>
+    <code>CR</code>
     tag,
 the data included in a new
-    <code>
-     CR
-    </code>
+    <code>CR</code>
     tag will overwrite the
 existing tag data.
    </li>
@@ -446,19 +398,15 @@ existing tag data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CR:2
-   </code>
+   <code>CR:2</code>
   </p>
   <p class="indent3">
    The character's challenge rating is increased by
 two.
   </p>
   <p class="indent2">
-   <code>
-    &lt;template name&gt;.MOD &lt;tab&gt;
-CR:3
-   </code>
+   <code>&lt;template name&gt;.MOD &lt;tab&gt;
+CR:3</code>
   </p>
   <p class="indent3">
    The character's challenge rating is increased by
@@ -471,24 +419,18 @@ three.
   </p>
   <p class="indent2">
    Initial Template:
-   <code>
-    Darkling &lt;tab&gt;
-CR:2
-   </code>
+   <code>Darkling &lt;tab&gt;
+CR:2</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    Darkling.MOD &lt;tab&gt;
-CR:3
-   </code>
+   <code>Darkling.MOD &lt;tab&gt;
+CR:3</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    Darkling &lt;tab&gt;
-CR:3
-   </code>
+   <code>Darkling &lt;tab&gt;
+CR:3</code>
   </p>
   <p class="indent3">
    Darklings have a "challenge rating" of "3".
@@ -536,18 +478,12 @@ sides.
     </strong>
     When modifying a template, with
 the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     FACE
-    </code>
+    <code>FACE</code>
     tag,
 the data included in a new
-    <code>
-     FACE
-    </code>
+    <code>FACE</code>
     tag will overwrite the
 existing tag data.
    </li>
@@ -563,26 +499,20 @@ statistic.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    FACE:5,10
-   </code>
+   <code>FACE:5,10</code>
   </p>
   <p class="indent3">
    The creature has a face/space of 5 by 10.
   </p>
   <p class="indent2">
-   <code>
-    FACE:10
-   </code>
+   <code>FACE:10</code>
   </p>
   <p class="indent3">
    The creature has a face/space of 10.
   </p>
   <p class="indent2">
-   <code>
-    &lt;template name&gt;.MOD &lt;tab&gt;
-FACE:20
-   </code>
+   <code>&lt;template name&gt;.MOD &lt;tab&gt;
+FACE:20</code>
   </p>
   <p class="indent3">
    The creature has a face/space of 20.
@@ -594,24 +524,18 @@ FACE:20
   </p>
   <p class="indent2">
    Initial Template:
-   <code>
-    Darkling &lt;tab&gt;
-FACE:10,5
-   </code>
+   <code>Darkling &lt;tab&gt;
+FACE:10,5</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    Darkling.MOD &lt;tab&gt;
-FACE:10
-   </code>
+   <code>Darkling.MOD &lt;tab&gt;
+FACE:10</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    Darkling &lt;tab&gt;
-FACE:10
-   </code>
+   <code>Darkling &lt;tab&gt;
+FACE:10</code>
   </p>
   <p class="indent3">
    Darklings have a "face/space" of "10".
@@ -675,17 +599,11 @@ class as Favored.
     </strong>
     When modifying a template, with
 the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     FAVOREDCLASS
-    </code>
+    <code>FAVOREDCLASS</code>
     tag, the data included in a new
-    <code>
-     FAVOREDCLASS
-    </code>
+    <code>FAVOREDCLASS</code>
     tag will be appended to the existing tag
 data.
    </li>
@@ -696,37 +614,29 @@ data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    FAVOREDCLASS:Wizard|Fighter
-   </code>
+   <code>FAVOREDCLASS:Wizard|Fighter</code>
   </p>
   <p class="indent3">
    The character's favored classes are "Wizard",
 including any of its sub-classes, and "Fighter".
   </p>
   <p class="indent2">
-   <code>
-    FAVOREDCLASS:Wizard.Wizard
-   </code>
+   <code>FAVOREDCLASS:Wizard.Wizard</code>
   </p>
   <p class="indent3">
    The character's favored class is "Wizard",
 excluding any of its sub-classes.
   </p>
   <p class="indent2">
-   <code>
-    FAVOREDCLASS:Wizard.Illusionist
-   </code>
+   <code>FAVOREDCLASS:Wizard.Illusionist</code>
   </p>
   <p class="indent3">
    The character's favored class is the "Wizard"
 sub-class, the "Illusionist".
   </p>
   <p class="indent2">
-   <code>
-    &lt;template name&gt;.MOD &lt;tab&gt;
-FAVOREDCLASS:Wizard.Necromancer
-   </code>
+   <code>&lt;template name&gt;.MOD &lt;tab&gt;
+FAVOREDCLASS:Wizard.Necromancer</code>
   </p>
   <p class="indent3">
    The character's favored class is the "Wizard"
@@ -739,24 +649,18 @@ sub-class, the "Necromancer".
   </p>
   <p class="indent2">
    Initial Template:
-   <code>
-    Darkling &lt;tab&gt;
-FAVOREDCLASS:Sorcerer
-   </code>
+   <code>Darkling &lt;tab&gt;
+FAVOREDCLASS:Sorcerer</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    Darkling.MOD &lt;tab&gt;
-FAVOREDCLASS:Wizard.Necromancer
-   </code>
+   <code>Darkling.MOD &lt;tab&gt;
+FAVOREDCLASS:Wizard.Necromancer</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    Darkling &lt;tab&gt;
-FAVOREDCLASS:Sorcerer|Wizard.Necromancer
-   </code>
+   <code>Darkling &lt;tab&gt;
+FAVOREDCLASS:Sorcerer|Wizard.Necromancer</code>
   </p>
   <p class="indent3">
    Darkling's "favored class" is the "Sorcerer" and
@@ -779,34 +683,24 @@ the "Wizard" sub-class, the "Necromancer".
     <ul class="incremental">
      <li>
       The
-      <code>
-       FEAT
-      </code>
+      <code>FEAT</code>
       tag is deprecated. Use
       <a href="../globalfilestagpages/globalfilesother.html#ability">
-       <code>
-        ABILITY
-       </code>
+       <code>ABILITY</code>
       </a>
       instead.
      </li>
      <li>
       All
-      <code>
-       FEAT
-      </code>
+      <code>FEAT</code>
       tags have been
       <strong>
        deprecated
       </strong>
       and replaced by the
-      <code>
-       ABILITY
-      </code>
+      <code>ABILITY</code>
       system, which is more general. The
-      <code>
-       ABILITY
-      </code>
+      <code>ABILITY</code>
       system can model feats, racial features, class
 features, traits, flaws, temporary bonuses, and so on, all using a
 common format.
@@ -840,9 +734,7 @@ selected and then granted to the character.
     </li>
     <li>
      The hyphen (-) is used only in the
-     <code>
-      OUTPUTNAME
-     </code>
+     <code>OUTPUTNAME</code>
      of
 feats and should NOT be used in the feat list for this tag.
     </li>
@@ -852,18 +744,12 @@ feats and should NOT be used in the feat list for this tag.
      </strong>
      When modifying a template, with
 the
-     <code>
-      .MOD
-     </code>
+     <code>.MOD</code>
      tag, given an existing
-     <code>
-      FEAT
-     </code>
+     <code>FEAT</code>
      tag,
 the data included in a new
-     <code>
-      FEAT
-     </code>
+     <code>FEAT</code>
      tag will overwrite the
 existing tag data.
     </li>
@@ -874,9 +760,7 @@ existing tag data.
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     FEAT:Blind Fight|Alertness
-    </code>
+    <code>FEAT:Blind Fight|Alertness</code>
    </p>
    <p class="indent3">
     Presents the "Blind-Fight" &amp; "Alertness"
@@ -890,24 +774,18 @@ character.
    </p>
    <p class="indent2">
     Initial Template:
-    <code>
-     Darkling &lt;tab&gt;
-FEAT:Blind Fight|Alertness
-    </code>
+    <code>Darkling &lt;tab&gt;
+FEAT:Blind Fight|Alertness</code>
    </p>
    <p class="indent2">
     Modified By:
-    <code>
-     Darkling.MOD &lt;tab&gt;
-FEAT:Blind Fight|Combat Reflexes
-    </code>
+    <code>Darkling.MOD &lt;tab&gt;
+FEAT:Blind Fight|Combat Reflexes</code>
    </p>
    <p class="indent2">
     Is Equivalent To:
-    <code>
-     Darkling &lt;tab&gt;
-FEAT:Blind Fight|Combat Reflexes
-    </code>
+    <code>Darkling &lt;tab&gt;
+FEAT:Blind Fight|Combat Reflexes</code>
    </p>
    <p class="indent3">
     Presents the "Blind-Fight" and "Combat Reflexes"
@@ -959,17 +837,11 @@ it.
     </strong>
     When modifying a template, with
 the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     GENDERLOCK
-    </code>
+    <code>GENDERLOCK</code>
     tag, the data included in a new
-    <code>
-     GENDERLOCK
-    </code>
+    <code>GENDERLOCK</code>
     tag will overwrite the existing tag
 data.
    </li>
@@ -980,9 +852,7 @@ data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    GENDERLOCK:Female
-   </code>
+   <code>GENDERLOCK:Female</code>
   </p>
   <p class="indent3">
    The character's gender is set to and locked as
@@ -995,24 +865,18 @@ data.
   </p>
   <p class="indent2">
    Initial Template:
-   <code>
-    Darkling Sorcerer
-&lt;tab&gt; GENDERLOCK:Female
-   </code>
+   <code>Darkling Sorcerer
+&lt;tab&gt; GENDERLOCK:Female</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    Darkling Sorcerer.MOD
-&lt;tab&gt; GENDERLOCK:Male
-   </code>
+   <code>Darkling Sorcerer.MOD
+&lt;tab&gt; GENDERLOCK:Male</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    Darkling Sorcerer
-&lt;tab&gt; GENDERLOCK:Male
-   </code>
+   <code>Darkling Sorcerer
+&lt;tab&gt; GENDERLOCK:Male</code>
   </p>
   <p class="indent3">
    The Darkling Sorcerer's gender is set to "Male"
@@ -1051,17 +915,11 @@ multiattacks and multidexterity.
     </strong>
     When modifying a template, with
 the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     HANDS
-    </code>
+    <code>HANDS</code>
     tag, the data included in a new
-    <code>
-     HANDS
-    </code>
+    <code>HANDS</code>
     tag will
 overwrite the existing tag data.
    </li>
@@ -1072,9 +930,7 @@ overwrite the existing tag data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    HANDS:4
-   </code>
+   <code>HANDS:4</code>
   </p>
   <p class="indent3">
    The creature has four hands.
@@ -1086,24 +942,18 @@ overwrite the existing tag data.
   </p>
   <p class="indent2">
    Initial Template:
-   <code>
-    Darkling Sorcerer
-&lt;tab&gt; HANDS:2
-   </code>
+   <code>Darkling Sorcerer
+&lt;tab&gt; HANDS:2</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    Darkling Sorcerer.MOD
-&lt;tab&gt; HANDS:4
-   </code>
+   <code>Darkling Sorcerer.MOD
+&lt;tab&gt; HANDS:4</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    Darkling Sorcerer
-&lt;tab&gt; HANDS:4
-   </code>
+   <code>Darkling Sorcerer
+&lt;tab&gt; HANDS:4</code>
   </p>
   <p class="indent3">
    The Darkling Sorcerer's number of hands is set
@@ -1207,18 +1057,12 @@ PRE tags can also be used
     </strong>
     When modifying a template, with
 the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     HD
-    </code>
+    <code>HD</code>
     tag,
 the data included in a new
-    <code>
-     HD
-    </code>
+    <code>HD</code>
     tag will be included as
 if it were a separate tag.
    </li>
@@ -1229,45 +1073,35 @@ if it were a separate tag.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    HD:1-3:DR:5/1
-   </code>
+   <code>HD:1-3:DR:5/1</code>
   </p>
   <p class="indent3">
    Grants Damage Reduction of 5/+1 if natural hit
 dice is between one and three.
   </p>
   <p class="indent2">
-   <code>
-    HD:1+:SR:15
-   </code>
+   <code>HD:1+:SR:15</code>
   </p>
   <p class="indent3">
    Grants Spell Resistance of 15 if natural hit
 dice is greater than one.
   </p>
   <p class="indent2">
-   <code>
-    HD:2-7:CR:2
-   </code>
+   <code>HD:2-7:CR:2</code>
   </p>
   <p class="indent3">
    Grants an increase in Challenge Rating of two if
 natural hit dice is between two and seven.
   </p>
   <p class="indent2">
-   <code>
-    HD:15+:SA:Uncanny Dodge
-   </code>
+   <code>HD:15+:SA:Uncanny Dodge</code>
   </p>
   <p class="indent3">
    Grants the "Uncanny Dodge" special ability if
 natural hit dice is greater than fifteen.
   </p>
   <p class="indent2">
-   <code>
-    HD:10+:FEAT:Alertness
-   </code>
+   <code>HD:10+:FEAT:Alertness</code>
   </p>
   <p class="indent3">
    Grants the "Alertness" feat if natural hit dice
@@ -1280,24 +1114,18 @@ is greater than ten.
   </p>
   <p class="indent2">
    Initial Template:
-   <code>
-    Werewolf &lt;tab&gt;
-HD:1-3:DR:5/1
-   </code>
+   <code>Werewolf &lt;tab&gt;
+HD:1-3:DR:5/1</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    Werewolf.MOD &lt;tab&gt;
-HD:2-7:CR:2
-   </code>
+   <code>Werewolf.MOD &lt;tab&gt;
+HD:2-7:CR:2</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    Werewolf &lt;tab&gt;
-HD:1-3:DR:5/1 &lt;tab&gt; HD:2-7:CR:2
-   </code>
+   <code>Werewolf &lt;tab&gt;
+HD:1-3:DR:5/1 &lt;tab&gt; HD:2-7:CR:2</code>
    .
   </p>
   <p class="indent3">
@@ -1423,34 +1251,22 @@ steps is defined by the Game Mode &gt; Misc Info File &gt;
     When using the step up function (%upNumber) or step down
 function (%downNumber), the minimum and maximum steps are set by
 the
-    <code>
-     MIN
-    </code>
+    <code>MIN</code>
     and
-    <code>
-     MAX
-    </code>
+    <code>MAX</code>
     parameters in the
-    <code>
-     DIESIZES
-    </code>
+    <code>DIESIZES</code>
     tag.
    </li>
    <li>
     The step up function (%Hup) and step down functions (%Hdown)
 will ignore the
-    <code>
-     MIN
-    </code>
+    <code>MIN</code>
     and
-    <code>
-     MAX
-    </code>
+    <code>MAX</code>
     settings and
 use the full range of die sizes specified by the
-    <code>
-     DIESIZES
-    </code>
+    <code>DIESIZES</code>
     tag.
    </li>
    <li>
@@ -1458,9 +1274,7 @@ use the full range of die sizes specified by the
 will never drop below "1".
    </li>
    <li>
-    <code>
-     HITDIE
-    </code>
+    <code>HITDIE</code>
     can be qualified with a Class or Class type
 in which case it will only be applied to the matching classes.
    </li>
@@ -1470,17 +1284,11 @@ in which case it will only be applied to the matching classes.
     </strong>
     When modifying a template, with
 the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     HITDIE
-    </code>
+    <code>HITDIE</code>
     tag, the data included in a new
-    <code>
-     HITDIE
-    </code>
+    <code>HITDIE</code>
     tag will
 overwrite the existing tag data.
    </li>
@@ -1491,67 +1299,51 @@ overwrite the existing tag data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    HITDIE:12
-   </code>
+   <code>HITDIE:12</code>
   </p>
   <p class="indent3">
    The character now has a Hit Die size of 12.
   </p>
   <p class="indent2">
-   <code>
-    HITDIE:%+2
-   </code>
+   <code>HITDIE:%+2</code>
   </p>
   <p class="indent3">
    Adds 2 to the current Hit Die size.
   </p>
   <p class="indent2">
-   <code>
-    HITDIE:%-4
-   </code>
+   <code>HITDIE:%-4</code>
   </p>
   <p class="indent3">
    Subtracts 4 from the current Hit Die size.
   </p>
   <p class="indent2">
-   <code>
-    HITDIE:%*3
-   </code>
+   <code>HITDIE:%*3</code>
   </p>
   <p class="indent3">
    Multiplies the current Hit Die size by 3.
   </p>
   <p class="indent2">
-   <code>
-    HITDIE:%/2
-   </code>
+   <code>HITDIE:%/2</code>
   </p>
   <p class="indent3">
    Divides the current Hit Die size by 2.
   </p>
   <p class="indent2">
-   <code>
-    HITDIE:%up2
-   </code>
+   <code>HITDIE:%up2</code>
   </p>
   <p class="indent3">
    Steps up the Hit Die size by two steps. If the
 creature has a Hit Die of d6 it will be stepped up to d10.
   </p>
   <p class="indent2">
-   <code>
-    HITDIE:%down1
-   </code>
+   <code>HITDIE:%down1</code>
   </p>
   <p class="indent3">
    Steps down the Hit Die size by one step. If the
 creature has a Hit Die of d6 it will be stepped down to d4.
   </p>
   <p class="indent2">
-   <code>
-    HITDIE:%up1|CLASS.TYPE=Monster
-   </code>
+   <code>HITDIE:%up1|CLASS.TYPE=Monster</code>
   </p>
   <p class="indent3">
    Steps up the Hit Die size by one step for any
@@ -1559,28 +1351,22 @@ Monster class levels the creature has. If the creature has a
 Monster class Hit Die of d8 it will be stepped up to d10.
   </p>
   <p class="indent2">
-   <code>
-    HITDIE:%Hup4
-   </code>
+   <code>HITDIE:%Hup4</code>
   </p>
   <p class="indent3">
    Steps up the Hit Die size by four steps. If the
 class has a Hit Die of d6 it will be stepped up to d20.
   </p>
   <p class="indent2">
-   <code>
-    HITDIE:%Hdown3
-   </code>
+   <code>HITDIE:%Hdown3</code>
   </p>
   <p class="indent3">
    Steps down the Hit Die size by three steps. If
 the class has a Hit Die of d6 it will be stepped down to d2.
   </p>
   <p class="indent2">
-   <code>
-    &lt;template name&gt;.MOD &lt;tab&gt;
-HITDIE:8
-   </code>
+   <code>&lt;template name&gt;.MOD &lt;tab&gt;
+HITDIE:8</code>
   </p>
   <p class="indent3">
    The character now has a Hit Die size of 8.
@@ -1592,24 +1378,18 @@ HITDIE:8
   </p>
   <p class="indent2">
    Initial Template:
-   <code>
-    Darkling Sorcerer
-&lt;tab&gt; HITDIE:6
-   </code>
+   <code>Darkling Sorcerer
+&lt;tab&gt; HITDIE:6</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    Darkling Sorcerer.MOD
-&lt;tab&gt; HITDIE:8
-   </code>
+   <code>Darkling Sorcerer.MOD
+&lt;tab&gt; HITDIE:8</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    Darkling Sorcerer
-&lt;tab&gt; HITDIE:8
-   </code>
+   <code>Darkling Sorcerer
+&lt;tab&gt; HITDIE:8</code>
   </p>
   <p class="indent3">
    The Darkling Sorcerer's Hit Die size is now
@@ -1671,17 +1451,11 @@ necessary.
     </strong>
     When modifying a template, with
 the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     LANGBONUS
-    </code>
+    <code>LANGBONUS</code>
     tag, the data included in a new
-    <code>
-     LANGBONUS
-    </code>
+    <code>LANGBONUS</code>
     tag will be
 appended to the existing tag data.
    </li>
@@ -1692,9 +1466,7 @@ appended to the existing tag data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    LANGBONUS:TYPE=Spoken,Draconic
-   </code>
+   <code>LANGBONUS:TYPE=Spoken,Draconic</code>
   </p>
   <p class="indent3">
    Add all "Spoken" type languages &amp; "Draconic"
@@ -1708,24 +1480,18 @@ character.
   </p>
   <p class="indent2">
    Initial Template:
-   <code>
-    Space Monkey &lt;tab&gt;
-LANGBONUS:Simian
-   </code>
+   <code>Space Monkey &lt;tab&gt;
+LANGBONUS:Simian</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    Space Monkey.MOD &lt;tab&gt;
-LANGBONUS:Martian
-   </code>
+   <code>Space Monkey.MOD &lt;tab&gt;
+LANGBONUS:Martian</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    Space Monkey &lt;tab&gt;
-LANGBONUS:Simian,Martian
-   </code>
+   <code>Space Monkey &lt;tab&gt;
+LANGBONUS:Simian,Martian</code>
    .
   </p>
   <p class="indent3">
@@ -1762,18 +1528,12 @@ than/less than 2).
    </li>
    <li>
     .MOD Behavior: When modifying a template, with the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     LEGS
-    </code>
+    <code>LEGS</code>
     tag, the
 data included in a new
-    <code>
-     LEGS
-    </code>
+    <code>LEGS</code>
     tag will overwrite the
 existing tag data.
    </li>
@@ -1784,27 +1544,21 @@ existing tag data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    LEGS:4
-   </code>
+   <code>LEGS:4</code>
   </p>
   <p class="indent3">
    A horse has four legs.
   </p>
   <p class="indent2">
-   <code>
-    LEGS:0
-   </code>
+   <code>LEGS:0</code>
   </p>
   <p class="indent3">
    Slime and ooze creatures/characters would have
 no legs!
   </p>
   <p class="indent2">
-   <code>
-    &lt;template name&gt;.MOD &lt;tab&gt;
-LEGS:8
-   </code>
+   <code>&lt;template name&gt;.MOD &lt;tab&gt;
+LEGS:8</code>
   </p>
   <p class="indent3">
    The creature has eight legs.
@@ -1816,24 +1570,18 @@ LEGS:8
   </p>
   <p class="indent2">
    Initial Template:
-   <code>
-    Odin's Blessing
-&lt;tab&gt; LEGS:8
-   </code>
+   <code>Odin's Blessing
+&lt;tab&gt; LEGS:8</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    Odin's Blessing.MOD
-&lt;tab&gt; LEGS:6
-   </code>
+   <code>Odin's Blessing.MOD
+&lt;tab&gt; LEGS:6</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    Odin's Blessing
-&lt;tab&gt; LEGS:6
-   </code>
+   <code>Odin's Blessing
+&lt;tab&gt; LEGS:6</code>
   </p>
   <p class="indent3">
    The recipient of this template now has "6"
@@ -1896,27 +1644,21 @@ call any global tag.
     <br/>
     <ul>
      <li>
-      <code>
-       ABILITY
-      </code>
+      <code>ABILITY</code>
       -
       <a href="../globalfilestagpages/globalfilesother.html#ability">
        Ability
       </a>
      </li>
      <li>
-      <code>
-       CR
-      </code>
+      <code>CR</code>
       -
       <a href="#cr">
        Challenge Rating
       </a>
      </li>
      <li>
-      <code>
-       DR
-      </code>
+      <code>DR</code>
       -
       <a href="../globalfilestagpages/globalfilesother.html#dr">
        Damage
@@ -1924,27 +1666,21 @@ Reduction
       </a>
      </li>
      <li>
-      <code>
-       FEAT
-      </code>
+      <code>FEAT</code>
       -
       <a href="#feat">
        Feat
       </a>
      </li>
      <li>
-      <code>
-       MOVE
-      </code>
+      <code>MOVE</code>
       -
       <a href="../globalfilestagpages/globalfilesother.html#move">
        Move
       </a>
      </li>
      <li>
-      <code>
-       SAB
-      </code>
+      <code>SAB</code>
       -
       <a href="../globalfilestagpages/globalfilesother.html#sab">
        Special
@@ -1952,9 +1688,7 @@ Ability
       </a>
      </li>
      <li>
-      <code>
-       SR
-      </code>
+      <code>SR</code>
       -
       <a href="../globalfilestagpages/globalfilesother.html#sr">
        Spell
@@ -1980,17 +1714,11 @@ not count against a PC's feat pool.
     </strong>
     When modifying a template with
 the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     LEVEL
-    </code>
+    <code>LEVEL</code>
     tag, the data included in a new
-    <code>
-     LEVEL
-    </code>
+    <code>LEVEL</code>
     tag will be
 included as if it were a separate tag.
    </li>
@@ -2001,69 +1729,53 @@ included as if it were a separate tag.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    LEVEL:1:DR:5/+1
-   </code>
+   <code>LEVEL:1:DR:5/+1</code>
   </p>
   <p class="indent3">
    Grants Damage Reduction of 5/+1 at Level 1.
   </p>
   <p class="indent2">
-   <code>
-    LEVEL:2:SR:15
-   </code>
+   <code>LEVEL:2:SR:15</code>
   </p>
   <p class="indent3">
    Grants Spell Resistance of 15 at Level 2.
   </p>
   <p class="indent2">
-   <code>
-    LEVEL:3:CR:2
-   </code>
+   <code>LEVEL:3:CR:2</code>
   </p>
   <p class="indent3">
    Grants an increase in Challenge Rating of two at
 Level 3.
   </p>
   <p class="indent2">
-   <code>
-    LEVEL:3:MOVE:Burrow,20
-   </code>
+   <code>LEVEL:3:MOVE:Burrow,20</code>
   </p>
   <p class="indent3">
    Grants an a burrowing rate of 20 at Level 3.
   </p>
   <p class="indent2">
-   <code>
-    LEVEL:4:SAB:Uncanny Dodge
-   </code>
+   <code>LEVEL:4:SAB:Uncanny Dodge</code>
   </p>
   <p class="indent3">
    Grants the "Uncanny Dodge" special ability at
 Level 4.
   </p>
   <p class="indent2">
-   <code>
-    LEVEL:5:FEAT:Alertness
-   </code>
+   <code>LEVEL:5:FEAT:Alertness</code>
   </p>
   <p class="indent3">
    Grants the "Alertness" feat at Level 5.
   </p>
   <p class="indent2">
-   <code>
-    LEVEL:6:FEAT:TYPE.Fighter
-   </code>
+   <code>LEVEL:6:FEAT:TYPE.Fighter</code>
   </p>
   <p class="indent3">
    Produces a popup menu at Level 6 from which a PC
 can choose a fighter feat.
   </p>
   <p class="indent2">
-   <code>
-    LEVEL:6:ABILITY:FEAT|AUTOMATIC|Empower
-Spell
-   </code>
+   <code>LEVEL:6:ABILITY:FEAT|AUTOMATIC|Empower
+Spell</code>
   </p>
   <p class="indent3">
    Grants the "Empower Spell" feat as an automatic
@@ -2076,24 +1788,18 @@ feat at Level 6.
   </p>
   <p class="indent2">
    Initial Template:
-   <code>
-    Werewolf &lt;tab&gt;
-LEVEL:1:DR:5/1
-   </code>
+   <code>Werewolf &lt;tab&gt;
+LEVEL:1:DR:5/1</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    Werewolf.MOD &lt;tab&gt;
-LEVEL:2-7:CR:2
-   </code>
+   <code>Werewolf.MOD &lt;tab&gt;
+LEVEL:2-7:CR:2</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    Werewolf &lt;tab&gt;
-HD:1:DR:5/1 &lt;tab&gt; HD:2:CR:2
-   </code>
+   <code>Werewolf &lt;tab&gt;
+HD:1:DR:5/1 &lt;tab&gt; HD:2:CR:2</code>
    .
   </p>
   <p class="indent3">
@@ -2144,17 +1850,11 @@ level adjustments would need to reach 5th level.
     </strong>
     When modifying a template, with
 the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     LEVELADJUSTMENT
-    </code>
+    <code>LEVELADJUSTMENT</code>
     tag, the data included in a new
-    <code>
-     LEVELADJUSTMENT
-    </code>
+    <code>LEVELADJUSTMENT</code>
     tag will overwrite the existing tag
 data.
    </li>
@@ -2165,18 +1865,14 @@ data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    LEVELADJUSTMENT:1
-   </code>
+   <code>LEVELADJUSTMENT:1</code>
   </p>
   <p class="indent3">
    Effective Character Level is raised by one.
   </p>
   <p class="indent2">
-   <code>
-    &lt;template name&gt;.MOD &lt;tab&gt;
-LEVELADJUSTMENT:3
-   </code>
+   <code>&lt;template name&gt;.MOD &lt;tab&gt;
+LEVELADJUSTMENT:3</code>
   </p>
   <p class="indent3">
    The character's ECL is raised by three.
@@ -2188,24 +1884,18 @@ LEVELADJUSTMENT:3
   </p>
   <p class="indent2">
    Initial Template:
-   <code>
-    Darkling &lt;tab&gt;
-LEVELADJUSTMENT:2
-   </code>
+   <code>Darkling &lt;tab&gt;
+LEVELADJUSTMENT:2</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    Darkling.MOD &lt;tab&gt;
-LEVELADJUSTMENT:4
-   </code>
+   <code>Darkling.MOD &lt;tab&gt;
+LEVELADJUSTMENT:4</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    Darkling &lt;tab&gt;
-LEVELADJUSTMENT:4
-   </code>
+   <code>Darkling &lt;tab&gt;
+LEVELADJUSTMENT:4</code>
   </p>
   <p class="indent3">
    The Darkling's Effective Character Level (ECL)
@@ -2248,17 +1938,11 @@ the number specified.
     </strong>
     When modifying a template, with
 the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     NONPP
-    </code>
+    <code>NONPP</code>
     tag, the data included in a new
-    <code>
-     NONPP
-    </code>
+    <code>NONPP</code>
     tag will
 overwrite the existing tag data.
    </li>
@@ -2269,9 +1953,7 @@ overwrite the existing tag data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    NONPP:-2
-   </code>
+   <code>NONPP:-2</code>
   </p>
   <p class="indent3">
    The non-proficiency penalty is minus two.
@@ -2283,24 +1965,18 @@ overwrite the existing tag data.
   </p>
   <p class="indent2">
    Initial Template:
-   <code>
-    &lt;template name&gt;
-&lt;tab&gt; NONPP:-2
-   </code>
+   <code>&lt;template name&gt;
+&lt;tab&gt; NONPP:-2</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;template name&gt;.MOD
-&lt;tab&gt; NONPP:-1
-   </code>
+   <code>&lt;template name&gt;.MOD
+&lt;tab&gt; NONPP:-1</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;template name&gt;
-&lt;tab&gt; NONPP:-1
-   </code>
+   <code>&lt;template name&gt;
+&lt;tab&gt; NONPP:-1</code>
    .
   </p>
   <p class="indent3">
@@ -2356,17 +2032,11 @@ as well as Humaniod subraces such as Elf, Orc, Dwarf, etc..
    </li>
    <li>
     .MOD Behavior: When modifying a template, with the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     RACESUBTYPE
-    </code>
+    <code>RACESUBTYPE</code>
     tag, the data included in a new
-    <code>
-     RACESUBTYPE
-    </code>
+    <code>RACESUBTYPE</code>
     tag will
 be appended to the existing tag data.
    </li>
@@ -2377,25 +2047,19 @@ be appended to the existing tag data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    RACESUBTYPE:Lawful|Air
-   </code>
+   <code>RACESUBTYPE:Lawful|Air</code>
   </p>
   <p class="indent3">
    Adds the "Lawful" and "Air" subtypes.
   </p>
   <p class="indent2">
-   <code>
-    RACESUBTYPE:.REMOVE.Evil
-   </code>
+   <code>RACESUBTYPE:.REMOVE.Evil</code>
   </p>
   <p class="indent3">
    Removes the "Evil" subtype.
   </p>
   <p class="indent2">
-   <code>
-    RACESUBTYPE:.REMOVE.Extraplanar|Native
-   </code>
+   <code>RACESUBTYPE:.REMOVE.Extraplanar|Native</code>
   </p>
   <p class="indent3">
    Removes the "Extraplanar" subtype and adds
@@ -2408,24 +2072,18 @@ be appended to the existing tag data.
   </p>
   <p class="indent2">
    Initial Template:
-   <code>
-    Ooze Monkey &lt;tab&gt;
-RACESUBTYPE:Simian
-   </code>
+   <code>Ooze Monkey &lt;tab&gt;
+RACESUBTYPE:Simian</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    Ooze Monkey.MOD &lt;tab&gt;
-RACESUBTYPE:Gooey
-   </code>
+   <code>Ooze Monkey.MOD &lt;tab&gt;
+RACESUBTYPE:Gooey</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    Ooze Monkey &lt;tab&gt;
-RACESUBTYPE:Simian|Gooey
-   </code>
+   <code>Ooze Monkey &lt;tab&gt;
+RACESUBTYPE:Simian|Gooey</code>
    .
   </p>
   <p class="indent3">
@@ -2484,17 +2142,11 @@ Plant, Shapechanger, Undead, and Vermin
     </strong>
     When modifying a template, with
 the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     RACETYPE
-    </code>
+    <code>RACETYPE</code>
     tag, the data included in a new
-    <code>
-     RACETYPE
-    </code>
+    <code>RACETYPE</code>
     tag will
 overwrite the existing tag data.
    </li>
@@ -2505,9 +2157,7 @@ overwrite the existing tag data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    RACETYPE:Undead
-   </code>
+   <code>RACETYPE:Undead</code>
   </p>
   <p class="indent3">
    The creature is now of the "Undead" type.
@@ -2519,24 +2169,18 @@ overwrite the existing tag data.
   </p>
   <p class="indent2">
    Initial Template:
-   <code>
-    &lt;template name&gt;
-&lt;tab&gt; RACETYPE:Undead
-   </code>
+   <code>&lt;template name&gt;
+&lt;tab&gt; RACETYPE:Undead</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;template name&gt;.MOD
-&lt;tab&gt; RACETYPE:Outsider
-   </code>
+   <code>&lt;template name&gt;.MOD
+&lt;tab&gt; RACETYPE:Outsider</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;template name&gt;
-&lt;tab&gt; RACETYPE:Outsider
-   </code>
+   <code>&lt;template name&gt;
+&lt;tab&gt; RACETYPE:Outsider</code>
    .
   </p>
   <p class="indent3">
@@ -2575,17 +2219,11 @@ Name:
     </strong>
     When modifying a template, with
 the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     REACH
-    </code>
+    <code>REACH</code>
     tag, the data included in a new
-    <code>
-     REACH
-    </code>
+    <code>REACH</code>
     tag will
 overwrite the existing tag data.
    </li>
@@ -2596,9 +2234,7 @@ overwrite the existing tag data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    REACH:10
-   </code>
+   <code>REACH:10</code>
   </p>
   <p class="indent3">
    The creature has a reach of ten (10) feet.
@@ -2610,24 +2246,18 @@ overwrite the existing tag data.
   </p>
   <p class="indent2">
    Initial Template:
-   <code>
-    &lt;template name&gt;
-&lt;tab&gt; REACH:10
-   </code>
+   <code>&lt;template name&gt;
+&lt;tab&gt; REACH:10</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;template name&gt;.MOD
-&lt;tab&gt; REACH:20
-   </code>
+   <code>&lt;template name&gt;.MOD
+&lt;tab&gt; REACH:20</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;template name&gt;
-&lt;tab&gt; REACH:20
-   </code>
+   <code>&lt;template name&gt;
+&lt;tab&gt; REACH:20</code>
    .
   </p>
   <p class="indent3">
@@ -2674,17 +2304,11 @@ default is none.
     </strong>
     When modifying a template, with
 the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     REGION
-    </code>
+    <code>REGION</code>
     tag, the data included in a new
-    <code>
-     REGION
-    </code>
+    <code>REGION</code>
     tag will
 overwrite the existing tag data.
    </li>
@@ -2695,9 +2319,7 @@ overwrite the existing tag data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    REGION:Timbuktu
-   </code>
+   <code>REGION:Timbuktu</code>
   </p>
   <p class="indent3">
    The character is from "Timbuktu".
@@ -2709,24 +2331,18 @@ overwrite the existing tag data.
   </p>
   <p class="indent2">
    Initial Template:
-   <code>
-    &lt;template name&gt;
-&lt;tab&gt; REGION:Timbuktu
-   </code>
+   <code>&lt;template name&gt;
+&lt;tab&gt; REGION:Timbuktu</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;template name&gt;.MOD
-&lt;tab&gt; REGION:Saskatewan
-   </code>
+   <code>&lt;template name&gt;.MOD
+&lt;tab&gt; REGION:Saskatewan</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;template name&gt;
-&lt;tab&gt; REGION:Saskatewan
-   </code>
+   <code>&lt;template name&gt;
+&lt;tab&gt; REGION:Saskatewan</code>
    .
   </p>
   <p class="indent3">
@@ -2772,17 +2388,11 @@ is chosen.
     </strong>
     When modifying a template, with
 the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     REMOVABLE
-    </code>
+    <code>REMOVABLE</code>
     tag, the data included in a new
-    <code>
-     REMOVABLE
-    </code>
+    <code>REMOVABLE</code>
     tag will
 overwrite the existing tag data.
    </li>
@@ -2793,18 +2403,14 @@ overwrite the existing tag data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    REMOVABLE:NO
-   </code>
+   <code>REMOVABLE:NO</code>
   </p>
   <p class="indent3">
    The template may not be removed if taken.
   </p>
   <p class="indent2">
-   <code>
-    &lt;template name&gt;.MOD &lt;tab&gt;
-REMOVABLE:YES
-   </code>
+   <code>&lt;template name&gt;.MOD &lt;tab&gt;
+REMOVABLE:YES</code>
   </p>
   <p class="indent3">
    The template may be removed after being
@@ -2817,24 +2423,18 @@ taken.
   </p>
   <p class="indent2">
    Initial Template:
-   <code>
-    &lt;template name&gt;
-&lt;tab&gt; REMOVABLE:NO
-   </code>
+   <code>&lt;template name&gt;
+&lt;tab&gt; REMOVABLE:NO</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;template name&gt;.MOD
-&lt;tab&gt; REMOVABLE:YES
-   </code>
+   <code>&lt;template name&gt;.MOD
+&lt;tab&gt; REMOVABLE:YES</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;template name&gt;
-&lt;tab&gt; REMOVABLE:YES
-   </code>
+   <code>&lt;template name&gt;
+&lt;tab&gt; REMOVABLE:YES</code>
   </p>
   <p class="indent3">
    The template is removable.
@@ -2920,25 +2520,15 @@ REPEATELEVEL tag.
    </li>
    <li>
     Valid tags to be used as part o the REPEATELEVEL tag are:
-    <code>
-     SR
-    </code>
+    <code>SR</code>
     ,
-    <code>
-     SAB
-    </code>
+    <code>SAB</code>
     ,
-    <code>
-     DR
-    </code>
+    <code>DR</code>
     ,
-    <code>
-     CR
-    </code>
+    <code>CR</code>
     , and
-    <code>
-     FEAT
-    </code>
+    <code>FEAT</code>
     , each with its own suntax
 and parameter requirements.
    </li>
@@ -2948,17 +2538,11 @@ and parameter requirements.
     </strong>
     When modifying a template, with
 the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     REPEATLEVEL
-    </code>
+    <code>REPEATLEVEL</code>
     tag, the data included in a new
-    <code>
-     REPEATLEVEL
-    </code>
+    <code>REPEATLEVEL</code>
     tag will be included as if it were a
 separate tag.
    </li>
@@ -2969,42 +2553,34 @@ separate tag.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    &lt;Template Name&gt; &lt;tab&gt;
-REPEATLEVEL:5|4|20:1:FEAT(ABonusFeat)
-   </code>
+   <code>&lt;Template Name&gt; &lt;tab&gt;
+REPEATLEVEL:5|4|20:1:FEAT(ABonusFeat)</code>
   </p>
   <p class="indent3">
    Would add "ABonusFeat" at levels 5, 10, 15, and
 20.
   </p>
   <p class="indent2">
-   <code>
-    &lt;Template Name&gt; &lt;tab&gt;
-REPEATLEVEL:1|0|20:1:FEAT(ABonusFeat)
-   </code>
+   <code>&lt;Template Name&gt; &lt;tab&gt;
+REPEATLEVEL:1|0|20:1:FEAT(ABonusFeat)</code>
   </p>
   <p class="indent3">
    Would add "ABonusFeat" at levels 1, 2, 3, 5, 6,
 7, 9, 10, 11, 13, 14, 15, 17, 18, and 19.
   </p>
   <p class="indent2">
-   <code>
-    &lt;Template Name&gt; &lt;tab&gt;
-REPEATLEVEL:2|1|20:2:FEAT(ABonusFeat)
-   </code>
+   <code>&lt;Template Name&gt; &lt;tab&gt;
+REPEATLEVEL:2|1|20:2:FEAT(ABonusFeat)</code>
   </p>
   <p class="indent3">
    Would add "ABonusFeat" at levels 2, 4, 6, 8,...
 up to level 20.
   </p>
   <p class="indent2">
-   <code>
-    Drow Male &lt;tab&gt;
+   <code>Drow Male &lt;tab&gt;
 REPEATLEVEL:1|0|10:1:FEAT(AWizardFeat) &lt;tab&gt; PRERACE:Elf
 (Drow) &lt;tab&gt; SUBRACE:Male &lt;tab&gt;
-GENDERLOCK:Male
-   </code>
+GENDERLOCK:Male</code>
   </p>
   <p class="indent3">
    Would add "AWizardFeat" at levels 1, 2, 3, 5, 6,
@@ -3017,26 +2593,20 @@ GENDERLOCK:Male
   </p>
   <p class="indent2">
    Initial Template:
-   <code>
-    Advanced Werewolf
-&lt;tab&gt; REPEATLEVEL:5|4|20:1:FEAT(ABonusFeat)
-   </code>
+   <code>Advanced Werewolf
+&lt;tab&gt; REPEATLEVEL:5|4|20:1:FEAT(ABonusFeat)</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    Advanced Werewolf.MOD
-&lt;tab&gt; REPEATLEVEL:2|1|20:2:FEAT(ABonusFeat)
-   </code>
+   <code>Advanced Werewolf.MOD
+&lt;tab&gt; REPEATLEVEL:2|1|20:2:FEAT(ABonusFeat)</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    Advanced Werewolf
+   <code>Advanced Werewolf
 &lt;tab&gt; REPEATLEVEL:5|4|20:1:FEAT(ABonusFeat)
     <br/>
-    &lt;tab&gt; REPEATLEVEL:2|1|20:2:FEAT(ABonusFeat)
-   </code>
+    &lt;tab&gt; REPEATLEVEL:2|1|20:2:FEAT(ABonusFeat)</code>
    .
   </p>
   <p class="indent3">
@@ -3100,18 +2670,12 @@ undefined.
     </strong>
     When modifying a template, with
 the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     SIZE
-    </code>
+    <code>SIZE</code>
     tag,
 the data included in a new
-    <code>
-     SIZE
-    </code>
+    <code>SIZE</code>
     tag will overwrite the
 existing tag data.
    </li>
@@ -3122,17 +2686,13 @@ existing tag data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SIZE:M
-   </code>
+   <code>SIZE:M</code>
   </p>
   <p class="indent3">
    The character is "Medium" size.
   </p>
   <p class="indent2">
-   <code>
-    SIZE:max(AnimalSize,SIZE)
-   </code>
+   <code>SIZE:max(AnimalSize,SIZE)</code>
   </p>
   <p class="indent3">
    Sets the character's size to the maximum of the
@@ -3145,24 +2705,18 @@ variable "AnimalSize" and current size.
   </p>
   <p class="indent2">
    Initial Template:
-   <code>
-    &lt;template name&gt;
-&lt;tab&gt; SIZE:M
-   </code>
+   <code>&lt;template name&gt;
+&lt;tab&gt; SIZE:M</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    &lt;template name&gt;.MOD
-&lt;tab&gt; SIZE:L
-   </code>
+   <code>&lt;template name&gt;.MOD
+&lt;tab&gt; SIZE:L</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    &lt;template name&gt;
-&lt;tab&gt; SIZE:L
-   </code>
+   <code>&lt;template name&gt;
+&lt;tab&gt; SIZE:L</code>
   </p>
   <p class="indent3">
    The creatue is "Large".
@@ -3206,9 +2760,7 @@ template in parenthesis after the race on character sheet
 output.
    </li>
    <li>
-    <code>
-     SUBRACE
-    </code>
+    <code>SUBRACE</code>
     should only be used once in a template
 line.
    </li>
@@ -3218,17 +2770,11 @@ line.
     </strong>
     When modifying a template, with
 the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     SUBRACE
-    </code>
+    <code>SUBRACE</code>
     tag, the data included in a new
-    <code>
-     SUBRACE
-    </code>
+    <code>SUBRACE</code>
     tag will
 overwrite the existing tag data.
    </li>
@@ -3239,9 +2785,7 @@ overwrite the existing tag data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SUBRACE:Ooze Monkey
-   </code>
+   <code>SUBRACE:Ooze Monkey</code>
   </p>
   <p class="indent3">
    The character is part of the "Monkey Ooze" sub
@@ -3254,24 +2798,18 @@ race.
   </p>
   <p class="indent2">
    Initial Template:
-   <code>
-    Ooze Monkey &lt;tab&gt;
-SUBRACE:Ooze Monkey
-   </code>
+   <code>Ooze Monkey &lt;tab&gt;
+SUBRACE:Ooze Monkey</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    Ooze Monkey.MOD &lt;tab&gt;
-SUBRACE:Tropical
-   </code>
+   <code>Ooze Monkey.MOD &lt;tab&gt;
+SUBRACE:Tropical</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    Ooze Monkey &lt;tab&gt;
-SUBRACE:Tropical
-   </code>
+   <code>Ooze Monkey &lt;tab&gt;
+SUBRACE:Tropical</code>
    .
   </p>
   <p class="indent3">
@@ -3322,17 +2860,11 @@ output.
     </strong>
     When modifying a template, with
 the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     SUBREGION
-    </code>
+    <code>SUBREGION</code>
     tag, the data included in a new
-    <code>
-     SUBREGION
-    </code>
+    <code>SUBREGION</code>
     tag will
 overwrite the existing tag data.
    </li>
@@ -3343,9 +2875,7 @@ overwrite the existing tag data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SUBREGION:South Side
-   </code>
+   <code>SUBREGION:South Side</code>
   </p>
   <p class="indent3">
    The character is from the "South Side"
@@ -3358,24 +2888,18 @@ subregion.
   </p>
   <p class="indent2">
    Initial Template:
-   <code>
-    South Philly &lt;tab&gt;
-SUBREGION:South Side
-   </code>
+   <code>South Philly &lt;tab&gt;
+SUBREGION:South Side</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    South Philly.MOD &lt;tab&gt;
-SUBREGION:Philadelphia
-   </code>
+   <code>South Philly.MOD &lt;tab&gt;
+SUBREGION:Philadelphia</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    South Philly &lt;tab&gt;
-SUBREGION:Philadelphia
-   </code>
+   <code>South Philly &lt;tab&gt;
+SUBREGION:Philadelphia</code>
    .
   </p>
   <p class="indent3">
@@ -3420,13 +2944,9 @@ to the character.
    </li>
    <li>
     Supports
-    <code>
-     %LIST
-    </code>
+    <code>%LIST</code>
     in conjunction with a
-    <code>
-     CHOOSE
-    </code>
+    <code>CHOOSE</code>
     tag.
    </li>
   </ul>
@@ -3436,9 +2956,7 @@ to the character.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TEMPLATE:Incorporeal|Undead|Celestial
-   </code>
+   <code>TEMPLATE:Incorporeal|Undead|Celestial</code>
   </p>
   <p class="indent3">
    The character is given the "Incorporeal",
@@ -3479,9 +2997,7 @@ to the character.
    <li>
     This is a pipe-delimited list of template choices that are
 added to the list presented by the original
-    <code>
-     TEMPLATE:CHOOSE
-    </code>
+    <code>TEMPLATE:CHOOSE</code>
     tag.
    </li>
    <li>
@@ -3489,21 +3005,13 @@ added to the list presented by the original
      .MOD Behavior:
     </strong>
     When using the
-    <code>
-     TEMPLATE:ADDCOICE
-    </code>
+    <code>TEMPLATE:ADDCOICE</code>
     tag as part of a
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     of a Template object that containes multiple
-    <code>
-     TEMPLATE:CHOOSE
-    </code>
+    <code>TEMPLATE:CHOOSE</code>
     tags, all instances of the
-    <code>
-     TEMPLATE:CHOOSE
-    </code>
+    <code>TEMPLATE:CHOOSE</code>
     tag will be modified.
    </li>
   </ul>
@@ -3513,9 +3021,7 @@ added to the list presented by the original
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TEMPLATE:ADDCHOICE:Demihuman|Beast
-   </code>
+   <code>TEMPLATE:ADDCHOICE:Demihuman|Beast</code>
   </p>
   <p class="indent3">
    The character has "Demihuman" and "Beast" added
@@ -3560,18 +3066,14 @@ list.
    </li>
    <li>
     Multiple
-    <code>
-     TEMPLATE:CHOOSE
-    </code>
+    <code>TEMPLATE:CHOOSE</code>
     tags can be used in the
 same LST object but PCGen's current Data Standard is to include no
 more that one in each LST object.
    </li>
    <li>
     Though the
-    <code>
-     TEMPLATE:CHOOSE
-    </code>
+    <code>TEMPLATE:CHOOSE</code>
     tag is not a gobal tag
 it can be used in the
     <a href="datafilesability.html#templatechoose">
@@ -3594,9 +3096,7 @@ it can be used in the
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TEMPLATE:CHOOSE:Celestial|Outsider
-   </code>
+   <code>TEMPLATE:CHOOSE:Celestial|Outsider</code>
   </p>
   <p class="indent3">
    The character is given the choice between
@@ -3644,30 +3144,22 @@ Name:
   </p>
   <ul class="indent2">
    <li>
-    <code>
-     YES
-    </code>
+    <code>YES</code>
     - Shows the Template name in PCGen and on
 export to a character sheet
    </li>
    <li>
-    <code>
-     NO
-    </code>
+    <code>NO</code>
     - Hides the Template name in PCGen and on
 export to a character sheet.
    </li>
    <li>
-    <code>
-     DISPLAY
-    </code>
+    <code>DISPLAY</code>
     - Displays the Template name in PCGen but
 not on the character sheet.
    </li>
    <li>
-    <code>
-     EXPORT
-    </code>
+    <code>EXPORT</code>
     - Hides the Template name from PCGen but
 displays it on the character sheet.
    </li>
@@ -3677,17 +3169,11 @@ displays it on the character sheet.
     </strong>
     When modifying a template, with
 the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     VISIBLE
-    </code>
+    <code>VISIBLE</code>
     tag, the data included in a new
-    <code>
-     VISIBLE
-    </code>
+    <code>VISIBLE</code>
     tag will
 overwrite the existing tag data.
    </li>
@@ -3698,19 +3184,15 @@ overwrite the existing tag data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    VISIBLE:YES
-   </code>
+   <code>VISIBLE:YES</code>
   </p>
   <p class="indent3">
    Shows the Template name in PCGen and on export
 to a character sheet.
   </p>
   <p class="indent2">
-   <code>
-    &lt;template name&gt;.MOD &lt;tab&gt;
-VISIBLE:NO
-   </code>
+   <code>&lt;template name&gt;.MOD &lt;tab&gt;
+VISIBLE:NO</code>
   </p>
   <p class="indent3">
    The template will not be visible either in the
@@ -3723,24 +3205,18 @@ GUI or on the character sheet..
   </p>
   <p class="indent2">
    Initial Template:
-   <code>
-    South Philly &lt;tab&gt;
-VISIBLE:YES
-   </code>
+   <code>South Philly &lt;tab&gt;
+VISIBLE:YES</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    South Philly.MOD &lt;tab&gt;
-VISIBLE:NO
-   </code>
+   <code>South Philly.MOD &lt;tab&gt;
+VISIBLE:NO</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    South Philly &lt;tab&gt;
-VISIBLE:NO
-   </code>
+   <code>South Philly &lt;tab&gt;
+VISIBLE:NO</code>
    .
   </p>
   <p class="indent3">
@@ -3790,17 +3266,11 @@ weapons.
     </strong>
     When modifying a template, with
 the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     WEAPONBONUS
-    </code>
+    <code>WEAPONBONUS</code>
     tag, the data included in a new
-    <code>
-     WEAPONBONUS
-    </code>
+    <code>WEAPONBONUS</code>
     tag will be appended to the existing tag
 data.
    </li>
@@ -3811,18 +3281,14 @@ data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    WEAPONBONUS:Rapier|Longbow
-   </code>
+   <code>WEAPONBONUS:Rapier|Longbow</code>
   </p>
   <p class="indent3">
    The race receives bonus proficiency in "Rapier"
 or "Longbow".
   </p>
   <p class="indent2">
-   <code>
-    WEAPONBONUS:TYPE.Simple
-   </code>
+   <code>WEAPONBONUS:TYPE.Simple</code>
   </p>
   <p class="indent3">
    The race receives bonus proficiency in any one
@@ -3835,24 +3301,18 @@ Simple weapon.
   </p>
   <p class="indent2">
    Initial Template:
-   <code>
-    Grunt &lt;tab&gt;
-WEAPONBONUS:TYPE.Simple
-   </code>
+   <code>Grunt &lt;tab&gt;
+WEAPONBONUS:TYPE.Simple</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    Grunt.MOD &lt;tab&gt;
-WEAPONBONUS:TYPE.Martial
-   </code>
+   <code>Grunt.MOD &lt;tab&gt;
+WEAPONBONUS:TYPE.Martial</code>
   </p>
   <p class="indent2">
    Is Equivalent To:
-   <code>
-    Grunt &lt;tab&gt;
-WEAPONBONUS:TYPE.Simple|TYPE.Martial
-   </code>
+   <code>Grunt &lt;tab&gt;
+WEAPONBONUS:TYPE.Simple|TYPE.Martial</code>
    .
   </p>
   <p class="indent3">

--- a/docs/listfilepages/datafilestagpages/datafilesweaponproficiencies.html
+++ b/docs/listfilepages/datafilestagpages/datafilesweaponproficiencies.html
@@ -65,9 +65,7 @@ no tag for it, just the name of the weapon proficiency.
 weapon. Defaults to a value of 1.
    </li>
    <li>
-    <code>
-     #IFLARGERTHANWEAPON
-    </code>
+    <code>#IFLARGERTHANWEAPON</code>
     is a flag that checks if the
 characters size is larger than the weapon.
     <ul>
@@ -85,18 +83,12 @@ both hands.
    </li>
    <li>
     When modifying a weapon proficiency with the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag, given an existing
-    <code>
-     HANDS
-    </code>
+    <code>HANDS</code>
     tag, the data included in
 a new
-    <code>
-     HANDS
-    </code>
+    <code>HANDS</code>
     tag will overwrite the existing tag
 data.
    </li>
@@ -107,17 +99,13 @@ data.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    HANDS:2
-   </code>
+   <code>HANDS:2</code>
   </p>
   <p class="indent3">
    Weapon is wielded with two hands.
   </p>
   <p class="indent2">
-   <code>
-    HANDS:1IFLARGERTHANWEAPON
-   </code>
+   <code>HANDS:1IFLARGERTHANWEAPON</code>
   </p>
   <p class="indent3">
    Weapon is wielded with one hand if the PC is
@@ -130,24 +118,18 @@ larger than the weapon size.
   </p>
   <p class="indent2">
    Initial Template:
-   <code>
-    Ogre Axe &lt;tab&gt;
-HANDS:1
-   </code>
+   <code>Ogre Axe &lt;tab&gt;
+HANDS:1</code>
   </p>
   <p class="indent2">
    Modified By:
-   <code>
-    Ogre Axe.MOD &lt;tab&gt;
-HANDS:2
-   </code>
+   <code>Ogre Axe.MOD &lt;tab&gt;
+HANDS:2</code>
   </p>
   <p class="indent2">
    Results In:
-   <code>
-    Ogre Axe &lt;tab&gt;
-HANDS:2
-   </code>
+   <code>Ogre Axe &lt;tab&gt;
+HANDS:2</code>
   </p>
   <p class="indent3">
    Weapon is wielded with two hands.

--- a/docs/listfilepages/globalfilestagpages/globalfilesadd.html
+++ b/docs/listfilepages/globalfilestagpages/globalfilesadd.html
@@ -43,9 +43,7 @@
     be used with at
 least one valid choice (like the CHOOSE tag) or it will not
 function, i.e. If
-    <code>
-     ADD:FEAT|TYPE=Foo
-    </code>
+    <code>ADD:FEAT|TYPE=Foo</code>
     and the character
 does not qualify for any TYPE=Foo feat, there will be no pop-up or
 choice.
@@ -113,43 +111,31 @@ not be supported in the future.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ADD:.CLEAR.LEVEL2
-   </code>
+   <code>ADD:.CLEAR.LEVEL2</code>
   </p>
   <p class="indent3">
    If this were used in a CLASS:Rogue.MOD line it
 would clear the
-   <code>
-    ADD:FEAT(Evasion, Improved Evasion)
-   </code>
+   <code>ADD:FEAT(Evasion, Improved Evasion)</code>
    tag normally found there and allow you to add a new one, perhaps:
-   <code>
-    ADD:FEAT (Evasion,Improved Evasion,Shadow)
-   </code>
+   <code>ADD:FEAT (Evasion,Improved Evasion,Shadow)</code>
    .
   </p>
   <p class="indent2">
-   <code>
-    ADD:.CLEAR
-   </code>
+   <code>ADD:.CLEAR</code>
   </p>
   <p class="indent3">
    If this were used in a Zombie.MOD line it would
 clear the
-   <code>
-    ADD:FEAT (TYPE=SlamWeapons)
-   </code>
+   <code>ADD:FEAT (TYPE=SlamWeapons)</code>
    tag normally
 found in that template.
   </p>
   <p class="indent2">
-   <code>
-    CLASS:Gunslinger.MOD &lt;tab&gt;
+   <code>CLASS:Gunslinger.MOD &lt;tab&gt;
 ADD:.CLEAR.LEVEL2 &lt;tab&gt; ADD:.CLEAR.LEVEL3 &lt;tab&gt;
 ADD:.CLEAR.LEVEL6 &lt;tab&gt; ADD:.CLEAR.LEVEL8 &lt;tab&gt;
-ADD:.CLEAR.LEVEL9
-   </code>
+ADD:.CLEAR.LEVEL9</code>
   </p>
   <p class="indent3">
    This modification of the Gunslinger Class
@@ -224,13 +210,9 @@ names and/or types.
    </li>
    <li>
     Valid ability natures are
-    <code>
-     NORMAL
-    </code>
+    <code>NORMAL</code>
     or
-    <code>
-     VIRTUAL
-    </code>
+    <code>VIRTUAL</code>
     .
    </li>
    <!--
@@ -239,14 +221,10 @@ names and/or types.
 -->
    <li>
     If the ability being added has a chooser
-    <code>
-     ADD:ABILITY
-    </code>
+    <code>ADD:ABILITY</code>
     is the only tag which will activate it
 (
-    <code>
-     ABILITY
-    </code>
+    <code>ABILITY</code>
     alone will not).
    </li>
   </ul>
@@ -256,19 +234,15 @@ names and/or types.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ADD:ABILITY|2|FEAT|NORMAL|Alertness,TYPE=Fighter,Electric
-Boogalo
-   </code>
+   <code>ADD:ABILITY|2|FEAT|NORMAL|Alertness,TYPE=Fighter,Electric
+Boogalo</code>
   </p>
   <p class="indent3">
    Add two feats from "Alertness", any "Fighter"
 type feats or "Electric Boogalo".
   </p>
   <p class="indent2">
-   <code>
-    ADD:ABILITY|FEAT|VIRTUAL|TYPE=General,TYPE=Metamagic,TYPE=ItemCreation
-   </code>
+   <code>ADD:ABILITY|FEAT|VIRTUAL|TYPE=General,TYPE=Metamagic,TYPE=ItemCreation</code>
   </p>
   <p class="indent3">
    Add one virtual feat from "General", any
@@ -331,47 +305,37 @@ assumed.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ADD:EQUIP|1|Torch,Lantern
-   </code>
+   <code>ADD:EQUIP|1|Torch,Lantern</code>
   </p>
   <p class="indent3">
    Add one of either a "Torch" or a "Lantern" to
 the character.
   </p>
   <p class="indent2">
-   <code>
-    ADD:EQUIP|Blastpowder (10)
-   </code>
+   <code>ADD:EQUIP|Blastpowder (10)</code>
   </p>
   <p class="indent3">
    Add one of "Blastpowder (10)" to the
 character.
   </p>
   <p class="indent2">
-   <code>
-    ADD:EQUIP|2|Synchronicity Watch,Secret
-Pockets,Daylight Flares
-   </code>
+   <code>ADD:EQUIP|2|Synchronicity Watch,Secret
+Pockets,Daylight Flares</code>
   </p>
   <p class="indent3">
    Add two of "Synchronicity Watch", "Secret
 Pockets" or "Daylight Flares" to the character.
   </p>
   <p class="indent2">
-   <code>
-    ADD:EQUIP|Dagger (Sarishan
-Steel)
-   </code>
+   <code>ADD:EQUIP|Dagger (Sarishan
+Steel)</code>
   </p>
   <p class="indent3">
    Add one of "Sarishan Steel Dagger" to the
 character.
   </p>
   <p class="indent2">
-   <code>
-    ADD:EQUIP|TYPE=Thrown
-   </code>
+   <code>ADD:EQUIP|TYPE=Thrown</code>
   </p>
   <p class="indent3">
    Add one piece of equipment of type "Thrown" to
@@ -448,13 +412,9 @@ tag.
 -->
    <li>
     If the feat being added has a chooser,
-    <code>
-     ADD:FEAT
-    </code>
+    <code>ADD:FEAT</code>
     will activate it. (
-    <code>
-     FEAT
-    </code>
+    <code>FEAT</code>
     alone will not.)
    </li>
   </ul>
@@ -464,19 +424,15 @@ tag.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ADD:FEAT|2|Alertness,TYPE=Fighter,Electric
-Boogalo
-   </code>
+   <code>ADD:FEAT|2|Alertness,TYPE=Fighter,Electric
+Boogalo</code>
   </p>
   <p class="indent3">
    Add two feats from a list of feats consisting of
 "Alertness", any "Fighter" type feats and "Electric Boogalo".
   </p>
   <p class="indent2">
-   <code>
-    ADD:FEAT|TYPE=General,TYPE=Metamagic,TYPE=ItemCreation
-   </code>
+   <code>ADD:FEAT|TYPE=General,TYPE=Metamagic,TYPE=ItemCreation</code>
   </p>
   <p class="indent3">
    Add one feat from the list of feats consisting
@@ -484,17 +440,13 @@ of "General", any "Metamagic", or any "ItemCreation" type
 feats.
   </p>
   <p class="indent2">
-   <code>
-    ADD:FEAT|2|ALL
-   </code>
+   <code>ADD:FEAT|2|ALL</code>
   </p>
   <p class="indent3">
    Add two feats from all feats available.
   </p>
   <p class="indent2">
-   <code>
-    ADD:FEAT|Skill Focus(Craft%)
-   </code>
+   <code>ADD:FEAT|Skill Focus(Craft%)</code>
   </p>
   <p class="indent3">
    Add the skill focus feat and choose only from
@@ -563,36 +515,28 @@ character can choose from.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ADD:LANGUAGE|Draconic,Elven,Undercommon
-   </code>
+   <code>ADD:LANGUAGE|Draconic,Elven,Undercommon</code>
   </p>
   <p class="indent3">
    Add "Draconic", "Elven" or "Undercommon" to the
 list of languages known.
   </p>
   <p class="indent2">
-   <code>
-    ADD:LANGUAGE|2|TYPE=Spoken
-   </code>
+   <code>ADD:LANGUAGE|2|TYPE=Spoken</code>
   </p>
   <p class="indent3">
    Adds two of any spoken type languages to the
 list of languages known.
   </p>
   <p class="indent2">
-   <code>
-    ADD:LANGUAGE|2|TYPE=Imperial,TYPE=Infernal
-   </code>
+   <code>ADD:LANGUAGE|2|TYPE=Imperial,TYPE=Infernal</code>
   </p>
   <p class="indent3">
    Adds two of any Imperial or Infernal type
 languages to the list of languages known.
   </p>
   <p class="indent2">
-   <code>
-    ADD:LANGUAGE|2|ALL
-   </code>
+   <code>ADD:LANGUAGE|2|ALL</code>
   </p>
   <p class="indent3">
    Adds two of any language to the list of
@@ -659,20 +603,16 @@ one to the limit of count (y) from the items listed (z).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ADD:SAB|Brick Wall|3|Damage
+   <code>ADD:SAB|Brick Wall|3|Damage
 Reduction,Concussion Resistance,Remain Concious, Melee
-Smash,Extreme Effort
-   </code>
+Smash,Extreme Effort</code>
   </p>
   <p class="indent3">
    Add three of special abilities listed.
   </p>
   <p class="indent2">
-   <code>
-    ADD:SAB|Shadow Slayer|1|Detect
-Shadow,Shadow Immunity
-   </code>
+   <code>ADD:SAB|Shadow Slayer|1|Detect
+Shadow,Shadow Immunity</code>
   </p>
   <p class="indent3">
    Add one of the two special abilities.
@@ -736,27 +676,21 @@ skills.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ADD:SKILL|1|Read/Write Language
-   </code>
+   <code>ADD:SKILL|1|Read/Write Language</code>
   </p>
   <p class="indent3">
    Add one of either a "Read/Write Language".
   </p>
   <p class="indent2">
-   <code>
-    ADD:SKILL|5|Balance,Craft
-(Structural),Demolitions
-   </code>
+   <code>ADD:SKILL|5|Balance,Craft
+(Structural),Demolitions</code>
   </p>
   <p class="indent3">
    Add five skill levels of "Balance" or "Craft
 (Structural)" or "Demolitions".
   </p>
   <p class="indent2">
-   <code>
-    ADD:SKILL|2|Speak Language
-   </code>
+   <code>ADD:SKILL|2|Speak Language</code>
   </p>
   <p class="indent3">
    Add two of "Speak Language".
@@ -856,36 +790,28 @@ in order to select them.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ADD:SPELLCASTER|ANY
-   </code>
+   <code>ADD:SPELLCASTER|ANY</code>
   </p>
   <p class="indent3">
    Adds a bonus level of spellcasting to any
 spellcasting class the character has levels in.
   </p>
   <p class="indent2">
-   <code>
-    ADD:SPELLCASTER|Divine
-   </code>
+   <code>ADD:SPELLCASTER|Divine</code>
   </p>
   <p class="indent3">
    Adds a bonus level of spellcasting to any Divine
 spellcasting class the character has levels in.
   </p>
   <p class="indent2">
-   <code>
-    ADD:SPELLCASTER|Arcane
-   </code>
+   <code>ADD:SPELLCASTER|Arcane</code>
   </p>
   <p class="indent3">
    Adds a bonus level of spellcasting to any Arcane
 spellcasting class the character has levels in.
   </p>
   <p class="indent2">
-   <code>
-    ADD:SPELLCASTER|Bard,Sorcerer
-   </code>
+   <code>ADD:SPELLCASTER|Bard,Sorcerer</code>
   </p>
   <p class="indent3">
    Adds a bonus level of spellcasting of either
@@ -941,27 +867,21 @@ to the character.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ADD:TEMPLATE|1|Scholar,Soldier
-   </code>
+   <code>ADD:TEMPLATE|1|Scholar,Soldier</code>
   </p>
   <p class="indent3">
    Add one of either a "Scholar" or a
 "Soldier".
   </p>
   <p class="indent2">
-   <code>
-    ADD:TEMPLATE|Robot
-   </code>
+   <code>ADD:TEMPLATE|Robot</code>
   </p>
   <p class="indent3">
    Add one of "Robot".
   </p>
   <p class="indent2">
-   <code>
-    ADD:TEMPLATE|2|Suite of St. Daris,Suite of
-St. Feldin,Suite of Lothian
-   </code>
+   <code>ADD:TEMPLATE|2|Suite of St. Daris,Suite of
+St. Feldin,Suite of Lothian</code>
   </p>
   <p class="indent3">
    Add two of "Suite of St. Daris", "Suite of St.
@@ -1033,13 +953,9 @@ of feats (y) to the character regardless of qualification.
 -->
    <li>
     If the feat being added has a chooser,
-    <code>
-     ADD:VFEAT
-    </code>
+    <code>ADD:VFEAT</code>
     will activate it. (
-    <code>
-     VFEAT
-    </code>
+    <code>VFEAT</code>
     alone will not.)
    </li>
    <li>
@@ -1052,28 +968,22 @@ of feats (y) to the character regardless of qualification.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ADD:VFEAT|Weapon
-Master(TYPE=Weapon)
-   </code>
+   <code>ADD:VFEAT|Weapon
+Master(TYPE=Weapon)</code>
   </p>
   <p class="indent3">
    Add Weapon Master feat, for any "Weapon" type,
 as a virtual feat.
   </p>
   <p class="indent2">
-   <code>
-    ADD:VFEAT|TYPE=General,TYPE=Metamagic,TYPE=ItemCreation
-   </code>
+   <code>ADD:VFEAT|TYPE=General,TYPE=Metamagic,TYPE=ItemCreation</code>
   </p>
   <p class="indent3">
    Add one virtual feat from types "General",
 "Metamagic", and "ItemCreation" type feats.
   </p>
   <p class="indent2">
-   <code>
-    ADD:VFEAT|2|ALL
-   </code>
+   <code>ADD:VFEAT|2|ALL</code>
   </p>
   <p class="indent3">
    Add two virtual feats selected from among all

--- a/docs/listfilepages/globalfilestagpages/globalfilesbonus.html
+++ b/docs/listfilepages/globalfilestagpages/globalfilesbonus.html
@@ -42,20 +42,14 @@ follows:
   </p>
   <blockquote>
    <p class="indent1">
-    <code>
-     BONUS:&lt;category&gt;|&lt;group&gt;|&lt;formula&gt;
-    </code>
+    <code>BONUS:&lt;category&gt;|&lt;group&gt;|&lt;formula&gt;</code>
    </p>
   </blockquote>
   <p class="indent1">
    This can be followed by pipe-delimitated
-   <code>
-    PRExxx
-   </code>
+   <code>PRExxx</code>
    or
-   <code>
-    TYPE=&lt;type&gt;
-   </code>
+   <code>TYPE=&lt;type&gt;</code>
    tags.
   </p>
   <p class="indent1">
@@ -71,23 +65,17 @@ follows:
    page.
   </p>
   <p class="indent1">
-   <code>
-    LIST
-   </code>
+   <code>LIST</code>
    is a special case in
    <span class="lstfile">
     feats.lst
    </span>
    . It can be placed in most
 &lt;group&gt; categories.
-   <code>
-    LIST
-   </code>
+   <code>LIST</code>
    will be replaced by the
 choice from a
-   <code>
-    CHOOSE
-   </code>
+   <code>CHOOSE</code>
    tag contained within the
 feat.
   </p>
@@ -146,9 +134,7 @@ feat.
   <ul class="indent2">
    <li>
     These have no
-    <code>
-     TYPE=
-    </code>
+    <code>TYPE=</code>
     statement, and are always
 added into the final result.
    </li>
@@ -163,9 +149,7 @@ in a breakdown by bonus type.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:HP|CURRENTMAX|3
-   </code>
+   <code>BONUS:HP|CURRENTMAX|3</code>
   </p>
   <p class="indent3">
    This bonus would grant the character an
@@ -173,9 +157,7 @@ additional three hit points.
    <br/>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SKILL|Bluff,Listen|4
-   </code>
+   <code>BONUS:SKILL|Bluff,Listen|4</code>
   </p>
   <p class="indent3">
    This bonus would grant the character a bonus to
@@ -183,9 +165,7 @@ the listed skills of four.
    <br/>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SKILL|STAT=DEX|1
-   </code>
+   <code>BONUS:SKILL|STAT=DEX|1</code>
   </p>
   <p class="indent3">
    This would grant the character a bonus of one to
@@ -229,11 +209,9 @@ the final result.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:HP|CURRENTMAX|2|TYPE=Luck
+   <code>BONUS:HP|CURRENTMAX|2|TYPE=Luck
     <br/>
-    BONUS:HP|CURRENTMAX|3|TYPE=Luck
-   </code>
+    BONUS:HP|CURRENTMAX|3|TYPE=Luck</code>
   </p>
   <p class="indent3">
    So long as the 'Luck' type is not listed in
@@ -242,11 +220,9 @@ is the largest 'Luck' type.
    <br/>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SKILL|Bluff,Listen|3|TYPE=Luck
+   <code>BONUS:SKILL|Bluff,Listen|3|TYPE=Luck
     <br/>
-    BONUS:SKILL|Bluff,Listen|4|TYPE=Divine
-   </code>
+    BONUS:SKILL|Bluff,Listen|4|TYPE=Divine</code>
   </p>
   <p class="indent3">
    These would return a 3 from Luck, and a 4 from
@@ -254,13 +230,11 @@ Divine, for a total of 7. They are different Types.
    <br/>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SKILL|Bluff,Listen|2|TYPE=Luck
+   <code>BONUS:SKILL|Bluff,Listen|2|TYPE=Luck
     <br/>
     BONUS:SKILL|Bluff,Listen|3|TYPE=Luck
     <br/>
-    BONUS:SKILL|Bluff,Listen|4|TYPE=Divine
-   </code>
+    BONUS:SKILL|Bluff,Listen|4|TYPE=Divine</code>
   </p>
   <p class="indent3">
    This would also return a value of 7, since 3 is
@@ -293,15 +267,13 @@ value of a particular TYPE.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SKILL|Bluff,Listen|3|TYPE=Luck.REPLACE
+   <code>BONUS:SKILL|Bluff,Listen|3|TYPE=Luck.REPLACE
     <br/>
     BONUS:SKILL|Bluff,Listen|2|TYPE=Luck.REPLACE
     <br/>
     BONUS:SKILL|Bluff,Listen|4|TYPE=Luck
     <br/>
-    BONUS:SKILL|Bluff,Listen|2|TYPE=Luck
-   </code>
+    BONUS:SKILL|Bluff,Listen|2|TYPE=Luck</code>
   </p>
   <p class="indent3">
    This would take the 2 and 3 with the .REPLACE
@@ -310,8 +282,7 @@ takes the highest value, for 5.
    <br/>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SKILL|Bluff,Listen|1|TYPE=Luck.REPLACE
+   <code>BONUS:SKILL|Bluff,Listen|1|TYPE=Luck.REPLACE
     <br/>
     BONUS:SKILL|Bluff,Listen|1|TYPE=Luck.REPLACE
     <br/>
@@ -319,8 +290,7 @@ takes the highest value, for 5.
     <br/>
     BONUS:SKILL|Bluff,Listen|2|TYPE=Luck
     <br/>
-    BONUS:SKILL|Bluff,Listen|6|TYPE=Luck
-   </code>
+    BONUS:SKILL|Bluff,Listen|6|TYPE=Luck</code>
   </p>
   <p class="indent3">
    This would take the values from the .REPLACE
@@ -332,9 +302,7 @@ takes the highest value, for 6.
    <strong>
     Bonus Type:
    </strong>
-   <code>
-    .STACK
-   </code>
+   <code>.STACK</code>
   </p>
   <p class="indent1">
    <strong>
@@ -344,32 +312,22 @@ takes the highest value, for 6.
   <ul class="indent2">
    <li>
     This is subtype of the
-    <code>
-     TYPE=&lt;type&gt;
-    </code>
+    <code>TYPE=&lt;type&gt;</code>
     standard
 type.
    </li>
    <li>
-    <code>
-     .STACK
-    </code>
+    <code>.STACK</code>
     items are counted in addition to the normal
 and
-    <code>
-     .REPLACE
-    </code>
+    <code>.REPLACE</code>
     to determine the final value of a
 particular type.
    </li>
    <li>
-    <code>
-     .STACK
-    </code>
+    <code>.STACK</code>
     stacks together with itself like
-    <code>
-     .REPLACE
-    </code>
+    <code>.REPLACE</code>
     , but is also added to normal types.
    </li>
   </ul>
@@ -379,117 +337,75 @@ particular type.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SKILL|Bluff,Listen|4|TYPE=Luck
-   </code>
+   <code>BONUS:SKILL|Bluff,Listen|4|TYPE=Luck</code>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SKILL|Bluff,Listen|2|TYPE=Luck.STACK
-   </code>
+   <code>BONUS:SKILL|Bluff,Listen|2|TYPE=Luck.STACK</code>
   </p>
   <p class="indent3">
    This would take the 4 of type
-   <code>
-    Luck
-   </code>
+   <code>Luck</code>
    ,
 and then add 2 more from the
-   <code>
-    Stack
-   </code>
+   <code>Stack</code>
    , on top of it.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SKILL|Bluff,Listen|4|TYPE=Luck.REPLACE
-   </code>
+   <code>BONUS:SKILL|Bluff,Listen|4|TYPE=Luck.REPLACE</code>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SKILL|Bluff,Listen|4|TYPE=Luck.STACK
-   </code>
+   <code>BONUS:SKILL|Bluff,Listen|4|TYPE=Luck.STACK</code>
   </p>
   <p class="indent3">
    This would take the 4 of type
-   <code>
-    Luck
-   </code>
+   <code>Luck</code>
    ,
 and then add 4 more from the
-   <code>
-    Stack
-   </code>
+   <code>Stack</code>
    , on top of it.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SKILL|Bluff,Listen|4|TYPE=Luck
-   </code>
+   <code>BONUS:SKILL|Bluff,Listen|4|TYPE=Luck</code>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SKILL|Bluff,Listen|3|TYPE=Luck.REPLACE
-   </code>
+   <code>BONUS:SKILL|Bluff,Listen|3|TYPE=Luck.REPLACE</code>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SKILL|Bluff,Listen|3|TYPE=Luck.REPLACE
-   </code>
+   <code>BONUS:SKILL|Bluff,Listen|3|TYPE=Luck.REPLACE</code>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SKILL|Bluff,Listen|1|TYPE=Luck.STACK
-   </code>
+   <code>BONUS:SKILL|Bluff,Listen|1|TYPE=Luck.STACK</code>
   </p>
   <p class="indent3">
    This would take the 4 normal, compare to the
-   <code>
-    .REPLACE
-   </code>
+   <code>.REPLACE</code>
    (6) and give the higher value, then add in
 the
-   <code>
-    .STACK
-   </code>
+   <code>.STACK</code>
    , for a final value of 7.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SKILL|Bluff,Listen|4|TYPE=Luck
-   </code>
+   <code>BONUS:SKILL|Bluff,Listen|4|TYPE=Luck</code>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SKILL|Bluff,Listen|1|TYPE=Luck.REPLACE
-   </code>
+   <code>BONUS:SKILL|Bluff,Listen|1|TYPE=Luck.REPLACE</code>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SKILL|Bluff,Listen|1|TYPE=Luck.REPLACE
-   </code>
+   <code>BONUS:SKILL|Bluff,Listen|1|TYPE=Luck.REPLACE</code>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SKILL|Bluff,Listen|3|TYPE=Luck.STACK
-   </code>
+   <code>BONUS:SKILL|Bluff,Listen|3|TYPE=Luck.STACK</code>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SKILL|Bluff,Listen|3|TYPE=Luck.STACK
-   </code>
+   <code>BONUS:SKILL|Bluff,Listen|3|TYPE=Luck.STACK</code>
   </p>
   <p class="indent3">
    This would take the normal (4), compare it to
 the total
-   <code>
-    .REPLACE
-   </code>
+   <code>.REPLACE</code>
    (2), give the higher value, then
 add in the
-   <code>
-    .STACK
-   </code>
+   <code>.STACK</code>
    (6) for a final value of 10.
   </p>
   <hr/>
@@ -524,9 +440,7 @@ in the
    </h3>
    <p class="indent1">
     Within PCGen, tags which do not have a
-    <code>
-     TYPE=&lt;type&gt;
-    </code>
+    <code>TYPE=&lt;type&gt;</code>
     sub-tag appended are assumed to
 stack, tags which do have a type appended do not normally stack.
 Some games have exceptions to this rule and list specific types
@@ -547,29 +461,19 @@ following are commonly used types that are defined within the
     file for this purpose.
    </p>
    <p class="indent2">
-    <code>
-     Defense
-    </code>
+    <code>Defense</code>
    </p>
    <p class="indent2">
-    <code>
-     Dodge
-    </code>
+    <code>Dodge</code>
    </p>
    <p class="indent2">
-    <code>
-     Circumstance
-    </code>
+    <code>Circumstance</code>
    </p>
    <p class="indent2">
-    <code>
-     NotRanged
-    </code>
+    <code>NotRanged</code>
    </p>
    <p class="indent2">
-    <code>
-     NotFlatFooted
-    </code>
+    <code>NotFlatFooted</code>
    </p>
    <h3>
     <a id="actype" name="actype">
@@ -590,74 +494,46 @@ that are defined with the
     file.
    </p>
    <p class="indent2">
-    <code>
-     Total
-    </code>
+    <code>Total</code>
    </p>
    <p class="indent2">
-    <code>
-     Flatfooted
-    </code>
+    <code>Flatfooted</code>
    </p>
    <p class="indent2">
-    <code>
-     Touch
-    </code>
+    <code>Touch</code>
    </p>
    <p class="indent2">
-    <code>
-     Base
-    </code>
+    <code>Base</code>
    </p>
    <p class="indent2">
-    <code>
-     Equipment
-    </code>
+    <code>Equipment</code>
    </p>
    <p class="indent2">
-    <code>
-     Armor
-    </code>
+    <code>Armor</code>
    </p>
    <p class="indent2">
-    <code>
-     Shield
-    </code>
+    <code>Shield</code>
    </p>
    <p class="indent2">
-    <code>
-     Ability
-    </code>
+    <code>Ability</code>
    </p>
    <p class="indent2">
-    <code>
-     Size
-    </code>
+    <code>Size</code>
    </p>
    <p class="indent2">
-    <code>
-     NaturalArmor
-    </code>
+    <code>NaturalArmor</code>
    </p>
    <p class="indent2">
-    <code>
-     NaturalArmorEnhancement
-    </code>
+    <code>NaturalArmorEnhancement</code>
    </p>
    <p class="indent2">
-    <code>
-     Misc
-    </code>
+    <code>Misc</code>
    </p>
    <p class="indent2">
-    <code>
-     ClassDefense
-    </code>
+    <code>ClassDefense</code>
    </p>
    <p class="indent2">
-    <code>
-     Dodge
-    </code>
+    <code>Dodge</code>
    </p>
   </blockquote>
   <hr/>
@@ -670,18 +546,12 @@ stack even when they have matching types.
   </p>
   <p class="indent1">
    While you can't
-   <code>
-    .CLEAR
-   </code>
+   <code>.CLEAR</code>
    a
-   <code>
-    BONUS
-   </code>
+   <code>BONUS</code>
    tag you can add a counter bonus that would
 negate it. In this case you would add a counter bonus and
-   <code>
-    PRExxx
-   </code>
+   <code>PRExxx</code>
    tag it with the reverse of the feat's
 prerequisite.
   </p>
@@ -733,10 +603,8 @@ character can take.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:ABILITYPOOL|Salient Divine
-Ability|1
-   </code>
+   <code>BONUS:ABILITYPOOL|Salient Divine
+Ability|1</code>
   </p>
   <p class="indent3">
    The character may take one additional Salient
@@ -868,52 +736,40 @@ innate racial spells.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:CASTERLEVEL|Sorcerer|1
-   </code>
+   <code>BONUS:CASTERLEVEL|Sorcerer|1</code>
   </p>
   <p class="indent3">
    Adds 1 to Sorcerer spell caster level.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:CASTERLEVEL|TYPE.Arcane|1
-   </code>
+   <code>BONUS:CASTERLEVEL|TYPE.Arcane|1</code>
   </p>
   <p class="indent3">
    Adds 1 to Arcane spell caster level.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:CASTERLEVEL|RACE.Gelfling|4
-   </code>
+   <code>BONUS:CASTERLEVEL|RACE.Gelfling|4</code>
   </p>
   <p class="indent3">
    Sets Gelfling innate racial spell caster level
 to 4.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:CASTERLEVEL|SPELL.Levitate|2
-   </code>
+   <code>BONUS:CASTERLEVEL|SPELL.Levitate|2</code>
   </p>
   <p class="indent3">
    Adds 2 to caster level for the 'Levitate'
 spell.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:CASTERLEVEL|SCHOOL.Transmutation|2
-   </code>
+   <code>BONUS:CASTERLEVEL|SCHOOL.Transmutation|2</code>
   </p>
   <p class="indent3">
    Adds 2 to caster level for all spells of the
 'Transmutation' school.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:CASTERLEVEL|Paladin|CL/2|PRECLASSLEVEL:Paladin=4
-   </code>
+   <code>BONUS:CASTERLEVEL|Paladin|CL/2|PRECLASSLEVEL:Paladin=4</code>
   </p>
   <p class="indent3">
    Sets the Paladin's spell caster level to half
@@ -924,13 +780,11 @@ his class level after he reaches level 4.
 is only valid in a class line)
   </p>
   <p class="indent2">
-   <code>
-    CLASS:Defender.MOD &lt;tab&gt;
+   <code>CLASS:Defender.MOD &lt;tab&gt;
 SPELLSTAT:INT &lt;tab&gt; BONUSSPELLSTAT:NONE &lt;tab&gt;
 SPELLTYPE:Arcane &lt;tab&gt; SPELLBOOK:NO &lt;tab&gt;
 BONUS:CASTERLEVEL|Defender|TL &lt;tab&gt;
-SPELLLIST:1|Channeler
-   </code>
+SPELLLIST:1|Channeler</code>
   </p>
   <p class="indent3">
    Modifying the class Defender changes all of
@@ -953,9 +807,7 @@ is reset even if other bonus tags do not have them. Also, multiple
   </p>
   <p class="indent2">
    The syntax is:
-   <code>
-    BONUS:CASTERLEVEL|subtag.text.RESET|number
-   </code>
+   <code>BONUS:CASTERLEVEL|subtag.text.RESET|number</code>
   </p>
   <p class="indent1">
    <strong>
@@ -963,9 +815,7 @@ is reset even if other bonus tags do not have them. Also, multiple
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CASTERLEVEL|TYPE.Divine.RESET|max(CASTERLEVEL.TOTAL,10)
-   </code>
+   <code>CASTERLEVEL|TYPE.Divine.RESET|max(CASTERLEVEL.TOTAL,10)</code>
   </p>
   <p class="indent3">
    In this example all Divine spells would have a
@@ -973,14 +823,10 @@ caster level of either 10 or the PC's default caster level,
 whichever is higher.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:CASTERLEVEL|SPELL.Fireball.RESET|7
-   </code>
+   <code>BONUS:CASTERLEVEL|SPELL.Fireball.RESET|7</code>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:CASTERLEVEL|SCHOOL.Evocation.RESET|3
-   </code>
+   <code>BONUS:CASTERLEVEL|SCHOOL.Evocation.RESET|3</code>
   </p>
   <p class="indent3">
    These two bonuses in combination would result in
@@ -1042,9 +888,7 @@ variable or formula (Save Bonus)
    </li>
    <li>
     Using the
-    <code>
-     BASE.x
-    </code>
+    <code>BASE.x</code>
     syntax adds to indicated base
 check (normally only used in class progressions).
    </li>
@@ -1054,9 +898,7 @@ GameMode.
    </li>
    <li>
     Substitution is allowed through the use of
-    <code>
-     %LIST
-    </code>
+    <code>%LIST</code>
     .
    </li>
   </ul>
@@ -1066,69 +908,51 @@ GameMode.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:CHECKS|Fortitude,Reflex|1
-   </code>
+   <code>BONUS:CHECKS|Fortitude,Reflex|1</code>
   </p>
   <p class="indent3">
    Adds one to "Fortitude" and "Reflex" saves.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:NUMCHOICES=1|CHECK|Fortitude|Reflex|Will &lt;tab&gt;
-BONUS:CHECKS|%LIST|1
-   </code>
+   <code>CHOOSE:NUMCHOICES=1|CHECK|Fortitude|Reflex|Will &lt;tab&gt;
+BONUS:CHECKS|%LIST|1</code>
   </p>
   <p class="indent3">
    The selection, "Fortitude", "Reflex" or "Will",
 is put into the
-   <code>
-    BONUS:CHECKS
-   </code>
+   <code>BONUS:CHECKS</code>
    tag in place of the
-   <code>
-    %LIST
-   </code>
+   <code>%LIST</code>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:CHECKS|Willpower||max(CHA,WIS)-WIS
-   </code>
+   <code>BONUS:CHECKS|Willpower||max(CHA,WIS)-WIS</code>
   </p>
   <p class="indent3">
    How does one code up something like 'you can add
 your Charisma modifier instead of Wisdom for Willpower saves'?
   </p>
   <p class="indent2">
-   <code>
-    BONUS:CHECKS|Fortitude|2|TYPE=Resistance
-   </code>
+   <code>BONUS:CHECKS|Fortitude|2|TYPE=Resistance</code>
   </p>
   <p class="indent3">
    Adds two to Fortitude checks due to
 Resistance.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:CHECKS|BASE.Fortitude,BASE.Reflex|1
-   </code>
+   <code>BONUS:CHECKS|BASE.Fortitude,BASE.Reflex|1</code>
   </p>
   <p class="indent3">
    Adds one to the base "Fortitude" and "Reflex"
 saves.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:CHECKS|ALL|1
-   </code>
+   <code>BONUS:CHECKS|ALL|1</code>
   </p>
   <p class="indent3">
    Adds one to the all saves.
   </p>
   <p class="indent2">
-   <code>
-    TEMPBONUS:ANYPC|CHECKS|ALL|3|TYPE=Morale
-   </code>
+   <code>TEMPBONUS:ANYPC|CHECKS|ALL|3|TYPE=Morale</code>
   </p>
   <p class="indent3">
    Adds three to all saves, due to morale, to all
@@ -1286,40 +1110,30 @@ Variable or Formula (Bonus value)
     <ul>
      <li>
       Using the
-      <code>
-       AC
-      </code>
+      <code>AC</code>
       syntax adds to the armor class.
      </li>
      <li>
       Using the
-      <code>
-       ATTACKS
-      </code>
+      <code>ATTACKS</code>
       syntax adds to the number of
 attacks the primary hand gets.
      </li>
      <li>
       Using the
-      <code>
-       BASEAB
-      </code>
+      <code>BASEAB</code>
       syntax increases the base attack
 bonus and may increase the number of attacks the primary hand
 gets.
      </li>
      <li>
       Using the
-      <code>
-       DAMAGE
-      </code>
+      <code>DAMAGE</code>
       syntax increases the damage bonus
 but the weapon and damage types specified must be valid equipment
 types assigned to a weapon in the current data set or must have
 been defined by the
-      <code>
-       WEAPONTYPE
-      </code>
+      <code>WEAPONTYPE</code>
       tag in the current
 gamemode. Examples of standard Weapon and Weapon Damage types can
 be found on the
@@ -1331,27 +1145,19 @@ Type
      </li>
      <li>
       Using the
-      <code>
-       DAMAGEMULT
-      </code>
+      <code>DAMAGEMULT</code>
       syntax increases the damage
 multiplier for the designated hand(s) wielding the weapon. Bonuses
 are additive between each
-      <code>
-       BONUS
-      </code>
+      <code>BONUS</code>
       . Two
-      <code>
-       BONUS:COMBAT|DAMAGEMULT:0|1.5
-      </code>
+      <code>BONUS:COMBAT|DAMAGEMULT:0|1.5</code>
       tags will do a total of
 x3 damage, not 2.25.
      </li>
      <li>
       Using the
-      <code>
-       DAMAGESIZE
-      </code>
+      <code>DAMAGESIZE</code>
       syntax increases, or
 decreases, the damage die size along the same scale as is used for
 weapon size, i.e.:
@@ -1481,100 +1287,76 @@ weapon size, i.e.:
      </li>
      <li>
       Using the
-      <code>
-       DAMAGE-SHORTRANGE
-      </code>
+      <code>DAMAGE-SHORTRANGE</code>
       syntax adds to the
 damage of a weapon at short range as defined in the GameMode
 files.
      </li>
      <li>
       Using the
-      <code>
-       EPICAB
-      </code>
+      <code>EPICAB</code>
       syntax increases the epic attack
 bonus and may increase the number of attacks the primary hand
 gets.
      </li>
      <li>
       Using the
-      <code>
-       INITIATIVE
-      </code>
+      <code>INITIATIVE</code>
       syntax increases the
 character's initiative.
      </li>
      <li>
       Using the
-      <code>
-       REACH
-      </code>
+      <code>REACH</code>
       syntax modifies the character's
 reach.
      </li>
      <li>
       Using the
-      <code>
-       RANGEPENALTY
-      </code>
+      <code>RANGEPENALTY</code>
       syntax modifies the
 character's range increment penalty.
      </li>
      <li>
       Using the
-      <code>
-       SECONDARYATTACKS
-      </code>
+      <code>SECONDARYATTACKS</code>
       syntax increases the
 number of secondary attacks.
      </li>
      <li>
       Using the
-      <code>
-       SECONDARYDAMAGE
-      </code>
+      <code>SECONDARYDAMAGE</code>
       syntax increases the
 damage modifier for secondary attacks.
      </li>
      <li>
       Using the
-      <code>
-       TOHIT
-      </code>
+      <code>TOHIT</code>
       syntax increases the primary
 attack bonus.
      </li>
      <li>
       Using the
-      <code>
-       TOHIT.x
-      </code>
+      <code>TOHIT.x</code>
       syntax increases the attack
 bonus for the designated attack, i.e. by weapon type, grapple,
 melee, or ranged attack.
      </li>
      <li>
       Using the
-      <code>
-       TOHIT-PRIMARY
-      </code>
+      <code>TOHIT-PRIMARY</code>
       syntax increases the
 primary attack bonus.
      </li>
      <li>
       Using the
-      <code>
-       TOHIT-SECONDARY
-      </code>
+      <code>TOHIT-SECONDARY</code>
       syntax increases the
 secondary attack bonus.
      </li>
      <li>
       Using the
-      <code>
-       TOHIT-SHORTRANGE
-      </code>
+      <code>TOHIT-SHORTRANGE</code>
       syntax adds to the
 ranged attack rolls that are less than the gamemode defined
       <strong>
@@ -1592,68 +1374,52 @@ round.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:COMBAT|AC|2|TYPE=Enhancement
-   </code>
+   <code>BONUS:COMBAT|AC|2|TYPE=Enhancement</code>
   </p>
   <p class="indent3">
    Increases the enhancement armor bonus by
 two.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:COMBAT|AC|7|TYPE=NaturalArmor.REPLACE
-   </code>
+   <code>BONUS:COMBAT|AC|7|TYPE=NaturalArmor.REPLACE</code>
   </p>
   <p class="indent3">
    Replaces the natural armor bonus to seven.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:COMBAT|ATTACKS|2
-   </code>
+   <code>BONUS:COMBAT|ATTACKS|2</code>
   </p>
   <p class="indent3">
    Increases number of attacks by two.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:COMBAT|BASEAB|1
-   </code>
+   <code>BONUS:COMBAT|BASEAB|1</code>
   </p>
   <p class="indent3">
    Increases base attack bonus by one.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:COMBAT|BAB|CL|TYPE=Base.REPLACE
-   </code>
+   <code>BONUS:COMBAT|BAB|CL|TYPE=Base.REPLACE</code>
   </p>
   <p class="indent3">
    Increases base attack bonus by Character Level,
 replacing the Base value.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:COMBAT|DAMAGE.Piercing|2
-   </code>
+   <code>BONUS:COMBAT|DAMAGE.Piercing|2</code>
   </p>
   <p class="indent3">
    Increases "Piercing" damage bonus by two.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:COMBAT|DAMAGE.Unarmed,DAMAGE.Thrown|DEX
-   </code>
+   <code>BONUS:COMBAT|DAMAGE.Unarmed,DAMAGE.Thrown|DEX</code>
   </p>
   <p class="indent3">
    Adds the character's dexterity modifier to both
 "Unarmed" and "Thrown" damage.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:COMBAT|DAMAGEMULT:0|0.5
-   </code>
+   <code>BONUS:COMBAT|DAMAGEMULT:0|0.5</code>
   </p>
   <p class="indent3">
    Increases the damage multiplier by half your
@@ -1661,173 +1427,133 @@ strength bonus. Combined with the existing bonus this bonus will
 total your full strength bonus for an off hand weapon.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:COMBAT|DAMAGEMULT:1|1
-   </code>
+   <code>BONUS:COMBAT|DAMAGEMULT:1|1</code>
   </p>
   <p class="indent3">
    Increases the damage multiplier of the weapon by
 your strength bonus when wielding in your primary hand.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:COMBAT|DAMAGEMULT:2|1.5
-   </code>
+   <code>BONUS:COMBAT|DAMAGEMULT:2|1.5</code>
   </p>
   <p class="indent3">
    Increases the damage multiplier of the weapon by
 one and a half your strength bonus when wielding it two-handed.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:COMBAT|DAMAGESIZE|2
-   </code>
+   <code>BONUS:COMBAT|DAMAGESIZE|2</code>
   </p>
   <p class="indent3">
    If the base damage dice is 1d8 this would scale
 it up to 3d6.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:COMBAT|DAMAGESIZE|-1
-   </code>
+   <code>BONUS:COMBAT|DAMAGESIZE|-1</code>
   </p>
   <p class="indent3">
    If the base damage dice is 1d4 this would scale
 it down to 1d3.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:COMBAT|DAMAGE-SHORTRANGE|1
-   </code>
+   <code>BONUS:COMBAT|DAMAGE-SHORTRANGE|1</code>
   </p>
   <p class="indent3">
    Increases the damage done by a weapon at short
 range by 1.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:COMBAT|EPICAB|1
-   </code>
+   <code>BONUS:COMBAT|EPICAB|1</code>
   </p>
   <p class="indent3">
    Increases epic attack bonus by one.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:COMBAT|INITIATIVE|3
-   </code>
+   <code>BONUS:COMBAT|INITIATIVE|3</code>
   </p>
   <p class="indent3">
    Increases initiative by three.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:COMBAT|INITIATIVE|2|TYPE=Competence
-   </code>
+   <code>BONUS:COMBAT|INITIATIVE|2|TYPE=Competence</code>
   </p>
   <p class="indent3">
    Increases initiative by two for Competence.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:COMBAT|REACH|10
-   </code>
+   <code>BONUS:COMBAT|REACH|10</code>
   </p>
   <p class="indent3">
    Increases reach by ten feet.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:COMBAT|RANGEPENALTY|1
-   </code>
+   <code>BONUS:COMBAT|RANGEPENALTY|1</code>
   </p>
   <p class="indent3">
    Reduces the range increment penalty by 1 (for
 example from -2 to -1).
   </p>
   <p class="indent2">
-   <code>
-    BONUS:COMBAT|RANGEPENALTY|-2
-   </code>
+   <code>BONUS:COMBAT|RANGEPENALTY|-2</code>
   </p>
   <p class="indent3">
    Increases the range increment penalty by 2 (for
 example from -2 to -4).
   </p>
   <p class="indent2">
-   <code>
-    BONUS:COMBAT|SECONDARYATTACKS|1
-   </code>
+   <code>BONUS:COMBAT|SECONDARYATTACKS|1</code>
   </p>
   <p class="indent3">
    Increases secondary attacks by one.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:COMBAT|SECONDARYDAMAGE|2
-   </code>
+   <code>BONUS:COMBAT|SECONDARYDAMAGE|2</code>
   </p>
   <p class="indent3">
    Increases the secondary attack damage bonus by
 two.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:COMBAT|TOHIT|2|TYPE=Luck
-   </code>
+   <code>BONUS:COMBAT|TOHIT|2|TYPE=Luck</code>
   </p>
   <p class="indent3">
    Increases Attack bonus by two.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:WEAPONPROFS|3 &lt;tab&gt;
-BONUS:COMBAT|TOHIT.%LIST|1|TYPE=Talent
-   </code>
+   <code>CHOOSE:WEAPONPROFS|3 &lt;tab&gt;
+BONUS:COMBAT|TOHIT.%LIST|1|TYPE=Talent</code>
   </p>
   <p class="indent3">
    Increases Attack bonus by one for three
 WEAPONPROFS based on Talent.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:COMBAT|TOHIT.THROWN|2|TYPE=Racial
-   </code>
+   <code>BONUS:COMBAT|TOHIT.THROWN|2|TYPE=Racial</code>
   </p>
   <p class="indent3">
    Increases Attack for thrown weapon's bonus by
 two.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:COMBAT|TOHIT.SLASHING|2|TYPE=Enhancement
-   </code>
+   <code>BONUS:COMBAT|TOHIT.SLASHING|2|TYPE=Enhancement</code>
   </p>
   <p class="indent3">
    Increases Attack bonus by two when using a
 Slashing weapon.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:COMBAT|TOHIT-PRIMARY|2
-   </code>
+   <code>BONUS:COMBAT|TOHIT-PRIMARY|2</code>
   </p>
   <p class="indent3">
    Increases Primary Attack bonus by two.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:COMBAT|TOHIT-SECONDARY|1
-   </code>
+   <code>BONUS:COMBAT|TOHIT-SECONDARY|1</code>
   </p>
   <p class="indent3">
    Increases Secondary Attack bonus by one.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:COMBAT|TOHIT-SHORTRANGE|1
-   </code>
+   <code>BONUS:COMBAT|TOHIT-SHORTRANGE|1</code>
   </p>
   <p class="indent3">
    Adds one to character's short range To-Hit
@@ -1842,15 +1568,11 @@ attack rolls.
    </span>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:COMBAT|BAB|1
-   </code>
+   <code>BONUS:COMBAT|BAB|1</code>
   </p>
   <p class="indent3">
    Becomes
-   <code>
-    BONUS:COMBAT|BASEAB|1
-   </code>
+   <code>BONUS:COMBAT|BASEAB|1</code>
   </p>
   <hr/>
   <p class="lstnew">
@@ -1947,9 +1669,7 @@ associated with it.
    </strong>
    This bonus is defined
 with the
-   <code>
-    SPELLBASECONCENTRATION
-   </code>
+   <code>SPELLBASECONCENTRATION</code>
    game mode tag. If the
 game mode does not contain a
    <a href="../systemfilestagpages/gamemodemiscinfolist.html#spellbaseconcentration">
@@ -1973,54 +1693,42 @@ should not display concentration check bonuses.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:CONCENTRATION|ALLSPELLS|1
-   </code>
+   <code>BONUS:CONCENTRATION|ALLSPELLS|1</code>
   </p>
   <p class="indent3">
    Adds 1 the concentration check bonuses for all
 spells.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:CONCENTRATION|Sorcerer|1
-   </code>
+   <code>BONUS:CONCENTRATION|Sorcerer|1</code>
   </p>
   <p class="indent3">
    Adds 1 to Sorcerer spell concentration check
 bonuses.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:CONCENTRATION|TYPE.Arcane|1
-   </code>
+   <code>BONUS:CONCENTRATION|TYPE.Arcane|1</code>
   </p>
   <p class="indent3">
    Adds 1 to Arcane spell concentration check
 bonuses.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:CONCENTRATION|SPELL.Levitate|2
-   </code>
+   <code>BONUS:CONCENTRATION|SPELL.Levitate|2</code>
   </p>
   <p class="indent3">
    Adds 2 to concentration check bonuses for the
 'Levitate' spell.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:CONCENTRATION|SCHOOL.Transmutation|2
-   </code>
+   <code>BONUS:CONCENTRATION|SCHOOL.Transmutation|2</code>
   </p>
   <p class="indent3">
    Adds 2 to concentration check bonuses for all
 spells of the 'Transmutation' school.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:CONCENTRATION|SPELL.Fireball|2
-   </code>
+   <code>BONUS:CONCENTRATION|SPELL.Fireball|2</code>
   </p>
   <p class="indent3">
    Adds 2 to concentration check bonuses for the
@@ -2123,14 +1831,10 @@ applied feat bonus, i.e. through the application of a metamagic
 feat, by raising the spell level of the affected spells.
    </li>
    <li>
-    <code>
-     %LIST
-    </code>
+    <code>%LIST</code>
     can be used with this tag to insert a choice
 made with a
-    <code>
-     CHOOSE
-    </code>
+    <code>CHOOSE</code>
     tag.
    </li>
   </ul>
@@ -2140,51 +1844,39 @@ made with a
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:DC|SPELL.Fireball|7
-   </code>
+   <code>BONUS:DC|SPELL.Fireball|7</code>
   </p>
   <p class="indent3">
    Adds 7 to the DC of the spell Fireball.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:DC|SCHOOLS|ALL &lt;tab&gt;
-BONUS:DC|SCHOOL.%LIST|1
-   </code>
+   <code>CHOOSE:DC|SCHOOLS|ALL &lt;tab&gt;
+BONUS:DC|SCHOOL.%LIST|1</code>
   </p>
   <p class="indent3">
    Choose 1 School and add 1 to its DC.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:DC|ALLSPELLS|1
-   </code>
+   <code>BONUS:DC|ALLSPELLS|1</code>
   </p>
   <p class="indent3">
    Adds 1 to the DC of all spells.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:DC|CLASS.Sorcerer|2
-   </code>
+   <code>BONUS:DC|CLASS.Sorcerer|2</code>
   </p>
   <p class="indent3">
    Adds 2 to the DC of sorcerer spells.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:DC|DESCRIPTOR.Law|4
-   </code>
+   <code>BONUS:DC|DESCRIPTOR.Law|4</code>
   </p>
   <p class="indent3">
    Adds 4 to the DC of any spells with the Law
 descriptor.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:DC|DESCRIPTOR.Law,DOMAIN.Law|3
-   </code>
+   <code>BONUS:DC|DESCRIPTOR.Law,DOMAIN.Law|3</code>
   </p>
   <p class="indent3">
    Adds 3 to the DC of any spells with the Law
@@ -2192,28 +1884,22 @@ domain or descriptor and would add 6 to a spell with both the Law
 Domain and Law Descriptor.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:DC|DOMAIN.War|6
-   </code>
+   <code>BONUS:DC|DOMAIN.War|6</code>
   </p>
   <p class="indent3">
    Adds 6 to the DC of War Domain spells.
   </p>
   <p class="indent2">
-   <code>
-    MULT:YES &lt;tab&gt;
+   <code>MULT:YES &lt;tab&gt;
 CHOOSE:|Air|Earth|Fire|Water &lt;tab&gt;
-BONUS:DC|DOMAIN.%LIST|1
-   </code>
+BONUS:DC|DOMAIN.%LIST|1</code>
   </p>
   <p class="indent3">
    Choose a domain and add 1 to the DC of spells
 for that domain. This may be used multiple times.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:DC|FEATBONUS|1
-   </code>
+   <code>BONUS:DC|FEATBONUS|1</code>
   </p>
   <p class="indent3">
    Adds 1 to the DC of spells that this bonus
@@ -2221,44 +1907,34 @@ applies to by raising the spell's level by 1. The Heighten Spell
 metamagic feat is an example of where this is used.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:DC|SCHOOL.Enchantment|2
-   </code>
+   <code>BONUS:DC|SCHOOL.Enchantment|2</code>
   </p>
   <p class="indent3">
    Adds 2 to Enchantment school spells.
   </p>
   <p class="indent2">
-   <code>
-    MULT:YES &lt;tab&gt; CHOOSE:FEAT=Psionic
-Focus &lt;tab&gt; BONUS:DC|SCHOOL.%LIST|2|TYPE=Psychic
-   </code>
+   <code>MULT:YES &lt;tab&gt; CHOOSE:FEAT=Psionic
+Focus &lt;tab&gt; BONUS:DC|SCHOOL.%LIST|2|TYPE=Psychic</code>
   </p>
   <p class="indent3">
    Adds 2 to 1 psychic school focus DC.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:DC|SCHOOL.Telepathy|SPELLSTAT-CHA|TYPE=Subdiscipline
-   </code>
+   <code>BONUS:DC|SCHOOL.Telepathy|SPELLSTAT-CHA|TYPE=Subdiscipline</code>
   </p>
   <p class="indent3">
    Subtracts the Chrisma Modifier to Telepathy
 School with a bonus type of "Subdiscipline".
   </p>
   <p class="indent2">
-   <code>
-    BONUS:DC|SUBSCHOOL.something|5
-   </code>
+   <code>BONUS:DC|SUBSCHOOL.something|5</code>
   </p>
   <p class="indent3">
    Adds 5 to the any spell with a subschool of
 "something".
   </p>
   <p class="indent2">
-   <code>
-    BONUS:DC|TYPE.Arcane|3
-   </code>
+   <code>BONUS:DC|TYPE.Arcane|3</code>
   </p>
   <p class="indent3">
    Adds 3 to arcane spell DCs.
@@ -2307,9 +1983,7 @@ coordinated with a DR:#/&lt;string&gt;).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:DR|+1|10
-   </code>
+   <code>BONUS:DR|+1|10</code>
   </p>
   <p class="indent3">
    If the +1 DR type was currently at 5/+1 this tag
@@ -2349,18 +2023,14 @@ chose from the domains.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:DOMAIN|NUMBER|1
-   </code>
+   <code>BONUS:DOMAIN|NUMBER|1</code>
   </p>
   <p class="indent3">
    Character gains access to one additional
 Domain.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:DOMAIN|NUMBER|3
-   </code>
+   <code>BONUS:DOMAIN|NUMBER|3</code>
   </p>
   <p class="indent3">
    Character gains access to three additional
@@ -2385,34 +2055,24 @@ Domains.
     <ul class="incremental">
      <li>
       The
-      <code>
-       FEATPOOL
-      </code>
+      <code>FEATPOOL</code>
       tag is deprecated. Use
       <a href="#abilitypool">
-       <code>
-        ABILITYPOOL
-       </code>
+       <code>ABILITYPOOL</code>
       </a>
       instead.
      </li>
      <li>
       All
-      <code>
-       FEAT
-      </code>
+      <code>FEAT</code>
       tags have been
       <strong>
        deprecated
       </strong>
       and replaced by the
-      <code>
-       ABILITY
-      </code>
+      <code>ABILITY</code>
       system, which is more general. The
-      <code>
-       ABILITY
-      </code>
+      <code>ABILITY</code>
       system can model feats, racial features, class
 features, traits, flaws, temporary bonuses, and so on, all using a
 common format.
@@ -2456,26 +2116,20 @@ qualified by PRExxx tags and TYPE tags like other BONUS tags.
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     BONUS:FEAT|POOL|1
-    </code>
+    <code>BONUS:FEAT|POOL|1</code>
    </p>
    <p class="indent3">
     Increases the feat pool by one.
    </p>
    <p class="indent2">
-    <code>
-     BONUS:FEAT|POOL|1|TYPE=Enhancement
-    </code>
+    <code>BONUS:FEAT|POOL|1|TYPE=Enhancement</code>
    </p>
    <p class="indent3">
     Increases the feat pool by one and will not
 stack with other BONUS:FEAT|POOL tags with TYPE=Enhancement.
    </p>
    <p class="indent2">
-    <code>
-     BONUS:FEAT|POOL|-1|PREFEAT:1,Alertness
-    </code>
+    <code>BONUS:FEAT|POOL|-1|PREFEAT:1,Alertness</code>
    </p>
    <p class="indent3">
     Decreases the feat pool by one if the character
@@ -2540,9 +2194,7 @@ has no effect.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:FOLLOWERS|Familiar|1
-   </code>
+   <code>BONUS:FOLLOWERS|Familiar|1</code>
   </p>
   <p class="indent3">
    A character is allowed 1 additional
@@ -2587,18 +2239,14 @@ in Class lines.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:HD|MAX|2
-   </code>
+   <code>BONUS:HD|MAX|2</code>
   </p>
   <p class="indent3">
    Increases maximum of the HD by two points (1d4
 goes to 1d6).
   </p>
   <p class="indent2">
-   <code>
-    BONUS:HD|MIN|1
-   </code>
+   <code>BONUS:HD|MIN|1</code>
   </p>
   <p class="indent3">
    Increases the minimum of the HD by 1 point (1d4
@@ -2676,37 +2324,29 @@ points are defined in the
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:HP|ALTHP|3
-   </code>
+   <code>BONUS:HP|ALTHP|3</code>
   </p>
   <p class="indent3">
    Adds three to the total secondary hit
 points.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:HP|ALTHP|5|TYPE=Species
-   </code>
+   <code>BONUS:HP|ALTHP|5|TYPE=Species</code>
   </p>
   <p class="indent3">
    Adds five to the total secondary hit points for
 species reasons.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:HP|CURRENTMAX|2
-   </code>
+   <code>BONUS:HP|CURRENTMAX|2</code>
   </p>
   <p class="indent3">
    Character gains two additional hit points.
   </p>
   <p class="indent2">
-   <code>
-    STACK:NO &lt;tab&gt; MULT:YES &lt;tab&gt;
+   <code>STACK:NO &lt;tab&gt; MULT:YES &lt;tab&gt;
 CHOOSE:NUMCHOICES=1|STAT|CON &lt;tab&gt;
-BONUS:HP|CURRENTMAX|%LIST-CON
-   </code>
+BONUS:HP|CURRENTMAX|%LIST-CON</code>
   </p>
   <p class="indent3">
    Character gains between 1 and CON Bonus
@@ -2714,9 +2354,7 @@ additional hit points, can be used multiple time, does not
 stack.
   </p>
   <p class="indent2">
-   <code>
-    TEMPBONUS:PC|HP|CURRENTMAX|AidSoulHitPoints*%CHOICE|TYPE=Temporary
-   </code>
+   <code>TEMPBONUS:PC|HP|CURRENTMAX|AidSoulHitPoints*%CHOICE|TYPE=Temporary</code>
   </p>
   <p class="indent3">
    Character gains additional hit points temporary
@@ -2767,18 +2405,14 @@ COST
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:ITEMCOST|TYPE.Weapon|200
-   </code>
+   <code>BONUS:ITEMCOST|TYPE.Weapon|200</code>
   </p>
   <p class="indent3">
    Adds 200 to the cost if the item has the Weapon
 type.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:ITEMCOST|TYPE.Armor.Light|BASECOST*2
-   </code>
+   <code>BONUS:ITEMCOST|TYPE.Armor.Light|BASECOST*2</code>
   </p>
   <p class="indent3">
    Doubles the cost if the item has the Armor and
@@ -2816,17 +2450,13 @@ available language slots available.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:LANGUAGES|NUMBER|1
-   </code>
+   <code>BONUS:LANGUAGES|NUMBER|1</code>
   </p>
   <p class="indent3">
    Adds 1 to the available language pool.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:LANGUAGES|NUMBER|-1
-   </code>
+   <code>BONUS:LANGUAGES|NUMBER|-1</code>
   </p>
   <p class="indent3">
    Reduces the available language pool by 1.
@@ -2872,9 +2502,7 @@ formula
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:LOCKEDSTAT|INT|2
-   </code>
+   <code>BONUS:LOCKEDSTAT|INT|2</code>
   </p>
   <p class="indent3">
    Adds 2 to a locked "Intelligence" ability
@@ -2976,43 +2604,33 @@ variable or formula (Number to apply as a bonus)
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:MISC|ACCHECK|1
-   </code>
+   <code>BONUS:MISC|ACCHECK|1</code>
   </p>
   <p class="indent3">
    Adds one to total Armor Check.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:MISC|CR|2
-   </code>
+   <code>BONUS:MISC|CR|2</code>
   </p>
   <p class="indent3">
    Adds 2 to the challange rating.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:MISC|MAXDEX|1
-   </code>
+   <code>BONUS:MISC|MAXDEX|1</code>
   </p>
   <p class="indent3">
    Adds one to total Maximum Dex allowed while
 wearing armor.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:MISC|SPELLFAILURE|20|PREEQUIP:2,TYPE=Armor,TYPE=Light
-   </code>
+   <code>BONUS:MISC|SPELLFAILURE|20|PREEQUIP:2,TYPE=Armor,TYPE=Light</code>
   </p>
   <p class="indent3">
    Adds 20% to Spell Failure chance if equipped
 with light armor.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:MISC|SR|10+CL|TYPE=EbonLink
-   </code>
+   <code>BONUS:MISC|SR|10+CL|TYPE=EbonLink</code>
   </p>
   <p class="indent3">
    Adds 10 plus the Character Level to the spell
@@ -3062,24 +2680,16 @@ variable or formula (Number to add to movement rate)
    </li>
    <li>
     Done before
-    <code>
-     MOVEMULT
-    </code>
+    <code>MOVEMULT</code>
     and
-    <code>
-     POSTMOVEADD
-    </code>
+    <code>POSTMOVEADD</code>
     calculations.
    </li>
    <li>
     It only works on MOVE types that have been defined in a
-    <code>
-     MOVE
-    </code>
+    <code>MOVE</code>
     or
-    <code>
-     MOVECLONE
-    </code>
+    <code>MOVECLONE</code>
     tag.
    </li>
   </ul>
@@ -3089,26 +2699,20 @@ variable or formula (Number to add to movement rate)
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:MOVEADD|TYPE.Walk|10
-   </code>
+   <code>BONUS:MOVEADD|TYPE.Walk|10</code>
   </p>
   <p class="indent3">
    Adds 10 to Walk.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:MOVEADD|TYPE.Walk|5|PREVARLT:ENCUMBERANCE,1
-   </code>
+   <code>BONUS:MOVEADD|TYPE.Walk|5|PREVARLT:ENCUMBERANCE,1</code>
   </p>
   <p class="indent3">
    Adds 5 to Walk so long as the character is not
 at medium load.
   </p>
   <p class="indent2">
-   <code>
-    TEMPBONUS:ANYPC|MOVEADD|TYPE.Walk|10|TYPE=Enhancement
-   </code>
+   <code>TEMPBONUS:ANYPC|MOVEADD|TYPE.Walk|10|TYPE=Enhancement</code>
   </p>
   <p class="indent3">
    Adds 5 to the character's Walk as an enhancement
@@ -3158,36 +2762,24 @@ variable or formula (Number to multiply the movement rate)
    </li>
    <li>
     Done before
-    <code>
-     MOVEMULT
-    </code>
+    <code>MOVEMULT</code>
     and
-    <code>
-     POSTMOVEADD
-    </code>
+    <code>POSTMOVEADD</code>
     calculations.
    </li>
    <li>
     It only works on MOVE types that have been defined in a
-    <code>
-     MOVE
-    </code>
+    <code>MOVE</code>
     or
-    <code>
-     MOVECLONE
-    </code>
+    <code>MOVECLONE</code>
     tag.
    </li>
   </ul>
   <p class="sidebar1">
    Note: PCGen does not use both
-   <code>
-    BONUS:MOVEMULT
-   </code>
+   <code>BONUS:MOVEMULT</code>
    and
-   <code>
-    BONUS:POSTMOVEADD
-   </code>
+   <code>BONUS:POSTMOVEADD</code>
    in
 calculating the total move adjustment. The total move adjustment is
 set to the greatest value between (Base Move + POSTMOVEADD) and
@@ -3199,18 +2791,14 @@ set to the greatest value between (Base Move + POSTMOVEADD) and
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:MOVEMULT|TYPE.Walk,TYPE.Fly|2
-   </code>
+   <code>BONUS:MOVEMULT|TYPE.Walk,TYPE.Fly|2</code>
   </p>
   <p class="indent3">
    Multiplies the Walk &amp; Fly movement rates by
 two.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:MOVEMULT|TYPE=Walk,TYPE=Fly,TYPE=Climb,TYPE=Hover,TYPE=Swim|2
-   </code>
+   <code>BONUS:MOVEMULT|TYPE=Walk,TYPE=Fly,TYPE=Climb,TYPE=Hover,TYPE=Swim|2</code>
   </p>
   <p class="indent3">
    Multiplies the Walk, Fly, Climb, Hover, Swim
@@ -3263,14 +2851,10 @@ to gain the bonus spellcasting level.
    </li>
    <li>
     The syntax
-    <code>
-     BONUS:PCLEVEL|TYPE=x|y
-    </code>
+    <code>BONUS:PCLEVEL|TYPE=x|y</code>
     is valid but in
 the context of this tag it is converted to
-    <code>
-     BONUS:PCLEVEL|TYPE.x|y
-    </code>
+    <code>BONUS:PCLEVEL|TYPE.x|y</code>
     by PCGen on the fly.
    </li>
   </ul>
@@ -3280,17 +2864,13 @@ the context of this tag it is converted to
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:PCLEVEL|Sorcerer|1
-   </code>
+   <code>BONUS:PCLEVEL|Sorcerer|1</code>
   </p>
   <p class="indent3">
    Adds 1 to Sorcerer spell caster level.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:PCLEVEL|TYPE.Arcane|1
-   </code>
+   <code>BONUS:PCLEVEL|TYPE.Arcane|1</code>
   </p>
   <p class="indent3">
    Adds 1 to Arcane spell caster level.
@@ -3337,36 +2917,24 @@ variable or formula (Number to add to movement rate)
    </li>
    <li>
     Done after
-    <code>
-     MOVEMULT
-    </code>
+    <code>MOVEMULT</code>
     and
-    <code>
-     MOVEADD
-    </code>
+    <code>MOVEADD</code>
     calculations.
    </li>
    <li>
     It only works on MOVE types that have been defined in a
-    <code>
-     MOVE
-    </code>
+    <code>MOVE</code>
     or
-    <code>
-     MOVECLONE
-    </code>
+    <code>MOVECLONE</code>
     tag.
    </li>
   </ul>
   <p class="sidebar1">
    Note: PCGen does not use both
-   <code>
-    BONUS:MOVEMULT
-   </code>
+   <code>BONUS:MOVEMULT</code>
    and
-   <code>
-    BONUS:POSTMOVEADD
-   </code>
+   <code>BONUS:POSTMOVEADD</code>
    in
 calculating the total move adjustment. The total move adjustment is
 set to the greatest value between (Base Move + POSTMOVEADD) and
@@ -3378,17 +2946,13 @@ set to the greatest value between (Base Move + POSTMOVEADD) and
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:POSTMOVEADD|TYPE.Walk|10
-   </code>
+   <code>BONUS:POSTMOVEADD|TYPE.Walk|10</code>
   </p>
   <p class="indent3">
    Adds 10 to Walk.
   </p>
   <p class="indent2">
-   <code>
-    TEMPBONUS:PC|POSTMOVEADD|TYPE.Walk,TYPE.Burrow,TYPE.Climb,TYPE.Fly,TYPE.Swim|30|TYPE=Enhancement
-   </code>
+   <code>TEMPBONUS:PC|POSTMOVEADD|TYPE.Walk,TYPE.Burrow,TYPE.Climb,TYPE.Fly,TYPE.Swim|30|TYPE=Enhancement</code>
   </p>
   <p class="indent3">
    Adds 30 to Walk, Burrow, Climb, Fly and Swim to
@@ -3444,18 +3008,14 @@ tags.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:POSTRANGEADD|PROJECTILE|5
-   </code>
+   <code>BONUS:POSTRANGEADD|PROJECTILE|5</code>
   </p>
   <p class="indent3">
    Would increase the range of projectile weapons
 by 5.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:POSTRANGEADD|THROWN|10
-   </code>
+   <code>BONUS:POSTRANGEADD|THROWN|10</code>
   </p>
   <p class="indent3">
    Would increase the range of thrown weapons by
@@ -3512,18 +3072,14 @@ tags.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:RANGEADD|PROJECTILE|5
-   </code>
+   <code>BONUS:RANGEADD|PROJECTILE|5</code>
   </p>
   <p class="indent3">
    Would increase the range of projectile weapons
 by 5.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:RANGEADD|THROWN|10
-   </code>
+   <code>BONUS:RANGEADD|THROWN|10</code>
   </p>
   <p class="indent3">
    Would increase the range of thrown weapons by
@@ -3580,36 +3136,28 @@ all POSTRANGEADD tags.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:RANGEMULT|PROJECTILE|50
-   </code>
+   <code>BONUS:RANGEMULT|PROJECTILE|50</code>
   </p>
   <p class="indent3">
    Would increase the range of projectile weapons
 by 50% (x1.5).
   </p>
   <p class="indent2">
-   <code>
-    BONUS:RANGEMULT|PROJECTILE|-50
-   </code>
+   <code>BONUS:RANGEMULT|PROJECTILE|-50</code>
   </p>
   <p class="indent3">
    Would decrease the range of projectile weapons
 by 50% (x.5).
   </p>
   <p class="indent2">
-   <code>
-    BONUS:RANGEMULT|THROWN|100
-   </code>
+   <code>BONUS:RANGEMULT|THROWN|100</code>
   </p>
   <p class="indent3">
    Would increase the range of thrown weapons by
 100% (x2).
   </p>
   <p class="indent2">
-   <code>
-    BONUS:RANGEMULT|TYPE=Starship|50
-   </code>
+   <code>BONUS:RANGEMULT|TYPE=Starship|50</code>
   </p>
   <p class="indent3">
    Would increase the range of starship weapons by
@@ -3665,9 +3213,7 @@ variable or formula (Save Bonus)
    </li>
    <li>
     Using the
-    <code>
-     BASE.x
-    </code>
+    <code>BASE.x</code>
     syntax adds to indicated base
 save (normally only used in class progressions).
    </li>
@@ -3677,9 +3223,7 @@ GameMode.
    </li>
    <li>
     Substitution is allowed through the use of
-    <code>
-     %LIST
-    </code>
+    <code>%LIST</code>
     .
    </li>
   </ul>
@@ -3689,69 +3233,51 @@ GameMode.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SAVE|Fortitude,Reflex|1
-   </code>
+   <code>BONUS:SAVE|Fortitude,Reflex|1</code>
   </p>
   <p class="indent3">
    Adds one to "Fortitude" and "Reflex" saves.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:NUMCHOICES=1|CHECKS|Fortitude|Reflex|Will &lt;tab&gt;
-BONUS:SAVE|%LIST|1
-   </code>
+   <code>CHOOSE:NUMCHOICES=1|CHECKS|Fortitude|Reflex|Will &lt;tab&gt;
+BONUS:SAVE|%LIST|1</code>
   </p>
   <p class="indent3">
    The selection, "Fortitude", "Reflex" or "Will",
 is put into the
-   <code>
-    BONUS:SAVE
-   </code>
+   <code>BONUS:SAVE</code>
    tag in place of the
-   <code>
-    %LIST
-   </code>
+   <code>%LIST</code>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SAVE|Willpower||max(CHA,WIS)-WIS
-   </code>
+   <code>BONUS:SAVE|Willpower||max(CHA,WIS)-WIS</code>
   </p>
   <p class="indent3">
    How does one code up something like 'you can add
 your Charisma modifier instead of Wisdom for Willpower saves'?
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SAVE|Fortitude|2|TYPE=Resistance
-   </code>
+   <code>BONUS:SAVE|Fortitude|2|TYPE=Resistance</code>
   </p>
   <p class="indent3">
    Adds two to Fortitude saves due to
 Resistance.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SAVE|BASE.Fortitude,BASE.Reflex|1
-   </code>
+   <code>BONUS:SAVE|BASE.Fortitude,BASE.Reflex|1</code>
   </p>
   <p class="indent3">
    Adds one to the base "Fortitude" and "Reflex"
 saves.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SAVE|ALL|1
-   </code>
+   <code>BONUS:SAVE|ALL|1</code>
   </p>
   <p class="indent3">
    Adds one to the all saves.
   </p>
   <p class="indent2">
-   <code>
-    TEMPBONUS:ANYPC|SAVE|ALL|3|TYPE=Morale
-   </code>
+   <code>TEMPBONUS:ANYPC|SAVE|ALL|3|TYPE=Morale</code>
   </p>
   <p class="indent3">
    Adds three to all saves, due to morale, to all
@@ -3805,9 +3331,7 @@ variable or formula (Number to add to skill level)
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SITUATION|Stealth=Woodlands|2
-   </code>
+   <code>BONUS:SITUATION|Stealth=Woodlands|2</code>
   </p>
   <p class="indent3">
    Adds two to "Stealth (Woodlands)" situational
@@ -3855,47 +3379,37 @@ Medium, Large, Huge, Gargantuan, Colossal.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SIZEMOD|NUMBER|1
-   </code>
+   <code>BONUS:SIZEMOD|NUMBER|1</code>
   </p>
   <p class="indent3">
    Adds one to size. A "Medium" character would
 become "Large".
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SIZEMOD|NUMBER|-2
-   </code>
+   <code>BONUS:SIZEMOD|NUMBER|-2</code>
   </p>
   <p class="indent3">
    Reduces size by two. A "Medium" character would
 become "Tiny".
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SIZEMOD|NUMBER|1|PRESIZEGT:T
-   </code>
+   <code>BONUS:SIZEMOD|NUMBER|1|PRESIZEGT:T</code>
   </p>
   <p class="indent3">
    If size is greater than Tiny (T) add 1 to
 SIZEMOD.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SIZEMOD|NUMBER|-1|PRERACE:Wolf,Dire
-Animal (Dire Rat)|PREVARGT:TL,3|PREVARLT:TL,7
-   </code>
+   <code>BONUS:SIZEMOD|NUMBER|-1|PRERACE:Wolf,Dire
+Animal (Dire Rat)|PREVARGT:TL,3|PREVARLT:TL,7</code>
   </p>
   <p class="indent3">
    If Total Levels (TL) are more than 3 and less
 than 7, and you are a Dire Wolf, reduce the SIZEMOD by 1.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SIZEMOD|NUMBER|-1|PRERACE:Wolf,Dire
-Animal (Dire Rat)|PREVARGT:TL,3|PREVARLT:TL,7.CLEAR
-   </code>
+   <code>BONUS:SIZEMOD|NUMBER|-1|PRERACE:Wolf,Dire
+Animal (Dire Rat)|PREVARGT:TL,3|PREVARLT:TL,7.CLEAR</code>
   </p>
   <p class="indent3">
    Removes the if Total Levels (TL) are more than 3
@@ -3903,19 +3417,15 @@ and less than 7, and you are a Dire Wolf, reduce the SIZEMOD by
 1.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SIZEMOD|NUMBER|1|PRESIZEGT:T.MOD
-&lt;tab&gt; BONUS:SIZEMOD|NUMBER|2|PRESIZEGT:T
-   </code>
+   <code>BONUS:SIZEMOD|NUMBER|1|PRESIZEGT:T.MOD
+&lt;tab&gt; BONUS:SIZEMOD|NUMBER|2|PRESIZEGT:T</code>
   </p>
   <p class="indent3">
    Changes the if size is greater than Tiny (T) add
 1 to SIZEMOD to add 2 to the SIZEMOD.
   </p>
   <p class="indent2">
-   <code>
-    TEMPBONUS:PC|SIZEMOD|NUMBER|1
-   </code>
+   <code>TEMPBONUS:PC|SIZEMOD|NUMBER|1</code>
   </p>
   <p class="indent3">
    Add 1 to SIZEMOD of any PC.
@@ -3984,29 +3494,21 @@ variable or formula (Number to add to skill level)
    </li>
    <li>
     When the
-    <code>
-     STAT
-    </code>
+    <code>STAT</code>
     subtag is used this will add to
 skills based on the listed stat.
    </li>
    <li>
     When the
-    <code>
-     TYPE
-    </code>
+    <code>TYPE</code>
     subtag is used this will add to
 skills of the listed type.
    </li>
    <li>
     The
-    <code>
-     LIST
-    </code>
+    <code>LIST</code>
     subtag is used in conjunction with a
-    <code>
-     CHOOSE
-    </code>
+    <code>CHOOSE</code>
     tag and will add to skills chosen.
    </li>
    <li>
@@ -4023,99 +3525,75 @@ between Craft and (Metalworking),Craft (Metalworking))
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SKILL|Bluff,Listen|10
-   </code>
+   <code>BONUS:SKILL|Bluff,Listen|10</code>
   </p>
   <p class="indent3">
    Adds 10 to "Bluff" &amp; "Listen".
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SKILL|TYPE=Charisma|2
-   </code>
+   <code>BONUS:SKILL|TYPE=Charisma|2</code>
   </p>
   <p class="indent3">
    Adds 2 to Charisma type skills.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SKILL|Spot|5|!PRESKILL:1,Spot=1
-   </code>
+   <code>BONUS:SKILL|Spot|5|!PRESKILL:1,Spot=1</code>
   </p>
   <p class="indent3">
    Gain a +5 bonus to Spot, provided you have zero ranks in Spot.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SKILL|Hide|1|TYPE=Talent.STACK
-   </code>
+   <code>BONUS:SKILL|Hide|1|TYPE=Talent.STACK</code>
   </p>
   <p class="indent3">
    Adds 1 to Hide skill due to Talent and does
 Stack with all other Talent type.
   </p>
   <p class="indent2">
-   <code>
-    Balance.MOD &lt;tab&gt;
-BONUS:SKILL|Balance|max(0,floor((var("SKILLRANK=Tumble")-5)/20))*SynergyBonus|TYPE=Synergy.STACK
-   </code>
+   <code>Balance.MOD &lt;tab&gt;
+BONUS:SKILL|Balance|max(0,floor((var("SKILLRANK=Tumble")-5)/20))*SynergyBonus|TYPE=Synergy.STACK</code>
   </p>
   <p class="indent3">
    Modifies the Balance skill to include the
 Synergy Bonus.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SKILL|STAT.STR|1
-   </code>
+   <code>BONUS:SKILL|STAT.STR|1</code>
   </p>
   <p class="indent3">
    Adds one to all "Strength" based skills.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SKILL|LIST|2
-   </code>
+   <code>BONUS:SKILL|LIST|2</code>
   </p>
   <p class="indent3">
    Adds a +2 bonus, to a skill selected by a
    <a href="./globalfileschoose.html#skill">
-    <code>
-     CHOOSE:SKILL
-    </code>
+    <code>CHOOSE:SKILL</code>
     tag
    </a>
    . The word
-   <code>
-    LIST
-   </code>
+   <code>LIST</code>
    is a placeholder for the skill chosen by the player.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:SKILLSNAMEDTOCSKILL|2 &lt;tab&gt;
-BONUS:SKILL|LIST|6|TYPE=Legendary
-   </code>
+   <code>CHOOSE:SKILLSNAMEDTOCSKILL|2 &lt;tab&gt;
+BONUS:SKILL|LIST|6|TYPE=Legendary</code>
   </p>
   <p class="indent3">
    Adds six to the two selected Class Skills skill
 learned during Legendary Class.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SKILL|ALL|1
-   </code>
+   <code>BONUS:SKILL|ALL|1</code>
   </p>
   <p class="indent3">
    Adds one to all skills.
   </p>
   <p class="indent2">
-   <code>
-    TEMPBONUS:ANYPC|SKILL|Hide|min(floor((%CHOICE+3)/4)*10,30)|TYPE=Competence
+   <code>TEMPBONUS:ANYPC|SKILL|Hide|min(floor((%CHOICE+3)/4)*10,30)|TYPE=Competence
 &lt;tab&gt; CHOOSE:NUMBER|MIN=1|MAX=20|TITLE=Choose spell caster
-level
-   </code>
+level</code>
   </p>
   <p class="indent3">
    A chooser that figures your hide % (I think) 1
@@ -4170,26 +3648,20 @@ apply).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SKILLRANK|Bluff,Listen|2
-   </code>
+   <code>BONUS:SKILLRANK|Bluff,Listen|2</code>
   </p>
   <p class="indent3">
    Adds two to "Bluff" &amp; "Listen" skills.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SKILLRANK|TYPE=Strength|2
-   </code>
+   <code>BONUS:SKILLRANK|TYPE=Strength|2</code>
   </p>
   <p class="indent3">
    Adds two to Strength type skills.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SKILLRANK|Speak Language,Decipher
-Script,Innuendo|2|TYPE=Insight
-   </code>
+   <code>BONUS:SKILLRANK|Speak Language,Decipher
+Script,Innuendo|2|TYPE=Insight</code>
   </p>
   <p class="indent3">
    Adds two to three skills for insight
@@ -4235,17 +3707,13 @@ PRELEVELMAX with this tag.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SKILLPOINTS|NUMBER|1
-   </code>
+   <code>BONUS:SKILLPOINTS|NUMBER|1</code>
   </p>
   <p class="indent3">
    Adds one skill point per level.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SKILLPOINTS|NUMBER|4|PRELEVELMAX:1
-   </code>
+   <code>BONUS:SKILLPOINTS|NUMBER|4|PRELEVELMAX:1</code>
   </p>
   <p class="indent3">
    Adds 4 additional skillpoints to the character
@@ -4253,9 +3721,7 @@ at first level only, above and beyond any other skillpoints gained
 for race or class, etc.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SKILLPOINTS|NUMBER|6|PRELEVELMAX:3
-   </code>
+   <code>BONUS:SKILLPOINTS|NUMBER|6|PRELEVELMAX:3</code>
   </p>
   <p class="indent3">
    Adds 6 additional skillpoints to the character
@@ -4311,9 +3777,7 @@ of the class at the level specified.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SKILLPOOL|CLASS=Fighter;LEVEL=2|2
-   </code>
+   <code>BONUS:SKILLPOOL|CLASS=Fighter;LEVEL=2|2</code>
   </p>
   <p class="indent3">
    Adds 2 additional skillpoints to the character's
@@ -4321,9 +3785,7 @@ skill pool at the second level of the character's Fighter
 Class.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SKILLPOOL|CLASS=Wizard;LEVEL=5|4|PRESTAT:1,INT=18
-   </code>
+   <code>BONUS:SKILLPOOL|CLASS=Wizard;LEVEL=5|4|PRESTAT:1,INT=18</code>
   </p>
   <p class="indent3">
    Adds 4 additional skillpoints to the character's
@@ -4449,18 +3911,14 @@ gameMode.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SLOTS|RING|1
-   </code>
+   <code>BONUS:SLOTS|RING|1</code>
   </p>
   <p class="indent3">
    Adds one ring slot to character.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SLOTS|LIST|1 &lt;tab&gt;
-CHOOSE:STRING|Armor|Shield|Bracer
-   </code>
+   <code>BONUS:SLOTS|LIST|1 &lt;tab&gt;
+CHOOSE:STRING|Armor|Shield|Bracer</code>
   </p>
   <p class="indent3">
    Adds one slot chosen from Armor, Shield or
@@ -4519,9 +3977,7 @@ Bracer to the character.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SPECIALTYSPELLKNOWN|CLASS=Abjurer;LEVEL=1|1
-   </code>
+   <code>BONUS:SPECIALTYSPELLKNOWN|CLASS=Abjurer;LEVEL=1|1</code>
   </p>
   <p class="indent3">
    You know and may cast 1 more 1
@@ -4532,9 +3988,7 @@ Bracer to the character.
 specialist Abjurer spell.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SPECIALTYSPELLKNOWN|CLASS=Conjurer;LEVEL=1|2
-   </code>
+   <code>BONUS:SPECIALTYSPELLKNOWN|CLASS=Conjurer;LEVEL=1|2</code>
   </p>
   <p class="indent3">
    You know and may cast 2 more 1
@@ -4601,9 +4055,7 @@ Name:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SPELLCAST|CLASS=Wizard;LEVEL=1|1
-   </code>
+   <code>BONUS:SPELLCAST|CLASS=Wizard;LEVEL=1|1</code>
   </p>
   <p class="indent3">
    You can cast 1 more 1
@@ -4611,15 +4063,11 @@ Name:
     st
    </sup>
    lvl
-   <code>
-    Wizard
-   </code>
+   <code>Wizard</code>
    spell.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SPELLCAST|TYPE=Arcane;LEVEL=1|1
-   </code>
+   <code>BONUS:SPELLCAST|TYPE=Arcane;LEVEL=1|1</code>
   </p>
   <p class="indent3">
    You can cast 1 more 1
@@ -4679,9 +4127,7 @@ Arcane type.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SPELLCASTMULT|CLASS=Wizard;LEVEL=1|2
-   </code>
+   <code>BONUS:SPELLCASTMULT|CLASS=Wizard;LEVEL=1|2</code>
   </p>
   <p class="indent3">
    You can cast 2 times as many 1
@@ -4689,15 +4135,11 @@ Arcane type.
     st
    </sup>
    lvl
-   <code>
-    Wizard
-   </code>
+   <code>Wizard</code>
    spells as normal.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SPELLCASTMULT|TYPE=Arcane;LEVEL=1|2
-   </code>
+   <code>BONUS:SPELLCASTMULT|TYPE=Arcane;LEVEL=1|2</code>
   </p>
   <p class="indent3">
    You can cast 2 times as many 1
@@ -4758,9 +4200,7 @@ Name:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SPELLKNOWN|CLASS=Bard;LEVEL=1|1
-   </code>
+   <code>BONUS:SPELLKNOWN|CLASS=Bard;LEVEL=1|1</code>
   </p>
   <p class="indent3">
    You know 1 more 1
@@ -4771,9 +4211,7 @@ Name:
 spell.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SPELLKNOWN|CLASS=Bard;LEVEL=1|2
-   </code>
+   <code>BONUS:SPELLKNOWN|CLASS=Bard;LEVEL=1|2</code>
   </p>
   <p class="indent3">
    You know 2 more 1
@@ -4836,9 +4274,7 @@ spells.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SPELLKNOWN|CLASS=Bard;LEVEL=1|2
-   </code>
+   <code>BONUS:SPELLKNOWN|CLASS=Bard;LEVEL=1|2</code>
   </p>
   <p class="indent3">
    You know 2 times more 1
@@ -4849,9 +4285,7 @@ spells.
 spells.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:SPELLKNOWN|TYPE=Arcane;LEVEL=1|2
-   </code>
+   <code>BONUS:SPELLKNOWN|TYPE=Arcane;LEVEL=1|2</code>
   </p>
   <p class="indent3">
    You know 2 times more 1
@@ -4900,40 +4334,32 @@ that has been defined in the statsandchecks.lst system file).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:STAT|STR|2
-   </code>
+   <code>BONUS:STAT|STR|2</code>
   </p>
   <p class="indent3">
    Adds two to character's STR stat.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:STAT|DEX,CON,INT|1
-   </code>
+   <code>BONUS:STAT|DEX,CON,INT|1</code>
   </p>
   <p class="indent3">
    Adds 1 to character's DEX, CON, &amp; INT
 stats.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:PCSTAT|STR|DEX|CON &lt;tab&gt;
+   <code>CHOOSE:PCSTAT|STR|DEX|CON &lt;tab&gt;
 STACK:NO &lt;tab&gt; MULT:YES &lt;tab&gt;
-BONUS:STAT|%LIST|1|TYPE=Inherent
-   </code>
+BONUS:STAT|%LIST|1|TYPE=Inherent</code>
   </p>
   <p class="indent3">
    Adds 1 to character's STR, DEX, &amp; CON stats,
 can be chosen multiple times, does not stack.
   </p>
   <p class="indent2">
-   <code>
-    #Dwarf Racial Progression.MOD &lt;tab&gt;
+   <code>#Dwarf Racial Progression.MOD &lt;tab&gt;
 BONUS:STAT|CON|2|PRELEVEL:3 &lt;tab&gt; BONUS:STAT|STR|2|PRELEVEL:5
 &lt;tab&gt; BONUS:STAT|CON|2|PRELEVEL:7 &lt;tab&gt;
-BONUS:STAT|WIS|2|PRELEVEL:9
-   </code>
+BONUS:STAT|WIS|2|PRELEVEL:9</code>
   </p>
   <p class="indent3">
    Modifies the character based on what level they
@@ -4941,11 +4367,9 @@ are, i.e. +2 to CON at 3, +2 to STR at 5, +2 to CON at 7, +2 to WIS
 at 9.
   </p>
   <p class="indent2">
-   <code>
-    STACK:NO &lt;tab&gt; MULT:YES &lt;tab&gt;
+   <code>STACK:NO &lt;tab&gt; MULT:YES &lt;tab&gt;
 CHOOSE:PCSTAT|STR|DEX|CON &lt;tab&gt;
-BONUS:STAT|%LIST|2|TYPE=Inherent
-   </code>
+BONUS:STAT|%LIST|2|TYPE=Inherent</code>
   </p>
   <p class="indent3">
    Adds two to character's Chosen stat from
@@ -4987,9 +4411,7 @@ knows.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:STAT|BASESPELLKNOWNSTAT|1
-   </code>
+   <code>BONUS:STAT|BASESPELLKNOWNSTAT|1</code>
   </p>
   <p class="indent3">
    Adds 1 to all of the character's base spell stat
@@ -5037,9 +4459,7 @@ knows for the class specified.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:STAT|BASESPELLKNOWNSTAT;Class=Wizard|2
-   </code>
+   <code>BONUS:STAT|BASESPELLKNOWNSTAT;Class=Wizard|2</code>
   </p>
   <p class="indent3">
    Adds 2 to character's base spell stat bonus for
@@ -5075,9 +4495,7 @@ variable or formula (Number to adjust stat bonus by)
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:STAT|BASESPELLSTAT|1
-   </code>
+   <code>BONUS:STAT|BASESPELLSTAT|1</code>
   </p>
   <p class="indent3">
    Adds 1 to all of the character's base spell stat
@@ -5121,9 +4539,7 @@ class specified.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:STAT|BASESPELLSTAT;Class=Wizard|2
-   </code>
+   <code>BONUS:STAT|BASESPELLSTAT;Class=Wizard|2</code>
   </p>
   <p class="indent3">
    Adds 2 to character's base spell stat bonus for
@@ -5170,18 +4586,14 @@ damage bonus as if he/she had gained those levels as a Monk.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:UDAM|CLASS.Monk|5
-   </code>
+   <code>BONUS:UDAM|CLASS.Monk|5</code>
   </p>
   <p class="indent3">
    Unarmed damage is treated as a Monk of five
 levels higher. For this to work you must have Monk levels.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:UDAM|CLASS.Monk|CL=SpecialMonk
-   </code>
+   <code>BONUS:UDAM|CLASS.Monk|CL=SpecialMonk</code>
   </p>
   <p class="indent3">
    Would raise the Monk's Unarmed Damage "level" by
@@ -5241,37 +4653,29 @@ effect.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:VAR|SneakAttack|2
-   </code>
+   <code>BONUS:VAR|SneakAttack|2</code>
   </p>
   <p class="indent3">
    Adds 2 to character's SneakAttack variable.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:VAR|SneakAttack,TrapSense|1
-   </code>
+   <code>BONUS:VAR|SneakAttack,TrapSense|1</code>
   </p>
   <p class="indent3">
    Adds 1 to character's SneakAttack and TrapSense
 variables.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:VAR|TurnTimesBase|3+CHA|TYPE=Base
-   </code>
+   <code>BONUS:VAR|TurnTimesBase|3+CHA|TYPE=Base</code>
   </p>
   <p class="indent3">
    Sets the character's base TurnTimesBase variable
 to three plus the Charisma Modifier.
   </p>
   <p class="indent2">
-   <code>
-    TEMPBONUS:ANYPC|VAR|LegacyPoints|%CHOICE|PRERACE:1,Titan
+   <code>TEMPBONUS:ANYPC|VAR|LegacyPoints|%CHOICE|PRERACE:1,Titan
 &lt;tab&gt; CHOOSE:NUMBER|MIN=1|MAX=10|TITLE=Legacy
-Points
-   </code>
+Points</code>
   </p>
   <p class="indent3">
    A chooser to let you select the number of points
@@ -5327,9 +4731,7 @@ Darkvision, Low-Light.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:VISION|Darkvision|30
-   </code>
+   <code>BONUS:VISION|Darkvision|30</code>
   </p>
   <p class="indent3">
    Adds DarkVision (30') if you don't have
@@ -5337,18 +4739,14 @@ Darkvision, otherwise it increases your darkvision range by
 30'.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:VISION|Darkvision|((CL/4).TRUNC+1)*10
-   </code>
+   <code>BONUS:VISION|Darkvision|((CL/4).TRUNC+1)*10</code>
   </p>
   <p class="indent3">
    Increases a character's Darkvision by 10 feet
 every four levels starting at 1st level.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:VISION|Darkvision|60|PRERACE:1,TYPE=Robot
-   </code>
+   <code>BONUS:VISION|Darkvision|60|PRERACE:1,TYPE=Robot</code>
   </p>
   <p class="indent3">
    Adds Darkvision (60') if you don't have
@@ -5404,29 +4802,21 @@ can be used, they only effect when they are applied.
     Weapon properties defined are:
     <ul>
      <li>
-      <code>
-       ATTACKS
-      </code>
+      <code>ATTACKS</code>
       - Adds a number of additional
 attacks.
      </li>
      <li>
-      <code>
-       ATTACKSPROGRESS
-      </code>
+      <code>ATTACKSPROGRESS</code>
       - Overrides the standard attack
 progression.
      </li>
      <li>
-      <code>
-       DAMAGE
-      </code>
+      <code>DAMAGE</code>
       - Adds to the damage of the weapon.
      </li>
      <li>
-      <code>
-       DAMAGEMULT
-      </code>
+      <code>DAMAGEMULT</code>
       - Adds to the damage multiplier, See
       <a href="#combatdamagemult">
        BONUS:COMBAT|DAMAGEMULT
@@ -5435,9 +4825,7 @@ progression.
 syntax.
      </li>
      <li>
-      <code>
-       DAMAGESIZE
-      </code>
+      <code>DAMAGESIZE</code>
       - Raises or lowers the damage dice on
 the same scale as weapon size, See
       <a href="#combatdamagesize">
@@ -5446,38 +4834,28 @@ the same scale as weapon size, See
       for the scale.
      </li>
      <li>
-      <code>
-       DAMAGE-SHORTRANGE
-      </code>
+      <code>DAMAGE-SHORTRANGE</code>
       - Adds to the damage of the
 weapon when used at short range.
      </li>
      <li>
-      <code>
-       TOHIT
-      </code>
+      <code>TOHIT</code>
       - Adds to the attack bonus of the
 weapon.
      </li>
      <li>
-      <code>
-       TOHIT-SHORTRANGE
-      </code>
+      <code>TOHIT-SHORTRANGE</code>
       - Adds to the attack bonus of the
 weapon when used at short range.
      </li>
      <li>
-      <code>
-       WEAPONBAB
-      </code>
+      <code>WEAPONBAB</code>
       - Modifies the character's BAB for the
 weapon the bonus is applied to, affecting both to-hit and attack
 progression.
      </li>
      <li>
-      <code>
-       WIELDCATEGORY
-      </code>
+      <code>WIELDCATEGORY</code>
       - Raises or lowers the wieldcatagory
 of the weapon.
      </li>
@@ -5490,85 +4868,65 @@ of the weapon.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:WEAPON|DAMAGE|1
-   </code>
+   <code>BONUS:WEAPON|DAMAGE|1</code>
   </p>
   <p class="indent3">
    Adds one to weapon damage.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:WEAPON|DAMAGE-SHORTRANGE|1
-   </code>
+   <code>BONUS:WEAPON|DAMAGE-SHORTRANGE|1</code>
   </p>
   <p class="indent3">
    Adds one to short range weapon damage.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:WEAPON|TOHIT|1
-   </code>
+   <code>BONUS:WEAPON|TOHIT|1</code>
   </p>
   <p class="indent3">
    Adds one to weapon to-hit.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:WEAPON|TOHIT-SHORTRANGE|1
-   </code>
+   <code>BONUS:WEAPON|TOHIT-SHORTRANGE|1</code>
   </p>
   <p class="indent3">
    Adds one to short range weapon to-hit.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:WEAPON|TOHIT,DAMGE|1
-   </code>
+   <code>BONUS:WEAPON|TOHIT,DAMGE|1</code>
   </p>
   <p class="indent3">
    Adds one to weapon to-hit and damage.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:WEAPON|ATTACKS|1
-   </code>
+   <code>BONUS:WEAPON|ATTACKS|1</code>
   </p>
   <p class="indent3">
    Adds one attack to the weapon's attack
 progression.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:WEAPON|ATTACKSPROGRESS|1
-   </code>
+   <code>BONUS:WEAPON|ATTACKSPROGRESS|1</code>
   </p>
   <p class="indent3">
    Limits the weapon's attack progression to
 one.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:WEAPON|WIELDCATEGORY|1
-   </code>
+   <code>BONUS:WEAPON|WIELDCATEGORY|1</code>
   </p>
   <p class="indent3">
    Raises the weapon's wieldcatagory, if it were
 Light it becomes OneHanded.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:WEAPON|DAMAGE,TOHIT|min(2,(TL/6)|TYPE=Enhancement|PRELEVEL:6
-   </code>
+   <code>BONUS:WEAPON|DAMAGE,TOHIT|min(2,(TL/6)|TYPE=Enhancement|PRELEVEL:6</code>
   </p>
   <p class="indent3">
    Raises the weapon's damage and to-hit, between 2
 and (Total Level divided by 6) if character is over level 6.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:WEAPON|DAMAGEMULT:1|.5
-   </code>
+   <code>BONUS:WEAPON|DAMAGEMULT:1|.5</code>
   </p>
   <p class="indent3">
    Increases the damage multiplier of the weapon by
@@ -5629,36 +4987,26 @@ weapon proficiency type.
     Weapon proficiency properties defined are:
     <ul>
      <li>
-      <code>
-       CRITMULTADD
-      </code>
+      <code>CRITMULTADD</code>
       adds to the critical multiplier of the
 weapon.
      </li>
      <li>
-      <code>
-       CRITRANGEADD
-      </code>
+      <code>CRITRANGEADD</code>
       (adds to the critical range of the
 weapon.
      </li>
      <li>
-      <code>
-       CRITRANGEDOUBLE
-      </code>
+      <code>CRITRANGEDOUBLE</code>
       doubles the critical range of the
 weapon.
      </li>
      <li>
-      <code>
-       DAMAGE
-      </code>
+      <code>DAMAGE</code>
       adds to the damage of the weapon.
      </li>
      <li>
-      <code>
-       DAMAGEMULT
-      </code>
+      <code>DAMAGEMULT</code>
       adds to the damage multiplier, See
       <a href="#combatdamagemult">
        BONUS:COMBAT|DAMAGEMULT
@@ -5667,9 +5015,7 @@ weapon.
 syntax.
      </li>
      <li>
-      <code>
-       DAMAGESIZE
-      </code>
+      <code>DAMAGESIZE</code>
       raises or lowers the damage dice on the
 same scale as weapon size, See
       <a href="#combatdamagesize">
@@ -5678,58 +5024,42 @@ same scale as weapon size, See
       for the scale.
      </li>
      <li>
-      <code>
-       DAMAGE-SHORTRANGE
-      </code>
+      <code>DAMAGE-SHORTRANGE</code>
       adds to the damage of the weapon
 at short range as defined in the GameMode files.
      </li>
      <li>
-      <code>
-       PCSIZE
-      </code>
+      <code>PCSIZE</code>
       adds to the character's size in relation to
 the weapon.
      </li>
      <li>
-      <code>
-       REACH
-      </code>
+      <code>REACH</code>
       modifies the REACH for the specified
 weapon.
      </li>
      <li>
-      <code>
-       TOHIT
-      </code>
+      <code>TOHIT</code>
       adds to the attack bonus of the weapon.
      </li>
      <li>
-      <code>
-       TOHIT-SHORTRANGE
-      </code>
+      <code>TOHIT-SHORTRANGE</code>
       adds to the attack bonus of the
 weapon at short range as defined in the GameMode files.
      </li>
      <li>
-      <code>
-       TOHITOVERSIZE
-      </code>
+      <code>TOHITOVERSIZE</code>
       decreases the handedness of a
 weapon.
      </li>
      <li>
-      <code>
-       WEAPONBAB
-      </code>
+      <code>WEAPONBAB</code>
       - Modifies the character's BAB for the
 weapon proficiency the bonus is applied to, affecting both to-hit
 and attack progression.
      </li>
      <li>
-      <code>
-       WIELDCATEGORY
-      </code>
+      <code>WIELDCATEGORY</code>
       raises or lowers the wieldcatagory
 of the weapon.
      </li>
@@ -5742,119 +5072,93 @@ of the weapon.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:WEAPONPROF=Dagger|DAMAGE|1
-   </code>
+   <code>BONUS:WEAPONPROF=Dagger|DAMAGE|1</code>
   </p>
   <p class="indent3">
    Adds one to dagger weapon damage.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:WEAPONPROF=Dagger|DAMAGE,TOHIT|2
-   </code>
+   <code>BONUS:WEAPONPROF=Dagger|DAMAGE,TOHIT|2</code>
   </p>
   <p class="indent3">
    Adds two to dagger weapon attack bonus and
 damage.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:WEAPONPROF=TYPE.Martial|CRITRANGEADD|1
-   </code>
+   <code>BONUS:WEAPONPROF=TYPE.Martial|CRITRANGEADD|1</code>
   </p>
   <p class="indent3">
    Adds one to the critical range of any Martial
 type weapon.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:WEAPONPROF=Shortbow|DAMAGE-SHORTRANGE|1
-   </code>
+   <code>BONUS:WEAPONPROF=Shortbow|DAMAGE-SHORTRANGE|1</code>
   </p>
   <p class="indent3">
    Adds one to the damage of Shortbows at short
 range.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:WEAPONPROF=Longsword|PCSIZE|1
-   </code>
+   <code>BONUS:WEAPONPROF=Longsword|PCSIZE|1</code>
   </p>
   <p class="indent3">
    Allows a small character to use a longsword as
 if he were medium sized.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:WEAPONPROF=Bite|REACH|5
-   </code>
+   <code>BONUS:WEAPONPROF=Bite|REACH|5</code>
   </p>
   <p class="indent3">
    Would increase the reach of a creature's Bite by
 5.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:WEAPONPROF=Greatsword|TOHITOVERSIZE|1
-   </code>
+   <code>BONUS:WEAPONPROF=Greatsword|TOHITOVERSIZE|1</code>
   </p>
   <p class="indent3">
    Allows a medium character to use a Greatsword
 one handed without penalty.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:WEAPONPROF=Longsword|WIELDCATEGORY|-1
-   </code>
+   <code>BONUS:WEAPONPROF=Longsword|WIELDCATEGORY|-1</code>
   </p>
   <p class="indent3">
    Lowers the weapon's wieldcatagory, if it were
 OneHanded it becomes Light.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:FEAT=Weapon Focus|1 &lt;tab&gt;
-BONUS:WEAPONPROF=%LIST|TOHIT|1
-   </code>
+   <code>CHOOSE:FEAT=Weapon Focus|1 &lt;tab&gt;
+BONUS:WEAPONPROF=%LIST|TOHIT|1</code>
   </p>
   <p class="indent3">
    Chooser for weapon's proficiency to add 1 to the
 to-hit of a Weapon Focus.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:FEAT=Greater Weapon Focus|1
-&lt;tab&gt; BONUS:WEAPONPROF=%LIST|DAMAGE|2
-   </code>
+   <code>CHOOSE:FEAT=Greater Weapon Focus|1
+&lt;tab&gt; BONUS:WEAPONPROF=%LIST|DAMAGE|2</code>
   </p>
   <p class="indent3">
    Chooser for weapon's proficiency to add 2 to the
 damager of a Weapon Focus.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:WEAPONPROF=Cannon|TOHIT|-2|TYPE=GunneryPenalty
-   </code>
+   <code>BONUS:WEAPONPROF=Cannon|TOHIT|-2|TYPE=GunneryPenalty</code>
   </p>
   <p class="indent3">
    Subtracts two from the to hit of Cannons due to
 gunnery.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:WEAPONPROF=Dagger|DAMAGEMULT:0|.5
-   </code>
+   <code>BONUS:WEAPONPROF=Dagger|DAMAGEMULT:0|.5</code>
   </p>
   <p class="indent3">
    Increases the damage multiplier of the dagger
 weapon by half your strength bonus when wielding it off handed.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:WEAPONPROF=Unarmed
-Strike|WEAPONBAB|MonkLVL-BAB
-   </code>
+   <code>BONUS:WEAPONPROF=Unarmed
+Strike|WEAPONBAB|MonkLVL-BAB</code>
   </p>
   <p class="indent3">
    When applied to a monk, this will change the
@@ -5935,27 +5239,21 @@ categories.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:WIELDCATEGORY|TwoHanded|-1
-   </code>
+   <code>BONUS:WIELDCATEGORY|TwoHanded|-1</code>
   </p>
   <p class="indent3">
    Allows a character to wield a larger Two Handed
 weapon than would normally be allowed.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:WIELDCATEGORY|ALL|-1
-   </code>
+   <code>BONUS:WIELDCATEGORY|ALL|-1</code>
   </p>
   <p class="indent3">
    Allows a character to use all weapons that are
 one Size Category larger.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:WIELDCATEGORY|OneHanded,Light|1
-   </code>
+   <code>BONUS:WIELDCATEGORY|OneHanded,Light|1</code>
   </p>
   <p class="indent3">
    Allows a character to use smaller 'Light' and
@@ -6031,32 +5329,22 @@ Bonus Tab
     The temporary bonus includes the following targets:
     <ul>
      <li>
-      <code>
-       PC
-      </code>
+      <code>PC</code>
       - The temporary bonus can only be applied to a
 character that has been 'granted' the LST object that contains the
-      <code>
-       TEMPBONUS
-      </code>
+      <code>TEMPBONUS</code>
       tag.
      </li>
      <li>
-      <code>
-       ANYPC
-      </code>
+      <code>ANYPC</code>
       - The temporary bonus can be applied to any
 character whether the LST object containing the
-      <code>
-       TEMPBONUS
-      </code>
+      <code>TEMPBONUS</code>
       tag has been granted to the character or
 not.
      </li>
      <li>
-      <code>
-       EQ
-      </code>
+      <code>EQ</code>
       - The temporary bonus can only be applied to
 equipment of the type identified by the (y) parameter.
      </li>
@@ -6065,35 +5353,25 @@ equipment of the type identified by the (y) parameter.
    <li>
     The equipment type, variable (y), is used only when the target
 of the bonus is
-    <code>
-     EQ
-    </code>
+    <code>EQ</code>
     , and in this case it is
 required.
    </li>
    <li>
     The bonus subtoken syntax and parameters are as per the
 appropriate bonus. (See standard
-    <code>
-     BONUS
-    </code>
+    <code>BONUS</code>
     tag
 documentation above.
    </li>
    <li>
     As with the standard bonus tags, the
-    <code>
-     TEMPBONUS
-    </code>
+    <code>TEMPBONUS</code>
     tag
 can take
-    <code>
-     TYPE
-    </code>
+    <code>TYPE</code>
     and
-    <code>
-     PRExxx
-    </code>
+    <code>PRExxx</code>
     tags.
    </li>
   </ul>
@@ -6103,49 +5381,35 @@ can take
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TEMPBONUS:PC|COMBAT|AC|2
-   </code>
+   <code>TEMPBONUS:PC|COMBAT|AC|2</code>
   </p>
   <p class="indent3">
    Increases armor class by two for the character
 granted the LST object containing the
-   <code>
-    TEMPBONUS
-   </code>
+   <code>TEMPBONUS</code>
    . This
 is equivalent to
-   <code>
-    BONUS:COMBAT|AC|2
-   </code>
+   <code>BONUS:COMBAT|AC|2</code>
    but is applied as a
 temporary bonus.
   </p>
   <p class="indent2">
-   <code>
-    TEMPBONUS:ANYPC|CHECKS|Fortitude,Reflex|1
-   </code>
+   <code>TEMPBONUS:ANYPC|CHECKS|Fortitude,Reflex|1</code>
   </p>
   <p class="indent3">
    Adds one to "Fortitude" and "Reflex" saves for
 any character. This is equivalent to
-   <code>
-    BONUS:CHECKS|Fortitude,Reflex|1
-   </code>
+   <code>BONUS:CHECKS|Fortitude,Reflex|1</code>
    but is applied as a
 temporary bonus.
   </p>
   <p class="indent2">
-   <code>
-    TEMPBONUS:EQ|TwoHanded|WEAPON|DAMAGE|1
-   </code>
+   <code>TEMPBONUS:EQ|TwoHanded|WEAPON|DAMAGE|1</code>
   </p>
   <p class="indent3">
    Adds one to the damage done by the two-handed
 weapon on which the bonus is applied. This is equivalent to
-   <code>
-    BONUS:WEAPON|DAMAGE|1
-   </code>
+   <code>BONUS:WEAPON|DAMAGE|1</code>
    but is applied as a temporary
 bonus.
   </p>
@@ -6156,13 +5420,9 @@ TEMPBONUS:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:COMBAT|AC|2|PREAPPLY:PC
-   </code>
+   <code>BONUS:COMBAT|AC|2|PREAPPLY:PC</code>
    becomes
-   <code>
-    TEMPBONUS:PC|COMBAT|AC|2
-   </code>
+   <code>TEMPBONUS:PC|COMBAT|AC|2</code>
   </p>
   <p class="indent1">
    <strong>

--- a/docs/listfilepages/globalfilestagpages/globalfileschoose.html
+++ b/docs/listfilepages/globalfilestagpages/globalfileschoose.html
@@ -75,14 +75,10 @@ tag.
 for it to work properly.
     <em>
      EXCEPTION:
-     <code>
-      MULT:YES
-     </code>
+     <code>MULT:YES</code>
      is
 not to be used with
-     <code>
-      CHOOSE:NUMBER
-     </code>
+     <code>CHOOSE:NUMBER</code>
      .
     </em>
    </li>
@@ -194,15 +190,11 @@ matches the stipulated criteria.
    </li>
    <li>
     Using the
-    <code>
-     FEAT=Text
-    </code>
+    <code>FEAT=Text</code>
     sub-tag will provide a list of
 abilities chosen by the referenced feat. The feat referenced must
 contain a
-    <code>
-     CHOOSE:ABILITY
-    </code>
+    <code>CHOOSE:ABILITY</code>
     tag.
    </li>
    <li>
@@ -236,9 +228,7 @@ for.
    <li>
     Qualifiers can be logically negated by prefacing with the
 exclamation point (!), i.e.
-    <code>
-     !PC
-    </code>
+    <code>!PC</code>
     is a valid usage.
    </li>
    <li>
@@ -269,9 +259,7 @@ before logical
     </a>
     tag is
 used in conjunction with this
-    <code>
-     CHOOSE
-    </code>
+    <code>CHOOSE</code>
     tag to define the
 number of "selections" that can be made.
    </li>
@@ -282,20 +270,16 @@ number of "selections" that can be made.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:ABILITY|FEAT|TYPE=Rogue
-Abilities
-   </code>
+   <code>CHOOSE:ABILITY|FEAT|TYPE=Rogue
+Abilities</code>
   </p>
   <p class="indent3">
    A list of all "Rogue Abilities" type feats will
 be presented.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:ABILITY|Special
-Ability|PC[TYPE=Mercy]
-   </code>
+   <code>CHOOSE:ABILITY|Special
+Ability|PC[TYPE=Mercy]</code>
   </p>
   <p class="indent3">
    A list of all "Mercy" type abilities will be
@@ -426,9 +410,7 @@ for.
    <li>
     Qualifiers can be logically negated by prefacing with the
 exclamation point (!), i.e.
-    <code>
-     !PC
-    </code>
+    <code>!PC</code>
     is a valid usage.
    </li>
    <li>
@@ -459,9 +441,7 @@ before logical
     </a>
     tag is
 used in conjunction with this
-    <code>
-     CHOOSE
-    </code>
+    <code>CHOOSE</code>
     tag to define the
 number of "selections" that can be made.
    </li>
@@ -472,20 +452,16 @@ number of "selections" that can be made.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:ABILITYSELECTION|FEAT|Weapon
-Focus
-   </code>
+   <code>CHOOSE:ABILITYSELECTION|FEAT|Weapon
+Focus</code>
   </p>
   <p class="indent3">
    Will display a list of feats comprised of the
 "Dodge" and "Toughness" feats.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:ABILITYSELECTION|Ranger ~ Favored
-Enemy,PC
-   </code>
+   <code>CHOOSE:ABILITYSELECTION|Ranger ~ Favored
+Enemy,PC</code>
   </p>
   <p class="indent3">
    This will produce a list of all the character's
@@ -559,14 +535,10 @@ for 3.5e gameMode).
    </li>
    <li>
     Use of the
-    <code>
-     FEAT
-    </code>
+    <code>FEAT</code>
     subtag will provide the alignment
 selected by the referenced feat. The feat referenced must contain a
-    <code>
-     CHOOSE:ALIGNMENT
-    </code>
+    <code>CHOOSE:ALIGNMENT</code>
     tag.
    </li>
    <li>
@@ -597,9 +569,7 @@ before logical
     </a>
     tag is
 used in conjunction with this
-    <code>
-     CHOOSE
-    </code>
+    <code>CHOOSE</code>
     tag to define the
 number of "selections" that can be made.
    </li>
@@ -708,22 +678,16 @@ the criteria.
    </li>
    <li>
     Using the
-    <code>
-     FEAT=Text
-    </code>
+    <code>FEAT=Text</code>
     sub-tag will provide a list of
 armor proficiencies selected by the referenced feat. The feat
 referenced must contain a
-    <code>
-     CHOOSE:ARMORPROFICIENCY
-    </code>
+    <code>CHOOSE:ARMORPROFICIENCY</code>
     tag.
    </li>
    <li>
     When using the
-    <code>
-     EQUIPMENT
-    </code>
+    <code>EQUIPMENT</code>
     qualifier the parameters
 included inside the brackets are used to identify a list of
 equipment from which the armor proficiencies are taken and added to
@@ -762,9 +726,7 @@ for.
    <li>
     Qualifiers can be logically negated by prefacing with the
 exclamation point (!), i.e.
-    <code>
-     !PC
-    </code>
+    <code>!PC</code>
     is a valid usage.
    </li>
    <li>
@@ -795,9 +757,7 @@ before logical
     </a>
     tag is
 used in conjunction with this
-    <code>
-     CHOOSE
-    </code>
+    <code>CHOOSE</code>
     tag to define the
 number of "selections" that can be made.
    </li>
@@ -808,37 +768,29 @@ number of "selections" that can be made.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:ARMORPROFICIENCY|TYPE=Heavy
-   </code>
+   <code>CHOOSE:ARMORPROFICIENCY|TYPE=Heavy</code>
   </p>
   <p class="indent3">
    Will display a list of proficiencies for all
 heavy armors.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:ARMORPROFICIENCY|Scale
-Mail|Chainmail
-   </code>
+   <code>CHOOSE:ARMORPROFICIENCY|Scale
+Mail|Chainmail</code>
   </p>
   <p class="indent3">
    Will display a list consisting of Scale Mail and
 Chainmail.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:ARMORPROFICIENCY|EQUIPMENT[Chainmail]
-   </code>
+   <code>CHOOSE:ARMORPROFICIENCY|EQUIPMENT[Chainmail]</code>
   </p>
   <p class="indent3">
    Will display a list the proficiencies for
 Chainmail.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:ARMORPROFICIENCY|EQUIPMENT
-   </code>
+   <code>CHOOSE:ARMORPROFICIENCY|EQUIPMENT</code>
   </p>
   <p class="indent3">
    Will display a list the proficiencies of all
@@ -911,14 +863,10 @@ etc).
    </li>
    <li>
     Use of the
-    <code>
-     FEAT
-    </code>
+    <code>FEAT</code>
     subtag will provide the stat
 selected by the referenced feat. The feat referenced must contain a
-    <code>
-     CHOOSE:CHECK
-    </code>
+    <code>CHOOSE:CHECK</code>
     tag.
    </li>
    <li>
@@ -949,9 +897,7 @@ before logical
     </a>
     tag is
 used in conjunction with this
-    <code>
-     CHOOSE
-    </code>
+    <code>CHOOSE</code>
     tag to define the
 number of "selections" that can be made.
    </li>
@@ -962,9 +908,7 @@ number of "selections" that can be made.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:CHECK|ALL
-   </code>
+   <code>CHOOSE:CHECK|ALL</code>
   </p>
   <p class="indent3">
    This will produce a list of all checks available
@@ -1069,30 +1013,22 @@ criteria.
    </li>
    <li>
     Using the
-    <code>
-     FEAT=Text
-    </code>
+    <code>FEAT=Text</code>
     sub-tag will provide a list of
 classes chosen by the referenced feat. The feat referenced must
 contain a
-    <code>
-     CHOOSE:CLASS
-    </code>
+    <code>CHOOSE:CLASS</code>
     tag.
    </li>
    <li>
     Using the
-    <code>
-     SPELLTYPE=Text
-    </code>
+    <code>SPELLTYPE=Text</code>
     sub-tag will provide a
 list of classes that cast spells of the designated type.
    </li>
    <li>
     Using the
-    <code>
-     SPELLCASTER
-    </code>
+    <code>SPELLCASTER</code>
     sub-tag will provide a list
 of classes that can cast spells.
    </li>
@@ -1125,9 +1061,7 @@ that the player character is otherwise qualified for.
    <li>
     Qualifiers can be logically negated by prefacing with the
 exclamation point (!), i.e.
-    <code>
-     !PC
-    </code>
+    <code>!PC</code>
     is a valid usage.
    </li>
    <li>
@@ -1158,9 +1092,7 @@ before logical
     </a>
     tag is
 used in conjunction with this
-    <code>
-     CHOOSE
-    </code>
+    <code>CHOOSE</code>
     tag to define the
 number of "selections" that can be made.
    </li>
@@ -1171,9 +1103,7 @@ number of "selections" that can be made.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:CLASS|TYPE=Prestige,PC
-   </code>
+   <code>CHOOSE:CLASS|TYPE=Prestige,PC</code>
   </p>
   <p class="indent3">
    A list of all
@@ -1184,9 +1114,7 @@ number of "selections" that can be made.
 classes that the PC has will be presented.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:CLASS|Wizard|Fighter
-   </code>
+   <code>CHOOSE:CLASS|Wizard|Fighter</code>
   </p>
   <p class="indent3">
    A list of all classes consisting of the
@@ -1201,9 +1129,7 @@ classes that the PC has will be presented.
 be presented.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:CLASS|Fighter|TYPE=Prestige,PC
-   </code>
+   <code>CHOOSE:CLASS|Fighter|TYPE=Prestige,PC</code>
   </p>
   <p class="indent3">
    A list of all
@@ -1317,30 +1243,22 @@ criteria.
    </li>
    <li>
     Using the
-    <code>
-     ALIGN=Text
-    </code>
+    <code>ALIGN=Text</code>
     sub-tag will provide a list
 of deities of the referenced alignment.
    </li>
    <li>
     Using the
-    <code>
-     FEAT=Text
-    </code>
+    <code>FEAT=Text</code>
     sub-tag will provide a list of
 deities selected by the referenced feat. The feat referenced must
 contain a
-    <code>
-     CHOOSE:DEITY
-    </code>
+    <code>CHOOSE:DEITY</code>
     tag.
    </li>
    <li>
     Using the
-    <code>
-     PANTEON=Text
-    </code>
+    <code>PANTEON=Text</code>
     sub-tag will provide a list
 of deities of the referenced pantheon.
    </li>
@@ -1373,9 +1291,7 @@ that the player character is otherwise qualified for.
    <li>
     Qualifiers can be logically negated by prefacing with the
 exclamation point (!), i.e.
-    <code>
-     !PC
-    </code>
+    <code>!PC</code>
     is a valid usage.
    </li>
    <li>
@@ -1406,9 +1322,7 @@ before logical
     </a>
     tag is
 used in conjunction with this
-    <code>
-     CHOOSE
-    </code>
+    <code>CHOOSE</code>
     tag to define the
 number of "selections" that can be made.
    </li>
@@ -1419,9 +1333,7 @@ number of "selections" that can be made.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:DEITY|Set|Ra
-   </code>
+   <code>CHOOSE:DEITY|Set|Ra</code>
   </p>
   <p class="indent3">
    A list of the deities
@@ -1435,9 +1347,7 @@ number of "selections" that can be made.
    will be presented.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:DEITY|Set,Ra
-   </code>
+   <code>CHOOSE:DEITY|Set,Ra</code>
   </p>
   <p class="indent3">
    No deity list will be presented because no deity
@@ -1452,9 +1362,7 @@ can be both
    .
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:DEITY|PANTHEON=Olympian,ALIGN=LG
-   </code>
+   <code>CHOOSE:DEITY|PANTHEON=Olympian,ALIGN=LG</code>
   </p>
   <p class="indent3">
    A list of all
@@ -1469,9 +1377,7 @@ can be both
 presented.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:DEITY|TYPE=Good,PC
-   </code>
+   <code>CHOOSE:DEITY|TYPE=Good,PC</code>
   </p>
   <p class="indent3">
    A list of all
@@ -1575,23 +1481,17 @@ criteria.
    </li>
    <li>
     Using the
-    <code>
-     DEITY=Text
-    </code>
+    <code>DEITY=Text</code>
     sub-tag will provide a list
 of domains for the referenced deity.
    </li>
    <li>
     Using the
-    <code>
-     FEAT=Text
-    </code>
+    <code>FEAT=Text</code>
     sub-tag will provide a list of
 domains selected by the referenced feat. The feat referenced must
 contain a
-    <code>
-     CHOOSE:DOMAIN
-    </code>
+    <code>CHOOSE:DOMAIN</code>
     tag.
    </li>
    <li>
@@ -1623,9 +1523,7 @@ that the player character is otherwise qualified for.
    <li>
     Qualifiers can be logically negated by prefacing with the
 exclamation point (!), i.e.
-    <code>
-     !PC
-    </code>
+    <code>!PC</code>
     is a valid usage.
    </li>
    <li>
@@ -1656,9 +1554,7 @@ before logical
     </a>
     tag is
 used in conjunction with this
-    <code>
-     CHOOSE
-    </code>
+    <code>CHOOSE</code>
     tag to define the
 number of "selections" that can be made.
    </li>
@@ -1669,9 +1565,7 @@ number of "selections" that can be made.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:DOMAIN|Air|Fire|Sun
-   </code>
+   <code>CHOOSE:DOMAIN|Air|Fire|Sun</code>
   </p>
   <p class="indent3">
    A list of domains including
@@ -1689,9 +1583,7 @@ number of "selections" that can be made.
    domains will be presented.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:DOMAIN|DIETY=Kong
-   </code>
+   <code>CHOOSE:DOMAIN|DIETY=Kong</code>
   </p>
   <p class="indent3">
    A list of domains granted by the deity
@@ -1799,9 +1691,7 @@ criteria.
    </li>
    <li>
     Using the
-    <code>
-     WIELD=Text
-    </code>
+    <code>WIELD=Text</code>
     sub-tag will provide a list
 of equipment of the referenced wield type. The wield type must one
 of the following three types: Light, One-Handed, Two-Handed.
@@ -1853,9 +1743,7 @@ that the player character has and is equipped.
    <li>
     Qualifiers can be logically negated by prefacing with the
 exclamation point (!), i.e.
-    <code>
-     !PC
-    </code>
+    <code>!PC</code>
     is a valid usage.
    </li>
    <li>
@@ -1886,9 +1774,7 @@ before logical
     </a>
     tag is
 used in conjunction with this
-    <code>
-     CHOOSE
-    </code>
+    <code>CHOOSE</code>
     tag to define the
 number of "selections" that can be made.
    </li>
@@ -1899,18 +1785,14 @@ number of "selections" that can be made.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:EQUIPMENT|TYPE=Melee.Simple
-   </code>
+   <code>CHOOSE:EQUIPMENT|TYPE=Melee.Simple</code>
   </p>
   <p class="indent3">
    A list of all "Simple" and "Melee" type feats
 will be presented.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:EQUIPMENT|TYPE=Simple,OWNED
-   </code>
+   <code>CHOOSE:EQUIPMENT|TYPE=Simple,OWNED</code>
   </p>
   <p class="indent3">
    A list of all simple equipment that the PC has
@@ -2012,15 +1894,11 @@ criteria.
    </li>
    <li>
     Using the
-    <code>
-     FEAT=Text
-    </code>
+    <code>FEAT=Text</code>
     sub-tag will provide a list of
 feats chosen by the referenced feat. The feat referenced must
 contain a
-    <code>
-     CHOOSE:FEAT
-    </code>
+    <code>CHOOSE:FEAT</code>
     tag.
    </li>
    <li>
@@ -2052,9 +1930,7 @@ that the player character is otherwise qualified for.
    <li>
     Qualifiers can be logically negated by prefacing with the
 exclamation point (!), i.e.
-    <code>
-     !PC
-    </code>
+    <code>!PC</code>
     is a valid usage.
    </li>
    <li>
@@ -2085,9 +1961,7 @@ before logical
     </a>
     tag is
 used in conjunction with this
-    <code>
-     CHOOSE
-    </code>
+    <code>CHOOSE</code>
     tag to define the
 number of "selections" that can be made.
    </li>
@@ -2098,36 +1972,28 @@ number of "selections" that can be made.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:FEAT|Dodge|Toughness
-   </code>
+   <code>CHOOSE:FEAT|Dodge|Toughness</code>
   </p>
   <p class="indent3">
    Will display a list of feats comprised of the
 "Dodge" and "Toughness" feats.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:FEAT|TYPE=Fighter,PC
-   </code>
+   <code>CHOOSE:FEAT|TYPE=Fighter,PC</code>
   </p>
   <p class="indent3">
    This will produce a list of all the character's
 fighter feats.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:FEAT|PC[TYPE=Fighter]
-   </code>
+   <code>CHOOSE:FEAT|PC[TYPE=Fighter]</code>
   </p>
   <p class="indent3">
    This will produce a list of all the character's
 fighter feats.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:FEAT|TYPE=Fighter
-   </code>
+   <code>CHOOSE:FEAT|TYPE=Fighter</code>
   </p>
   <p class="indent3">
    This will produce a list of all fighter
@@ -2247,9 +2113,7 @@ that the player character is otherwise qualified for.
    <li>
     Qualifiers can be logically negated by prefacing with the
 exclamation point (!), i.e.
-    <code>
-     !PC
-    </code>
+    <code>!PC</code>
     is a valid usage.
    </li>
    <li>
@@ -2280,9 +2144,7 @@ before logical
     </a>
     tag is
 used in conjunction with this
-    <code>
-     CHOOSE
-    </code>
+    <code>CHOOSE</code>
     tag to define the
 number of "selections" that can be made.
    </li>
@@ -2293,36 +2155,28 @@ number of "selections" that can be made.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:FEATSELECTION|Dodge|Toughness
-   </code>
+   <code>CHOOSE:FEATSELECTION|Dodge|Toughness</code>
   </p>
   <p class="indent3">
    Will display a list of feats comprised of the
 "Dodge" and "Toughness" feats.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:FEATSELECTION|TYPE=Fighter,PC
-   </code>
+   <code>CHOOSE:FEATSELECTION|TYPE=Fighter,PC</code>
   </p>
   <p class="indent3">
    This will produce a list of all the character's
 fighter feats.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:FEATSELECTION|PC[TYPE=Fighter]
-   </code>
+   <code>CHOOSE:FEATSELECTION|PC[TYPE=Fighter]</code>
   </p>
   <p class="indent3">
    This will produce a list of all the character's
 fighter feats.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:FEATSELECTION|TYPE=Fighter
-   </code>
+   <code>CHOOSE:FEATSELECTION|TYPE=Fighter</code>
   </p>
   <p class="indent3">
    This will produce a list of all fighter
@@ -2419,26 +2273,18 @@ files.
    </li>
    <li>
     Use of the
-    <code>
-     FEAT
-    </code>
+    <code>FEAT</code>
     sub-tag will provide the language
 selected by the referenced feat. The feat referenced must contain a
-    <code>
-     CHOOSE:LANG
-    </code>
+    <code>CHOOSE:LANG</code>
     tag.
    </li>
    <li>
     Use of
-    <code>
-     LANBONUS
-    </code>
+    <code>LANBONUS</code>
     will provide a list of languages
 granted to the character by the
-    <code>
-     LANGBONUS
-    </code>
+    <code>LANGBONUS</code>
     tag through
 the character's race, class or template.
    </li>
@@ -2473,9 +2319,7 @@ for.
    <li>
     Qualifiers can be logically negated by prefacing with the
 exclamation point (!), i.e.
-    <code>
-     !PC
-    </code>
+    <code>!PC</code>
     is a valid usage.
    </li>
    <li>
@@ -2506,9 +2350,7 @@ before logical
     </a>
     tag is
 used in conjunction with this
-    <code>
-     CHOOSE
-    </code>
+    <code>CHOOSE</code>
     tag to define the
 number of "selections" that can be made.
    </li>
@@ -2519,27 +2361,21 @@ number of "selections" that can be made.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:LANG|Common|Goblin
-   </code>
+   <code>CHOOSE:LANG|Common|Goblin</code>
   </p>
   <p class="indent3">
    Presents the "Common" and "Goblin" languages for
 selection.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:LANG|Common,Goblin
-   </code>
+   <code>CHOOSE:LANG|Common,Goblin</code>
   </p>
   <p class="indent3">
    No languages are presented as no language is
 both "Common" and "Goblin".
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:LANG|Common|TYPE=Foo,PC
-   </code>
+   <code>CHOOSE:LANG|Common|TYPE=Foo,PC</code>
   </p>
   <p class="indent3">
    Presents the "Common" language and any languages
@@ -2573,9 +2409,7 @@ files.
     Suppresses the pop-up window for this CHOOSE tag.
    </li>
    <li>
-    <code>
-     MULT:YES
-    </code>
+    <code>MULT:YES</code>
     must be used when using this tag.
    </li>
    <li>
@@ -2588,13 +2422,9 @@ number of times the feat was chosen.
     When used for a "nested" choice, the "outer" choice isn't
 displayed. Example: Given feats "X" and "Y" where feat "X" includes
 the
-    <code>
-     ADD:FEAT|Y
-    </code>
+    <code>ADD:FEAT|Y</code>
     tag and feat "X" also includes a
-    <code>
-     CHOOSE
-    </code>
+    <code>CHOOSE</code>
     tag, the feat "X(Y)" is displayed in the
 chooser. With this option it will show up as "Y".
    </li>
@@ -2605,9 +2435,7 @@ chooser. With this option it will show up as "Y".
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:NOCHOICE
-   </code>
+   <code>CHOOSE:NOCHOICE</code>
   </p>
   <p class="indent3">
    The feat is added without a chooser window.
@@ -2660,18 +2488,12 @@ values, inclusive
    </li>
    <li>
     Unlike other
-    <code>
-     CHOOSE
-    </code>
+    <code>CHOOSE</code>
     tags,
-    <code>
-     MULT:YES
-    </code>
+    <code>MULT:YES</code>
     is
 not to be used with
-    <code>
-     CHOOSE:NUMBER
-    </code>
+    <code>CHOOSE:NUMBER</code>
     .
    </li>
    <li>
@@ -2681,9 +2503,7 @@ not to be used with
     </a>
     tag is
 used in conjunction with this
-    <code>
-     CHOOSE
-    </code>
+    <code>CHOOSE</code>
     tag to define the
 number of "selections" that can be made.
    </li>
@@ -2701,10 +2521,8 @@ the chooser if invoked from the Temporary Bonus tab.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:NUMBER|MIN=2|MAX=5|TITLE=Roll 1d4+1
-and pick a number
-   </code>
+   <code>CHOOSE:NUMBER|MIN=2|MAX=5|TITLE=Roll 1d4+1
+and pick a number</code>
   </p>
   <p class="indent3">
    Will let you choose a number between 2 and 5.
@@ -2780,9 +2598,7 @@ Game Mode file.
     </a>
     tag is
 used in conjunction with this
-    <code>
-     CHOOSE
-    </code>
+    <code>CHOOSE</code>
     tag to define the
 number of "selections" that can be made.
    </li>
@@ -2800,30 +2616,20 @@ modes distributed with PCGen do not use stat types.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:STAT|DEX|CON
-   </code>
+   <code>CHOOSE:STAT|DEX|CON</code>
   </p>
   <p class="indent3">
    Un-intuitively, this produces a list of all stats
    <em>
     except
    </em>
-   <code>
-    DEX
-   </code>
+   <code>DEX</code>
    and
-   <code>
-    CON
-   </code>
+   <code>CON</code>
    . Due to the potential for confusion, the
-   <code>
-    CHOOSE:STAT
-   </code>
+   <code>CHOOSE:STAT</code>
    syntax has been replaced by the
-   <code>
-    CHOOSE:PCSTAT
-   </code>
+   <code>CHOOSE:PCSTAT</code>
    syntax below.
   </p>
   <p class="indent1">
@@ -2833,13 +2639,9 @@ Syntax:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:STAT|STR|CON
-   </code>
+   <code>CHOOSE:STAT|STR|CON</code>
    becomes
-   <code>
-    CHOOSE:PCSTAT|DEX|INT|WIS|CHA
-   </code>
+   <code>CHOOSE:PCSTAT|DEX|INT|WIS|CHA</code>
   </p>
   <p class="indent1">
    <strong>
@@ -2946,48 +2748,34 @@ criteria.
    </li>
    <li>
     Using the
-    <code>
-     FEAT=Text
-    </code>
+    <code>FEAT=Text</code>
     sub-tag will provide a list of
 races selected by the referenced feat. The feat referenced must
 contain a
-    <code>
-     CHOOSE:RACE
-    </code>
+    <code>CHOOSE:RACE</code>
     tag.
    </li>
    <li>
     Using the
-    <code>
-     RACETYPE=Text
-    </code>
+    <code>RACETYPE=Text</code>
     sub-tag will provide a
 list of races selected by the referenced race-type. The referenced
 race-type is defined in the race's
-    <code>
-     RACETYPE
-    </code>
+    <code>RACETYPE</code>
     tag.
    </li>
    <li>
     Using the
-    <code>
-     RACESUBTYPE=Text
-    </code>
+    <code>RACESUBTYPE=Text</code>
     sub-tag will provide a
 list of races selected by the referenced race-subtype. The
 referenced race-subtype is defined in the race's
-    <code>
-     RACESUBTYPE
-    </code>
+    <code>RACESUBTYPE</code>
     tag.
    </li>
    <li>
     Using the
-    <code>
-     BASESIZE=Text
-    </code>
+    <code>BASESIZE=Text</code>
     sub-tag will provide a
 list of races selected by the referenced size as defined in the
     <span class="lstfile">
@@ -2996,9 +2784,7 @@ list of races selected by the referenced size as defined in the
     gameMode file. The
 size referenced will be compared to the base size, e.i. the
 contents of the
-    <code>
-     SIZE
-    </code>
+    <code>SIZE</code>
     tag in the
     <strong>
      RACE
@@ -3035,9 +2821,7 @@ that the player character is otherwise qualified for.
    <li>
     Qualifiers can be logically negated by prefacing with the
 exclamation point (!), i.e.
-    <code>
-     !PC
-    </code>
+    <code>!PC</code>
     is a valid usage.
    </li>
    <li>
@@ -3068,9 +2852,7 @@ before logical
     </a>
     tag is
 used in conjunction with this
-    <code>
-     CHOOSE
-    </code>
+    <code>CHOOSE</code>
     tag to define the
 number of "selections" that can be made.
    </li>
@@ -3081,18 +2863,14 @@ number of "selections" that can be made.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:RACE|RACETYPE=Dragon
-   </code>
+   <code>CHOOSE:RACE|RACETYPE=Dragon</code>
   </p>
   <p class="indent3">
    This will produce a list of all races that have
 the Dragon racial type.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:RACE|Dwarf|Elf
-   </code>
+   <code>CHOOSE:RACE|Dwarf|Elf</code>
   </p>
   <p class="indent3">
    This will produce a list of races including only
@@ -3107,18 +2885,14 @@ the
    .
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:RACE|RACETYPE=Humanoid,RACESUBTYPE=Aquatic
-   </code>
+   <code>CHOOSE:RACE|RACETYPE=Humanoid,RACESUBTYPE=Aquatic</code>
   </p>
   <p class="indent3">
    This will produce a list of all Humanoid races
 that have the Aquatic subtype.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:RACE|BASESIZE=M
-   </code>
+   <code>CHOOSE:RACE|BASESIZE=M</code>
   </p>
   <p class="indent3">
    This will produce a list of all races that have
@@ -3178,18 +2952,14 @@ Abjuration, Evocation, etc.).
    </li>
    <li>
     Use of the
-    <code>
-     FEAT
-    </code>
+    <code>FEAT</code>
     subtag will provide the
     <strong>
      SCHOOL
     </strong>
     selection made in the referenced feat. The
 feat referenced must contain a
-    <code>
-     CHOOSE:SCHOOLS
-    </code>
+    <code>CHOOSE:SCHOOLS</code>
     tag.
    </li>
    <li>
@@ -3199,9 +2969,7 @@ feat referenced must contain a
     </a>
     tag is
 used in conjunction with this
-    <code>
-     CHOOSE
-    </code>
+    <code>CHOOSE</code>
     tag to define the
 number of "selections" that can be made.
    </li>
@@ -3212,18 +2980,14 @@ number of "selections" that can be made.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:SCHOOLS|ALL
-   </code>
+   <code>CHOOSE:SCHOOLS|ALL</code>
   </p>
   <p class="indent3">
    This will produce a list of all schools of magic
 (abjuration, evocation, etc.).
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:SCHOOLS|FEAT=Spell Focus
-   </code>
+   <code>CHOOSE:SCHOOLS|FEAT=Spell Focus</code>
   </p>
   <p class="indent3">
    This will produce a list of all schools for
@@ -3235,13 +2999,9 @@ which the character has the "Spell Focus" feat.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:SCHOOLS
-   </code>
+   <code>CHOOSE:SCHOOLS</code>
    becomes
-   <code>
-    CHOOSE:SCHOOLS|ALL
-   </code>
+   <code>CHOOSE:SCHOOLS|ALL</code>
   </p>
   <p class="indent1">
    <strong>
@@ -3335,22 +3095,16 @@ the criteria.
    </li>
    <li>
     Using the
-    <code>
-     FEAT=Text
-    </code>
+    <code>FEAT=Text</code>
     sub-tag will provide a list of
 shield proficiencies selected by the referenced feat. The feat
 referenced must contain a
-    <code>
-     CHOOSE:SHIELDPROFICIENCY
-    </code>
+    <code>CHOOSE:SHIELDPROFICIENCY</code>
     tag.
    </li>
    <li>
     When using the
-    <code>
-     EQUIPMENT
-    </code>
+    <code>EQUIPMENT</code>
     qualifier the parameters
 included inside the brackets are used to identify a list of
 equipment from which the shield proficiencies are taken and added
@@ -3389,9 +3143,7 @@ for.
    <li>
     Qualifiers can be logically negated by prefacing with the
 exclamation point (!), i.e.
-    <code>
-     !PC
-    </code>
+    <code>!PC</code>
     is a valid usage.
    </li>
    <li>
@@ -3422,9 +3174,7 @@ before logical
     </a>
     tag is
 used in conjunction with this
-    <code>
-     CHOOSE
-    </code>
+    <code>CHOOSE</code>
     tag to define the
 number of "selections" that can be made.
    </li>
@@ -3435,9 +3185,7 @@ number of "selections" that can be made.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:SHIELDPROFICIENCY|TYPE=Foo
-   </code>
+   <code>CHOOSE:SHIELDPROFICIENCY|TYPE=Foo</code>
   </p>
   <p class="indent3">
    Will display a list of proficiencies for all
@@ -3448,28 +3196,22 @@ shield proficiencies of type
    .
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:SHIELDPROFICIENCY|Buckler|Tower
-Shield
-   </code>
+   <code>CHOOSE:SHIELDPROFICIENCY|Buckler|Tower
+Shield</code>
   </p>
   <p class="indent3">
    Will display no proficiencies as no shield will
 have both proficiencies lisyted.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:SHIELDPROFICIENCY|EQUIPMENT[Buckler]
-   </code>
+   <code>CHOOSE:SHIELDPROFICIENCY|EQUIPMENT[Buckler]</code>
   </p>
   <p class="indent3">
    Will display a list the proficiencies for the
 Buckler.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:SHIELDPROFICIENCY|EQUIPMENT
-   </code>
+   <code>CHOOSE:SHIELDPROFICIENCY|EQUIPMENT</code>
   </p>
   <p class="indent3">
    Will display a list the shield proficiencies of
@@ -3548,9 +3290,7 @@ logical
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:SIZE|ALL
-   </code>
+   <code>CHOOSE:SIZE|ALL</code>
   </p>
   <p class="indent3">
    This will produce a list of all sizes available
@@ -3685,66 +3425,48 @@ partial name provided.
    </li>
    <li>
     Using the
-    <code>
-     FEAT=Text
-    </code>
+    <code>FEAT=Text</code>
     sub-tag will provide a list of
 skills chosen by the referenced feat. The feat referenced must
 contain a
-    <code>
-     CHOOSE:SKILL
-    </code>
+    <code>CHOOSE:SKILL</code>
     tag.
    </li>
    <li>
     Using the
-    <code>
-     CLASS
-    </code>
+    <code>CLASS</code>
     sub-tag will provide a list of all
 class skills for the PC.
    </li>
    <li>
     Using the
-    <code>
-     CROSSCLASS
-    </code>
+    <code>CROSSCLASS</code>
     sub-tag will provide a list
 of all crossclass skills for the PC.
    </li>
    <li>
     Using the
-    <code>
-     EXCLUSIVE
-    </code>
+    <code>EXCLUSIVE</code>
     sub-tag will provide a list of
 all exclusive skills for the PC.
    </li>
    <li>
     Using the
-    <code>
-     NORANK
-    </code>
+    <code>NORANK</code>
     sub-tag will provide a list of
 all skills in which the PC has no rank.
    </li>
    <li>
     Using the
-    <code>
-     RANKS=n
-    </code>
+    <code>RANKS=n</code>
     sub-tag will provide a list of
 all skills in which the PC has n or more ranks.
     <ul>
      <li>
       The special value
-      <code>
-       MAXRANK
-      </code>
+      <code>MAXRANK</code>
       can be used with the
-      <code>
-       RANKS
-      </code>
+      <code>RANKS</code>
       qualifier to identify skills that are currently
 at the maximum ranks allowed.
      </li>
@@ -3779,9 +3501,7 @@ skills that the player character can use intrained.
    <li>
     Qualifiers can be logically negated by prefacing with the
 exclamation point (!), i.e.
-    <code>
-     !PC
-    </code>
+    <code>!PC</code>
     is a valid usage.
    </li>
    <li>
@@ -3812,9 +3532,7 @@ before logical
     </a>
     tag is
 used in conjunction with this
-    <code>
-     CHOOSE
-    </code>
+    <code>CHOOSE</code>
     tag to define the
 number of "selections" that can be made.
    </li>
@@ -3825,9 +3543,7 @@ number of "selections" that can be made.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:SKILL|Search|Spot
-   </code>
+   <code>CHOOSE:SKILL|Search|Spot</code>
   </p>
   <p class="indent3">
    Will display a list of skills comprised of the
@@ -3841,36 +3557,28 @@ number of "selections" that can be made.
    skills.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:SKILL|CLASS
-   </code>
+   <code>CHOOSE:SKILL|CLASS</code>
   </p>
   <p class="indent3">
    This will produce a list of all the character's
 class skills.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:SKILL|RANKS=1
-   </code>
+   <code>CHOOSE:SKILL|RANKS=1</code>
   </p>
   <p class="indent3">
    This will produce a list of all skills the
 character's has one or more ranks in.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:SKILL|!RANKS=MAXRANK
-   </code>
+   <code>CHOOSE:SKILL|!RANKS=MAXRANK</code>
   </p>
   <p class="indent3">
    This will produce a list of all skills the
 character's has that are not at the maximum ranks allowed.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:SKILL|Knowledge%
-   </code>
+   <code>CHOOSE:SKILL|Knowledge%</code>
   </p>
   <p class="indent3">
    This will produce a list of all knowledge
@@ -3973,34 +3681,24 @@ formula (Minimum level)
 class or type.
    </li>
    <li>
-    <code>
-     TITLE
-    </code>
+    <code>TITLE</code>
     provides a descriptive title for the
 chooser.
    </li>
    <li>
-    <code>
-     CLASS=Text
-    </code>
+    <code>CLASS=Text</code>
     will include spell levels of the
 designated classe.
    </li>
    <li>
-    <code>
-     SPELLTYPE=Text
-    </code>
+    <code>SPELLTYPE=Text</code>
     will include spell levels of the
 designated spell type.
    </li>
    <li>
-    <code>
-     TYPE
-    </code>
+    <code>TYPE</code>
     will include, or exclude in the case of
-    <code>
-     !TYPE
-    </code>
+    <code>!TYPE</code>
     , spell levels of the designated spell type.
    </li>
    <li>
@@ -4014,9 +3712,7 @@ minimum Level (y) and maximum Level (z), inclusive.
     </a>
     tag is
 used in conjunction with this
-    <code>
-     CHOOSE
-    </code>
+    <code>CHOOSE</code>
     tag to define the
 number of "selections" that can be made.
    </li>
@@ -4027,9 +3723,7 @@ number of "selections" that can be made.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:SPELLLEVEL|CLASS=Wizard|0|MAXLEVEL|SPELLTYPE=Divine|1|3
-   </code>
+   <code>CHOOSE:SPELLLEVEL|CLASS=Wizard|0|MAXLEVEL|SPELLTYPE=Divine|1|3</code>
   </p>
   <p class="indent3">
    Would present a list of the character's castable
@@ -4038,10 +3732,8 @@ level Wizard) and Cleric 1 Cleric 2 Cleric 3 if the character had
 Cleric as a class.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:SPELLLEVEL|SPELLTYPE=Arcane|0|MAXLEVEL &lt;tab&gt;
-BONUS:SPELLCAST|%LIST|1
-   </code>
+   <code>CHOOSE:SPELLLEVEL|SPELLTYPE=Arcane|0|MAXLEVEL &lt;tab&gt;
+BONUS:SPELLCAST|%LIST|1</code>
   </p>
   <p class="indent3">
    Would present a list of the character's castable
@@ -4055,17 +3747,13 @@ Syntax:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:SPELLLEVEL||2|TYPE.Arcane|4|MAXLEVEL+30[BONUS:SPELLCAST|CLASS=%;LEVEL=%|1]
-   </code>
+   <code>CHOOSE:SPELLLEVEL||2|TYPE.Arcane|4|MAXLEVEL+30[BONUS:SPELLCAST|CLASS=%;LEVEL=%|1]</code>
    becomes
   </p>
   <p class="indent3">
-   <code>
-    SELECT:2 &lt;tab&gt;
+   <code>SELECT:2 &lt;tab&gt;
 CHOOSE:SPELLLEVEL|SPELLTYPE=Arcane|4|MAXLEVEL+30 &lt;tab&gt;
-BONUS:SPELLCAST|%LIST|1
-   </code>
+BONUS:SPELLCAST|%LIST|1</code>
   </p>
   <p class="indent1">
    <strong>
@@ -4190,58 +3878,44 @@ included sub-tags.
    </li>
    <li>
     The
-    <code>
-     PROHIBITED
-    </code>
+    <code>PROHIBITED</code>
     sub-tag will restrict the presented
 spell list to prohibited ("YES") spells or non-prohibited ("NO")
 spells. If it is not included, both are presented.
    </li>
    <li>
     The
-    <code>
-     SPELLBOOK
-    </code>
+    <code>SPELLBOOK</code>
     sub-tag is used to reference the
 specific spell book, such as "Innate", in which the spells is
 located.
    </li>
    <li>
     The spell type used in the
-    <code>
-     SPELLTYPE
-    </code>
+    <code>SPELLTYPE</code>
     sub-tag above
 MUST be used in a
-    <code>
-     SPELLTYPE
-    </code>
+    <code>SPELLTYPE</code>
     tag within a loaded
 class.
    </li>
    <li>
     The
-    <code>
-     KNOWN
-    </code>
+    <code>KNOWN</code>
     sub-tag will restrict the presented
 spell list to known ("YES") spells or unknown ("NO") spells. If it
 is not included, both are presented.
    </li>
    <li>
     The
-    <code>
-     LEVELMIN
-    </code>
+    <code>LEVELMIN</code>
     sub-tag references all spells of the
 specified level and higher within the context of the "y" variable
 preceding the brackets.
    </li>
    <li>
     The
-    <code>
-     LEVELMAX
-    </code>
+    <code>LEVELMAX</code>
     sub-tag references all spells of the
 specified level and lower within the context of the "y" variable
 preceding the brackets.
@@ -4279,9 +3953,7 @@ not.
     </a>
     tag is
 used in conjunction with this
-    <code>
-     CHOOSE
-    </code>
+    <code>CHOOSE</code>
     tag to define the
 number of "selections" that can be made.
    </li>
@@ -4292,65 +3964,49 @@ number of "selections" that can be made.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:SPELLS|Acid Arrow|Magic Missile|Ray
-of Frost
-   </code>
+   <code>CHOOSE:SPELLS|Acid Arrow|Magic Missile|Ray
+of Frost</code>
   </p>
   <p class="indent3">
    Choose between Acid Arrow, Magic Missile and Ray
 of Frost
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:SPELLS|CLASSLIST=Psion[LEVELMIN=1;LEVELMAX=3]
-   </code>
+   <code>CHOOSE:SPELLS|CLASSLIST=Psion[LEVELMIN=1;LEVELMAX=3]</code>
   </p>
   <p class="indent3">
    Choose from Psion spells between first level and
 third level
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:SPELLS|SPELLTYPE=Arcane,SCHOOL=Evocation
-   </code>
+   <code>CHOOSE:SPELLS|SPELLTYPE=Arcane,SCHOOL=Evocation</code>
   </p>
   <p class="indent3">
    Choose from Arcane Evocation spells
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:SPELLS|DESCRIPTOR=Good
-   </code>
+   <code>CHOOSE:SPELLS|DESCRIPTOR=Good</code>
   </p>
   <p class="indent3">
    Choose from spells with the Good descriptor
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:SPELLS|ALL[KNOWN=YES]
-   </code>
+   <code>CHOOSE:SPELLS|ALL[KNOWN=YES]</code>
   </p>
   <p class="indent3">
    Choose from spells known by the PC.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:SPELLS|ALL[LEVELMAX=MAXCASTABLE-1],SPELLTYPE=Arcane
-   </code>
+   <code>CHOOSE:SPELLS|ALL[LEVELMAX=MAXCASTABLE-1],SPELLTYPE=Arcane</code>
   </p>
   <p class="indent3">
    Choose from spells that are both up to the
 maximum castable (of any spell) level minus 1 AND
-   <code>
-    SPELLTYPE=Arcane
-   </code>
+   <code>SPELLTYPE=Arcane</code>
    .
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:SPELLS|CLASSLIST=Sorcerer[LEVELMIN=1;LEVELMAX=MAXCASTABLE-1]
-   </code>
+   <code>CHOOSE:SPELLS|CLASSLIST=Sorcerer[LEVELMIN=1;LEVELMAX=MAXCASTABLE-1]</code>
   </p>
   <p class="indent3">
    Choose from Sorcerer spells between first level
@@ -4358,45 +4014,31 @@ and one less than your max castable level of spell taken from the
 Sorcerer list
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:SPELLS|SPELLTYPE=Psionic[KNOWN=YES]|SPELLTYPE=Psionic[LEVELMAX=MAXCASTABLE-1]
-   </code>
+   <code>CHOOSE:SPELLS|SPELLTYPE=Psionic[KNOWN=YES]|SPELLTYPE=Psionic[LEVELMAX=MAXCASTABLE-1]</code>
   </p>
   <p class="indent3">
    Choose from any Psionic "Spell" known by the PC
 or available to any Psionic Caster at a level at least one less
 than the maximum level of Psionic "Spell" castable by the PC.
 Notice the independence of the
-   <code>
-    KNOWN
-   </code>
+   <code>KNOWN</code>
    and
-   <code>
-    LEVELMAX
-   </code>
+   <code>LEVELMAX</code>
    subtags forces the use of two sets of square
 brackets ([ ]).
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:SPELLS|SPELLTYPE=Psionic[KNOWN=YES;LEVELMAX=MAXCASTABLE-1]
-   </code>
+   <code>CHOOSE:SPELLS|SPELLTYPE=Psionic[KNOWN=YES;LEVELMAX=MAXCASTABLE-1]</code>
   </p>
   <p class="indent3">
    Choose from any Psionic "Spell" known by the PC
 at a level at least one less than the maximum level of Psionic
 "Spell" castable by the PC. Notice the common case between the
-   <code>
-    KNOWN
-   </code>
+   <code>KNOWN</code>
    ,
-   <code>
-    LEVELMIN
-   </code>
+   <code>LEVELMIN</code>
    , and
-   <code>
-    LEVELMAX
-   </code>
+   <code>LEVELMAX</code>
    subtags can be done with one set of square
 brackets ([ ]).
   </p>
@@ -4445,9 +4087,7 @@ files.
     </a>
     tag is
 used in conjunction with this
-    <code>
-     CHOOSE
-    </code>
+    <code>CHOOSE</code>
     tag to define the
 number of "selections" that can be made.
    </li>
@@ -4458,18 +4098,14 @@ number of "selections" that can be made.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:STRING|+1|+2
-   </code>
+   <code>CHOOSE:STRING|+1|+2</code>
   </p>
   <p class="indent3">
    This will produce a list consisting of "+1" and
 "+2".
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:STRING|Undead|Constructs|Monkeys
-   </code>
+   <code>CHOOSE:STRING|Undead|Constructs|Monkeys</code>
   </p>
   <p class="indent3">
    This will produce a list consisting of "Undead",
@@ -4556,23 +4192,17 @@ files.
    </li>
    <li>
     Use of the
-    <code>
-     FEAT
-    </code>
+    <code>FEAT</code>
     sub-tag will provide a list of
 templates selected by the referenced feat. The feat referenced must
 contain a
-    <code>
-     CHOOSE:TEMPLATE
-    </code>
+    <code>CHOOSE:TEMPLATE</code>
     tag.
    </li>
    <li>
     Qualifiers can be logically negated by prefacing with the
 exclamation point (!), i.e.
-    <code>
-     !PC
-    </code>
+    <code>!PC</code>
     is a valid usage.
    </li>
    <li>
@@ -4603,9 +4233,7 @@ before logical
     </a>
     tag is
 used in conjunction with this
-    <code>
-     CHOOSE
-    </code>
+    <code>CHOOSE</code>
     tag to define the
 number of "selections" that can be made.
    </li>
@@ -4616,27 +4244,21 @@ number of "selections" that can be made.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:TEMPLATE|Mindless|Undead
-   </code>
+   <code>CHOOSE:TEMPLATE|Mindless|Undead</code>
   </p>
   <p class="indent3">
    Presents the "Mindless" and "Undead" templates
 for selection.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:TEMPLATE|Mindless,Undead
-   </code>
+   <code>CHOOSE:TEMPLATE|Mindless,Undead</code>
   </p>
   <p class="indent3">
    No templates are presented as no template is
 both "Mindless" and "Undead".
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:TEMPLATE|Mindless|TYPE=Foo,PC
-   </code>
+   <code>CHOOSE:TEMPLATE|Mindless|TYPE=Foo,PC</code>
   </p>
   <p class="indent3">
    Presents the "Mindless" template and any
@@ -4644,9 +4266,7 @@ templates that have the "Foo" type which are already selected by
 the Player Character.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:TEMPLATE|Mindless|PC[TYPE=Foo]
-   </code>
+   <code>CHOOSE:TEMPLATE|Mindless|PC[TYPE=Foo]</code>
   </p>
   <p class="indent3">
    Presents the "Mindless" template and any
@@ -4704,10 +4324,8 @@ user's entry via keyboard input.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:USERINPUT|1|TITLE=Hobby
-Name
-   </code>
+   <code>CHOOSE:USERINPUT|1|TITLE=Hobby
+Name</code>
   </p>
   <p class="indent3">
    This will produce a chooser for the user to
@@ -4756,9 +4374,7 @@ Weapon Focus Feat.
     </a>
     tag is
 used in conjunction with this
-    <code>
-     CHOOSE
-    </code>
+    <code>CHOOSE</code>
     tag to define the
 number of "selections" that can be made.
    </li>
@@ -4769,9 +4385,7 @@ number of "selections" that can be made.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:WEAPONFOCUS|TYPE.Sword
-   </code>
+   <code>CHOOSE:WEAPONFOCUS|TYPE.Sword</code>
   </p>
   <p class="indent3">
    Present a list of weaponprofs associated with a
@@ -4826,9 +4440,7 @@ files.
    </strong>
    WIELD=Text
 (Weapon wield type. Used in
-   <code>
-    EQUIPMENT
-   </code>
+   <code>EQUIPMENT</code>
    qualifier
 only.)
   </p>
@@ -4895,31 +4507,23 @@ the criteria.
    </li>
    <li>
     Using the
-    <code>
-     DEITYWEAPON
-    </code>
+    <code>DEITYWEAPON</code>
     sub-tag will provide the
 weapon listed as the favored weapon for the player character's
 selected deity.
    </li>
    <li>
     Using the
-    <code>
-     FEAT=Text
-    </code>
+    <code>FEAT=Text</code>
     sub-tag will provide a list of
 weapon proficiencies selected by the referenced feat. The feat
 referenced must contain a
-    <code>
-     CHOOSE:WEAPONPROFICIENCY
-    </code>
+    <code>CHOOSE:WEAPONPROFICIENCY</code>
     tag.
    </li>
    <li>
     Using the
-    <code>
-     WIELD=Text
-    </code>
+    <code>WIELD=Text</code>
     sub-tag will provide a list
 of weapon proficiencies for weapons of the referenced wield type.
 The wield type must one of the following three types: Light,
@@ -4932,47 +4536,33 @@ weapon in the equipment LST file.
    </li>
    <li>
     Using the
-    <code>
-     WIELD=Text
-    </code>
+    <code>WIELD=Text</code>
     sub-tag in an
-    <code>
-     EQUIPMENT
-    </code>
+    <code>EQUIPMENT</code>
     qualifier will provide a list of weapon
 proficiencies for weapons of the referenced wield type. The wield
 type must one of the following three types: Light, One-Handed,
 Two-Handed. Wield type is set for each weapon in the equipment LST
 file. Note: Not all game modes support
-    <code>
-     WIELD
-    </code>
+    <code>WIELD</code>
     .
    </li>
    <li>
     Using the
-    <code>
-     EQUIPMENT
-    </code>
+    <code>EQUIPMENT</code>
     qualifier will allow the
 selection of proficiencies based on weapons. It can be combined
 with
-    <code>
-     TYPE=Text
-    </code>
+    <code>TYPE=Text</code>
     and
-    <code>
-     WIELD=Text
-    </code>
+    <code>WIELD=Text</code>
     criteria,
 contained in square-brackets ([x]) to restrict the proficiencies
 offered.
    </li>
    <li>
     When using the
-    <code>
-     SPELLCASTER
-    </code>
+    <code>SPELLCASTER</code>
     qualifier will provide
 a list of proficiencies matching the included criteria as long as
 the player character is a spellcaster.
@@ -5008,9 +4598,7 @@ for.
    <li>
     Qualifiers can be logically negated by prefacing with the
 exclamation point (!), i.e.
-    <code>
-     !PC
-    </code>
+    <code>!PC</code>
     is a valid usage.
    </li>
    <li>
@@ -5041,9 +4629,7 @@ before logical
     </a>
     tag is
 used in conjunction with this
-    <code>
-     CHOOSE
-    </code>
+    <code>CHOOSE</code>
     tag to define the
 number of "selections" that can be made.
    </li>
@@ -5054,9 +4640,7 @@ number of "selections" that can be made.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:WEAPONPROFICIENCY|Longsword|Flail
-   </code>
+   <code>CHOOSE:WEAPONPROFICIENCY|Longsword|Flail</code>
   </p>
   <p class="indent3">
    Will display a list of weapon proficiencies
@@ -5071,9 +4655,7 @@ including only
    .
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:WEAPONPROFICIENCY|Longsword|TYPE=Ranged,PC
-   </code>
+   <code>CHOOSE:WEAPONPROFICIENCY|Longsword|TYPE=Ranged,PC</code>
   </p>
   <p class="indent3">
    Will display a list of weapon proficiencies of
@@ -5085,9 +4667,7 @@ the
 with.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:WEAPONPROFICIENCY|SPELLCASTER[Ray]
-   </code>
+   <code>CHOOSE:WEAPONPROFICIENCY|SPELLCASTER[Ray]</code>
   </p>
   <p class="indent3">
    Will add proficiency with the
@@ -5097,9 +4677,7 @@ with.
    if the PC is a spellcaster.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:WEAPONPROFICIENCY|EQUIPMENT[TYPE=Finesseable]
-   </code>
+   <code>CHOOSE:WEAPONPROFICIENCY|EQUIPMENT[TYPE=Finesseable]</code>
   </p>
   <p class="indent3">
    Will display a list of weapon proficiencies for
@@ -5110,9 +4688,7 @@ all weapons with a type of
    .
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:WEAPONPROFICIENCY|EQUIPMENT[TYPE=Melee,WIELD=Light]
-   </code>
+   <code>CHOOSE:WEAPONPROFICIENCY|EQUIPMENT[TYPE=Melee,WIELD=Light]</code>
   </p>
   <p class="indent3">
    Will display a list of weapon proficiencies for
@@ -5180,9 +4756,7 @@ particular feat multiple times.
    </li>
    <li>
     When used in conjunction with the
-    <code>
-     SELECT
-    </code>
+    <code>SELECT</code>
     tag, the
 NUMCHOICES value should equal a multiple of the SELECT value.
    </li>
@@ -5193,9 +4767,7 @@ NUMCHOICES value should equal a multiple of the SELECT value.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:NUMCHOICES=3|SKILLSNAMED|Spot|Listen|Search
-   </code>
+   <code>CHOOSE:NUMCHOICES=3|SKILLSNAMED|Spot|Listen|Search</code>
   </p>
   <p class="indent3">
    The user can select the same choice more than
@@ -5203,9 +4775,7 @@ once, but the user will never be allowed more than 3 choices total,
 each made one at a time.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:NUMCHOICES=6|SKILLSNAMED|Craft%|3
-   </code>
+   <code>CHOOSE:NUMCHOICES=6|SKILLSNAMED|Craft%|3</code>
   </p>
   <p class="indent3">
    The user can select this chooser multiple times
@@ -5214,9 +4784,7 @@ chooser is selected, but may only make 6 Craft subskill sellection
 total.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:NUMCHOICES=3|SKILLSNAMED|TYPE=Strength|TYPE=Dexterity|TYPE=Constitution|TYPE=Intelligence|TYPE=Wisdom
-   </code>
+   <code>CHOOSE:NUMCHOICES=3|SKILLSNAMED|TYPE=Strength|TYPE=Dexterity|TYPE=Constitution|TYPE=Intelligence|TYPE=Wisdom</code>
   </p>
   <p class="indent3">
    The user will be allowed to select one skill
@@ -5225,10 +4793,8 @@ from "Strength" "Dexterity" "Constitution" "Intelligence" and
 maximum of three such selections through this chooser.
   </p>
   <p class="indent2">
-   <code>
-    SELECT:3 &lt;tab&gt;
-CHOOSE:NUMCHOICES=6|SKILLSNAMED|TYPE=Knowledge
-   </code>
+   <code>SELECT:3 &lt;tab&gt;
+CHOOSE:NUMCHOICES=6|SKILLSNAMED|TYPE=Knowledge</code>
   </p>
   <p class="indent3">
    The user can select three (3) "Knowledge" type
@@ -5237,17 +4803,13 @@ than six (6) "Knowledge" type skills total no matter how many times
 the feat is taken.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:NUMCHOICES=3|NOCHOICE
-   </code>
+   <code>CHOOSE:NUMCHOICES=3|NOCHOICE</code>
   </p>
   <p class="indent3">
    A feat, or ability, containing this tag may be
 applied three times, with no CHOOSER window being displayed, as
 long as there is no
-   <code>
-    SELECT
-   </code>
+   <code>SELECT</code>
    tag included giving more
 than 1 choice per feat application.
   </p>

--- a/docs/listfilepages/globalfilestagpages/globalfilesdefine.html
+++ b/docs/listfilepages/globalfilestagpages/globalfilesdefine.html
@@ -31,9 +31,7 @@
   <p class="indent1">
    This page is broken into two sections. The first
 section will describe the
-   <code>
-    DEFINE
-   </code>
+   <code>DEFINE</code>
    tag and its uses. The
 second section will discuss variables and their use in PCGen.
   </p>
@@ -80,9 +78,7 @@ value to the number or formula given.
    </li>
    <li>
     Many classes use
-    <code>
-     PREVARxx
-    </code>
+    <code>PREVARxx</code>
     tags, which are
 prerequisites based upon variable values.
    </li>
@@ -94,9 +90,7 @@ to it.
    <li>
     PCGen scans the character's race, templates, classes, feats,
 skills, deity, domains and equipped items for
-    <code>
-     DEFINE
-    </code>
+    <code>DEFINE</code>
     tags that match this variable name.
    </li>
    <li>
@@ -105,43 +99,31 @@ value.
    </li>
    <li>
     PCGen then scans the same list of items and looks for
-    <code>
-     BONUS:VAR
-    </code>
+    <code>BONUS:VAR</code>
     tags and after figuring out which ones
 stack, adds those to the highest define value.
    </li>
    <li>
     The resulting value is then compared to the
-    <code>
-     PREVARxx
-    </code>
+    <code>PREVARxx</code>
     requirement and PCGen then indicates if the
 character meets this requirement or not.
    </li>
    <li>
-    <code>
-     BONUS:VAR
-    </code>
+    <code>BONUS:VAR</code>
     tags which reference variables which
 have not been defined have no effect and the value of that variable
 will effectively remain at zero (0).
    </li>
    <li>
     The standard use of
-    <code>
-     DEFINE
-    </code>
+    <code>DEFINE</code>
     in PCGen release files
 is to use only one
-    <code>
-     DEFINE
-    </code>
+    <code>DEFINE</code>
     per variable and to
 initially set the value to zero (0) and adjust it with
-    <code>
-     BONUS:VAR
-    </code>
+    <code>BONUS:VAR</code>
     tags as needed.
    </li>
   </ul>
@@ -151,19 +133,15 @@ initially set the value to zero (0) and adjust it with
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DEFINE:MonkeyChop|2
-   </code>
+   <code>DEFINE:MonkeyChop|2</code>
   </p>
   <p class="indent3">
    Creates a new variable named MonkeyChop and sets
 the initial value to 2.
   </p>
   <p class="indent2">
-   <code>
-    DEFINE:MonkeySwing|0 &lt;tab&gt;
-BONUS:VAR|MonkeySwing|TL/2
-   </code>
+   <code>DEFINE:MonkeySwing|0 &lt;tab&gt;
+BONUS:VAR|MonkeySwing|TL/2</code>
   </p>
   <p class="indent3">
    Creates a new variable named
@@ -192,9 +170,7 @@ system-defined, that is they are hard-coded into PCGen's code-base.
 While both types of variable can be used in any formula in any LST
 file, only system-defined variables can be used in any gameMode.
 Only user-defined variables can be modified through the use of the
-   <code>
-    BONUS:VAR
-   </code>
+   <code>BONUS:VAR</code>
    tag.
   </p>
   <p class="indent0">
@@ -269,14 +245,10 @@ for the BAB is set for each individual class in the
    </span>
    file. The BAB progression is set using
 the global
-   <code>
-    BONUS:COMBAT|BAB
-   </code>
+   <code>BONUS:COMBAT|BAB</code>
    tag, which will take a
 formula. As an example,
-   <code>
-    BONUS:COMBAT|BAB|CL*2
-   </code>
+   <code>BONUS:COMBAT|BAB|CL*2</code>
    would
 grant a BAB of +2 per class-level.
   </p>
@@ -305,9 +277,7 @@ character's race.
   <p class="indent2">
    This is the unmodified number of hit dice of the
 creature in question, as specified with the
-   <code>
-    MONSTERCLASS
-   </code>
+   <code>MONSTERCLASS</code>
    race tag. If that tag is absent, the
 variable will return 0.
   </p>
@@ -367,25 +337,17 @@ your
     Cleric
    </strong>
    level.
-   <code>
-    BL=Wizard
-   </code>
+   <code>BL=Wizard</code>
    would
 return 5 and
-   <code>
-    BL=Cleric
-   </code>
+   <code>BL=Cleric</code>
    would return 3. Replace "{"
 with "(" and "}" with ")", e.g.
-   <code>
-    BL=Cleric {Special}
-   </code>
+   <code>BL=Cleric {Special}</code>
    would return the bonus levels of "Cleric (Special)" since "(" and
 ")" have other meanings in DEFINE variables. If used within a JEP
 formula you will need to enclose it in a variable function e.g.
-   <code>
-    var("BL=Cleric {Special}")
-   </code>
+   <code>var("BL=Cleric {Special}")</code>
    .
   </p>
   <p class="indent1">

--- a/docs/listfilepages/globalfilestagpages/globalfilesformulas.html
+++ b/docs/listfilepages/globalfilestagpages/globalfilesformulas.html
@@ -61,16 +61,12 @@ equality. If you are curious you can check out the JEP library at
 negative) use -1*(). EXAMPLE:
   </p>
   <p class="indent2">
-   <code>
-    BONUS:CHECKS|BASE.Will|CL/3
-   </code>
+   <code>BONUS:CHECKS|BASE.Will|CL/3</code>
    is a
 positive 1 at 3rd level and
   </p>
   <p class="indent2">
-   <code>
-    BONUS:CHECKS|BASE.Will|-1*(CL/3)
-   </code>
+   <code>BONUS:CHECKS|BASE.Will|-1*(CL/3)</code>
    is
 a -1 at 3rd level.
   </p>
@@ -108,10 +104,8 @@ is defined as: '$', '_', a-z and A-Z.
 alone:
   </p>
   <p class="indent3">
-   <code>
-    CL, TL, ARMORACCHECK,
-BardicKnowledgeLevel, TirelessRage.
-   </code>
+   <code>CL, TL, ARMORACCHECK,
+BardicKnowledgeLevel, TirelessRage.</code>
    ,
   </p>
   <p class="indent2">
@@ -119,10 +113,8 @@ BardicKnowledgeLevel, TirelessRage.
 the getvar() function:
   </p>
   <p class="indent3">
-   <code>
-    var("CL=Fighter"), var("COUNT[FEATS]"),
-var("COUNT[FEATTYPE=type]").
-   </code>
+   <code>var("CL=Fighter"), var("COUNT[FEATS]"),
+var("COUNT[FEATTYPE=type]").</code>
   </p>
   <p class="indent2">
    Consult the
@@ -143,9 +135,7 @@ processing:
 processing is done left-to-right.
   </p>
   <p class="indent2">
-   <code>
-    2+(3*5+2)/2
-   </code>
+   <code>2+(3*5+2)/2</code>
   </p>
   <p class="indent3">
    Would become 2+(15+2)/2 (3*5 replaced)
@@ -185,33 +175,25 @@ floor(a) or ceil(a) tags.
    <strong>
     Addition:
    </strong>
-   <code>
-    x+y
-   </code>
+   <code>x+y</code>
   </p>
   <p class="indent1">
    <strong>
     Subtraction:
    </strong>
-   <code>
-    x-y
-   </code>
+   <code>x-y</code>
   </p>
   <p class="indent1">
    <strong>
     Division:
    </strong>
-   <code>
-    x/y
-   </code>
+   <code>x/y</code>
   </p>
   <p class="indent1">
    <strong>
     Multiplication:
    </strong>
-   <code>
-    x*y
-   </code>
+   <code>x*y</code>
   </p>
   <blockquote>
    <p class="indent1">
@@ -262,44 +244,34 @@ processed first.
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     2+1
-    </code>
+    <code>2+1</code>
    </p>
    <p class="indent3">
     Returns a value of 3.
    </p>
    <p class="indent2">
-    <code>
-     CL-1
-    </code>
+    <code>CL-1</code>
    </p>
    <p class="indent3">
     Returns a value equal to the Class Level minus
 1.
    </p>
    <p class="indent2">
-    <code>
-     CL/2
-    </code>
+    <code>CL/2</code>
    </p>
    <p class="indent3">
     Returns a value equal to the Class Level divided
 by 2.
    </p>
    <p class="indent2">
-    <code>
-     CL*3
-    </code>
+    <code>CL*3</code>
    </p>
    <p class="indent3">
     Returns a value equal to the Class Level
 multiplied by 3.
    </p>
    <p class="indent2">
-    <code>
-     ((CL+1)+(3*TL)/2)+4
-    </code>
+    <code>((CL+1)+(3*TL)/2)+4</code>
     (JEP
 Expression)
    </p>
@@ -309,9 +281,7 @@ Level divided by two, plus Class Level plus 1, plus four. Assuming
 CL=TL=4, this expression returns 15.
    </p>
    <p class="indent2">
-    <code>
-     ((CL+1)+(3*TL)/2)+4
-    </code>
+    <code>((CL+1)+(3*TL)/2)+4</code>
     (Non-JEP
 Expression)
    </p>
@@ -331,65 +301,49 @@ Assuming CL=TL=4, this expression returns 12.
    <strong>
     Equal:
    </strong>
-   <code>
-    x==y
-   </code>
+   <code>x==y</code>
   </p>
   <p class="indent1">
    <strong>
     Not Equal:
    </strong>
-   <code>
-    x!=y
-   </code>
+   <code>x!=y</code>
   </p>
   <p class="indent1">
    <strong>
     Greater Than:
    </strong>
-   <code>
-    x&gt;y
-   </code>
+   <code>x&gt;y</code>
   </p>
   <p class="indent1">
    <strong>
     Less Than:
    </strong>
-   <code>
-    x&lt;y
-   </code>
+   <code>x&lt;y</code>
   </p>
   <p class="indent1">
    <strong>
     Greater Than or Equal:
    </strong>
-   <code>
-    x&gt;=y
-   </code>
+   <code>x&gt;=y</code>
   </p>
   <p class="indent1">
    <strong>
     Less Than or Equal:
    </strong>
-   <code>
-    x&lt;=y
-   </code>
+   <code>x&lt;=y</code>
   </p>
   <p class="indent1">
    <strong>
     Logical AND:
    </strong>
-   <code>
-    x&amp;&amp;y
-   </code>
+   <code>x&amp;&amp;y</code>
   </p>
   <p class="indent1">
    <strong>
     Logical OR:
    </strong>
-   <code>
-    x||y
-   </code>
+   <code>x||y</code>
   </p>
   <blockquote>
    <p class="indent1">
@@ -421,63 +375,49 @@ or 0 (true or false respectively).
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     CL==1
-    </code>
+    <code>CL==1</code>
    </p>
    <p class="indent3">
     Will return "True" if Class Level is equal to
 1.
    </p>
    <p class="indent2">
-    <code>
-     CL!=1
-    </code>
+    <code>CL!=1</code>
    </p>
    <p class="indent3">
     Will return "True" if Class Level is not equal
 to 1.
    </p>
    <p class="indent2">
-    <code>
-     CL&gt;1
-    </code>
+    <code>CL&gt;1</code>
    </p>
    <p class="indent3">
     Will return "True" if Class Level is greater
 than 1.
    </p>
    <p class="indent2">
-    <code>
-     CL&lt;1
-    </code>
+    <code>CL&lt;1</code>
    </p>
    <p class="indent3">
     Will return "True" if Class Level is less than
 1.
    </p>
    <p class="indent2">
-    <code>
-     CL&gt;=1
-    </code>
+    <code>CL&gt;=1</code>
    </p>
    <p class="indent3">
     Will return "True" if Class Level is greater
 than or equal to 1.
    </p>
    <p class="indent2">
-    <code>
-     CL&lt;=1
-    </code>
+    <code>CL&lt;=1</code>
    </p>
    <p class="indent3">
     Will return "True" if Class Level is less than
 or equal to 1.
    </p>
    <p class="indent2">
-    <code>
-     (CL&gt;5)&amp;&amp;(TL&gt;5)
-    </code>
+    <code>(CL&gt;5)&amp;&amp;(TL&gt;5)</code>
    </p>
    <p class="indent3">
     Will return "True" if Class Level
@@ -487,9 +427,7 @@ or equal to 1.
     Total Level are greater than 5.
    </p>
    <p class="indent2">
-    <code>
-     (CL&gt;5)||(TL&gt;5)
-    </code>
+    <code>(CL&gt;5)||(TL&gt;5)</code>
    </p>
    <p class="indent3">
     Will return "True" if Class Level
@@ -511,9 +449,7 @@ or equal to 1.
    <strong>
     Choice:
    </strong>
-   <code>
-    %CHOICE
-   </code>
+   <code>%CHOICE</code>
   </p>
   <blockquote>
    <p class="indent1">
@@ -544,10 +480,8 @@ into its place.
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     SPROP:Unreliable (%CHOICE) &lt;tab&gt;
-CHOOSE:5%|10%|15%|20%|25%|30%|35%|40%|45%|50%|55%|60%|65%|70%|75%|80%|85%|90%|95%|100%
-    </code>
+    <code>SPROP:Unreliable (%CHOICE) &lt;tab&gt;
+CHOOSE:5%|10%|15%|20%|25%|30%|35%|40%|45%|50%|55%|60%|65%|70%|75%|80%|85%|90%|95%|100%</code>
    </p>
    <p class="indent3">
     Chooser to select the level of unreliablty.
@@ -559,9 +493,7 @@ CHOOSE:5%|10%|15%|20%|25%|30%|35%|40%|45%|50%|55%|60%|65%|70%|75%|80%|85%|90%|95
    <strong>
     List:
    </strong>
-   <code>
-    %LIST
-   </code>
+   <code>%LIST</code>
   </p>
   <blockquote>
    <p class="indent1">
@@ -592,10 +524,8 @@ into its place.
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     CHOOSE:NUMCHOICES=1|FORTITUDE|REFLEX|WILL
-&lt;tab&gt; BONUS:CHECKS|%LIST|1
-    </code>
+    <code>CHOOSE:NUMCHOICES=1|FORTITUDE|REFLEX|WILL
+&lt;tab&gt; BONUS:CHECKS|%LIST|1</code>
    </p>
    <p class="indent3">
     Will insert the "Choice" made in the "CHOOSE:"
@@ -609,9 +539,7 @@ tag into the "Bonus" tag and apply the bonus of "1" to the chosen
    <strong>
     Not:
    </strong>
-   <code>
-    !
-   </code>
+   <code>!</code>
   </p>
   <blockquote>
    <p class="indent1">
@@ -628,9 +556,7 @@ tag into the "Bonus" tag and apply the bonus of "1" to the chosen
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     BONUS:SKILL|Swim|1|!PRESKILL:1,Swim=1.
-    </code>
+    <code>BONUS:SKILL|Swim|1|!PRESKILL:1,Swim=1.</code>
    </p>
    <p class="indent3">
     If the character does not have swim, add 1 to
@@ -643,9 +569,7 @@ it.
    <strong>
     Replacement/Substitution:
    </strong>
-   <code>
-    %
-   </code>
+   <code>%</code>
   </p>
   <blockquote>
    <p class="indent1">
@@ -675,10 +599,8 @@ the
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     SAB:Resistance to %
-5|MyFooVariable
-    </code>
+    <code>SAB:Resistance to %
+5|MyFooVariable</code>
    </p>
    <p class="indent3">
     Will substitute the value of "MyFooVariable" for
@@ -708,9 +630,7 @@ the "%" in the
    <strong>
     Formula:
    </strong>
-   <code>
-    x%y
-   </code>
+   <code>x%y</code>
   </p>
   <blockquote>
    <p class="indent1">
@@ -742,9 +662,7 @@ the operation.
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     CL%3
-    </code>
+    <code>CL%3</code>
    </p>
    <p class="indent3">
     Divides the character's class level by 3 and
@@ -768,13 +686,9 @@ Expression)
    <strong>
     Formula:
    </strong>
-   <code>
-    min(x,x)
-   </code>
+   <code>min(x,x)</code>
    or
-   <code>
-    max(x,x)
-   </code>
+   <code>max(x,x)</code>
   </p>
   <blockquote>
    <p class="indent1">
@@ -808,9 +722,7 @@ compared.
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     min(10,CL,TL/2)
-    </code>
+    <code>min(10,CL,TL/2)</code>
     given a multi-class
 character: Wiz8/Ftr6 and looking at it from the Wizard's
 perspective.
@@ -820,9 +732,7 @@ perspective.
 -&gt; (14/2)=7]) -&gt; min returns the value "7".
    </p>
    <p class="indent2">
-    <code>
-     max(3,CL,TL/2)
-    </code>
+    <code>max(3,CL,TL/2)</code>
     given a multi-class
 character: Wiz4/Rog6 and looking at it from the Rogue's
 perspective.
@@ -845,13 +755,9 @@ Expression)
    <strong>
     Formula:
    </strong>
-   <code>
-    floor(x)
-   </code>
+   <code>floor(x)</code>
    or
-   <code>
-    ceil(x)
-   </code>
+   <code>ceil(x)</code>
   </p>
   <blockquote>
    <p class="indent1">
@@ -880,9 +786,7 @@ that is greater than 'x'.
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     floor((FooVariable+4)/6)
-    </code>
+    <code>floor((FooVariable+4)/6)</code>
     Assume
 FooVariable is "7"
    </p>
@@ -891,9 +795,7 @@ FooVariable is "7"
 11/6 -&gt; 1 5/6 - &gt; floor returns 1.
    </p>
    <p class="indent2">
-    <code>
-     ceil(STR/2)
-    </code>
+    <code>ceil(STR/2)</code>
     Assume STR=15
    </p>
    <p class="indent3">
@@ -913,9 +815,7 @@ ceil returns 8.
    <strong>
     Formula:
    </strong>
-   <code>
-    if(x,y,z)
-   </code>
+   <code>if(x,y,z)</code>
    <br/>
   </p>
   <blockquote>
@@ -969,27 +869,21 @@ the "False" result (z) is returned.
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     if(CL&lt;10,1,2)
-    </code>
+    <code>if(CL&lt;10,1,2)</code>
    </p>
    <p class="indent3">
     Asks if Class Level is less than 10 then returns
 1 or else returns 2.
    </p>
    <p class="indent2">
-    <code>
-     if(CL&gt;=4,10,0)
-    </code>
+    <code>if(CL&gt;=4,10,0)</code>
    </p>
    <p class="indent3">
     Asks if Class Level is greater than or equal to
 4 then returns 10 or else returns 0.
    </p>
    <p class="indent2">
-    <code>
-     if((CL&gt;5)||(TL&gt;5),2,-4)
-    </code>
+    <code>if((CL&gt;5)||(TL&gt;5),2,-4)</code>
    </p>
    <p class="indent3">
     Asks if Class Level
@@ -1000,9 +894,7 @@ the "False" result (z) is returned.
 Level is greater than 5 then returns 2 or else returns -4.
    </p>
    <p class="indent2">
-    <code>
-     if(STR,5,0)
-    </code>
+    <code>if(STR,5,0)</code>
    </p>
    <p class="indent3">
     Asks if Strength modifier is greater than or
@@ -1019,9 +911,7 @@ less than 0 then returns 5 or else returns 0.
    <strong>
     Formula:
    </strong>
-   <code>
-    roll("x")
-   </code>
+   <code>roll("x")</code>
   </p>
   <blockquote>
    <p class="indent1">
@@ -1048,39 +938,25 @@ function and must be encapsulated in a roll("x") call to function
 properly:
      <ul>
       <li>
-       <code>
-        min(v1,v2)
-       </code>
+       <code>min(v1,v2)</code>
       </li>
       <li>
-       <code>
-        max(v1,v2)
-       </code>
+       <code>max(v1,v2)</code>
       </li>
       <li>
-       <code>
-        pow(base, exponent)
-       </code>
+       <code>pow(base, exponent)</code>
       </li>
       <li>
-       <code>
-        roll(times, sides)
-       </code>
+       <code>roll(times, sides)</code>
       </li>
       <li>
-       <code>
-        roll(times, sides, [keep])
-       </code>
+       <code>roll(times, sides, [keep])</code>
       </li>
       <li>
-       <code>
-        roll(times, [sides])
-       </code>
+       <code>roll(times, [sides])</code>
       </li>
       <li>
-       <code>
-        roll(times, [sides], [keep])
-       </code>
+       <code>roll(times, [sides], [keep])</code>
       </li>
      </ul>
     </li>
@@ -1113,76 +989,58 @@ functions in a useful way.
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     roll("3d6")
-    </code>
+    <code>roll("3d6")</code>
    </p>
    <p class="indent3">
     Simulates rolling 3 six-sided dice.
    </p>
    <p class="indent2">
-    <code>
-     roll("1d20+10")
-    </code>
+    <code>roll("1d20+10")</code>
    </p>
    <p class="indent3">
     Simulates rolling a twenty-sided die and adds
 10.
    </p>
    <p class="indent2">
-    <code>
-     roll("min(4,7)")
-    </code>
+    <code>roll("min(4,7)")</code>
    </p>
    <p class="indent3">
     Returns a value of "4".
    </p>
    <p class="indent2">
-    <code>
-     roll("max(4,7)")
-    </code>
+    <code>roll("max(4,7)")</code>
    </p>
    <p class="indent3">
     Returns a value of "7".
    </p>
    <p class="indent2">
-    <code>
-     roll("pow(10,2)")
-    </code>
+    <code>roll("pow(10,2)")</code>
    </p>
    <p class="indent3">
     Returns a value of "100".
    </p>
    <p class="indent2">
-    <code>
-     roll("roll(3,6)")
-    </code>
+    <code>roll("roll(3,6)")</code>
    </p>
    <p class="indent3">
     Simulates rolling 3 six-sided dice.
    </p>
    <p class="indent2">
-    <code>
-     roll("roll(4,6,[2,3,4])")
-    </code>
+    <code>roll("roll(4,6,[2,3,4])")</code>
    </p>
    <p class="indent3">
     Simulates rolling 4 six-sided dice and keeps the
 3 highest rolls.
    </p>
    <p class="indent2">
-    <code>
-     roll("roll(1,[3,5,7,9])")
-    </code>
+    <code>roll("roll(1,[3,5,7,9])")</code>
    </p>
    <p class="indent3">
     Similates rolling one 3, 5, 7 or 9 sided die,
 randomly selected.
    </p>
    <p class="indent2">
-    <code>
-     roll("roll(3,[2,3,4,5,6],[2,3])")
-    </code>
+    <code>roll("roll(3,[2,3,4,5,6],[2,3])")</code>
    </p>
    <p class="indent3">
     Simulates rolling three 2, 3, 4, 5, or 6 sided
@@ -1206,9 +1064,7 @@ Expression)
    <strong>
     Formula:
    </strong>
-   <code>
-    classlevel("x")
-   </code>
+   <code>classlevel("x")</code>
   </p>
   <blockquote>
    <p class="indent1">
@@ -1247,9 +1103,7 @@ specified class.
       Class
      </span>
      by
-     <code>
-      TYPE
-     </code>
+     <code>TYPE</code>
      , use of a period-delimited list of types will
 return the level of the
      <span class="lstobj">
@@ -1265,9 +1119,7 @@ of all types listed.
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     classlevel("Bard")
-    </code>
+    <code>classlevel("Bard")</code>
    </p>
    <p class="indent3">
     Returns the number of levels of
@@ -1277,9 +1129,7 @@ of all types listed.
     .
    </p>
    <p class="indent2">
-    <code>
-     classlevel("TYPE=PC.Prestige")
-    </code>
+    <code>classlevel("TYPE=PC.Prestige")</code>
    </p>
    <p class="indent3">
     Returns the number of levels of the class of
@@ -1294,9 +1144,7 @@ types
     .
    </p>
    <p class="indent2">
-    <code>
-     classlevel("APPLIEDAS=NONEPIC")
-    </code>
+    <code>classlevel("APPLIEDAS=NONEPIC")</code>
    </p>
    <p class="indent3">
     Returns the number of levels of applied as
@@ -1308,9 +1156,7 @@ non-epic levels.
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     CL=&lt;Bard&gt;
-    </code>
+    <code>CL=&lt;Bard&gt;</code>
    </p>
   </blockquote>
   <hr/>
@@ -1331,9 +1177,7 @@ Expression)
    <strong>
     Formula:
    </strong>
-   <code>
-    skillinfo("x","y")
-   </code>
+   <code>skillinfo("x","y")</code>
   </p>
   <blockquote>
    <p class="indent1">
@@ -1426,54 +1270,42 @@ bonuses.
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     skillinfo("RANK", "Hide")
-    </code>
+    <code>skillinfo("RANK", "Hide")</code>
    </p>
    <p class="indent3">
     Returns the number of base ranks in Hide.
    </p>
    <p class="indent2">
-    <code>
-     skillinfo("TOTALRANK", "Climb")
-    </code>
+    <code>skillinfo("TOTALRANK", "Climb")</code>
    </p>
    <p class="indent3">
     Returns the number ranks in Climb including
 those gained from BONUS:SKILLRANK tags.
    </p>
    <p class="indent2">
-    <code>
-     skillinfo("MODIFIER", "Bluff")
-    </code>
+    <code>skillinfo("MODIFIER", "Bluff")</code>
    </p>
    <p class="indent3">
     Returns the total number of bonuses in
 Bluff.
    </p>
    <p class="indent2">
-    <code>
-     skillinfo("STAT", "Diplomacy")
-    </code>
+    <code>skillinfo("STAT", "Diplomacy")</code>
    </p>
    <p class="indent3">
     Returns the ability bonus for Diplomacy.
    </p>
    <p class="indent2">
-    <code>
-     skillinfo("MISC", "Use Magic
-Device")
-    </code>
+    <code>skillinfo("MISC", "Use Magic
+Device")</code>
    </p>
    <p class="indent3">
     Returns the total miscellaneous bonuses in Use
 Magic Device.
    </p>
    <p class="indent2">
-    <code>
-     skillinfo("TOTAL",
-"Spellcraft")
-    </code>
+    <code>skillinfo("TOTAL",
+"Spellcraft")</code>
    </p>
    <p class="indent3">
     Returns the grand total in Spellcraft.
@@ -1492,9 +1324,7 @@ Expression)
    <strong>
     Formula:
    </strong>
-   <code>
-    charbonusto("x","y")
-   </code>
+   <code>charbonusto("x","y")</code>
   </p>
   <blockquote>
    <p class="indent1">
@@ -1583,9 +1413,7 @@ default to "PCLEVEL".
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     charbonusto("PCLEVEL","Cleric")
-    </code>
+    <code>charbonusto("PCLEVEL","Cleric")</code>
    </p>
    <p class="indent3">
     Returns the number of bonus Spellcaster Levels
@@ -1593,9 +1421,7 @@ to the class specified, which usually come from Prestige
 classes.
    </p>
    <p class="indent2">
-    <code>
-     charbonusto("CHECKS","Reflex")
-    </code>
+    <code>charbonusto("CHECKS","Reflex")</code>
    </p>
    <p class="indent3">
     Will return Reflex bonuses from a high Dexterity
@@ -1619,9 +1445,7 @@ and other bonuses but not the full reflex save value.
    <strong>
     Formula:
    </strong>
-   <code>
-    count(x,y)
-   </code>
+   <code>count(x,y)</code>
   </p>
   <blockquote>
    <p class="indent1">
@@ -1655,25 +1479,17 @@ being counted.
     </li>
     <li>
      "
-     <code>
-      [and]
-     </code>
+     <code>[and]</code>
      " and "
-     <code>
-      [or]
-     </code>
+     <code>[or]</code>
      " can be used
 between parameters.
     </li>
     <li>
      Use of this token in conjunction with output sheet tokens
-     <code>
-      IIF
-     </code>
+     <code>IIF</code>
      and
-     <code>
-      VAR
-     </code>
+     <code>VAR</code>
      require a semicolon-delimited
 (;) list of quotated parameters instead of a comma-delimited
 list.
@@ -1687,16 +1503,12 @@ max.
 &lt;Matching criteria&gt; are listed below:
      <ul>
       <li>
-       <code>
-        ABILITIES
-       </code>
+       <code>ABILITIES</code>
        - Will count the abilities that satisfy
 the following criteria:
        <ul>
         <li>
-         <code>
-          "CATEGORY=&lt;text&gt;"
-         </code>
+         <code>"CATEGORY=&lt;text&gt;"</code>
          - The ability category as
 defined in the
          <em>
@@ -1709,9 +1521,7 @@ defined in the
          file.
         </li>
         <li>
-         <code>
-          "NAME=&lt;text&gt;"
-         </code>
+         <code>"NAME=&lt;text&gt;"</code>
          - The name of a specific
 Ability which can be taken multiple times, returns the number of
 times it was taken. For abilities with internal choices you include
@@ -1719,9 +1529,7 @@ the specific choices to be counted within parenthesis, i.e. Weapon
 Focus (Longsword).
         </li>
         <li>
-         <code>
-          "KEY=&lt;text&gt;"
-         </code>
+         <code>"KEY=&lt;text&gt;"</code>
          - The key of a specific Ability
 which can be taken multiple times, returns the number of times it
 was taken. For abilities with internal choices you include the
@@ -1729,24 +1537,18 @@ specific choices to be counted within parenthesis, i.e. Weapon
 Focus (Longsword).
         </li>
         <li>
-         <code>
-          "NATURE=&lt;text&gt;"
-         </code>
+         <code>"NATURE=&lt;text&gt;"</code>
          - "NORMAL", "VIRTUAL", or
 "AUTOMATIC".
         </li>
         <li>
-         <code>
-          "TYPE=&lt;text&gt;"
-         </code>
+         <code>"TYPE=&lt;text&gt;"</code>
          - The ability type as defined
 in the ability.lst file. (e.g. "General", "Fighter", "Metamagic",
 etc.)
         </li>
         <li>
-         <code>
-          "VISIBILITY=&lt;text&gt;"
-         </code>
+         <code>"VISIBILITY=&lt;text&gt;"</code>
          <ul>
           <li>
            "HIDDEN", includes abilities with VISIBLE:NO
@@ -1764,9 +1566,7 @@ tag at all
          </ul>
         </li>
         <li>
-         <code>
-          "ASPECT=&lt;text&gt;"
-         </code>
+         <code>"ASPECT=&lt;text&gt;"</code>
          - The aspect as defined for
 the ability objects in the ability.lst file.
         </li>
@@ -1774,57 +1574,39 @@ the ability objects in the ability.lst file.
        <br/>
       </li>
       <li>
-       <code>
-        CAMPAIGNHISTORY
-       </code>
+       <code>CAMPAIGNHISTORY</code>
        - Will count the number of entries
 in the character's campaign history page.
       </li>
       <li>
-       <code>
-        CLASSES
-       </code>
+       <code>CLASSES</code>
        - Not yet implemented.
       </li>
       <li>
-       <code>
-        DOMAINS
-       </code>
+       <code>DOMAINS</code>
        - Not yet implemented.
       </li>
       <li>
-       <code>
-        EQUIPMENT
-       </code>
+       <code>EQUIPMENT</code>
        - Not yet implemented..
       </li>
       <li>
-       <code>
-        FOLLOWERS
-       </code>
+       <code>FOLLOWERS</code>
        - Not yet implemented..
       </li>
       <li>
-       <code>
-        LANGUAGES
-       </code>
+       <code>LANGUAGES</code>
        - Not yet implemented.
       </li>
       <li>
-       <code>
-        RACESUBTYPES
-       </code>
+       <code>RACESUBTYPES</code>
        - Not yet implemented.
       </li>
       <li>
-       <code>
-        SKILLSIT
-       </code>
+       <code>SKILLSIT</code>
        - Will count skills/situations that
 satisfy the stipulated criteria (y) as
-       <code>
-        "VIEW=&lt;text&gt;"
-       </code>
+       <code>"VIEW=&lt;text&gt;"</code>
        . Valid views are as per tag
        <a href="">
         TBD
@@ -1832,33 +1614,23 @@ satisfy the stipulated criteria (y) as
        .
       </li>
       <li>
-       <code>
-        SPELLBOOKS
-       </code>
+       <code>SPELLBOOKS</code>
        - Not yet implemented.
       </li>
       <li>
-       <code>
-        SPELLS
-       </code>
+       <code>SPELLS</code>
        - Not yet implemented.
       </li>
       <li>
-       <code>
-        SPELLSKNOWN
-       </code>
+       <code>SPELLSKNOWN</code>
        - Not yet implemented.
       </li>
       <li>
-       <code>
-        SPELLSINBOOK
-       </code>
+       <code>SPELLSINBOOK</code>
        - Not yet implemented.
       </li>
       <li>
-       <code>
-        TEMPLATES
-       </code>
+       <code>TEMPLATES</code>
        - Not yet implemented.
       </li>
      </ul>
@@ -1870,46 +1642,36 @@ satisfy the stipulated criteria (y) as
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     count("ABILITIES","CATEGORY=FEAT","TYPE=Metamagic","VISIBILITY=DEFAULT[or]VISIBILITY=OUTPUT_ONLY")
-    </code>
+    <code>count("ABILITIES","CATEGORY=FEAT","TYPE=Metamagic","VISIBILITY=DEFAULT[or]VISIBILITY=OUTPUT_ONLY")</code>
    </p>
    <p class="indent3">
     This token returns the number of visible
 metamagic feats the character has.
    </p>
    <p class="indent2">
-    <code>
-     count("ABILITIES","CATEGORY=FEAT","TYPE=Fighter","VISIBILITY=DEFAULT[or]VISIBILITY=OUTPUT_ONLY")
-    </code>
+    <code>count("ABILITIES","CATEGORY=FEAT","TYPE=Fighter","VISIBILITY=DEFAULT[or]VISIBILITY=OUTPUT_ONLY")</code>
    </p>
    <p class="indent3">
     Returns the number of all visible Fighter type
 feat abilities.
    </p>
    <p class="indent2">
-    <code>
-     count("ABILITIES","CATEGORY=FEAT","NAME=Toughness")
-    </code>
+    <code>count("ABILITIES","CATEGORY=FEAT","NAME=Toughness")</code>
    </p>
    <p class="indent3">
     Returns the number of times the Toughness feat
 was taken.
    </p>
    <p class="indent2">
-    <code>
-     count("ABILITIES","CATEGORY=FEAT","KEY=Toughness")
-    </code>
+    <code>count("ABILITIES","CATEGORY=FEAT","KEY=Toughness")</code>
    </p>
    <p class="indent3">
     Returns the number of times the Toughness feat
 was taken.
    </p>
    <p class="indent2">
-    <code>
-     count("ABILITIES","CATEGORY=Special
-Ability","NATURE=VIRTUAL[or]NATURE=AUTOMATIC")
-    </code>
+    <code>count("ABILITIES","CATEGORY=Special
+Ability","NATURE=VIRTUAL[or]NATURE=AUTOMATIC")</code>
    </p>
    <p class="indent3">
     Returns the number of abilities of category
@@ -1917,36 +1679,28 @@ Ability","NATURE=VIRTUAL[or]NATURE=AUTOMATIC")
 automatic.
    </p>
    <p class="indent2">
-    <code>
-     count("ABILITIES","CATEGORY=FEAT","VISIBILITY=HIDDEN[or]VISIBILITY=DISPLAY_ONLY")
-    </code>
+    <code>count("ABILITIES","CATEGORY=FEAT","VISIBILITY=HIDDEN[or]VISIBILITY=DISPLAY_ONLY")</code>
    </p>
    <p class="indent3">
     Returns the number of hidden feats.
    </p>
    <p class="indent2">
-    <code>
-     |VAR.count("ABILITIES","CATEGORY=Maneuver")|
-    </code>
+    <code>|VAR.count("ABILITIES","CATEGORY=Maneuver")|</code>
    </p>
    <p class="indent3">
     Outputs the number of "Maneuver" abilities the
 character has.
    </p>
    <p class="indent2">
-    <code>
-     count("CAMPAIGNHISTORY")
-    </code>
+    <code>count("CAMPAIGNHISTORY")</code>
    </p>
    <p class="indent3">
     This token returns the number of campaign
 history chronicles marked as being for export.
    </p>
    <p class="indent2">
-    <code>
-     count("CAMPAIGNHISTORY",
-"EXPORT=YES[or]EXPORT=NO")
-    </code>
+    <code>count("CAMPAIGNHISTORY",
+"EXPORT=YES[or]EXPORT=NO")</code>
    </p>
    <p class="indent3">
     This token returns the number of campaign
@@ -1969,9 +1723,7 @@ history chronicles no matter how they are marked.
    <strong>
     Formula:
    </strong>
-   <code>
-    isgamemode("x")
-   </code>
+   <code>isgamemode("x")</code>
   </p>
   <blockquote>
    <p class="indent1">
@@ -1997,9 +1749,7 @@ is running and a "0" if it is not.
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     isgamemode("35e")
-    </code>
+    <code>isgamemode("35e")</code>
    </p>
    <p class="indent3">
     Returns a "1" if the designated gameMode is
@@ -2022,9 +1772,7 @@ running and a "0" if it is not.
    <strong>
     Formula:
    </strong>
-   <code>
-    mastervar("x")
-   </code>
+   <code>mastervar("x")</code>
   </p>
   <blockquote>
    <p class="indent1">
@@ -2050,9 +1798,7 @@ relevant companion's Master PC.
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     mastervar("BAB")
-    </code>
+    <code>mastervar("BAB")</code>
    </p>
    <p class="indent3">
     Returns the base attack bonus of the relevant
@@ -2075,9 +1821,7 @@ companion's Master PC.
    <strong>
     Formula:
    </strong>
-   <code>
-    xdyz
-   </code>
+   <code>xdyz</code>
   </p>
   <blockquote>
    <p class="indent1">
@@ -2124,9 +1868,7 @@ companion's Master PC.
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     4d8+5
-    </code>
+    <code>4d8+5</code>
    </p>
    <p class="indent3">
     Returns a number between 9 and 37.
@@ -2137,13 +1879,9 @@ companion's Master PC.
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     DAMAGE
-    </code>
+    <code>DAMAGE</code>
     and
-    <code>
-     ALTDAMAGE
-    </code>
+    <code>ALTDAMAGE</code>
     tags.
    </p>
   </blockquote>
@@ -2158,9 +1896,7 @@ companion's Master PC.
 version 5.7.1. The syntax will be replaced with JEP syntax.
   </p>
   <p class="indent2">
-   <code>
-    ((TL/3).TRUNC)*2
-   </code>
+   <code>((TL/3).TRUNC)*2</code>
   </p>
   <p class="indent3">
    Truncation - would divide TL by 3, truncate (or
@@ -2170,9 +1906,7 @@ round down) and then multiply by 2.
    Deprecated, use floor(a).
   </p>
   <p class="indent2">
-   <code>
-    2MIN4
-   </code>
+   <code>2MIN4</code>
   </p>
   <p class="indent3">
    Minimum - would return 2 since it's taking the
@@ -2182,9 +1916,7 @@ minimum of the two values (MIN is always between the values).
    Deprecated, use min(a,b).
   </p>
   <p class="indent2">
-   <code>
-    2MAX4
-   </code>
+   <code>2MAX4</code>
   </p>
   <p class="indent3">
    Maximum - would return 4 since it's the max of

--- a/docs/listfilepages/globalfilestagpages/globalfileskey.html
+++ b/docs/listfilepages/globalfilestagpages/globalfileskey.html
@@ -114,9 +114,7 @@ calling purposes.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    KEY:MUT_SECOND_WIND
-   </code>
+   <code>KEY:MUT_SECOND_WIND</code>
   </p>
   <p class="indent3">
    Creates the unique KEY for the MSRD Feat
@@ -125,9 +123,7 @@ calling purposes.
    </em>
   </p>
   <p class="indent2">
-   <code>
-    KEY:SDA_POWER_OF_NATURE
-   </code>
+   <code>KEY:SDA_POWER_OF_NATURE</code>
   </p>
   <p class="indent3">
    Creates the unique KEY for the RSRD Special
@@ -137,9 +133,7 @@ Divine Abilities feat
    </em>
   </p>
   <p class="indent2">
-   <code>
-    KEY:SDA_UNDEAD_MASTERY
-   </code>
+   <code>KEY:SDA_UNDEAD_MASTERY</code>
   </p>
   <p class="indent3">
    Creates the unique KEY for the RSRD Special
@@ -149,9 +143,7 @@ Divine Abilities feat
    </em>
   </p>
   <p class="indent2">
-   <code>
-    KEY:FEAT_FRIGHTFUL_PRESENCE_MP
-   </code>
+   <code>KEY:FEAT_FRIGHTFUL_PRESENCE_MP</code>
   </p>
   <p class="indent3">
    Creates the unique KEY for -
@@ -161,9 +153,7 @@ Presence
    </em>
   </p>
   <p class="indent2">
-   <code>
-    KEY:SKL_DISABLE_DEVICE_MP
-   </code>
+   <code>KEY:SKL_DISABLE_DEVICE_MP</code>
   </p>
   <p class="indent3">
    Creates the unique KEY for Swords Edge
@@ -704,944 +694,580 @@ Coast (WotC): Standard Reference Document
     </strong>
    </p>
    <p>
-    <code>
-     KEY:A_1USEMA
-    </code>
+    <code>KEY:A_1USEMA</code>
     - Spell Effect (Single Use/Completion)
 [Major]
     <br/>
-    <code>
-     KEY:A_1USEME
-    </code>
+    <code>KEY:A_1USEME</code>
     - Spell Effect (Single Use/Completion)
 [Medium]
     <br/>
-    <code>
-     KEY:A_1USEMI
-    </code>
+    <code>KEY:A_1USEMI</code>
     - Spell Effect (Single Use/Completion)
 [Minor]
     <br/>
-    <code>
-     KEY:ADAM
-    </code>
+    <code>KEY:ADAM</code>
     - Adamantine
     <span class="new">
      (deprecated)
     </span>
     <br/>
-    <code>
-     KEY:ADAMANT_AMMO
-    </code>
+    <code>KEY:ADAMANT_AMMO</code>
     - Adamantine (Ammo)
     <br/>
-    <code>
-     KEY:ADAMANT_ARMR_HVY
-    </code>
+    <code>KEY:ADAMANT_ARMR_HVY</code>
     - Adamantine (Armor/Heavy)
     <br/>
-    <code>
-     KEY:ADAMANT_ARMR_LT
-    </code>
+    <code>KEY:ADAMANT_ARMR_LT</code>
     - Adamantine (Armor/Light)
     <br/>
-    <code>
-     KEY:ADAMANT_ARMR_MED
-    </code>
+    <code>KEY:ADAMANT_ARMR_MED</code>
     - Adamantine (Armor/Medium)
     <br/>
-    <code>
-     KEY:ADAMANT_FORT
-    </code>
+    <code>KEY:ADAMANT_FORT</code>
     - Adamantine (Fortification)
     <br/>
-    <code>
-     KEY:ADAMANT_SHLD
-    </code>
+    <code>KEY:ADAMANT_SHLD</code>
     - Adamantine (Shield)
     <br/>
-    <code>
-     KEY:ADAMANT_WEAP
-    </code>
+    <code>KEY:ADAMANT_WEAP</code>
     - Adamantine (Weapon)
     <br/>
-    <code>
-     KEY:ADAMANT_WONDROUS
-    </code>
+    <code>KEY:ADAMANT_WONDROUS</code>
     - Adamantine (Wondrous)
     <br/>
-    <code>
-     KEY:ADD_TYPE
-    </code>
+    <code>KEY:ADD_TYPE</code>
     - # Add Type
     <br/>
-    <code>
-     KEY:ANMATD
-    </code>
+    <code>KEY:ANMATD</code>
     - Animated
     <br/>
-    <code>
-     KEY:ARCANE_ARCHER_AMMO
-    </code>
+    <code>KEY:ARCANE_ARCHER_AMMO</code>
     - Arcane Archer
 Enchantement
     <br/>
-    <code>
-     KEY:ARW_DEF
-    </code>
+    <code>KEY:ARW_DEF</code>
     - Arrow Deflection
     <br/>
-    <code>
-     KEY:BANE_A
-    </code>
+    <code>KEY:BANE_A</code>
     - Bane [Ammunition]
     <br/>
-    <code>
-     KEY:BANE_M
-    </code>
+    <code>KEY:BANE_M</code>
     - Bane [Melee]
     <br/>
-    <code>
-     KEY:BANE_R
-    </code>
+    <code>KEY:BANE_R</code>
     - Bane [Ranged]
     <br/>
-    <code>
-     KEY:BASH_H
-    </code>
+    <code>KEY:BASH_H</code>
     - Bashing [Heavy]
     <br/>
-    <code>
-     KEY:BASH_L
-    </code>
+    <code>KEY:BASH_L</code>
     - Bashing [Light]
     <br/>
-    <code>
-     KEY:BIND
-    </code>
+    <code>KEY:BIND</code>
     - Blinding
     <br/>
-    <code>
-     KEY:BNS_AC_DEFL
-    </code>
+    <code>KEY:BNS_AC_DEFL</code>
     - AC Bonus (Deflection)
     <br/>
-    <code>
-     KEY:BNS_ENHC_AB
-    </code>
+    <code>KEY:BNS_ENHC_AB</code>
     - Ability Bonus (Enhancement)
     <br/>
-    <code>
-     KEY:BNS_ENHC_AC
-    </code>
+    <code>KEY:BNS_ENHC_AC</code>
     - Armor Bonus (Enhancement)
     <br/>
-    <code>
-     KEY:BNS_ENHC_NAT
-    </code>
+    <code>KEY:BNS_ENHC_NAT</code>
     - Natural Armor Bonus
 (Enhancement)
     <br/>
-    <code>
-     KEY:BNS_SAV_LUC
-    </code>
+    <code>KEY:BNS_SAV_LUC</code>
     - Save Bonus (Luck)
     <br/>
-    <code>
-     KEY:BNS_SAV_RES
-    </code>
+    <code>KEY:BNS_SAV_RES</code>
     - Save Bonus (Resistance)
     <br/>
-    <code>
-     KEY:BNS_SKL_CIR
-    </code>
+    <code>KEY:BNS_SKL_CIR</code>
     - Skill Bonus (Circumstance)
     <br/>
-    <code>
-     KEY:BNS_SKL_CMP
-    </code>
+    <code>KEY:BNS_SKL_CMP</code>
     - Skill Bonus (Competence)
     <br/>
-    <code>
-     KEY:BNS_SKL_LCK
-    </code>
+    <code>KEY:BNS_SKL_LCK</code>
     - Skill Luck Bonus
     <br/>
-    <code>
-     KEY:BNS_SPELL
-    </code>
+    <code>KEY:BNS_SPELL</code>
     - Bonus Spell
     <br/>
-    <code>
-     KEY:BNS_SPL_RST
-    </code>
+    <code>KEY:BNS_SPL_RST</code>
     - Spell Resistance
     <br/>
-    <code>
-     KEY:BONE
-    </code>
+    <code>KEY:BONE</code>
     - Bone
     <br/>
-    <code>
-     KEY:BRASS
-    </code>
+    <code>KEY:BRASS</code>
     - Brass
     <br/>
-    <code>
-     KEY:BRI_EN_A
-    </code>
+    <code>KEY:BRI_EN_A</code>
     - Brilliant Energy [Ammunition]
     <br/>
-    <code>
-     KEY:BRI_EN_M
-    </code>
+    <code>KEY:BRI_EN_M</code>
     - Brilliant Energy [Melee]
     <br/>
-    <code>
-     KEY:BRI_EN_T
-    </code>
+    <code>KEY:BRI_EN_T</code>
     - Brilliant Energy [Ranged]
     <br/>
-    <code>
-     KEY:BRONZE
-    </code>
+    <code>KEY:BRONZE</code>
     - Bronze
     <br/>
-    <code>
-     KEY:CHAOS_A
-    </code>
+    <code>KEY:CHAOS_A</code>
     - Anarchic, Chaotic [Ammunition]
     <br/>
-    <code>
-     KEY:CHAOS_M
-    </code>
+    <code>KEY:CHAOS_M</code>
     - Anarchic, Chaotic [Melee]
     <br/>
-    <code>
-     KEY:CHAOS_R
-    </code>
+    <code>KEY:CHAOS_R</code>
     - Anarchic, Chaotic [Ranged]
     <br/>
-    <code>
-     KEY:CHARGED_ITEM_3
-    </code>
+    <code>KEY:CHARGED_ITEM_3</code>
     - Charges (3)
     <br/>
-    <code>
-     KEY:CHARGED_ITEM_5
-    </code>
+    <code>KEY:CHARGED_ITEM_5</code>
     - Charges (5)
     <br/>
-    <code>
-     KEY:CHARGED_ITEM_10
-    </code>
+    <code>KEY:CHARGED_ITEM_10</code>
     - Charges (10)
     <br/>
-    <code>
-     KEY:CHARGED_ITEM_12
-    </code>
+    <code>KEY:CHARGED_ITEM_12</code>
     - Charges (12)
     <br/>
-    <code>
-     KEY:CHARGED_ITEM_36
-    </code>
+    <code>KEY:CHARGED_ITEM_36</code>
     - Charges (36)
     <br/>
-    <code>
-     KEY:CHARGED_ITEM_50
-    </code>
+    <code>KEY:CHARGED_ITEM_50</code>
     - Charges (50)
     <br/>
-    <code>
-     KEY:CHARGED_ITEM_101
-    </code>
+    <code>KEY:CHARGED_ITEM_101</code>
     - Charges (101)
     <br/>
-    <code>
-     KEY:CLAY
-    </code>
+    <code>KEY:CLAY</code>
     - Clay
     <br/>
-    <code>
-     KEY:CLOTH
-    </code>
+    <code>KEY:CLOTH</code>
     - Cloth
     <br/>
-    <code>
-     KEY:D_1USEMA
-    </code>
+    <code>KEY:D_1USEMA</code>
     - Spell Effect (Single Use/Completion)
 [Major]
     <br/>
-    <code>
-     KEY:D_1USEME
-    </code>
+    <code>KEY:D_1USEME</code>
     - Spell Effect (Single Use/Completion)
 [Medium]
     <br/>
-    <code>
-     KEY:D_1USEMI
-    </code>
+    <code>KEY:D_1USEMI</code>
     - Spell Effect (Single Use/Completion)
 [Minor]
     <br/>
-    <code>
-     KEY:DANCE
-    </code>
+    <code>KEY:DANCE</code>
     - Dancing
     <br/>
-    <code>
-     KEY:DARK
-    </code>
+    <code>KEY:DARK</code>
     - Darkwood
     <br/>
-    <code>
-     KEY:DEFEND
-    </code>
+    <code>KEY:DEFEND</code>
     - Defending
     <br/>
-    <code>
-     KEY:DISRPT
-    </code>
+    <code>KEY:DISRPT</code>
     - Disruption
     <br/>
-    <code>
-     KEY:DISTNC
-    </code>
+    <code>KEY:DISTNC</code>
     - Distance
     <br/>
-    <code>
-     KEY:ETHERE
-    </code>
+    <code>KEY:ETHERE</code>
     - Etherealness
     <br/>
-    <code>
-     KEY:FLM_A
-    </code>
+    <code>KEY:FLM_A</code>
     - Flaming
     <br/>
-    <code>
-     KEY:FLM_BR_A
-    </code>
+    <code>KEY:FLM_BR_A</code>
     - Flaming Burst [Ammunition]
     <br/>
-    <code>
-     KEY:FLM_BR_M
-    </code>
+    <code>KEY:FLM_BR_M</code>
     - Flaming Burst [Melee]
     <br/>
-    <code>
-     KEY:FLM_BR_R
-    </code>
+    <code>KEY:FLM_BR_R</code>
     - Flaming Burst [Ranged]
     <br/>
-    <code>
-     KEY:FLM_M
-    </code>
+    <code>KEY:FLM_M</code>
     - Flaming [Melee]
     <br/>
-    <code>
-     KEY:FLM_R
-    </code>
+    <code>KEY:FLM_R</code>
     - Flaming [Ranged]
     <br/>
-    <code>
-     KEY:FROST_A
-    </code>
+    <code>KEY:FROST_A</code>
     - Frost [Ammunition]
     <br/>
-    <code>
-     KEY:FROST_M
-    </code>
+    <code>KEY:FROST_M</code>
     - Frost [Melee]
     <br/>
-    <code>
-     KEY:FROST_R
-    </code>
+    <code>KEY:FROST_R</code>
     - Frost [Ranged]
     <br/>
-    <code>
-     KEY:FRT_HVY
-    </code>
+    <code>KEY:FRT_HVY</code>
     - Fortification (Heavy)
     <br/>
-    <code>
-     KEY:FRT_LGHT
-    </code>
+    <code>KEY:FRT_LGHT</code>
     - Fortification (Light)
     <br/>
-    <code>
-     KEY:FRT_MOD
-    </code>
+    <code>KEY:FRT_MOD</code>
     - Fortification (Moderate)
     <br/>
-    <code>
-     KEY:GHOST_A
-    </code>
+    <code>KEY:GHOST_A</code>
     - Ghost touch [Armor and Shield]
     <br/>
-    <code>
-     KEY:GHOST_AM
-    </code>
+    <code>KEY:GHOST_AM</code>
     - Ghost touch [Ammunition]
     <br/>
-    <code>
-     KEY:GHOST_M
-    </code>
+    <code>KEY:GHOST_M</code>
     - Ghost touch [ Melee]
     <br/>
-    <code>
-     KEY:GHOST_R
-    </code>
+    <code>KEY:GHOST_R</code>
     - Ghost touch [Ranged]
     <br/>
-    <code>
-     KEY:GLAM
-    </code>
+    <code>KEY:GLAM</code>
     - Glamered
     <br/>
-    <code>
-     KEY:GLASS
-    </code>
+    <code>KEY:GLASS</code>
     - Glass
     <br/>
-    <code>
-     KEY:GOLD
-    </code>
+    <code>KEY:GOLD</code>
     - Gold
     <br/>
-    <code>
-     KEY:HEMP
-    </code>
+    <code>KEY:HEMP</code>
     - Hemp
     <br/>
-    <code>
-     KEY:HOLY_A
-    </code>
+    <code>KEY:HOLY_A</code>
     - Holy [Ammunition]
     <br/>
-    <code>
-     KEY:HOLY_M
-    </code>
+    <code>KEY:HOLY_M</code>
     - Holy [Melee]
     <br/>
-    <code>
-     KEY:HOLY_R
-    </code>
+    <code>KEY:HOLY_R</code>
     - Holy [Ranged]
     <br/>
-    <code>
-     KEY:ICE
-    </code>
+    <code>KEY:ICE</code>
     - Ice
     <br/>
-    <code>
-     KEY:ICE_BR_A
-    </code>
+    <code>KEY:ICE_BR_A</code>
     - Icy Burst [Ammunition]
     <br/>
-    <code>
-     KEY:ICE_BR_M
-    </code>
+    <code>KEY:ICE_BR_M</code>
     - Icy Burst [Melee]
     <br/>
-    <code>
-     KEY:ICE_BR_R
-    </code>
+    <code>KEY:ICE_BR_R</code>
     - Icy Burst [Ranged]
     <br/>
-    <code>
-     KEY:IRON
-    </code>
+    <code>KEY:IRON</code>
     - Iron
     <br/>
-    <code>
-     KEY:IRONWOOD
-    </code>
+    <code>KEY:IRONWOOD</code>
     - Ironwood
     <br/>
-    <code>
-     KEY:IRONWOOD_PLUS
-    </code>
+    <code>KEY:IRONWOOD_PLUS</code>
     - Ironwood (+1)
     <br/>
-    <code>
-     KEY:INVULN
-    </code>
+    <code>KEY:INVULN</code>
     - Invulnerability
     <br/>
-    <code>
-     KEY:KEEN
-    </code>
+    <code>KEY:KEEN</code>
     - Keen
     <br/>
-    <code>
-     KEY:LAW_A
-    </code>
+    <code>KEY:LAW_A</code>
     - Axiomatic, Lawful [Ammunition]
     <br/>
-    <code>
-     KEY:LAW_M
-    </code>
+    <code>KEY:LAW_M</code>
     - Axiomatic, Lawful [Melee]
     <br/>
-    <code>
-     KEY:LAW_R
-    </code>
+    <code>KEY:LAW_R</code>
     - Axiomatic, Lawful [Ranged]
     <br/>
-    <code>
-     KEY:LEATHER
-    </code>
+    <code>KEY:LEATHER</code>
     - Leather
     <br/>
-    <code>
-     KEY:Lock_G
-    </code>
+    <code>KEY:Lock_G</code>
     - Locked Gauntlets
     <br/>
-    <code>
-     KEY:MI_CLE
-    </code>
+    <code>KEY:MI_CLE</code>
     - Mighty Cleaving
     <br/>
-    <code>
-     KEY:MITHRAL_ARMR_HVY
-    </code>
+    <code>KEY:MITHRAL_ARMR_HVY</code>
     - Mithral (Armor/Heavy)
     <br/>
-    <code>
-     KEY:MITHRAL_ARMR_LT
-    </code>
+    <code>KEY:MITHRAL_ARMR_LT</code>
     - Mithral (Armor/Light)
     <br/>
-    <code>
-     KEY:MITHRAL_ARMR_MED
-    </code>
+    <code>KEY:MITHRAL_ARMR_MED</code>
     - Mithral (Armor/Medium)
     <br/>
-    <code>
-     KEY:MITHRAL_ITEM
-    </code>
+    <code>KEY:MITHRAL_ITEM</code>
     - Mithral
 (Weapon/Ammo/Instrument)
     <br/>
-    <code>
-     KEY:MITHRAL_SHLD
-    </code>
+    <code>KEY:MITHRAL_SHLD</code>
     - Mithral (Shield)
     <br/>
-    <code>
-     KEY:MTHRL
-    </code>
+    <code>KEY:MTHRL</code>
     - Mithral
     <span class="new">
      (deprecated)
     </span>
     <br/>
-    <code>
-     KEY:MTHRL_MDHV
-    </code>
+    <code>KEY:MTHRL_MDHV</code>
     - Mithral
     <span class="new">
      (deprecated)
     </span>
     <br/>
-    <code>
-     KEY:MWORKA
-    </code>
+    <code>KEY:MWORKA</code>
     - Masterwork (Armor)
     <br/>
-    <code>
-     KEY:MWORKI
-    </code>
+    <code>KEY:MWORKI</code>
     - Masterwork (Instrument)
     <br/>
-    <code>
-     KEY:MWORKT
-    </code>
+    <code>KEY:MWORKT</code>
     - Masterwork (Tool)
     <br/>
-    <code>
-     KEY:MWORKW
-    </code>
+    <code>KEY:MWORKW</code>
     - Masterwork (Weapon/Ammo)
     <br/>
-    <code>
-     KEY:NONHUMANOID
-    </code>
+    <code>KEY:NONHUMANOID</code>
     - Nonhumanoid (Armor)
     <br/>
-    <code>
-     KEY:PAPER
-    </code>
+    <code>KEY:PAPER</code>
     - Paper
     <br/>
-    <code>
-     KEY:PLUS1A
-    </code>
+    <code>KEY:PLUS1A</code>
     - +1 (Enhancement to Armor)
     <br/>
-    <code>
-     KEY:PLUS1S
-    </code>
+    <code>KEY:PLUS1S</code>
     - +1 (Enhancement to Shield)
     <br/>
-    <code>
-     KEY:PLUS1W
-    </code>
+    <code>KEY:PLUS1W</code>
     - +1 (Enhancement to Weapon or
 Ammunition)
     <br/>
-    <code>
-     KEY:PLUS2A
-    </code>
+    <code>KEY:PLUS2A</code>
     - +2 (Enhancement to Armor)
     <br/>
-    <code>
-     KEY:PLUS2S
-    </code>
+    <code>KEY:PLUS2S</code>
     - +2 (Enhancement to Shield)
     <br/>
-    <code>
-     KEY:PLUS2W
-    </code>
+    <code>KEY:PLUS2W</code>
     - +2 (Enhancement to Weapon or
 Ammunition)
     <br/>
-    <code>
-     KEY:PLUS3A
-    </code>
+    <code>KEY:PLUS3A</code>
     - +3 (Enhancement to Armor)
     <br/>
-    <code>
-     KEY:PLUS3S
-    </code>
+    <code>KEY:PLUS3S</code>
     - +3 (Enhancement to Shield)
     <br/>
-    <code>
-     KEY:PLUS3W
-    </code>
+    <code>KEY:PLUS3W</code>
     - +3 (Enhancement to Weapon or
 Ammunition)
     <br/>
-    <code>
-     KEY:PLUS4A
-    </code>
+    <code>KEY:PLUS4A</code>
     - +4 (Enhancement to Armor)
     <br/>
-    <code>
-     KEY:PLUS4S
-    </code>
+    <code>KEY:PLUS4S</code>
     - +4 (Enhancement to Shield)
     <br/>
-    <code>
-     KEY:PLUS4W
-    </code>
+    <code>KEY:PLUS4W</code>
     - +4 (Enhancement to Weapon or
 Ammunition)
     <br/>
-    <code>
-     KEY:PLUS5A
-    </code>
+    <code>KEY:PLUS5A</code>
     - +5 (Enhancement to Armor)
     <br/>
-    <code>
-     KEY:PLUS5S
-    </code>
+    <code>KEY:PLUS5S</code>
     - +5 (Enhancement to Shield)
     <br/>
-    <code>
-     KEY:PLUS5W
-    </code>
+    <code>KEY:PLUS5W</code>
     - +5 (Enhancement to Weapon or
 Ammunition)
     <br/>
-    <code>
-     KEY:REFLC
-    </code>
+    <code>KEY:REFLC</code>
     - Reflecting
     <br/>
-    <code>
-     KEY:RETRN
-    </code>
+    <code>KEY:RETRN</code>
     - Returning
     <br/>
-    <code>
-     KEY:RING
-    </code>
+    <code>KEY:RING</code>
     - Ring
     <br/>
-    <code>
-     KEY:RST_ACD
-    </code>
+    <code>KEY:RST_ACD</code>
     - Acid Resistance
     <br/>
-    <code>
-     KEY:RST_CLD
-    </code>
+    <code>KEY:RST_CLD</code>
     - Cold Resistance
     <br/>
-    <code>
-     KEY:RST_ELE
-    </code>
+    <code>KEY:RST_ELE</code>
     - Electricity Resistance Lightning
 Resistance
     <br/>
-    <code>
-     KEY:RST_FR
-    </code>
+    <code>KEY:RST_FR</code>
     - Fire Resistance
     <br/>
-    <code>
-     KEY:RST_SNC
-    </code>
+    <code>KEY:RST_SNC</code>
     - Sonic Resistance
     <br/>
-    <code>
-     KEY:SCROLL
-    </code>
+    <code>KEY:SCROLL</code>
     - SCROLL
     <br/>
-    <code>
-     KEY:SCROLL_ARCANE
-    </code>
+    <code>KEY:SCROLL_ARCANE</code>
     - SCROLL (Arcane)
     <br/>
-    <code>
-     KEY:SCROLL_DIVINE
-    </code>
+    <code>KEY:SCROLL_DIVINE</code>
     - SCROLL (Divine)
     <br/>
-    <code>
-     KEY:SCROLL_MAJOR
-    </code>
+    <code>KEY:SCROLL_MAJOR</code>
     - SCROLL (Major)
     <br/>
-    <code>
-     KEY:SCROLL_MEDIUM
-    </code>
+    <code>KEY:SCROLL_MEDIUM</code>
     - SCROLL (Medium)
     <br/>
-    <code>
-     KEY:SCROLL_MINOR
-    </code>
+    <code>KEY:SCROLL_MINOR</code>
     - SCROLL (Minor)
     <br/>
-    <code>
-     KEY:SHDW
-    </code>
+    <code>KEY:SHDW</code>
     - Shadow
     <br/>
-    <code>
-     KEY:SHK_BR_A
-    </code>
+    <code>KEY:SHK_BR_A</code>
     - Shocking Burst [Ammunition]
     <br/>
-    <code>
-     KEY:SHK_BR_M
-    </code>
+    <code>KEY:SHK_BR_M</code>
     - Shocking Burst [Melee]
     <br/>
-    <code>
-     KEY:SHK_BR_R
-    </code>
+    <code>KEY:SHK_BR_R</code>
     - Shocking Burst [Ranged]
     <br/>
-    <code>
-     KEY:SHOCK_A
-    </code>
+    <code>KEY:SHOCK_A</code>
     - Shock [Ammunition]
     <br/>
-    <code>
-     KEY:SHOCK_M
-    </code>
+    <code>KEY:SHOCK_M</code>
     - Shock [Melee]
     <br/>
-    <code>
-     KEY:SHOCK_R
-    </code>
+    <code>KEY:SHOCK_R</code>
     - Shock [Ranged]
     <br/>
-    <code>
-     KEY:SILK
-    </code>
+    <code>KEY:SILK</code>
     - Silk
     <br/>
-    <code>
-     KEY:SILVER
-    </code>
+    <code>KEY:SILVER</code>
     - Silver
     <br/>
-    <code>
-     KEY:SLK
-    </code>
+    <code>KEY:SLK</code>
     - Slick
     <br/>
-    <code>
-     KEY:SLNT_MV
-    </code>
+    <code>KEY:SLNT_MV</code>
     - Silent moves
     <br/>
-    <code>
-     KEY:SLVR
-    </code>
+    <code>KEY:SLVR</code>
     - Silvered
     <br/>
-    <code>
-     KEY:SPEED
-    </code>
+    <code>KEY:SPEED</code>
     - Speed
     <br/>
-    <code>
-     KEY:SPELL_RES_13
-    </code>
+    <code>KEY:SPELL_RES_13</code>
     - Spell Resistance (SR 13)
     <br/>
-    <code>
-     KEY:SPELL_RES_15
-    </code>
+    <code>KEY:SPELL_RES_15</code>
     - Spell Resistance (SR 15)
     <br/>
-    <code>
-     KEY:SPELL_RES_17
-    </code>
+    <code>KEY:SPELL_RES_17</code>
     - Spell Resistance (SR 17)
     <br/>
-    <code>
-     KEY:SPELL_RES_19
-    </code>
+    <code>KEY:SPELL_RES_19</code>
     - Spell Resistance (SR 19)
     <br/>
-    <code>
-     KEY:SPELLFOCUS
-    </code>
+    <code>KEY:SPELLFOCUS</code>
     - Spell Focus Value
     <br/>
-    <code>
-     KEY:SPELLMATERIAL
-    </code>
+    <code>KEY:SPELLMATERIAL</code>
     - Spell Material Component
 Value
     <br/>
-    <code>
-     KEY:SPIKE_A
-    </code>
+    <code>KEY:SPIKE_A</code>
     - Armor Spikes
     <br/>
-    <code>
-     KEY:SPIKE_S
-    </code>
+    <code>KEY:SPIKE_S</code>
     - Shield Spikes
     <br/>
-    <code>
-     KEY:SPIKE_SB
-    </code>
+    <code>KEY:SPIKE_SB</code>
     - Shield Bash
     <br/>
-    <code>
-     KEY:SPL_1USE
-    </code>
+    <code>KEY:SPL_1USE</code>
     - Spell Effect (Single Use/Use
 Activated)
     <br/>
-    <code>
-     KEY:SPL_ACT
-    </code>
+    <code>KEY:SPL_ACT</code>
     - Spell Effect (Use Activated)
     <br/>
-    <code>
-     KEY:SPL_CHRG
-    </code>
+    <code>KEY:SPL_CHRG</code>
     - Spell Effect (50 Charges/Spell
 Trigger)
     <br/>
-    <code>
-     KEY:SPL_CMD
-    </code>
+    <code>KEY:SPL_CMD</code>
     - Spell Effect (Command Word)
     <br/>
-    <code>
-     KEY:SPL_RST
-    </code>
+    <code>KEY:SPL_RST</code>
     - Spell Resistance
     <span class="new">
      (deprecated)
     </span>
     <br/>
-    <code>
-     KEY:SPL_STR
-    </code>
+    <code>KEY:SPL_STR</code>
     - Spell Storing
     <br/>
-    <code>
-     KEY:STEEL
-    </code>
+    <code>KEY:STEEL</code>
     - Mundane (Weapon/Ammo)
     <br/>
-    <code>
-     KEY:STONE
-    </code>
+    <code>KEY:STONE</code>
     - Stone
     <br/>
-    <code>
-     KEY:THNDR_A
-    </code>
+    <code>KEY:THNDR_A</code>
     - Thundering [Ammunition]
     <br/>
-    <code>
-     KEY:THNDR_M
-    </code>
+    <code>KEY:THNDR_M</code>
     - Thundering [Melee]
     <br/>
-    <code>
-     KEY:THNDR_R
-    </code>
+    <code>KEY:THNDR_R</code>
     - Thundering [Ranged]
     <br/>
-    <code>
-     KEY:THROW
-    </code>
+    <code>KEY:THROW</code>
     - Throwing
     <br/>
-    <code>
-     KEY:UNHLY_A
-    </code>
+    <code>KEY:UNHLY_A</code>
     - Unholy [Ammunition]
     <br/>
-    <code>
-     KEY:UNHLY_M
-    </code>
+    <code>KEY:UNHLY_M</code>
     - Unholy [Melee]
     <br/>
-    <code>
-     KEY:UNHLY_R
-    </code>
+    <code>KEY:UNHLY_R</code>
     - Unholy [Ranged]
     <br/>
-    <code>
-     KEY:VORPAL
-    </code>
+    <code>KEY:VORPAL</code>
     - Vorpal
     <br/>
-    <code>
-     KEY:WAND
-    </code>
+    <code>KEY:WAND</code>
     - Wand
     <br/>
-    <code>
-     KEY:WAX
-    </code>
+    <code>KEY:WAX</code>
     - Wax
     <br/>
-    <code>
-     KEY:WOOD
-    </code>
+    <code>KEY:WOOD</code>
     - Mundane (Weapon/Ammo)
     <br/>
-    <code>
-     KEY:WOUND
-    </code>
+    <code>KEY:WOUND</code>
     - Wounding
     <br/>
    </p>
@@ -1651,9 +1277,7 @@ Trigger)
     </strong>
    </p>
    <p>
-    <code>
-     KEY:Scroll (Ice Storm)
-    </code>
+    <code>KEY:Scroll (Ice Storm)</code>
     - Scroll (Ice
 Storm/Arcane)
     <br/>
@@ -1664,270 +1288,168 @@ Storm/Arcane)
     </strong>
    </p>
    <p>
-    <code>
-     KEY:APRTR
-    </code>
+    <code>KEY:APRTR</code>
     - Aporter
     <br/>
-    <code>
-     KEY:ARMPR13
-    </code>
+    <code>KEY:ARMPR13</code>
     - # Power Resistance (PR13) -
 Armor.Shield
     <br/>
-    <code>
-     KEY:ARMPR15
-    </code>
+    <code>KEY:ARMPR15</code>
     - # Power Resistance (PR15) -
 Armor.Shield
     <br/>
-    <code>
-     KEY:ARMPR17
-    </code>
+    <code>KEY:ARMPR17</code>
     - # Power Resistance (PR17) -
 Armor.Shield
     <br/>
-    <code>
-     KEY:ARMPR19
-    </code>
+    <code>KEY:ARMPR19</code>
     - # Power Resistance (PR19) -
 Armor.Shield
     <br/>
-    <code>
-     KEY:AVRTR
-    </code>
+    <code>KEY:AVRTR</code>
     - Averter
     <br/>
-    <code>
-     KEY:BDY_FDR
-    </code>
+    <code>KEY:BDY_FDR</code>
     - Body Feeder
     <br/>
-    <code>
-     KEY:CHRGD
-    </code>
+    <code>KEY:CHRGD</code>
     - Charged
     <br/>
-    <code>
-     KEY:CRYSTAL
-    </code>
+    <code>KEY:CRYSTAL</code>
     - Crystalline
     <br/>
-    <code>
-     KEY:DISSIP
-    </code>
+    <code>KEY:DISSIP</code>
     - Dissipater
     <br/>
-    <code>
-     KEY:ECTO
-    </code>
+    <code>KEY:ECTO</code>
     - Ectoplasmic
     <br/>
-    <code>
-     KEY:FERROPLASM
-    </code>
+    <code>KEY:FERROPLASM</code>
     - Ferroplasm
     <br/>
-    <code>
-     KEY:FLOAT
-    </code>
+    <code>KEY:FLOAT</code>
     - Floating
     <br/>
-    <code>
-     KEY:HEART
-    </code>
+    <code>KEY:HEART</code>
     - Hearten
     <br/>
-    <code>
-     KEY:IMPCT
-    </code>
+    <code>KEY:IMPCT</code>
     - Impact
     <br/>
-    <code>
-     KEY:LANDING
-    </code>
+    <code>KEY:LANDING</code>
     - Landing
     <br/>
-    <code>
-     KEY:LINKED
-    </code>
+    <code>KEY:LINKED</code>
     - Linked
     <br/>
-    <code>
-     KEY:LUCKY
-    </code>
+    <code>KEY:LUCKY</code>
     - Lucky
     <br/>
-    <code>
-     KEY:MND_ARMR
-    </code>
+    <code>KEY:MND_ARMR</code>
     - Mindarmor
     <br/>
-    <code>
-     KEY:MND_CRSHR
-    </code>
+    <code>KEY:MND_CRSHR</code>
     - Mindcrusher
     <br/>
-    <code>
-     KEY:MND_FDR
-    </code>
+    <code>KEY:MND_FDR</code>
     - Mind Feeder
     <br/>
-    <code>
-     KEY:MNFSTR_S
-    </code>
+    <code>KEY:MNFSTR_S</code>
     - Manifester
     <br/>
-    <code>
-     KEY:MNFSTR_W
-    </code>
+    <code>KEY:MNFSTR_W</code>
     - Manifester
     <br/>
-    <code>
-     KEY:MNTL_ADBL
-    </code>
+    <code>KEY:MNTL_ADBL</code>
     - Mentally Audible
     <br/>
-    <code>
-     KEY:PARRYING
-    </code>
+    <code>KEY:PARRYING</code>
     - Parrying
     <br/>
-    <code>
-     KEY:PHASING
-    </code>
+    <code>KEY:PHASING</code>
     - Phasing
     <br/>
-    <code>
-     KEY:POWER STORING
-    </code>
+    <code>KEY:POWER STORING</code>
     - Power Storing
     <br/>
-    <code>
-     KEY:PSIARMFORH
-    </code>
+    <code>KEY:PSIARMFORH</code>
     - #Reinforcement (Heavy) -
 Armor.Shield
     <br/>
-    <code>
-     KEY:PSIARMFORL
-    </code>
+    <code>KEY:PSIARMFORL</code>
     - #Reinforcement (Light) -
 Armor.Shield
     <br/>
-    <code>
-     KEY:PSIARMFORM
-    </code>
+    <code>KEY:PSIARMFORM</code>
     - #Reinforcement (Moderate) -
 Armor.Shield
     <br/>
-    <code>
-     KEY:PSIBANE
-    </code>
+    <code>KEY:PSIBANE</code>
     - Psibane
     <br/>
-    <code>
-     KEY:PSYCHIC
-    </code>
+    <code>KEY:PSYCHIC</code>
     - Psychic
     <br/>
-    <code>
-     KEY:PWR_CRWL
-    </code>
+    <code>KEY:PWR_CRWL</code>
     - |Power Effect (Single Use/Use
 Activated)
     <br/>
-    <code>
-     KEY:PWR_DRJ
-    </code>
+    <code>KEY:PWR_DRJ</code>
     - |Power Effect (50 Charges/Power
 Trigger)
     <br/>
-    <code>
-     KEY:PWR_PS
-    </code>
+    <code>KEY:PWR_PS</code>
     - |Power Effect (Single
 Use/Completion)
     <br/>
-    <code>
-     KEY:PWR_PT
-    </code>
+    <code>KEY:PWR_PT</code>
     - |Power Effect (Single Use/Use
 Activated)
     <br/>
-    <code>
-     KEY:PWR_RST
-    </code>
+    <code>KEY:PWR_RST</code>
     - Power Resistance
     <br/>
-    <code>
-     KEY:QUICKNESS
-    </code>
+    <code>KEY:QUICKNESS</code>
     - Quickness
     <br/>
-    <code>
-     KEY:RADIANT
-    </code>
+    <code>KEY:RADIANT</code>
     - Radiant
     <br/>
-    <code>
-     KEY:RNFRC_HVY
-    </code>
+    <code>KEY:RNFRC_HVY</code>
     - Reinforcement (Heavy)
     <br/>
-    <code>
-     KEY:RNFRC_LGHT
-    </code>
+    <code>KEY:RNFRC_LGHT</code>
     - Reinforcement (Light)
     <br/>
-    <code>
-     KEY:RNFRC_MOD
-    </code>
+    <code>KEY:RNFRC_MOD</code>
     - Reinforcement (Moderate)
     <br/>
-    <code>
-     KEY:RNGED
-    </code>
+    <code>KEY:RNGED</code>
     - Ranged
     <br/>
-    <code>
-     KEY:SIGHT
-    </code>
+    <code>KEY:SIGHT</code>
     - Sight
     <br/>
-    <code>
-     KEY:SL_FDR
-    </code>
+    <code>KEY:SL_FDR</code>
     - Soul Feeder
     <br/>
-    <code>
-     KEY:SPPRSSN
-    </code>
+    <code>KEY:SPPRSSN</code>
     - Suppression
     <br/>
-    <code>
-     KEY:SUNDERER
-    </code>
+    <code>KEY:SUNDERER</code>
     - Sunderer
     <br/>
-    <code>
-     KEY:THGHT_BSTN
-    </code>
+    <code>KEY:THGHT_BSTN</code>
     - Thought Bastion
     <br/>
-    <code>
-     KEY:TIME_BTTRS
-    </code>
+    <code>KEY:TIME_BTTRS</code>
     - Time Buttress
     <br/>
-    <code>
-     KEY:VANISHING
-    </code>
+    <code>KEY:VANISHING</code>
     - Vanishing
     <br/>
-    <code>
-     KEY:WALL
-    </code>
+    <code>KEY:WALL</code>
     - Wall
     <br/>
    </p>
@@ -1937,14 +1459,10 @@ Activated)
     </strong>
    </p>
    <p>
-    <code>
-     KEY:EXCLUDEEQ_MAGIC
-    </code>
+    <code>KEY:EXCLUDEEQ_MAGIC</code>
     - Magic
     <br/>
-    <code>
-     KEY:EXCLUDEEQ_MUNDANE
-    </code>
+    <code>KEY:EXCLUDEEQ_MUNDANE</code>
     - Mundane
     <br/>
    </p>
@@ -1967,110 +1485,72 @@ RSRD (35e)
     </strong>
    </p>
    <p>
-    <code>
-     KEY:ART
-    </code>
+    <code>KEY:ART</code>
     - Art Value
     <br/>
-    <code>
-     KEY:GEM
-    </code>
+    <code>KEY:GEM</code>
     - Gem Value
     <br/>
-    <code>
-     KEY:Gloves of Swimming/Climbing
-    </code>
+    <code>KEY:Gloves of Swimming/Climbing</code>
     - Gloves of Swimming
 and Climbing
     <br/>
-    <code>
-     KEY:Helm of Comprehending Languages and Reading Magic
-    </code>
+    <code>KEY:Helm of Comprehending Languages and Reading Magic</code>
     - Helm of Comprehend Languages and Read Magic
     <br/>
-    <code>
-     KEY:Potion(Oil of Shillelagh)
-    </code>
+    <code>KEY:Potion(Oil of Shillelagh)</code>
     - Potion (Oil of
 Shillelagh)
     <br/>
-    <code>
-     KEY:Potion(Oil of Bless Weapon)
-    </code>
+    <code>KEY:Potion(Oil of Bless Weapon)</code>
     - Potion (Oil of Bless
 Weapon)
     <br/>
-    <code>
-     KEY:Potion (Darkness)
-    </code>
+    <code>KEY:Potion (Darkness)</code>
     - Potion (Darkvision)
     <br/>
-    <code>
-     KEY:Scroll (Analayze Dweomer)
-    </code>
+    <code>KEY:Scroll (Analayze Dweomer)</code>
     - Scroll (Analyze
 Dweomer)
     <br/>
-    <code>
-     KEY:Scroll (Banishement/Arcane)
-    </code>
+    <code>KEY:Scroll (Banishement/Arcane)</code>
     - Scroll
 (Banishment/Arcane)
     <br/>
-    <code>
-     KEY:Scroll (Control Water/Divine)
-    </code>
+    <code>KEY:Scroll (Control Water/Divine)</code>
     - Scroll (Control
 Water)
     <br/>
-    <code>
-     KEY:Scroll (Control Weather/Arcane)
-    </code>
+    <code>KEY:Scroll (Control Weather/Arcane)</code>
     - Scroll (Control
 Weather/Arcane/Lvl 7)
     <br/>
-    <code>
-     KEY:Scroll (Gate/Arcane)
-    </code>
+    <code>KEY:Scroll (Gate/Arcane)</code>
     - Scroll (Gate)
     <br/>
-    <code>
-     KEY:Scroll (Protection from Energy/Arcane)
-    </code>
+    <code>KEY:Scroll (Protection from Energy/Arcane)</code>
     - Scroll
 (Protection from Energy)
     <br/>
-    <code>
-     KEY:Scroll (Stone Shape/Arcane)
-    </code>
+    <code>KEY:Scroll (Stone Shape/Arcane)</code>
     - Scroll (Stone
 Shape)
     <br/>
-    <code>
-     KEY:Scroll (Summon Monster IX/Arcane)
-    </code>
+    <code>KEY:Scroll (Summon Monster IX/Arcane)</code>
     - Scroll (Summon
 Monster IX)
     <br/>
-    <code>
-     KEY:Scroll (Tongues/Arcane)
-    </code>
+    <code>KEY:Scroll (Tongues/Arcane)</code>
     - Scroll (Tongues)
     <br/>
-    <code>
-     KEY:Scroll (Wall of Stone/Arcane)
-    </code>
+    <code>KEY:Scroll (Wall of Stone/Arcane)</code>
     - Scroll (Wall of
 Stone)
     <br/>
-    <code>
-     KEY:Sunblade (Bastard)
-    </code>
+    <code>KEY:Sunblade (Bastard)</code>
     - Sun Blade (Bastard)
     <br/>
-    <code>
-     KEY:Sunblade (Short)
-    </code>
+    <code>KEY:Sunblade (Short)</code>
     - Sun Blade (Short)
     <br/>
    </p>
@@ -2080,1221 +1560,751 @@ Stone)
     </strong>
    </p>
    <p>
-    <code>
-     KEY:A_1USEMA
-    </code>
+    <code>KEY:A_1USEMA</code>
     - Spell Effect (Single Use/Completion)
 [Major Arcane]
     <br/>
-    <code>
-     KEY:A_1USEME
-    </code>
+    <code>KEY:A_1USEME</code>
     - Spell Effect (Single Use/Completion)
 [Medium Arcane]
     <br/>
-    <code>
-     KEY:A_1USEMI
-    </code>
+    <code>KEY:A_1USEMI</code>
     - Spell Effect (Single Use/Completion)
 [Minor Arcane]
     <br/>
-    <code>
-     KEY:ADAM
-    </code>
+    <code>KEY:ADAM</code>
     - Adamantine
     <span class="new">
      (deprecated)
     </span>
     <br/>
-    <code>
-     KEY:ADAMANT_AMMO
-    </code>
+    <code>KEY:ADAMANT_AMMO</code>
     - Adamantine (Ammo)
     <br/>
-    <code>
-     KEY:ADAMANT_ARMR_HVY
-    </code>
+    <code>KEY:ADAMANT_ARMR_HVY</code>
     - Adamantine (Armor/Heavy)
     <br/>
-    <code>
-     KEY:ADAMANT_ARMR_LT
-    </code>
+    <code>KEY:ADAMANT_ARMR_LT</code>
     - Adamantine (Armor/Light)
     <br/>
-    <code>
-     KEY:ADAMANT_ARMR_MED
-    </code>
+    <code>KEY:ADAMANT_ARMR_MED</code>
     - Adamantine (Armor/Medium)
     <br/>
-    <code>
-     KEY:ADAMANT_SHLD
-    </code>
+    <code>KEY:ADAMANT_SHLD</code>
     - Adamantine (Shield)
     <br/>
-    <code>
-     KEY:ADAMANT_WEAP
-    </code>
+    <code>KEY:ADAMANT_WEAP</code>
     - Adamantine (Weapon)
     <br/>
-    <code>
-     KEY:ADD_TYPE
-    </code>
+    <code>KEY:ADD_TYPE</code>
     - # Add Type
     <br/>
-    <code>
-     KEY:ALCHM
-    </code>
+    <code>KEY:ALCHM</code>
     - Alchemical Silver
     <br/>
-    <code>
-     KEY:ALCHM/2
-    </code>
+    <code>KEY:ALCHM/2</code>
     - 1/2 Alchemical Silver
     <span class="new">
      (deprecated)
     </span>
     <br/>
-    <code>
-     KEY:ANMATD
-    </code>
+    <code>KEY:ANMATD</code>
     - Animated
     <br/>
-    <code>
-     KEY:ARCANE_ARCHER_AMMO
-    </code>
+    <code>KEY:ARCANE_ARCHER_AMMO</code>
     - Arcane Archer
 Enchantement
     <br/>
-    <code>
-     KEY:ARW_CAT
-    </code>
+    <code>KEY:ARW_CAT</code>
     - Arrow Catching
     <br/>
-    <code>
-     KEY:ARW_DEF
-    </code>
+    <code>KEY:ARW_DEF</code>
     - Arrow Deflection
     <br/>
-    <code>
-     KEY:BANE_A
-    </code>
+    <code>KEY:BANE_A</code>
     - Bane
     <br/>
-    <code>
-     KEY:BANE_M
-    </code>
+    <code>KEY:BANE_M</code>
     - Bane
     <br/>
-    <code>
-     KEY:BANE_R
-    </code>
+    <code>KEY:BANE_R</code>
     - Bane
     <br/>
-    <code>
-     KEY:BASH_H
-    </code>
+    <code>KEY:BASH_H</code>
     - Bashing
     <br/>
-    <code>
-     KEY:BASH_L
-    </code>
+    <code>KEY:BASH_L</code>
     - Bashing
     <br/>
-    <code>
-     KEY:BIND
-    </code>
+    <code>KEY:BIND</code>
     - Blinding
     <br/>
-    <code>
-     KEY:BNS_AC_DEFL
-    </code>
+    <code>KEY:BNS_AC_DEFL</code>
     - AC Bonus (Deflection)
     <br/>
-    <code>
-     KEY:BNS_AC_INSI
-    </code>
+    <code>KEY:BNS_AC_INSI</code>
     - AC Bonus (Insight)
     <br/>
-    <code>
-     KEY:BNS_AC_LUCK
-    </code>
+    <code>KEY:BNS_AC_LUCK</code>
     - AC Bonus (Luck)
     <br/>
-    <code>
-     KEY:BNS_AC_OTHE
-    </code>
+    <code>KEY:BNS_AC_OTHE</code>
     - AC Bonus (Other)
     <br/>
-    <code>
-     KEY:BNS_AC_PROF
-    </code>
+    <code>KEY:BNS_AC_PROF</code>
     - AC Bonus (Profane)
     <br/>
-    <code>
-     KEY:BNS_AC_SCRD
-    </code>
+    <code>KEY:BNS_AC_SCRD</code>
     - AC Bonus (Sacred)
     <br/>
-    <code>
-     KEY:BNS_ENHC_AB
-    </code>
+    <code>KEY:BNS_ENHC_AB</code>
     - Ability Bonus (Enhancement)
     <br/>
-    <code>
-     KEY:BNS_ENHC_AC
-    </code>
+    <code>KEY:BNS_ENHC_AC</code>
     - Armor Bonus (Enhancement)
     <br/>
-    <code>
-     KEY:BNS_ENHC_NAT
-    </code>
+    <code>KEY:BNS_ENHC_NAT</code>
     - Natural Armor Bonus
 (Enhancement)
     <br/>
-    <code>
-     KEY:BNS_SAV_INS
-    </code>
+    <code>KEY:BNS_SAV_INS</code>
     - Save Bonus (Insight)
     <br/>
-    <code>
-     KEY:BNS_SAV_LUC
-    </code>
+    <code>KEY:BNS_SAV_LUC</code>
     - Save Bonus (Luck)
     <br/>
-    <code>
-     KEY:BNS_SAV_OTH
-    </code>
+    <code>KEY:BNS_SAV_OTH</code>
     - Save Bonus (Other)
     <br/>
-    <code>
-     KEY:BNS_SAV_PRO
-    </code>
+    <code>KEY:BNS_SAV_PRO</code>
     - Save Bonus (Profane)
     <br/>
-    <code>
-     KEY:BNS_SAV_RES
-    </code>
+    <code>KEY:BNS_SAV_RES</code>
     - Save Bonus (Resistance)
     <br/>
-    <code>
-     KEY:BNS_SAV_SAC
-    </code>
+    <code>KEY:BNS_SAV_SAC</code>
     - Save Bonus (Sacred)
     <br/>
-    <code>
-     KEY:BNS_SKL_CMP
-    </code>
+    <code>KEY:BNS_SKL_CMP</code>
     - Skill Bonus (Competence)
     <br/>
-    <code>
-     KEY:BNS_SPELL
-    </code>
+    <code>KEY:BNS_SPELL</code>
     - Bonus Spell
     <br/>
-    <code>
-     KEY:BNS_SPL_RST
-    </code>
+    <code>KEY:BNS_SPL_RST</code>
     - |Spell Resistance
     <br/>
-    <code>
-     KEY:BONE
-    </code>
+    <code>KEY:BONE</code>
     - Bone
     <br/>
-    <code>
-     KEY:BOWSTR
-    </code>
+    <code>KEY:BOWSTR</code>
     - Bow_STR
     <br/>
-    <code>
-     KEY:BRASS
-    </code>
+    <code>KEY:BRASS</code>
     - Brass
     <br/>
-    <code>
-     KEY:BRI_EN_A
-    </code>
+    <code>KEY:BRI_EN_A</code>
     - Brilliant Energy
     <br/>
-    <code>
-     KEY:BRI_EN_M
-    </code>
+    <code>KEY:BRI_EN_M</code>
     - Brilliant Energy
     <br/>
-    <code>
-     KEY:BRI_EN_T
-    </code>
+    <code>KEY:BRI_EN_T</code>
     - Brilliant Energy
     <br/>
-    <code>
-     KEY:BRONZE
-    </code>
+    <code>KEY:BRONZE</code>
     - Bronze
     <br/>
-    <code>
-     KEY:C_IRON
-    </code>
+    <code>KEY:C_IRON</code>
     - Cold Iron
     <br/>
-    <code>
-     KEY:C_IRON/2
-    </code>
+    <code>KEY:C_IRON/2</code>
     - 1/2 Cold Iron
     <span class="new">
      (deprecated)
     </span>
     <br/>
-    <code>
-     KEY:CHAOS_A
-    </code>
+    <code>KEY:CHAOS_A</code>
     - Anarchic, Chaotic
     <br/>
-    <code>
-     KEY:CHAOS_M
-    </code>
+    <code>KEY:CHAOS_M</code>
     - Anarchic, Chaotic
     <br/>
-    <code>
-     KEY:CHAOS_R
-    </code>
+    <code>KEY:CHAOS_R</code>
     - Anarchic, Chaotic
     <br/>
-    <code>
-     KEY:CHARGED_ITEM_3
-    </code>
+    <code>KEY:CHARGED_ITEM_3</code>
     - Charges (3)
     <br/>
-    <code>
-     KEY:CHARGED_ITEM_4
-    </code>
+    <code>KEY:CHARGED_ITEM_4</code>
     - Charges (4)
     <br/>
-    <code>
-     KEY:CHARGED_ITEM_5
-    </code>
+    <code>KEY:CHARGED_ITEM_5</code>
     - Charges (5)
     <br/>
-    <code>
-     KEY:CHARGED_ITEM_10
-    </code>
+    <code>KEY:CHARGED_ITEM_10</code>
     - Charges (10)
     <br/>
-    <code>
-     KEY:CHARGED_ITEM_12
-    </code>
+    <code>KEY:CHARGED_ITEM_12</code>
     - Charges (12)
     <br/>
-    <code>
-     KEY:CHARGED_ITEM_34
-    </code>
+    <code>KEY:CHARGED_ITEM_34</code>
     - Charges (34)
     <br/>
-    <code>
-     KEY:CHARGED_ITEM_36
-    </code>
+    <code>KEY:CHARGED_ITEM_36</code>
     - Charges (36)
     <br/>
-    <code>
-     KEY:CHARGED_ITEM_50
-    </code>
+    <code>KEY:CHARGED_ITEM_50</code>
     - Charges (50)
     <br/>
-    <code>
-     KEY:CHARGED_ITEM_101
-    </code>
+    <code>KEY:CHARGED_ITEM_101</code>
     - Charges (101)
     <br/>
-    <code>
-     KEY:CLAY
-    </code>
+    <code>KEY:CLAY</code>
     - Clay
     <br/>
-    <code>
-     KEY:CLOTH
-    </code>
+    <code>KEY:CLOTH</code>
     - Cloth
     <br/>
-    <code>
-     KEY:D_1USEMA
-    </code>
+    <code>KEY:D_1USEMA</code>
     - Spell Effect (Single Use/Completion)
 [Major Divine]
     <br/>
-    <code>
-     KEY:D_1USEME
-    </code>
+    <code>KEY:D_1USEME</code>
     - Spell Effect (Single Use/Completion)
 [Medium Divine]
     <br/>
-    <code>
-     KEY:D_1USEMI
-    </code>
+    <code>KEY:D_1USEMI</code>
     - Spell Effect (Single Use/Completion)
 [Minor Divine]
     <br/>
-    <code>
-     KEY:DANCE
-    </code>
+    <code>KEY:DANCE</code>
     - Dancing
     <br/>
-    <code>
-     KEY:DARK
-    </code>
+    <code>KEY:DARK</code>
     - Darkwood
     <br/>
-    <code>
-     KEY:DEFEND
-    </code>
+    <code>KEY:DEFEND</code>
     - Defending
     <br/>
-    <code>
-     KEY:DISRPT
-    </code>
+    <code>KEY:DISRPT</code>
     - Disruption
     <br/>
-    <code>
-     KEY:DISTNC
-    </code>
+    <code>KEY:DISTNC</code>
     - Distance
     <br/>
-    <code>
-     KEY:DRACO
-    </code>
+    <code>KEY:DRACO</code>
     - Dragonhide
     <br/>
-    <code>
-     KEY:ETHERE
-    </code>
+    <code>KEY:ETHERE</code>
     - Etherealness
     <br/>
-    <code>
-     KEY:FLM_A
-    </code>
+    <code>KEY:FLM_A</code>
     - Flaming
     <br/>
-    <code>
-     KEY:FLM_BR_A
-    </code>
+    <code>KEY:FLM_BR_A</code>
     - Flaming Burst
     <br/>
-    <code>
-     KEY:FLM_BR_M
-    </code>
+    <code>KEY:FLM_BR_M</code>
     - Flaming Burst
     <br/>
-    <code>
-     KEY:FLM_BR_R
-    </code>
+    <code>KEY:FLM_BR_R</code>
     - Flaming Burst
     <br/>
-    <code>
-     KEY:FLM_M
-    </code>
+    <code>KEY:FLM_M</code>
     - Flaming
     <br/>
-    <code>
-     KEY:FLM_R
-    </code>
+    <code>KEY:FLM_R</code>
     - Flaming
     <br/>
-    <code>
-     KEY:FROST_A
-    </code>
+    <code>KEY:FROST_A</code>
     - Frost
     <br/>
-    <code>
-     KEY:FROST_M
-    </code>
+    <code>KEY:FROST_M</code>
     - Frost
     <br/>
-    <code>
-     KEY:FROST_R
-    </code>
+    <code>KEY:FROST_R</code>
     - Frost
     <br/>
-    <code>
-     KEY:FRT_HVY
-    </code>
+    <code>KEY:FRT_HVY</code>
     - Fortification (Heavy)
     <br/>
-    <code>
-     KEY:FRT_LGHT
-    </code>
+    <code>KEY:FRT_LGHT</code>
     - Fortification (Light)
     <br/>
-    <code>
-     KEY:FRT_MOD
-    </code>
+    <code>KEY:FRT_MOD</code>
     - Fortification (Moderate)
     <br/>
-    <code>
-     KEY:GHOST_A
-    </code>
+    <code>KEY:GHOST_A</code>
     - Ghost touch
     <br/>
-    <code>
-     KEY:GHOST_AM
-    </code>
+    <code>KEY:GHOST_AM</code>
     - Ghost touch
     <br/>
-    <code>
-     KEY:GHOST_M
-    </code>
+    <code>KEY:GHOST_M</code>
     - Ghost touch
     <br/>
-    <code>
-     KEY:GHOST_R
-    </code>
+    <code>KEY:GHOST_R</code>
     - Ghost touch
     <br/>
-    <code>
-     KEY:GLAM
-    </code>
+    <code>KEY:GLAM</code>
     - Glamered
     <br/>
-    <code>
-     KEY:GLASS
-    </code>
+    <code>KEY:GLASS</code>
     - Glass
     <br/>
-    <code>
-     KEY:GOLD
-    </code>
+    <code>KEY:GOLD</code>
     - Gold
     <br/>
-    <code>
-     KEY:HIDE
-    </code>
+    <code>KEY:HIDE</code>
     - Hide
     <br/>
-    <code>
-     KEY:HOLY_A
-    </code>
+    <code>KEY:HOLY_A</code>
     - Holy
     <br/>
-    <code>
-     KEY:HOLY_M
-    </code>
+    <code>KEY:HOLY_M</code>
     - Holy
     <br/>
-    <code>
-     KEY:HOLY_R
-    </code>
+    <code>KEY:HOLY_R</code>
     - Holy
     <br/>
-    <code>
-     KEY:ICE
-    </code>
+    <code>KEY:ICE</code>
     - Ice
     <br/>
-    <code>
-     KEY:ICE_BR_A
-    </code>
+    <code>KEY:ICE_BR_A</code>
     - Icy Burst
     <br/>
-    <code>
-     KEY:ICE_BR_M
-    </code>
+    <code>KEY:ICE_BR_M</code>
     - Icy Burst
     <br/>
-    <code>
-     KEY:ICE_BR_R
-    </code>
+    <code>KEY:ICE_BR_R</code>
     - Icy Burst
     <br/>
-    <code>
-     KEY:INVULN
-    </code>
+    <code>KEY:INVULN</code>
     - Invulnerability
     <br/>
-    <code>
-     KEY:IRON
-    </code>
+    <code>KEY:IRON</code>
     - Iron
     <br/>
-    <code>
-     KEY:IRONWOOD
-    </code>
+    <code>KEY:IRONWOOD</code>
     - Ironwood
     <br/>
-    <code>
-     KEY:IRONWOOD_PLUS
-    </code>
+    <code>KEY:IRONWOOD_PLUS</code>
     - Ironwood (+1)
     <br/>
-    <code>
-     KEY:KEEN
-    </code>
+    <code>KEY:KEEN</code>
     - Keen
     <br/>
-    <code>
-     KEY:KIFOC
-    </code>
+    <code>KEY:KIFOC</code>
     - Ki Focus
     <br/>
-    <code>
-     KEY:LAW_A
-    </code>
+    <code>KEY:LAW_A</code>
     - Axiomatic, Lawful
     <br/>
-    <code>
-     KEY:LAW_M
-    </code>
+    <code>KEY:LAW_M</code>
     - Axiomatic, Lawful
     <br/>
-    <code>
-     KEY:LAW_R
-    </code>
+    <code>KEY:LAW_R</code>
     - Axiomatic, Lawful
     <br/>
-    <code>
-     KEY:LEATHER
-    </code>
+    <code>KEY:LEATHER</code>
     - Leather
     <br/>
-    <code>
-     KEY:Lock_G
-    </code>
+    <code>KEY:Lock_G</code>
     - Locked Gauntlets
     <br/>
-    <code>
-     KEY:MAGIC_COST
-    </code>
+    <code>KEY:MAGIC_COST</code>
     - Magical Enhancment Cost
     <br/>
-    <code>
-     KEY:MAGIC_ENHANCE_1
-    </code>
+    <code>KEY:MAGIC_ENHANCE_1</code>
     - Magical Enhancments (+1)
     <br/>
-    <code>
-     KEY:MAGIC_ENHANCE_2
-    </code>
+    <code>KEY:MAGIC_ENHANCE_2</code>
     - Magical Enhancments (+2)
     <br/>
-    <code>
-     KEY:MAGIC_ENHANCE_3
-    </code>
+    <code>KEY:MAGIC_ENHANCE_3</code>
     - Magical Enhancments (+3)
     <br/>
-    <code>
-     KEY:MAGIC_ENHANCE_4
-    </code>
+    <code>KEY:MAGIC_ENHANCE_4</code>
     - Magical Enhancments (+4)
     <br/>
-    <code>
-     KEY:MAGIC_ENHANCE_5
-    </code>
+    <code>KEY:MAGIC_ENHANCE_5</code>
     - Magical Enhancments (+5)
     <br/>
-    <code>
-     KEY:MAGIC_ENHANCE_6
-    </code>
+    <code>KEY:MAGIC_ENHANCE_6</code>
     - Magical Enhancments (+6)
     <br/>
-    <code>
-     KEY:MAGIC_ENHANCE_7
-    </code>
+    <code>KEY:MAGIC_ENHANCE_7</code>
     - Magical Enhancments (+7)
     <br/>
-    <code>
-     KEY:MAGIC_ENHANCE_8
-    </code>
+    <code>KEY:MAGIC_ENHANCE_8</code>
     - Magical Enhancments (+8)
     <br/>
-    <code>
-     KEY:MAGIC_ENHANCE_9
-    </code>
+    <code>KEY:MAGIC_ENHANCE_9</code>
     - Magical Enhancments (+9)
     <br/>
-    <code>
-     KEY:MAGIC_ENHANCE_10
-    </code>
+    <code>KEY:MAGIC_ENHANCE_10</code>
     - Magical Enhancments (+10)
     <br/>
-    <code>
-     KEY:MERC_A
-    </code>
+    <code>KEY:MERC_A</code>
     - Merciful
     <br/>
-    <code>
-     KEY:MERC_M
-    </code>
+    <code>KEY:MERC_M</code>
     - Merciful
     <br/>
-    <code>
-     KEY:MERC_R
-    </code>
+    <code>KEY:MERC_R</code>
     - Merciful
     <br/>
-    <code>
-     KEY:MI_CLE
-    </code>
+    <code>KEY:MI_CLE</code>
     - Mighty Cleaving
     <br/>
-    <code>
-     KEY:MITHRAL_ARMR_HVY
-    </code>
+    <code>KEY:MITHRAL_ARMR_HVY</code>
     - Mithral (Armor/Heavy)
     <br/>
-    <code>
-     KEY:MITHRAL_ARMR_LT
-    </code>
+    <code>KEY:MITHRAL_ARMR_LT</code>
     - Mithral (Armor/Light)
     <br/>
-    <code>
-     KEY:MITHRAL_ARMR_MED
-    </code>
+    <code>KEY:MITHRAL_ARMR_MED</code>
     - Mithral (Armor/Medium)
     <br/>
-    <code>
-     KEY:MITHRAL_ITEM
-    </code>
+    <code>KEY:MITHRAL_ITEM</code>
     - Mithral
 (Weapon/Ammo/Instrument)
     <br/>
-    <code>
-     KEY:MITHRAL_SHLD
-    </code>
+    <code>KEY:MITHRAL_SHLD</code>
     - Mithral (Shield)
     <br/>
-    <code>
-     KEY:MTHRL
-    </code>
+    <code>KEY:MTHRL</code>
     - Mithral
     <span class="new">
      (deprecated)
     </span>
     <br/>
-    <code>
-     KEY:MTHRL_MDHV
-    </code>
+    <code>KEY:MTHRL_MDHV</code>
     - Mithral
     <span class="new">
      (deprecated)
     </span>
     <br/>
-    <code>
-     KEY:MWORKA
-    </code>
+    <code>KEY:MWORKA</code>
     - Masterwork (Armor)
     <br/>
-    <code>
-     KEY:MWORKI
-    </code>
+    <code>KEY:MWORKI</code>
     - Masterwork (Instrument)
     <br/>
-    <code>
-     KEY:MWORKT
-    </code>
+    <code>KEY:MWORKT</code>
     - Masterwork (Tool)
     <br/>
-    <code>
-     KEY:MWORKW
-    </code>
+    <code>KEY:MWORKW</code>
     - Masterwork (Weapon/Ammo)
     <br/>
-    <code>
-     KEY:NONHUMANOID
-    </code>
+    <code>KEY:NONHUMANOID</code>
     - Nonhumanoid (Armor)
     <br/>
-    <code>
-     KEY:PAPER
-    </code>
+    <code>KEY:PAPER</code>
     - Paper
     <br/>
-    <code>
-     KEY:PARCHMENT
-    </code>
+    <code>KEY:PARCHMENT</code>
     - Parchment
     <br/>
-    <code>
-     KEY:PLUS1A
-    </code>
+    <code>KEY:PLUS1A</code>
     - +1 (Enhancement to Armor)
     <br/>
-    <code>
-     KEY:PLUS1S
-    </code>
+    <code>KEY:PLUS1S</code>
     - +1 (Enhancement to Shield)
     <br/>
-    <code>
-     KEY:PLUS1W
-    </code>
+    <code>KEY:PLUS1W</code>
     - +1 (Enhancement to Weapon or
 Ammunition)
     <br/>
-    <code>
-     KEY:PLUS2A
-    </code>
+    <code>KEY:PLUS2A</code>
     - +2 (Enhancement to Armor)
     <br/>
-    <code>
-     KEY:PLUS2S
-    </code>
+    <code>KEY:PLUS2S</code>
     - +2 (Enhancement to Shield)
     <br/>
-    <code>
-     KEY:PLUS2W
-    </code>
+    <code>KEY:PLUS2W</code>
     - +2 (Enhancement to Weapon or
 Ammunition)
     <br/>
-    <code>
-     KEY:PLUS3A
-    </code>
+    <code>KEY:PLUS3A</code>
     - +3 (Enhancement to Armor)
     <br/>
-    <code>
-     KEY:PLUS3S
-    </code>
+    <code>KEY:PLUS3S</code>
     - +3 (Enhancement to Shield)
     <br/>
-    <code>
-     KEY:PLUS3W
-    </code>
+    <code>KEY:PLUS3W</code>
     - +3 (Enhancement to Weapon or
 Ammunition)
     <br/>
-    <code>
-     KEY:PLUS4A
-    </code>
+    <code>KEY:PLUS4A</code>
     - +4 (Enhancement to Armor)
     <br/>
-    <code>
-     KEY:PLUS4S
-    </code>
+    <code>KEY:PLUS4S</code>
     - +4 (Enhancement to Shield)
     <br/>
-    <code>
-     KEY:PLUS4W
-    </code>
+    <code>KEY:PLUS4W</code>
     - +4 (Enhancement to Weapon or
 Ammunition)
     <br/>
-    <code>
-     KEY:PLUS5A
-    </code>
+    <code>KEY:PLUS5A</code>
     - +5 (Enhancement to Armor)
     <br/>
-    <code>
-     KEY:PLUS5S
-    </code>
+    <code>KEY:PLUS5S</code>
     - +5 (Enhancement to Shield)
     <br/>
-    <code>
-     KEY:PLUS5W
-    </code>
+    <code>KEY:PLUS5W</code>
     - +5 (Enhancement to Weapon or
 Ammunition)
     <br/>
-    <code>
-     KEY:REFLC
-    </code>
+    <code>KEY:REFLC</code>
     - Reflecting
     <br/>
-    <code>
-     KEY:RES_ACD_GRT
-    </code>
+    <code>KEY:RES_ACD_GRT</code>
     - Acid Resistance (Greater)
     <br/>
-    <code>
-     KEY:RES_CLD_GRT
-    </code>
+    <code>KEY:RES_CLD_GRT</code>
     - Cold Resistance (Greater)
     <br/>
-    <code>
-     KEY:RES_ELE_GRT
-    </code>
+    <code>KEY:RES_ELE_GRT</code>
     - Electricity Resistance
 (Greater)
     <br/>
-    <code>
-     KEY:RES_FR_GRT
-    </code>
+    <code>KEY:RES_FR_GRT</code>
     - Fire Resistance (Greater)
     <br/>
-    <code>
-     KEY:RES_SNC_GRT
-    </code>
+    <code>KEY:RES_SNC_GRT</code>
     - Sonic Resistance (Greater)
     <br/>
-    <code>
-     KEY:RETRN
-    </code>
+    <code>KEY:RETRN</code>
     - Returning
     <br/>
-    <code>
-     KEY:ROPE
-    </code>
+    <code>KEY:ROPE</code>
     - Rope
     <br/>
-    <code>
-     KEY:RST_ACD
-    </code>
+    <code>KEY:RST_ACD</code>
     - Acid Resistance
     <br/>
-    <code>
-     KEY:RST_ACD_IMP
-    </code>
+    <code>KEY:RST_ACD_IMP</code>
     - Acid Resistance (Improved)
     <br/>
-    <code>
-     KEY:RST_CLD
-    </code>
+    <code>KEY:RST_CLD</code>
     - Cold Resistance
     <br/>
-    <code>
-     KEY:RST_CLD_IMP
-    </code>
+    <code>KEY:RST_CLD_IMP</code>
     - Cold Resistance (Improved)
     <br/>
-    <code>
-     KEY:RST_ELE
-    </code>
+    <code>KEY:RST_ELE</code>
     - Electricity Resistance Lightning
 Resistance
     <br/>
-    <code>
-     KEY:RST_ELE_IMP
-    </code>
+    <code>KEY:RST_ELE_IMP</code>
     - Electricity Resistance
 (Improved)
     <br/>
-    <code>
-     KEY:RST_FR
-    </code>
+    <code>KEY:RST_FR</code>
     - Fire Resistance
     <br/>
-    <code>
-     KEY:RST_FR_IMP
-    </code>
+    <code>KEY:RST_FR_IMP</code>
     - Fire Resistance (Improved)
     <br/>
-    <code>
-     KEY:RST_SNC
-    </code>
+    <code>KEY:RST_SNC</code>
     - Sonic Resistance
     <br/>
-    <code>
-     KEY:RST_SNC_IMP
-    </code>
+    <code>KEY:RST_SNC_IMP</code>
     - Sonic Resistance (Improved)
     <br/>
-    <code>
-     KEY:SCROLL_ARCANE
-    </code>
+    <code>KEY:SCROLL_ARCANE</code>
     - SCROLL (Arcane)
     <br/>
-    <code>
-     KEY:SCROLL_DIVINE
-    </code>
+    <code>KEY:SCROLL_DIVINE</code>
     - SCROLL (Divine)
     <br/>
-    <code>
-     KEY:SCROLL_MAJOR
-    </code>
+    <code>KEY:SCROLL_MAJOR</code>
     - SCROLL(Major)
     <br/>
-    <code>
-     KEY:SCROLL_MEDIUM
-    </code>
+    <code>KEY:SCROLL_MEDIUM</code>
     - SCROLL (Medium)
     <br/>
-    <code>
-     KEY:SCROLL_MINOR
-    </code>
+    <code>KEY:SCROLL_MINOR</code>
     - SCROLL (Minor)
     <br/>
-    <code>
-     KEY:SEEK
-    </code>
+    <code>KEY:SEEK</code>
     - Seeking
     <br/>
-    <code>
-     KEY:SHDW
-    </code>
+    <code>KEY:SHDW</code>
     - Shadow
     <br/>
-    <code>
-     KEY:SHDW_GRT
-    </code>
+    <code>KEY:SHDW_GRT</code>
     - Shadow (Greater)
     <br/>
-    <code>
-     KEY:SHDW_IMP
-    </code>
+    <code>KEY:SHDW_IMP</code>
     - Shadow (Improved)
     <br/>
-    <code>
-     KEY:SHK_BR_A
-    </code>
+    <code>KEY:SHK_BR_A</code>
     - Shocking Burst
     <br/>
-    <code>
-     KEY:SHK_BR_M
-    </code>
+    <code>KEY:SHK_BR_M</code>
     - Shocking Burst
     <br/>
-    <code>
-     KEY:SHK_BR_R
-    </code>
+    <code>KEY:SHK_BR_R</code>
     - Shocking Burst
     <br/>
-    <code>
-     KEY:SHOCK_A
-    </code>
+    <code>KEY:SHOCK_A</code>
     - Shock
     <br/>
-    <code>
-     KEY:SHOCK_M
-    </code>
+    <code>KEY:SHOCK_M</code>
     - Shock
     <br/>
-    <code>
-     KEY:SHOCK_R
-    </code>
+    <code>KEY:SHOCK_R</code>
     - Shock
     <br/>
-    <code>
-     KEY:SILK
-    </code>
+    <code>KEY:SILK</code>
     - Silk
     <br/>
-    <code>
-     KEY:SILVER
-    </code>
+    <code>KEY:SILVER</code>
     - Silver
     <br/>
-    <code>
-     KEY:SLK
-    </code>
+    <code>KEY:SLK</code>
     - Slick
     <br/>
-    <code>
-     KEY:SLK_GRT
-    </code>
+    <code>KEY:SLK_GRT</code>
     - Slick (Greater)
     <br/>
-    <code>
-     KEY:SLK_IMP
-    </code>
+    <code>KEY:SLK_IMP</code>
     - Slick (Improved)
     <br/>
-    <code>
-     KEY:SLNT_MV
-    </code>
+    <code>KEY:SLNT_MV</code>
     - Silent moves
     <br/>
-    <code>
-     KEY:SLNT_MV_GRT
-    </code>
+    <code>KEY:SLNT_MV_GRT</code>
     - Silent moves (Greater)
     <br/>
-    <code>
-     KEY:SLNT_MV_IM
-    </code>
+    <code>KEY:SLNT_MV_IM</code>
     - Silent moves (Improved)
     <br/>
-    <code>
-     KEY:SPEED
-    </code>
+    <code>KEY:SPEED</code>
     - Speed
     <br/>
-    <code>
-     KEY:SPELL_RES_13
-    </code>
+    <code>KEY:SPELL_RES_13</code>
     - Spell Resistance (SR 13)
     <br/>
-    <code>
-     KEY:SPELL_RES_15
-    </code>
+    <code>KEY:SPELL_RES_15</code>
     - Spell Resistance (SR 15)
     <br/>
-    <code>
-     KEY:SPELL_RES_17
-    </code>
+    <code>KEY:SPELL_RES_17</code>
     - Spell Resistance (SR 17)
     <br/>
-    <code>
-     KEY:SPELL_RES_19
-    </code>
+    <code>KEY:SPELL_RES_19</code>
     - Spell Resistance (SR 19)
     <br/>
-    <code>
-     KEY:SPELLFOCUS
-    </code>
+    <code>KEY:SPELLFOCUS</code>
     - Spell Focus Value
     <br/>
-    <code>
-     KEY:SPELLMATERIAL
-    </code>
+    <code>KEY:SPELLMATERIAL</code>
     - Spell Material Component
 Value
     <br/>
-    <code>
-     KEY:SPIKE_A
-    </code>
+    <code>KEY:SPIKE_A</code>
     - Armor Spikes
     <br/>
-    <code>
-     KEY:SPIKE_S
-    </code>
+    <code>KEY:SPIKE_S</code>
     - Shield Spikes
     <br/>
-    <code>
-     KEY:SPIKE_SB
-    </code>
+    <code>KEY:SPIKE_SB</code>
     - Shield Bash
     <br/>
-    <code>
-     KEY:SPL_1USE
-    </code>
+    <code>KEY:SPL_1USE</code>
     - Spell Effect (Single Use/Use
 Activated)
     <br/>
-    <code>
-     KEY:SPL_ACT
-    </code>
+    <code>KEY:SPL_ACT</code>
     - Spell Effect (Use Activated)
     <br/>
-    <code>
-     KEY:SPL_CHRG
-    </code>
+    <code>KEY:SPL_CHRG</code>
     - Spell Effect (50 Charges/Spell
 Trigger)
     <br/>
-    <code>
-     KEY:SPL_CMD
-    </code>
+    <code>KEY:SPL_CMD</code>
     - Spell Effect (Command Word)
     <br/>
-    <code>
-     KEY:SPL_CON_ROUND
-    </code>
+    <code>KEY:SPL_CON_ROUND</code>
     - |Spell Effect (Continuous/Spell
 duration measured in rounds)
     <br/>
-    <code>
-     KEY:SPL_CON_MINUTES
-    </code>
+    <code>KEY:SPL_CON_MINUTES</code>
     - |Spell Effect (Continuous/Spell
 duration 1 minute/level)
     <br/>
-    <code>
-     KEY:SPL_CON_HOURS
-    </code>
+    <code>KEY:SPL_CON_HOURS</code>
     - |Spell Effect (Continuous/Spell
 duration 10 minutes/level)
     <br/>
-    <code>
-     KEY:SPL_CON_DAYS
-    </code>
+    <code>KEY:SPL_CON_DAYS</code>
     - |Spell Effect (Continuous/Spell
 duration 24-hours or more)
     <br/>
-    <code>
-     KEY:SPL_STR
-    </code>
+    <code>KEY:SPL_STR</code>
     - Spell Storing
     <br/>
-    <code>
-     KEY:SPL_RST
-    </code>
+    <code>KEY:SPL_RST</code>
     - Spell Resistance
     <span class="new">
      (deprecated)
     </span>
     <br/>
-    <code>
-     KEY:STEEL
-    </code>
+    <code>KEY:STEEL</code>
     - Mundane (Weapon/Ammo)
     <br/>
-    <code>
-     KEY:STONE
-    </code>
+    <code>KEY:STONE</code>
     - Stone
     <br/>
-    <code>
-     KEY:THNDR_A
-    </code>
+    <code>KEY:THNDR_A</code>
     - Thundering
     <br/>
-    <code>
-     KEY:THNDR_M
-    </code>
+    <code>KEY:THNDR_M</code>
     - Thundering
     <br/>
-    <code>
-     KEY:THNDR_R
-    </code>
+    <code>KEY:THNDR_R</code>
     - Thundering
     <br/>
-    <code>
-     KEY:THROW
-    </code>
+    <code>KEY:THROW</code>
     - Throwing
     <br/>
-    <code>
-     KEY:THROWN_AMMO
-    </code>
+    <code>KEY:THROWN_AMMO</code>
     - Thrown Ammunition
     <br/>
-    <code>
-     KEY:UNDEAD
-    </code>
+    <code>KEY:UNDEAD</code>
     - Undead controlling
     <br/>
-    <code>
-     KEY:UNHLY_A
-    </code>
+    <code>KEY:UNHLY_A</code>
     - Unholy
     <br/>
-    <code>
-     KEY:UNHLY_M
-    </code>
+    <code>KEY:UNHLY_M</code>
     - Unholy
     <br/>
-    <code>
-     KEY:UNHLY_R
-    </code>
+    <code>KEY:UNHLY_R</code>
     - Unholy
     <br/>
-    <code>
-     KEY:VICIOU
-    </code>
+    <code>KEY:VICIOU</code>
     - Vicious
     <br/>
-    <code>
-     KEY:VORPAL
-    </code>
+    <code>KEY:VORPAL</code>
     - Vorpal
     <br/>
-    <code>
-     KEY:WAX
-    </code>
+    <code>KEY:WAX</code>
     - Wax
     <br/>
-    <code>
-     KEY:WILD_A
-    </code>
+    <code>KEY:WILD_A</code>
     - Wild
     <br/>
-    <code>
-     KEY:WILD_S
-    </code>
+    <code>KEY:WILD_S</code>
     - Wild
     <br/>
-    <code>
-     KEY:WOOD
-    </code>
+    <code>KEY:WOOD</code>
     - Mundane (Weapon/Ammo)
     <br/>
-    <code>
-     KEY:WOUND
-    </code>
+    <code>KEY:WOUND</code>
     - Wounding
     <br/>
    </p>
@@ -3304,14 +2314,10 @@ duration 24-hours or more)
     </strong>
    </p>
    <p>
-    <code>
-     KEY:SDA_POWER_OF_NATURE
-    </code>
+    <code>KEY:SDA_POWER_OF_NATURE</code>
     - Power of Nature
     <br/>
-    <code>
-     KEY:SDA_UNDEAD_MASTERY
-    </code>
+    <code>KEY:SDA_UNDEAD_MASTERY</code>
     - Undead Mastery
     <br/>
    </p>
@@ -3321,469 +2327,295 @@ duration 24-hours or more)
     </strong>
    </p>
    <p>
-    <code>
-     KEY:ACID_BLAST_AMMO
-    </code>
+    <code>KEY:ACID_BLAST_AMMO</code>
     - Acidic Blast
     <br/>
-    <code>
-     KEY:ACID_BLAST_MELEE
-    </code>
+    <code>KEY:ACID_BLAST_MELEE</code>
     - Acidic Blast
     <br/>
-    <code>
-     KEY:ACID_BLAST_RANGED
-    </code>
+    <code>KEY:ACID_BLAST_RANGED</code>
     - Acidic Blast
     <br/>
-    <code>
-     KEY:ACID_WARD
-    </code>
+    <code>KEY:ACID_WARD</code>
     - Acid Warding
     <br/>
-    <code>
-     KEY:ARROW_DEFLECT_EXC
-    </code>
+    <code>KEY:ARROW_DEFLECT_EXC</code>
     - Exceptional Arrow
 Deflection
     <br/>
-    <code>
-     KEY:ARROW_DEFLECT_INF
-    </code>
+    <code>KEY:ARROW_DEFLECT_INF</code>
     - Infinite Arrow
 Deflection
     <br/>
-    <code>
-     KEY:CHAOS_POWER_AMMO
-    </code>
+    <code>KEY:CHAOS_POWER_AMMO</code>
     - Anarchic Energy
     <br/>
-    <code>
-     KEY:CHAOS_POWER_MELEE
-    </code>
+    <code>KEY:CHAOS_POWER_MELEE</code>
     - Anarchic Energy
     <br/>
-    <code>
-     KEY:CHAOS_POWER_RANGED
-    </code>
+    <code>KEY:CHAOS_POWER_RANGED</code>
     - Anarchic Energy
     <br/>
-    <code>
-     KEY:COLD_WARD
-    </code>
+    <code>KEY:COLD_WARD</code>
     - Cold Warding
     <br/>
-    <code>
-     KEY:DISRUPTION_MIGHTY
-    </code>
+    <code>KEY:DISRUPTION_MIGHTY</code>
     - Mighty Disruption
     <br/>
-    <code>
-     KEY:DISTANT_SHOT
-    </code>
+    <code>KEY:DISTANT_SHOT</code>
     - Distant Shot
     <br/>
-    <code>
-     KEY:DREAD_AMMO
-    </code>
+    <code>KEY:DREAD_AMMO</code>
     - Dread
     <br/>
-    <code>
-     KEY:DREAD_MELEE
-    </code>
+    <code>KEY:DREAD_MELEE</code>
     - Dread
     <br/>
-    <code>
-     KEY:DREAD_RANGED
-    </code>
+    <code>KEY:DREAD_RANGED</code>
     - Dread
     <br/>
-    <code>
-     KEY:ELECTRIC_WARD
-    </code>
+    <code>KEY:ELECTRIC_WARD</code>
     - Lightning Warding
     <br/>
-    <code>
-     KEY:EPIC_ABILITY_BONUS_ENHANCE
-    </code>
+    <code>KEY:EPIC_ABILITY_BONUS_ENHANCE</code>
     - |Epic Ability Bonus
 (Enhancement)
     <br/>
-    <code>
-     KEY:EPIC_AC_BONUS_DEFLECT
-    </code>
+    <code>KEY:EPIC_AC_BONUS_DEFLECT</code>
     - |Epic AC Bonus
 (Deflection)
     <br/>
-    <code>
-     KEY:EPIC_AC_BONUS_LUCK
-    </code>
+    <code>KEY:EPIC_AC_BONUS_LUCK</code>
     - |Epic AC Bonus (Luck)
     <br/>
-    <code>
-     KEY:EPIC_AC_BONUS_INSIGHT
-    </code>
+    <code>KEY:EPIC_AC_BONUS_INSIGHT</code>
     - |Epic AC Bonus
 (Insight)
     <br/>
-    <code>
-     KEY:EPIC_AC_BONUS_SACRED
-    </code>
+    <code>KEY:EPIC_AC_BONUS_SACRED</code>
     - |Epic AC Bonus
 (Sacred)
     <br/>
-    <code>
-     KEY:EPIC_AC_BONUS_PROFANE
-    </code>
+    <code>KEY:EPIC_AC_BONUS_PROFANE</code>
     - |Epic AC Bonus
 (Profane)
     <br/>
-    <code>
-     KEY:EPIC_AC_BONUS_OTHER
-    </code>
+    <code>KEY:EPIC_AC_BONUS_OTHER</code>
     - |Epic AC Bonus (Other)
     <br/>
-    <code>
-     KEY:EPIC_BONUS_ARMR_ENHANCE
-    </code>
+    <code>KEY:EPIC_BONUS_ARMR_ENHANCE</code>
     - |Epic Armor Bonus
 (Enhancement)
     <br/>
-    <code>
-     KEY:EPIC_BONUS_SPELL
-    </code>
+    <code>KEY:EPIC_BONUS_SPELL</code>
     - |Epic Bonus Spell
     <br/>
-    <code>
-     KEY:EPIC_NATURAL_ARMR_ENHANCE
-    </code>
+    <code>KEY:EPIC_NATURAL_ARMR_ENHANCE</code>
     - |Epic Natural Armor
 Bonus (Enhancement)
     <br/>
-    <code>
-     KEY:EPIC_SAVE_BONUS_INSIGHT
-    </code>
+    <code>KEY:EPIC_SAVE_BONUS_INSIGHT</code>
     - |Epic Save Bonus
 (Insight)
     <br/>
-    <code>
-     KEY:EPIC_SAVE_BONUS_LUCK
-    </code>
+    <code>KEY:EPIC_SAVE_BONUS_LUCK</code>
     - |Epic Save Bonus
 (Luck)
     <br/>
-    <code>
-     KEY:EPIC_SAVE_BONUS_OTHER
-    </code>
+    <code>KEY:EPIC_SAVE_BONUS_OTHER</code>
     - |Epic Save Bonus
 (Other)
     <br/>
-    <code>
-     KEY:EPIC_SAVE_BONUS_PROFANE
-    </code>
+    <code>KEY:EPIC_SAVE_BONUS_PROFANE</code>
     - |Epic Save Bonus
 (Profane)
     <br/>
-    <code>
-     KEY:EPIC_SAVE_BONUS_SACRED
-    </code>
+    <code>KEY:EPIC_SAVE_BONUS_SACRED</code>
     - |Epic Save Bonus
 (Sacred)
     <br/>
-    <code>
-     KEY:EPIC_SAVE_BONUS_RES
-    </code>
+    <code>KEY:EPIC_SAVE_BONUS_RES</code>
     - |Epic Save Bonus
 (Resistance)
     <br/>
-    <code>
-     KEY:EPIC_SKILL_BONUS_COMPETANCE
-    </code>
+    <code>KEY:EPIC_SKILL_BONUS_COMPETANCE</code>
     - |Epic Skill Bonus
 (Competance)
     <br/>
-    <code>
-     KEY:EPIC_SPELL_RES
-    </code>
+    <code>KEY:EPIC_SPELL_RES</code>
     - |Epic Spell Resistance
     <br/>
-    <code>
-     KEY:EVERDANCING
-    </code>
+    <code>KEY:EVERDANCING</code>
     - Everdancing
     <br/>
-    <code>
-     KEY:FIRE_BLAST_AMMO
-    </code>
+    <code>KEY:FIRE_BLAST_AMMO</code>
     - Fiery Blast
     <br/>
-    <code>
-     KEY:FIRE_BLAST_MELEE
-    </code>
+    <code>KEY:FIRE_BLAST_MELEE</code>
     - Fiery Blast
     <br/>
-    <code>
-     KEY:FIRE_BLAST_RANGED
-    </code>
+    <code>KEY:FIRE_BLAST_RANGED</code>
     - Fiery Blast
     <br/>
-    <code>
-     KEY:FIRE_WARD
-    </code>
+    <code>KEY:FIRE_WARD</code>
     - Fire Warding
     <br/>
-    <code>
-     KEY:HOLY_POWER_AMMO
-    </code>
+    <code>KEY:HOLY_POWER_AMMO</code>
     - Holy Power
     <br/>
-    <code>
-     KEY:HOLY_POWER_MELEE
-    </code>
+    <code>KEY:HOLY_POWER_MELEE</code>
     - Holy Power
     <br/>
-    <code>
-     KEY:HOLY_POWER_RANGED
-    </code>
+    <code>KEY:HOLY_POWER_RANGED</code>
     - Holy Power
     <br/>
-    <code>
-     KEY:ICE_BLAST_AMMO
-    </code>
+    <code>KEY:ICE_BLAST_AMMO</code>
     - Icy Blast
     <br/>
-    <code>
-     KEY:ICE_BLAST_MELEE
-    </code>
+    <code>KEY:ICE_BLAST_MELEE</code>
     - Icy Blast
     <br/>
-    <code>
-     KEY:ICE_BLAST_RANGED
-    </code>
+    <code>KEY:ICE_BLAST_RANGED</code>
     - Icy Blast
     <br/>
-    <code>
-     KEY:INVULN_GRT_5E
-    </code>
+    <code>KEY:INVULN_GRT_5E</code>
     - Greater Invulnerability (+6)
     <br/>
-    <code>
-     KEY:INVULN_GRT_10E
-    </code>
+    <code>KEY:INVULN_GRT_10E</code>
     - Greater Invulnerability
 (+7)
     <br/>
-    <code>
-     KEY:INVULN_GRT_10M
-    </code>
+    <code>KEY:INVULN_GRT_10M</code>
     - Greater Invulnerability
 (+4)
     <br/>
-    <code>
-     KEY:INVULN_GRT_15M
-    </code>
+    <code>KEY:INVULN_GRT_15M</code>
     - Greater Invulnerability
 (+5)
     <br/>
-    <code>
-     KEY:LAW_POWER_AMMO
-    </code>
+    <code>KEY:LAW_POWER_AMMO</code>
     - Axiomatic Power
     <br/>
-    <code>
-     KEY:LAW_POWER_MELEE
-    </code>
+    <code>KEY:LAW_POWER_MELEE</code>
     - Axiomatic Power
     <br/>
-    <code>
-     KEY:LAW_POWER_RANGED
-    </code>
+    <code>KEY:LAW_POWER_RANGED</code>
     - Axiomatic Power
     <br/>
-    <code>
-     KEY:NEGATING
-    </code>
+    <code>KEY:NEGATING</code>
     - Negating
     <br/>
-    <code>
-     KEY:PLUS_6_ARMR
-    </code>
+    <code>KEY:PLUS_6_ARMR</code>
     - +6 (Enhancement to Armor)
     <br/>
-    <code>
-     KEY:PLUS_6_SHLD
-    </code>
+    <code>KEY:PLUS_6_SHLD</code>
     - +6 (Enhancement to Shield)
     <br/>
-    <code>
-     KEY:PLUS_6_WEAP
-    </code>
+    <code>KEY:PLUS_6_WEAP</code>
     - +6 (Enhancement to Weapon or
 Ammunition)
     <br/>
-    <code>
-     KEY:PLUS_7_ARMR
-    </code>
+    <code>KEY:PLUS_7_ARMR</code>
     - +7 (Enhancement to Armor)
     <br/>
-    <code>
-     KEY:PLUS_7_SHLD
-    </code>
+    <code>KEY:PLUS_7_SHLD</code>
     - +7 (Enhancement to Shield)
     <br/>
-    <code>
-     KEY:PLUS_7_WEAP
-    </code>
+    <code>KEY:PLUS_7_WEAP</code>
     - +7 (Enhancement to Weapon or
 Ammunition)
     <br/>
-    <code>
-     KEY:PLUS_8_ARMR
-    </code>
+    <code>KEY:PLUS_8_ARMR</code>
     - +8 (Enhancement to Armor)
     <br/>
-    <code>
-     KEY:PLUS_8_SHLD
-    </code>
+    <code>KEY:PLUS_8_SHLD</code>
     - +8 (Enhancement to Shield)
     <br/>
-    <code>
-     KEY:PLUS_8_WEAP
-    </code>
+    <code>KEY:PLUS_8_WEAP</code>
     - +8 (Enhancement to Weapon or
 Ammunition)
     <br/>
-    <code>
-     KEY:PLUS_9_ARMR
-    </code>
+    <code>KEY:PLUS_9_ARMR</code>
     - +9 (Enhancement to Armor)
     <br/>
-    <code>
-     KEY:PLUS_9_SHLD
-    </code>
+    <code>KEY:PLUS_9_SHLD</code>
     - +9 (Enhancement to Shield)
     <br/>
-    <code>
-     KEY:PLUS_9_WEAP
-    </code>
+    <code>KEY:PLUS_9_WEAP</code>
     - +9 (Enhancement to Weapon or
 Ammunition)
     <br/>
-    <code>
-     KEY:PLUS_10_ARMR
-    </code>
+    <code>KEY:PLUS_10_ARMR</code>
     - +10 (Enhancement to Armor)
     <br/>
-    <code>
-     KEY:PLUS_10_SHLD
-    </code>
+    <code>KEY:PLUS_10_SHLD</code>
     - +10 (Enhancement to Shield)
     <br/>
-    <code>
-     KEY:PLUS_10_WEAP
-    </code>
+    <code>KEY:PLUS_10_WEAP</code>
     - +10 (Enhancement to Weapon or
 Ammunition)
     <br/>
-    <code>
-     KEY:REFLECT_GRT
-    </code>
+    <code>KEY:REFLECT_GRT</code>
     - Greater Reflection
     <br/>
-    <code>
-     KEY:SCROLL_ARCANE_EPIC
-    </code>
+    <code>KEY:SCROLL_ARCANE_EPIC</code>
     - |Spell Effect (Single
 Use/Completion)
     <br/>
-    <code>
-     KEY:SCROLL_DIVINE_EPIC
-    </code>
+    <code>KEY:SCROLL_DIVINE_EPIC</code>
     - |Spell Effect (Single
 Use/Completion)
     <br/>
-    <code>
-     KEY:SHOCK_BLAST_AMMO
-    </code>
+    <code>KEY:SHOCK_BLAST_AMMO</code>
     - Lightning Blast
     <br/>
-    <code>
-     KEY:SHOCK_BLAST_MELEE
-    </code>
+    <code>KEY:SHOCK_BLAST_MELEE</code>
     - Lightning Blast
     <br/>
-    <code>
-     KEY:SHOCK_BLAST_RANGED
-    </code>
+    <code>KEY:SHOCK_BLAST_RANGED</code>
     - Lightning Blast
     <br/>
-    <code>
-     KEY:SONIC_BLAST_AMMO
-    </code>
+    <code>KEY:SONIC_BLAST_AMMO</code>
     - Sonic Blast
     <br/>
-    <code>
-     KEY:SONIC_BLAST_MELEE
-    </code>
+    <code>KEY:SONIC_BLAST_MELEE</code>
     - Sonic Blast
     <br/>
-    <code>
-     KEY:SONIC_BLAST_RANGED
-    </code>
+    <code>KEY:SONIC_BLAST_RANGED</code>
     - Sonic Blast
     <br/>
-    <code>
-     KEY:SONIC_WARD
-    </code>
+    <code>KEY:SONIC_WARD</code>
     - Sonic Warding
     <br/>
-    <code>
-     KEY:SPELL_RES_21
-    </code>
+    <code>KEY:SPELL_RES_21</code>
     - Greater Spell Resistance (SR
 21)
     <br/>
-    <code>
-     KEY:SPELL_RES_23
-    </code>
+    <code>KEY:SPELL_RES_23</code>
     - Greater Spell Resistance (SR
 23)
     <br/>
-    <code>
-     KEY:SPELL_RES_25
-    </code>
+    <code>KEY:SPELL_RES_25</code>
     - Greater Spell Resistance (SR
 25)
     <br/>
-    <code>
-     KEY:SPELL_RES_27
-    </code>
+    <code>KEY:SPELL_RES_27</code>
     - Greater Spell Resistance (SR
 27)
     <br/>
-    <code>
-     KEY:TRIPLE_THROW
-    </code>
+    <code>KEY:TRIPLE_THROW</code>
     - Triple Throw
     <br/>
-    <code>
-     KEY:UNERRING_ACCURACY
-    </code>
+    <code>KEY:UNERRING_ACCURACY</code>
     - Unerring Accuracy
     <br/>
-    <code>
-     KEY:UNHOLY_POWER_AMMO
-    </code>
+    <code>KEY:UNHOLY_POWER_AMMO</code>
     - Unholy Power
     <br/>
-    <code>
-     KEY:UNHOLY_POWER_MELEE
-    </code>
+    <code>KEY:UNHOLY_POWER_MELEE</code>
     - Unholy Power
     <br/>
-    <code>
-     KEY:UNHOLY_POWER_RANGED
-    </code>
+    <code>KEY:UNHOLY_POWER_RANGED</code>
     - Unholy Power
     <br/>
    </p>
@@ -3793,377 +2625,231 @@ Use/Completion)
     </strong>
    </p>
    <p>
-    <code>
-     KEY:APORT
-    </code>
+    <code>KEY:APORT</code>
     - Aporter
     <br/>
-    <code>
-     KEY:AVRTR
-    </code>
+    <code>KEY:AVRTR</code>
     - Averter
     <br/>
-    <code>
-     KEY:BODYFEED
-    </code>
+    <code>KEY:BODYFEED</code>
     - Bodyfeeder
     <br/>
-    <code>
-     KEY:COLLI_A
-    </code>
+    <code>KEY:COLLI_A</code>
     - Collision (+2)
     <br/>
-    <code>
-     KEY:COLLI_M
-    </code>
+    <code>KEY:COLLI_M</code>
     - Collision (+2)
     <br/>
-    <code>
-     KEY:COLLI_R
-    </code>
+    <code>KEY:COLLI_R</code>
     - Collision (+2)
     <br/>
-    <code>
-     KEY:COUPGR_A
-    </code>
+    <code>KEY:COUPGR_A</code>
     - Coup de Grace (+5)
     <br/>
-    <code>
-     KEY:COUPGR_M
-    </code>
+    <code>KEY:COUPGR_M</code>
     - Coup de Grace (+5)
     <br/>
-    <code>
-     KEY:COUPGR_R
-    </code>
+    <code>KEY:COUPGR_R</code>
     - Coup de Grace (+5)
     <br/>
-    <code>
-     KEY:CRYS_DEEP
-    </code>
+    <code>KEY:CRYS_DEEP</code>
     - Crystal (Deep)
     <br/>
-    <code>
-     KEY:CRYS_DEEP_ITEM
-    </code>
+    <code>KEY:CRYS_DEEP_ITEM</code>
     - Crystal (Deep)
     <br/>
-    <code>
-     KEY:CRYS_MUN
-    </code>
+    <code>KEY:CRYS_MUN</code>
     - Crystal (Mundane)
     <br/>
-    <code>
-     KEY:CRYS_MUN_ITEM
-    </code>
+    <code>KEY:CRYS_MUN_ITEM</code>
     - Crystal (Mundane)
     <br/>
-    <code>
-     KEY:DISLOC_A
-    </code>
+    <code>KEY:DISLOC_A</code>
     - Dislocator (+3)
     <br/>
-    <code>
-     KEY:DISLOC_GRT_A
-    </code>
+    <code>KEY:DISLOC_GRT_A</code>
     - Dislocator (Greater) (+4)
     <br/>
-    <code>
-     KEY:DISLOC_GRT_M
-    </code>
+    <code>KEY:DISLOC_GRT_M</code>
     - Dislocator (Greater) (+4)
     <br/>
-    <code>
-     KEY:DISLOC_GRT_R
-    </code>
+    <code>KEY:DISLOC_GRT_R</code>
     - Dislocator (Greater) (+4)
     <br/>
-    <code>
-     KEY:DISLOC_M
-    </code>
+    <code>KEY:DISLOC_M</code>
     - Dislocator (+3)
     <br/>
-    <code>
-     KEY:DISLOC_R
-    </code>
+    <code>KEY:DISLOC_R</code>
     - Dislocator (+3)
     <br/>
-    <code>
-     KEY:DISSIP
-    </code>
+    <code>KEY:DISSIP</code>
     - Dissipater
     <br/>
-    <code>
-     KEY:ECTOPLAS
-    </code>
+    <code>KEY:ECTOPLAS</code>
     - Ectoplasmic
     <br/>
-    <code>
-     KEY:FLOAT
-    </code>
+    <code>KEY:FLOAT</code>
     - Floating
     <br/>
-    <code>
-     KEY:GLEAM
-    </code>
+    <code>KEY:GLEAM</code>
     - Gleaming
     <br/>
-    <code>
-     KEY:HEART
-    </code>
+    <code>KEY:HEART</code>
     - Heartening
     <br/>
-    <code>
-     KEY:LANDI
-    </code>
+    <code>KEY:LANDI</code>
     - Landing
     <br/>
-    <code>
-     KEY:LNKED
-    </code>
+    <code>KEY:LNKED</code>
     - Linked
     <br/>
-    <code>
-     KEY:LUCKY
-    </code>
+    <code>KEY:LUCKY</code>
     - Lucky
     <br/>
-    <code>
-     KEY:MANIF_SHLD
-    </code>
+    <code>KEY:MANIF_SHLD</code>
     - Manifester
     <br/>
-    <code>
-     KEY:MANIF_WPN_M
-    </code>
+    <code>KEY:MANIF_WPN_M</code>
     - Manifester
     <br/>
-    <code>
-     KEY:MANIF_WPN_R
-    </code>
+    <code>KEY:MANIF_WPN_R</code>
     - Manifester
     <br/>
-    <code>
-     KEY:MNDARMR
-    </code>
+    <code>KEY:MNDARMR</code>
     - Mindarmor
     <br/>
-    <code>
-     KEY:MINDCRU
-    </code>
+    <code>KEY:MINDCRU</code>
     - Mindcrusher
     <br/>
-    <code>
-     KEY:MINDFEED
-    </code>
+    <code>KEY:MINDFEED</code>
     - Mind Feeder
     <br/>
-    <code>
-     KEY:PARRYING
-    </code>
+    <code>KEY:PARRYING</code>
     - Parrying
     <br/>
-    <code>
-     KEY:PHASING
-    </code>
+    <code>KEY:PHASING</code>
     - Phasing
     <br/>
-    <code>
-     KEY:PKIN_A
-    </code>
+    <code>KEY:PKIN_A</code>
     - Psychokinetic
     <br/>
-    <code>
-     KEY:PKIN_BR_A
-    </code>
+    <code>KEY:PKIN_BR_A</code>
     - Psychokinetic Burst
     <br/>
-    <code>
-     KEY:PKIN_BR_M
-    </code>
+    <code>KEY:PKIN_BR_M</code>
     - Psychokinetic Burst
     <br/>
-    <code>
-     KEY:PKIN_BR_R
-    </code>
+    <code>KEY:PKIN_BR_R</code>
     - Psychokinetic Burst
     <br/>
-    <code>
-     KEY:PKIN_M
-    </code>
+    <code>KEY:PKIN_M</code>
     - Psychokinetic
     <br/>
-    <code>
-     KEY:PKIN_R
-    </code>
+    <code>KEY:PKIN_R</code>
     - Psychokinetic
     <br/>
-    <code>
-     KEY:PSIBANE_A
-    </code>
+    <code>KEY:PSIBANE_A</code>
     - Psibane
     <br/>
-    <code>
-     KEY:PSIBANE_M
-    </code>
+    <code>KEY:PSIBANE_M</code>
     - Psibane
     <br/>
-    <code>
-     KEY:PSIBANE_R
-    </code>
+    <code>KEY:PSIBANE_R</code>
     - Psibane
     <br/>
-    <code>
-     KEY:PSIBLADE
-    </code>
+    <code>KEY:PSIBLADE</code>
     - Psionic Blade
     <br/>
-    <code>
-     KEY:PSYCHIC
-    </code>
+    <code>KEY:PSYCHIC</code>
     - Psychic
     <br/>
-    <code>
-     KEY:PWR_CRWL
-    </code>
+    <code>KEY:PWR_CRWL</code>
     - |Power Effect (Single Use/Use
 Activated)
     <br/>
-    <code>
-     KEY:PWR_DRJ
-    </code>
+    <code>KEY:PWR_DRJ</code>
     - |Power Effect (50 Charges/Power
 Trigger)
     <br/>
-    <code>
-     KEY:PWR_PCWN_1
-    </code>
+    <code>KEY:PWR_PCWN_1</code>
     - |Power Effect (Power Trigger/1st
 Power)
     <br/>
-    <code>
-     KEY:PWR_PCWN_2
-    </code>
+    <code>KEY:PWR_PCWN_2</code>
     - |Power Effect (Power Trigger/2nd
 Power)
     <br/>
-    <code>
-     KEY:PWR_PCWN_3
-    </code>
+    <code>KEY:PWR_PCWN_3</code>
     - |Power Effect (Power Trigger/3+
 Power)
     <br/>
-    <code>
-     KEY:PWR_PS
-    </code>
+    <code>KEY:PWR_PS</code>
     - |Power Effect (Single
 Use/Completion)
     <br/>
-    <code>
-     KEY:PWR_PT
-    </code>
+    <code>KEY:PWR_PT</code>
     - |Power Effect (Single Use/Use
 Activated)
     <br/>
-    <code>
-     KEY:PWR_PT_P
-    </code>
+    <code>KEY:PWR_PT_P</code>
     - |Power Effect (Single Use/Use
 Activated/Personal)
     <br/>
-    <code>
-     KEY:PWRRST_13
-    </code>
+    <code>KEY:PWRRST_13</code>
     - Power Resistance (13)
     <br/>
-    <code>
-     KEY:PWRRST_15
-    </code>
+    <code>KEY:PWRRST_15</code>
     - Power Resistance (15)
     <br/>
-    <code>
-     KEY:PWRRST_17
-    </code>
+    <code>KEY:PWRRST_17</code>
     - Power Resistance (17)
     <br/>
-    <code>
-     KEY:PWRRST_19
-    </code>
+    <code>KEY:PWRRST_19</code>
     - Power Resistance (19)
     <br/>
-    <code>
-     KEY:PWRSTOR
-    </code>
+    <code>KEY:PWRSTOR</code>
     - Power Storing
     <br/>
-    <code>
-     KEY:QUICKN
-    </code>
+    <code>KEY:QUICKN</code>
     - Quickness
     <br/>
-    <code>
-     KEY:RADIANT
-    </code>
+    <code>KEY:RADIANT</code>
     - Radiant
     <br/>
-    <code>
-     KEY:RNGD
-    </code>
+    <code>KEY:RNGD</code>
     - Ranged
     <br/>
-    <code>
-     KEY:SEEING
-    </code>
+    <code>KEY:SEEING</code>
     - Seeing
     <br/>
-    <code>
-     KEY:SOULBREAK
-    </code>
+    <code>KEY:SOULBREAK</code>
     - Soulbreaker
     <br/>
-    <code>
-     KEY:SUNDERER
-    </code>
+    <code>KEY:SUNDERER</code>
     - Sunderer
     <br/>
-    <code>
-     KEY:SUPPRESS_A
-    </code>
+    <code>KEY:SUPPRESS_A</code>
     - Suppression
     <br/>
-    <code>
-     KEY:SUPPRESS_M
-    </code>
+    <code>KEY:SUPPRESS_M</code>
     - Suppression
     <br/>
-    <code>
-     KEY:SUPPRESS_R
-    </code>
+    <code>KEY:SUPPRESS_R</code>
     - Suppression
     <br/>
-    <code>
-     KEY:T_PSIBLADE
-    </code>
+    <code>KEY:T_PSIBLADE</code>
     - Thrown Psiblade
     <br/>
-    <code>
-     KEY:TIMEBUT
-    </code>
+    <code>KEY:TIMEBUT</code>
     - Time Buttress
     <br/>
-    <code>
-     KEY:TPORTING
-    </code>
+    <code>KEY:TPORTING</code>
     - Teleporting
     <br/>
-    <code>
-     KEY:VANISH
-    </code>
+    <code>KEY:VANISH</code>
     - Vanishing
     <br/>
-    <code>
-     KEY:WALL
-    </code>
+    <code>KEY:WALL</code>
     - Wall
     <br/>
    </p>
@@ -4190,554 +2876,338 @@ Coast(WotC): Modern Standard Reference Documen (MSRD)
     </strong>
    </p>
    <p>
-    <code>
-     KEY:ACID_RES
-    </code>
+    <code>KEY:ACID_RES</code>
     - Acid Resistance
     <br/>
-    <code>
-     KEY:ACIDIC
-    </code>
+    <code>KEY:ACIDIC</code>
     - Acidic
     <br/>
-    <code>
-     KEY:ANIMATED
-    </code>
+    <code>KEY:ANIMATED</code>
     - Animated
     <br/>
-    <code>
-     KEY:ARMR_PIERCING
-    </code>
+    <code>KEY:ARMR_PIERCING</code>
     - Armor Piercing
     <br/>
-    <code>
-     KEY:BANE_AMMO
-    </code>
+    <code>KEY:BANE_AMMO</code>
     - Bane
     <br/>
-    <code>
-     KEY:BANE_MELEE
-    </code>
+    <code>KEY:BANE_MELEE</code>
     - Bane
     <br/>
-    <code>
-     KEY:BANE_RANGED
-    </code>
+    <code>KEY:BANE_RANGED</code>
     - Bane
     <br/>
-    <code>
-     KEY:BASH_HVY
-    </code>
+    <code>KEY:BASH_HVY</code>
     - Bashing
     <br/>
-    <code>
-     KEY:BASH_LT
-    </code>
+    <code>KEY:BASH_LT</code>
     - Bashing
     <br/>
-    <code>
-     KEY:BLADEGUN1
-    </code>
+    <code>KEY:BLADEGUN1</code>
     - Bladegun
     <br/>
-    <code>
-     KEY:BLADEGUN2
-    </code>
+    <code>KEY:BLADEGUN2</code>
     - Bladegun
     <br/>
-    <code>
-     KEY:BLADEGUN3
-    </code>
+    <code>KEY:BLADEGUN3</code>
     - Bladegun
     <br/>
-    <code>
-     KEY:BLINDING
-    </code>
+    <code>KEY:BLINDING</code>
     - Blinding
     <br/>
-    <code>
-     KEY:BRILNT_MELEE
-    </code>
+    <code>KEY:BRILNT_MELEE</code>
     - Brilliant
     <br/>
-    <code>
-     KEY:BUMP_BLAST
-    </code>
+    <code>KEY:BUMP_BLAST</code>
     - Bumpers of Blasting
     <br/>
-    <code>
-     KEY:BUMP_RAM
-    </code>
+    <code>KEY:BUMP_RAM</code>
     - Bumper of the Ram
     <br/>
-    <code>
-     KEY:CATCHING
-    </code>
+    <code>KEY:CATCHING</code>
     - Catching
     <br/>
-    <code>
-     KEY:CHAOTIC_MELEE
-    </code>
+    <code>KEY:CHAOTIC_MELEE</code>
     - Chaotic
     <br/>
-    <code>
-     KEY:CHAOTIC_RANGED
-    </code>
+    <code>KEY:CHAOTIC_RANGED</code>
     - Chaotic
     <br/>
-    <code>
-     KEY:CHARGED_ITEM_7
-    </code>
+    <code>KEY:CHARGED_ITEM_7</code>
     - Charges (7)
     <br/>
-    <code>
-     KEY:COLD_RES
-    </code>
+    <code>KEY:COLD_RES</code>
     - Cold Resistance
     <br/>
-    <code>
-     KEY:CPNT_ABLATV
-    </code>
+    <code>KEY:CPNT_ABLATV</code>
     - Ablative Paint Job
     <br/>
-    <code>
-     KEY:CPNT_BLUR
-    </code>
+    <code>KEY:CPNT_BLUR</code>
     - Paint Job of Blurring
     <br/>
-    <code>
-     KEY:CPNT_FLAME
-    </code>
+    <code>KEY:CPNT_FLAME</code>
     - Flame Job
     <br/>
-    <code>
-     KEY:CPNT_NDSCRPT
-    </code>
+    <code>KEY:CPNT_NDSCRPT</code>
     - Nondescript Paint Job
     <br/>
-    <code>
-     KEY:CPNT_SHRNK
-    </code>
+    <code>KEY:CPNT_SHRNK</code>
     - Shrinking Paint Job
     <br/>
-    <code>
-     KEY:CTAR_TRNKMSK
-    </code>
+    <code>KEY:CTAR_TRNKMSK</code>
     - Trunk of Masking
     <br/>
-    <code>
-     KEY:DAMAGE_REDUCT_5
-    </code>
+    <code>KEY:DAMAGE_REDUCT_5</code>
     - Damage Reduction (5/+1)
     <br/>
-    <code>
-     KEY:DAMAGE_REDUCT_10
-    </code>
+    <code>KEY:DAMAGE_REDUCT_10</code>
     - Damage Reduction (10/+1)
     <br/>
-    <code>
-     KEY:DANCING
-    </code>
+    <code>KEY:DANCING</code>
     - Dancing
     <br/>
-    <code>
-     KEY:DBL_SIDED
-    </code>
+    <code>KEY:DBL_SIDED</code>
     - Double-sided
     <br/>
-    <code>
-     KEY:DEFENDING
-    </code>
+    <code>KEY:DEFENDING</code>
     - Defending
     <br/>
-    <code>
-     KEY:DISRUPTING
-    </code>
+    <code>KEY:DISRUPTING</code>
     - Disruption
     <br/>
-    <code>
-     KEY:DISTANCE
-    </code>
+    <code>KEY:DISTANCE</code>
     - Distance
     <br/>
-    <code>
-     KEY:ELAC_PRLTCAL
-    </code>
+    <code>KEY:ELAC_PRLTCAL</code>
     - Paralytic Alarm
     <br/>
-    <code>
-     KEY:ELEC_RES
-    </code>
+    <code>KEY:ELEC_RES</code>
     - Electricity Resistance
     <br/>
-    <code>
-     KEY:ELAC_SLNTWRN
-    </code>
+    <code>KEY:ELAC_SLNTWRN</code>
     - Silent Warning Alarm
     <br/>
-    <code>
-     KEY:ENERGY_BLAST_ACID
-    </code>
+    <code>KEY:ENERGY_BLAST_ACID</code>
     - Acid Blast
     <br/>
-    <code>
-     KEY:ENERGY_BLAST_COLD
-    </code>
+    <code>KEY:ENERGY_BLAST_COLD</code>
     - Icy Blast
     <br/>
-    <code>
-     KEY:ENERGY_BLAST_ELEC
-    </code>
+    <code>KEY:ENERGY_BLAST_ELEC</code>
     - Electrical Blast
     <br/>
-    <code>
-     KEY:ENERGY_BLAST_FIRE
-    </code>
+    <code>KEY:ENERGY_BLAST_FIRE</code>
     - Fiery Blast
     <br/>
-    <code>
-     KEY:ENERGY_BLAST_SONIC
-    </code>
+    <code>KEY:ENERGY_BLAST_SONIC</code>
     - Concussive Blast
     <br/>
-    <code>
-     KEY:ENGN_INFSPD
-    </code>
+    <code>KEY:ENGN_INFSPD</code>
     - Engine of Infernal Speed
     <br/>
-    <code>
-     KEY:EVIL_MELEE
-    </code>
+    <code>KEY:EVIL_MELEE</code>
     - Unholy
     <br/>
-    <code>
-     KEY:EVIL_RANGED
-    </code>
+    <code>KEY:EVIL_RANGED</code>
     - Unholy
     <br/>
-    <code>
-     KEY:FIRE_RES
-    </code>
+    <code>KEY:FIRE_RES</code>
     - Fire Resistance
     <br/>
-    <code>
-     KEY:FLAMING_MELEE
-    </code>
+    <code>KEY:FLAMING_MELEE</code>
     - Flaming
     <br/>
-    <code>
-     KEY:FLAMING_RANGED
-    </code>
+    <code>KEY:FLAMING_RANGED</code>
     - Flaming
     <br/>
-    <code>
-     KEY:FLECHETTE_AMMO
-    </code>
+    <code>KEY:FLECHETTE_AMMO</code>
     - Flechette
     <br/>
-    <code>
-     KEY:FORT_HVY
-    </code>
+    <code>KEY:FORT_HVY</code>
     - Fortification (Heavy)
     <br/>
-    <code>
-     KEY:FORT_LT
-    </code>
+    <code>KEY:FORT_LT</code>
     - Fortification (Light)
     <br/>
-    <code>
-     KEY:FORT_MODERATE
-    </code>
+    <code>KEY:FORT_MODERATE</code>
     - Fortification (Moderate)
     <br/>
-    <code>
-     KEY:FRANGIBLE_AMMO
-    </code>
+    <code>KEY:FRANGIBLE_AMMO</code>
     - Frangible
     <br/>
-    <code>
-     KEY:FROST_MELEE
-    </code>
+    <code>KEY:FROST_MELEE</code>
     - Frost
     <br/>
-    <code>
-     KEY:FROST_RANGED
-    </code>
+    <code>KEY:FROST_RANGED</code>
     - Frost
     <br/>
-    <code>
-     KEY:GHOST_ARMR
-    </code>
+    <code>KEY:GHOST_ARMR</code>
     - Ghost Touch
     <br/>
-    <code>
-     KEY:GHOST_MELEE
-    </code>
+    <code>KEY:GHOST_MELEE</code>
     - Ghost touch
     <br/>
-    <code>
-     KEY:GLAMER
-    </code>
+    <code>KEY:GLAMER</code>
     - Glamered
     <br/>
-    <code>
-     KEY:GOOD_MELEE
-    </code>
+    <code>KEY:GOOD_MELEE</code>
     - Holy
     <br/>
-    <code>
-     KEY:GOOD_RANGED
-    </code>
+    <code>KEY:GOOD_RANGED</code>
     - Holy
     <br/>
-    <code>
-     KEY:HDLT_BLND
-    </code>
+    <code>KEY:HDLT_BLND</code>
     - Headlights of Blinding
     <br/>
-    <code>
-     KEY:HI_EXPLOSIVE
-    </code>
+    <code>KEY:HI_EXPLOSIVE</code>
     - High Explosive
     <br/>
-    <code>
-     KEY:HOSI_BLST
-    </code>
+    <code>KEY:HOSI_BLST</code>
     - Horn of Blasting
     <br/>
-    <code>
-     KEY:HOSI_DRED
-    </code>
+    <code>KEY:HOSI_DRED</code>
     - Horn of Dread
     <br/>
-    <code>
-     KEY:KEEN
-    </code>
+    <code>KEY:KEEN</code>
     - Keen
     <br/>
-    <code>
-     KEY:LAWFUL_MELEE
-    </code>
+    <code>KEY:LAWFUL_MELEE</code>
     - Lawful
     <br/>
-    <code>
-     KEY:LAWFUL_RANGED
-    </code>
+    <code>KEY:LAWFUL_RANGED</code>
     - Lawful
     <br/>
-    <code>
-     KEY:MERCIFUL_MELEE
-    </code>
+    <code>KEY:MERCIFUL_MELEE</code>
     - Merciful
     <br/>
-    <code>
-     KEY:MERCIFUL_RANGED
-    </code>
+    <code>KEY:MERCIFUL_RANGED</code>
     - Merciful
     <br/>
-    <code>
-     KEY:MIGHTY_CLEAVE
-    </code>
+    <code>KEY:MIGHTY_CLEAVE</code>
     - Mighty Cleaving
     <br/>
-    <code>
-     KEY:NAKAMURA_ANGR
-    </code>
+    <code>KEY:NAKAMURA_ANGR</code>
     - Nakamura Blade / Personality
 (Angry) /
     <br/>
-    <code>
-     KEY:NAKAMURA_BLDT
-    </code>
+    <code>KEY:NAKAMURA_BLDT</code>
     - Nakamura Blade / Personality
 (Bloodthirsty) /
     <br/>
-    <code>
-     KEY:NAKAMURA_IMPT
-    </code>
+    <code>KEY:NAKAMURA_IMPT</code>
     - Nakamura Blade / Personality
 (Impatient) /
     <br/>
-    <code>
-     KEY:NAKAMURA_INST
-    </code>
+    <code>KEY:NAKAMURA_INST</code>
     - Nakamura Blade / Personality
 (Insightful) /
     <br/>
-    <code>
-     KEY:NAKAMURA_PCLV
-    </code>
+    <code>KEY:NAKAMURA_PCLV</code>
     - Nakamura Blade / Personality
 (Peace Loving) /
     <br/>
-    <code>
-     KEY:NAKAMURA_PTNT
-    </code>
+    <code>KEY:NAKAMURA_PTNT</code>
     - Nakamura Blade / Personality
 (Patient) /
     <br/>
-    <code>
-     KEY:NAKAMURA_STHG
-    </code>
+    <code>KEY:NAKAMURA_STHG</code>
     - Nakamura Blade / Personality
 (Soothing) /
     <br/>
-    <code>
-     KEY:NAKAMURA_VLNT
-    </code>
+    <code>KEY:NAKAMURA_VLNT</code>
     - Nakamura Blade / Personality
 (Violent) /
     <br/>
-    <code>
-     KEY:NEAC_FDOL
-    </code>
+    <code>KEY:NEAC_FDOL</code>
     - Fuzzy Dice of Luck
     <br/>
-    <code>
-     KEY:NEAC_FIG_HUM
-    </code>
+    <code>KEY:NEAC_FIG_HUM</code>
     - Dashboard Figurine [humorous]
     <br/>
-    <code>
-     KEY:NEAC_FIG_MON
-    </code>
+    <code>KEY:NEAC_FIG_MON</code>
     - Dashboard Figurine
 [monstrous]
     <br/>
-    <code>
-     KEY:NEAC_FIG_REL
-    </code>
+    <code>KEY:NEAC_FIG_REL</code>
     - Dashboard Figurine
 [religious]
     <br/>
-    <code>
-     KEY:RETURNING
-    </code>
+    <code>KEY:RETURNING</code>
     - Returning
     <br/>
-    <code>
-     KEY:RUBBER_ROUND
-    </code>
+    <code>KEY:RUBBER_ROUND</code>
     - Rubber Round
     <br/>
-    <code>
-     KEY:SEAT_HLDMNSTR
-    </code>
+    <code>KEY:SEAT_HLDMNSTR</code>
     - Seat of Hold Monster
     <br/>
-    <code>
-     KEY:SEAT_SAFETY
-    </code>
+    <code>KEY:SEAT_SAFETY</code>
     - Seats of Safety
     <br/>
-    <code>
-     KEY:SHADOW
-    </code>
+    <code>KEY:SHADOW</code>
     - Shadow
     <br/>
-    <code>
-     KEY:SHOCK_MELEE
-    </code>
+    <code>KEY:SHOCK_MELEE</code>
     - Shock
     <br/>
-    <code>
-     KEY:SHOCK_RANGED
-    </code>
+    <code>KEY:SHOCK_RANGED</code>
     - Shock
     <br/>
-    <code>
-     KEY:SILENT_MOVES
-    </code>
+    <code>KEY:SILENT_MOVES</code>
     - Silent Moves
     <br/>
-    <code>
-     KEY:SILVER_AMMO
-    </code>
+    <code>KEY:SILVER_AMMO</code>
     - Silver
     <br/>
-    <code>
-     KEY:SLICK
-    </code>
+    <code>KEY:SLICK</code>
     - Slick
     <br/>
-    <code>
-     KEY:SONIC_RES
-    </code>
+    <code>KEY:SONIC_RES</code>
     - Sonic Resistance
     <br/>
-    <code>
-     KEY:SPEED
-    </code>
+    <code>KEY:SPEED</code>
     - Speed
     <br/>
-    <code>
-     KEY:SPELL_RES_15
-    </code>
+    <code>KEY:SPELL_RES_15</code>
     - Spell Resistance 15
     <br/>
-    <code>
-     KEY:SPELL_RES_19
-    </code>
+    <code>KEY:SPELL_RES_19</code>
     - Spell Resistance 19
     <br/>
-    <code>
-     KEY:SPELL_RES_23
-    </code>
+    <code>KEY:SPELL_RES_23</code>
     - Spell Resistance 23
     <br/>
-    <code>
-     KEY:SPONSOR
-    </code>
+    <code>KEY:SPONSOR</code>
     - Sponsorship
     <br/>
-    <code>
-     KEY:SUBSONIC_AMMO
-    </code>
+    <code>KEY:SUBSONIC_AMMO</code>
     - Subsonic
     <br/>
-    <code>
-     KEY:THUNDER_MELEE
-    </code>
+    <code>KEY:THUNDER_MELEE</code>
     - Thundering
     <br/>
-    <code>
-     KEY:THUNDER_RANGED
-    </code>
+    <code>KEY:THUNDER_RANGED</code>
     - Thundering
     <br/>
-    <code>
-     KEY:TIRE_IMPVS
-    </code>
+    <code>KEY:TIRE_IMPVS</code>
     - Impervious Tires
     <br/>
-    <code>
-     KEY:TIRE_REINFLT
-    </code>
+    <code>KEY:TIRE_REINFLT</code>
     - Reinflating Tires
     <br/>
-    <code>
-     KEY:TIRE_ZEPHYR
-    </code>
+    <code>KEY:TIRE_ZEPHYR</code>
     - Zephyr Tires
     <br/>
-    <code>
-     KEY:TRACER_AMMO
-    </code>
+    <code>KEY:TRACER_AMMO</code>
     - Tracer
     <br/>
-    <code>
-     KEY:WHITE_PHOSPHOR
-    </code>
+    <code>KEY:WHITE_PHOSPHOR</code>
     - White Phosphorous
     <br/>
-    <code>
-     KEY:WNDW_DCPTN
-    </code>
+    <code>KEY:WNDW_DCPTN</code>
     - Windows of Deception
     <br/>
-    <code>
-     KEY:WOUNDING
-    </code>
+    <code>KEY:WOUNDING</code>
     - Wounding
     <br/>
    </p>
@@ -4747,245 +3217,151 @@ Coast(WotC): Modern Standard Reference Documen (MSRD)
     </strong>
    </p>
    <p>
-    <code>
-     KEY:AAVEHICLE
-    </code>
+    <code>KEY:AAVEHICLE</code>
     - Vehicle
     <br/>
-    <code>
-     KEY:ADD_TYPE
-    </code>
+    <code>KEY:ADD_TYPE</code>
     - #Add Type
     <br/>
-    <code>
-     KEY:ALUMINIUM
-    </code>
+    <code>KEY:ALUMINIUM</code>
     - Aluminium
     <br/>
-    <code>
-     KEY:AUTOFIRE
-    </code>
+    <code>KEY:AUTOFIRE</code>
     - Autofire
     <br/>
-    <code>
-     KEY:BURSTFIRE
-    </code>
+    <code>KEY:BURSTFIRE</code>
     - Burst fire
     <br/>
-    <code>
-     KEY:CERAMIC
-    </code>
+    <code>KEY:CERAMIC</code>
     - Ceramic
     <br/>
-    <code>
-     KEY:CLOTH
-    </code>
+    <code>KEY:CLOTH</code>
     - Cloth
     <br/>
-    <code>
-     KEY:CONCRETE
-    </code>
+    <code>KEY:CONCRETE</code>
     - Concrete
     <br/>
-    <code>
-     KEY:DBLTAP
-    </code>
+    <code>KEY:DBLTAP</code>
     - Double Tap fire
     <br/>
-    <code>
-     KEY:GLASS
-    </code>
+    <code>KEY:GLASS</code>
     - Glass
     <br/>
-    <code>
-     KEY:ICE
-    </code>
+    <code>KEY:ICE</code>
     - Ice
     <br/>
-    <code>
-     KEY:ILLUMINATOR
-    </code>
+    <code>KEY:ILLUMINATOR</code>
     - Illuminator
     <br/>
-    <code>
-     KEY:ILLUMINATOR
-    </code>
+    <code>KEY:ILLUMINATOR</code>
     - #Illuminator
     <br/>
-    <code>
-     KEY:LSR_SIGHT
-    </code>
+    <code>KEY:LSR_SIGHT</code>
     - Laser Sight
     <br/>
-    <code>
-     KEY:LSR_SIGHT
-    </code>
+    <code>KEY:LSR_SIGHT</code>
     - #Laser Sight
     <br/>
-    <code>
-     KEY:MASTERCRAFT_ARMR_1
-    </code>
+    <code>KEY:MASTERCRAFT_ARMR_1</code>
     - Mastercraft +1
     <br/>
-    <code>
-     KEY:MASTERCRAFT_ARMR_2
-    </code>
+    <code>KEY:MASTERCRAFT_ARMR_2</code>
     - Mastercraft +2
     <br/>
-    <code>
-     KEY:MASTERCRAFT_ARMR_3
-    </code>
+    <code>KEY:MASTERCRAFT_ARMR_3</code>
     - Mastercraft +3
     <br/>
-    <code>
-     KEY:MASTERCRAFT_SHLD_1
-    </code>
+    <code>KEY:MASTERCRAFT_SHLD_1</code>
     - Mastercraft +1
     <br/>
-    <code>
-     KEY:MASTERCRAFT_SHLD_2
-    </code>
+    <code>KEY:MASTERCRAFT_SHLD_2</code>
     - Mastercraft +2
     <br/>
-    <code>
-     KEY:MASTERCRAFT_SHLD_3
-    </code>
+    <code>KEY:MASTERCRAFT_SHLD_3</code>
     - Mastercraft +3
     <br/>
-    <code>
-     KEY:MASTERCRAFT_TOOL_1
-    </code>
+    <code>KEY:MASTERCRAFT_TOOL_1</code>
     - Mastercraft +1
     <br/>
-    <code>
-     KEY:MASTERCRAFT_TOOL_2
-    </code>
+    <code>KEY:MASTERCRAFT_TOOL_2</code>
     - Mastercraft +2
     <br/>
-    <code>
-     KEY:MASTERCRAFT_TOOL_3
-    </code>
+    <code>KEY:MASTERCRAFT_TOOL_3</code>
     - Mastercraft +3
     <br/>
-    <code>
-     KEY:MASTERCRAFT_WEAP_DAM_1
-    </code>
+    <code>KEY:MASTERCRAFT_WEAP_DAM_1</code>
     - Mastercraft +1
 Damage
     <br/>
-    <code>
-     KEY:MASTERCRAFT_WEAP_DAM_2
-    </code>
+    <code>KEY:MASTERCRAFT_WEAP_DAM_2</code>
     - Mastercraft +2
 Damage
     <br/>
-    <code>
-     KEY:MASTERCRAFT_WEAP_DAM_3
-    </code>
+    <code>KEY:MASTERCRAFT_WEAP_DAM_3</code>
     - Mastercraft +3
 Damage
     <br/>
-    <code>
-     KEY:MASTERCRAFT_WEAP_HIT_1
-    </code>
+    <code>KEY:MASTERCRAFT_WEAP_HIT_1</code>
     - Mastercraft +1 To
 Hit
     <br/>
-    <code>
-     KEY:MASTERCRAFT_WEAP_HIT_2
-    </code>
+    <code>KEY:MASTERCRAFT_WEAP_HIT_2</code>
     - Mastercraft +2 To
 Hit
     <br/>
-    <code>
-     KEY:MASTERCRAFT_WEAP_HIT_3
-    </code>
+    <code>KEY:MASTERCRAFT_WEAP_HIT_3</code>
     - Mastercraft +3 To
 Hit
     <br/>
-    <code>
-     KEY:MWORKA
-    </code>
+    <code>KEY:MWORKA</code>
     - Masterwork
     <br/>
-    <code>
-     KEY:MWORKT
-    </code>
+    <code>KEY:MWORKT</code>
     - Masterwork
     <br/>
-    <code>
-     KEY:MWORKW
-    </code>
+    <code>KEY:MWORKW</code>
     - Masterwork
     <br/>
-    <code>
-     KEY:PLASTIC_HARD
-    </code>
+    <code>KEY:PLASTIC_HARD</code>
     - Hard Plastic
     <br/>
-    <code>
-     KEY:PLASTIC_SOFT
-    </code>
+    <code>KEY:PLASTIC_SOFT</code>
     - Soft Plastic
     <br/>
-    <code>
-     KEY:PAPER
-    </code>
+    <code>KEY:PAPER</code>
     - Paper
     <br/>
-    <code>
-     KEY:ROPE
-    </code>
+    <code>KEY:ROPE</code>
     - Rope
     <br/>
-    <code>
-     KEY:SCP_ELE_OP
-    </code>
+    <code>KEY:SCP_ELE_OP</code>
     - Scope (Electro-optical)
     <br/>
-    <code>
-     KEY:SCP_STD
-    </code>
+    <code>KEY:SCP_STD</code>
     - Scope (Standard)
     <br/>
-    <code>
-     KEY:SCP_STD
-    </code>
+    <code>KEY:SCP_STD</code>
     - #Scope (Standard)
     <br/>
-    <code>
-     KEY:SPEED_LD
-    </code>
+    <code>KEY:SPEED_LD</code>
     - Speed Loader
     <br/>
-    <code>
-     KEY:SPPRSS_PIS
-    </code>
+    <code>KEY:SPPRSS_PIS</code>
     - Suppressor (Pistol)
     <br/>
-    <code>
-     KEY:SPPRSS_RFL
-    </code>
+    <code>KEY:SPPRSS_RFL</code>
     - Suppressor (Rifle)
     <br/>
-    <code>
-     KEY:SPPRSS_RFL
-    </code>
+    <code>KEY:SPPRSS_RFL</code>
     - #Suppressor (Rifle)
     <br/>
-    <code>
-     KEY:STEEL
-    </code>
+    <code>KEY:STEEL</code>
     - Steel
     <br/>
-    <code>
-     KEY:UPGRADE
-    </code>
+    <code>KEY:UPGRADE</code>
     - Upgrade
     <br/>
-    <code>
-     KEY:WOOD
-    </code>
+    <code>KEY:WOOD</code>
     - Wood
     <br/>
    </p>
@@ -4995,166 +3371,104 @@ Hit
     </strong>
    </p>
    <p>
-    <code>
-     KEY:CHARGED_ITEM_3
-    </code>
+    <code>KEY:CHARGED_ITEM_3</code>
     - Charges (3)
     <br/>
-    <code>
-     KEY:CHARGED_ITEM_5
-    </code>
+    <code>KEY:CHARGED_ITEM_5</code>
     - Charges (5)
     <br/>
-    <code>
-     KEY:CHARGED_ITEM_10
-    </code>
+    <code>KEY:CHARGED_ITEM_10</code>
     - Charges (10)
     <br/>
-    <code>
-     KEY:CHARGED_ITEM_12
-    </code>
+    <code>KEY:CHARGED_ITEM_12</code>
     - Charges (12)
     <br/>
-    <code>
-     KEY:CHARGED_ITEM_14
-    </code>
+    <code>KEY:CHARGED_ITEM_14</code>
     - Charges (14)
     <br/>
-    <code>
-     KEY:CHARGED_ITEM_36
-    </code>
+    <code>KEY:CHARGED_ITEM_36</code>
     - Charges (36)
     <br/>
-    <code>
-     KEY:CHARGED_ITEM_50
-    </code>
+    <code>KEY:CHARGED_ITEM_50</code>
     - Charges (50)
     <br/>
-    <code>
-     KEY:CHARGED_ITEM_101
-    </code>
+    <code>KEY:CHARGED_ITEM_101</code>
     - Charges (101)
     <br/>
-    <code>
-     KEY:PLUS1A
-    </code>
+    <code>KEY:PLUS1A</code>
     - +1 (Enhancement to Armor)
     <br/>
-    <code>
-     KEY:PLUS1S
-    </code>
+    <code>KEY:PLUS1S</code>
     - +1 (Enhancement to Shield)
     <br/>
-    <code>
-     KEY:PLUS1W
-    </code>
+    <code>KEY:PLUS1W</code>
     - +1 (Enhancement to Weapon
     <br/>
-    <code>
-     KEY:PLUS2A
-    </code>
+    <code>KEY:PLUS2A</code>
     - +2 (Enhancement to Armor)
     <br/>
-    <code>
-     KEY:PLUS2S
-    </code>
+    <code>KEY:PLUS2S</code>
     - +2 (Enhancement to Shield)
     <br/>
-    <code>
-     KEY:PLUS2W
-    </code>
+    <code>KEY:PLUS2W</code>
     - +2 (Enhancement to Weapon)
     <br/>
-    <code>
-     KEY:PLUS3A
-    </code>
+    <code>KEY:PLUS3A</code>
     - +3 (Enhancement to Armor)
     <br/>
-    <code>
-     KEY:PLUS3S
-    </code>
+    <code>KEY:PLUS3S</code>
     - +3 (Enhancement to Shield)
     <br/>
-    <code>
-     KEY:PLUS3W
-    </code>
+    <code>KEY:PLUS3W</code>
     - +3 (Enhancement to Weapon)
     <br/>
-    <code>
-     KEY:PLUS4A
-    </code>
+    <code>KEY:PLUS4A</code>
     - +4 (Enhancement to Armor)
     <br/>
-    <code>
-     KEY:PLUS4S
-    </code>
+    <code>KEY:PLUS4S</code>
     - +4 (Enhancement to Shield)
     <br/>
-    <code>
-     KEY:PLUS4W
-    </code>
+    <code>KEY:PLUS4W</code>
     - +4 (Enhancement to Weapon)
     <br/>
-    <code>
-     KEY:PLUS5A
-    </code>
+    <code>KEY:PLUS5A</code>
     - +5 (Enhancement to Armor)
     <br/>
-    <code>
-     KEY:PLUS5S
-    </code>
+    <code>KEY:PLUS5S</code>
     - +5 (Enhancement to Shield)
     <br/>
-    <code>
-     KEY:PLUS5W
-    </code>
+    <code>KEY:PLUS5W</code>
     - +5 (Enhancement to Weapon)
     <br/>
-    <code>
-     KEY:SCROLL_ARCANE
-    </code>
+    <code>KEY:SCROLL_ARCANE</code>
     - |Spell Effect (Arcane
 Scroll)
     <br/>
-    <code>
-     KEY:SCROLL_DIVINE
-    </code>
+    <code>KEY:SCROLL_DIVINE</code>
     - |Spell Effect (Divine
 Scroll)
     <br/>
-    <code>
-     KEY:SPL_1USE
-    </code>
+    <code>KEY:SPL_1USE</code>
     - |Spell Effect (Single Use/Use
 Activated)
     <br/>
-    <code>
-     KEY:SPL_ACT_RING
-    </code>
+    <code>KEY:SPL_ACT_RING</code>
     - |Spell Effect (Use Activated
 Ring)
     <br/>
-    <code>
-     KEY:SPL_CHRG
-    </code>
+    <code>KEY:SPL_CHRG</code>
     - |Spell Effect (50 Charges/Spell
 Trigger)
     <br/>
-    <code>
-     KEY:TATTOO_ARCANE
-    </code>
+    <code>KEY:TATTOO_ARCANE</code>
     - |Spell Effect (Arcane
 Tattoo)
     <br/>
-    <code>
-     KEY:TATTOO_DIVINE
-    </code>
+    <code>KEY:TATTOO_DIVINE</code>
     - |Spell Effect (Divine
 Tattoo)
     <br/>
-    <code>
-     KEY:TATTOO_PSIONIC
-    </code>
+    <code>KEY:TATTOO_PSIONIC</code>
     - |Power Effect (Psionic
 Tattoo)
     <br/>
@@ -5165,19 +3479,13 @@ Tattoo)
     </strong>
    </p>
    <p>
-    <code>
-     KEY:ARTIFICIALORGAN
-    </code>
+    <code>KEY:ARTIFICIALORGAN</code>
     - Artificial Organ
     <br/>
-    <code>
-     KEY:EDUCATEDFEATIMPLANT
-    </code>
+    <code>KEY:EDUCATEDFEATIMPLANT</code>
     - Educated Feat Implant
     <br/>
-    <code>
-     KEY:SKILLIMPLANT
-    </code>
+    <code>KEY:SKILLIMPLANT</code>
     - Skill Implant
     <br/>
    </p>
@@ -5187,1241 +3495,779 @@ Tattoo)
     </strong>
    </p>
    <p>
-    <code>
-     KEY:AASTARSHIP_LB
-    </code>
+    <code>KEY:AASTARSHIP_LB</code>
     - Starship
     <br/>
-    <code>
-     KEY:AASTARSHIP_TON
-    </code>
+    <code>KEY:AASTARSHIP_TON</code>
     - Starship
     <br/>
-    <code>
-     KEY:AAVEHICLE_FUTURE
-    </code>
+    <code>KEY:AAVEHICLE_FUTURE</code>
     - Vehicle
     <br/>
-    <code>
-     KEY:ALT_WPN_GDGT
-    </code>
+    <code>KEY:ALT_WPN_GDGT</code>
     - Alternate Weapon Gadget
     <br/>
-    <code>
-     KEY:ANTI_ACCDNT_SYS
-    </code>
+    <code>KEY:ANTI_ACCDNT_SYS</code>
     - Anti-Accident System
     <br/>
-    <code>
-     KEY:AOO_PNT_DEF_SYS
-    </code>
+    <code>KEY:AOO_PNT_DEF_SYS</code>
     - Point-defense system
     <br/>
-    <code>
-     KEY:ARMR_ABLATIVE
-    </code>
+    <code>KEY:ARMR_ABLATIVE</code>
     - Ablative Armor
     <br/>
-    <code>
-     KEY:ARMR_ALLOY_PLATING
-    </code>
+    <code>KEY:ARMR_ALLOY_PLATING</code>
     - Alloy Plating Armor
     <br/>
-    <code>
-     KEY:ARMR_CERAMETAL
-    </code>
+    <code>KEY:ARMR_CERAMETAL</code>
     - Cerametal Armor
     <br/>
-    <code>
-     KEY:ARMR_DEFLECTIVE
-    </code>
+    <code>KEY:ARMR_DEFLECTIVE</code>
     - Deflective Armor
     <br/>
-    <code>
-     KEY:ARMR_NANOFLUIDIC
-    </code>
+    <code>KEY:ARMR_NANOFLUIDIC</code>
     - Nanofluidic Armor
     <br/>
-    <code>
-     KEY:ARMR_NEUTRONITE
-    </code>
+    <code>KEY:ARMR_NEUTRONITE</code>
     - Neutronite Armor
     <br/>
-    <code>
-     KEY:ARMR_POLYMERIC
-    </code>
+    <code>KEY:ARMR_POLYMERIC</code>
     - Polymeric Armor
     <br/>
-    <code>
-     KEY:ARMR_VANADIUM
-    </code>
+    <code>KEY:ARMR_VANADIUM</code>
     - Vanadium Armor
     <br/>
-    <code>
-     KEY:ATFR_MDL_GDGT
-    </code>
+    <code>KEY:ATFR_MDL_GDGT</code>
     - Autofire Module Gadget
     <br/>
-    <code>
-     KEY:ATLDR_MDL_GDGT
-    </code>
+    <code>KEY:ATLDR_MDL_GDGT</code>
     - Autoloader Module Gadget
     <br/>
-    <code>
-     KEY:ATTK_ANTIMATTER
-    </code>
+    <code>KEY:ATTK_ANTIMATTER</code>
     - Antimatter Gun
     <br/>
-    <code>
-     KEY:ATTK_ANTIMATTER_4B
-    </code>
+    <code>KEY:ATTK_ANTIMATTER_4B</code>
     - Battery of 4 Antimatter
 Guns
     <br/>
-    <code>
-     KEY:ATTK_AUTOMASER
-    </code>
+    <code>KEY:ATTK_AUTOMASER</code>
     - Blacklaser
     <br/>
-    <code>
-     KEY:ATTK_BLACKLASER
-    </code>
+    <code>KEY:ATTK_BLACKLASER</code>
     - Blacklaser
     <br/>
-    <code>
-     KEY:ATTK_CHE_MISSL
-    </code>
+    <code>KEY:ATTK_CHE_MISSL</code>
     - CHE Missile Launcher
     <br/>
-    <code>
-     KEY:ATTK_CHE_MISSL_2
-    </code>
+    <code>KEY:ATTK_CHE_MISSL_2</code>
     - 2 CHE Missile Launcher
     <br/>
-    <code>
-     KEY:ATTK_CHE_MISSL_2B_2
-    </code>
+    <code>KEY:ATTK_CHE_MISSL_2B_2</code>
     - 2 Batteries of 2 CHE Missile
 Launcher
     <br/>
-    <code>
-     KEY:ATTK_CHE_MISSL_3B
-    </code>
+    <code>KEY:ATTK_CHE_MISSL_3B</code>
     - Battery of 3 CHE Missile
 Launcher
     <br/>
-    <code>
-     KEY:ATTK_EMP_CANN
-    </code>
+    <code>KEY:ATTK_EMP_CANN</code>
     - EMP Cannon
     <br/>
-    <code>
-     KEY:ATTK_FUSN_BEAM
-    </code>
+    <code>KEY:ATTK_FUSN_BEAM</code>
     - Fusion Beam
     <br/>
-    <code>
-     KEY:ATTK_FUSN_BEAM_2L
-    </code>
+    <code>KEY:ATTK_FUSN_BEAM_2L</code>
     - 2 fire-linked Fusion
 Beams
     <br/>
-    <code>
-     KEY:ATTK_FUSN_BEAM_4B
-    </code>
+    <code>KEY:ATTK_FUSN_BEAM_4B</code>
     - Battery of 4 Fusion
 Beams
     <br/>
-    <code>
-     KEY:ATTK_GAUSS_GUN
-    </code>
+    <code>KEY:ATTK_GAUSS_GUN</code>
     - Gauss Gun
     <br/>
-    <code>
-     KEY:ATTK_GAUSS_GUN_3B
-    </code>
+    <code>KEY:ATTK_GAUSS_GUN_3B</code>
     - Battery of 3 Gauss Guns
     <br/>
-    <code>
-     KEY:ATTK_HLASER
-    </code>
+    <code>KEY:ATTK_HLASER</code>
     - Heavy Laser
     <br/>
-    <code>
-     KEY:ATTK_HLASER_2L
-    </code>
+    <code>KEY:ATTK_HLASER_2L</code>
     - 2 fire-linked Heavy Laser
     <br/>
-    <code>
-     KEY:ATTK_HLASER_3B
-    </code>
+    <code>KEY:ATTK_HLASER_3B</code>
     - Battery of 3 Heavy Laser
     <br/>
-    <code>
-     KEY:ATTK_HLASER_4B
-    </code>
+    <code>KEY:ATTK_HLASER_4B</code>
     - Battery of 4 Heavy Laser
     <br/>
-    <code>
-     KEY:ATTK_HLASER_4L
-    </code>
+    <code>KEY:ATTK_HLASER_4L</code>
     - 4 fire-linked Heavy Laser
     <br/>
-    <code>
-     KEY:ATTK_HMASER_CANN
-    </code>
+    <code>KEY:ATTK_HMASER_CANN</code>
     - Heavy Maser Cannon
     <br/>
-    <code>
-     KEY:ATTK_HMASS_CANN
-    </code>
+    <code>KEY:ATTK_HMASS_CANN</code>
     - Heavy Mass Cannon
     <br/>
-    <code>
-     KEY:ATTK_HMASS_CANN_4B
-    </code>
+    <code>KEY:ATTK_HMASS_CANN_4B</code>
     - Battery of 4 heavy Mass
 Cannons
     <br/>
-    <code>
-     KEY:ATTK_HNTRN_GUN
-    </code>
+    <code>KEY:ATTK_HNTRN_GUN</code>
     - Heavy Neutron Gun
     <br/>
-    <code>
-     KEY:ATTK_HNTRN_GUN_2F
-    </code>
+    <code>KEY:ATTK_HNTRN_GUN_2F</code>
     - 2 fire-linked Heavy Neutron
 Guns
     <br/>
-    <code>
-     KEY:ATTK_HNTRN_GUN_3B
-    </code>
+    <code>KEY:ATTK_HNTRN_GUN_3B</code>
     - Battery of 3 Heavy Neutron
 Guns
     <br/>
-    <code>
-     KEY:ATTK_HNTRN_GUN_4F
-    </code>
+    <code>KEY:ATTK_HNTRN_GUN_4F</code>
     - 4 fire-linked Heavy Neutron
 Guns
     <br/>
-    <code>
-     KEY:ATTK_HPRTCL_BEAM
-    </code>
+    <code>KEY:ATTK_HPRTCL_BEAM</code>
     - Heavy Particle Beam
     <br/>
-    <code>
-     KEY:ATTK_HPTCL_BEAM_3B_2
-    </code>
+    <code>KEY:ATTK_HPTCL_BEAM_3B_2</code>
     - 2 Batteries of 3 Heavy
 Particle Beams
     <br/>
-    <code>
-     KEY:ATTK_HPTCL_BEAM_4L
-    </code>
+    <code>KEY:ATTK_HPTCL_BEAM_4L</code>
     - 4 fire-linked Heavy Particle
 Beams
     <br/>
-    <code>
-     KEY:ATTK_HPLASM_CANN
-    </code>
+    <code>KEY:ATTK_HPLASM_CANN</code>
     - Heavy Plasma Cannon
     <br/>
-    <code>
-     KEY:ATTK_HPLASM_CANN_2L
-    </code>
+    <code>KEY:ATTK_HPLASM_CANN_2L</code>
     - 2 fire-linked Heavy Plasma
 Cannons
     <br/>
-    <code>
-     KEY:ATTK_HPLASM_CANN_3L
-    </code>
+    <code>KEY:ATTK_HPLASM_CANN_3L</code>
     - 3 fire-linked Heavy Plasma
 Cannons
     <br/>
-    <code>
-     KEY:ATTK_KES_MISSL
-    </code>
+    <code>KEY:ATTK_KES_MISSL</code>
     - KE Submunition Missile
 Launcher
     <br/>
-    <code>
-     KEY:ATTK_KNTC_LANCE
-    </code>
+    <code>KEY:ATTK_KNTC_LANCE</code>
     - Kinetic Lance
     <br/>
-    <code>
-     KEY:ATTK_LASER
-    </code>
+    <code>KEY:ATTK_LASER</code>
     - Laser
     <br/>
-    <code>
-     KEY:ATTK_LASER_5B
-    </code>
+    <code>KEY:ATTK_LASER_5B</code>
     - Battery of 5 Laser
     <br/>
-    <code>
-     KEY:ATTK_MASER_CANN
-    </code>
+    <code>KEY:ATTK_MASER_CANN</code>
     - Maser Cannon
     <br/>
-    <code>
-     KEY:ATTK_MASER_CANN_2L
-    </code>
+    <code>KEY:ATTK_MASER_CANN_2L</code>
     - 2 fire-linked Maser
 Cannons
     <br/>
-    <code>
-     KEY:ATTK_MASS_CANN
-    </code>
+    <code>KEY:ATTK_MASS_CANN</code>
     - Mass Cannon
     <br/>
-    <code>
-     KEY:ATTK_MASS_CANN_5B
-    </code>
+    <code>KEY:ATTK_MASS_CANN_5B</code>
     - Battery of 5 Mass
 Cannons
     <br/>
-    <code>
-     KEY:ATTK_MASS_MISSL
-    </code>
+    <code>KEY:ATTK_MASS_MISSL</code>
     - Mass Reaction Missile
 Launcher
     <br/>
-    <code>
-     KEY:ATTK_MASS_MISSL_2L
-    </code>
+    <code>KEY:ATTK_MASS_MISSL_2L</code>
     - 2 fire-linked Mass Reaction
 Missile Launcher
     <br/>
-    <code>
-     KEY:ATTK_MINELAYER
-    </code>
+    <code>KEY:ATTK_MINELAYER</code>
     - Minelayer
     <br/>
-    <code>
-     KEY:ATTK_NDL_DRVR
-    </code>
+    <code>KEY:ATTK_NDL_DRVR</code>
     - Needle Driver
     <br/>
-    <code>
-     KEY:ATTK_NTRN_GUN
-    </code>
+    <code>KEY:ATTK_NTRN_GUN</code>
     - Neutron Gun
     <br/>
-    <code>
-     KEY:ATTK_NTRN_GUN_5B
-    </code>
+    <code>KEY:ATTK_NTRN_GUN_5B</code>
     - Battery of 5 Neutron Guns
     <br/>
-    <code>
-     KEY:ATTK_NTRNM_DRVR
-    </code>
+    <code>KEY:ATTK_NTRNM_DRVR</code>
     - Neutronium Driver
     <br/>
-    <code>
-     KEY:ATTK_NOVA_MISSL
-    </code>
+    <code>KEY:ATTK_NOVA_MISSL</code>
     - Nova Burst Missile
 Launcher
     <br/>
-    <code>
-     KEY:ATTK_NUKE_MISSL
-    </code>
+    <code>KEY:ATTK_NUKE_MISSL</code>
     - Nuclear Missile Launcher
     <br/>
-    <code>
-     KEY:ATTK_NUKE_MISSL_2
-    </code>
+    <code>KEY:ATTK_NUKE_MISSL_2</code>
     - 2 Nuclear Missile
 Launcher
     <br/>
-    <code>
-     KEY:ATTK_NUKE_MISSL_2L
-    </code>
+    <code>KEY:ATTK_NUKE_MISSL_2L</code>
     - 2 fire-linked Nuclear
 Missiles Launcher
     <br/>
-    <code>
-     KEY:ATTK_PRTCL_BEAM
-    </code>
+    <code>KEY:ATTK_PRTCL_BEAM</code>
     - Particle Beam
     <br/>
-    <code>
-     KEY:ATTK_PRTCL_BEAM_2L
-    </code>
+    <code>KEY:ATTK_PRTCL_BEAM_2L</code>
     - 2 fire-linked Particle
 Beams
     <br/>
-    <code>
-     KEY:ATTK_PRTCL_BEAM_4B
-    </code>
+    <code>KEY:ATTK_PRTCL_BEAM_4B</code>
     - Battery of 4 Particle
 Beams
     <br/>
-    <code>
-     KEY:ATTK_PLASMA_CANN
-    </code>
+    <code>KEY:ATTK_PLASMA_CANN</code>
     - Plasma Cannon
     <br/>
-    <code>
-     KEY:ATTK_PLASMA_CANN_4B
-    </code>
+    <code>KEY:ATTK_PLASMA_CANN_4B</code>
     - Battery of 4 Plasma
 Cannons
     <br/>
-    <code>
-     KEY:ATTK_PLSM_MISSL
-    </code>
+    <code>KEY:ATTK_PLSM_MISSL</code>
     - Plasma Missile Launcher
     <br/>
-    <code>
-     KEY:ATTK_PLSM_MISSL_2B
-    </code>
+    <code>KEY:ATTK_PLSM_MISSL_2B</code>
     - Battery of 2 Plasma Missile
 Launcher
     <br/>
-    <code>
-     KEY:ATTK_PLSM_MISSL_3B
-    </code>
+    <code>KEY:ATTK_PLSM_MISSL_3B</code>
     - Battery of 3 Plasma Missile
 Launcher
     <br/>
-    <code>
-     KEY:ATTK_QUNTM_CANN
-    </code>
+    <code>KEY:ATTK_QUNTM_CANN</code>
     - Quantum Cannon
     <br/>
-    <code>
-     KEY:ATTK_QUNTM_CANN_2L
-    </code>
+    <code>KEY:ATTK_QUNTM_CANN_2L</code>
     - 2 fire-linked Quantum
 Cannons
     <br/>
-    <code>
-     KEY:ATTK_QUNTM_CANN_4L
-    </code>
+    <code>KEY:ATTK_QUNTM_CANN_4L</code>
     - 4 fire-linked Quantum
 Cannons
     <br/>
-    <code>
-     KEY:ATTK_RAIL_CANNON
-    </code>
+    <code>KEY:ATTK_RAIL_CANNON</code>
     - Rail Cannon
     <br/>
-    <code>
-     KEY:ATTK_RAIL_CANNON_2L
-    </code>
+    <code>KEY:ATTK_RAIL_CANNON_2L</code>
     - 2 fire-linked rail
 Cannons
     <br/>
-    <code>
-     KEY:ATTK_RAIL_CANNON_4L
-    </code>
+    <code>KEY:ATTK_RAIL_CANNON_4L</code>
     - 4 fire-linked rail
 Cannons
     <br/>
-    <code>
-     KEY:ATTK_SNGLRT_CANN
-    </code>
+    <code>KEY:ATTK_SNGLRT_CANN</code>
     - Singularity Cannon
     <br/>
-    <code>
-     KEY:ATTK_SLIVER_GUN
-    </code>
+    <code>KEY:ATTK_SLIVER_GUN</code>
     - Sliver Gun
     <br/>
-    <code>
-     KEY:ATTK_STRLD_MISSL
-    </code>
+    <code>KEY:ATTK_STRLD_MISSL</code>
     - Starload Missile Launcher
     <br/>
-    <code>
-     KEY:ATTK_STRNG_PRJCTR
-    </code>
+    <code>KEY:ATTK_STRNG_PRJCTR</code>
     - String Projector
     <br/>
-    <code>
-     KEY:ATTK_ZERO_BORE
-    </code>
+    <code>KEY:ATTK_ZERO_BORE</code>
     - Zero Bore
     <br/>
-    <code>
-     KEY:AUTOCMP_DRVR_DERVISH
-    </code>
+    <code>KEY:AUTOCMP_DRVR_DERVISH</code>
     - Dervish AI-400 (Driver
 Autocomp)
     <br/>
-    <code>
-     KEY:AUTOCMP_DRVR_PEGASUS
-    </code>
+    <code>KEY:AUTOCMP_DRVR_PEGASUS</code>
     - Pegasus AI-200 (Driver
 Autocomp
     <br/>
-    <code>
-     KEY:AUTOCMP_DRVR_ROADLRD
-    </code>
+    <code>KEY:AUTOCMP_DRVR_ROADLRD</code>
     - Roadlord AI-GA (Driver
 Autocomp
     <br/>
-    <code>
-     KEY:AUTOCMP_DRVR_TWISTER
-    </code>
+    <code>KEY:AUTOCMP_DRVR_TWISTER</code>
     - Twister AI-800 (Driver
 Autocomp
     <br/>
-    <code>
-     KEY:AUTOCMP_DRVR_ZEPHYR
-    </code>
+    <code>KEY:AUTOCMP_DRVR_ZEPHYR</code>
     - Zephyr AI-1200 (Driver
 Autocomp
     <br/>
-    <code>
-     KEY:AUTOCMP_GUNR_ADDER
-    </code>
+    <code>KEY:AUTOCMP_GUNR_ADDER</code>
     - Adder AI-G2 (Gunner
 Autocomp)
     <br/>
-    <code>
-     KEY:AUTOCMP_GUNR_DEADEYE
-    </code>
+    <code>KEY:AUTOCMP_GUNR_DEADEYE</code>
     - Deadeye AI-G4 (Gunner
 Autocomp
     <br/>
-    <code>
-     KEY:AUTOCMP_GUNR_HOTSHOT
-    </code>
+    <code>KEY:AUTOCMP_GUNR_HOTSHOT</code>
     - Hotshot AI-G8 (Gunner
 Autocomp)
     <br/>
-    <code>
-     KEY:AUTOCMP_GUNR_MARKSMN
-    </code>
+    <code>KEY:AUTOCMP_GUNR_MARKSMN</code>
     - Marksman AI-GA (Gunner
 Autocomp)
     <br/>
-    <code>
-     KEY:AUTOCMP_GUNR_RTTLSNK
-    </code>
+    <code>KEY:AUTOCMP_GUNR_RTTLSNK</code>
     - Rattlesnake AI-GX (Gunner
 Autocomp)
     <br/>
-    <code>
-     KEY:BATTERY_OF_2
-    </code>
+    <code>KEY:BATTERY_OF_2</code>
     - Battery of 2
     <br/>
-    <code>
-     KEY:BATTERY_OF_3
-    </code>
+    <code>KEY:BATTERY_OF_3</code>
     - Battery of 3
     <br/>
-    <code>
-     KEY:BATTERY_OF_4
-    </code>
+    <code>KEY:BATTERY_OF_4</code>
     - Battery of 4
     <br/>
-    <code>
-     KEY:BATTERY_OF_5
-    </code>
+    <code>KEY:BATTERY_OF_5</code>
     - Battery of 5
     <br/>
-    <code>
-     KEY:BB_TRP_GDGT_BRB
-    </code>
+    <code>KEY:BB_TRP_GDGT_BRB</code>
     - Booby Trapped Gadget
 (Barbs)
     <br/>
-    <code>
-     KEY:BB_TRP_GDGT_ELS
-    </code>
+    <code>KEY:BB_TRP_GDGT_ELS</code>
     - Booby Trapped Gadget (Electric
 Shock)
     <br/>
-    <code>
-     KEY:BB_TRP_GDGT_STB
-    </code>
+    <code>KEY:BB_TRP_GDGT_STB</code>
     - Booby Trapped Gadget (Stun
 Bolt)
     <br/>
-    <code>
-     KEY:BB_TRP_GDGT_TIW
-    </code>
+    <code>KEY:BB_TRP_GDGT_TIW</code>
     - Booby Trapped Gadget (Trigger
 Integrated Weapon)
     <br/>
-    <code>
-     KEY:CHMLNC_SRFC_GDGT
-    </code>
+    <code>KEY:CHMLNC_SRFC_GDGT</code>
     - Chameleonic Surface
 Gadget
     <br/>
-    <code>
-     KEY:CLLPSBL_GDGT
-    </code>
+    <code>KEY:CLLPSBL_GDGT</code>
     - Collapsible Gadget
     <br/>
-    <code>
-     KEY:CMPCT_GDGT_EQP
-    </code>
+    <code>KEY:CMPCT_GDGT_EQP</code>
     - Compact Gadget
     <br/>
-    <code>
-     KEY:CMPCT_GDGT_WPN
-    </code>
+    <code>KEY:CMPCT_GDGT_WPN</code>
     - Compact Gadget
     <br/>
-    <code>
-     KEY:COL_JUMP_DRIVE
-    </code>
+    <code>KEY:COL_JUMP_DRIVE</code>
     - Jump Drive (Colossal)
     <br/>
-    <code>
-     KEY:COMM_ANSIBLE
-    </code>
+    <code>KEY:COMM_ANSIBLE</code>
     - Ansible
     <br/>
-    <code>
-     KEY:COMM_DRIVE_TRNSCVR
-    </code>
+    <code>KEY:COMM_DRIVE_TRNSCVR</code>
     - Drive Transceiver
     <br/>
-    <code>
-     KEY:COMM_DRIVESAT
-    </code>
+    <code>KEY:COMM_DRIVESAT</code>
     - Drivesat Comm Array
     <br/>
-    <code>
-     KEY:COMM_INTERNAL_AUDIO
-    </code>
+    <code>KEY:COMM_INTERNAL_AUDIO</code>
     - Internal Audio Comm
 System
     <br/>
-    <code>
-     KEY:COMM_INTERNAL_VIDEO
-    </code>
+    <code>KEY:COMM_INTERNAL_VIDEO</code>
     - Internal Video Comm
 System
     <br/>
-    <code>
-     KEY:COMM_LASER_TRNSCVR
-    </code>
+    <code>KEY:COMM_LASER_TRNSCVR</code>
     - Laser Transceiver
     <br/>
-    <code>
-     KEY:COMM_MASS_TRNSCVR
-    </code>
+    <code>KEY:COMM_MASS_TRNSCVR</code>
     - Mass Transceiver
     <br/>
-    <code>
-     KEY:COMM_RADIO_TRNSCVR
-    </code>
+    <code>KEY:COMM_RADIO_TRNSCVR</code>
     - Radio Transceiver
     <br/>
-    <code>
-     KEY:D_DRV_GNRTR8
-    </code>
+    <code>KEY:D_DRV_GNRTR8</code>
     - D-Drive Generator (PL8)
     <br/>
-    <code>
-     KEY:D_DRV_GNRTR9
-    </code>
+    <code>KEY:D_DRV_GNRTR9</code>
     - D-Drive Generator (PL9)
     <br/>
-    <code>
-     KEY:DFNS_ADV_DMG_CTRL
-    </code>
+    <code>KEY:DFNS_ADV_DMG_CTRL</code>
     - Advanced Damage Control
     <br/>
-    <code>
-     KEY:DFNS_AUTOPILOT
-    </code>
+    <code>KEY:DFNS_AUTOPILOT</code>
     - Autopilot System
     <br/>
-    <code>
-     KEY:DFNS_CHAFF_LNCH
-    </code>
+    <code>KEY:DFNS_CHAFF_LNCH</code>
     - Chaff launcher
     <br/>
-    <code>
-     KEY:DFNS_CHAFF_LNCH_8
-    </code>
+    <code>KEY:DFNS_CHAFF_LNCH_8</code>
     - Chaff launcher
     <br/>
-    <code>
-     KEY:DFNS_CHAFF_LNCH_8_2
-    </code>
+    <code>KEY:DFNS_CHAFF_LNCH_8_2</code>
     - 2 Chaff launchers
     <br/>
-    <code>
-     KEY:DFNS_CLOAK_SCRN
-    </code>
+    <code>KEY:DFNS_CLOAK_SCRN</code>
     - Cloaking Screen
     <br/>
-    <code>
-     KEY:DFNS_DMG_CTRL_SYS
-    </code>
+    <code>KEY:DFNS_DMG_CTRL_SYS</code>
     - Damage Control System
     <br/>
-    <code>
-     KEY:DFNS_DECOY_LNCH
-    </code>
+    <code>KEY:DFNS_DECOY_LNCH</code>
     - Decoy drone launcher
     <br/>
-    <code>
-     KEY:DFNS_DECOY_LNCH_2
-    </code>
+    <code>KEY:DFNS_DECOY_LNCH_2</code>
     - Decoy drone launcher
     <br/>
-    <code>
-     KEY:DFNS_DECOY_LNCH_4_2
-    </code>
+    <code>KEY:DFNS_DECOY_LNCH_4_2</code>
     - 2 Decoy drone
 launchers
     <br/>
-    <code>
-     KEY:DFNS_DECOY_LNCH_8
-    </code>
+    <code>KEY:DFNS_DECOY_LNCH_8</code>
     - Decoy drone launcher
     <br/>
-    <code>
-     KEY:DFNS_DISPLACER
-    </code>
+    <code>KEY:DFNS_DISPLACER</code>
     - Displacer
     <br/>
-    <code>
-     KEY:DFNS_HEAVY_FRTFCTN
-    </code>
+    <code>KEY:DFNS_HEAVY_FRTFCTN</code>
     - Heavy Fortification
     <br/>
-    <code>
-     KEY:DFNS_IMP_AUTOPILOT
-    </code>
+    <code>KEY:DFNS_IMP_AUTOPILOT</code>
     - Improved Autopilot
 System
     <br/>
-    <code>
-     KEY:DFNS_IMP_DMG_CTRL
-    </code>
+    <code>KEY:DFNS_IMP_DMG_CTRL</code>
     - Improved Damage Control
     <br/>
-    <code>
-     KEY:DFNS_LGHT_FRTFCTN
-    </code>
+    <code>KEY:DFNS_LGHT_FRTFCTN</code>
     - Light Fortification
     <br/>
-    <code>
-     KEY:DFNS_MGNT_FLD
-    </code>
+    <code>KEY:DFNS_MGNT_FLD</code>
     - Magnetic Field
     <br/>
-    <code>
-     KEY:DFNS_MEDM_FRTFCTN
-    </code>
+    <code>KEY:DFNS_MEDM_FRTFCTN</code>
     - Medium Fortification
     <br/>
-    <code>
-     KEY:DFNS_NANITE_REPAIR
-    </code>
+    <code>KEY:DFNS_NANITE_REPAIR</code>
     - Nanite Repair Array
     <br/>
-    <code>
-     KEY:DFNS_PRTCL_FLD
-    </code>
+    <code>KEY:DFNS_PRTCL_FLD</code>
     - Particle Field
     <br/>
-    <code>
-     KEY:DFNS_RAD_SHLD
-    </code>
+    <code>KEY:DFNS_RAD_SHLD</code>
     - Radiation Shielding
     <br/>
-    <code>
-     KEY:DFNS_REPAIR_DRONE
-    </code>
+    <code>KEY:DFNS_REPAIR_DRONE</code>
     - Repair drones
     <br/>
-    <code>
-     KEY:DFNS_SLF_DSTR_SYS
-    </code>
+    <code>KEY:DFNS_SLF_DSTR_SYS</code>
     - Self-destruct System
     <br/>
-    <code>
-     KEY:DFNS_SNSR_JAM
-    </code>
+    <code>KEY:DFNS_SNSR_JAM</code>
     - Sensor Jammer
     <br/>
-    <code>
-     KEY:DFNS_STLTH_SCRN
-    </code>
+    <code>KEY:DFNS_STLTH_SCRN</code>
     - Stealth Screen
     <br/>
-    <code>
-     KEY:ENGN_FUSION
-    </code>
+    <code>KEY:ENGN_FUSION</code>
     - Fusion Torch
     <br/>
-    <code>
-     KEY:ENGN_GRAVITIC
-    </code>
+    <code>KEY:ENGN_GRAVITIC</code>
     - Gravitic Redirector
     <br/>
-    <code>
-     KEY:ENGN_INDCTN
-    </code>
+    <code>KEY:ENGN_INDCTN</code>
     - Induction Engine
     <br/>
-    <code>
-     KEY:ENGN_INRT_FLUX
-    </code>
+    <code>KEY:ENGN_INRT_FLUX</code>
     - Inertial Flux Engine
     <br/>
-    <code>
-     KEY:ENGN_ION
-    </code>
+    <code>KEY:ENGN_ION</code>
     - Ion Engine
     <br/>
-    <code>
-     KEY:ENGN_PARTCL
-    </code>
+    <code>KEY:ENGN_PARTCL</code>
     - Particle Impulse
     <br/>
-    <code>
-     KEY:ENGN_PHOTON
-    </code>
+    <code>KEY:ENGN_PHOTON</code>
     - Photon Sails
     <br/>
-    <code>
-     KEY:ENGN_SPATIAL
-    </code>
+    <code>KEY:ENGN_SPATIAL</code>
     - Spatial Compressor
     <br/>
-    <code>
-     KEY:ENGN_THRUST
-    </code>
+    <code>KEY:ENGN_THRUST</code>
     - Thrusters
     <br/>
-    <code>
-     KEY:ENVRNMNT_SL_GDGT
-    </code>
+    <code>KEY:ENVRNMNT_SL_GDGT</code>
     - Environment Seal Gadget
     <br/>
-    <code>
-     KEY:GNTC_TGS_GDGT
-    </code>
+    <code>KEY:GNTC_TGS_GDGT</code>
     - Genetic Tags Gadget
     <br/>
-    <code>
-     KEY:GRAP_GRAPPLER
-    </code>
+    <code>KEY:GRAP_GRAPPLER</code>
     - Grappler
     <br/>
-    <code>
-     KEY:GRAP_TRACTOR_BEAM
-    </code>
+    <code>KEY:GRAP_TRACTOR_BEAM</code>
     - Tractor Beam Emitter
     <br/>
-    <code>
-     KEY:GRG_JUMP_DRIVE
-    </code>
+    <code>KEY:GRG_JUMP_DRIVE</code>
     - Jump Drive (Gargantuan)
     <br/>
-    <code>
-     KEY:GRVT_ANCHR_GDGT
-    </code>
+    <code>KEY:GRVT_ANCHR_GDGT</code>
     - Gravity Anchor Gadget
     <br/>
-    <code>
-     KEY:HGE_JUMP_DRIVE
-    </code>
+    <code>KEY:HGE_JUMP_DRIVE</code>
     - Jump Drive (Huge)
     <br/>
-    <code>
-     KEY:HUD_SFTWR_AMMO_TRK
-    </code>
+    <code>KEY:HUD_SFTWR_AMMO_TRK</code>
     - HUD Software (Ammunition
 Tracker)
     <br/>
-    <code>
-     KEY:HUD_SFTWR_AMMO_TRK_AMR
-    </code>
+    <code>KEY:HUD_SFTWR_AMMO_TRK_AMR</code>
     - HUD Software (Ammunition
 Tracker)
     <br/>
-    <code>
-     KEY:HUD_SFTWR_BIOSNSR
-    </code>
+    <code>KEY:HUD_SFTWR_BIOSNSR</code>
     - HUD Software (Biosensor)
     <br/>
-    <code>
-     KEY:HUD_SFTWR_BIOSNSR_AMR
-    </code>
+    <code>KEY:HUD_SFTWR_BIOSNSR_AMR</code>
     - HUD Software
 (Biosensor)
     <br/>
-    <code>
-     KEY:HUD_SFTWR_SNSR_LNK
-    </code>
+    <code>KEY:HUD_SFTWR_SNSR_LNK</code>
     - HUD Software (Sensor
 Link)
     <br/>
-    <code>
-     KEY:HUD_SFTWR_SNSR_LNK_AMR
-    </code>
+    <code>KEY:HUD_SFTWR_SNSR_LNK_AMR</code>
     - HUD Software (Sensor
 Link)
     <br/>
-    <code>
-     KEY:HUD_SFTWR_TRGT
-    </code>
+    <code>KEY:HUD_SFTWR_TRGT</code>
     - HUD Software (Targetting)
     <br/>
-    <code>
-     KEY:HUD_SFTWR_TRGT_AMR
-    </code>
+    <code>KEY:HUD_SFTWR_TRGT_AMR</code>
     - HUD Software
 (Targetting)
     <br/>
-    <code>
-     KEY:HUD_SFTWR_VHCL_LNK
-    </code>
+    <code>KEY:HUD_SFTWR_VHCL_LNK</code>
     - HUD Software (Vehicle
 Link)
     <br/>
-    <code>
-     KEY:HUD_SFTWR_VHCL_LNK_AMR
-    </code>
+    <code>KEY:HUD_SFTWR_VHCL_LNK_AMR</code>
     - HUD Software (Vehicle
 Link)
     <br/>
-    <code>
-     KEY:INT_EQ_GDGT_AMR
-    </code>
+    <code>KEY:INT_EQ_GDGT_AMR</code>
     - Integrated Equipment
 Gadget
     <br/>
-    <code>
-     KEY:INT_EQ_GDGT_WPN
-    </code>
+    <code>KEY:INT_EQ_GDGT_WPN</code>
     - Integrated Equipment
 Gadget
     <br/>
-    <code>
-     KEY:INT_WPN_GDGT
-    </code>
+    <code>KEY:INT_WPN_GDGT</code>
     - Integrated Weapon Gadget
     <br/>
-    <code>
-     KEY:MDFNS_CLOAK_SCRN
-    </code>
+    <code>KEY:MDFNS_CLOAK_SCRN</code>
     - Cloaking Screen
     <br/>
-    <code>
-     KEY:MDFNS_DISPLACER
-    </code>
+    <code>KEY:MDFNS_DISPLACER</code>
     - Displacer
     <br/>
-    <code>
-     KEY:MDFNS_MGNT_FLD
-    </code>
+    <code>KEY:MDFNS_MGNT_FLD</code>
     - Magnetic Field
     <br/>
-    <code>
-     KEY:MDFNS_PRTCL_FLD
-    </code>
+    <code>KEY:MDFNS_PRTCL_FLD</code>
     - Particle Field
     <br/>
-    <code>
-     KEY:MDFNS_STLTH_SCRN
-    </code>
+    <code>KEY:MDFNS_STLTH_SCRN</code>
     - Stealth Screen
     <br/>
-    <code>
-     KEY:MLTPL_US_ITM_GDGT
-    </code>
+    <code>KEY:MLTPL_US_ITM_GDGT</code>
     - Multiple Use Item Gadget
     <br/>
-    <code>
-     KEY:MNTRZD_GDGT_EQP
-    </code>
+    <code>KEY:MNTRZD_GDGT_EQP</code>
     - Miniaturized Gadget
     <br/>
-    <code>
-     KEY:MNTRZD_GDGT_WPN
-    </code>
+    <code>KEY:MNTRZD_GDGT_WPN</code>
     - Miniaturized Gadget
     <br/>
-    <code>
-     KEY:MRPH_MTL_ALL_GDGT
-    </code>
+    <code>KEY:MRPH_MTL_ALL_GDGT</code>
     - Morphic Metal Alloy
 Gadget
     <br/>
-    <code>
-     KEY:NEG_GRV_BOOST_GDGT
-    </code>
+    <code>KEY:NEG_GRV_BOOST_GDGT</code>
     - Neg-grav Boosters
 Gadget
     <br/>
-    <code>
-     KEY:PNT_ON_LCD_GDGT_AMR
-    </code>
+    <code>KEY:PNT_ON_LCD_GDGT_AMR</code>
     - Paint-On LCD Gadget
     <br/>
-    <code>
-     KEY:PNT_ON_LCD_GDGT_EQP
-    </code>
+    <code>KEY:PNT_ON_LCD_GDGT_EQP</code>
     - Paint-On LCD Gadget
     <br/>
-    <code>
-     KEY:PNT_ON_LCD_GDGT_WPN
-    </code>
+    <code>KEY:PNT_ON_LCD_GDGT_WPN</code>
     - Paint-On LCD Gadget
     <br/>
-    <code>
-     KEY:PRHNSL_APPNDG_GDGT
-    </code>
+    <code>KEY:PRHNSL_APPNDG_GDGT</code>
     - Prehensile Appendage
 Gadget
     <br/>
-    <code>
-     KEY:REMOTE_SHUTDOWN_SYS
-    </code>
+    <code>KEY:REMOTE_SHUTDOWN_SYS</code>
     - Remote Shutdown System
     <br/>
-    <code>
-     KEY:RGFD_LSR_SCP_GDGT
-    </code>
+    <code>KEY:RGFD_LSR_SCP_GDGT</code>
     - Rangefinding Laser Scope
 Gadget
     <br/>
-    <code>
-     KEY:SAT_DTALNK_GDGT
-    </code>
+    <code>KEY:SAT_DTALNK_GDGT</code>
     - Satellite Datalink Gadget
     <br/>
-    <code>
-     KEY:SLF_RPRNG_GDGT
-    </code>
+    <code>KEY:SLF_RPRNG_GDGT</code>
     - Self-Repairing Gadget -
 Armor
     <br/>
-    <code>
-     KEY:SLF_RPRNG_GDGT_EQM
-    </code>
+    <code>KEY:SLF_RPRNG_GDGT_EQM</code>
     - Self-Repairing Gadget -
 Goods
     <br/>
-    <code>
-     KEY:SND_SPPRSSR_GDGT_EQP
-    </code>
+    <code>KEY:SND_SPPRSSR_GDGT_EQP</code>
     - Sound Suppressor
 Gadget
     <br/>
-    <code>
-     KEY:SND_SPPRSSR_GDGT_WPN
-    </code>
+    <code>KEY:SND_SPPRSSR_GDGT_WPN</code>
     - Sound Suppressor
 Gadget
     <br/>
-    <code>
-     KEY:SNSR_ACHILLES
-    </code>
+    <code>KEY:SNSR_ACHILLES</code>
     - Achilles Targeting Software
     <br/>
-    <code>
-     KEY:SNSR_BFFLNG_GDGT
-    </code>
+    <code>KEY:SNSR_BFFLNG_GDGT</code>
     - Sensor Baffling Gadget
     <br/>
-    <code>
-     KEY:SNSR_CLASS_1
-    </code>
+    <code>KEY:SNSR_CLASS_1</code>
     - Class I Sensor Array
     <br/>
-    <code>
-     KEY:SNSR_CLASS_2
-    </code>
+    <code>KEY:SNSR_CLASS_2</code>
     - Class II Sensor Array
     <br/>
-    <code>
-     KEY:SNSR_CLASS_3
-    </code>
+    <code>KEY:SNSR_CLASS_3</code>
     - Class III Sensor Array
     <br/>
-    <code>
-     KEY:SNSR_CLASS_4
-    </code>
+    <code>KEY:SNSR_CLASS_4</code>
     - Class IV Sensor Array
     <br/>
-    <code>
-     KEY:SNSR_CLASS_5
-    </code>
+    <code>KEY:SNSR_CLASS_5</code>
     - Class V Sensor Array
     <br/>
-    <code>
-     KEY:SNSR_CLASS_6
-    </code>
+    <code>KEY:SNSR_CLASS_6</code>
     - Class VI Sensor Array
     <br/>
-    <code>
-     KEY:SNSR_CLASS_7
-    </code>
+    <code>KEY:SNSR_CLASS_7</code>
     - Class VII Sensor Array
     <br/>
-    <code>
-     KEY:SNSR_CLASS_8
-    </code>
+    <code>KEY:SNSR_CLASS_8</code>
     - Class VIII Sensor Array
     <br/>
-    <code>
-     KEY:SNSR_CLASS_9
-    </code>
+    <code>KEY:SNSR_CLASS_9</code>
     - Class IX Sensor Array
     <br/>
-    <code>
-     KEY:SNSR_IMP_TRGT_SYS
-    </code>
+    <code>KEY:SNSR_IMP_TRGT_SYS</code>
     - Improved Targeting
 System
     <br/>
-    <code>
-     KEY:SNSR_TRGT_SYS
-    </code>
+    <code>KEY:SNSR_TRGT_SYS</code>
     - Targeting System
     <br/>
-    <code>
-     KEY:SPRNG_LDD_GDGT
-    </code>
+    <code>KEY:SPRNG_LDD_GDGT</code>
     - Spring Loaded Gadget
     <br/>
-    <code>
-     KEY:STN_MDL_GDGT_12
-    </code>
+    <code>KEY:STN_MDL_GDGT_12</code>
     - Stun Module Gadget (Fort DC
 12)
     <br/>
-    <code>
-     KEY:STN_MDL_GDGT_15
-    </code>
+    <code>KEY:STN_MDL_GDGT_15</code>
     - Stun Module Gadget (Fort DC
 15)
     <br/>
-    <code>
-     KEY:STN_MDL_GDGT_18
-    </code>
+    <code>KEY:STN_MDL_GDGT_18</code>
     - Stun Module Gadget (Fort DC
 18)
     <br/>
-    <code>
-     KEY:STOR_CMPRT_GDGT_AMR
-    </code>
+    <code>KEY:STOR_CMPRT_GDGT_AMR</code>
     - Storage Compartment
 Gadget
     <br/>
-    <code>
-     KEY:STOR_CMPRT_GDGT_EQP
-    </code>
+    <code>KEY:STOR_CMPRT_GDGT_EQP</code>
     - Storage Compartment
 Gadget
     <br/>
-    <code>
-     KEY:T_DRV_GNRTR
-    </code>
+    <code>KEY:T_DRV_GNRTR</code>
     - Temporal Drive Generator (PL9)
     <br/>
-    <code>
-     KEY:T_ORG_MUP_GDGT_AMR
-    </code>
+    <code>KEY:T_ORG_MUP_GDGT_AMR</code>
     - Techno-Organic Makeup
 Gadget
     <br/>
-    <code>
-     KEY:T_ORG_MUP_GDGT_WPN
-    </code>
+    <code>KEY:T_ORG_MUP_GDGT_WPN</code>
     - Techno-Organic Makeup
 Gadget
     <br/>
-    <code>
-     KEY:TLPRT_MAG_GDGT
-    </code>
+    <code>KEY:TLPRT_MAG_GDGT</code>
     - Teleporting Magazine Gadget
     <br/>
-    <code>
-     KEY:ULTRLT_CMPSTN_GDGT
-    </code>
+    <code>KEY:ULTRLT_CMPSTN_GDGT</code>
     - Ultralight Composition
 Gadget
     <br/>
-    <code>
-     KEY:VAR_AMMNTN_GDGT
-    </code>
+    <code>KEY:VAR_AMMNTN_GDGT</code>
     - Variable Ammunition Gadget
     <br/>
-    <code>
-     KEY:VAR_CHRG_GDGT
-    </code>
+    <code>KEY:VAR_CHRG_GDGT</code>
     - Variable Charge Gadget
     <br/>
-    <code>
-     KEY:VC_RCGNTN_SYS_GDGT
-    </code>
+    <code>KEY:VC_RCGNTN_SYS_GDGT</code>
     - Voice Recognition System
 Gadget
     <br/>
-    <code>
-     KEY:VHCL_ALUMISTEEL_ARMR
-    </code>
+    <code>KEY:VHCL_ALUMISTEEL_ARMR</code>
     - Alumisteel Armor
 (PL5)
     <br/>
-    <code>
-     KEY:VHCL_DURAPLASTC_ARMR
-    </code>
+    <code>KEY:VHCL_DURAPLASTC_ARMR</code>
     - Duraplastic Armor
 (PL5)
     <br/>
-    <code>
-     KEY:VHCL_DURALLOY_ARMR
-    </code>
+    <code>KEY:VHCL_DURALLOY_ARMR</code>
     - Duralloy Armor (PL6)
     <br/>
-    <code>
-     KEY:VHCL_RESILIUM_ARMR
-    </code>
+    <code>KEY:VHCL_RESILIUM_ARMR</code>
     - Resilium Armor (PL6)
     <br/>
-    <code>
-     KEY:VHCL_CRSTL_CRBN_ARMR
-    </code>
+    <code>KEY:VHCL_CRSTL_CRBN_ARMR</code>
     - Crystal Carbon Armor
 (PL7)
     <br/>
-    <code>
-     KEY:VHCL_MEGATANIUM_ARMR
-    </code>
+    <code>KEY:VHCL_MEGATANIUM_ARMR</code>
     - Megatanium Armor
 (PL8)
     <br/>
-    <code>
-     KEY:VHCL_NEOVULCANM_ARMR
-    </code>
+    <code>KEY:VHCL_NEOVULCANM_ARMR</code>
     - Neovulcanium Armor
 (PL7)
     <br/>
-    <code>
-     KEY:VHCL_REACTIVE_ARMR
-    </code>
+    <code>KEY:VHCL_REACTIVE_ARMR</code>
     - Reactive Armor (PL8)
     <br/>
-    <code>
-     KEY:VID_SCP_GDGT
-    </code>
+    <code>KEY:VID_SCP_GDGT</code>
     - Video Scope Gadget
     <br/>
-    <code>
-     KEY:XP_MGZN_GDGT
-    </code>
+    <code>KEY:XP_MGZN_GDGT</code>
     - Expanded Magazine Gadget
     <br/>
    </p>
@@ -6431,714 +4277,458 @@ Gadget
     </strong>
    </p>
    <p>
-    <code>
-     KEY:A3X_DRGN_FLMTHRWR
-    </code>
+    <code>KEY:A3X_DRGN_FLMTHRWR</code>
     - A3X Dragon Flame-Thrower
 (PL 5)
     <br/>
-    <code>
-     KEY:ADVANCD_DGNSTCS
-    </code>
+    <code>KEY:ADVANCD_DGNSTCS</code>
     - Advanced Diagnostics (PL
 7)
     <br/>
-    <code>
-     KEY:AFTRBRNR_SYS
-    </code>
+    <code>KEY:AFTRBRNR_SYS</code>
     - Afterburner System (PL6)
     <br/>
-    <code>
-     KEY:ALUMISTL
-    </code>
+    <code>KEY:ALUMISTL</code>
     - Alumisteel (PL5)
     <br/>
-    <code>
-     KEY:ALUMISTL_ARMR
-    </code>
+    <code>KEY:ALUMISTL_ARMR</code>
     - Alumisteel Armor (PL5)
     <br/>
-    <code>
-     KEY:AMMO_LT5_LNGSHT_MSSDRV
-    </code>
+    <code>KEY:AMMO_LT5_LNGSHT_MSSDRV</code>
     - Ammo bay for LT-5
 Longshot Mass Driver
     <br/>
-    <code>
-     KEY:AMMO_M9_BRRGE_CHAINGUN
-    </code>
+    <code>KEY:AMMO_M9_BRRGE_CHAINGUN</code>
     - 6 50-round ammo belts for
 M-9 Barrage chaingun
     <br/>
-    <code>
-     KEY:AMMO_M53_FRST_RCKTLNCH
-    </code>
+    <code>KEY:AMMO_M53_FRST_RCKTLNCH</code>
     - 6-rocket pack for M-53
 Firestar Rocket Launcher
     <br/>
-    <code>
-     KEY:AMMO_M55_CRUD_RCKTLNCH
-    </code>
+    <code>KEY:AMMO_M55_CRUD_RCKTLNCH</code>
     - 6-rocket pack for M-55
 Crud Rocket Launcher
     <br/>
-    <code>
-     KEY:AMMO_M70_EMP_RCKTLNCHR
-    </code>
+    <code>KEY:AMMO_M70_EMP_RCKTLNCHR</code>
     - 6-rocket pack for M-70
 EMP Rocket Launcher
     <br/>
-    <code>
-     KEY:AMMO_M75_CRKT_RCKTLNCH
-    </code>
+    <code>KEY:AMMO_M75_CRKT_RCKTLNCH</code>
     - 6-rocket pack for M-75
 Cricket Rocket Launcher
     <br/>
-    <code>
-     KEY:AMMO_M87_TALN_MSSLLNCH
-    </code>
+    <code>KEY:AMMO_M87_TALN_MSSLLNCH</code>
     - 4-missile pack for M-87
 Talon Missile Launcher
     <br/>
-    <code>
-     KEY:AMMO_T95_CVLCD_CHAINGN
-    </code>
+    <code>KEY:AMMO_T95_CVLCD_CHAINGN</code>
     - 6 50-round ammo belts for
 T-95 Cavalcade Chaingun
     <br/>
-    <code>
-     KEY:AMMO_WARPTH_RCLLSS_RFL
-    </code>
+    <code>KEY:AMMO_WARPTH_RCLLSS_RFL</code>
     - 20-round magazine for
 Warpath Recoilless Rifle
     <br/>
-    <code>
-     KEY:AMMO2_M70_EMP_RCKTLNCHR
-    </code>
+    <code>KEY:AMMO2_M70_EMP_RCKTLNCHR</code>
     - 6-rocket pack for M-70
 EMP Rocket Launcher
     <br/>
-    <code>
-     KEY:AMMO2_M87_TALN_MSSLLNCH
-    </code>
+    <code>KEY:AMMO2_M87_TALN_MSSLLNCH</code>
     - 4-missile pack for M-87
 Talon Missile Launcher
     <br/>
-    <code>
-     KEY:BLWK_TAC_SHLD
-    </code>
+    <code>KEY:BLWK_TAC_SHLD</code>
     - Bulwark Tactical Shield
 (PL5)
     <br/>
-    <code>
-     KEY:BRCD_TAC_SHLD
-    </code>
+    <code>KEY:BRCD_TAC_SHLD</code>
     - Barricade Tactical Shield
 (PL7)
     <br/>
-    <code>
-     KEY:BSTN_TAC_SHLD
-    </code>
+    <code>KEY:BSTN_TAC_SHLD</code>
     - Bastion Tactical Shield
 (PL6)
     <br/>
-    <code>
-     KEY:CHRSNTHMM_LSR_ARR
-    </code>
+    <code>KEY:CHRSNTHMM_LSR_ARR</code>
     - Chrysanthemum Laser Array (PL
 6)
     <br/>
-    <code>
-     KEY:CL1_SNSR_SYS
-    </code>
+    <code>KEY:CL1_SNSR_SYS</code>
     - Class I Sensor System (PL6)
     <br/>
-    <code>
-     KEY:CL2_SNSR_SYS
-    </code>
+    <code>KEY:CL2_SNSR_SYS</code>
     - Class II Sensor System (PL6)
     <br/>
-    <code>
-     KEY:CL3_SNSR_SYS
-    </code>
+    <code>KEY:CL3_SNSR_SYS</code>
     - Class III Sensor System (PL6)
     <br/>
-    <code>
-     KEY:CL4_SNSR_SYS
-    </code>
+    <code>KEY:CL4_SNSR_SYS</code>
     - Class IV Sensor System (PL7)
     <br/>
-    <code>
-     KEY:CL5_SNSR_SYS
-    </code>
+    <code>KEY:CL5_SNSR_SYS</code>
     - Class V Sensor System (PL7)
     <br/>
-    <code>
-     KEY:CL6_SNSR_SYS
-    </code>
+    <code>KEY:CL6_SNSR_SYS</code>
     - Class VI Sensor System (PL8)
     <br/>
-    <code>
-     KEY:CLOAKING_SCRN
-    </code>
+    <code>KEY:CLOAKING_SCRN</code>
     - Cloaking Screen (PL8)
     <br/>
-    <code>
-     KEY:COCKPIT_COPILOT
-    </code>
+    <code>KEY:COCKPIT_COPILOT</code>
     - Cockpit (Copilot)
     <br/>
-    <code>
-     KEY:COCKPIT_PASSNGR
-    </code>
+    <code>KEY:COCKPIT_PASSNGR</code>
     - Cockpit (Passenger)
     <br/>
-    <code>
-     KEY:COCKPIT_PILOT
-    </code>
+    <code>KEY:COCKPIT_PILOT</code>
     - Cockpit (Pilot)
     <br/>
-    <code>
-     KEY:COL_AVNG_ELCT_SCM
-    </code>
+    <code>KEY:COL_AVNG_ELCT_SCM</code>
     - Avenger Electro-Scimitar (PL
 8)
     <br/>
-    <code>
-     KEY:COL_LK8_AMRPCG_PK
-    </code>
+    <code>KEY:COL_LK8_AMRPCG_PK</code>
     - LK8 Armor-Piercing Pike (PL
 6)
     <br/>
-    <code>
-     KEY:COL_MCH
-    </code>
+    <code>KEY:COL_MCH</code>
     - Colossal Mecha
     <br/>
-    <code>
-     KEY:COL_PS15_PNTR_CLW
-    </code>
+    <code>KEY:COL_PS15_PNTR_CLW</code>
     - PS-15 Panther Claws (PL
 5)
     <br/>
-    <code>
-     KEY:COL_PS25_TIGR_CLW
-    </code>
+    <code>KEY:COL_PS25_TIGR_CLW</code>
     - PS-25 Tiger Claws (PL 7)
     <br/>
-    <code>
-     KEY:COL_PTHN_ELCT_WHP
-    </code>
+    <code>KEY:COL_PTHN_ELCT_WHP</code>
     - XJ-A Python Electro-Whip (PL
 7)
     <br/>
-    <code>
-     KEY:COL_QUAD_MCH
-    </code>
+    <code>KEY:COL_QUAD_MCH</code>
     - Quadrupedal
     <br/>
-    <code>
-     KEY:COL_RP91_RPR_LSCT
-    </code>
+    <code>KEY:COL_RP91_RPR_LSCT</code>
     - RP-91 Reaper Laser Scythe (PL
 8)
     <br/>
-    <code>
-     KEY:COL_THNDRB_SHK_RD
-    </code>
+    <code>KEY:COL_THNDRB_SHK_RD</code>
     - Thunderbolt Shock Rod (PL
 5)
     <br/>
-    <code>
-     KEY:COMM_SYSTEM
-    </code>
+    <code>KEY:COMM_SYSTEM</code>
     - Comm System
     <br/>
-    <code>
-     KEY:CORONA_MICROWV_BM
-    </code>
+    <code>KEY:CORONA_MICROWV_BM</code>
     - Corona Microwave Beam (PL
 6)
     <br/>
-    <code>
-     KEY:CRKRJCK_NRL_LNK
-    </code>
+    <code>KEY:CRKRJCK_NRL_LNK</code>
     - Crackerjack Neural Link (PL
 8)
     <br/>
-    <code>
-     KEY:CRSTLCBN_ARMR
-    </code>
+    <code>KEY:CRSTLCBN_ARMR</code>
     - Crystal Carbon Armor (PL7)
     <br/>
-    <code>
-     KEY:DEFLECTN_FLD1
-    </code>
+    <code>KEY:DEFLECTN_FLD1</code>
     - Deflection Field Mk 1(PL8)
     <br/>
-    <code>
-     KEY:DEFLECTN_FLD2
-    </code>
+    <code>KEY:DEFLECTN_FLD2</code>
     - Deflection Field Mk 2(PL8)
     <br/>
-    <code>
-     KEY:DEFLECTN_FLD3
-    </code>
+    <code>KEY:DEFLECTN_FLD3</code>
     - Deflection Field Mk 3(PL8)
     <br/>
-    <code>
-     KEY:DEFLECTN_FLD4
-    </code>
+    <code>KEY:DEFLECTN_FLD4</code>
     - Deflection Field Mk 4(PL8)
     <br/>
-    <code>
-     KEY:DEFLECTN_FLD5
-    </code>
+    <code>KEY:DEFLECTN_FLD5</code>
     - Deflection Field Mk 5(PL8)
     <br/>
-    <code>
-     KEY:DLPHI_DEF_ST1
-    </code>
+    <code>KEY:DLPHI_DEF_ST1</code>
     - Delphi Defense Suite Mk 1
 (PL7)
     <br/>
-    <code>
-     KEY:DLPHI_DEF_ST2
-    </code>
+    <code>KEY:DLPHI_DEF_ST2</code>
     - Delphi Defense Suite Mk 2
 (PL7)
     <br/>
-    <code>
-     KEY:DLPHI_DEF_ST3
-    </code>
+    <code>KEY:DLPHI_DEF_ST3</code>
     - Delphi Defense Suite Mk 3
 (PL7)
     <br/>
-    <code>
-     KEY:DLPHI_DEF_ST4
-    </code>
+    <code>KEY:DLPHI_DEF_ST4</code>
     - Delphi Defense Suite Mk 4
 (PL7)
     <br/>
-    <code>
-     KEY:DLPHI_DEF_ST5
-    </code>
+    <code>KEY:DLPHI_DEF_ST5</code>
     - Delphi Defense Suite Mk 5
 (PL7)
     <br/>
-    <code>
-     KEY:DURALLOY
-    </code>
+    <code>KEY:DURALLOY</code>
     - Duralloy (PL6)
     <br/>
-    <code>
-     KEY:DURALLOY_ARMR
-    </code>
+    <code>KEY:DURALLOY_ARMR</code>
     - Duralloy Armor (PL6)
     <br/>
-    <code>
-     KEY:DURPLSTC_ARMR
-    </code>
+    <code>KEY:DURPLSTC_ARMR</code>
     - Duraplastic Armor (PL5)
     <br/>
-    <code>
-     KEY:ENGM_SNSR_ST
-    </code>
+    <code>KEY:ENGM_SNSR_ST</code>
     - Enigma Sensor Suite (PL6)
     <br/>
-    <code>
-     KEY:GRG_AVNG_ELCT_SCM
-    </code>
+    <code>KEY:GRG_AVNG_ELCT_SCM</code>
     - Avenger Electro-Scimitar (PL
 8)
     <br/>
-    <code>
-     KEY:GRG_LK8_AMRPCG_PK
-    </code>
+    <code>KEY:GRG_LK8_AMRPCG_PK</code>
     - LK8 Armor-Piercing Pike (PL
 6)
     <br/>
-    <code>
-     KEY:GRG_MCH
-    </code>
+    <code>KEY:GRG_MCH</code>
     - Gargantuan Mecha
     <br/>
-    <code>
-     KEY:GRG_PS15_PNTR_CLW
-    </code>
+    <code>KEY:GRG_PS15_PNTR_CLW</code>
     - PS-15 Panther Claws (PL
 5)
     <br/>
-    <code>
-     KEY:GRG_PS25_TIGR_CLW
-    </code>
+    <code>KEY:GRG_PS25_TIGR_CLW</code>
     - PS-25 Tiger Claws (PL 7)
     <br/>
-    <code>
-     KEY:GRG_PTHN_ELCT_WHP
-    </code>
+    <code>KEY:GRG_PTHN_ELCT_WHP</code>
     - XJ-A Python Electro-Whip (PL
 7)
     <br/>
-    <code>
-     KEY:GRG_QUAD_MCH
-    </code>
+    <code>KEY:GRG_QUAD_MCH</code>
     - Quadrupedal
     <br/>
-    <code>
-     KEY:GRG_RP91_RPR_LSCT
-    </code>
+    <code>KEY:GRG_RP91_RPR_LSCT</code>
     - RP-91 Reaper Laser Scythe (PL
 8)
     <br/>
-    <code>
-     KEY:GRG_THNDRB_SHK_RD
-    </code>
+    <code>KEY:GRG_THNDRB_SHK_RD</code>
     - Thunderbolt Shock Rod (PL
 5)
     <br/>
-    <code>
-     KEY:HEVY_FORTFCTN
-    </code>
+    <code>KEY:HEVY_FORTFCTN</code>
     - Heavy Fortification (PL9)
     <br/>
-    <code>
-     KEY:HGE_AVNG_ELCT_SCM
-    </code>
+    <code>KEY:HGE_AVNG_ELCT_SCM</code>
     - Avenger Electro-Scimitar (PL
 8)
     <br/>
-    <code>
-     KEY:HGE_LK8_AMRPCG_PK
-    </code>
+    <code>KEY:HGE_LK8_AMRPCG_PK</code>
     - LK8 Armor-Piercing Pike (PL
 6)
     <br/>
-    <code>
-     KEY:HGE_MCH
-    </code>
+    <code>KEY:HGE_MCH</code>
     - Huge Mecha
     <br/>
-    <code>
-     KEY:HGE_PS15_PNTR_CLW
-    </code>
+    <code>KEY:HGE_PS15_PNTR_CLW</code>
     - PS-15 Panther Claws (PL
 5)
     <br/>
-    <code>
-     KEY:HGE_PS25_TIGR_CLW
-    </code>
+    <code>KEY:HGE_PS25_TIGR_CLW</code>
     - PS-25 Tiger Claws (PL 7)
     <br/>
-    <code>
-     KEY:HGE_PTHN_ELCT_WHP
-    </code>
+    <code>KEY:HGE_PTHN_ELCT_WHP</code>
     - XJ-A Python Electro-Whip (PL
 7)
     <br/>
-    <code>
-     KEY:HGE_QUAD_MCH
-    </code>
+    <code>KEY:HGE_QUAD_MCH</code>
     - Quadrupedal
     <br/>
-    <code>
-     KEY:HGE_RP91_RPR_LSCT
-    </code>
+    <code>KEY:HGE_RP91_RPR_LSCT</code>
     - RP-91 Reaper Laser Scythe (PL
 8)
     <br/>
-    <code>
-     KEY:HGE_THNDRB_SHK_RD
-    </code>
+    <code>KEY:HGE_THNDRB_SHK_RD</code>
     - Thunderbolt Shock Rod (PL
 5)
     <br/>
-    <code>
-     KEY:HV5_HVN_ESCP_PD
-    </code>
+    <code>KEY:HV5_HVN_ESCP_PD</code>
     - HV-5 Haven Escape Pod (PL
 6)
     <br/>
-    <code>
-     KEY:JETPACK
-    </code>
+    <code>KEY:JETPACK</code>
     - Jetpack (PL6)
     <br/>
-    <code>
-     KEY:JETASSSTWNGS
-    </code>
+    <code>KEY:JETASSSTWNGS</code>
     - Jet-Assist Wings (PL7)
     <br/>
-    <code>
-     KEY:LF_SPPRT_SYSTEM
-    </code>
+    <code>KEY:LF_SPPRT_SYSTEM</code>
     - Life Support System
     <br/>
-    <code>
-     KEY:LGHT_FORTFCTN
-    </code>
+    <code>KEY:LGHT_FORTFCTN</code>
     - Light Fortification (PL7)
     <br/>
-    <code>
-     KEY:LRG_AVNG_ELCT_SCM
-    </code>
+    <code>KEY:LRG_AVNG_ELCT_SCM</code>
     - Avenger Electro-Scimitar (PL
 8)
     <br/>
-    <code>
-     KEY:LRG_LK8_AMRPCG_PK
-    </code>
+    <code>KEY:LRG_LK8_AMRPCG_PK</code>
     - LK8 Armor-Piercing Pike (PL
 6)
     <br/>
-    <code>
-     KEY:LRG_MCH
-    </code>
+    <code>KEY:LRG_MCH</code>
     - Large Mecha
     <br/>
-    <code>
-     KEY:LRG_PS15_PNTR_CLW
-    </code>
+    <code>KEY:LRG_PS15_PNTR_CLW</code>
     - PS-15 Panther Claws (PL
 5)
     <br/>
-    <code>
-     KEY:LRG_PS25_TIGR_CLW
-    </code>
+    <code>KEY:LRG_PS25_TIGR_CLW</code>
     - PS-25 Tiger Claws (PL 7)
     <br/>
-    <code>
-     KEY:LRG_PTHN_ELCT_WHP
-    </code>
+    <code>KEY:LRG_PTHN_ELCT_WHP</code>
     - XJ-A Python Electro-Whip (PL
 7)
     <br/>
-    <code>
-     KEY:LRG_QUAD_MCH
-    </code>
+    <code>KEY:LRG_QUAD_MCH</code>
     - Quadrupedal
     <br/>
-    <code>
-     KEY:LRG_RP91_RPR_LSCT
-    </code>
+    <code>KEY:LRG_RP91_RPR_LSCT</code>
     - RP-91 Reaper Laser Scythe (PL
 8)
     <br/>
-    <code>
-     KEY:LRG_THNDRB_SHK_RD
-    </code>
+    <code>KEY:LRG_THNDRB_SHK_RD</code>
     - Thunderbolt Shock Rod (PL
 5)
     <br/>
-    <code>
-     KEY:LT5_LNGSHT_MSSDRV
-    </code>
+    <code>KEY:LT5_LNGSHT_MSSDRV</code>
     - LT-5 Longshot Mass Driver (PL
 8)
     <br/>
-    <code>
-     KEY:LX10_ANTISHCK
-    </code>
+    <code>KEY:LX10_ANTISHCK</code>
     - LX-10 Antishock Array (PL6)
     <br/>
-    <code>
-     KEY:LX20_ANTISHCK
-    </code>
+    <code>KEY:LX20_ANTISHCK</code>
     - LX-20 Antishock Array (PL7)
     <br/>
-    <code>
-     KEY:M9_BRRGE_CHAINGUN
-    </code>
+    <code>KEY:M9_BRRGE_CHAINGUN</code>
     - M-9 Barrage Chaingun (PL
 5)
     <br/>
-    <code>
-     KEY:M21_COMET_AUTOLSR
-    </code>
+    <code>KEY:M21_COMET_AUTOLSR</code>
     - M-21 Comet Autolaser (PL
 6)
     <br/>
-    <code>
-     KEY:M53_FRST_RCKTLNCH
-    </code>
+    <code>KEY:M53_FRST_RCKTLNCH</code>
     - M-53 Firestar Rocket Launcher
 (PL 5)
     <br/>
-    <code>
-     KEY:M55_CRUD_RCKTLNCH
-    </code>
+    <code>KEY:M55_CRUD_RCKTLNCH</code>
     - M-55 Crud Rocket Launcher (PL
 5)
     <br/>
-    <code>
-     KEY:M70_EMP_RCKTLNCHR
-    </code>
+    <code>KEY:M70_EMP_RCKTLNCHR</code>
     - M-70 EMP Rocket Launcher (PL
 6)
     <br/>
-    <code>
-     KEY:M75_CRKT_RCKTLNCH
-    </code>
+    <code>KEY:M75_CRKT_RCKTLNCH</code>
     - M-75 Cricket Rocket Launcher
 (PL 6)
     <br/>
-    <code>
-     KEY:M87_TALN_MSSLLNCH
-    </code>
+    <code>KEY:M87_TALN_MSSLLNCH</code>
     - M-87 Talon Missile Launcher
 (PL 5)
     <br/>
-    <code>
-     KEY:MECHA_M300_RHINO_MSSCNN
-    </code>
+    <code>KEY:MECHA_M300_RHINO_MSSCNN</code>
     - M-300 Rhino Mass Cannon
 (PL 7)
     <br/>
-    <code>
-     KEY:MEDM_FORTFCTN
-    </code>
+    <code>KEY:MEDM_FORTFCTN</code>
     - Medium Fortification (PL8)
     <br/>
-    <code>
-     KEY:MEGATANM
-    </code>
+    <code>KEY:MEGATANM</code>
     - Megatanium (PL 8)
     <br/>
-    <code>
-     KEY:MEGATANM_ARMR
-    </code>
+    <code>KEY:MEGATANM_ARMR</code>
     - Megatanium Armor (PL8)
     <br/>
-    <code>
-     KEY:NANOREPAIR_UNIT
-    </code>
+    <code>KEY:NANOREPAIR_UNIT</code>
     - Nanorepair Unit (PL 8)
     <br/>
-    <code>
-     KEY:NEOVLCNM
-    </code>
+    <code>KEY:NEOVLCNM</code>
     - Neovulcanium (PL 7)
     <br/>
-    <code>
-     KEY:NEOVLCNM_ARMR
-    </code>
+    <code>KEY:NEOVLCNM_ARMR</code>
     - Neovulcanium Armor (PL7)
     <br/>
-    <code>
-     KEY:NEUTRONT
-    </code>
+    <code>KEY:NEUTRONT</code>
     - Neutronite (PL7)
     <br/>
-    <code>
-     KEY:NKP_PUMA_PPUP_TRT
-    </code>
+    <code>KEY:NKP_PUMA_PPUP_TRT</code>
     - NKP Puma Pop-Up Turret (PL
 6)
     <br/>
-    <code>
-     KEY:ORCL_TG_SYS1
-    </code>
+    <code>KEY:ORCL_TG_SYS1</code>
     - Oracle Targeting System Mk 1
 (PL6)
     <br/>
-    <code>
-     KEY:ORCL_TG_SYS2
-    </code>
+    <code>KEY:ORCL_TG_SYS2</code>
     - Oracle Targeting System Mk 2
 (PL6)
     <br/>
-    <code>
-     KEY:ORCL_TG_SYS3
-    </code>
+    <code>KEY:ORCL_TG_SYS3</code>
     - Oracle Targeting System Mk 3
 (PL6)
     <br/>
-    <code>
-     KEY:ORCL_TG_SYS4
-    </code>
+    <code>KEY:ORCL_TG_SYS4</code>
     - Oracle Targeting System Mk 4
 (PL6)
     <br/>
-    <code>
-     KEY:ORCL_TG_SYS5
-    </code>
+    <code>KEY:ORCL_TG_SYS5</code>
     - Oracle Targeting System Mk 5
 (PL6)
     <br/>
-    <code>
-     KEY:REACTIVE_ARMR
-    </code>
+    <code>KEY:REACTIVE_ARMR</code>
     - Reactive Armor (PL8)
     <br/>
-    <code>
-     KEY:RESILIUM_ARMR
-    </code>
+    <code>KEY:RESILIUM_ARMR</code>
     - Resilium Armor (PL6)
     <br/>
-    <code>
-     KEY:RJTTHRST_BTS
-    </code>
+    <code>KEY:RJTTHRST_BTS</code>
     - Ramjet Thruster Boots (PL8)
     <br/>
-    <code>
-     KEY:SPACE_SKIN
-    </code>
+    <code>KEY:SPACE_SKIN</code>
     - Space Skin (PL 6)
     <br/>
-    <code>
-     KEY:STEALTH_SUITE
-    </code>
+    <code>KEY:STEALTH_SUITE</code>
     - Stealth Suite (PL 6)
     <br/>
-    <code>
-     KEY:STRCTRL_ENHNCMT
-    </code>
+    <code>KEY:STRCTRL_ENHNCMT</code>
     - Structural Enhancement (PL
 7)
     <br/>
-    <code>
-     KEY:STRCTRL_ENHNCMT2
-    </code>
+    <code>KEY:STRCTRL_ENHNCMT2</code>
     - Structural Enhancement (PL
 7)
     <br/>
-    <code>
-     KEY:T95_CVLCD_CHAINGN
-    </code>
+    <code>KEY:T95_CVLCD_CHAINGN</code>
     - T-95 Cavalcade Chaingun (PL
 6)
     <br/>
-    <code>
-     KEY:THRUSTER_BTS
-    </code>
+    <code>KEY:THRUSTER_BTS</code>
     - Thruster Boots (PL7)
     <br/>
-    <code>
-     KEY:TSNM_480_PLSM_CNN
-    </code>
+    <code>KEY:TSNM_480_PLSM_CNN</code>
     - Tsunami 480 Plasma Cannon (PL
 7)
     <br/>
-    <code>
-     KEY:TYPHN_240_LSR_CNN
-    </code>
+    <code>KEY:TYPHN_240_LSR_CNN</code>
     - Typhoon 240 Laser Cannon (PL
 6)
     <br/>
-    <code>
-     KEY:VANADIUM
-    </code>
+    <code>KEY:VANADIUM</code>
     - Vanadium (PL6)
     <br/>
-    <code>
-     KEY:WARPTH_RCLLSS_RFL
-    </code>
+    <code>KEY:WARPTH_RCLLSS_RFL</code>
     - Warpath Recoilless Rifle (PL
 5)
     <br/>
-    <code>
-     KEY:ZERO_G_STABILZR
-    </code>
+    <code>KEY:ZERO_G_STABILZR</code>
     - Zero-G Stabilizer (PL
 7)
     <br/>
@@ -7149,9 +4739,7 @@ Talon Missile Launcher
     </strong>
    </p>
    <p>
-    <code>
-     KEY:MUT_SECOND_WIND
-    </code>
+    <code>KEY:MUT_SECOND_WIND</code>
     - Second Wind
     <br/>
    </p>
@@ -7161,209 +4749,127 @@ Talon Missile Launcher
     </strong>
    </p>
    <p>
-    <code>
-     KEY:ROBOT_FLY_05
-    </code>
+    <code>KEY:ROBOT_FLY_05</code>
     - +5 Speed
     <br/>
-    <code>
-     KEY:ROBOT_FLY_10
-    </code>
+    <code>KEY:ROBOT_FLY_10</code>
     - +10 Speed
     <br/>
-    <code>
-     KEY:ROBOT_FLY_15
-    </code>
+    <code>KEY:ROBOT_FLY_15</code>
     - +15 Speed
     <br/>
-    <code>
-     KEY:ROBOT_FLY_20
-    </code>
+    <code>KEY:ROBOT_FLY_20</code>
     - +20 Speed
     <br/>
-    <code>
-     KEY:ROBOT_FLY_25
-    </code>
+    <code>KEY:ROBOT_FLY_25</code>
     - +25 Speed
     <br/>
-    <code>
-     KEY:ROBOT_FLY_30
-    </code>
+    <code>KEY:ROBOT_FLY_30</code>
     - +30 Speed
     <br/>
-    <code>
-     KEY:ROBOT_FLY_35
-    </code>
+    <code>KEY:ROBOT_FLY_35</code>
     - +35 Speed
     <br/>
-    <code>
-     KEY:ROBOT_FLY_40
-    </code>
+    <code>KEY:ROBOT_FLY_40</code>
     - +40 Speed
     <br/>
-    <code>
-     KEY:ROBOT_SPEED_05
-    </code>
+    <code>KEY:ROBOT_SPEED_05</code>
     - +5 Speed
     <br/>
-    <code>
-     KEY:ROBOT_SPEED_10
-    </code>
+    <code>KEY:ROBOT_SPEED_10</code>
     - +10 Speed
     <br/>
-    <code>
-     KEY:ROBOT_SPEED_15
-    </code>
+    <code>KEY:ROBOT_SPEED_15</code>
     - +15 Speed
     <br/>
-    <code>
-     KEY:ROBOT_SPEED_20
-    </code>
+    <code>KEY:ROBOT_SPEED_20</code>
     - +20 Speed
     <br/>
-    <code>
-     KEY:ROBOT_SPEED_25
-    </code>
+    <code>KEY:ROBOT_SPEED_25</code>
     - +25 Speed
     <br/>
-    <code>
-     KEY:ROBOT_SPEED_30
-    </code>
+    <code>KEY:ROBOT_SPEED_30</code>
     - +30 Speed
     <br/>
-    <code>
-     KEY:ROBOT_SWIM_05
-    </code>
+    <code>KEY:ROBOT_SWIM_05</code>
     - +5 Speed
     <br/>
-    <code>
-     KEY:ROBOT_SWIM_10
-    </code>
+    <code>KEY:ROBOT_SWIM_10</code>
     - +10 Speed
     <br/>
-    <code>
-     KEY:ROBOT_SWIM_15
-    </code>
+    <code>KEY:ROBOT_SWIM_15</code>
     - +15 Speed
     <br/>
-    <code>
-     KEY:ROBOT_SWIM_20
-    </code>
+    <code>KEY:ROBOT_SWIM_20</code>
     - +20 Speed
     <br/>
-    <code>
-     KEY:SKILLCHIP1
-    </code>
+    <code>KEY:SKILLCHIP1</code>
     - Skill Software
     <br/>
-    <code>
-     KEY:SKILLCHIP2
-    </code>
+    <code>KEY:SKILLCHIP2</code>
     - Skill Software
     <br/>
-    <code>
-     KEY:SKILLCHIP3
-    </code>
+    <code>KEY:SKILLCHIP3</code>
     - Skill Software
     <br/>
-    <code>
-     KEY:SKILLCHIP4
-    </code>
+    <code>KEY:SKILLCHIP4</code>
     - Skill Software
     <br/>
-    <code>
-     KEY:SKILLCHIP5
-    </code>
+    <code>KEY:SKILLCHIP5</code>
     - Skill Software
     <br/>
-    <code>
-     KEY:SKILLCHIP6
-    </code>
+    <code>KEY:SKILLCHIP6</code>
     - Skill Software
     <br/>
-    <code>
-     KEY:SKILLCHIP7
-    </code>
+    <code>KEY:SKILLCHIP7</code>
     - Skill Software
     <br/>
-    <code>
-     KEY:SKILLCHIP8
-    </code>
+    <code>KEY:SKILLCHIP8</code>
     - Skill Software
     <br/>
-    <code>
-     KEY:SKILLNET4A
-    </code>
+    <code>KEY:SKILLNET4A</code>
     - Skill Software 1
     <br/>
-    <code>
-     KEY:SKILLNET4B
-    </code>
+    <code>KEY:SKILLNET4B</code>
     - Skill Software 2
     <br/>
-    <code>
-     KEY:SKILLNET4C
-    </code>
+    <code>KEY:SKILLNET4C</code>
     - Skill Software 3
     <br/>
-    <code>
-     KEY:SKILLNET4D
-    </code>
+    <code>KEY:SKILLNET4D</code>
     - Skill Software 4
     <br/>
-    <code>
-     KEY:SKILLNET8A
-    </code>
+    <code>KEY:SKILLNET8A</code>
     - Skill Software 1
     <br/>
-    <code>
-     KEY:SKILLNET8B
-    </code>
+    <code>KEY:SKILLNET8B</code>
     - Skill Software 2
     <br/>
-    <code>
-     KEY:SKILLNET8C
-    </code>
+    <code>KEY:SKILLNET8C</code>
     - Skill Software 3
     <br/>
-    <code>
-     KEY:SKILLNET8D
-    </code>
+    <code>KEY:SKILLNET8D</code>
     - Skill Software 4
     <br/>
-    <code>
-     KEY:SKILLNET12A
-    </code>
+    <code>KEY:SKILLNET12A</code>
     - Skill Software 1
     <br/>
-    <code>
-     KEY:SKILLNET12B
-    </code>
+    <code>KEY:SKILLNET12B</code>
     - Skill Software 2
     <br/>
-    <code>
-     KEY:SKILLNET12C
-    </code>
+    <code>KEY:SKILLNET12C</code>
     - Skill Software 3
     <br/>
-    <code>
-     KEY:SKILLNET12D
-    </code>
+    <code>KEY:SKILLNET12D</code>
     - Skill Software 4
     <br/>
-    <code>
-     KEY:SKILLPROGIT4
-    </code>
+    <code>KEY:SKILLPROGIT4</code>
     - Skill Software 1
     <br/>
-    <code>
-     KEY:SKILLPROGIT8
-    </code>
+    <code>KEY:SKILLPROGIT8</code>
     - Skill Software 1
     <br/>
-    <code>
-     KEY:SKILLPROGIT12
-    </code>
+    <code>KEY:SKILLPROGIT12</code>
     - Skill Software 1
     <br/>
    </p>
@@ -7389,29 +4895,19 @@ Group (APG) - Quests (35e)
     </strong>
    </p>
    <p>
-    <code>
-     KEY:CORRUPTED
-    </code>
+    <code>KEY:CORRUPTED</code>
     - Corrupted
     <br/>
-    <code>
-     KEY:CORRUPTING
-    </code>
+    <code>KEY:CORRUPTING</code>
     - Corrupting
     <br/>
-    <code>
-     KEY:HONORABLE
-    </code>
+    <code>KEY:HONORABLE</code>
     - Honorable
     <br/>
-    <code>
-     KEY:REDEEMING
-    </code>
+    <code>KEY:REDEEMING</code>
     - Redeeming
     <br/>
-    <code>
-     KEY:SUPPRESSION
-    </code>
+    <code>KEY:SUPPRESSION</code>
     - Suppression
     <br/>
    </p>
@@ -7437,9 +4933,7 @@ Penumbra (3e)
     </strong>
    </p>
    <p>
-    <code>
-     KEY:BTVSUNDER
-    </code>
+    <code>KEY:BTVSUNDER</code>
     - Sundering
     <br/>
    </p>
@@ -7470,234 +4964,142 @@ Dwarves
     </strong>
    </p>
    <p>
-    <code>
-     KEY:CUSTL1
-    </code>
+    <code>KEY:CUSTL1</code>
     - Custom Fitx1 [Light Armor]
     <br/>
-    <code>
-     KEY:CUSTL2
-    </code>
+    <code>KEY:CUSTL2</code>
     - Custom Fitx2 [Light Armor]
     <br/>
-    <code>
-     KEY:CUSTL3
-    </code>
+    <code>KEY:CUSTL3</code>
     - Custom Fitx3 [Light Armor]
     <br/>
-    <code>
-     KEY:CUSTM1
-    </code>
+    <code>KEY:CUSTM1</code>
     - Custom Fitx1 [Medium Armor]
     <br/>
-    <code>
-     KEY:CUSTM2
-    </code>
+    <code>KEY:CUSTM2</code>
     - Custom Fitx2 [Medium Armor]
     <br/>
-    <code>
-     KEY:CUSTM3
-    </code>
+    <code>KEY:CUSTM3</code>
     - Custom Fitx3 [Medium Armor]
     <br/>
-    <code>
-     KEY:CUSTH1
-    </code>
+    <code>KEY:CUSTH1</code>
     - Custom Fitx1 [Heavy Armor]
     <br/>
-    <code>
-     KEY:CUSTH2
-    </code>
+    <code>KEY:CUSTH2</code>
     - Custom Fitx2 [Heavy Armor]
     <br/>
-    <code>
-     KEY:CUSTH3
-    </code>
+    <code>KEY:CUSTH3</code>
     - Custom Fitx3 [Heavy Armor]
     <br/>
-    <code>
-     KEY:DURAL1
-    </code>
+    <code>KEY:DURAL1</code>
     - Durabilityx1 [Light Armor]
     <br/>
-    <code>
-     KEY:DURAL2
-    </code>
+    <code>KEY:DURAL2</code>
     - Durabilityx2 [Light Armor]
     <br/>
-    <code>
-     KEY:DURAL3
-    </code>
+    <code>KEY:DURAL3</code>
     - Durabilityx3 [Light Armor]
     <br/>
-    <code>
-     KEY:DURAL4
-    </code>
+    <code>KEY:DURAL4</code>
     - Durabilityx4 [Light Armor]
     <br/>
-    <code>
-     KEY:DURAL5
-    </code>
+    <code>KEY:DURAL5</code>
     - Durabilityx5 [Light Armor]
     <br/>
-    <code>
-     KEY:DURAM1
-    </code>
+    <code>KEY:DURAM1</code>
     - Durabilityx1 [Medium Armor]
     <br/>
-    <code>
-     KEY:DURAM2
-    </code>
+    <code>KEY:DURAM2</code>
     - Durabilityx2 [Medium Armor]
     <br/>
-    <code>
-     KEY:DURAM3
-    </code>
+    <code>KEY:DURAM3</code>
     - Durabilityx3 [Medium Armor]
     <br/>
-    <code>
-     KEY:DURAM4
-    </code>
+    <code>KEY:DURAM4</code>
     - Durabilityx4 [Medium Armor]
     <br/>
-    <code>
-     KEY:DURAM5
-    </code>
+    <code>KEY:DURAM5</code>
     - Durabilityx5 [Medium Armor]
     <br/>
-    <code>
-     KEY:DURAH1
-    </code>
+    <code>KEY:DURAH1</code>
     - Durabilityx1 [Heavy Armor]
     <br/>
-    <code>
-     KEY:DURAH2
-    </code>
+    <code>KEY:DURAH2</code>
     - Durabilityx2 [Heavy Armor]
     <br/>
-    <code>
-     KEY:DURAH3
-    </code>
+    <code>KEY:DURAH3</code>
     - Durabilityx3 [Heavy Armor]
     <br/>
-    <code>
-     KEY:DURAH4
-    </code>
+    <code>KEY:DURAH4</code>
     - Durabilityx4 [Heavy Armor]
     <br/>
-    <code>
-     KEY:DURAH5
-    </code>
+    <code>KEY:DURAH5</code>
     - Durabilityx5 [Heavy Armor]
     <br/>
-    <code>
-     KEY:ENH_ALL1
-    </code>
+    <code>KEY:ENH_ALL1</code>
     - Enhanced Alloyx1
     <br/>
-    <code>
-     KEY:ENH_ALL2
-    </code>
+    <code>KEY:ENH_ALL2</code>
     - Enhanced Alloyx2
     <br/>
-    <code>
-     KEY:ENH_ALL3
-    </code>
+    <code>KEY:ENH_ALL3</code>
     - Enhanced Alloyx3
     <br/>
-    <code>
-     KEY:HARDL1
-    </code>
+    <code>KEY:HARDL1</code>
     - Hardenedx1 [Light Armor]
     <br/>
-    <code>
-     KEY:HARDL2
-    </code>
+    <code>KEY:HARDL2</code>
     - Hardenedx2 [Light Armor]
     <br/>
-    <code>
-     KEY:HARDS1
-    </code>
+    <code>KEY:HARDS1</code>
     - Hardenedx1 [Shield]
     <br/>
-    <code>
-     KEY:HARDS2
-    </code>
+    <code>KEY:HARDS2</code>
     - Hardenedx2 [Shield]
     <br/>
-    <code>
-     KEY:HARDM1
-    </code>
+    <code>KEY:HARDM1</code>
     - Hardenedx1 [Medium Armor]
     <br/>
-    <code>
-     KEY:HARDM2
-    </code>
+    <code>KEY:HARDM2</code>
     - Hardenedx2 [Medium Armor]
     <br/>
-    <code>
-     KEY:HARDH1
-    </code>
+    <code>KEY:HARDH1</code>
     - Hardenedx1 [Heavy Armor]
     <br/>
-    <code>
-     KEY:HARDH2
-    </code>
+    <code>KEY:HARDH2</code>
     - Hardenedx2 [Heavy Armor]
     <br/>
-    <code>
-     KEY:MMARK
-    </code>
+    <code>KEY:MMARK</code>
     - Maker's Mark
     <br/>
-    <code>
-     KEY:MOBILITY_ARMR_LT
-    </code>
+    <code>KEY:MOBILITY_ARMR_LT</code>
     - Mobility [Light Armor]
     <br/>
-    <code>
-     KEY:MOBILITY_ARMR_MED
-    </code>
+    <code>KEY:MOBILITY_ARMR_MED</code>
     - Mobility [Medium Armor]
     <br/>
-    <code>
-     KEY:MOBILITY_ARMR_HVY
-    </code>
+    <code>KEY:MOBILITY_ARMR_HVY</code>
     - Mobility [Heavy Armor]
     <br/>
-    <code>
-     KEY:RWT
-    </code>
+    <code>KEY:RWT</code>
     - Reduced Weight
     <br/>
-    <code>
-     KEY:SBALL1
-    </code>
+    <code>KEY:SBALL1</code>
     - Superb Balancex1 [Light Armor]
     <br/>
-    <code>
-     KEY:SBALL2
-    </code>
+    <code>KEY:SBALL2</code>
     - Superb Balancex2 [Light Armor]
     <br/>
-    <code>
-     KEY:SBALM1
-    </code>
+    <code>KEY:SBALM1</code>
     - Superb Balancex1 [Medium Armor]
     <br/>
-    <code>
-     KEY:SBALM2
-    </code>
+    <code>KEY:SBALM2</code>
     - Superb Balancex2 [Medium Armor]
     <br/>
-    <code>
-     KEY:SBALH1
-    </code>
+    <code>KEY:SBALH1</code>
     - Superb Balancex1 [Heavy Armor]
     <br/>
-    <code>
-     KEY:SBALH2
-    </code>
+    <code>KEY:SBALH2</code>
     - Superb Balancex2 [Heavy Armor]
     <br/>
    </p>
@@ -7723,74 +5125,46 @@ Dwarves
     </strong>
    </p>
    <p>
-    <code>
-     KEY:ARMRDBCL
-    </code>
+    <code>KEY:ARMRDBCL</code>
     - Celestial Bone
     <br/>
-    <code>
-     KEY:ARMRDFL1
-    </code>
+    <code>KEY:ARMRDFL1</code>
     - Deflecting +1
     <br/>
-    <code>
-     KEY:ARMRDFL2
-    </code>
+    <code>KEY:ARMRDFL2</code>
     - Deflecting +2
     <br/>
-    <code>
-     KEY:ARMRDFL3
-    </code>
+    <code>KEY:ARMRDFL3</code>
     - Deflecting +3
     <br/>
-    <code>
-     KEY:ARMRDFL4
-    </code>
+    <code>KEY:ARMRDFL4</code>
     - Deflecting +4
     <br/>
-    <code>
-     KEY:ARMRRSHP
-    </code>
+    <code>KEY:ARMRRSHP</code>
     - Reshaping
     <br/>
-    <code>
-     KEY:WPNDBLD
-    </code>
+    <code>KEY:WPNDBLD</code>
     - Blinding
     <br/>
-    <code>
-     KEY:WPNDBLK
-    </code>
+    <code>KEY:WPNDBLK</code>
     - Blinking
     <br/>
-    <code>
-     KEY:WPNDBCL
-    </code>
+    <code>KEY:WPNDBCL</code>
     - Celestial Bone
     <br/>
-    <code>
-     KEY:WPNDFL1
-    </code>
+    <code>KEY:WPNDFL1</code>
     - Deflecting +1
     <br/>
-    <code>
-     KEY:WPNDFL2
-    </code>
+    <code>KEY:WPNDFL2</code>
     - Deflecting +2
     <br/>
-    <code>
-     KEY:WPNDFL3
-    </code>
+    <code>KEY:WPNDFL3</code>
     - Deflecting +3
     <br/>
-    <code>
-     KEY:WPNDFL4
-    </code>
+    <code>KEY:WPNDFL4</code>
     - Deflecting +4
     <br/>
-    <code>
-     KEY:WPNDPRS
-    </code>
+    <code>KEY:WPNDPRS</code>
     - Persuading
     <br/>
    </p>
@@ -7817,9 +5191,7 @@ File.
     </strong>
    </p>
    <p>
-    <code>
-     KEY:RAGE_FLAW
-    </code>
+    <code>KEY:RAGE_FLAW</code>
     - Rage
     <br/>
    </p>
@@ -7845,14 +5217,10 @@ Press (BFP) - Cityscape (3e)
     </strong>
    </p>
    <p>
-    <code>
-     KEY:ARMCAM
-    </code>
+    <code>KEY:ARMCAM</code>
     - Camouflage
     <br/>
-    <code>
-     KEY:ARMREF
-    </code>
+    <code>KEY:ARMREF</code>
     - Reflective
     <br/>
    </p>
@@ -7878,118 +5246,76 @@ Press (BFP) - Pulp Fantasy (Modern)
     </strong>
    </p>
    <p>
-    <code>
-     KEY:AAVEHICLE
-    </code>
+    <code>KEY:AAVEHICLE</code>
     - Vehicle
     <br/>
-    <code>
-     KEY:CHARGED_ITEM_12
-    </code>
+    <code>KEY:CHARGED_ITEM_12</code>
     - Charges (12)
     <br/>
-    <code>
-     KEY:GDGT_EXTND
-    </code>
+    <code>KEY:GDGT_EXTND</code>
     - Extend Invention Feat
     <br/>
-    <code>
-     KEY:GDGT_FDBCK
-    </code>
+    <code>KEY:GDGT_FDBCK</code>
     - Feedback Flaw
     <br/>
-    <code>
-     KEY:GDGT_IMPRO
-    </code>
+    <code>KEY:GDGT_IMPRO</code>
     - Improvised Invention Feat
     <br/>
-    <code>
-     KEY:GDGT_INV_LVL
-    </code>
+    <code>KEY:GDGT_INV_LVL</code>
     - Base Invention Level
     <br/>
-    <code>
-     KEY:GDGT_LOSS_AB
-    </code>
+    <code>KEY:GDGT_LOSS_AB</code>
     - Ability Loss Flaw
     <br/>
-    <code>
-     KEY:GDGT_MINI
-    </code>
+    <code>KEY:GDGT_MINI</code>
     - Miniaturize Invention Feat
     <br/>
-    <code>
-     KEY:GDGT_PWR_DRN
-    </code>
+    <code>KEY:GDGT_PWR_DRN</code>
     - Power Drain Flaw
     <br/>
-    <code>
-     KEY:GDGT_SMPL
-    </code>
+    <code>KEY:GDGT_SMPL</code>
     - Simplified Invention Feat
     <br/>
-    <code>
-     KEY:GDGT_SPL_CMD1
-    </code>
+    <code>KEY:GDGT_SPL_CMD1</code>
     - |1st level Spell Effect (50
 Uses/Gadget)
     <br/>
-    <code>
-     KEY:GDGT_SPL_CMD2
-    </code>
+    <code>KEY:GDGT_SPL_CMD2</code>
     - |2nd level Spell Effect (50
 Uses/Gadget)
     <br/>
-    <code>
-     KEY:GDGT_SPL_CMD3
-    </code>
+    <code>KEY:GDGT_SPL_CMD3</code>
     - |3rd level Spell Effect (50
 Uses/Gadget)
     <br/>
-    <code>
-     KEY:GDGT_SPL_CMD4
-    </code>
+    <code>KEY:GDGT_SPL_CMD4</code>
     - |4th level Spell Effect (50
 Uses/Gadget)
     <br/>
-    <code>
-     KEY:GDGT_SPL_CMD5
-    </code>
+    <code>KEY:GDGT_SPL_CMD5</code>
     - |5th level Spell Effect (50
 Uses/Gadget)
     <br/>
-    <code>
-     KEY:GDGT_SPL_CMD6
-    </code>
+    <code>KEY:GDGT_SPL_CMD6</code>
     - |6th level Spell Effect (50
 Uses/Gadget)
     <br/>
-    <code>
-     KEY:GDGT_SPL_CMD7
-    </code>
+    <code>KEY:GDGT_SPL_CMD7</code>
     - |7th level Spell Effect (50
 Uses/Gadget)
     <br/>
-    <code>
-     KEY:GDGT_SPL_CMD8
-    </code>
+    <code>KEY:GDGT_SPL_CMD8</code>
     - |8th level Spell Effect (50
 Uses/Gadget)
     <br/>
-    <code>
-     KEY:GDGT_SPL_CMD9
-    </code>
+    <code>KEY:GDGT_SPL_CMD9</code>
     - |9th level Spell Effect (50
 Uses/Gadget)
     <br/>
-    <code>
-     KEY:GDGT_SPR_SHDN
-    </code>
+    <code>KEY:GDGT_SPR_SHDN</code>
     - Sporadic Shut Down Flaw
     <br/>
-    <code>
-     KEY:Linguist_BP_PFF
-    </code>
+    <code>KEY:Linguist_BP_PFF</code>
     - Linguist
     <br/>
    </p>
@@ -8016,108 +5342,70 @@ Press (BFP) - Rocket Rangers - King of the Rocket Men
     </strong>
    </p>
    <p>
-    <code>
-     KEY:AAVEHICLE
-    </code>
+    <code>KEY:AAVEHICLE</code>
     - Vehicle
     <br/>
-    <code>
-     KEY:GDGT_EXTND
-    </code>
+    <code>KEY:GDGT_EXTND</code>
     - Extend Invention Feat
     <br/>
-    <code>
-     KEY:GDGT_FDBCK
-    </code>
+    <code>KEY:GDGT_FDBCK</code>
     - Feedback Flaw
     <br/>
-    <code>
-     KEY:GDGT_IMPRO
-    </code>
+    <code>KEY:GDGT_IMPRO</code>
     - Improvised Invention Feat
     <br/>
-    <code>
-     KEY:GDGT_INV_LVL
-    </code>
+    <code>KEY:GDGT_INV_LVL</code>
     - Base Invention Level
     <br/>
-    <code>
-     KEY:GDGT_LOSS_AB
-    </code>
+    <code>KEY:GDGT_LOSS_AB</code>
     - Ability Loss Flaw
     <br/>
-    <code>
-     KEY:GDGT_MINI
-    </code>
+    <code>KEY:GDGT_MINI</code>
     - Miniaturize Invention Feat
     <br/>
-    <code>
-     KEY:GDGT_PWR_DRN
-    </code>
+    <code>KEY:GDGT_PWR_DRN</code>
     - Power Drain Flaw
     <br/>
-    <code>
-     KEY:GDGT_SMPL
-    </code>
+    <code>KEY:GDGT_SMPL</code>
     - Simplified Invention Feat
     <br/>
-    <code>
-     KEY:GDGT_SPL_CMD1
-    </code>
+    <code>KEY:GDGT_SPL_CMD1</code>
     - |1st level Spell Effect (50
 Uses/Gadget)
     <br/>
-    <code>
-     KEY:GDGT_SPL_CMD2
-    </code>
+    <code>KEY:GDGT_SPL_CMD2</code>
     - |2nd level Spell Effect (50
 Uses/Gadget)
     <br/>
-    <code>
-     KEY:GDGT_SPL_CMD3
-    </code>
+    <code>KEY:GDGT_SPL_CMD3</code>
     - |3rd level Spell Effect (50
 Uses/Gadget)
     <br/>
-    <code>
-     KEY:GDGT_SPL_CMD4
-    </code>
+    <code>KEY:GDGT_SPL_CMD4</code>
     - |4th level Spell Effect (50
 Uses/Gadget)
     <br/>
-    <code>
-     KEY:GDGT_SPL_CMD5
-    </code>
+    <code>KEY:GDGT_SPL_CMD5</code>
     - |5th level Spell Effect (50
 Uses/Gadget)
     <br/>
-    <code>
-     KEY:GDGT_SPL_CMD6
-    </code>
+    <code>KEY:GDGT_SPL_CMD6</code>
     - |6th level Spell Effect (50
 Uses/Gadget)
     <br/>
-    <code>
-     KEY:GDGT_SPL_CMD7
-    </code>
+    <code>KEY:GDGT_SPL_CMD7</code>
     - |7th level Spell Effect (50
 Uses/Gadget)
     <br/>
-    <code>
-     KEY:GDGT_SPL_CMD8
-    </code>
+    <code>KEY:GDGT_SPL_CMD8</code>
     - |8th level Spell Effect (50
 Uses/Gadget)
     <br/>
-    <code>
-     KEY:GDGT_SPL_CMD9
-    </code>
+    <code>KEY:GDGT_SPL_CMD9</code>
     - |9th level Spell Effect (50
 Uses/Gadget)
     <br/>
-    <code>
-     KEY:GDGT_SPR_SHDN
-    </code>
+    <code>KEY:GDGT_SPR_SHDN</code>
     - Sporadic Shut Down Flaw
     <br/>
    </p>
@@ -8143,99 +5431,61 @@ Uses/Gadget)
     </strong>
    </p>
    <p>
-    <code>
-     KEY:ARTICULATED
-    </code>
+    <code>KEY:ARTICULATED</code>
     - Articulated
     <br/>
-    <code>
-     KEY:BAL_THROWN
-    </code>
+    <code>KEY:BAL_THROWN</code>
     - Balanced
     <br/>
-    <code>
-     KEY:BAL_RANGE
-    </code>
+    <code>KEY:BAL_RANGE</code>
     - Balanced
     <br/>
-    <code>
-     KEY:BARBED
-    </code>
+    <code>KEY:BARBED</code>
     - Barbed
     <br/>
-    <code>
-     KEY:CUST_HILT
-    </code>
+    <code>KEY:CUST_HILT</code>
     - Custom Hilt
     <br/>
-    <code>
-     KEY:DIRE
-    </code>
+    <code>KEY:DIRE</code>
     - Dire
     <br/>
-    <code>
-     KEY:FLEXIBLE
-    </code>
+    <code>KEY:FLEXIBLE</code>
     - Flexible
     <br/>
-    <code>
-     KEY:FORTIFIED
-    </code>
+    <code>KEY:FORTIFIED</code>
     - Fortified
     <br/>
-    <code>
-     KEY:GUARD
-    </code>
+    <code>KEY:GUARD</code>
     - Guard
     <br/>
-    <code>
-     KEY:HOOK
-    </code>
+    <code>KEY:HOOK</code>
     - Hook
     <br/>
-    <code>
-     KEY:INSULATED
-    </code>
+    <code>KEY:INSULATED</code>
     - Insulated
     <br/>
-    <code>
-     KEY:MULTIPART
-    </code>
+    <code>KEY:MULTIPART</code>
     - Multipart
     <br/>
-    <code>
-     KEY:PERF_BAL
-    </code>
+    <code>KEY:PERF_BAL</code>
     - Perfect Balance - Weapon
     <br/>
-    <code>
-     KEY:PERF_EDGE
-    </code>
+    <code>KEY:PERF_EDGE</code>
     - Perfect Edge - Weapon
     <br/>
-    <code>
-     KEY:REINFRCD_ARMR
-    </code>
+    <code>KEY:REINFRCD_ARMR</code>
     - Reinforced - Armor
     <br/>
-    <code>
-     KEY:REINFRCD_WEAP
-    </code>
+    <code>KEY:REINFRCD_WEAP</code>
     - Reinforced - Weapon
     <br/>
-    <code>
-     KEY:SERRATED
-    </code>
+    <code>KEY:SERRATED</code>
     - Serrated
     <br/>
-    <code>
-     KEY:TASSLE
-    </code>
+    <code>KEY:TASSLE</code>
     - Tassel
     <br/>
-    <code>
-     KEY:TRAP
-    </code>
+    <code>KEY:TRAP</code>
     - Trap
     <br/>
    </p>
@@ -8262,54 +5512,34 @@ File.
     </strong>
    </p>
    <p>
-    <code>
-     KEY:CERAMIC_ARM
-    </code>
+    <code>KEY:CERAMIC_ARM</code>
     - Ceramics
     <br/>
-    <code>
-     KEY:CERAMIC_WEAP
-    </code>
+    <code>KEY:CERAMIC_WEAP</code>
     - Ceramics
     <br/>
-    <code>
-     KEY:DURASTEEL_ARM
-    </code>
+    <code>KEY:DURASTEEL_ARM</code>
     - Durasteel
     <br/>
-    <code>
-     KEY:DURASTEEL_SHIELD
-    </code>
+    <code>KEY:DURASTEEL_SHIELD</code>
     - Durasteel
     <br/>
-    <code>
-     KEY:DURASTEEL_WEAP
-    </code>
+    <code>KEY:DURASTEEL_WEAP</code>
     - Durasteel
     <br/>
-    <code>
-     KEY:HONED_DURA_WEAP
-    </code>
+    <code>KEY:HONED_DURA_WEAP</code>
     - Honed Durasteel
     <br/>
-    <code>
-     KEY:LUMINSTONE
-    </code>
+    <code>KEY:LUMINSTONE</code>
     - Luminstone
     <br/>
-    <code>
-     KEY:PLAS_EFF_MAT
-    </code>
+    <code>KEY:PLAS_EFF_MAT</code>
     - Plasma Efficiency Matrix
     <br/>
-    <code>
-     KEY:REF_SPR_MOD
-    </code>
+    <code>KEY:REF_SPR_MOD</code>
     - Reflecting Spread Module
     <br/>
-    <code>
-     KEY:SMART_LINK
-    </code>
+    <code>KEY:SMART_LINK</code>
     - Smart Link
     <br/>
    </p>
@@ -8335,105 +5565,67 @@ Spycraft (Spycraft)
     </strong>
    </p>
    <p>
-    <code>
-     KEY:BACKFIRE_PALMPRINT_ID
-    </code>
+    <code>KEY:BACKFIRE_PALMPRINT_ID</code>
     - Backfire Palmprint
 ID
     <br/>
-    <code>
-     KEY:BACKUP_IDCARD
-    </code>
+    <code>KEY:BACKUP_IDCARD</code>
     - Backup ID
     <br/>
-    <code>
-     KEY:BLINDMAN_EARIMPLANT
-    </code>
+    <code>KEY:BLINDMAN_EARIMPLANT</code>
     - Blindman Unit
     <br/>
-    <code>
-     KEY:BLOWBACK_PALMPRINT_ID
-    </code>
+    <code>KEY:BLOWBACK_PALMPRINT_ID</code>
     - Blowback Palmprint
 ID
     <br/>
-    <code>
-     KEY:DANGER_EARIMPLANT
-    </code>
+    <code>KEY:DANGER_EARIMPLANT</code>
     - Danger Unit
     <br/>
-    <code>
-     KEY:DIVINGSUIT_PROPELLERS
-    </code>
+    <code>KEY:DIVINGSUIT_PROPELLERS</code>
     - Propellers
     <br/>
-    <code>
-     KEY:DUPLICATION_IDCARD
-    </code>
+    <code>KEY:DUPLICATION_IDCARD</code>
     - Duplication
     <br/>
-    <code>
-     KEY:ELECTRONIC_LOCKPICK_IDCARD
-    </code>
+    <code>KEY:ELECTRONIC_LOCKPICK_IDCARD</code>
     - Electronic
 Lockpick
     <br/>
-    <code>
-     KEY:FLUID_BREATH_TANKS
-    </code>
+    <code>KEY:FLUID_BREATH_TANKS</code>
     - Fluid Breath Tanks
     <br/>
-    <code>
-     KEY:GARAGE_SUITE
-    </code>
+    <code>KEY:GARAGE_SUITE</code>
     - Garage Suite
     <br/>
-    <code>
-     KEY:MARK_I_STANDARD_PALMPRINT_ID
-    </code>
+    <code>KEY:MARK_I_STANDARD_PALMPRINT_ID</code>
     - Mark I Standard
 Palmprint ID
     <br/>
-    <code>
-     KEY:MEDICAL_SUITE
-    </code>
+    <code>KEY:MEDICAL_SUITE</code>
     - Medical Suite
     <br/>
-    <code>
-     KEY:PHONE_REMOTE_CONTROL
-    </code>
+    <code>KEY:PHONE_REMOTE_CONTROL</code>
     - Remote Control
     <br/>
-    <code>
-     KEY:PHONE_SLIP_AWAY_UNIT
-    </code>
+    <code>KEY:PHONE_SLIP_AWAY_UNIT</code>
     - Slip-Away Unit
     <br/>
-    <code>
-     KEY:POLYGRAPH_EARIMPLANT
-    </code>
+    <code>KEY:POLYGRAPH_EARIMPLANT</code>
     - Polygraph/Voice Stress
 Analyzer
     <br/>
-    <code>
-     KEY:PROPS_SUITE
-    </code>
+    <code>KEY:PROPS_SUITE</code>
     - Props Suite
     <br/>
-    <code>
-     KEY:SURVEILLANCE_SUITE
-    </code>
+    <code>KEY:SURVEILLANCE_SUITE</code>
     - Surveillance Suite
     <br/>
-    <code>
-     KEY:TRACKING_MODIFICATION_PALMPRINT_ID
-    </code>
+    <code>KEY:TRACKING_MODIFICATION_PALMPRINT_ID</code>
     - Tracking
 Modification Palmprint ID
     <br/>
-    <code>
-     KEY:WARNING_SIGNAL_IDCARD
-    </code>
+    <code>KEY:WARNING_SIGNAL_IDCARD</code>
     - Warning Signal
     <br/>
    </p>
@@ -8443,426 +5635,260 @@ Modification Palmprint ID
     </strong>
    </p>
    <p>
-    <code>
-     KEY:ALL_IN_ONE
-    </code>
+    <code>KEY:ALL_IN_ONE</code>
     - All-in-one
     <br/>
-    <code>
-     KEY:AUTO_TINT
-    </code>
+    <code>KEY:AUTO_TINT</code>
     - Auto-tint
     <br/>
-    <code>
-     KEY:AUTOPILOT
-    </code>
+    <code>KEY:AUTOPILOT</code>
     - Autopilot
     <br/>
-    <code>
-     KEY:BLACK_HEADLIGHTS
-    </code>
+    <code>KEY:BLACK_HEADLIGHTS</code>
     - Black headlights
     <br/>
-    <code>
-     KEY:BLADE_SHOE
-    </code>
+    <code>KEY:BLADE_SHOE</code>
     - Blade
     <br/>
-    <code>
-     KEY:BOOBY_TRAPPED
-    </code>
+    <code>KEY:BOOBY_TRAPPED</code>
     - Booby trapped
     <br/>
-    <code>
-     KEY:BREAKDOWN_GUN
-    </code>
+    <code>KEY:BREAKDOWN_GUN</code>
     - Electronic Scope
     <br/>
-    <code>
-     KEY:CBQ_WEAPON
-    </code>
+    <code>KEY:CBQ_WEAPON</code>
     - CBQ
     <br/>
-    <code>
-     KEY:CLOAKING_DEVICE
-    </code>
+    <code>KEY:CLOAKING_DEVICE</code>
     - Cloaking device
     <br/>
-    <code>
-     KEY:COMPUTER_PLUS_1
-    </code>
+    <code>KEY:COMPUTER_PLUS_1</code>
     - +1
     <br/>
-    <code>
-     KEY:COMPUTER_PLUS_2
-    </code>
+    <code>KEY:COMPUTER_PLUS_2</code>
     - +2
     <br/>
-    <code>
-     KEY:COMPUTER_PLUS_3
-    </code>
+    <code>KEY:COMPUTER_PLUS_3</code>
     - +3
     <br/>
-    <code>
-     KEY:CONCEALED_MACHINE_GUN
-    </code>
+    <code>KEY:CONCEALED_MACHINE_GUN</code>
     - Concealed machine
 gun
     <br/>
-    <code>
-     KEY:COPYCAT
-    </code>
+    <code>KEY:COPYCAT</code>
     - Copycat
     <br/>
-    <code>
-     KEY:COUNTER_SURVEILLANCE
-    </code>
+    <code>KEY:COUNTER_SURVEILLANCE</code>
     - Counter surveillance
     <br/>
-    <code>
-     KEY:DUMMY_LINE
-    </code>
+    <code>KEY:DUMMY_LINE</code>
     - Dummy line
     <br/>
-    <code>
-     KEY:EJECTION_SEATS
-    </code>
+    <code>KEY:EJECTION_SEATS</code>
     - Ejection seats
     <br/>
-    <code>
-     KEY:ELECTRIFIED_FRAME
-    </code>
+    <code>KEY:ELECTRIFIED_FRAME</code>
     - Electrified frame
     <br/>
-    <code>
-     KEY:EXPLOSIVE_WATCH
-    </code>
+    <code>KEY:EXPLOSIVE_WATCH</code>
     - Explosive
     <br/>
-    <code>
-     KEY:EXTRA_ARMOR
-    </code>
+    <code>KEY:EXTRA_ARMOR</code>
     - Extra armor
     <br/>
-    <code>
-     KEY:FACEPRINT_LENSES
-    </code>
+    <code>KEY:FACEPRINT_LENSES</code>
     - Faceprint
     <br/>
-    <code>
-     KEY:FLASH_SUPPRESSOR
-    </code>
+    <code>KEY:FLASH_SUPPRESSOR</code>
     - Flash Suppressor
     <br/>
-    <code>
-     KEY:GARROTE_WATCH
-    </code>
+    <code>KEY:GARROTE_WATCH</code>
     - Garrote
     <br/>
-    <code>
-     KEY:GPS_WATCH
-    </code>
+    <code>KEY:GPS_WATCH</code>
     - GPS
     <br/>
-    <code>
-     KEY:GUN_SHOE
-    </code>
+    <code>KEY:GUN_SHOE</code>
     - Gun
     <br/>
-    <code>
-     KEY:HEADS_UP_DISPLAY
-    </code>
+    <code>KEY:HEADS_UP_DISPLAY</code>
     - Heads Up Display
     <br/>
-    <code>
-     KEY:HIDDEN_COMPARTMENT
-    </code>
+    <code>KEY:HIDDEN_COMPARTMENT</code>
     - Hidden compartment
     <br/>
-    <code>
-     KEY:HOMING_BEACON_SHOE
-    </code>
+    <code>KEY:HOMING_BEACON_SHOE</code>
     - Homing beacon
     <br/>
-    <code>
-     KEY:HUSH_PUPPY
-    </code>
+    <code>KEY:HUSH_PUPPY</code>
     - Hush Puppy
     <br/>
-    <code>
-     KEY:HYPNOSIS_LENSES
-    </code>
+    <code>KEY:HYPNOSIS_LENSES</code>
     - Hypnosis
     <br/>
-    <code>
-     KEY:IMPROVED_HANDLING
-    </code>
+    <code>KEY:IMPROVED_HANDLING</code>
     - Improved handling
     <br/>
-    <code>
-     KEY:IRIS_LENSES
-    </code>
+    <code>KEY:IRIS_LENSES</code>
     - Iris
     <br/>
-    <code>
-     KEY:LASER_MOUNT
-    </code>
+    <code>KEY:LASER_MOUNT</code>
     - Laser mount
     <br/>
-    <code>
-     KEY:LASER_SIGHT
-    </code>
+    <code>KEY:LASER_SIGHT</code>
     - Laser Sight
     <br/>
-    <code>
-     KEY:LCD_LENSES
-    </code>
+    <code>KEY:LCD_LENSES</code>
     - LCD
     <br/>
-    <code>
-     KEY:LOCKPICK_SET
-    </code>
+    <code>KEY:LOCKPICK_SET</code>
     - Lockpick set
     <br/>
-    <code>
-     KEY:MACHINE_PISTOL
-    </code>
+    <code>KEY:MACHINE_PISTOL</code>
     - Machine pistol
     <br/>
-    <code>
-     KEY:MAGIC_BOX
-    </code>
+    <code>KEY:MAGIC_BOX</code>
     - Magic box
     <br/>
-    <code>
-     KEY:MAGNET_EYES_LENSES
-    </code>
+    <code>KEY:MAGNET_EYES_LENSES</code>
     - Magnet eyes
     <br/>
-    <code>
-     KEY:MATCH_GRADE_WEAPON
-    </code>
+    <code>KEY:MATCH_GRADE_WEAPON</code>
     - Match grade weapon
     <br/>
-    <code>
-     KEY:MEMORY_CACHE_WATCH
-    </code>
+    <code>KEY:MEMORY_CACHE_WATCH</code>
     - Memory cache
     <br/>
-    <code>
-     KEY:NITROUS_OXIDE_SYSTEM
-    </code>
+    <code>KEY:NITROUS_OXIDE_SYSTEM</code>
     - Nitrous oxide system
     <br/>
-    <code>
-     KEY:NON_SINUSOIDAL
-    </code>
+    <code>KEY:NON_SINUSOIDAL</code>
     - Non-sinusoidal transmission
     <br/>
-    <code>
-     KEY:OIL_SLICK
-    </code>
+    <code>KEY:OIL_SLICK</code>
     - Oil slick
     <br/>
-    <code>
-     KEY:OTHER_DIRECTIONAL_GLASSES
-    </code>
+    <code>KEY:OTHER_DIRECTIONAL_GLASSES</code>
     - Other directional
 glasses
     <br/>
-    <code>
-     KEY:PHONE_SHOE
-    </code>
+    <code>KEY:PHONE_SHOE</code>
     - Phone
     <br/>
-    <code>
-     KEY:PIEZO_BUG
-    </code>
+    <code>KEY:PIEZO_BUG</code>
     - Piezo-bug
     <br/>
-    <code>
-     KEY:POISON_SPIKE_WATCH
-    </code>
+    <code>KEY:POISON_SPIKE_WATCH</code>
     - Poison spike
     <br/>
-    <code>
-     KEY:POP_UP_SHIELD
-    </code>
+    <code>KEY:POP_UP_SHIELD</code>
     - Pop-up shield
     <br/>
-    <code>
-     KEY:PORTABLE_PC
-    </code>
+    <code>KEY:PORTABLE_PC</code>
     - Portable PC
     <br/>
-    <code>
-     KEY:PROTEUS_PACKAGE
-    </code>
+    <code>KEY:PROTEUS_PACKAGE</code>
     - Proteus package
     <br/>
-    <code>
-     KEY:RAZORS_EDGE
-    </code>
+    <code>KEY:RAZORS_EDGE</code>
     - Razor's edge
     <br/>
-    <code>
-     KEY:REINFORCED_TIRES
-    </code>
+    <code>KEY:REINFORCED_TIRES</code>
     - Reinforced tires
     <br/>
-    <code>
-     KEY:REMOTE_CONTROL
-    </code>
+    <code>KEY:REMOTE_CONTROL</code>
     - Remote control
     <br/>
-    <code>
-     KEY:REVOLVING_LICENSE_PLATE
-    </code>
+    <code>KEY:REVOLVING_LICENSE_PLATE</code>
     - Revolving license
 plate
     <br/>
-    <code>
-     KEY:ROCKET_LAUNCHER
-    </code>
+    <code>KEY:ROCKET_LAUNCHER</code>
     - Rocket launcher
     <br/>
-    <code>
-     KEY:ROLLER_ICE_BLADES_SHOE
-    </code>
+    <code>KEY:ROLLER_ICE_BLADES_SHOE</code>
     - Roller/ice blades
     <br/>
-    <code>
-     KEY:ROTARY_SAW_WATCH
-    </code>
+    <code>KEY:ROTARY_SAW_WATCH</code>
     - Rotary saw
     <br/>
-    <code>
-     KEY:SAFE_PASSAGE
-    </code>
+    <code>KEY:SAFE_PASSAGE</code>
     - Safe passage
     <br/>
-    <code>
-     KEY:SEALED_LENSES
-    </code>
+    <code>KEY:SEALED_LENSES</code>
     - Sealed lenses
     <br/>
-    <code>
-     KEY:SHOCK_TIP_SHOE
-    </code>
+    <code>KEY:SHOCK_TIP_SHOE</code>
     - Shock tip
     <br/>
-    <code>
-     KEY:SILENCED_REVOLVER
-    </code>
+    <code>KEY:SILENCED_REVOLVER</code>
     - Silenced revolver
     <br/>
-    <code>
-     KEY:SILENCER
-    </code>
+    <code>KEY:SILENCER</code>
     - Silencer
     <br/>
-    <code>
-     KEY:SMOKE_SCREEN
-    </code>
+    <code>KEY:SMOKE_SCREEN</code>
     - Smoke screen
     <br/>
-    <code>
-     KEY:SPIKE_DROPPER
-    </code>
+    <code>KEY:SPIKE_DROPPER</code>
     - Spike dropper
     <br/>
-    <code>
-     KEY:STARLIGHT_LENSES
-    </code>
+    <code>KEY:STARLIGHT_LENSES</code>
     - Starlight lenses
     <br/>
-    <code>
-     KEY:SUBMACHINE_GUN
-    </code>
+    <code>KEY:SUBMACHINE_GUN</code>
     - Submachine gun
     <br/>
-    <code>
-     KEY:SUCTION_SHOE
-    </code>
+    <code>KEY:SUCTION_SHOE</code>
     - Suction
     <br/>
-    <code>
-     KEY:SURVEILLANCE
-    </code>
+    <code>KEY:SURVEILLANCE</code>
     - Surveillance
     <br/>
-    <code>
-     KEY:TELESCOPIC_LENSES
-    </code>
+    <code>KEY:TELESCOPIC_LENSES</code>
     - Telescopic lenses
     <br/>
-    <code>
-     KEY:TELESCOPIC_SIGHT
-    </code>
+    <code>KEY:TELESCOPIC_SIGHT</code>
     - Telescopic Sight
     <br/>
-    <code>
-     KEY:THERMPGRAPHIC_LENSES
-    </code>
+    <code>KEY:THERMPGRAPHIC_LENSES</code>
     - Thermpgraphic lenses
     <br/>
-    <code>
-     KEY:TIRE_SLASHER
-    </code>
+    <code>KEY:TIRE_SLASHER</code>
     - Tire slasher
     <br/>
-    <code>
-     KEY:TRANSLATOR_LENSES
-    </code>
+    <code>KEY:TRANSLATOR_LENSES</code>
     - Translator lenses
     <br/>
-    <code>
-     KEY:TRANSMITTER_LENSES
-    </code>
+    <code>KEY:TRANSMITTER_LENSES</code>
     - Transmitter lenses
     <br/>
-    <code>
-     KEY:TREADS_SHOE
-    </code>
+    <code>KEY:TREADS_SHOE</code>
     - Treads
     <br/>
-    <code>
-     KEY:TRI_FERENCE_PHOTOGRAPHY
-    </code>
+    <code>KEY:TRI_FERENCE_PHOTOGRAPHY</code>
     - Tri-ference
 photography
     <br/>
-    <code>
-     KEY:TUBULAR_SPACE_FRAME
-    </code>
+    <code>KEY:TUBULAR_SPACE_FRAME</code>
     - Tubular space frame
     <br/>
-    <code>
-     KEY:VOICE_ACTIVATED_COMMAND
-    </code>
+    <code>KEY:VOICE_ACTIVATED_COMMAND</code>
     - Voice Activated Command
 System
     <br/>
-    <code>
-     KEY:WEAPON_ACCURIZING
-    </code>
+    <code>KEY:WEAPON_ACCURIZING</code>
     - Weapon accurizing
     <br/>
-    <code>
-     KEY:WIND_RESISTANCE_REDUCTION_1
-    </code>
+    <code>KEY:WIND_RESISTANCE_REDUCTION_1</code>
     - Wind resistance
 reduction (+1)
     <br/>
-    <code>
-     KEY:WIND_RESISTANCE_REDUCTION_2
-    </code>
+    <code>KEY:WIND_RESISTANCE_REDUCTION_2</code>
     - Wind resistance
 reduction (+2)
     <br/>
-    <code>
-     KEY:X_RAY_LENSES
-    </code>
+    <code>KEY:X_RAY_LENSES</code>
     - X ray lenses
     <br/>
    </p>
@@ -8888,49 +5914,31 @@ reduction (+2)
     </strong>
    </p>
    <p>
-    <code>
-     KEY:CUSGRIP
-    </code>
+    <code>KEY:CUSGRIP</code>
     - Custom Grip
     <br/>
-    <code>
-     KEY:CUSSIT
-    </code>
+    <code>KEY:CUSSIT</code>
     - Custom Sights
     <br/>
-    <code>
-     KEY:DETSTK
-    </code>
+    <code>KEY:DETSTK</code>
     - Detachable Stock
     <br/>
-    <code>
-     KEY:HRTRGR
-    </code>
+    <code>KEY:HRTRGR</code>
     - Hair Trigger
     <br/>
-    <code>
-     KEY:LNGBRL_L
-    </code>
+    <code>KEY:LNGBRL_L</code>
     - Lengthened Barrel
     <br/>
-    <code>
-     KEY:LNGBRL_P
-    </code>
+    <code>KEY:LNGBRL_P</code>
     - Lengthened Barrel
     <br/>
-    <code>
-     KEY:SAWBRL
-    </code>
+    <code>KEY:SAWBRL</code>
     - Sawed-Off Barrel
     <br/>
-    <code>
-     KEY:SHTBRL_L
-    </code>
+    <code>KEY:SHTBRL_L</code>
     - Shortened Barrel
     <br/>
-    <code>
-     KEY:SHTBRL_P
-    </code>
+    <code>KEY:SHTBRL_P</code>
     - Shortened Barrel
     <br/>
    </p>
@@ -8956,9 +5964,7 @@ Games (FFG) - Midnight (3e)
     </strong>
    </p>
    <p>
-    <code>
-     KEY:ICEWD
-    </code>
+    <code>KEY:ICEWD</code>
     - Icewood
     <br/>
    </p>
@@ -8968,29 +5974,19 @@ Games (FFG) - Midnight (3e)
     </strong>
    </p>
    <p>
-    <code>
-     KEY:BONE
-    </code>
+    <code>KEY:BONE</code>
     - Bone
     <br/>
-    <code>
-     KEY:FOLD
-    </code>
+    <code>KEY:FOLD</code>
     - Foldable
     <br/>
-    <code>
-     KEY:HORN
-    </code>
+    <code>KEY:HORN</code>
     - Horn
     <br/>
-    <code>
-     KEY:ROPE
-    </code>
+    <code>KEY:ROPE</code>
     - Rope
     <br/>
-    <code>
-     KEY:STONE
-    </code>
+    <code>KEY:STONE</code>
     - Stone
     <br/>
    </p>
@@ -9010,104 +6006,64 @@ Flight Games (FFG) - Dragonstar (3e)
     </strong>
    </p>
    <p>
-    <code>
-     KEY:SF_CAMO
-    </code>
+    <code>KEY:SF_CAMO</code>
     - Camouflage
     <br/>
-    <code>
-     KEY:SF_DATA
-    </code>
+    <code>KEY:SF_DATA</code>
     - Program
     <br/>
-    <code>
-     KEY:SF_ELECSCOPE
-    </code>
+    <code>KEY:SF_ELECSCOPE</code>
     - Electronic Scope
     <br/>
-    <code>
-     KEY:SF_KNBLD_WEAP
-    </code>
+    <code>KEY:SF_KNBLD_WEAP</code>
     - Keenblade
     <br/>
-    <code>
-     KEY:SF_LASERSIGHT
-    </code>
+    <code>KEY:SF_LASERSIGHT</code>
     - Laser Sight
     <br/>
-    <code>
-     KEY:SF_SECURITY
-    </code>
+    <code>KEY:SF_SECURITY</code>
     - Security Upgrade
     <br/>
-    <code>
-     KEY:SF_SILENCER
-    </code>
+    <code>KEY:SF_SILENCER</code>
     - Silencer
     <br/>
-    <code>
-     KEY:SF_SPELLWARE_1
-    </code>
+    <code>KEY:SF_SPELLWARE_1</code>
     - Spellware_1st_lev
     <br/>
-    <code>
-     KEY:SF_SPELLWARE_2
-    </code>
+    <code>KEY:SF_SPELLWARE_2</code>
     - Spellware_2nd_lev
     <br/>
-    <code>
-     KEY:SF_SPELLWARE_3
-    </code>
+    <code>KEY:SF_SPELLWARE_3</code>
     - Spellware_3rd_lev
     <br/>
-    <code>
-     KEY:SF_SPELLWARE_4
-    </code>
+    <code>KEY:SF_SPELLWARE_4</code>
     - Spellware_4th_lev
     <br/>
-    <code>
-     KEY:SF_SPELLWARE_5
-    </code>
+    <code>KEY:SF_SPELLWARE_5</code>
     - Spellware_5th_lev
     <br/>
-    <code>
-     KEY:SF_SPELLWARE_6
-    </code>
+    <code>KEY:SF_SPELLWARE_6</code>
     - Spellware_6th_lev
     <br/>
-    <code>
-     KEY:SF_SPELLWARE_7
-    </code>
+    <code>KEY:SF_SPELLWARE_7</code>
     - Spellware_7th_lev
     <br/>
-    <code>
-     KEY:SF_SPELLWARE_8
-    </code>
+    <code>KEY:SF_SPELLWARE_8</code>
     - Spellware_8th_lev
     <br/>
-    <code>
-     KEY:SF_SPELLWARE_9
-    </code>
+    <code>KEY:SF_SPELLWARE_9</code>
     - Spellware_9th_lev
     <br/>
-    <code>
-     KEY:SF_TOOLSMW
-    </code>
+    <code>KEY:SF_TOOLSMW</code>
     - Masterwork
     <br/>
-    <code>
-     KEY:SF_TOOLSNM
-    </code>
+    <code>KEY:SF_TOOLSNM</code>
     - Normal
     <br/>
-    <code>
-     KEY:SF_TOOLSSP
-    </code>
+    <code>KEY:SF_TOOLSSP</code>
     - Specialized
     <br/>
-    <code>
-     KEY:SF_TOOLSSPM
-    </code>
+    <code>KEY:SF_TOOLSSPM</code>
     - Specialized Masterwork
     <br/>
    </p>
@@ -9133,9 +6089,7 @@ File.
     </strong>
    </p>
    <p>
-    <code>
-     KEY:FIREWRK
-    </code>
+    <code>KEY:FIREWRK</code>
     - Masterwork - Firework
     <br/>
    </p>
@@ -9146,125 +6100,77 @@ File.
     </strong>
    </p>
    <p>
-    <code>
-     KEY:ADAMANTITE
-    </code>
+    <code>KEY:ADAMANTITE</code>
     - Adamantite Plated
     <br/>
-    <code>
-     KEY:HULL_BUILT
-    </code>
+    <code>KEY:HULL_BUILT</code>
     - Built to Last
     <br/>
-    <code>
-     KEY:HULL_BULL
-    </code>
+    <code>KEY:HULL_BULL</code>
     - Bull of the Sea
     <br/>
-    <code>
-     KEY:HULL_BUOYANCY
-    </code>
+    <code>KEY:HULL_BUOYANCY</code>
     - Improved Buoyancy
     <br/>
-    <code>
-     KEY:HULL_CLEAVER
-    </code>
+    <code>KEY:HULL_CLEAVER</code>
     - Clever Construction
     <br/>
-    <code>
-     KEY:HULL_FIRE_TESTED
-    </code>
+    <code>KEY:HULL_FIRE_TESTED</code>
     - Fire Tested
     <br/>
-    <code>
-     KEY:HULL_GRACE
-    </code>
+    <code>KEY:HULL_GRACE</code>
     - Grace Under Pressure
     <br/>
-    <code>
-     KEY:HULL_ICE_QUEEN
-    </code>
+    <code>KEY:HULL_ICE_QUEEN</code>
     - Ice Queen
     <br/>
-    <code>
-     KEY:HULL_MIGHTY-OARS
-    </code>
+    <code>KEY:HULL_MIGHTY-OARS</code>
     - Mighty Oars
     <br/>
-    <code>
-     KEY:HULL_OCEABWORTHY
-    </code>
+    <code>KEY:HULL_OCEABWORTHY</code>
     - Oceanworthy
     <br/>
-    <code>
-     KEY:HULL_SEA_SCRAPPER
-    </code>
+    <code>KEY:HULL_SEA_SCRAPPER</code>
     - Sea Scrapper
     <br/>
-    <code>
-     KEY:HULL_SEA_SKIMMER
-    </code>
+    <code>KEY:HULL_SEA_SKIMMER</code>
     - Sea Skimmer
     <br/>
-    <code>
-     KEY:HULL_STORM_RIDER
-    </code>
+    <code>KEY:HULL_STORM_RIDER</code>
     - Storm Rider
     <br/>
-    <code>
-     KEY:HULL_TOUGH
-    </code>
+    <code>KEY:HULL_TOUGH</code>
     - Tough Old Girl
     <br/>
-    <code>
-     KEY:HULL_TOUGH_SAILS
-    </code>
+    <code>KEY:HULL_TOUGH_SAILS</code>
     - Reinforced Sails
     <br/>
-    <code>
-     KEY:HULL_TRANSPORT
-    </code>
+    <code>KEY:HULL_TRANSPORT</code>
     - Transport
     <br/>
-    <code>
-     KEY:HULL_WAR_DOG
-    </code>
+    <code>KEY:HULL_WAR_DOG</code>
     - War Dog
     <br/>
-    <code>
-     KEY:HULL_WAVE_RIDER
-    </code>
+    <code>KEY:HULL_WAVE_RIDER</code>
     - Wave Rider
     <br/>
-    <code>
-     KEY:IRON_PLATED
-    </code>
+    <code>KEY:IRON_PLATED</code>
     - Iron Plated
     <br/>
-    <code>
-     KEY:MITHRAL_PLATED
-    </code>
+    <code>KEY:MITHRAL_PLATED</code>
     - Mithral Plated
     <br/>
-    <code>
-     KEY:SE_1COMPLET_WP
-    </code>
+    <code>KEY:SE_1COMPLET_WP</code>
     - |Spell Effect
 (Single/Completion)
     <br/>
-    <code>
-     KEY:WaterbaneArm
-    </code>
+    <code>KEY:WaterbaneArm</code>
     - Waterbane - Armor
     <br/>
-    <code>
-     KEY:WaterbaneWeap
-    </code>
+    <code>KEY:WaterbaneWeap</code>
     - Waterbane - Weapon
     <br/>
-    <code>
-     KEY:WOOD_PLATED
-    </code>
+    <code>KEY:WOOD_PLATED</code>
     - Wood Plated
     <br/>
    </p>
@@ -9275,206 +6181,134 @@ File.
     </strong>
    </p>
    <p>
-    <code>
-     KEY:BAYONET
-    </code>
+    <code>KEY:BAYONET</code>
     - Bayonet
     <br/>
-    <code>
-     KEY:GUN_GLYPH_WEAPON
-    </code>
+    <code>KEY:GUN_GLYPH_WEAPON</code>
     - Gun Glyph Weapon
     <br/>
-    <code>
-     KEY:OPTICAL_SCOPE
-    </code>
+    <code>KEY:OPTICAL_SCOPE</code>
     - Optical Scope
     <br/>
-    <code>
-     KEY:SAS_AIR_FINLTERS
-    </code>
+    <code>KEY:SAS_AIR_FINLTERS</code>
     - Air Filters
     <br/>
-    <code>
-     KEY:SAS_AQUATIC_GEAR
-    </code>
+    <code>KEY:SAS_AQUATIC_GEAR</code>
     - Aquatic Gear
     <br/>
-    <code>
-     KEY:SAS_CLIMBING_CLAWS
-    </code>
+    <code>KEY:SAS_CLIMBING_CLAWS</code>
     - Climbing Claws
     <br/>
-    <code>
-     KEY:SAS_ELEM_FIELD
-    </code>
+    <code>KEY:SAS_ELEM_FIELD</code>
     - Electrical Field
     <br/>
-    <code>
-     KEY:SAS_ELEM_RES_ACID_5
-    </code>
+    <code>KEY:SAS_ELEM_RES_ACID_5</code>
     - Elemental Resistance (Acid
 5)
     <br/>
-    <code>
-     KEY:SAS_ELEM_RES_ACID_10
-    </code>
+    <code>KEY:SAS_ELEM_RES_ACID_10</code>
     - Elemental Resistance (Acid
 10)
     <br/>
-    <code>
-     KEY:SAS_ELEM_RES_FIRE_5
-    </code>
+    <code>KEY:SAS_ELEM_RES_FIRE_5</code>
     - Elemental Resistance (Fire
 5)
     <br/>
-    <code>
-     KEY:SAS_ELEM_RES_FIRE_10
-    </code>
+    <code>KEY:SAS_ELEM_RES_FIRE_10</code>
     - Elemental Resistance (Fire
 10)
     <br/>
-    <code>
-     KEY:SAS_ELEM_RES_COLD_5
-    </code>
+    <code>KEY:SAS_ELEM_RES_COLD_5</code>
     - Elemental Resistance (Cold
 5)
     <br/>
-    <code>
-     KEY:SAS_ELEM_RES_COLD_10
-    </code>
+    <code>KEY:SAS_ELEM_RES_COLD_10</code>
     - Elemental Resistance (Cold
 10)
     <br/>
-    <code>
-     KEY:SAS_ELEM_RES_ELEC_5
-    </code>
+    <code>KEY:SAS_ELEM_RES_ELEC_5</code>
     - Elemental Resistance
 (Electricity 5)
     <br/>
-    <code>
-     KEY:SAS_ELEM_RES_ELEC_10
-    </code>
+    <code>KEY:SAS_ELEM_RES_ELEC_10</code>
     - Elemental Resistance
 (Electricity 10)
     <br/>
-    <code>
-     KEY:SAS_ELEM_RES_SONIC_5
-    </code>
+    <code>KEY:SAS_ELEM_RES_SONIC_5</code>
     - Elemental Resistance (Sonic
 5)
     <br/>
-    <code>
-     KEY:SAS_ELEM_RES_SONIC_10
-    </code>
+    <code>KEY:SAS_ELEM_RES_SONIC_10</code>
     - Elemental Resistance
 (Sonic 10)
     <br/>
-    <code>
-     KEY:SAS_HEAVY_SHIELDING
-    </code>
+    <code>KEY:SAS_HEAVY_SHIELDING</code>
     - Heavy Shielding
     <br/>
-    <code>
-     KEY:SAS_INTERNAL_CHRONOMETER
-    </code>
+    <code>KEY:SAS_INTERNAL_CHRONOMETER</code>
     - Internal
 Chronometer
     <br/>
-    <code>
-     KEY:SAS_NIGHT_OWL_LENSES
-    </code>
+    <code>KEY:SAS_NIGHT_OWL_LENSES</code>
     - Lenses of the Night
 Owl
     <br/>
-    <code>
-     KEY:SAS_NOISE_BAFFLERS
-    </code>
+    <code>KEY:SAS_NOISE_BAFFLERS</code>
     - Noise Bafflers
     <br/>
-    <code>
-     KEY:SAS_ORNAMENTATION
-    </code>
+    <code>KEY:SAS_ORNAMENTATION</code>
     - Ornamentation
     <br/>
-    <code>
-     KEY:SAS_PARTING_GAUNTLETS
-    </code>
+    <code>KEY:SAS_PARTING_GAUNTLETS</code>
     - Parting Gauntlets
     <br/>
-    <code>
-     KEY:SAS_REINFORCED_STRUCTURE
-    </code>
+    <code>KEY:SAS_REINFORCED_STRUCTURE</code>
     - Reinforced
 Structure
     <br/>
-    <code>
-     KEY:SAS_SERVO_ARTICULATION_2
-    </code>
+    <code>KEY:SAS_SERVO_ARTICULATION_2</code>
     - Servomotor Articulation
 (2)
     <br/>
-    <code>
-     KEY:SAS_SERVO_ARTICULATION_4
-    </code>
+    <code>KEY:SAS_SERVO_ARTICULATION_4</code>
     - Servomotor Articulation
 (4)
     <br/>
-    <code>
-     KEY:SAS_SERVO_ARTICULATION_6
-    </code>
+    <code>KEY:SAS_SERVO_ARTICULATION_6</code>
     - Servomotor Articulation
 (6)
     <br/>
-    <code>
-     KEY:SAS_SERVO_ARTICULATION_8
-    </code>
+    <code>KEY:SAS_SERVO_ARTICULATION_8</code>
     - Servomotor Articulation
 (8)
     <br/>
-    <code>
-     KEY:SAS_SERVO_ARTICULATION_10
-    </code>
+    <code>KEY:SAS_SERVO_ARTICULATION_10</code>
     - Servomotor
 Articulation (10)
     <br/>
-    <code>
-     KEY:SAS_SNAP_SHIELD
-    </code>
+    <code>KEY:SAS_SNAP_SHIELD</code>
     - Snap Shield
     <br/>
-    <code>
-     KEY:SAS_SOUND_GATHERERS
-    </code>
+    <code>KEY:SAS_SOUND_GATHERERS</code>
     - Sound Gatherers
     <br/>
-    <code>
-     KEY:SAS_SPEED_ENHANCERS_5
-    </code>
+    <code>KEY:SAS_SPEED_ENHANCERS_5</code>
     - Speed Enhancers (+5
 ft.)
     <br/>
-    <code>
-     KEY:SAS_SPEED_ENHANCERS_10
-    </code>
+    <code>KEY:SAS_SPEED_ENHANCERS_10</code>
     - Speed Enhancers (+10
 ft.)
     <br/>
-    <code>
-     KEY:SAS_STRENGTH_BOOSTING_2
-    </code>
+    <code>KEY:SAS_STRENGTH_BOOSTING_2</code>
     - Strength Boosting
 (+2)
     <br/>
-    <code>
-     KEY:SAS_STRENGTH_BOOSTING_4
-    </code>
+    <code>KEY:SAS_STRENGTH_BOOSTING_4</code>
     - Strength Boosting
 (+4)
     <br/>
-    <code>
-     KEY:SAS_STRENGTH_BOOSTING_6
-    </code>
+    <code>KEY:SAS_STRENGTH_BOOSTING_6</code>
     - Strength Boosting
 (+6)
     <br/>
@@ -9501,308 +6335,188 @@ ft.)
     </strong>
    </p>
    <p>
-    <code>
-     KEY:ARCBLAST_M
-    </code>
+    <code>KEY:ARCBLAST_M</code>
     - Arcane Blasting -
 Weapon.Melee
     <br/>
-    <code>
-     KEY:ARCBLAST_R
-    </code>
+    <code>KEY:ARCBLAST_R</code>
     - Arcane Blasting - Weapon.Ranged
     <br/>
-    <code>
-     KEY:ARMPIERC_A
-    </code>
+    <code>KEY:ARMPIERC_A</code>
     - Armor Piercing - Ammunition
     <br/>
-    <code>
-     KEY:ARMPIERC_R
-    </code>
+    <code>KEY:ARMPIERC_R</code>
     - Armor Piercing - Weapon.Ranged
     <br/>
-    <code>
-     KEY:ARMSHATTER
-    </code>
+    <code>KEY:ARMSHATTER</code>
     - Armor Shattering - Weapon.Melee
     <br/>
-    <code>
-     KEY:BANE_AR
-    </code>
+    <code>KEY:BANE_AR</code>
     - Bane
     <br/>
-    <code>
-     KEY:CAST
-    </code>
+    <code>KEY:CAST</code>
     - Spellcasting
     <br/>
-    <code>
-     KEY:CASTSUP
-    </code>
+    <code>KEY:CASTSUP</code>
     - Spellcasting (Superior)
     <br/>
-    <code>
-     KEY:CHAMPDET
-    </code>
+    <code>KEY:CHAMPDET</code>
     - Champion Detecting
     <br/>
-    <code>
-     KEY:CLIMB
-    </code>
+    <code>KEY:CLIMB</code>
     - Climbing
     <br/>
-    <code>
-     KEY:COMFORT
-    </code>
+    <code>KEY:COMFORT</code>
     - Comfort
     <br/>
-    <code>
-     KEY:CREATDET
-    </code>
+    <code>KEY:CREATDET</code>
     - Creature Detecting
     <br/>
-    <code>
-     KEY:DEMONREP
-    </code>
+    <code>KEY:DEMONREP</code>
     - Demon Repelling
     <br/>
-    <code>
-     KEY:DISPEL
-    </code>
+    <code>KEY:DISPEL</code>
     - Dispelling
     <br/>
-    <code>
-     KEY:ELDBLAST_M
-    </code>
+    <code>KEY:ELDBLAST_M</code>
     - Eldritch Blasting -
 Weapon.Melee
     <br/>
-    <code>
-     KEY:ELDBLAST_R
-    </code>
+    <code>KEY:ELDBLAST_R</code>
     - Eldritch Blasting -
 Weapon.Ranged
     <br/>
-    <code>
-     KEY:GRACE
-    </code>
+    <code>KEY:GRACE</code>
     - Grace
     <br/>
-    <code>
-     KEY:GRIP2
-    </code>
+    <code>KEY:GRIP2</code>
     - Gripping (+2)
     <br/>
-    <code>
-     KEY:GRIP4
-    </code>
+    <code>KEY:GRIP4</code>
     - Gripping (+4)
     <br/>
-    <code>
-     KEY:GRIP6
-    </code>
+    <code>KEY:GRIP6</code>
     - Gripping (+6)
     <br/>
-    <code>
-     KEY:GRIP8
-    </code>
+    <code>KEY:GRIP8</code>
     - Gripping (+8)
     <br/>
-    <code>
-     KEY:GRIP10
-    </code>
+    <code>KEY:GRIP10</code>
     - Gripping (+10)
     <br/>
-    <code>
-     KEY:HARDENED1
-    </code>
+    <code>KEY:HARDENED1</code>
     - Hardened (+1)
     <br/>
-    <code>
-     KEY:HARDENED2
-    </code>
+    <code>KEY:HARDENED2</code>
     - Hardened (+2)
     <br/>
-    <code>
-     KEY:HARDENED3
-    </code>
+    <code>KEY:HARDENED3</code>
     - Hardened (+3)
     <br/>
-    <code>
-     KEY:HARDENED4
-    </code>
+    <code>KEY:HARDENED4</code>
     - Hardened (+4)
     <br/>
-    <code>
-     KEY:HARDENED5
-    </code>
+    <code>KEY:HARDENED5</code>
     - Hardened (+5)
     <br/>
-    <code>
-     KEY:HIDE
-    </code>
+    <code>KEY:HIDE</code>
     - Hiding
     <br/>
-    <code>
-     KEY:KARMIC
-    </code>
+    <code>KEY:KARMIC</code>
     - Karmic
     <br/>
-    <code>
-     KEY:KICHAN
-    </code>
+    <code>KEY:KICHAN</code>
     - Ki Channel
     <br/>
-    <code>
-     KEY:KNOCKBACK
-    </code>
+    <code>KEY:KNOCKBACK</code>
     - Knockback
     <br/>
-    <code>
-     KEY:MAGETUNE
-    </code>
+    <code>KEY:MAGETUNE</code>
     - Mage Tuned
     <br/>
-    <code>
-     KEY:MANAWALL
-    </code>
+    <code>KEY:MANAWALL</code>
     - Manawall Crushing
     <br/>
-    <code>
-     KEY:MANAWALLELD
-    </code>
+    <code>KEY:MANAWALLELD</code>
     - Manawall Crushing (Eldritch)
     <br/>
-    <code>
-     KEY:MANEU
-    </code>
+    <code>KEY:MANEU</code>
     - Maneuvering
     <br/>
-    <code>
-     KEY:MANEUGR
-    </code>
+    <code>KEY:MANEUGR</code>
     - Maneuvering (Greater)
     <br/>
-    <code>
-     KEY:MOVESIL
-    </code>
+    <code>KEY:MOVESIL</code>
     - Moving Silently
     <br/>
-    <code>
-     KEY:NONLETHAL
-    </code>
+    <code>KEY:NONLETHAL</code>
     - Nonlethal
     <br/>
-    <code>
-     KEY:POISON1
-    </code>
+    <code>KEY:POISON1</code>
     - Poisonwarding (+1)
     <br/>
-    <code>
-     KEY:POISON2
-    </code>
+    <code>KEY:POISON2</code>
     - Poisonwarding (+2)
     <br/>
-    <code>
-     KEY:POISON3
-    </code>
+    <code>KEY:POISON3</code>
     - Poisonwarding (+3)
     <br/>
-    <code>
-     KEY:POISON4
-    </code>
+    <code>KEY:POISON4</code>
     - Poisonwarding (+4)
     <br/>
-    <code>
-     KEY:POISON5
-    </code>
+    <code>KEY:POISON5</code>
     - Poisonwarding (+5)
     <br/>
-    <code>
-     KEY:POISONST
-    </code>
+    <code>KEY:POISONST</code>
     - Potion Storing
     <br/>
-    <code>
-     KEY:ROGUEFR
-    </code>
+    <code>KEY:ROGUEFR</code>
     - Roguefriend
     <br/>
-    <code>
-     KEY:SHLDPIERC_A
-    </code>
+    <code>KEY:SHLDPIERC_A</code>
     - Shield Piercing - Ammunition
     <br/>
-    <code>
-     KEY:SHLDPIERC_R
-    </code>
+    <code>KEY:SHLDPIERC_R</code>
     - Shield Piercing -
 Weapon.Ranged
     <br/>
-    <code>
-     KEY:SPELLW1
-    </code>
+    <code>KEY:SPELLW1</code>
     - Spellwarding (+1)
     <br/>
-    <code>
-     KEY:SPELLW2
-    </code>
+    <code>KEY:SPELLW2</code>
     - Spellwarding (+2)
     <br/>
-    <code>
-     KEY:SPELLW3
-    </code>
+    <code>KEY:SPELLW3</code>
     - Spellwarding (+3)
     <br/>
-    <code>
-     KEY:SPELLW4
-    </code>
+    <code>KEY:SPELLW4</code>
     - Spellwarding (+4)
     <br/>
-    <code>
-     KEY:SPELLW5
-    </code>
+    <code>KEY:SPELLW5</code>
     - Spellwarding (+5)
     <br/>
-    <code>
-     KEY:TRAPW1
-    </code>
+    <code>KEY:TRAPW1</code>
     - Trapwarding (+1)
     <br/>
-    <code>
-     KEY:TRAPW2
-    </code>
+    <code>KEY:TRAPW2</code>
     - Trapwarding (+2)
     <br/>
-    <code>
-     KEY:TRAPW3
-    </code>
+    <code>KEY:TRAPW3</code>
     - Trapwarding (+3)
     <br/>
-    <code>
-     KEY:TRAPW4
-    </code>
+    <code>KEY:TRAPW4</code>
     - Trapwarding (+4)
     <br/>
-    <code>
-     KEY:TRAPW5
-    </code>
+    <code>KEY:TRAPW5</code>
     - Trapwarding (+5)
     <br/>
-    <code>
-     KEY:TUMBLE
-    </code>
+    <code>KEY:TUMBLE</code>
     - Tumbling
     <br/>
-    <code>
-     KEY:UNCANNY
-    </code>
+    <code>KEY:UNCANNY</code>
     - Uncanny Protection
     <br/>
-    <code>
-     KEY:UNRULY
-    </code>
+    <code>KEY:UNRULY</code>
     - Unruly
     <br/>
    </p>
@@ -9822,79 +6536,49 @@ Weapon.Ranged
     </strong>
    </p>
    <p>
-    <code>
-     KEY:BOHMASABCOUR
-    </code>
+    <code>KEY:BOHMASABCOUR</code>
     - Absolute Courage
     <br/>
-    <code>
-     KEY:BOHMASABPUR
-    </code>
+    <code>KEY:BOHMASABPUR</code>
     - Absolute Purity
     <br/>
-    <code>
-     KEY:BOHMASCHAR
-    </code>
+    <code>KEY:BOHMASCHAR</code>
     - Charity
     <br/>
-    <code>
-     KEY:BOHMASCOUR
-    </code>
+    <code>KEY:BOHMASCOUR</code>
     - Courage
     <br/>
-    <code>
-     KEY:BOHMASCRYS
-    </code>
+    <code>KEY:BOHMASCRYS</code>
     - Crystal
     <br/>
-    <code>
-     KEY:BOHMASDWARD
-    </code>
+    <code>KEY:BOHMASDWARD</code>
     - Deathward
     <br/>
-    <code>
-     KEY:BOHMASFAITH
-    </code>
+    <code>KEY:BOHMASFAITH</code>
     - Faith
     <br/>
-    <code>
-     KEY:BOHMASGOLD
-    </code>
+    <code>KEY:BOHMASGOLD</code>
     - Gold
     <br/>
-    <code>
-     KEY:BOHMASPLAT
-    </code>
+    <code>KEY:BOHMASPLAT</code>
     - Platinum
     <br/>
-    <code>
-     KEY:BOHMASPUR
-    </code>
+    <code>KEY:BOHMASPUR</code>
     - Purity
     <br/>
-    <code>
-     KEY:BOHMASSILV
-    </code>
+    <code>KEY:BOHMASSILV</code>
     - Silver
     <br/>
-    <code>
-     KEY:BOHMWEAPCRYS
-    </code>
+    <code>KEY:BOHMWEAPCRYS</code>
     - Crystal
     <br/>
-    <code>
-     KEY:BOHMWEAPGLD
-    </code>
+    <code>KEY:BOHMWEAPGLD</code>
     - Gold
     <br/>
-    <code>
-     KEY:BOHMWEAPPLAT
-    </code>
+    <code>KEY:BOHMWEAPPLAT</code>
     - Platinum
     <br/>
-    <code>
-     KEY:BOHMWEAPSILV
-    </code>
+    <code>KEY:BOHMWEAPSILV</code>
     - Silver
     <br/>
    </p>
@@ -9921,9 +6605,7 @@ File.
     </strong>
    </p>
    <p>
-    <code>
-     KEY:ARMRPAD
-    </code>
+    <code>KEY:ARMRPAD</code>
     - Padding
     <br/>
    </p>
@@ -9933,9 +6615,7 @@ File.
     </strong>
    </p>
    <p>
-    <code>
-     KEY:ASSUMPTION
-    </code>
+    <code>KEY:ASSUMPTION</code>
     - Assumption
     <br/>
    </p>
@@ -9945,29 +6625,19 @@ File.
     </strong>
    </p>
    <p>
-    <code>
-     KEY:FEY_EARTHEN_GRASP
-    </code>
+    <code>KEY:FEY_EARTHEN_GRASP</code>
     - Earthen Grasp
     <br/>
-    <code>
-     KEY:FEY_SLUMBER
-    </code>
+    <code>KEY:FEY_SLUMBER</code>
     - Slumber
     <br/>
-    <code>
-     KEY:FEY_TRACKLESS
-    </code>
+    <code>KEY:FEY_TRACKLESS</code>
     - Trackless
     <br/>
-    <code>
-     KEY:FEY_TREE
-    </code>
+    <code>KEY:FEY_TREE</code>
     - Tree
     <br/>
-    <code>
-     KEY:FEY_UNSEEN
-    </code>
+    <code>KEY:FEY_UNSEEN</code>
     - Unseen
     <br/>
    </p>
@@ -9977,29 +6647,19 @@ File.
     </strong>
    </p>
    <p>
-    <code>
-     KEY:RINGFinerQuality
-    </code>
+    <code>KEY:RINGFinerQuality</code>
     - Finer Quality
     <br/>
-    <code>
-     KEY:RINGHighQuality
-    </code>
+    <code>KEY:RINGHighQuality</code>
     - High Quality
     <br/>
-    <code>
-     KEY:RINGPoisonDrip
-    </code>
+    <code>KEY:RINGPoisonDrip</code>
     - Poison Dripper
     <br/>
-    <code>
-     KEY:RINGPoisonNeedle
-    </code>
+    <code>KEY:RINGPoisonNeedle</code>
     - Poison Needle
     <br/>
-    <code>
-     KEY:RINGPoisonSquirt
-    </code>
+    <code>KEY:RINGPoisonSquirt</code>
     - Poison Squirter
     <br/>
    </p>
@@ -10026,19 +6686,13 @@ Studios (MDS) - Dark Inheritance (Modern)
     </strong>
    </p>
    <p>
-    <code>
-     KEY:ARNOLDSCLIP
-    </code>
+    <code>KEY:ARNOLDSCLIP</code>
     - Arnold's Clip
     <br/>
-    <code>
-     KEY:STWL_STUNTMN
-    </code>
+    <code>KEY:STWL_STUNTMN</code>
     - Stuntman's Steering Wheel
     <br/>
-    <code>
-     KEY:UNRELIABLE
-    </code>
+    <code>KEY:UNRELIABLE</code>
     - Unreliable
     <br/>
    </p>
@@ -10064,9 +6718,7 @@ Games (NG) - Eldritch Sorcery (35e)
     </strong>
    </p>
    <p>
-    <code>
-     KEY:TRANSSTEEL
-    </code>
+    <code>KEY:TRANSSTEEL</code>
     - Transparent Steel
     <br/>
    </p>
@@ -10091,19 +6743,13 @@ Games (NG) - Tome of Horrors (35e)
     </strong>
    </p>
    <p>
-    <code>
-     KEY:CRUSH
-    </code>
+    <code>KEY:CRUSH</code>
     - Crushing
     <br/>
-    <code>
-     KEY:SMITE
-    </code>
+    <code>KEY:SMITE</code>
     - Smiting
     <br/>
-    <code>
-     KEY:TELE
-    </code>
+    <code>KEY:TELE</code>
     - Telescoping
     <br/>
    </p>
@@ -10129,79 +6775,49 @@ Games (NG) - Tome of Horrors (35e)
     </strong>
    </p>
    <p>
-    <code>
-     KEY:BLBD
-    </code>
+    <code>KEY:BLBD</code>
     - Billboard
     <br/>
-    <code>
-     KEY:CHTR
-    </code>
+    <code>KEY:CHTR</code>
     - Chemical Treating
     <br/>
-    <code>
-     KEY:DWMW
-    </code>
+    <code>KEY:DWMW</code>
     - Dwarven Masterwork
     <br/>
-    <code>
-     KEY:ELMW
-    </code>
+    <code>KEY:ELMW</code>
     - Elvish Masterwork
     <br/>
-    <code>
-     KEY:EOLA
-    </code>
+    <code>KEY:EOLA</code>
     - Easy-Off (Light Armor)
     <br/>
-    <code>
-     KEY:EOLM
-    </code>
+    <code>KEY:EOLM</code>
     - Easy-Off (Medium Armor)
     <br/>
-    <code>
-     KEY:EOLH
-    </code>
+    <code>KEY:EOLH</code>
     - Easy-Off (Heavy Armor)
     <br/>
-    <code>
-     KEY:EXTR
-    </code>
+    <code>KEY:EXTR</code>
     - Exterior Tread
     <br/>
-    <code>
-     KEY:GNMW
-    </code>
+    <code>KEY:GNMW</code>
     - Gnomish Masterwork
     <br/>
-    <code>
-     KEY:HFMW
-    </code>
+    <code>KEY:HFMW</code>
     - Halfling Mastework
     <br/>
-    <code>
-     KEY:HTRES
-    </code>
+    <code>KEY:HTRES</code>
     - Heat Resistant
     <br/>
-    <code>
-     KEY:PKNIFE
-    </code>
+    <code>KEY:PKNIFE</code>
     - Popknife
     <br/>
-    <code>
-     KEY:SECCOMP
-    </code>
+    <code>KEY:SECCOMP</code>
     - Secret Compartment
     <br/>
-    <code>
-     KEY:SHCOR
-    </code>
+    <code>KEY:SHCOR</code>
     - Shock Core
     <br/>
-    <code>
-     KEY:WPNBAL
-    </code>
+    <code>KEY:WPNBAL</code>
     - Weapon Balancing
     <br/>
    </p>
@@ -10227,39 +6843,25 @@ Concepts Inc (PCI) - Codex Arcanis (3e)
     </strong>
    </p>
    <p>
-    <code>
-     KEY:FLINTGRMW
-    </code>
+    <code>KEY:FLINTGRMW</code>
     - Greater Mastercraft
     <br/>
-    <code>
-     KEY:HVYARMALTHST
-    </code>
+    <code>KEY:HVYARMALTHST</code>
     - Altherian Steel
     <br/>
-    <code>
-     KEY:LTMEDARMALTHST
-    </code>
+    <code>KEY:LTMEDARMALTHST</code>
     - Altherian Steel
     <br/>
-    <code>
-     KEY:SHIELDALTHST
-    </code>
+    <code>KEY:SHIELDALTHST</code>
     - Altherian Steel
     <br/>
-    <code>
-     KEY:TOOLSGRMW
-    </code>
+    <code>KEY:TOOLSGRMW</code>
     - Greater Mastercraft
     <br/>
-    <code>
-     KEY:WEAPALTHST
-    </code>
+    <code>KEY:WEAPALTHST</code>
     - Altherian Steel
     <br/>
-    <code>
-     KEY:WEAPGRMW
-    </code>
+    <code>KEY:WEAPGRMW</code>
     - Greater Mastercraft
     <br/>
    </p>
@@ -10280,308 +6882,192 @@ Concepts Inc (PCI) - World of Arcanis (35e)
     </strong>
    </p>
    <p>
-    <code>
-     KEY:CUSTOMA
-    </code>
+    <code>KEY:CUSTOMA</code>
     - Custom - Armor.Shield
     <br/>
-    <code>
-     KEY:CUSTOMW
-    </code>
+    <code>KEY:CUSTOMW</code>
     - Custom - Weapon
     <br/>
-    <code>
-     KEY:GMWORKA
-    </code>
+    <code>KEY:GMWORKA</code>
     - Greater Masterwork - Armor.Shield
     <br/>
-    <code>
-     KEY:GMWORKR
-    </code>
+    <code>KEY:GMWORKR</code>
     - Greater Masterwork - Ranged
     <br/>
-    <code>
-     KEY:GMWORKW
-    </code>
+    <code>KEY:GMWORKW</code>
     - Greater Masterwork -
 Melee.Ammunition
     <br/>
-    <code>
-     KEY:LEGENDWA
-    </code>
+    <code>KEY:LEGENDWA</code>
     - Legendary 2 - Weapon
     <br/>
-    <code>
-     KEY:LEGENDWB
-    </code>
+    <code>KEY:LEGENDWB</code>
     - Legendary 3 - Weapon
     <br/>
-    <code>
-     KEY:LEGENDWC
-    </code>
+    <code>KEY:LEGENDWC</code>
     - Legendary 4 - Weapon
     <br/>
-    <code>
-     KEY:LEGENDWD
-    </code>
+    <code>KEY:LEGENDWD</code>
     - Legendary 5 - Weapon
     <br/>
-    <code>
-     KEY:LEGENDAFA
-    </code>
+    <code>KEY:LEGENDAFA</code>
     - Fitted Legendary 2 -
 Armor.Shield
     <br/>
-    <code>
-     KEY:LEGENDAFB
-    </code>
+    <code>KEY:LEGENDAFB</code>
     - Fitted Legendary 3 -
 Armor.Shield
     <br/>
-    <code>
-     KEY:LEGENDAFC
-    </code>
+    <code>KEY:LEGENDAFC</code>
     - Fitted Legendary 4 -
 Armor.Shield
     <br/>
-    <code>
-     KEY:LEGENDAFD
-    </code>
+    <code>KEY:LEGENDAFD</code>
     - Fitted Legendary 5 -
 Armor.Shield
     <br/>
-    <code>
-     KEY:LEGENDANA
-    </code>
+    <code>KEY:LEGENDANA</code>
     - Nimble Legendary 2 -
 Armor.Shield
     <br/>
-    <code>
-     KEY:LEGENDANB
-    </code>
+    <code>KEY:LEGENDANB</code>
     - Nimble Legendary 3 -
 Armor.Shield
     <br/>
-    <code>
-     KEY:LEGENDANC
-    </code>
+    <code>KEY:LEGENDANC</code>
     - Nimble Legendary 4 -
 Armor.Shield
     <br/>
-    <code>
-     KEY:LEGENDAND
-    </code>
+    <code>KEY:LEGENDAND</code>
     - Nimble Legendary 5 -
 Armor.Shield
     <br/>
-    <code>
-     KEY:LEGENDAPA
-    </code>
+    <code>KEY:LEGENDAPA</code>
     - Proof Legendary 2 - Armor.Shield
     <br/>
-    <code>
-     KEY:LEGENDAPB
-    </code>
+    <code>KEY:LEGENDAPB</code>
     - Proof Legendary 3 - Armor.Shield
     <br/>
-    <code>
-     KEY:LEGENDAPC
-    </code>
+    <code>KEY:LEGENDAPC</code>
     - Proof Legendary 4 - Armor.Shield
     <br/>
-    <code>
-     KEY:LEGENDAPD
-    </code>
+    <code>KEY:LEGENDAPD</code>
     - Proof Legendary 5 - Armor.Shield
     <br/>
-    <code>
-     KEY:PLUS1A
-    </code>
+    <code>KEY:PLUS1A</code>
     - +1 (Enhancement to Armor)
     <br/>
-    <code>
-     KEY:PLUS1S
-    </code>
+    <code>KEY:PLUS1S</code>
     - +1 (Enhancement to Shield)
     <br/>
-    <code>
-     KEY:PLUS1W
-    </code>
+    <code>KEY:PLUS1W</code>
     - +1 (Enhancement to Weapon or
 Ammunition)
     <br/>
-    <code>
-     KEY:PLUS2A
-    </code>
+    <code>KEY:PLUS2A</code>
     - +2 (Enhancement to Armor)
     <br/>
-    <code>
-     KEY:PLUS2S
-    </code>
+    <code>KEY:PLUS2S</code>
     - +2 (Enhancement to Shield)
     <br/>
-    <code>
-     KEY:PLUS2W
-    </code>
+    <code>KEY:PLUS2W</code>
     - +2 (Enhancement to Weapon or
 Ammunition)
     <br/>
-    <code>
-     KEY:PLUS3A
-    </code>
+    <code>KEY:PLUS3A</code>
     - +3 (Enhancement to Armor)
     <br/>
-    <code>
-     KEY:PLUS3S
-    </code>
+    <code>KEY:PLUS3S</code>
     - +3 (Enhancement to Shield)
     <br/>
-    <code>
-     KEY:PLUS3W
-    </code>
+    <code>KEY:PLUS3W</code>
     - +3 (Enhancement to Weapon or
 Ammunition)
     <br/>
-    <code>
-     KEY:PLUS4A
-    </code>
+    <code>KEY:PLUS4A</code>
     - +4 (Enhancement to Armor)
     <br/>
-    <code>
-     KEY:PLUS4S
-    </code>
+    <code>KEY:PLUS4S</code>
     - +4 (Enhancement to Shield)
     <br/>
-    <code>
-     KEY:PLUS4W
-    </code>
+    <code>KEY:PLUS4W</code>
     - +4 (Enhancement to Weapon or
 Ammunition)
     <br/>
-    <code>
-     KEY:PLUS5A
-    </code>
+    <code>KEY:PLUS5A</code>
     - +5 (Enhancement to Armor)
     <br/>
-    <code>
-     KEY:PLUS5S
-    </code>
+    <code>KEY:PLUS5S</code>
     - +5 (Enhancement to Shield)
     <br/>
-    <code>
-     KEY:PLUS5W
-    </code>
+    <code>KEY:PLUS5W</code>
     - +5 (Enhancement to Weapon or
 Ammunition)
     <br/>
-    <code>
-     KEY:SAR_GMWLARM
-    </code>
+    <code>KEY:SAR_GMWLARM</code>
     - GMW Sarishan Steel (Lg)
     <br/>
-    <code>
-     KEY:SAR_GMWLSHD
-    </code>
+    <code>KEY:SAR_GMWLSHD</code>
     - GMW Sarishan Steel (Lg)
     <br/>
-    <code>
-     KEY:SAR_GMWLWEAP
-    </code>
+    <code>KEY:SAR_GMWLWEAP</code>
     - GMW Sarishan Steel (Lg)
     <br/>
-    <code>
-     KEY:SAR_GMWSARM
-    </code>
+    <code>KEY:SAR_GMWSARM</code>
     - GMW Sarishan Steel (Sm)
     <br/>
-    <code>
-     KEY:SAR_GMWSSHD
-    </code>
+    <code>KEY:SAR_GMWSSHD</code>
     - GMW Sarishan Steel (Sm)
     <br/>
-    <code>
-     KEY:SAR_GMWSWEAP
-    </code>
+    <code>KEY:SAR_GMWSWEAP</code>
     - GMW Sarishan Steel (Sm)
     <br/>
-    <code>
-     KEY:SAR_GMWMARM
-    </code>
+    <code>KEY:SAR_GMWMARM</code>
     - GMW Sarishan Steel (Med)
     <br/>
-    <code>
-     KEY:SAR_GMWMSHD
-    </code>
+    <code>KEY:SAR_GMWMSHD</code>
     - GMW Sarishan Steel (Med)
     <br/>
-    <code>
-     KEY:SAR_GMWMWEAP
-    </code>
+    <code>KEY:SAR_GMWMWEAP</code>
     - GMW Sarishan Steel (Med)
     <br/>
-    <code>
-     KEY:SARISH_GMWLBRD
-    </code>
+    <code>KEY:SARISH_GMWLBRD</code>
     - GMW Sarishan Steel (Lg)
     <br/>
-    <code>
-     KEY:SARISH_GMWMBRD
-    </code>
+    <code>KEY:SARISH_GMWMBRD</code>
     - GMW Sarishan Steel (Med)
     <br/>
-    <code>
-     KEY:SARISH_LARM
-    </code>
+    <code>KEY:SARISH_LARM</code>
     - Sarishan Steel (Lg)
     <br/>
-    <code>
-     KEY:SARISH_LBRD
-    </code>
+    <code>KEY:SARISH_LBRD</code>
     - Sarishan Steel (Lg)
     <br/>
-    <code>
-     KEY:SARISH_LSHD
-    </code>
+    <code>KEY:SARISH_LSHD</code>
     - Sarishan Steel (Lg)
     <br/>
-    <code>
-     KEY:SARISH_LWEAP
-    </code>
+    <code>KEY:SARISH_LWEAP</code>
     - Sarishan Steel (Lg)
     <br/>
-    <code>
-     KEY:SARISH_MARM
-    </code>
+    <code>KEY:SARISH_MARM</code>
     - Sarishan Steel (Med)
     <br/>
-    <code>
-     KEY:SARISH_MBRD
-    </code>
+    <code>KEY:SARISH_MBRD</code>
     - Sarishan Steel (Med)
     <br/>
-    <code>
-     KEY:SARISH_MSHD
-    </code>
+    <code>KEY:SARISH_MSHD</code>
     - Sarishan Steel (Med)
     <br/>
-    <code>
-     KEY:SARISH_MWEAP
-    </code>
+    <code>KEY:SARISH_MWEAP</code>
     - Sarishan Steel (Med)
     <br/>
-    <code>
-     KEY:SARISH_SARM
-    </code>
+    <code>KEY:SARISH_SARM</code>
     - Sarishan Steel (Sm)
     <br/>
-    <code>
-     KEY:SARISH_SSHD
-    </code>
+    <code>KEY:SARISH_SSHD</code>
     - Sarishan Steel (Sm)
     <br/>
-    <code>
-     KEY:SARISH_SWEAP
-    </code>
+    <code>KEY:SARISH_SWEAP</code>
     - Sarishan Steel (Sm)
     <br/>
    </p>
@@ -10607,39 +7093,25 @@ Entertainment (PE) - Deadlands d20 (Deadlands)
     </strong>
    </p>
    <p>
-    <code>
-     KEY:AMMOMW
-    </code>
+    <code>KEY:AMMOMW</code>
     - Masterwork - Ammunition
     <br/>
-    <code>
-     KEY:AMMOSLVR
-    </code>
+    <code>KEY:AMMOSLVR</code>
     - Silvered - Ammunition
     <br/>
-    <code>
-     KEY:ARMRMW
-    </code>
+    <code>KEY:ARMRMW</code>
     - Masterwork - Armor.Shield
     <br/>
-    <code>
-     KEY:DAGSLVR
-    </code>
+    <code>KEY:DAGSLVR</code>
     - Silvered - Dagger
     <br/>
-    <code>
-     KEY:INSTMW
-    </code>
+    <code>KEY:INSTMW</code>
     - Masterwork - Instruments
     <br/>
-    <code>
-     KEY:TOOLSMW
-    </code>
+    <code>KEY:TOOLSMW</code>
     - Masterwork - Tools
     <br/>
-    <code>
-     KEY:WEAPMW
-    </code>
+    <code>KEY:WEAPMW</code>
     - Masterwork - Weapon
     <br/>
    </p>
@@ -10667,29 +7139,19 @@ File.
     </strong>
    </p>
    <p>
-    <code>
-     KEY:BNB_IMPROVED_CRITICAL
-    </code>
+    <code>KEY:BNB_IMPROVED_CRITICAL</code>
     - Improved Critical
     <br/>
-    <code>
-     KEY:BNB_IMPROVED_GRAPPLE
-    </code>
+    <code>KEY:BNB_IMPROVED_GRAPPLE</code>
     - Improved Grapple
     <br/>
-    <code>
-     KEY:BNB_IMPROVED_OVERRUN
-    </code>
+    <code>KEY:BNB_IMPROVED_OVERRUN</code>
     - Improved Overrun
     <br/>
-    <code>
-     KEY:BNB_MASTER_OF_DISGUISE
-    </code>
+    <code>KEY:BNB_MASTER_OF_DISGUISE</code>
     - Master of Disguise
     <br/>
-    <code>
-     KEY:BNB_SCENT
-    </code>
+    <code>KEY:BNB_SCENT</code>
     - Scent
     <br/>
    </p>
@@ -10700,9 +7162,7 @@ File.
     </strong>
    </p>
    <p>
-    <code>
-     KEY:ATTK_SLNG_MSSDRVR
-    </code>
+    <code>KEY:ATTK_SLNG_MSSDRVR</code>
     - Slingshot
 Massdriver
     <br/>
@@ -10713,29 +7173,19 @@ Massdriver
     </strong>
    </p>
    <p>
-    <code>
-     KEY:BNS_EVASIVE_MANEUVERS
-    </code>
+    <code>KEY:BNS_EVASIVE_MANEUVERS</code>
     - Evasive Maneuvers
     <br/>
-    <code>
-     KEY:BNS_FIGHTER_ESCORT
-    </code>
+    <code>KEY:BNS_FIGHTER_ESCORT</code>
     - Fighter Escort
     <br/>
-    <code>
-     KEY:BNS_FORMATION_FLYING
-    </code>
+    <code>KEY:BNS_FORMATION_FLYING</code>
     - Formation Flying
     <br/>
-    <code>
-     KEY:BNS_SEMPER_FI
-    </code>
+    <code>KEY:BNS_SEMPER_FI</code>
     - Semper Fi
     <br/>
-    <code>
-     KEY:BNS_WINGMAN
-    </code>
+    <code>KEY:BNS_WINGMAN</code>
     - Wingman
     <br/>
    </p>
@@ -10746,120 +7196,78 @@ File.
     </strong>
    </p>
    <p>
-    <code>
-     KEY:ARMR_PENETRATION_AMMO_1
-    </code>
+    <code>KEY:ARMR_PENETRATION_AMMO_1</code>
     - Armor Penetration
 (+1)
     <br/>
-    <code>
-     KEY:ARMR_PENETRATION_AMMO_2
-    </code>
+    <code>KEY:ARMR_PENETRATION_AMMO_2</code>
     - Armor Penetration
 (+2)
     <br/>
-    <code>
-     KEY:ARMR_PENETRATION_BLUDGEONING
-    </code>
+    <code>KEY:ARMR_PENETRATION_BLUDGEONING</code>
     - Armor
 Penetration
     <br/>
-    <code>
-     KEY:ARMR_PENETRATION_EXPL0SIVE
-    </code>
+    <code>KEY:ARMR_PENETRATION_EXPL0SIVE</code>
     - Armor
 Penetration
     <br/>
-    <code>
-     KEY:ARMR_PENETRATION_EXPL0SIVE_ENH
-    </code>
+    <code>KEY:ARMR_PENETRATION_EXPL0SIVE_ENH</code>
     - Armor Penetration
 (Enhanced)
     <br/>
-    <code>
-     KEY:ARMR_PENETRATION_FIREARM
-    </code>
+    <code>KEY:ARMR_PENETRATION_FIREARM</code>
     - EArmor
 Penetration
     <br/>
-    <code>
-     KEY:ARMR_PENETRATION_PIERCING
-    </code>
+    <code>KEY:ARMR_PENETRATION_PIERCING</code>
     - Armor
 Penetration
     <br/>
-    <code>
-     KEY:ARMR_PENETRATION_SLASHING
-    </code>
+    <code>KEY:ARMR_PENETRATION_SLASHING</code>
     - Armor
 Penetration
     <br/>
-    <code>
-     KEY:DR_CONVERSION_ARCHAIC
-    </code>
+    <code>KEY:DR_CONVERSION_ARCHAIC</code>
     - Damage Reduction
 Conversion
     <br/>
-    <code>
-     KEY:DR_CONVERSION_MODERN
-    </code>
+    <code>KEY:DR_CONVERSION_MODERN</code>
     - Damage Reduction
 Conversion
     <br/>
-    <code>
-     KEY:DR_CONVERSION_POWERED
-    </code>
+    <code>KEY:DR_CONVERSION_POWERED</code>
     - Damage Reduction
 Conversion
     <br/>
-    <code>
-     KEY:INSERT_ANTI_STAB
-    </code>
+    <code>KEY:INSERT_ANTI_STAB</code>
     - Anti Stab Insert
     <br/>
-    <code>
-     KEY:INSERT_BUOYANCY
-    </code>
+    <code>KEY:INSERT_BUOYANCY</code>
     - Buoyancy Insert
     <br/>
-    <code>
-     KEY:INSERT_FLEX_TRAUMA
-    </code>
+    <code>KEY:INSERT_FLEX_TRAUMA</code>
     - Flexible Trauma Insert
     <br/>
-    <code>
-     KEY:INSERT_HVY_CERAMIC
-    </code>
+    <code>KEY:INSERT_HVY_CERAMIC</code>
     - Heavy Ceramic Insert
     <br/>
-    <code>
-     KEY:INSERT_LT_CERAMIC
-    </code>
+    <code>KEY:INSERT_LT_CERAMIC</code>
     - Light Ceramic Insert
     <br/>
-    <code>
-     KEY:INSERT_MED_CERAMIC
-    </code>
+    <code>KEY:INSERT_MED_CERAMIC</code>
     - Medium Ceramic Insert
     <br/>
-    <code>
-     KEY:INSERT_STEEL_TRAUMA
-    </code>
+    <code>KEY:INSERT_STEEL_TRAUMA</code>
     - Steel Trauma Insert
     <br/>
-    <code>
-     KEY:INSERT_TITAN_TRAUMA
-    </code>
+    <code>KEY:INSERT_TITAN_TRAUMA</code>
     - Titanium Trauma Insert
     <br/>
-    <code>
-     KEY:OUTERSHELL
-    </code>
+    <code>KEY:OUTERSHELL</code>
     - Outershell
     <br/>
-    <code>
-     KEY:TACTICAL_OUTERSHELL
-    </code>
+    <code>KEY:TACTICAL_OUTERSHELL</code>
     - Tactical
 Outershell
     <br/>
@@ -10871,9 +7279,7 @@ Firearms.
     </strong>
    </p>
    <p>
-    <code>
-     KEY:AIR_TAZER_CT_SOCOM
-    </code>
+    <code>KEY:AIR_TAZER_CT_SOCOM</code>
     - Air Tazer CT
 SOCOM
     <br/>
@@ -10900,14 +7306,10 @@ SOCOM
     </strong>
    </p>
    <p>
-    <code>
-     KEY:MAG_ENH_FUR_ARMOR
-    </code>
+    <code>KEY:MAG_ENH_FUR_ARMOR</code>
     - Magic Enhanced Fur
     <br/>
-    <code>
-     KEY:MAG_ENH_FUR_CLOTHING
-    </code>
+    <code>KEY:MAG_ENH_FUR_CLOTHING</code>
     - Magic Enhanced
 Fur
     <br/>
@@ -10936,15 +7338,11 @@ File.
     </strong>
    </p>
    <p>
-    <code>
-     KEY:FEAT_FRIGHTFUL_PRESENCE_MP
-    </code>
+    <code>KEY:FEAT_FRIGHTFUL_PRESENCE_MP</code>
     - Frightful
 Presence
     <br/>
-    <code>
-     KEY:SKL_DISABLE_DEVICE_MP
-    </code>
+    <code>KEY:SKL_DISABLE_DEVICE_MP</code>
     - Disable Device
     <br/>
    </p>
@@ -10970,44 +7368,28 @@ Mechanics (TGM) - d20 Modern (Modern)
     </strong>
    </p>
    <p>
-    <code>
-     KEY:ARW_DRGN_TNG_A
-    </code>
+    <code>KEY:ARW_DRGN_TNG_A</code>
     - Dragon's Tongue
     <br/>
-    <code>
-     KEY:ARW_EXPLSV_A
-    </code>
+    <code>KEY:ARW_EXPLSV_A</code>
     - Explosive
     <br/>
-    <code>
-     KEY:ARW_HIKIME_A
-    </code>
+    <code>KEY:ARW_HIKIME_A</code>
     - Hikime
     <br/>
-    <code>
-     KEY:ARW_SLVR_A
-    </code>
+    <code>KEY:ARW_SLVR_A</code>
     - Silver
     <br/>
-    <code>
-     KEY:ARW_WT_PHSPHR_A
-    </code>
+    <code>KEY:ARW_WT_PHSPHR_A</code>
     - White Phosphorous
     <br/>
-    <code>
-     KEY:ARW_WLLW_LF_A
-    </code>
+    <code>KEY:ARW_WLLW_LF_A</code>
     - Willow Leaf
     <br/>
-    <code>
-     KEY:CLOTHYRD_SHAFT
-    </code>
+    <code>KEY:CLOTHYRD_SHAFT</code>
     - Clothyard Shaft
     <br/>
-    <code>
-     KEY:SPIKE_S
-    </code>
+    <code>KEY:SPIKE_S</code>
     - Shield Spikes
     <br/>
    </p>
@@ -11017,49 +7399,31 @@ Mechanics (TGM) - d20 Modern (Modern)
     </strong>
    </p>
    <p>
-    <code>
-     KEY:AMMO_AET
-    </code>
+    <code>KEY:AMMO_AET</code>
     - #Accelerated Energy Transfer
     <br/>
-    <code>
-     KEY:AMMO_AP
-    </code>
+    <code>KEY:AMMO_AP</code>
     - #Armor Piercing
     <br/>
-    <code>
-     KEY:AMMO_HOT_LOAD
-    </code>
+    <code>KEY:AMMO_HOT_LOAD</code>
     - Hot Loads
     <br/>
-    <code>
-     KEY:AMMO_COLD_LOAD
-    </code>
+    <code>KEY:AMMO_COLD_LOAD</code>
     - Cold Loads
     <br/>
-    <code>
-     KEY:AMMO_EXPLOSIVE
-    </code>
+    <code>KEY:AMMO_EXPLOSIVE</code>
     - #Explosive
     <br/>
-    <code>
-     KEY:AMMO_FLECHETTE
-    </code>
+    <code>KEY:AMMO_FLECHETTE</code>
     - #Flechette
     <br/>
-    <code>
-     KEY:AMMO_GLASER
-    </code>
+    <code>KEY:AMMO_GLASER</code>
     - #Glaser
     <br/>
-    <code>
-     KEY:AMMO_HOLLOW_POINT
-    </code>
+    <code>KEY:AMMO_HOLLOW_POINT</code>
     - #Hollow-point
     <br/>
-    <code>
-     KEY:AMMO_INCENDIARY
-    </code>
+    <code>KEY:AMMO_INCENDIARY</code>
     - #Incendiary
     <br/>
    </p>
@@ -11085,60 +7449,38 @@ Coast (WotC) - d20 Modern (Modern)
     </strong>
    </p>
    <p>
-    <code>
-     KEY:KAHLES_SIGHT
-    </code>
+    <code>KEY:KAHLES_SIGHT</code>
     - Kahles ZF69
     <br/>
-    <code>
-     KEY:MOUNT_SCP_RFL
-    </code>
+    <code>KEY:MOUNT_SCP_RFL</code>
     - Rifle Scope Mount
     <br/>
-    <code>
-     KEY:SPPRSS_FN57
-    </code>
+    <code>KEY:SPPRSS_FN57</code>
     - FN Five-seveN Suppressor
     <br/>
-    <code>
-     KEY:SPPRSS_MAC10
-    </code>
+    <code>KEY:SPPRSS_MAC10</code>
     - Ingram MAC-10 Suppressor
     <br/>
-    <code>
-     KEY:SPPRSS_MAC11
-    </code>
+    <code>KEY:SPPRSS_MAC11</code>
     - Ingram MAC-11 Suppressor
     <br/>
-    <code>
-     KEY:SPPRSS_OTS02
-    </code>
+    <code>KEY:SPPRSS_OTS02</code>
     - OTs-02 Kiparis Suppressor
     <br/>
-    <code>
-     KEY:SPPRSS_SCH21
-    </code>
+    <code>KEY:SPPRSS_SCH21</code>
     - SCH-21 Gorda Suppressor
 Barrel
     <br/>
-    <code>
-     KEY:SPPRSS_MPI69
-    </code>
+    <code>KEY:SPPRSS_MPI69</code>
     - Steyr MPi69 Suppressor
     <br/>
-    <code>
-     KEY:SPPRSS_MPI81
-    </code>
+    <code>KEY:SPPRSS_MPI81</code>
     - Steyr MPi81 Suppressor
     <br/>
-    <code>
-     KEY:SPPRSS_PGM_UR
-    </code>
+    <code>KEY:SPPRSS_PGM_UR</code>
     - Silenced Barrel
     <br/>
-    <code>
-     KEY:SUSAT_SIGHT
-    </code>
+    <code>KEY:SUSAT_SIGHT</code>
     - SUSAT
     <br/>
    </p>
@@ -11169,51 +7511,33 @@ Cavalry
     </strong>
    </p>
    <p>
-    <code>
-     KEY:MOUNT_BAG_OF_BONES
-    </code>
+    <code>KEY:MOUNT_BAG_OF_BONES</code>
     - Mount Quality (Bag of
 Bones)
     <br/>
-    <code>
-     KEY:MOUNT_CHARGER
-    </code>
+    <code>KEY:MOUNT_CHARGER</code>
     - Mount Quality (Charger)
     <br/>
-    <code>
-     KEY:MOUNT_COURSER
-    </code>
+    <code>KEY:MOUNT_COURSER</code>
     - Mount Quality (Courser)
     <br/>
-    <code>
-     KEY:MOUNT_FLIGHTY
-    </code>
+    <code>KEY:MOUNT_FLIGHTY</code>
     - Mount Quality (Flighty)
     <br/>
-    <code>
-     KEY:MOUNT_NAG
-    </code>
+    <code>KEY:MOUNT_NAG</code>
     - Mount Quality (Nag)
     <br/>
-    <code>
-     KEY:MOUNT_NOBLE_STEED
-    </code>
+    <code>KEY:MOUNT_NOBLE_STEED</code>
     - Mount Quality (Noble
 Steed)
     <br/>
-    <code>
-     KEY:MOUNT_OLD_NAG
-    </code>
+    <code>KEY:MOUNT_OLD_NAG</code>
     - Mount Quality (Old Nag)
     <br/>
-    <code>
-     KEY:MOUNT_RACER
-    </code>
+    <code>KEY:MOUNT_RACER</code>
     - Mount Quality (Racer)
     <br/>
-    <code>
-     KEY:MOUNT_STEED
-    </code>
+    <code>KEY:MOUNT_STEED</code>
     - Mount Quality (Steed)
     <br/>
    </p>
@@ -11235,8317 +7559,5131 @@ Keys
   <hr/>
   <blockquote>
    <p>
-    <code>
-     KEY:A_1USEMA
-    </code>
+    <code>KEY:A_1USEMA</code>
     - Spell Effect (Single
 Use/Completion)
     <br/>
-    <code>
-     KEY:A_1USEME
-    </code>
+    <code>KEY:A_1USEME</code>
     - Spell Effect (Single
 Use/Completion)
     <br/>
-    <code>
-     KEY:A_1USEMI
-    </code>
+    <code>KEY:A_1USEMI</code>
     - Spell Effect (Single
 Use/Completion)
     <br/>
-    <code>
-     KEY:AOO_PNT_DEF_SYS
-    </code>
+    <code>KEY:AOO_PNT_DEF_SYS</code>
     - Point-defense system
     <br/>
-    <code>
-     KEY:A3X_DRGN_FLMTHRWR
-    </code>
+    <code>KEY:A3X_DRGN_FLMTHRWR</code>
     - A3X Dragon Flame - Thrower (PL
 5)
     <br/>
-    <code>
-     KEY:AASTARSHIP_LB
-    </code>
+    <code>KEY:AASTARSHIP_LB</code>
     - Starship
     <br/>
-    <code>
-     KEY:AASTARSHIP_TON
-    </code>
+    <code>KEY:AASTARSHIP_TON</code>
     - Starship
     <br/>
-    <code>
-     KEY:AAVEHICLE
-    </code>
+    <code>KEY:AAVEHICLE</code>
     - Vehicle
     <br/>
-    <code>
-     KEY:AAVEHICLE_FUTURE
-    </code>
+    <code>KEY:AAVEHICLE_FUTURE</code>
     - Vehicle
     <br/>
-    <code>
-     KEY:ACID_BLAST_AMMO
-    </code>
+    <code>KEY:ACID_BLAST_AMMO</code>
     - Acidic Blast
     <br/>
-    <code>
-     KEY:ACID_BLAST_MELEE
-    </code>
+    <code>KEY:ACID_BLAST_MELEE</code>
     - Acidic Blast
     <br/>
-    <code>
-     KEY:ACID_BLAST_RANGED
-    </code>
+    <code>KEY:ACID_BLAST_RANGED</code>
     - Acidic Blast
     <br/>
-    <code>
-     KEY:ACID_RES
-    </code>
+    <code>KEY:ACID_RES</code>
     - Acid Resistance
     <br/>
-    <code>
-     KEY:ACID_WARD
-    </code>
+    <code>KEY:ACID_WARD</code>
     - Acid Warding
     <br/>
-    <code>
-     KEY:ACIDIC
-    </code>
+    <code>KEY:ACIDIC</code>
     - Acidic
     <br/>
-    <code>
-     KEY:ADAM
-    </code>
+    <code>KEY:ADAM</code>
     - Adamantine
     <span class="new">
      (deprecated)
     </span>
     <br/>
-    <code>
-     KEY:ADAMANT_AMMO
-    </code>
+    <code>KEY:ADAMANT_AMMO</code>
     - Adamantine (Ammo)
     <br/>
-    <code>
-     KEY:ADAMANT_ARMR_HVY
-    </code>
+    <code>KEY:ADAMANT_ARMR_HVY</code>
     - Adamantine (Armor/Heavy)
     <br/>
-    <code>
-     KEY:ADAMANT_ARMR_LT
-    </code>
+    <code>KEY:ADAMANT_ARMR_LT</code>
     - Adamantine (Armor/Light)
     <br/>
-    <code>
-     KEY:ADAMANT_ARMR_MED
-    </code>
+    <code>KEY:ADAMANT_ARMR_MED</code>
     - Adamantine (Armor/Medium)
     <br/>
-    <code>
-     KEY:ADAMANT_FORT
-    </code>
+    <code>KEY:ADAMANT_FORT</code>
     - Adamantine (Fortification)
     <br/>
-    <code>
-     KEY:ADAMANT_SHLD
-    </code>
+    <code>KEY:ADAMANT_SHLD</code>
     - Adamantine (Shield)
     <br/>
-    <code>
-     KEY:ADAMANT_WEAP
-    </code>
+    <code>KEY:ADAMANT_WEAP</code>
     - Adamantine (Weapon)
     <br/>
-    <code>
-     KEY:ADAMANT_WONDROUS
-    </code>
+    <code>KEY:ADAMANT_WONDROUS</code>
     - Adamantine (Wondrous)
     <br/>
-    <code>
-     KEY:ADAMANTITE
-    </code>
+    <code>KEY:ADAMANTITE</code>
     - Adamantite Plated
     <br/>
-    <code>
-     KEY:ADD_TYPE
-    </code>
+    <code>KEY:ADD_TYPE</code>
     - #Add Type
     <br/>
-    <code>
-     KEY:ADDTYPE
-    </code>
+    <code>KEY:ADDTYPE</code>
     - Add Type
     <br/>
-    <code>
-     KEY:ADVANCD_DGNSTCS
-    </code>
+    <code>KEY:ADVANCD_DGNSTCS</code>
     - Advanced Diagnostics (PL
 7)
     <br/>
-    <code>
-     KEY:AFTRBRNR_SYS
-    </code>
+    <code>KEY:AFTRBRNR_SYS</code>
     - Afterburner System (PL6)
     <br/>
-    <code>
-     KEY:AIR_TAZER_CT_SOCOM
-    </code>
+    <code>KEY:AIR_TAZER_CT_SOCOM</code>
     - Air Tazer CT SOCOM
     <br/>
-    <code>
-     KEY:ALCHM
-    </code>
+    <code>KEY:ALCHM</code>
     - Alchemical Silver
     <br/>
-    <code>
-     KEY:ALCHM/2
-    </code>
+    <code>KEY:ALCHM/2</code>
     - 1/2 Alchemical Silver
     <span class="new">
      (deprecated)
     </span>
     <br/>
-    <code>
-     KEY:ALL_IN_ONE
-    </code>
+    <code>KEY:ALL_IN_ONE</code>
     - All-in-one
     <br/>
-    <code>
-     KEY:ALT_WPN_GDGT
-    </code>
+    <code>KEY:ALT_WPN_GDGT</code>
     - Alternate Weapon Gadget
     <br/>
-    <code>
-     KEY:ALUMINIUM
-    </code>
+    <code>KEY:ALUMINIUM</code>
     - Aluminium
     <br/>
-    <code>
-     KEY:ALUMISTL
-    </code>
+    <code>KEY:ALUMISTL</code>
     - Alumisteel (PL5)
     <br/>
-    <code>
-     KEY:ALUMISTL_ARMR
-    </code>
+    <code>KEY:ALUMISTL_ARMR</code>
     - Alumisteel Armor (PL5)
     <br/>
-    <code>
-     KEY:AMMO_AET
-    </code>
+    <code>KEY:AMMO_AET</code>
     - #Accelerated Energy Transfer
     <br/>
-    <code>
-     KEY:AMMO_AP
-    </code>
+    <code>KEY:AMMO_AP</code>
     - #Armor Piercing
     <br/>
-    <code>
-     KEY:AMMO_HOT_LOAD
-    </code>
+    <code>KEY:AMMO_HOT_LOAD</code>
     - Hot Loads
     <br/>
-    <code>
-     KEY:AMMO_COLD_LOAD
-    </code>
+    <code>KEY:AMMO_COLD_LOAD</code>
     - Cold Loads
     <br/>
-    <code>
-     KEY:AMMO_EXPLOSIVE
-    </code>
+    <code>KEY:AMMO_EXPLOSIVE</code>
     - #Explosive
     <br/>
-    <code>
-     KEY:AMMO_FLECHETTE
-    </code>
+    <code>KEY:AMMO_FLECHETTE</code>
     - #Flechette
     <br/>
-    <code>
-     KEY:AMMO_GLASER
-    </code>
+    <code>KEY:AMMO_GLASER</code>
     - #Glaser
     <br/>
-    <code>
-     KEY:AMMO_HOLLOW_POINT
-    </code>
+    <code>KEY:AMMO_HOLLOW_POINT</code>
     - #Hollow-point
     <br/>
-    <code>
-     KEY:AMMO_INCENDIARY
-    </code>
+    <code>KEY:AMMO_INCENDIARY</code>
     - #Incendiary
     <br/>
-    <code>
-     KEY:AMMO_LT5_LNGSHT_MSSDRV
-    </code>
+    <code>KEY:AMMO_LT5_LNGSHT_MSSDRV</code>
     - Ammo bay for LT-5
 Longshot Mass Driver
     <br/>
-    <code>
-     KEY:AMMO_M9_BRRGE_CHAINGUN
-    </code>
+    <code>KEY:AMMO_M9_BRRGE_CHAINGUN</code>
     - 6 50-round ammo belts for
 M-9 Barrage chaingun
     <br/>
-    <code>
-     KEY:AMMO_M53_FRST_RCKTLNCH
-    </code>
+    <code>KEY:AMMO_M53_FRST_RCKTLNCH</code>
     - 6-rocket pack for M-53
 Firestar Rocket Launcher
     <br/>
-    <code>
-     KEY:AMMO_M55_CRUD_RCKTLNCH
-    </code>
+    <code>KEY:AMMO_M55_CRUD_RCKTLNCH</code>
     - 6-rocket pack for M-55
 Crud Rocket Launcher
     <br/>
-    <code>
-     KEY:AMMO_M70_EMP_RCKTLNCHR
-    </code>
+    <code>KEY:AMMO_M70_EMP_RCKTLNCHR</code>
     - 6-rocket pack for M-70
 EMP Rocket Launcher
     <br/>
-    <code>
-     KEY:AMMO_M75_CRKT_RCKTLNCH
-    </code>
+    <code>KEY:AMMO_M75_CRKT_RCKTLNCH</code>
     - 6-rocket pack for M-75
 Cricket Rocket Launcher
     <br/>
-    <code>
-     KEY:AMMO_M87_TALN_MSSLLNCH
-    </code>
+    <code>KEY:AMMO_M87_TALN_MSSLLNCH</code>
     - 4-missile pack for M-87
 Talon Missile Launcher
     <br/>
-    <code>
-     KEY:AMMO_T95_CVLCD_CHAINGN
-    </code>
+    <code>KEY:AMMO_T95_CVLCD_CHAINGN</code>
     - 6 50-round ammo belts for
 T-95 Cavalcade Chaingun
     <br/>
-    <code>
-     KEY:AMMO_WARPTH_RCLLSS_RFL
-    </code>
+    <code>KEY:AMMO_WARPTH_RCLLSS_RFL</code>
     - 20-round magazine for
 Warpath Recoilless Rifle
     <br/>
-    <code>
-     KEY:AMMOMW
-    </code>
+    <code>KEY:AMMOMW</code>
     - Masterwork - Ammunition
     <br/>
-    <code>
-     KEY:AMMOSLVR
-    </code>
+    <code>KEY:AMMOSLVR</code>
     - Silvered - Ammunition
     <br/>
-    <code>
-     KEY:AMMO2_M70_EMP_RCKTLNCHR
-    </code>
+    <code>KEY:AMMO2_M70_EMP_RCKTLNCHR</code>
     - 6-rocket pack for M-70
 EMP Rocket Launcher
     <br/>
-    <code>
-     KEY:AMMO2_M87_TALN_MSSLLNCH
-    </code>
+    <code>KEY:AMMO2_M87_TALN_MSSLLNCH</code>
     - 4-missile pack for M-87
 Talon Missile Launcher
     <br/>
-    <code>
-     KEY:ANIMATED
-    </code>
+    <code>KEY:ANIMATED</code>
     - Animated
     <br/>
-    <code>
-     KEY:ANMATD
-    </code>
+    <code>KEY:ANMATD</code>
     - Animated
     <br/>
-    <code>
-     KEY:ANTI_ACCDNT_SYS
-    </code>
+    <code>KEY:ANTI_ACCDNT_SYS</code>
     - Anti-Accident System
     <br/>
-    <code>
-     KEY:APORT
-    </code>
+    <code>KEY:APORT</code>
     - Aporter
     <br/>
-    <code>
-     KEY:APRTR
-    </code>
+    <code>KEY:APRTR</code>
     - Aporter
     <br/>
-    <code>
-     KEY:ARCBLAST_M
-    </code>
+    <code>KEY:ARCBLAST_M</code>
     - Arcane Blasting - Weapon.Melee
     <br/>
-    <code>
-     KEY:ARCBLAST_R
-    </code>
+    <code>KEY:ARCBLAST_R</code>
     - Arcane Blasting - Weapon.Ranged
     <br/>
-    <code>
-     KEY:ARCANE_ARCHER_AMMO
-    </code>
+    <code>KEY:ARCANE_ARCHER_AMMO</code>
     - Arcane Archer
 Enchantement
     <br/>
-    <code>
-     KEY:ARMCAM
-    </code>
+    <code>KEY:ARMCAM</code>
     - Camouflage
     <br/>
-    <code>
-     KEY:ARMR_PIERCING
-    </code>
+    <code>KEY:ARMR_PIERCING</code>
     - Armor Piercing
     <br/>
-    <code>
-     KEY:ARMRDBCL
-    </code>
+    <code>KEY:ARMRDBCL</code>
     - Celestial Bone
     <br/>
-    <code>
-     KEY:ARMRDFL1
-    </code>
+    <code>KEY:ARMRDFL1</code>
     - Deflecting +1
     <br/>
-    <code>
-     KEY:ARMRDFL2
-    </code>
+    <code>KEY:ARMRDFL2</code>
     - Deflecting +2
     <br/>
-    <code>
-     KEY:ARMRDFL3
-    </code>
+    <code>KEY:ARMRDFL3</code>
     - Deflecting +3
     <br/>
-    <code>
-     KEY:ARMRDFL4
-    </code>
+    <code>KEY:ARMRDFL4</code>
     - Deflecting +4
     <br/>
-    <code>
-     KEY:ARMREF
-    </code>
+    <code>KEY:ARMREF</code>
     - Reflective
     <br/>
-    <code>
-     KEY:ARMRMW
-    </code>
+    <code>KEY:ARMRMW</code>
     - Masterwork - Armor.Shield
     <br/>
-    <code>
-     KEY:ARMRPAD
-    </code>
+    <code>KEY:ARMRPAD</code>
     - Padding
     <br/>
-    <code>
-     KEY:ARMRRSHP
-    </code>
+    <code>KEY:ARMRRSHP</code>
     - Reshaping
     <br/>
-    <code>
-     KEY:ARMPIERC_A
-    </code>
+    <code>KEY:ARMPIERC_A</code>
     - Armor Piercing - Ammunition
     <br/>
-    <code>
-     KEY:ARMPIERC_R
-    </code>
+    <code>KEY:ARMPIERC_R</code>
     - Armor Piercing - Weapon.Ranged
     <br/>
-    <code>
-     KEY:ARMPR13
-    </code>
+    <code>KEY:ARMPR13</code>
     - # Power Resistance (PR13) -
 Armor.Shield
     <br/>
-    <code>
-     KEY:ARMPR15
-    </code>
+    <code>KEY:ARMPR15</code>
     - # Power Resistance (PR15) -
 Armor.Shield
     <br/>
-    <code>
-     KEY:ARMPR17
-    </code>
+    <code>KEY:ARMPR17</code>
     - # Power Resistance (PR17) -
 Armor.Shield
     <br/>
-    <code>
-     KEY:ARMPR19
-    </code>
+    <code>KEY:ARMPR19</code>
     - # Power Resistance (PR19) -
 Armor.Shield
     <br/>
-    <code>
-     KEY:ARMR_ABLATIVE
-    </code>
+    <code>KEY:ARMR_ABLATIVE</code>
     - Ablative Armor
     <br/>
-    <code>
-     KEY:ARMR_ALLOY_PLATING
-    </code>
+    <code>KEY:ARMR_ALLOY_PLATING</code>
     - Alloy Plating Armor
     <br/>
-    <code>
-     KEY:ARMR_CERAMETAL
-    </code>
+    <code>KEY:ARMR_CERAMETAL</code>
     - Cerametal Armor
     <br/>
-    <code>
-     KEY:ARMR_DEFLECTIVE
-    </code>
+    <code>KEY:ARMR_DEFLECTIVE</code>
     - Deflective Armor
     <br/>
-    <code>
-     KEY:ARMR_NANOFLUIDIC
-    </code>
+    <code>KEY:ARMR_NANOFLUIDIC</code>
     - Nanofluidic Armor
     <br/>
-    <code>
-     KEY:ARMR_NEUTRONITE
-    </code>
+    <code>KEY:ARMR_NEUTRONITE</code>
     - Neutronite Armor
     <br/>
-    <code>
-     KEY:ARMR_PENETRATION_AMMO_1
-    </code>
+    <code>KEY:ARMR_PENETRATION_AMMO_1</code>
     - Armor Penetration
 (+1)
     <br/>
-    <code>
-     KEY:ARMR_PENETRATION_AMMO_2
-    </code>
+    <code>KEY:ARMR_PENETRATION_AMMO_2</code>
     - Armor Penetration
 (+2)
     <br/>
-    <code>
-     KEY:ARMR_PENETRATION_BLUDGEONING
-    </code>
+    <code>KEY:ARMR_PENETRATION_BLUDGEONING</code>
     - Armor
 Penetration
     <br/>
-    <code>
-     KEY:ARMR_PENETRATION_EXPL0SIVE
-    </code>
+    <code>KEY:ARMR_PENETRATION_EXPL0SIVE</code>
     - Armor
 Penetration
     <br/>
-    <code>
-     KEY:ARMR_PENETRATION_EXPL0SIVE_ENH
-    </code>
+    <code>KEY:ARMR_PENETRATION_EXPL0SIVE_ENH</code>
     - Armor Penetration
 (Enhanced)
     <br/>
-    <code>
-     KEY:ARMR_PENETRATION_FIREARM
-    </code>
+    <code>KEY:ARMR_PENETRATION_FIREARM</code>
     - EArmor
 Penetration
     <br/>
-    <code>
-     KEY:ARMR_PENETRATION_PIERCING
-    </code>
+    <code>KEY:ARMR_PENETRATION_PIERCING</code>
     - Armor
 Penetration
     <br/>
-    <code>
-     KEY:ARMR_PENETRATION_SLASHING
-    </code>
+    <code>KEY:ARMR_PENETRATION_SLASHING</code>
     - Armor
 Penetration
     <br/>
-    <code>
-     KEY:ARMR_PIERCING
-    </code>
+    <code>KEY:ARMR_PIERCING</code>
     - Armor Piercing
     <br/>
-    <code>
-     KEY:ARMR_POLYMERIC
-    </code>
+    <code>KEY:ARMR_POLYMERIC</code>
     - Polymeric Armor
     <br/>
-    <code>
-     KEY:ARMR_VANADIUM
-    </code>
+    <code>KEY:ARMR_VANADIUM</code>
     - Vanadium Armor
     <br/>
-    <code>
-     KEY:ARMRDBCL
-    </code>
+    <code>KEY:ARMRDBCL</code>
     - Celestial Bone
     <br/>
-    <code>
-     KEY:ARMRDFL1
-    </code>
+    <code>KEY:ARMRDFL1</code>
     - Deflecting +1
     <br/>
-    <code>
-     KEY:ARMRDFL2
-    </code>
+    <code>KEY:ARMRDFL2</code>
     - Deflecting +2
     <br/>
-    <code>
-     KEY:ARMRDFL3
-    </code>
+    <code>KEY:ARMRDFL3</code>
     - Deflecting +3
     <br/>
-    <code>
-     KEY:ARMRDFL4
-    </code>
+    <code>KEY:ARMRDFL4</code>
     - Deflecting +4
     <br/>
-    <code>
-     KEY:ARMRRSHP
-    </code>
+    <code>KEY:ARMRRSHP</code>
     - Reshaping
     <br/>
-    <code>
-     KEY:ARMSHATTER
-    </code>
+    <code>KEY:ARMSHATTER</code>
     - Armor Shattering - Weapon.Melee
     <br/>
-    <code>
-     KEY:ARMRMW
-    </code>
+    <code>KEY:ARMRMW</code>
     - Masterwork - Armor.Shield
     <br/>
-    <code>
-     KEY:ARNOLDSCLIP
-    </code>
+    <code>KEY:ARNOLDSCLIP</code>
     - Arnold's Clip
     <br/>
-    <code>
-     KEY:ARROW_DEFLECT_EXC
-    </code>
+    <code>KEY:ARROW_DEFLECT_EXC</code>
     - Exceptional Arrow
 Deflection
     <br/>
-    <code>
-     KEY:ARROW_DEFLECT_INF
-    </code>
+    <code>KEY:ARROW_DEFLECT_INF</code>
     - Infinite Arrow
 Deflection
     <br/>
-    <code>
-     KEY:ART
-    </code>
+    <code>KEY:ART</code>
     - Art Value
     <br/>
-    <code>
-     KEY:ARTICULATED
-    </code>
+    <code>KEY:ARTICULATED</code>
     - Articulated
     <br/>
-    <code>
-     KEY:ARTIFICIALORGAN
-    </code>
+    <code>KEY:ARTIFICIALORGAN</code>
     - Artificial Organ
     <br/>
-    <code>
-     KEY:ARW_CAT
-    </code>
+    <code>KEY:ARW_CAT</code>
     - Arrow Catching
     <br/>
-    <code>
-     KEY:ARW_DEF
-    </code>
+    <code>KEY:ARW_DEF</code>
     - Arrow Deflection
     <br/>
-    <code>
-     KEY:ARW_DRGN_TNG_A
-    </code>
+    <code>KEY:ARW_DRGN_TNG_A</code>
     - Dragon's Tongue
     <br/>
-    <code>
-     KEY:ARW_EXPLSV_A
-    </code>
+    <code>KEY:ARW_EXPLSV_A</code>
     - Explosive
     <br/>
-    <code>
-     KEY:ARW_HIKIME_A
-    </code>
+    <code>KEY:ARW_HIKIME_A</code>
     - Hikime
     <br/>
-    <code>
-     KEY:ARW_SLVR_A
-    </code>
+    <code>KEY:ARW_SLVR_A</code>
     - Silver
     <br/>
-    <code>
-     KEY:ARW_WT_PHSPHR_A
-    </code>
+    <code>KEY:ARW_WT_PHSPHR_A</code>
     - White Phosphorous
     <br/>
-    <code>
-     KEY:ARW_WLLW_LF_A
-    </code>
+    <code>KEY:ARW_WLLW_LF_A</code>
     - Willow Leaf
     <br/>
-    <code>
-     KEY:ASSUMPTION
-    </code>
+    <code>KEY:ASSUMPTION</code>
     - Assumption
     <br/>
-    <code>
-     KEY:ATFR_MDL_GDGT
-    </code>
+    <code>KEY:ATFR_MDL_GDGT</code>
     - Autofire Module Gadget
     <br/>
-    <code>
-     KEY:ATLDR_MDL_GDGT
-    </code>
+    <code>KEY:ATLDR_MDL_GDGT</code>
     - Autoloader Module Gadget
     <br/>
-    <code>
-     KEY:ATTK_ANTIMATTER
-    </code>
+    <code>KEY:ATTK_ANTIMATTER</code>
     - Antimatter Gun
     <br/>
-    <code>
-     KEY:ATTK_ANTIMATTER_4B
-    </code>
+    <code>KEY:ATTK_ANTIMATTER_4B</code>
     - Battery of 4 Antimatter
 Guns
     <br/>
-    <code>
-     KEY:ATTK_AUTOMASER
-    </code>
+    <code>KEY:ATTK_AUTOMASER</code>
     - Automaser
     <br/>
-    <code>
-     KEY:ATTK_BLACKLASER
-    </code>
+    <code>KEY:ATTK_BLACKLASER</code>
     - Blacklaser
     <br/>
-    <code>
-     KEY:ATTK_CHE_MISSL
-    </code>
+    <code>KEY:ATTK_CHE_MISSL</code>
     - CHE Missile Launcher
     <br/>
-    <code>
-     KEY:ATTK_CHE_MISSL_2
-    </code>
+    <code>KEY:ATTK_CHE_MISSL_2</code>
     - 2 CHE Missile Launcher
     <br/>
-    <code>
-     KEY:ATTK_CHE_MISSL_2B_2
-    </code>
+    <code>KEY:ATTK_CHE_MISSL_2B_2</code>
     - 2 Batteries of 2 CHE Missile
 Launcher
     <br/>
-    <code>
-     KEY:ATTK_CHE_MISSL_3B
-    </code>
+    <code>KEY:ATTK_CHE_MISSL_3B</code>
     - Battery of 3 CHE Missile
 Launcher
     <br/>
-    <code>
-     KEY:ATTK_EMP_CANN
-    </code>
+    <code>KEY:ATTK_EMP_CANN</code>
     - EMP Cannon
     <br/>
-    <code>
-     KEY:ATTK_FUSN_BEAM
-    </code>
+    <code>KEY:ATTK_FUSN_BEAM</code>
     - Fusion Beam
     <br/>
-    <code>
-     KEY:ATTK_FUSN_BEAM_2L
-    </code>
+    <code>KEY:ATTK_FUSN_BEAM_2L</code>
     - 2 fire-linked Fusion
 Beams
     <br/>
-    <code>
-     KEY:ATTK_FUSN_BEAM_4B
-    </code>
+    <code>KEY:ATTK_FUSN_BEAM_4B</code>
     - Battery of 4 Fusion
 Beams
     <br/>
-    <code>
-     KEY:ATTK_GAUSS_GUN
-    </code>
+    <code>KEY:ATTK_GAUSS_GUN</code>
     - Gauss Gun
     <br/>
-    <code>
-     KEY:ATTK_GAUSS_GUN_3B
-    </code>
+    <code>KEY:ATTK_GAUSS_GUN_3B</code>
     - Battery of 3 Gauss Guns
     <br/>
-    <code>
-     KEY:ATTK_HLASER
-    </code>
+    <code>KEY:ATTK_HLASER</code>
     - Heavy Laser
     <br/>
-    <code>
-     KEY:ATTK_HLASER_2L
-    </code>
+    <code>KEY:ATTK_HLASER_2L</code>
     - 2 fire-linked Heavy Laser
     <br/>
-    <code>
-     KEY:ATTK_HLASER_3B
-    </code>
+    <code>KEY:ATTK_HLASER_3B</code>
     - Battery of 3 Heavy Laser
     <br/>
-    <code>
-     KEY:ATTK_HLASER_4B
-    </code>
+    <code>KEY:ATTK_HLASER_4B</code>
     - Battery of 4 Heavy Laser
     <br/>
-    <code>
-     KEY:ATTK_HLASER_4L
-    </code>
+    <code>KEY:ATTK_HLASER_4L</code>
     - 4 fire-linked Heavy Laser
     <br/>
-    <code>
-     KEY:ATTK_HMASER_CANN
-    </code>
+    <code>KEY:ATTK_HMASER_CANN</code>
     - Heavy Maser Cannon
     <br/>
-    <code>
-     KEY:ATTK_HMASS_CANN
-    </code>
+    <code>KEY:ATTK_HMASS_CANN</code>
     - Heavy Mass Cannon
     <br/>
-    <code>
-     KEY:ATTK_HMASS_CANN_4B
-    </code>
+    <code>KEY:ATTK_HMASS_CANN_4B</code>
     - Battery of 4 heavy Mass
 Cannons
     <br/>
-    <code>
-     KEY:ATTK_HNTRN_GUN
-    </code>
+    <code>KEY:ATTK_HNTRN_GUN</code>
     - Heavy Neutron Gun
     <br/>
-    <code>
-     KEY:ATTK_HNTRN_GUN_2F
-    </code>
+    <code>KEY:ATTK_HNTRN_GUN_2F</code>
     - 2 fire-linked Heavy Neutron
 Guns
     <br/>
-    <code>
-     KEY:ATTK_HNTRN_GUN_3B
-    </code>
+    <code>KEY:ATTK_HNTRN_GUN_3B</code>
     - Battery of 3 Heavy Neutron
 Guns
     <br/>
-    <code>
-     KEY:ATTK_HNTRN_GUN_4F
-    </code>
+    <code>KEY:ATTK_HNTRN_GUN_4F</code>
     - 4 fire-linked Heavy Neutron
 Guns
     <br/>
-    <code>
-     KEY:ATTK_HPRTCL_BEAM
-    </code>
+    <code>KEY:ATTK_HPRTCL_BEAM</code>
     - Heavy Particle Beam
     <br/>
-    <code>
-     KEY:ATTK_HPTCL_BEAM_3B_2
-    </code>
+    <code>KEY:ATTK_HPTCL_BEAM_3B_2</code>
     - 2 Batteries of 3 Heavy
 Particle Beams
     <br/>
-    <code>
-     KEY:ATTK_HPTCL_BEAM_4L
-    </code>
+    <code>KEY:ATTK_HPTCL_BEAM_4L</code>
     - 4 fire-linked Heavy Particle
 Beams
     <br/>
-    <code>
-     KEY:ATTK_HPLASM_CANN
-    </code>
+    <code>KEY:ATTK_HPLASM_CANN</code>
     - Heavy Plasma Cannon
     <br/>
-    <code>
-     KEY:ATTK_HPLASM_CANN_2L
-    </code>
+    <code>KEY:ATTK_HPLASM_CANN_2L</code>
     - 2 fire-linked Heavy Plasma
 Cannons
     <br/>
-    <code>
-     KEY:ATTK_HPLASM_CANN_3L
-    </code>
+    <code>KEY:ATTK_HPLASM_CANN_3L</code>
     - 3 fire-linked Heavy Plasma
 Cannons
     <br/>
-    <code>
-     KEY:ATTK_KES_MISSL
-    </code>
+    <code>KEY:ATTK_KES_MISSL</code>
     - KE Submunition Missile
 Launcher
     <br/>
-    <code>
-     KEY:ATTK_KNTC_LANCE
-    </code>
+    <code>KEY:ATTK_KNTC_LANCE</code>
     - Kinetic Lance
     <br/>
-    <code>
-     KEY:ATTK_LASER
-    </code>
+    <code>KEY:ATTK_LASER</code>
     - Laser
     <br/>
-    <code>
-     KEY:ATTK_LASER_5B
-    </code>
+    <code>KEY:ATTK_LASER_5B</code>
     - Battery of 5 Laser
     <br/>
-    <code>
-     KEY:ATTK_MASER_CANN
-    </code>
+    <code>KEY:ATTK_MASER_CANN</code>
     - Maser Cannon
     <br/>
-    <code>
-     KEY:ATTK_MASER_CANN_2L
-    </code>
+    <code>KEY:ATTK_MASER_CANN_2L</code>
     - 2 fire-linked Maser
 Cannons
     <br/>
-    <code>
-     KEY:ATTK_MASS_CANN
-    </code>
+    <code>KEY:ATTK_MASS_CANN</code>
     - Mass Cannon
     <br/>
-    <code>
-     KEY:ATTK_MASS_CANN_5B
-    </code>
+    <code>KEY:ATTK_MASS_CANN_5B</code>
     - Battery of 5 Mass
 Cannons
     <br/>
-    <code>
-     KEY:ATTK_MASS_MISSL
-    </code>
+    <code>KEY:ATTK_MASS_MISSL</code>
     - Mass Reaction Missile
 Launcher
     <br/>
-    <code>
-     KEY:ATTK_MASS_MISSL_2L
-    </code>
+    <code>KEY:ATTK_MASS_MISSL_2L</code>
     - 2 fire-linked Mass Reaction
 Missile Launcher
     <br/>
-    <code>
-     KEY:ATTK_MINELAYER
-    </code>
+    <code>KEY:ATTK_MINELAYER</code>
     - Minelayer
     <br/>
-    <code>
-     KEY:ATTK_NDL_DRVR
-    </code>
+    <code>KEY:ATTK_NDL_DRVR</code>
     - Needle Driver
     <br/>
-    <code>
-     KEY:ATTK_NTRN_GUN
-    </code>
+    <code>KEY:ATTK_NTRN_GUN</code>
     - Neutron Gun
     <br/>
-    <code>
-     KEY:ATTK_NTRN_GUN_5B
-    </code>
+    <code>KEY:ATTK_NTRN_GUN_5B</code>
     - Battery of 5 Neutron Guns
     <br/>
-    <code>
-     KEY:ATTK_NTRNM_DRVR
-    </code>
+    <code>KEY:ATTK_NTRNM_DRVR</code>
     - Neutronium Driver
     <br/>
-    <code>
-     KEY:ATTK_NOVA_MISSL
-    </code>
+    <code>KEY:ATTK_NOVA_MISSL</code>
     - Nova Burst Missile
 Launcher
     <br/>
-    <code>
-     KEY:ATTK_NUKE_MISSL
-    </code>
+    <code>KEY:ATTK_NUKE_MISSL</code>
     - Nuclear Missile Launcher
     <br/>
-    <code>
-     KEY:ATTK_NUKE_MISSL_2
-    </code>
+    <code>KEY:ATTK_NUKE_MISSL_2</code>
     - 2 Nuclear Missile
 Launcher
     <br/>
-    <code>
-     KEY:ATTK_NUKE_MISSL_2L
-    </code>
+    <code>KEY:ATTK_NUKE_MISSL_2L</code>
     - 2 fire-linked Nuclear
 Missiles Launcher
     <br/>
-    <code>
-     KEY:ATTK_PRTCL_BEAM
-    </code>
+    <code>KEY:ATTK_PRTCL_BEAM</code>
     - Particle Beam
     <br/>
-    <code>
-     KEY:ATTK_PRTCL_BEAM_2L
-    </code>
+    <code>KEY:ATTK_PRTCL_BEAM_2L</code>
     - 2 fire-linked Particle
 Beams
     <br/>
-    <code>
-     KEY:ATTK_PRTCL_BEAM_4B
-    </code>
+    <code>KEY:ATTK_PRTCL_BEAM_4B</code>
     - Battery of 4 Particle
 Beams
     <br/>
-    <code>
-     KEY:ATTK_PLASMA_CANN
-    </code>
+    <code>KEY:ATTK_PLASMA_CANN</code>
     - Plasma Cannon
     <br/>
-    <code>
-     KEY:ATTK_PLASMA_CANN_4B
-    </code>
+    <code>KEY:ATTK_PLASMA_CANN_4B</code>
     - Battery of 4 Plasma
 Cannons
     <br/>
-    <code>
-     KEY:ATTK_PLSM_MISSL
-    </code>
+    <code>KEY:ATTK_PLSM_MISSL</code>
     - Plasma Missile Launcher
     <br/>
-    <code>
-     KEY:ATTK_PLSM_MISSL_2B
-    </code>
+    <code>KEY:ATTK_PLSM_MISSL_2B</code>
     - Battery of 2 Plasma Missile
 Launcher
     <br/>
-    <code>
-     KEY:ATTK_PLSM_MISSL_3B
-    </code>
+    <code>KEY:ATTK_PLSM_MISSL_3B</code>
     - Battery of 3 Plasma Missile
 Launcher
     <br/>
-    <code>
-     KEY:ATTK_QUNTM_CANN
-    </code>
+    <code>KEY:ATTK_QUNTM_CANN</code>
     - Quantum Cannon
     <br/>
-    <code>
-     KEY:ATTK_QUNTM_CANN_2L
-    </code>
+    <code>KEY:ATTK_QUNTM_CANN_2L</code>
     - 2 fire-linked Quantum
 Cannons
     <br/>
-    <code>
-     KEY:ATTK_QUNTM_CANN_4L
-    </code>
+    <code>KEY:ATTK_QUNTM_CANN_4L</code>
     - 4 fire-linked Quantum
 Cannons
     <br/>
-    <code>
-     KEY:ATTK_RAIL_CANNON
-    </code>
+    <code>KEY:ATTK_RAIL_CANNON</code>
     - Rail Cannon
     <br/>
-    <code>
-     KEY:ATTK_RAIL_CANNON_2L
-    </code>
+    <code>KEY:ATTK_RAIL_CANNON_2L</code>
     - 2 fire-linked rail
 cannons
     <br/>
-    <code>
-     KEY:ATTK_RAIL_CANNON_4L
-    </code>
+    <code>KEY:ATTK_RAIL_CANNON_4L</code>
     - 4 fire-linked rail
 cannons
     <br/>
-    <code>
-     KEY:ATTK_SNGLRT_CANN
-    </code>
+    <code>KEY:ATTK_SNGLRT_CANN</code>
     - Singularity Cannon
     <br/>
-    <code>
-     KEY:ATTK_SLNG_MSSDRVR
-    </code>
+    <code>KEY:ATTK_SLNG_MSSDRVR</code>
     - Slingshot Massdriver
     <br/>
-    <code>
-     KEY:ATTK_SLIVER_GUN
-    </code>
+    <code>KEY:ATTK_SLIVER_GUN</code>
     - Sliver Gun
     <br/>
-    <code>
-     KEY:ATTK_STRLD_MISSL
-    </code>
+    <code>KEY:ATTK_STRLD_MISSL</code>
     - Starload Missile Launcher
     <br/>
-    <code>
-     KEY:ATTK_STRNG_PRJCTR
-    </code>
+    <code>KEY:ATTK_STRNG_PRJCTR</code>
     - String Projector
     <br/>
-    <code>
-     KEY:ATTK_ZERO_BORE
-    </code>
+    <code>KEY:ATTK_ZERO_BORE</code>
     - Zero Bore
     <br/>
-    <code>
-     KEY:AUTO_TINT
-    </code>
+    <code>KEY:AUTO_TINT</code>
     - Auto-tint
     <br/>
-    <code>
-     KEY:AUTOFIRE
-    </code>
+    <code>KEY:AUTOFIRE</code>
     - Autofire
     <br/>
-    <code>
-     KEY:AUTOCMP_DRVR_DERVISH
-    </code>
+    <code>KEY:AUTOCMP_DRVR_DERVISH</code>
     - Dervish AI-400 (Driver
 Autocomp)
     <br/>
-    <code>
-     KEY:AUTOCMP_DRVR_PEGASUS
-    </code>
+    <code>KEY:AUTOCMP_DRVR_PEGASUS</code>
     - Pegasus AI-200 (Driver
 Autocomp)
     <br/>
-    <code>
-     KEY:AUTOCMP_DRVR_ROADLRD
-    </code>
+    <code>KEY:AUTOCMP_DRVR_ROADLRD</code>
     - Roadlord AI-GA (Driver
 Autocomp)
     <br/>
-    <code>
-     KEY:AUTOCMP_DRVR_TWISTER
-    </code>
+    <code>KEY:AUTOCMP_DRVR_TWISTER</code>
     - Twister AI-800 (Driver
 Autocomp)
     <br/>
-    <code>
-     KEY:AUTOCMP_DRVR_ZEPHYR
-    </code>
+    <code>KEY:AUTOCMP_DRVR_ZEPHYR</code>
     - Zephyr AI-1200 (Driver
 Autocomp)
     <br/>
-    <code>
-     KEY:AUTOCMP_GUNR_ADDER
-    </code>
+    <code>KEY:AUTOCMP_GUNR_ADDER</code>
     - Adder AI-G2 (Gunner
 Autocomp)
     <br/>
-    <code>
-     KEY:AUTOCMP_GUNR_DEADEYE
-    </code>
+    <code>KEY:AUTOCMP_GUNR_DEADEYE</code>
     - Deadeye AI-G4 (Gunner
 Autocomp)
     <br/>
-    <code>
-     KEY:AUTOCMP_GUNR_HOTSHOT
-    </code>
+    <code>KEY:AUTOCMP_GUNR_HOTSHOT</code>
     - Hotshot AI-G8 (Gunner
 Autocomp)
     <br/>
-    <code>
-     KEY:AUTOCMP_GUNR_MARKSMN
-    </code>
+    <code>KEY:AUTOCMP_GUNR_MARKSMN</code>
     - Marksman AI-GA (Gunner
 Autocomp)
     <br/>
-    <code>
-     KEY:AUTOCMP_GUNR_RTTLSNK
-    </code>
+    <code>KEY:AUTOCMP_GUNR_RTTLSNK</code>
     - Rattlesnake AI-GX (Gunner
 Autocomp)
     <br/>
-    <code>
-     KEY:AUTOFIRE
-    </code>
+    <code>KEY:AUTOFIRE</code>
     - Autofire
     <br/>
-    <code>
-     KEY:AUTOPILOT
-    </code>
+    <code>KEY:AUTOPILOT</code>
     - Autopilot
     <br/>
-    <code>
-     KEY:APRTR
-    </code>
+    <code>KEY:APRTR</code>
     - Aporter
     <br/>
-    <code>
-     KEY:BACKFIRE_PALMPRINT_ID
-    </code>
+    <code>KEY:BACKFIRE_PALMPRINT_ID</code>
     - Backfire Palmprint
 ID
     <br/>
-    <code>
-     KEY:BACKUP_IDCARD
-    </code>
+    <code>KEY:BACKUP_IDCARD</code>
     - Backup ID
     <br/>
-    <code>
-     KEY:BAL_THROWN
-    </code>
+    <code>KEY:BAL_THROWN</code>
     - Balanced
     <br/>
-    <code>
-     KEY:BAL_RANGE
-    </code>
+    <code>KEY:BAL_RANGE</code>
     - Balanced
     <br/>
-    <code>
-     KEY:BANE_A
-    </code>
+    <code>KEY:BANE_A</code>
     - Bane
     <br/>
-    <code>
-     KEY:BANE_AMMO
-    </code>
+    <code>KEY:BANE_AMMO</code>
     - Bane
     <br/>
-    <code>
-     KEY:BANE_AR
-    </code>
+    <code>KEY:BANE_AR</code>
     - Bane
     <br/>
-    <code>
-     KEY:BANE_M
-    </code>
+    <code>KEY:BANE_M</code>
     - Bane
     <br/>
-    <code>
-     KEY:BANE_MELEE
-    </code>
+    <code>KEY:BANE_MELEE</code>
     - Bane
     <br/>
-    <code>
-     KEY:BANE_R
-    </code>
+    <code>KEY:BANE_R</code>
     - Bane
     <br/>
-    <code>
-     KEY:BANE_RANGED
-    </code>
+    <code>KEY:BANE_RANGED</code>
     - Bane
     <br/>
-    <code>
-     KEY:BARBED
-    </code>
+    <code>KEY:BARBED</code>
     - Barbed
     <br/>
-    <code>
-     KEY:BASH_H
-    </code>
+    <code>KEY:BASH_H</code>
     - Bashing
     <br/>
-    <code>
-     KEY:BASH_HVY
-    </code>
+    <code>KEY:BASH_HVY</code>
     - Bashing
     <br/>
-    <code>
-     KEY:BASH_L
-    </code>
+    <code>KEY:BASH_L</code>
     - Bashing
     <br/>
-    <code>
-     KEY:BASH_LT
-    </code>
+    <code>KEY:BASH_LT</code>
     - Bashing
     <br/>
-    <code>
-     KEY:BATTERY_OF_2
-    </code>
+    <code>KEY:BATTERY_OF_2</code>
     - Battery of 2
     <br/>
-    <code>
-     KEY:BATTERY_OF_3
-    </code>
+    <code>KEY:BATTERY_OF_3</code>
     - Battery of 3
     <br/>
-    <code>
-     KEY:BATTERY_OF_4
-    </code>
+    <code>KEY:BATTERY_OF_4</code>
     - Battery of 4
     <br/>
-    <code>
-     KEY:BATTERY_OF_5
-    </code>
+    <code>KEY:BATTERY_OF_5</code>
     - Battery of 5
     <br/>
-    <code>
-     KEY:BAYONET
-    </code>
+    <code>KEY:BAYONET</code>
     - Bayonet
     <br/>
-    <code>
-     KEY:BB_TRP_GDGT_BRB
-    </code>
+    <code>KEY:BB_TRP_GDGT_BRB</code>
     - Booby Trapped Gadget
 (Barbs)
     <br/>
-    <code>
-     KEY:BB_TRP_GDGT_ELS
-    </code>
+    <code>KEY:BB_TRP_GDGT_ELS</code>
     - Booby Trapped Gadget (Electric
 Shock)
     <br/>
-    <code>
-     KEY:BB_TRP_GDGT_STB
-    </code>
+    <code>KEY:BB_TRP_GDGT_STB</code>
     - Booby Trapped Gadget (Stun
 Bolt)
     <br/>
-    <code>
-     KEY:BB_TRP_GDGT_TIW
-    </code>
+    <code>KEY:BB_TRP_GDGT_TIW</code>
     - Booby Trapped Gadget (Trigger
 Integrated Weapon)
     <br/>
-    <code>
-     KEY:BDY_FDR
-    </code>
+    <code>KEY:BDY_FDR</code>
     - Body Feeder
     <br/>
-    <code>
-     KEY:BIND
-    </code>
+    <code>KEY:BIND</code>
     - Blinding
     <br/>
-    <code>
-     KEY:BLACK_HEADLIGHTS
-    </code>
+    <code>KEY:BLACK_HEADLIGHTS</code>
     - Black headlights
     <br/>
-    <code>
-     KEY:BLADE_SHOE
-    </code>
+    <code>KEY:BLADE_SHOE</code>
     - Blade
     <br/>
-    <code>
-     KEY:BLADEGUN1
-    </code>
+    <code>KEY:BLADEGUN1</code>
     - Bladegun
     <br/>
-    <code>
-     KEY:BLADEGUN2
-    </code>
+    <code>KEY:BLADEGUN2</code>
     - Bladegun
     <br/>
-    <code>
-     KEY:BLADEGUN3
-    </code>
+    <code>KEY:BLADEGUN3</code>
     - Bladegun
     <br/>
-    <code>
-     KEY:BLBD
-    </code>
+    <code>KEY:BLBD</code>
     - Billboard
     <br/>
-    <code>
-     KEY:BLINDING
-    </code>
+    <code>KEY:BLINDING</code>
     - Blinding
     <br/>
-    <code>
-     KEY:BLINDMAN_EARIMPLANT
-    </code>
+    <code>KEY:BLINDMAN_EARIMPLANT</code>
     - Blindman Unit
     <br/>
-    <code>
-     KEY:BLOWBACK_PALMPRINT_ID
-    </code>
+    <code>KEY:BLOWBACK_PALMPRINT_ID</code>
     - Blowback Palmprint
 ID
     <br/>
-    <code>
-     KEY:BLWK_TAC_SHLD
-    </code>
+    <code>KEY:BLWK_TAC_SHLD</code>
     - Bulwark Tactical Shield
 (PL5)
     <br/>
-    <code>
-     KEY:BNB_IMPROVED_CRITICAL
-    </code>
+    <code>KEY:BNB_IMPROVED_CRITICAL</code>
     - Improved Critical
     <br/>
-    <code>
-     KEY:BNB_IMPROVED_GRAPPLE
-    </code>
+    <code>KEY:BNB_IMPROVED_GRAPPLE</code>
     - Improved Grapple
     <br/>
-    <code>
-     KEY:BNB_IMPROVED_OVERRUN
-    </code>
+    <code>KEY:BNB_IMPROVED_OVERRUN</code>
     - Improved Overrun
     <br/>
-    <code>
-     KEY:BNB_MASTER_OF_DISGUISE
-    </code>
+    <code>KEY:BNB_MASTER_OF_DISGUISE</code>
     - Master of Disguise
     <br/>
-    <code>
-     KEY:BNB_SCENT
-    </code>
+    <code>KEY:BNB_SCENT</code>
     - Scent
     <br/>
-    <code>
-     KEY:BNS_AC_DEFL
-    </code>
+    <code>KEY:BNS_AC_DEFL</code>
     - AC Bonus (Deflection)
     <br/>
-    <code>
-     KEY:BNS_AC_INSI
-    </code>
+    <code>KEY:BNS_AC_INSI</code>
     - AC Bonus (Insight)
     <br/>
-    <code>
-     KEY:BNS_AC_LUCK
-    </code>
+    <code>KEY:BNS_AC_LUCK</code>
     - AC Bonus (Luck)
     <br/>
-    <code>
-     KEY:BNS_AC_OTHE
-    </code>
+    <code>KEY:BNS_AC_OTHE</code>
     - AC Bonus (Other)
     <br/>
-    <code>
-     KEY:BNS_AC_PROF
-    </code>
+    <code>KEY:BNS_AC_PROF</code>
     - AC Bonus (Profane)
     <br/>
-    <code>
-     KEY:BNS_AC_SCRD
-    </code>
+    <code>KEY:BNS_AC_SCRD</code>
     - AC Bonus (Sacred)
     <br/>
-    <code>
-     KEY:BNS_ENHC_AB
-    </code>
+    <code>KEY:BNS_ENHC_AB</code>
     - Ability Bonus (Enhancement)
     <br/>
-    <code>
-     KEY:BNS_ENHC_AC
-    </code>
+    <code>KEY:BNS_ENHC_AC</code>
     - Armor Bonus (Enhancement)
     <br/>
-    <code>
-     KEY:BNS_ENHC_NAT
-    </code>
+    <code>KEY:BNS_ENHC_NAT</code>
     - Natural Armor Bonus
 (Enhancement)
     <br/>
-    <code>
-     KEY:BNS_EVASIVE_MANEUVERS
-    </code>
+    <code>KEY:BNS_EVASIVE_MANEUVERS</code>
     - Evasive Maneuvers
     <br/>
-    <code>
-     KEY:BNS_FIGHTER_ESCORT
-    </code>
+    <code>KEY:BNS_FIGHTER_ESCORT</code>
     - Fighter Escort
     <br/>
-    <code>
-     KEY:BNS_FORMATION_FLYING
-    </code>
+    <code>KEY:BNS_FORMATION_FLYING</code>
     - Formation Flying
     <br/>
-    <code>
-     KEY:BNS_SAV_INS
-    </code>
+    <code>KEY:BNS_SAV_INS</code>
     - Save Bonus (Insight)
     <br/>
-    <code>
-     KEY:BNS_SAV_LUC
-    </code>
+    <code>KEY:BNS_SAV_LUC</code>
     - Save Bonus (Luck)
     <br/>
-    <code>
-     KEY:BNS_SAV_OTH
-    </code>
+    <code>KEY:BNS_SAV_OTH</code>
     - Save Bonus (Other)
     <br/>
-    <code>
-     KEY:BNS_SAV_PRO
-    </code>
+    <code>KEY:BNS_SAV_PRO</code>
     - Save Bonus (Profane)
     <br/>
-    <code>
-     KEY:BNS_SAV_RES
-    </code>
+    <code>KEY:BNS_SAV_RES</code>
     - Save Bonus (Resistance)
     <br/>
-    <code>
-     KEY:BNS_SAV_SAC
-    </code>
+    <code>KEY:BNS_SAV_SAC</code>
     - Save Bonus (Sacred)
     <br/>
-    <code>
-     KEY:BNS_SEMPER_FI
-    </code>
+    <code>KEY:BNS_SEMPER_FI</code>
     - Semper Fi
     <br/>
-    <code>
-     KEY:BNS_SKL_CIR
-    </code>
+    <code>KEY:BNS_SKL_CIR</code>
     - Skill Bonus (Circumstance)
     <br/>
-    <code>
-     KEY:BNS_SKL_CMP
-    </code>
+    <code>KEY:BNS_SKL_CMP</code>
     - Skill Bonus (Competence)
     <br/>
-    <code>
-     KEY:BNS_SKL_LCK
-    </code>
+    <code>KEY:BNS_SKL_LCK</code>
     - Skill Luck Bonus
     <br/>
-    <code>
-     KEY:BNS_SPELL
-    </code>
+    <code>KEY:BNS_SPELL</code>
     - Bonus Spell
     <br/>
-    <code>
-     KEY:BNS_SPL_RST
-    </code>
+    <code>KEY:BNS_SPL_RST</code>
     - Spell Resistance
     <br/>
-    <code>
-     KEY:BNS_WINGMAN
-    </code>
+    <code>KEY:BNS_WINGMAN</code>
     - Wingman
     <br/>
-    <code>
-     KEY:BODYFEED
-    </code>
+    <code>KEY:BODYFEED</code>
     - Bodyfeeder
     <br/>
-    <code>
-     KEY:BOHMASABCOUR
-    </code>
+    <code>KEY:BOHMASABCOUR</code>
     - Absolute Courage
     <br/>
-    <code>
-     KEY:BOHMASABPUR
-    </code>
+    <code>KEY:BOHMASABPUR</code>
     - Absolute Purity
     <br/>
-    <code>
-     KEY:BOHMASCHAR
-    </code>
+    <code>KEY:BOHMASCHAR</code>
     - Charity
     <br/>
-    <code>
-     KEY:BOHMASCOUR
-    </code>
+    <code>KEY:BOHMASCOUR</code>
     - Courage
     <br/>
-    <code>
-     KEY:BOHMASCRYS
-    </code>
+    <code>KEY:BOHMASCRYS</code>
     - Crystal
     <br/>
-    <code>
-     KEY:BOHMASDWARD
-    </code>
+    <code>KEY:BOHMASDWARD</code>
     - Deathward
     <br/>
-    <code>
-     KEY:BOHMASFAITH
-    </code>
+    <code>KEY:BOHMASFAITH</code>
     - Faith
     <br/>
-    <code>
-     KEY:BOHMASGOLD
-    </code>
+    <code>KEY:BOHMASGOLD</code>
     - Gold
     <br/>
-    <code>
-     KEY:BOHMASPLAT
-    </code>
+    <code>KEY:BOHMASPLAT</code>
     - Platinum
     <br/>
-    <code>
-     KEY:BOHMASPUR
-    </code>
+    <code>KEY:BOHMASPUR</code>
     - Purity
     <br/>
-    <code>
-     KEY:BOHMASSILV
-    </code>
+    <code>KEY:BOHMASSILV</code>
     - Silver
     <br/>
-    <code>
-     KEY:BOHMWEAPCRYS
-    </code>
+    <code>KEY:BOHMWEAPCRYS</code>
     - Crystal
     <br/>
-    <code>
-     KEY:BOHMWEAPGLD
-    </code>
+    <code>KEY:BOHMWEAPGLD</code>
     - Gold
     <br/>
-    <code>
-     KEY:BOHMWEAPPLAT
-    </code>
+    <code>KEY:BOHMWEAPPLAT</code>
     - Platinum
     <br/>
-    <code>
-     KEY:BOHMWEAPSILV
-    </code>
+    <code>KEY:BOHMWEAPSILV</code>
     - Silver
     <br/>
-    <code>
-     KEY:BONE
-    </code>
+    <code>KEY:BONE</code>
     - Bone
     <br/>
-    <code>
-     KEY:BOOBY_TRAPPED
-    </code>
+    <code>KEY:BOOBY_TRAPPED</code>
     - Booby trapped
     <br/>
-    <code>
-     KEY:BOWSTR
-    </code>
+    <code>KEY:BOWSTR</code>
     - Bow_STR
     <br/>
-    <code>
-     KEY:BOWSTR
-    </code>
+    <code>KEY:BOWSTR</code>
     - #Bow_STR
     <br/>
-    <code>
-     KEY:BRASS
-    </code>
+    <code>KEY:BRASS</code>
     - Brass
     <br/>
-    <code>
-     KEY:BREAKDOWN_GUN
-    </code>
+    <code>KEY:BREAKDOWN_GUN</code>
     - Electronic Scope
     <br/>
-    <code>
-     KEY:BRCD_TAC_SHLD
-    </code>
+    <code>KEY:BRCD_TAC_SHLD</code>
     - Barricade Tactical Shield
 (PL7)
     <br/>
-    <code>
-     KEY:BRI_EN_A
-    </code>
+    <code>KEY:BRI_EN_A</code>
     - Brilliant Energy
     <br/>
-    <code>
-     KEY:BRI_EN_M
-    </code>
+    <code>KEY:BRI_EN_M</code>
     - Brilliant Energy
     <br/>
-    <code>
-     KEY:BRI_EN_T
-    </code>
+    <code>KEY:BRI_EN_T</code>
     - Brilliant Energy
     <br/>
-    <code>
-     KEY:BRILNT_MELEE
-    </code>
+    <code>KEY:BRILNT_MELEE</code>
     - Brilliant
     <br/>
-    <code>
-     KEY:BRONZE
-    </code>
+    <code>KEY:BRONZE</code>
     - Bronze
     <br/>
-    <code>
-     KEY:BSTN_TAC_SHLD
-    </code>
+    <code>KEY:BSTN_TAC_SHLD</code>
     - Bastion Tactical Shield
 (PL6)
     <br/>
-    <code>
-     KEY:BTVSUNDER
-    </code>
+    <code>KEY:BTVSUNDER</code>
     - Sundering
     <br/>
-    <code>
-     KEY:BUMP_BLAST
-    </code>
+    <code>KEY:BUMP_BLAST</code>
     - Bumpers of Blasting
     <br/>
-    <code>
-     KEY:BUMP_RAM
-    </code>
+    <code>KEY:BUMP_RAM</code>
     - Bumper of the Ram
     <br/>
-    <code>
-     KEY:BURSTFIRE
-    </code>
+    <code>KEY:BURSTFIRE</code>
     - Burst fire
     <br/>
-    <code>
-     KEY:C_IRON
-    </code>
+    <code>KEY:C_IRON</code>
     - Cold Iron
     <br/>
-    <code>
-     KEY:C_IRON/2
-    </code>
+    <code>KEY:C_IRON/2</code>
     - 1/2 Cold Iron
     <span class="new">
      (deprecated)
     </span>
     <br/>
-    <code>
-     KEY:CAST
-    </code>
+    <code>KEY:CAST</code>
     - Spellcasting
     <br/>
-    <code>
-     KEY:CASTSUP
-    </code>
+    <code>KEY:CASTSUP</code>
     - Spellcasting (Superior)
     <br/>
-    <code>
-     KEY:CATCHING
-    </code>
+    <code>KEY:CATCHING</code>
     - Catching
     <br/>
-    <code>
-     KEY:CBQ_WEAPON
-    </code>
+    <code>KEY:CBQ_WEAPON</code>
     - CBQ
     <br/>
-    <code>
-     KEY:CERAMIC
-    </code>
+    <code>KEY:CERAMIC</code>
     - Ceramic
     <br/>
-    <code>
-     KEY:CERAMIC_ARM
-    </code>
+    <code>KEY:CERAMIC_ARM</code>
     - Ceramics
     <br/>
-    <code>
-     KEY:CERAMIC_WEAP
-    </code>
+    <code>KEY:CERAMIC_WEAP</code>
     - Ceramics
     <br/>
-    <code>
-     KEY:CHAMPDET
-    </code>
+    <code>KEY:CHAMPDET</code>
     - Champion Detecting
     <br/>
-    <code>
-     KEY:CHARGED_ITEM_12
-    </code>
+    <code>KEY:CHARGED_ITEM_12</code>
     - Charges (12)
     <br/>
-    <code>
-     KEY:CHAOS_A
-    </code>
+    <code>KEY:CHAOS_A</code>
     - Anarchic, Chaotic
     <br/>
-    <code>
-     KEY:CHAOS_M
-    </code>
+    <code>KEY:CHAOS_M</code>
     - Anarchic, Chaotic
     <br/>
-    <code>
-     KEY:CHAOS_POWER_AMMO
-    </code>
+    <code>KEY:CHAOS_POWER_AMMO</code>
     - Anarchic Energy
     <br/>
-    <code>
-     KEY:CHAOS_POWER_MELEE
-    </code>
+    <code>KEY:CHAOS_POWER_MELEE</code>
     - Anarchic Energy
     <br/>
-    <code>
-     KEY:CHAOS_POWER_RANGED
-    </code>
+    <code>KEY:CHAOS_POWER_RANGED</code>
     - Anarchic Energy
     <br/>
-    <code>
-     KEY:CHAOS_R
-    </code>
+    <code>KEY:CHAOS_R</code>
     - Anarchic, Chaotic
     <br/>
-    <code>
-     KEY:CHAOTIC_MELEE
-    </code>
+    <code>KEY:CHAOTIC_MELEE</code>
     - Chaotic
     <br/>
-    <code>
-     KEY:CHAOTIC_RANGED
-    </code>
+    <code>KEY:CHAOTIC_RANGED</code>
     - Chaotic
     <br/>
-    <code>
-     KEY:CHARGED_ITEM_3
-    </code>
+    <code>KEY:CHARGED_ITEM_3</code>
     - Charges (3)
     <br/>
-    <code>
-     KEY:CHARGED_ITEM_4
-    </code>
+    <code>KEY:CHARGED_ITEM_4</code>
     - Charges (4)
     <br/>
-    <code>
-     KEY:CHARGED_ITEM_5
-    </code>
+    <code>KEY:CHARGED_ITEM_5</code>
     - Charges (5)
     <br/>
-    <code>
-     KEY:CHARGED_ITEM_7
-    </code>
+    <code>KEY:CHARGED_ITEM_7</code>
     - Charges (7)
     <br/>
-    <code>
-     KEY:CHARGED_ITEM_10
-    </code>
+    <code>KEY:CHARGED_ITEM_10</code>
     - Charges (10)
     <br/>
-    <code>
-     KEY:CHARGED_ITEM_12
-    </code>
+    <code>KEY:CHARGED_ITEM_12</code>
     - Charges (12)
     <br/>
-    <code>
-     KEY:CHARGED_ITEM_14
-    </code>
+    <code>KEY:CHARGED_ITEM_14</code>
     - Charges (14)
     <br/>
-    <code>
-     KEY:CHARGED_ITEM_34
-    </code>
+    <code>KEY:CHARGED_ITEM_34</code>
     - Charges (34)
     <br/>
-    <code>
-     KEY:CHARGED_ITEM_36
-    </code>
+    <code>KEY:CHARGED_ITEM_36</code>
     - Charges (36)
     <br/>
-    <code>
-     KEY:CHARGED_ITEM_50
-    </code>
+    <code>KEY:CHARGED_ITEM_50</code>
     - Charges (50)
     <br/>
-    <code>
-     KEY:CHARGED_ITEM_101
-    </code>
+    <code>KEY:CHARGED_ITEM_101</code>
     - Charges (101)
     <br/>
-    <code>
-     KEY:CHMLNC_SRFC_GDGT
-    </code>
+    <code>KEY:CHMLNC_SRFC_GDGT</code>
     - Chameleonic Surface
 Gadget
     <br/>
-    <code>
-     KEY:CHRGD
-    </code>
+    <code>KEY:CHRGD</code>
     - Charged
     <br/>
-    <code>
-     KEY:CHRSNTHMM_LSR_ARR
-    </code>
+    <code>KEY:CHRSNTHMM_LSR_ARR</code>
     - Chrysanthemum Laser Array (PL
 6)
     <br/>
-    <code>
-     KEY:CHTR
-    </code>
+    <code>KEY:CHTR</code>
     - Chemical Treating
     <br/>
-    <code>
-     KEY:CLAY
-    </code>
+    <code>KEY:CLAY</code>
     - Clay
     <br/>
-    <code>
-     KEY:CLIMB
-    </code>
+    <code>KEY:CLIMB</code>
     - Climbing
     <br/>
-    <code>
-     KEY:CLOTH
-    </code>
+    <code>KEY:CLOTH</code>
     - Cloth
     <br/>
-    <code>
-     KEY:CL1_SNSR_SYS
-    </code>
+    <code>KEY:CL1_SNSR_SYS</code>
     - Class I Sensor System (PL6)
     <br/>
-    <code>
-     KEY:CL2_SNSR_SYS
-    </code>
+    <code>KEY:CL2_SNSR_SYS</code>
     - Class II Sensor System (PL6)
     <br/>
-    <code>
-     KEY:CL3_SNSR_SYS
-    </code>
+    <code>KEY:CL3_SNSR_SYS</code>
     - Class III Sensor System (PL6)
     <br/>
-    <code>
-     KEY:CL4_SNSR_SYS
-    </code>
+    <code>KEY:CL4_SNSR_SYS</code>
     - Class IV Sensor System (PL7)
     <br/>
-    <code>
-     KEY:CL5_SNSR_SYS
-    </code>
+    <code>KEY:CL5_SNSR_SYS</code>
     - Class V Sensor System (PL7)
     <br/>
-    <code>
-     KEY:CL6_SNSR_SYS
-    </code>
+    <code>KEY:CL6_SNSR_SYS</code>
     - Class VI Sensor System (PL8)
     <br/>
-    <code>
-     KEY:CLLPSBL_GDGT
-    </code>
+    <code>KEY:CLLPSBL_GDGT</code>
     - Collapsible Gadget
     <br/>
-    <code>
-     KEY:CLOAKING_DEVICE
-    </code>
+    <code>KEY:CLOAKING_DEVICE</code>
     - Cloaking device
     <br/>
-    <code>
-     KEY:CLOAKING_SCRN
-    </code>
+    <code>KEY:CLOAKING_SCRN</code>
     - Cloaking Screen (PL8)
     <br/>
-    <code>
-     KEY:CLOTHYRD_SHAFT
-    </code>
+    <code>KEY:CLOTHYRD_SHAFT</code>
     - Clothyard Shaft
     <br/>
-    <code>
-     KEY:CLLPSBL_GDGT
-    </code>
+    <code>KEY:CLLPSBL_GDGT</code>
     - Collapsible Gadget
     <br/>
-    <code>
-     KEY:CMPCT_GDGT_EQP
-    </code>
+    <code>KEY:CMPCT_GDGT_EQP</code>
     - Compact Gadget
     <br/>
-    <code>
-     KEY:CMPCT_GDGT_WPN
-    </code>
+    <code>KEY:CMPCT_GDGT_WPN</code>
     - Compact Gadget
     <br/>
-    <code>
-     KEY:COCKPIT_COPILOT
-    </code>
+    <code>KEY:COCKPIT_COPILOT</code>
     - Cockpit (Copilot)
     <br/>
-    <code>
-     KEY:COCKPIT_PASSNGR
-    </code>
+    <code>KEY:COCKPIT_PASSNGR</code>
     - Cockpit (Passenger)
     <br/>
-    <code>
-     KEY:COCKPIT_PILOT
-    </code>
+    <code>KEY:COCKPIT_PILOT</code>
     - Cockpit (Pilot)
     <br/>
-    <code>
-     KEY:COL_AVNG_ELCT_SCM
-    </code>
+    <code>KEY:COL_AVNG_ELCT_SCM</code>
     - Avenger Electro-Scimitar (PL
 8)
     <br/>
-    <code>
-     KEY:COL_JUMP_DRIVE
-    </code>
+    <code>KEY:COL_JUMP_DRIVE</code>
     - Jump Drive (Colossal)
     <br/>
-    <code>
-     KEY:COL_LK8_AMRPCG_PK
-    </code>
+    <code>KEY:COL_LK8_AMRPCG_PK</code>
     - LK8 Armor-Piercing Pike (PL
 6)
     <br/>
-    <code>
-     KEY:COL_MCH
-    </code>
+    <code>KEY:COL_MCH</code>
     - Colossal Mecha
     <br/>
-    <code>
-     KEY:COL_PS15_PNTR_CLW
-    </code>
+    <code>KEY:COL_PS15_PNTR_CLW</code>
     - PS-15 Panther Claws (PL
 5)
     <br/>
-    <code>
-     KEY:COL_PS25_TIGR_CLW
-    </code>
+    <code>KEY:COL_PS25_TIGR_CLW</code>
     - PS-25 Tiger Claws (PL 7)
     <br/>
-    <code>
-     KEY:COL_PTHN_ELCT_WHP
-    </code>
+    <code>KEY:COL_PTHN_ELCT_WHP</code>
     - XJ-A Python Electro-Whip (PL
 7)
     <br/>
-    <code>
-     KEY:COL_QUAD_MCH
-    </code>
+    <code>KEY:COL_QUAD_MCH</code>
     - Quadrupedal
     <br/>
-    <code>
-     KEY:COL_RP91_RPR_LSCT
-    </code>
+    <code>KEY:COL_RP91_RPR_LSCT</code>
     - RP-91 Reaper Laser Scythe (PL
 8)
     <br/>
-    <code>
-     KEY:COL_THNDRB_SHK_RD
-    </code>
+    <code>KEY:COL_THNDRB_SHK_RD</code>
     - Thunderbolt Shock Rod (PL
 5)
     <br/>
-    <code>
-     KEY:COLD_RES
-    </code>
+    <code>KEY:COLD_RES</code>
     - Cold Resistance
     <br/>
-    <code>
-     KEY:COLD_WARD
-    </code>
+    <code>KEY:COLD_WARD</code>
     - Cold Warding
     <br/>
-    <code>
-     KEY:COLLI_A
-    </code>
+    <code>KEY:COLLI_A</code>
     - Collision (+2)
     <br/>
-    <code>
-     KEY:COLLI_M
-    </code>
+    <code>KEY:COLLI_M</code>
     - Collision (+2)
     <br/>
-    <code>
-     KEY:COLLI_R
-    </code>
+    <code>KEY:COLLI_R</code>
     - Collision (+2)
     <br/>
-    <code>
-     KEY:COMFORT
-    </code>
+    <code>KEY:COMFORT</code>
     - Comfort
     <br/>
-    <code>
-     KEY:COMM_ANSIBLE
-    </code>
+    <code>KEY:COMM_ANSIBLE</code>
     - Ansible
     <br/>
-    <code>
-     KEY:COMM_DRIVE_TRNSCVR
-    </code>
+    <code>KEY:COMM_DRIVE_TRNSCVR</code>
     - Drive Transceiver
     <br/>
-    <code>
-     KEY:COMM_DRIVESAT
-    </code>
+    <code>KEY:COMM_DRIVESAT</code>
     - Drivesat Comm Array
     <br/>
-    <code>
-     KEY:COMM_INTERNAL_AUDIO
-    </code>
+    <code>KEY:COMM_INTERNAL_AUDIO</code>
     - Internal Audio Comm
 System
     <br/>
-    <code>
-     KEY:COMM_INTERNAL_VIDEO
-    </code>
+    <code>KEY:COMM_INTERNAL_VIDEO</code>
     - Internal Video Comm
 System
     <br/>
-    <code>
-     KEY:COMM_LASER_TRNSCVR
-    </code>
+    <code>KEY:COMM_LASER_TRNSCVR</code>
     - Laser Transceiver
     <br/>
-    <code>
-     KEY:COMM_MASS_TRNSCVR
-    </code>
+    <code>KEY:COMM_MASS_TRNSCVR</code>
     - Mass Transceiver
     <br/>
-    <code>
-     KEY:COMM_RADIO_TRNSCVR
-    </code>
+    <code>KEY:COMM_RADIO_TRNSCVR</code>
     - Radio Transceiver
     <br/>
-    <code>
-     KEY:COMM_SYSTEM
-    </code>
+    <code>KEY:COMM_SYSTEM</code>
     - Comm System
     <br/>
-    <code>
-     KEY:COMPUTER_PLUS_1
-    </code>
+    <code>KEY:COMPUTER_PLUS_1</code>
     - +1
     <br/>
-    <code>
-     KEY:COMPUTER_PLUS_2
-    </code>
+    <code>KEY:COMPUTER_PLUS_2</code>
     - +2
     <br/>
-    <code>
-     KEY:COMPUTER_PLUS_3
-    </code>
+    <code>KEY:COMPUTER_PLUS_3</code>
     - +3
     <br/>
-    <code>
-     KEY:CONCEALED_MACHINE_GUN
-    </code>
+    <code>KEY:CONCEALED_MACHINE_GUN</code>
     - Concealed machine
 gun
     <br/>
-    <code>
-     KEY:CONCRETE
-    </code>
+    <code>KEY:CONCRETE</code>
     - Concrete
     <br/>
-    <code>
-     KEY:COPYCAT
-    </code>
+    <code>KEY:COPYCAT</code>
     - Copycat
     <br/>
-    <code>
-     KEY:CORONA_MICROWV_BM
-    </code>
+    <code>KEY:CORONA_MICROWV_BM</code>
     - Corona Microwave Beam (PL
 6)
     <br/>
-    <code>
-     KEY:CORRUPTED
-    </code>
+    <code>KEY:CORRUPTED</code>
     - Corrupted
     <br/>
-    <code>
-     KEY:CORRUPTING
-    </code>
+    <code>KEY:CORRUPTING</code>
     - Corrupting
     <br/>
-    <code>
-     KEY:COUNTER_SURVEILLANCE
-    </code>
+    <code>KEY:COUNTER_SURVEILLANCE</code>
     - Counter surveillance
     <br/>
-    <code>
-     KEY:COUPGR_A
-    </code>
+    <code>KEY:COUPGR_A</code>
     - Coup de Grace (+5)
     <br/>
-    <code>
-     KEY:COUPGR_M
-    </code>
+    <code>KEY:COUPGR_M</code>
     - Coup de Grace (+5)
     <br/>
-    <code>
-     KEY:COUPGR_R
-    </code>
+    <code>KEY:COUPGR_R</code>
     - Coup de Grace (+5)
     <br/>
-    <code>
-     KEY:CPNT_ABLATV
-    </code>
+    <code>KEY:CPNT_ABLATV</code>
     - Ablative Paint Job
     <br/>
-    <code>
-     KEY:CPNT_BLUR
-    </code>
+    <code>KEY:CPNT_BLUR</code>
     - Paint Job of Blurring
     <br/>
-    <code>
-     KEY:CPNT_FLAME
-    </code>
+    <code>KEY:CPNT_FLAME</code>
     - Flame Job
     <br/>
-    <code>
-     KEY:CPNT_NDSCRPT
-    </code>
+    <code>KEY:CPNT_NDSCRPT</code>
     - Nondescript Paint Job
     <br/>
-    <code>
-     KEY:CPNT_SHRNK
-    </code>
+    <code>KEY:CPNT_SHRNK</code>
     - Shrinking Paint Job
     <br/>
-    <code>
-     KEY:CREATDET
-    </code>
+    <code>KEY:CREATDET</code>
     - Creature Detecting
     <br/>
-    <code>
-     KEY:CRKRJCK_NRL_LNK
-    </code>
+    <code>KEY:CRKRJCK_NRL_LNK</code>
     - Crackerjack Neural Link (PL
 8)
     <br/>
-    <code>
-     KEY:CRSTLCBN_ARMR
-    </code>
+    <code>KEY:CRSTLCBN_ARMR</code>
     - Crystal Carbon Armor (PL7)
     <br/>
-    <code>
-     KEY:CRUSH
-    </code>
+    <code>KEY:CRUSH</code>
     - Crushing
     <br/>
-    <code>
-     KEY:CRYS_DEEP
-    </code>
+    <code>KEY:CRYS_DEEP</code>
     - Crystal (Deep)
     <br/>
-    <code>
-     KEY:CRYS_DEEP_ITEM
-    </code>
+    <code>KEY:CRYS_DEEP_ITEM</code>
     - Crystal (Deep)
     <br/>
-    <code>
-     KEY:CRYS_MUN
-    </code>
+    <code>KEY:CRYS_MUN</code>
     - Crystal (Mundane)
     <br/>
-    <code>
-     KEY:CRYS_MUN_ITEM
-    </code>
+    <code>KEY:CRYS_MUN_ITEM</code>
     - Crystal (Mundane)
     <br/>
-    <code>
-     KEY:CRYSTAL
-    </code>
+    <code>KEY:CRYSTAL</code>
     - Crystalline
     <br/>
-    <code>
-     KEY:CTAR_TRNKMSK
-    </code>
+    <code>KEY:CTAR_TRNKMSK</code>
     - Trunk of Masking
     <br/>
-    <code>
-     KEY:CUSGRIP
-    </code>
+    <code>KEY:CUSGRIP</code>
     - Custom Grip
     <br/>
-    <code>
-     KEY:CUSSIT
-    </code>
+    <code>KEY:CUSSIT</code>
     - Custom Sights
     <br/>
-    <code>
-     KEY:CUST_HILT
-    </code>
+    <code>KEY:CUST_HILT</code>
     - Custom Hilt
     <br/>
-    <code>
-     KEY:CUSTH1
-    </code>
+    <code>KEY:CUSTH1</code>
     - Custom Fitx1 [Heavy Armor]
     <br/>
-    <code>
-     KEY:CUSTH2
-    </code>
+    <code>KEY:CUSTH2</code>
     - Custom Fitx2 [Heavy Armor]
     <br/>
-    <code>
-     KEY:CUSTH3
-    </code>
+    <code>KEY:CUSTH3</code>
     - Custom Fitx3 [Heavy Armor]
     <br/>
-    <code>
-     KEY:CUSTL1
-    </code>
+    <code>KEY:CUSTL1</code>
     - Custom Fitx1 [Light Armor]
     <br/>
-    <code>
-     KEY:CUSTL2
-    </code>
+    <code>KEY:CUSTL2</code>
     - Custom Fitx2 [Light Armor]
     <br/>
-    <code>
-     KEY:CUSTL3
-    </code>
+    <code>KEY:CUSTL3</code>
     - Custom Fitx3 [Light Armor]
     <br/>
-    <code>
-     KEY:CUSTM1
-    </code>
+    <code>KEY:CUSTM1</code>
     - Custom Fitx1 [Medium Armor]
     <br/>
-    <code>
-     KEY:CUSTM2
-    </code>
+    <code>KEY:CUSTM2</code>
     - Custom Fitx2 [Medium Armor]
     <br/>
-    <code>
-     KEY:CUSTM3
-    </code>
+    <code>KEY:CUSTM3</code>
     - Custom Fitx3 [Medium Armor]
     <br/>
-    <code>
-     KEY:CUSTOMA
-    </code>
+    <code>KEY:CUSTOMA</code>
     - Custom - Armor.Shield
     <br/>
-    <code>
-     KEY:CUSTOMW
-    </code>
+    <code>KEY:CUSTOMW</code>
     - Custom - Weapon
     <br/>
-    <code>
-     KEY:D_DRV_GNRTR8
-    </code>
+    <code>KEY:D_DRV_GNRTR8</code>
     - D-Drive Generator (PL8)
     <br/>
-    <code>
-     KEY:D_DRV_GNRTR9
-    </code>
+    <code>KEY:D_DRV_GNRTR9</code>
     - D-Drive Generator (PL9)
     <br/>
-    <code>
-     KEY:D_1USEMA
-    </code>
+    <code>KEY:D_1USEMA</code>
     - Spell Effect (Single
 Use/Completion)
     <br/>
-    <code>
-     KEY:D_1USEME
-    </code>
+    <code>KEY:D_1USEME</code>
     - Spell Effect (Single
 Use/Completion)
     <br/>
-    <code>
-     KEY:D_1USEMI
-    </code>
+    <code>KEY:D_1USEMI</code>
     - Spell Effect (Single
 Use/Completion)
     <br/>
-    <code>
-     KEY:DAGSLVR
-    </code>
+    <code>KEY:DAGSLVR</code>
     - Silvered - Dagger
     <br/>
-    <code>
-     KEY:DAMAGE_REDUCT_5
-    </code>
+    <code>KEY:DAMAGE_REDUCT_5</code>
     - Damage Reduction (5/+1)
     <br/>
-    <code>
-     KEY:DAMAGE_REDUCT_10
-    </code>
+    <code>KEY:DAMAGE_REDUCT_10</code>
     - Damage Reduction (10/+1)
     <br/>
-    <code>
-     KEY:DANCE
-    </code>
+    <code>KEY:DANCE</code>
     - Dancing
     <br/>
-    <code>
-     KEY:DANCING
-    </code>
+    <code>KEY:DANCING</code>
     - Dancing
     <br/>
-    <code>
-     KEY:DANGER_EARIMPLANT
-    </code>
+    <code>KEY:DANGER_EARIMPLANT</code>
     - Danger Unit
     <br/>
-    <code>
-     KEY:DARK
-    </code>
+    <code>KEY:DARK</code>
     - Darkwood
     <br/>
-    <code>
-     KEY:DBL_SIDED
-    </code>
+    <code>KEY:DBL_SIDED</code>
     - Double-sided
     <br/>
-    <code>
-     KEY:DBLTAP
-    </code>
+    <code>KEY:DBLTAP</code>
     - Double Tap fire
     <br/>
-    <code>
-     KEY:DEFEND
-    </code>
+    <code>KEY:DEFEND</code>
     - Defending
     <br/>
-    <code>
-     KEY:DEFENDING
-    </code>
+    <code>KEY:DEFENDING</code>
     - Defending
     <br/>
-    <code>
-     KEY:DEFLECTN_FLD1
-    </code>
+    <code>KEY:DEFLECTN_FLD1</code>
     - Deflection Field Mk 1(PL8)
     <br/>
-    <code>
-     KEY:DEFLECTN_FLD2
-    </code>
+    <code>KEY:DEFLECTN_FLD2</code>
     - Deflection Field Mk 2(PL8)
     <br/>
-    <code>
-     KEY:DEFLECTN_FLD3
-    </code>
+    <code>KEY:DEFLECTN_FLD3</code>
     - Deflection Field Mk 3(PL8)
     <br/>
-    <code>
-     KEY:DEFLECTN_FLD4
-    </code>
+    <code>KEY:DEFLECTN_FLD4</code>
     - Deflection Field Mk 4(PL8)
     <br/>
-    <code>
-     KEY:DEFLECTN_FLD5
-    </code>
+    <code>KEY:DEFLECTN_FLD5</code>
     - Deflection Field Mk 5(PL8)
     <br/>
-    <code>
-     KEY:DEMONREP
-    </code>
+    <code>KEY:DEMONREP</code>
     - Demon Repelling
     <br/>
-    <code>
-     KEY:DETSTK
-    </code>
+    <code>KEY:DETSTK</code>
     - Detachable Stock
     <br/>
-    <code>
-     KEY:DFNS_ADV_DMG_CTRL
-    </code>
+    <code>KEY:DFNS_ADV_DMG_CTRL</code>
     - Advanced Damage Control
     <br/>
-    <code>
-     KEY:DFNS_AUTOPILOT
-    </code>
+    <code>KEY:DFNS_AUTOPILOT</code>
     - Autopilot System
     <br/>
-    <code>
-     KEY:DFNS_CHAFF_LNCH
-    </code>
+    <code>KEY:DFNS_CHAFF_LNCH</code>
     - Chaff launcher
     <br/>
-    <code>
-     KEY:DFNS_CHAFF_LNCH_8
-    </code>
+    <code>KEY:DFNS_CHAFF_LNCH_8</code>
     - Chaff launcher
     <br/>
-    <code>
-     KEY:DFNS_CHAFF_LNCH_8_2
-    </code>
+    <code>KEY:DFNS_CHAFF_LNCH_8_2</code>
     - 2 Chaff launchers
     <br/>
-    <code>
-     KEY:DFNS_CLOAK_SCRN
-    </code>
+    <code>KEY:DFNS_CLOAK_SCRN</code>
     - Cloaking Screen
     <br/>
-    <code>
-     KEY:DFNS_DMG_CTRL_SYS
-    </code>
+    <code>KEY:DFNS_DMG_CTRL_SYS</code>
     - Damage Control System
     <br/>
-    <code>
-     KEY:DFNS_DECOY_LNCH
-    </code>
+    <code>KEY:DFNS_DECOY_LNCH</code>
     - Decoy drone launcher
     <br/>
-    <code>
-     KEY:DFNS_DECOY_LNCH_2
-    </code>
+    <code>KEY:DFNS_DECOY_LNCH_2</code>
     - Decoy drone launcher
     <br/>
-    <code>
-     KEY:DFNS_DECOY_LNCH_4_2
-    </code>
+    <code>KEY:DFNS_DECOY_LNCH_4_2</code>
     - 2 Decoy drone
 launchers
     <br/>
-    <code>
-     KEY:DFNS_DECOY_LNCH_8
-    </code>
+    <code>KEY:DFNS_DECOY_LNCH_8</code>
     - Decoy drone launcher
     <br/>
-    <code>
-     KEY:DFNS_DISPLACER
-    </code>
+    <code>KEY:DFNS_DISPLACER</code>
     - Displacer
     <br/>
-    <code>
-     KEY:DFNS_HEAVY_FRTFCTN
-    </code>
+    <code>KEY:DFNS_HEAVY_FRTFCTN</code>
     - Heavy Fortification
     <br/>
-    <code>
-     KEY:DFNS_IMP_AUTOPILOT
-    </code>
+    <code>KEY:DFNS_IMP_AUTOPILOT</code>
     - Improved Autopilot
 System
     <br/>
-    <code>
-     KEY:DFNS_IMP_DMG_CTRL
-    </code>
+    <code>KEY:DFNS_IMP_DMG_CTRL</code>
     - Improved Damage Control
     <br/>
-    <code>
-     KEY:DFNS_LGHT_FRTFCTN
-    </code>
+    <code>KEY:DFNS_LGHT_FRTFCTN</code>
     - Light Fortification
     <br/>
-    <code>
-     KEY:DFNS_MGNT_FLD
-    </code>
+    <code>KEY:DFNS_MGNT_FLD</code>
     - Magnetic Field
     <br/>
-    <code>
-     KEY:DFNS_MEDM_FRTFCTN
-    </code>
+    <code>KEY:DFNS_MEDM_FRTFCTN</code>
     - Medium Fortification
     <br/>
-    <code>
-     KEY:DFNS_NANITE_REPAIR
-    </code>
+    <code>KEY:DFNS_NANITE_REPAIR</code>
     - Nanite Repair Array
     <br/>
-    <code>
-     KEY:DFNS_PRTCL_FLD
-    </code>
+    <code>KEY:DFNS_PRTCL_FLD</code>
     - Particle Field
     <br/>
-    <code>
-     KEY:DFNS_RAD_SHLD
-    </code>
+    <code>KEY:DFNS_RAD_SHLD</code>
     - Radiation Shielding
     <br/>
-    <code>
-     KEY:DFNS_REPAIR_DRONE
-    </code>
+    <code>KEY:DFNS_REPAIR_DRONE</code>
     - Repair drones
     <br/>
-    <code>
-     KEY:DFNS_SLF_DSTR_SYS
-    </code>
+    <code>KEY:DFNS_SLF_DSTR_SYS</code>
     - Self-destruct System
     <br/>
-    <code>
-     KEY:DFNS_SNSR_JAM
-    </code>
+    <code>KEY:DFNS_SNSR_JAM</code>
     - Sensor Jammer
     <br/>
-    <code>
-     KEY:DFNS_STLTH_SCRN
-    </code>
+    <code>KEY:DFNS_STLTH_SCRN</code>
     - Stealth Screen
     <br/>
-    <code>
-     KEY:DIRE
-    </code>
+    <code>KEY:DIRE</code>
     - Dire
     <br/>
-    <code>
-     KEY:DISLOC_A
-    </code>
+    <code>KEY:DISLOC_A</code>
     - Dislocator (+3)
     <br/>
-    <code>
-     KEY:DISLOC_GRT_A
-    </code>
+    <code>KEY:DISLOC_GRT_A</code>
     - Dislocator (Greater) (+4)
     <br/>
-    <code>
-     KEY:DISLOC_GRT_M
-    </code>
+    <code>KEY:DISLOC_GRT_M</code>
     - Dislocator (Greater) (+4)
     <br/>
-    <code>
-     KEY:DISLOC_GRT_R
-    </code>
+    <code>KEY:DISLOC_GRT_R</code>
     - Dislocator (Greater) (+4)
     <br/>
-    <code>
-     KEY:DISLOC_M
-    </code>
+    <code>KEY:DISLOC_M</code>
     - Dislocator (+3)
     <br/>
-    <code>
-     KEY:DISLOC_R
-    </code>
+    <code>KEY:DISLOC_R</code>
     - Dislocator (+3)
     <br/>
-    <code>
-     KEY:DISPEL
-    </code>
+    <code>KEY:DISPEL</code>
     - Dispelling
     <br/>
-    <code>
-     KEY:DISRPT
-    </code>
+    <code>KEY:DISRPT</code>
     - Disruption
     <br/>
-    <code>
-     KEY:DISRUPTING
-    </code>
+    <code>KEY:DISRUPTING</code>
     - Disruption
     <br/>
-    <code>
-     KEY:DISRUPTION_MIGHTY
-    </code>
+    <code>KEY:DISRUPTION_MIGHTY</code>
     - Mighty Disruption
     <br/>
-    <code>
-     KEY:DISSIP
-    </code>
+    <code>KEY:DISSIP</code>
     - Dissipater
     <br/>
-    <code>
-     KEY:DISTANT_SHOT
-    </code>
+    <code>KEY:DISTANT_SHOT</code>
     - Distant Shot
     <br/>
-    <code>
-     KEY:DISTANCE
-    </code>
+    <code>KEY:DISTANCE</code>
     - Distance
     <br/>
-    <code>
-     KEY:DISTNC
-    </code>
+    <code>KEY:DISTNC</code>
     - Distance
     <br/>
-    <code>
-     KEY:DIVINGSUIT_PROPELLERS
-    </code>
+    <code>KEY:DIVINGSUIT_PROPELLERS</code>
     - Propellers
     <br/>
-    <code>
-     KEY:DLPHI_DEF_ST1
-    </code>
+    <code>KEY:DLPHI_DEF_ST1</code>
     - Delphi Defense Suite Mk 1
 (PL7)
     <br/>
-    <code>
-     KEY:DLPHI_DEF_ST2
-    </code>
+    <code>KEY:DLPHI_DEF_ST2</code>
     - Delphi Defense Suite Mk 2
 (PL7)
     <br/>
-    <code>
-     KEY:DLPHI_DEF_ST3
-    </code>
+    <code>KEY:DLPHI_DEF_ST3</code>
     - Delphi Defense Suite Mk 3
 (PL7)
     <br/>
-    <code>
-     KEY:DLPHI_DEF_ST4
-    </code>
+    <code>KEY:DLPHI_DEF_ST4</code>
     - Delphi Defense Suite Mk 4
 (PL7)
     <br/>
-    <code>
-     KEY:DLPHI_DEF_ST5
-    </code>
+    <code>KEY:DLPHI_DEF_ST5</code>
     - Delphi Defense Suite Mk 5
 (PL7)
     <br/>
-    <code>
-     KEY:DR_CONVERSION_ARCHAIC
-    </code>
+    <code>KEY:DR_CONVERSION_ARCHAIC</code>
     - Damage Reduction
 Conversion
     <br/>
-    <code>
-     KEY:DR_CONVERSION_MODERN
-    </code>
+    <code>KEY:DR_CONVERSION_MODERN</code>
     - Damage Reduction
 Conversion
     <br/>
-    <code>
-     KEY:DR_CONVERSION_POWERED
-    </code>
+    <code>KEY:DR_CONVERSION_POWERED</code>
     - Damage Reduction
 Conversion
     <br/>
-    <code>
-     KEY:DRACO
-    </code>
+    <code>KEY:DRACO</code>
     - Dragonhide
     <br/>
-    <code>
-     KEY:DREAD_AMMO
-    </code>
+    <code>KEY:DREAD_AMMO</code>
     - Dread
     <br/>
-    <code>
-     KEY:DREAD_MELEE
-    </code>
+    <code>KEY:DREAD_MELEE</code>
     - Dread
     <br/>
-    <code>
-     KEY:DREAD_RANGED
-    </code>
+    <code>KEY:DREAD_RANGED</code>
     - Dread
     <br/>
-    <code>
-     KEY:DUMMY_LINE
-    </code>
+    <code>KEY:DUMMY_LINE</code>
     - Dummy line
     <br/>
-    <code>
-     KEY:DUPLICATION_IDCARD
-    </code>
+    <code>KEY:DUPLICATION_IDCARD</code>
     - Duplication
     <br/>
-    <code>
-     KEY:DURAH1
-    </code>
+    <code>KEY:DURAH1</code>
     - Durabilityx1 [Heavy Armor]
     <br/>
-    <code>
-     KEY:DURAH2
-    </code>
+    <code>KEY:DURAH2</code>
     - Durabilityx2 [Heavy Armor]
     <br/>
-    <code>
-     KEY:DURAH3
-    </code>
+    <code>KEY:DURAH3</code>
     - Durabilityx3 [Heavy Armor]
     <br/>
-    <code>
-     KEY:DURAH4
-    </code>
+    <code>KEY:DURAH4</code>
     - Durabilityx4 [Heavy Armor]
     <br/>
-    <code>
-     KEY:DURAH5
-    </code>
+    <code>KEY:DURAH5</code>
     - Durabilityx5 [Heavy Armor]
     <br/>
-    <code>
-     KEY:DURAL1
-    </code>
+    <code>KEY:DURAL1</code>
     - Durabilityx1 [Light Armor]
     <br/>
-    <code>
-     KEY:DURAL2
-    </code>
+    <code>KEY:DURAL2</code>
     - Durabilityx2 [Light Armor]
     <br/>
-    <code>
-     KEY:DURAL3
-    </code>
+    <code>KEY:DURAL3</code>
     - Durabilityx3 [Light Armor]
     <br/>
-    <code>
-     KEY:DURAL4
-    </code>
+    <code>KEY:DURAL4</code>
     - Durabilityx4 [Light Armor]
     <br/>
-    <code>
-     KEY:DURAL5
-    </code>
+    <code>KEY:DURAL5</code>
     - Durabilityx5 [Light Armor]
     <br/>
-    <code>
-     KEY:DURAM1
-    </code>
+    <code>KEY:DURAM1</code>
     - Durabilityx1 [Medium Armor]
     <br/>
-    <code>
-     KEY:DURAM2
-    </code>
+    <code>KEY:DURAM2</code>
     - Durabilityx2 [Medium Armor]
     <br/>
-    <code>
-     KEY:DURAM3
-    </code>
+    <code>KEY:DURAM3</code>
     - Durabilityx3 [Medium Armor]
     <br/>
-    <code>
-     KEY:DURAM4
-    </code>
+    <code>KEY:DURAM4</code>
     - Durabilityx4 [Medium Armor]
     <br/>
-    <code>
-     KEY:DURAM5
-    </code>
+    <code>KEY:DURAM5</code>
     - Durabilityx5 [Medium Armor]
     <br/>
-    <code>
-     KEY:DURALLOY
-    </code>
+    <code>KEY:DURALLOY</code>
     - Duralloy (PL6)
     <br/>
-    <code>
-     KEY:DURALLOY_ARMR
-    </code>
+    <code>KEY:DURALLOY_ARMR</code>
     - Duralloy Armor (PL6)
     <br/>
-    <code>
-     KEY:DURASTEEL_ARM
-    </code>
+    <code>KEY:DURASTEEL_ARM</code>
     - Durasteel
     <br/>
-    <code>
-     KEY:DURASTEEL_SHIELD
-    </code>
+    <code>KEY:DURASTEEL_SHIELD</code>
     - Durasteel
     <br/>
-    <code>
-     KEY:DURASTEEL_WEAP
-    </code>
+    <code>KEY:DURASTEEL_WEAP</code>
     - Durasteel
     <br/>
-    <code>
-     KEY:DURPLSTC_ARMR
-    </code>
+    <code>KEY:DURPLSTC_ARMR</code>
     - Duraplastic Armor (PL5)
     <br/>
-    <code>
-     KEY:DWMW
-    </code>
+    <code>KEY:DWMW</code>
     - Dwarven Masterwork
     <br/>
-    <code>
-     KEY:ECTO
-    </code>
+    <code>KEY:ECTO</code>
     - Ectoplasmic
     <br/>
-    <code>
-     KEY:ECTOPLAS
-    </code>
+    <code>KEY:ECTOPLAS</code>
     - Ectoplasmic
     <br/>
-    <code>
-     KEY:EDUCATEDFEATIMPLANT
-    </code>
+    <code>KEY:EDUCATEDFEATIMPLANT</code>
     - Educated Feat Implant
     <br/>
-    <code>
-     KEY:EJECTION_SEATS
-    </code>
+    <code>KEY:EJECTION_SEATS</code>
     - Ejection seats
     <br/>
-    <code>
-     KEY:ELAC_PRLTCAL
-    </code>
+    <code>KEY:ELAC_PRLTCAL</code>
     - Paralytic Alarm
     <br/>
-    <code>
-     KEY:ELEC_RES
-    </code>
+    <code>KEY:ELEC_RES</code>
     - Electricity Resistance
     <br/>
-    <code>
-     KEY:ELAC_SLNTWRN
-    </code>
+    <code>KEY:ELAC_SLNTWRN</code>
     - Silent Warning Alarm
     <br/>
-    <code>
-     KEY:ELDBLAST_M
-    </code>
+    <code>KEY:ELDBLAST_M</code>
     - Eldritch Blasting -
 Weapon.Melee
     <br/>
-    <code>
-     KEY:ELDBLAST_R
-    </code>
+    <code>KEY:ELDBLAST_R</code>
     - Eldritch Blasting -
 Weapon.Ranged
     <br/>
-    <code>
-     KEY:ELECTRIC_WARD
-    </code>
+    <code>KEY:ELECTRIC_WARD</code>
     - Lightning Warding
     <br/>
-    <code>
-     KEY:ELECTRIFIED_FRAME
-    </code>
+    <code>KEY:ELECTRIFIED_FRAME</code>
     - Electrified frame
     <br/>
-    <code>
-     KEY:ELECTRONIC_LOCKPICK_IDCARD
-    </code>
+    <code>KEY:ELECTRONIC_LOCKPICK_IDCARD</code>
     - Electronic
 Lockpick
     <br/>
-    <code>
-     KEY:ELMW
-    </code>
+    <code>KEY:ELMW</code>
     - Elvish Masterwork
     <br/>
-    <code>
-     KEY:ENERGY_BLAST_ACID
-    </code>
+    <code>KEY:ENERGY_BLAST_ACID</code>
     - Acid Blast
     <br/>
-    <code>
-     KEY:ENERGY_BLAST_COLD
-    </code>
+    <code>KEY:ENERGY_BLAST_COLD</code>
     - Icy Blast
     <br/>
-    <code>
-     KEY:ENERGY_BLAST_ELEC
-    </code>
+    <code>KEY:ENERGY_BLAST_ELEC</code>
     - Electrical Blast
     <br/>
-    <code>
-     KEY:ENERGY_BLAST_FIRE
-    </code>
+    <code>KEY:ENERGY_BLAST_FIRE</code>
     - Fiery Blast
     <br/>
-    <code>
-     KEY:ENERGY_BLAST_SONIC
-    </code>
+    <code>KEY:ENERGY_BLAST_SONIC</code>
     - Concussive Blast
     <br/>
-    <code>
-     KEY:ENGM_SNSR_ST
-    </code>
+    <code>KEY:ENGM_SNSR_ST</code>
     - Enigma Sensor Suite (PL6)
     <br/>
-    <code>
-     KEY:ENGN_FUSION
-    </code>
+    <code>KEY:ENGN_FUSION</code>
     - Fusion Torch
     <br/>
-    <code>
-     KEY:ENGN_GRAVITIC
-    </code>
+    <code>KEY:ENGN_GRAVITIC</code>
     - Gravitic Redirector
     <br/>
-    <code>
-     KEY:ENGN_INDCTN
-    </code>
+    <code>KEY:ENGN_INDCTN</code>
     - Induction Engine
     <br/>
-    <code>
-     KEY:ENGN_INFSPD
-    </code>
+    <code>KEY:ENGN_INFSPD</code>
     - Engine of Infernal Speed
     <br/>
-    <code>
-     KEY:ENGN_INRT_FLUX
-    </code>
+    <code>KEY:ENGN_INRT_FLUX</code>
     - Inertial Flux Engine
     <br/>
-    <code>
-     KEY:ENGN_ION
-    </code>
+    <code>KEY:ENGN_ION</code>
     - Ion Engine
     <br/>
-    <code>
-     KEY:ENGN_PARTCL
-    </code>
+    <code>KEY:ENGN_PARTCL</code>
     - Particle Impulse
     <br/>
-    <code>
-     KEY:ENGN_PHOTON
-    </code>
+    <code>KEY:ENGN_PHOTON</code>
     - Photon Sails
     <br/>
-    <code>
-     KEY:ENGN_SPATIAL
-    </code>
+    <code>KEY:ENGN_SPATIAL</code>
     - Spatial Compressor
     <br/>
-    <code>
-     KEY:ENGN_THRUST
-    </code>
+    <code>KEY:ENGN_THRUST</code>
     - Thrusters
     <br/>
-    <code>
-     KEY:ENH_ALL1
-    </code>
+    <code>KEY:ENH_ALL1</code>
     - Enhanced Alloyx1
     <br/>
-    <code>
-     KEY:ENH_ALL2
-    </code>
+    <code>KEY:ENH_ALL2</code>
     - Enhanced Alloyx2
     <br/>
-    <code>
-     KEY:ENH_ALL3
-    </code>
+    <code>KEY:ENH_ALL3</code>
     - Enhanced Alloyx3
     <br/>
-    <code>
-     KEY:ENVRNMNT_SL_GDGT
-    </code>
+    <code>KEY:ENVRNMNT_SL_GDGT</code>
     - Environment Seal Gadget
     <br/>
-    <code>
-     KEY:EOLA
-    </code>
+    <code>KEY:EOLA</code>
     - Easy-Off (Light Armor)
     <br/>
-    <code>
-     KEY:EOLM
-    </code>
+    <code>KEY:EOLM</code>
     - Easy-Off (Medium Armor)
     <br/>
-    <code>
-     KEY:EOLH
-    </code>
+    <code>KEY:EOLH</code>
     - Easy-Off (Heavy Armor)
     <br/>
-    <code>
-     KEY:EPIC_ABILITY_BONUS_ENHANCE
-    </code>
+    <code>KEY:EPIC_ABILITY_BONUS_ENHANCE</code>
     - |Epic Ability Bonus
 (Enhancement)
     <br/>
-    <code>
-     KEY:EPIC_AC_BONUS_DEFLECT
-    </code>
+    <code>KEY:EPIC_AC_BONUS_DEFLECT</code>
     - |Epic AC Bonus
 (Deflection)
     <br/>
-    <code>
-     KEY:EPIC_AC_BONUS_LUCK
-    </code>
+    <code>KEY:EPIC_AC_BONUS_LUCK</code>
     - |Epic AC Bonus (Luck)
     <br/>
-    <code>
-     KEY:EPIC_AC_BONUS_INSIGHT
-    </code>
+    <code>KEY:EPIC_AC_BONUS_INSIGHT</code>
     - |Epic AC Bonus
 (Insight)
     <br/>
-    <code>
-     KEY:EPIC_AC_BONUS_SACRED
-    </code>
+    <code>KEY:EPIC_AC_BONUS_SACRED</code>
     - |Epic AC Bonus
 (Sacred)
     <br/>
-    <code>
-     KEY:EPIC_AC_BONUS_PROFANE
-    </code>
+    <code>KEY:EPIC_AC_BONUS_PROFANE</code>
     - |Epic AC Bonus
 (Profane)
     <br/>
-    <code>
-     KEY:EPIC_AC_BONUS_OTHER
-    </code>
+    <code>KEY:EPIC_AC_BONUS_OTHER</code>
     - |Epic AC Bonus (Other)
     <br/>
-    <code>
-     KEY:EPIC_BONUS_ARMR_ENHANCE
-    </code>
+    <code>KEY:EPIC_BONUS_ARMR_ENHANCE</code>
     - |Epic Armor Bonus
 (Enhancement)
     <br/>
-    <code>
-     KEY:EPIC_BONUS_SPELL
-    </code>
+    <code>KEY:EPIC_BONUS_SPELL</code>
     - |Epic Bonus Spell
     <br/>
-    <code>
-     KEY:EPIC_NATURAL_ARMR_ENHANCE
-    </code>
+    <code>KEY:EPIC_NATURAL_ARMR_ENHANCE</code>
     - |Epic Natural Armor
 Bonus (Enhancement)
     <br/>
-    <code>
-     KEY:EPIC_SAVE_BONUS_INSIGHT
-    </code>
+    <code>KEY:EPIC_SAVE_BONUS_INSIGHT</code>
     - |Epic Save Bonus
 (Insight)
     <br/>
-    <code>
-     KEY:EPIC_SAVE_BONUS_LUCK
-    </code>
+    <code>KEY:EPIC_SAVE_BONUS_LUCK</code>
     - |Epic Save Bonus
 (Luck)
     <br/>
-    <code>
-     KEY:EPIC_SAVE_BONUS_OTHER
-    </code>
+    <code>KEY:EPIC_SAVE_BONUS_OTHER</code>
     - |Epic Save Bonus
 (Other)
     <br/>
-    <code>
-     KEY:EPIC_SAVE_BONUS_PROFANE
-    </code>
+    <code>KEY:EPIC_SAVE_BONUS_PROFANE</code>
     - |Epic Save Bonus
 (Profane)
     <br/>
-    <code>
-     KEY:EPIC_SAVE_BONUS_RES
-    </code>
+    <code>KEY:EPIC_SAVE_BONUS_RES</code>
     - |Epic Save Bonus
 (Resistance)
     <br/>
-    <code>
-     KEY:EPIC_SAVE_BONUS_SACRED
-    </code>
+    <code>KEY:EPIC_SAVE_BONUS_SACRED</code>
     - |Epic Save Bonus
 (Sacred)
     <br/>
-    <code>
-     KEY:EPIC_SKILL_BONUS_COMPETANCE
-    </code>
+    <code>KEY:EPIC_SKILL_BONUS_COMPETANCE</code>
     - |Epic Skill Bonus
 (Competance)
     <br/>
-    <code>
-     KEY:EPIC_SPELL_RES
-    </code>
+    <code>KEY:EPIC_SPELL_RES</code>
     - |Epic Spell Resistance
     <br/>
-    <code>
-     KEY:ETHERE
-    </code>
+    <code>KEY:ETHERE</code>
     - Etherealness
     <br/>
-    <code>
-     KEY:EVERDANCING
-    </code>
+    <code>KEY:EVERDANCING</code>
     - Everdancing
     <br/>
-    <code>
-     KEY:EVIL_MELEE
-    </code>
+    <code>KEY:EVIL_MELEE</code>
     - Unholy
     <br/>
-    <code>
-     KEY:EVIL_RANGED
-    </code>
+    <code>KEY:EVIL_RANGED</code>
     - Unholy
     <br/>
-    <code>
-     KEY:EXCLUDEEQ_MAGIC
-    </code>
+    <code>KEY:EXCLUDEEQ_MAGIC</code>
     - Magic
     <br/>
-    <code>
-     KEY:EXCLUDEEQ_MUNDANE
-    </code>
+    <code>KEY:EXCLUDEEQ_MUNDANE</code>
     - Mundane
     <br/>
-    <code>
-     KEY:EXCLUDEEQ_PHB
-    </code>
+    <code>KEY:EXCLUDEEQ_PHB</code>
     - PHB
     <br/>
-    <code>
-     KEY:EXPLOSIVE_WATCH
-    </code>
+    <code>KEY:EXPLOSIVE_WATCH</code>
     - Explosive
     <br/>
-    <code>
-     KEY:EXTR
-    </code>
+    <code>KEY:EXTR</code>
     - Exterior Tread
     <br/>
-    <code>
-     KEY:EXTRA_ARMOR
-    </code>
+    <code>KEY:EXTRA_ARMOR</code>
     - Extra armor
     <br/>
-    <code>
-     KEY:FACEPRINT_LENSES
-    </code>
+    <code>KEY:FACEPRINT_LENSES</code>
     - Faceprint
     <br/>
-    <code>
-     KEY:FERROPLASM
-    </code>
+    <code>KEY:FERROPLASM</code>
     - Ferroplasm
     <br/>
-    <code>
-     KEY:FEAT_FRIGHTFUL_PRESENCE_MP
-    </code>
+    <code>KEY:FEAT_FRIGHTFUL_PRESENCE_MP</code>
     - Frightful
 Presence
     <br/>
-    <code>
-     KEY:FEY_EARTHEN_GRASP
-    </code>
+    <code>KEY:FEY_EARTHEN_GRASP</code>
     - Earthen Grasp
     <br/>
-    <code>
-     KEY:FEY_SLUMBER
-    </code>
+    <code>KEY:FEY_SLUMBER</code>
     - Slumber
     <br/>
-    <code>
-     KEY:FEY_TRACKLESS
-    </code>
+    <code>KEY:FEY_TRACKLESS</code>
     - Trackless
     <br/>
-    <code>
-     KEY:FEY_TREE
-    </code>
+    <code>KEY:FEY_TREE</code>
     - Tree
     <br/>
-    <code>
-     KEY:FEY_UNSEEN
-    </code>
+    <code>KEY:FEY_UNSEEN</code>
     - Unseen
     <br/>
-    <code>
-     KEY:FIRE_BLAST_AMMO
-    </code>
+    <code>KEY:FIRE_BLAST_AMMO</code>
     - Fiery Blast
     <br/>
-    <code>
-     KEY:FIRE_BLAST_MELEE
-    </code>
+    <code>KEY:FIRE_BLAST_MELEE</code>
     - Fiery Blast
     <br/>
-    <code>
-     KEY:FIRE_BLAST_RANGED
-    </code>
+    <code>KEY:FIRE_BLAST_RANGED</code>
     - Fiery Blast
     <br/>
-    <code>
-     KEY:FIRE_RES
-    </code>
+    <code>KEY:FIRE_RES</code>
     - Fire Resistance
     <br/>
-    <code>
-     KEY:FIRE_WARD
-    </code>
+    <code>KEY:FIRE_WARD</code>
     - Fire Warding
     <br/>
-    <code>
-     KEY:FIREWRK
-    </code>
+    <code>KEY:FIREWRK</code>
     - Masterwork - Firework
     <br/>
-    <code>
-     KEY:FLAMING_MELEE
-    </code>
+    <code>KEY:FLAMING_MELEE</code>
     - Flaming
     <br/>
-    <code>
-     KEY:FLAMING_RANGED
-    </code>
+    <code>KEY:FLAMING_RANGED</code>
     - Flaming
     <br/>
-    <code>
-     KEY:FLASH_SUPPRESSOR
-    </code>
+    <code>KEY:FLASH_SUPPRESSOR</code>
     - Flash Suppressor
     <br/>
-    <code>
-     KEY:FLECHETTE_AMMO
-    </code>
+    <code>KEY:FLECHETTE_AMMO</code>
     - Flechette
     <br/>
-    <code>
-     KEY:FLEXIBLE
-    </code>
+    <code>KEY:FLEXIBLE</code>
     - Flexible
     <br/>
-    <code>
-     KEY:FLINTGRMW
-    </code>
+    <code>KEY:FLINTGRMW</code>
     - Greater Mastercraft
     <br/>
-    <code>
-     KEY:FLM_A
-    </code>
+    <code>KEY:FLM_A</code>
     - Flaming
     <br/>
-    <code>
-     KEY:FLM_BR_A
-    </code>
+    <code>KEY:FLM_BR_A</code>
     - Flaming Burst
     <br/>
-    <code>
-     KEY:FLM_BR_M
-    </code>
+    <code>KEY:FLM_BR_M</code>
     - Flaming Burst
     <br/>
-    <code>
-     KEY:FLM_BR_R
-    </code>
+    <code>KEY:FLM_BR_R</code>
     - Flaming Burst
     <br/>
-    <code>
-     KEY:FLM_M
-    </code>
+    <code>KEY:FLM_M</code>
     - Flaming
     <br/>
-    <code>
-     KEY:FLM_R
-    </code>
+    <code>KEY:FLM_R</code>
     - Flaming
     <br/>
-    <code>
-     KEY:FLOAT
-    </code>
+    <code>KEY:FLOAT</code>
     - Floating
     <br/>
-    <code>
-     KEY:FLUID_BREATH_TANKS
-    </code>
+    <code>KEY:FLUID_BREATH_TANKS</code>
     - Fluid Breath Tanks
     <br/>
-    <code>
-     KEY:FOLD
-    </code>
+    <code>KEY:FOLD</code>
     - Foldable
     <br/>
-    <code>
-     KEY:FORT_HVY
-    </code>
+    <code>KEY:FORT_HVY</code>
     - Fortification (Heavy)
     <br/>
-    <code>
-     KEY:FORT_LT
-    </code>
+    <code>KEY:FORT_LT</code>
     - Fortification (Light)
     <br/>
-    <code>
-     KEY:FORT_MODERATE
-    </code>
+    <code>KEY:FORT_MODERATE</code>
     - Fortification (Moderate)
     <br/>
-    <code>
-     KEY:FORTIFIED
-    </code>
+    <code>KEY:FORTIFIED</code>
     - Fortified
     <br/>
-    <code>
-     KEY:FRANGIBLE_AMMO
-    </code>
+    <code>KEY:FRANGIBLE_AMMO</code>
     - Frangible
     <br/>
-    <code>
-     KEY:FROST_A
-    </code>
+    <code>KEY:FROST_A</code>
     - Frost
     <br/>
-    <code>
-     KEY:FROST_M
-    </code>
+    <code>KEY:FROST_M</code>
     - Frost
     <br/>
-    <code>
-     KEY:FROST_MELEE
-    </code>
+    <code>KEY:FROST_MELEE</code>
     - Frost
     <br/>
-    <code>
-     KEY:FROST_R
-    </code>
+    <code>KEY:FROST_R</code>
     - Frost
     <br/>
-    <code>
-     KEY:FROST_RANGED
-    </code>
+    <code>KEY:FROST_RANGED</code>
     - Frost
     <br/>
-    <code>
-     KEY:FRT_HVY
-    </code>
+    <code>KEY:FRT_HVY</code>
     - Fortification (Heavy)
     <br/>
-    <code>
-     KEY:FRT_LGHT
-    </code>
+    <code>KEY:FRT_LGHT</code>
     - Fortification (Light)
     <br/>
-    <code>
-     KEY:FRT_MOD
-    </code>
+    <code>KEY:FRT_MOD</code>
     - Fortification (Moderate)
     <br/>
-    <code>
-     KEY:GARAGE_SUITE
-    </code>
+    <code>KEY:GARAGE_SUITE</code>
     - Garage Suite
     <br/>
-    <code>
-     KEY:GARROTE_WATCH
-    </code>
+    <code>KEY:GARROTE_WATCH</code>
     - Garrote
     <br/>
-    <code>
-     KEY:GDGT_EXTND
-    </code>
+    <code>KEY:GDGT_EXTND</code>
     - Extend Invention Feat
     <br/>
-    <code>
-     KEY:GDGT_FDBCK
-    </code>
+    <code>KEY:GDGT_FDBCK</code>
     - Feedback Flaw
     <br/>
-    <code>
-     KEY:GDGT_IMPRO
-    </code>
+    <code>KEY:GDGT_IMPRO</code>
     - Improvised Invention Feat
     <br/>
-    <code>
-     KEY:GDGT_INV_LVL
-    </code>
+    <code>KEY:GDGT_INV_LVL</code>
     - Base Invention Level
     <br/>
-    <code>
-     KEY:GDGT_LOSS_AB
-    </code>
+    <code>KEY:GDGT_LOSS_AB</code>
     - Ability Loss Flaw
     <br/>
-    <code>
-     KEY:GDGT_MINI
-    </code>
+    <code>KEY:GDGT_MINI</code>
     - Miniaturize Invention Feat
     <br/>
-    <code>
-     KEY:GDGT_PWR_DRN
-    </code>
+    <code>KEY:GDGT_PWR_DRN</code>
     - Power Drain Flaw
     <br/>
-    <code>
-     KEY:GDGT_SMPL
-    </code>
+    <code>KEY:GDGT_SMPL</code>
     - Simplified Invention Feat
     <br/>
-    <code>
-     KEY:GDGT_SPL_CMD1
-    </code>
+    <code>KEY:GDGT_SPL_CMD1</code>
     - |1st level Spell Effect (50
 Uses/Gadget)
     <br/>
-    <code>
-     KEY:GDGT_SPL_CMD2
-    </code>
+    <code>KEY:GDGT_SPL_CMD2</code>
     - |2nd level Spell Effect (50
 Uses/Gadget)
     <br/>
-    <code>
-     KEY:GDGT_SPL_CMD3
-    </code>
+    <code>KEY:GDGT_SPL_CMD3</code>
     - |3rd level Spell Effect (50
 Uses/Gadget)
     <br/>
-    <code>
-     KEY:GDGT_SPL_CMD4
-    </code>
+    <code>KEY:GDGT_SPL_CMD4</code>
     - |4th level Spell Effect (50
 Uses/Gadget)
     <br/>
-    <code>
-     KEY:GDGT_SPL_CMD5
-    </code>
+    <code>KEY:GDGT_SPL_CMD5</code>
     - |5th level Spell Effect (50
 Uses/Gadget)
     <br/>
-    <code>
-     KEY:GDGT_SPL_CMD6
-    </code>
+    <code>KEY:GDGT_SPL_CMD6</code>
     - |6th level Spell Effect (50
 Uses/Gadget)
     <br/>
-    <code>
-     KEY:GDGT_SPL_CMD7
-    </code>
+    <code>KEY:GDGT_SPL_CMD7</code>
     - |7th level Spell Effect (50
 Uses/Gadget)
     <br/>
-    <code>
-     KEY:GDGT_SPL_CMD8
-    </code>
+    <code>KEY:GDGT_SPL_CMD8</code>
     - |8th level Spell Effect (50
 Uses/Gadget)
     <br/>
-    <code>
-     KEY:GDGT_SPL_CMD9
-    </code>
+    <code>KEY:GDGT_SPL_CMD9</code>
     - |9th level Spell Effect (50
 Uses/Gadget)
     <br/>
-    <code>
-     KEY:GDGT_SPR_SHDN
-    </code>
+    <code>KEY:GDGT_SPR_SHDN</code>
     - Sporadic Shut Down Flaw
     <br/>
-    <code>
-     KEY:GEM
-    </code>
+    <code>KEY:GEM</code>
     - Gem Value
     <br/>
-    <code>
-     KEY:GHOST_A
-    </code>
+    <code>KEY:GHOST_A</code>
     - Ghost touch
     <br/>
-    <code>
-     KEY:GHOST_AM
-    </code>
+    <code>KEY:GHOST_AM</code>
     - Ghost touch
     <br/>
-    <code>
-     KEY:GHOST_ARMR
-    </code>
+    <code>KEY:GHOST_ARMR</code>
     - Ghost Touch
     <br/>
-    <code>
-     KEY:GHOST_M
-    </code>
+    <code>KEY:GHOST_M</code>
     - Ghost touch
     <br/>
-    <code>
-     KEY:GHOST_MELEE
-    </code>
+    <code>KEY:GHOST_MELEE</code>
     - Ghost touch
     <br/>
-    <code>
-     KEY:GHOST_R
-    </code>
+    <code>KEY:GHOST_R</code>
     - Ghost touch
     <br/>
-    <code>
-     KEY:GLAM
-    </code>
+    <code>KEY:GLAM</code>
     - Glamered
     <br/>
-    <code>
-     KEY:GLAMER
-    </code>
+    <code>KEY:GLAMER</code>
     - Glamered
     <br/>
-    <code>
-     KEY:GLASS
-    </code>
+    <code>KEY:GLASS</code>
     - Glass
     <br/>
-    <code>
-     KEY:GLEAM
-    </code>
+    <code>KEY:GLEAM</code>
     - Gleaming
     <br/>
-    <code>
-     KEY:Gloves of Swimming/Climbing
-    </code>
+    <code>KEY:Gloves of Swimming/Climbing</code>
     - Gloves of Swimming
 and Climbing
     <br/>
-    <code>
-     KEY:GNMW
-    </code>
+    <code>KEY:GNMW</code>
     - Gnomish Masterwork
     <br/>
-    <code>
-     KEY:GNTC_TGS_GDGT
-    </code>
+    <code>KEY:GNTC_TGS_GDGT</code>
     - Genetic Tags Gadget
     <br/>
-    <code>
-     KEY:GOLD
-    </code>
+    <code>KEY:GOLD</code>
     - Gold
     <br/>
-    <code>
-     KEY:GOOD_MELEE
-    </code>
+    <code>KEY:GOOD_MELEE</code>
     - Holy
     <br/>
-    <code>
-     KEY:GOOD_RANGED
-    </code>
+    <code>KEY:GOOD_RANGED</code>
     - Holy
     <br/>
-    <code>
-     KEY:GPS_WATCH
-    </code>
+    <code>KEY:GPS_WATCH</code>
     - GPS
     <br/>
-    <code>
-     KEY:GRACE
-    </code>
+    <code>KEY:GRACE</code>
     - Grace
     <br/>
-    <code>
-     KEY:GRAP_GRAPPLER
-    </code>
+    <code>KEY:GRAP_GRAPPLER</code>
     - Grappler
     <br/>
-    <code>
-     KEY:GRAP_TRACTOR_BEAM
-    </code>
+    <code>KEY:GRAP_TRACTOR_BEAM</code>
     - Tractor Beam Emitter
     <br/>
-    <code>
-     KEY:GRG_AVNG_ELCT_SCM
-    </code>
+    <code>KEY:GRG_AVNG_ELCT_SCM</code>
     - Avenger Electro-Scimitar (PL
 8)
     <br/>
-    <code>
-     KEY:GRG_JUMP_DRIVE
-    </code>
+    <code>KEY:GRG_JUMP_DRIVE</code>
     - Jump Drive (Gargantuan)
     <br/>
-    <code>
-     KEY:GRG_LK8_AMRPCG_PK
-    </code>
+    <code>KEY:GRG_LK8_AMRPCG_PK</code>
     - LK8 Armor-Piercing Pike (PL
 6)
     <br/>
-    <code>
-     KEY:GRG_MCH
-    </code>
+    <code>KEY:GRG_MCH</code>
     - Gargantuan Mecha
     <br/>
-    <code>
-     KEY:GRG_PS15_PNTR_CLW
-    </code>
+    <code>KEY:GRG_PS15_PNTR_CLW</code>
     - PS-15 Panther Claws (PL
 5)
     <br/>
-    <code>
-     KEY:GRG_PS25_TIGR_CLW
-    </code>
+    <code>KEY:GRG_PS25_TIGR_CLW</code>
     - PS-25 Tiger Claws (PL 7)
     <br/>
-    <code>
-     KEY:GRG_PTHN_ELCT_WHP
-    </code>
+    <code>KEY:GRG_PTHN_ELCT_WHP</code>
     - XJ-A Python Electro-Whip (PL
 7)
     <br/>
-    <code>
-     KEY:GRG_QUAD_MCH
-    </code>
+    <code>KEY:GRG_QUAD_MCH</code>
     - Quadrupedal
     <br/>
-    <code>
-     KEY:GRG_RP91_RPR_LSCT
-    </code>
+    <code>KEY:GRG_RP91_RPR_LSCT</code>
     - RP-91 Reaper Laser Scythe (PL
 8)
     <br/>
-    <code>
-     KEY:GRG_THNDRB_SHK_RD
-    </code>
+    <code>KEY:GRG_THNDRB_SHK_RD</code>
     - Thunderbolt Shock Rod (PL
 5)
     <br/>
-    <code>
-     KEY:GRIP2
-    </code>
+    <code>KEY:GRIP2</code>
     - Gripping (+2)
     <br/>
-    <code>
-     KEY:GRIP4
-    </code>
+    <code>KEY:GRIP4</code>
     - Gripping (+4)
     <br/>
-    <code>
-     KEY:GRIP6
-    </code>
+    <code>KEY:GRIP6</code>
     - Gripping (+6)
     <br/>
-    <code>
-     KEY:GRIP8
-    </code>
+    <code>KEY:GRIP8</code>
     - Gripping (+8)
     <br/>
-    <code>
-     KEY:GRIP10
-    </code>
+    <code>KEY:GRIP10</code>
     - Gripping (+10)
     <br/>
-    <code>
-     KEY:GRVT_ANCHR_GDGT
-    </code>
+    <code>KEY:GRVT_ANCHR_GDGT</code>
     - Gravity Anchor Gadget
     <br/>
-    <code>
-     KEY:GMWORKA
-    </code>
+    <code>KEY:GMWORKA</code>
     - Greater Masterwork - Armor.Shield
     <br/>
-    <code>
-     KEY:GMWORKR
-    </code>
+    <code>KEY:GMWORKR</code>
     - Greater Masterwork - Ranged
     <br/>
-    <code>
-     KEY:GMWORKW
-    </code>
+    <code>KEY:GMWORKW</code>
     - Greater Masterwork -
 Melee.Ammunition
     <br/>
-    <code>
-     KEY:GUARD
-    </code>
+    <code>KEY:GUARD</code>
     - Guard
     <br/>
-    <code>
-     KEY:GUN_GLYPH_WEAPON
-    </code>
+    <code>KEY:GUN_GLYPH_WEAPON</code>
     - Gun Glyph Weapon
     <br/>
-    <code>
-     KEY:GUN_SHOE
-    </code>
+    <code>KEY:GUN_SHOE</code>
     - Gun
     <br/>
-    <code>
-     KEY:HARDENED1
-    </code>
+    <code>KEY:HARDENED1</code>
     - Hardened (+1)
     <br/>
-    <code>
-     KEY:HARDENED2
-    </code>
+    <code>KEY:HARDENED2</code>
     - Hardened (+2)
     <br/>
-    <code>
-     KEY:HARDENED3
-    </code>
+    <code>KEY:HARDENED3</code>
     - Hardened (+3)
     <br/>
-    <code>
-     KEY:HARDENED4
-    </code>
+    <code>KEY:HARDENED4</code>
     - Hardened (+4)
     <br/>
-    <code>
-     KEY:HARDENED5
-    </code>
+    <code>KEY:HARDENED5</code>
     - Hardened (+5)
     <br/>
-    <code>
-     KEY:HARDH1
-    </code>
+    <code>KEY:HARDH1</code>
     - Hardenedx1 [Heavy Armor]
     <br/>
-    <code>
-     KEY:HARDH2
-    </code>
+    <code>KEY:HARDH2</code>
     - Hardenedx2 [Heavy Armor]
     <br/>
-    <code>
-     KEY:HARDL1
-    </code>
+    <code>KEY:HARDL1</code>
     - Hardenedx1 [Light Armor]
     <br/>
-    <code>
-     KEY:HARDL2
-    </code>
+    <code>KEY:HARDL2</code>
     - Hardenedx2 [Light Armor]
     <br/>
-    <code>
-     KEY:HARDM1
-    </code>
+    <code>KEY:HARDM1</code>
     - Hardenedx1 [Medium Armor]
     <br/>
-    <code>
-     KEY:HARDM2
-    </code>
+    <code>KEY:HARDM2</code>
     - Hardenedx2 [Medium Armor]
     <br/>
-    <code>
-     KEY:HARDS1
-    </code>
+    <code>KEY:HARDS1</code>
     - Hardenedx1 [Shield]
     <br/>
-    <code>
-     KEY:HARDS2
-    </code>
+    <code>KEY:HARDS2</code>
     - Hardenedx2 [Shield]
     <br/>
-    <code>
-     KEY:HDLT_BLND
-    </code>
+    <code>KEY:HDLT_BLND</code>
     - Headlights of Blinding
     <br/>
-    <code>
-     KEY:HEADS_UP_DISPLAY
-    </code>
+    <code>KEY:HEADS_UP_DISPLAY</code>
     - Heads Up Display
     <br/>
-    <code>
-     KEY:HEART
-    </code>
+    <code>KEY:HEART</code>
     - Hearten
     <br/>
-    <code>
-     KEY:HEART
-    </code>
+    <code>KEY:HEART</code>
     - Heartening
     <br/>
-    <code>
-     KEY:Helm of Comprehending Languages and Reading Magic
-    </code>
+    <code>KEY:Helm of Comprehending Languages and Reading Magic</code>
     - Helm of Comprehend Languages and Read Magic
     <br/>
-    <code>
-     KEY:HEMP
-    </code>
+    <code>KEY:HEMP</code>
     - Hemp
     <br/>
-    <code>
-     KEY:HEVY_FORTFCTN
-    </code>
+    <code>KEY:HEVY_FORTFCTN</code>
     - Heavy Fortification (PL9)
     <br/>
-    <code>
-     KEY:HFMW
-    </code>
+    <code>KEY:HFMW</code>
     - Halfling Mastework
     <br/>
-    <code>
-     KEY:HGE_AVNG_ELCT_SCM
-    </code>
+    <code>KEY:HGE_AVNG_ELCT_SCM</code>
     - Avenger Electro-Scimitar (PL
 8)
     <br/>
-    <code>
-     KEY:HGE_JUMP_DRIVE
-    </code>
+    <code>KEY:HGE_JUMP_DRIVE</code>
     - Jump Drive (Huge)
     <br/>
-    <code>
-     KEY:HGE_LK8_AMRPCG_PK
-    </code>
+    <code>KEY:HGE_LK8_AMRPCG_PK</code>
     - LK8 Armor-Piercing Pike (PL
 6)
     <br/>
-    <code>
-     KEY:HGE_MCH
-    </code>
+    <code>KEY:HGE_MCH</code>
     - Huge Mecha
     <br/>
-    <code>
-     KEY:HGE_PS15_PNTR_CLW
-    </code>
+    <code>KEY:HGE_PS15_PNTR_CLW</code>
     - PS-15 Panther Claws (PL
 5)
     <br/>
-    <code>
-     KEY:HGE_PS25_TIGR_CLW
-    </code>
+    <code>KEY:HGE_PS25_TIGR_CLW</code>
     - PS-25 Tiger Claws (PL 7)
     <br/>
-    <code>
-     KEY:HGE_PTHN_ELCT_WHP
-    </code>
+    <code>KEY:HGE_PTHN_ELCT_WHP</code>
     - XJ-A Python Electro-Whip (PL
 7)
     <br/>
-    <code>
-     KEY:HGE_QUAD_MCH
-    </code>
+    <code>KEY:HGE_QUAD_MCH</code>
     - Quadrupedal
     <br/>
-    <code>
-     KEY:HGE_RP91_RPR_LSCT
-    </code>
+    <code>KEY:HGE_RP91_RPR_LSCT</code>
     - RP-91 Reaper Laser Scythe (PL
 8)
     <br/>
-    <code>
-     KEY:HGE_THNDRB_SHK_RD
-    </code>
+    <code>KEY:HGE_THNDRB_SHK_RD</code>
     - Thunderbolt Shock Rod (PL
 5)
     <br/>
-    <code>
-     KEY:HI_EXPLOSIVE
-    </code>
+    <code>KEY:HI_EXPLOSIVE</code>
     - High Explosive
     <br/>
-    <code>
-     KEY:HIDDEN_COMPARTMENT
-    </code>
+    <code>KEY:HIDDEN_COMPARTMENT</code>
     - Hidden compartment
     <br/>
-    <code>
-     KEY:HIDE
-    </code>
+    <code>KEY:HIDE</code>
     - Hiding
     <br/>
-    <code>
-     KEY:HOLY_A
-    </code>
+    <code>KEY:HOLY_A</code>
     - Holy
     <br/>
-    <code>
-     KEY:HOLY_M
-    </code>
+    <code>KEY:HOLY_M</code>
     - Holy
     <br/>
-    <code>
-     KEY:HOLY_POWER_AMMO
-    </code>
+    <code>KEY:HOLY_POWER_AMMO</code>
     - Holy Power
     <br/>
-    <code>
-     KEY:HOLY_POWER_MELEE
-    </code>
+    <code>KEY:HOLY_POWER_MELEE</code>
     - Holy Power
     <br/>
-    <code>
-     KEY:HOLY_POWER_RANGED
-    </code>
+    <code>KEY:HOLY_POWER_RANGED</code>
     - Holy Power
     <br/>
-    <code>
-     KEY:HOLY_R
-    </code>
+    <code>KEY:HOLY_R</code>
     - Holy
     <br/>
-    <code>
-     KEY:HOMING_BEACON_SHOE
-    </code>
+    <code>KEY:HOMING_BEACON_SHOE</code>
     - Homing beacon
     <br/>
-    <code>
-     KEY:HONED_DURA_WEAP
-    </code>
+    <code>KEY:HONED_DURA_WEAP</code>
     - Honed Durasteel
     <br/>
-    <code>
-     KEY:HONORABLE
-    </code>
+    <code>KEY:HONORABLE</code>
     - Honorable
     <br/>
-    <code>
-     KEY:HOOK
-    </code>
+    <code>KEY:HOOK</code>
     - Hook
     <br/>
-    <code>
-     KEY:HORN
-    </code>
+    <code>KEY:HORN</code>
     - Horn
     <br/>
-    <code>
-     KEY:HOSI_BLST
-    </code>
+    <code>KEY:HOSI_BLST</code>
     - Horn of Blasting
     <br/>
-    <code>
-     KEY:HOSI_DRED
-    </code>
+    <code>KEY:HOSI_DRED</code>
     - Horn of Dread
     <br/>
-    <code>
-     KEY:HRTRGR
-    </code>
+    <code>KEY:HRTRGR</code>
     - Hair Trigger
     <br/>
-    <code>
-     KEY:HTRES
-    </code>
+    <code>KEY:HTRES</code>
     - Heat Resistant
     <br/>
-    <code>
-     KEY:HUD_SFTWR_AMMO_TRK
-    </code>
+    <code>KEY:HUD_SFTWR_AMMO_TRK</code>
     - HUD Software (Ammunition
 Tracker)
     <br/>
-    <code>
-     KEY:HUD_SFTWR_AMMO_TRK_AMR
-    </code>
+    <code>KEY:HUD_SFTWR_AMMO_TRK_AMR</code>
     - HUD Software (Ammunition
 Tracker)
     <br/>
-    <code>
-     KEY:HUD_SFTWR_BIOSNSR
-    </code>
+    <code>KEY:HUD_SFTWR_BIOSNSR</code>
     - HUD Software (Biosensor)
     <br/>
-    <code>
-     KEY:HUD_SFTWR_BIOSNSR_AMR
-    </code>
+    <code>KEY:HUD_SFTWR_BIOSNSR_AMR</code>
     - HUD Software
 (Biosensor)
     <br/>
-    <code>
-     KEY:HUD_SFTWR_SNSR_LNK
-    </code>
+    <code>KEY:HUD_SFTWR_SNSR_LNK</code>
     - HUD Software (Sensor
 Link)
     <br/>
-    <code>
-     KEY:HUD_SFTWR_SNSR_LNK_AMR
-    </code>
+    <code>KEY:HUD_SFTWR_SNSR_LNK_AMR</code>
     - HUD Software (Sensor
 Link)
     <br/>
-    <code>
-     KEY:HUD_SFTWR_TRGT
-    </code>
+    <code>KEY:HUD_SFTWR_TRGT</code>
     - HUD Software (Targetting)
     <br/>
-    <code>
-     KEY:HUD_SFTWR_TRGT_AMR
-    </code>
+    <code>KEY:HUD_SFTWR_TRGT_AMR</code>
     - HUD Software
 (Targetting)
     <br/>
-    <code>
-     KEY:HUD_SFTWR_VHCL_LNK
-    </code>
+    <code>KEY:HUD_SFTWR_VHCL_LNK</code>
     - HUD Software (Vehicle
 Link)
     <br/>
-    <code>
-     KEY:HUD_SFTWR_VHCL_LNK_AMR
-    </code>
+    <code>KEY:HUD_SFTWR_VHCL_LNK_AMR</code>
     - HUD Software (Vehicle
 Link)
     <br/>
-    <code>
-     KEY:HULL_BUILT
-    </code>
+    <code>KEY:HULL_BUILT</code>
     - Built to Last
     <br/>
-    <code>
-     KEY:HULL_BULL
-    </code>
+    <code>KEY:HULL_BULL</code>
     - Bull of the Sea
     <br/>
-    <code>
-     KEY:HULL_BUOYANCY
-    </code>
+    <code>KEY:HULL_BUOYANCY</code>
     - Improved Buoyancy
     <br/>
-    <code>
-     KEY:HULL_CLEAVER
-    </code>
+    <code>KEY:HULL_CLEAVER</code>
     - Clever Construction
     <br/>
-    <code>
-     KEY:HULL_FIRE_TESTED
-    </code>
+    <code>KEY:HULL_FIRE_TESTED</code>
     - Fire Tested
     <br/>
-    <code>
-     KEY:HULL_GRACE
-    </code>
+    <code>KEY:HULL_GRACE</code>
     - Grace Under Pressure
     <br/>
-    <code>
-     KEY:HULL_ICE_QUEEN
-    </code>
+    <code>KEY:HULL_ICE_QUEEN</code>
     - Ice Queen
     <br/>
-    <code>
-     KEY:HULL_MIGHTY-OARS
-    </code>
+    <code>KEY:HULL_MIGHTY-OARS</code>
     - Mighty Oars
     <br/>
-    <code>
-     KEY:HULL_OCEABWORTHY
-    </code>
+    <code>KEY:HULL_OCEABWORTHY</code>
     - Oceanworthy
     <br/>
-    <code>
-     KEY:HULL_SEA_SCRAPPER
-    </code>
+    <code>KEY:HULL_SEA_SCRAPPER</code>
     - Sea Scrapper
     <br/>
-    <code>
-     KEY:HULL_SEA_SKIMMER
-    </code>
+    <code>KEY:HULL_SEA_SKIMMER</code>
     - Sea Skimmer
     <br/>
-    <code>
-     KEY:HULL_STORM_RIDER
-    </code>
+    <code>KEY:HULL_STORM_RIDER</code>
     - Storm Rider
     <br/>
-    <code>
-     KEY:HULL_TOUGH
-    </code>
+    <code>KEY:HULL_TOUGH</code>
     - Tough Old Girl
     <br/>
-    <code>
-     KEY:HULL_TOUGH_SAILS
-    </code>
+    <code>KEY:HULL_TOUGH_SAILS</code>
     - Reinforced Sails
     <br/>
-    <code>
-     KEY:HULL_TRANSPORT
-    </code>
+    <code>KEY:HULL_TRANSPORT</code>
     - Transport
     <br/>
-    <code>
-     KEY:HULL_WAR_DOG
-    </code>
+    <code>KEY:HULL_WAR_DOG</code>
     - War Dog
     <br/>
-    <code>
-     KEY:HULL_WAVE_RIDER
-    </code>
+    <code>KEY:HULL_WAVE_RIDER</code>
     - Wave Rider
     <br/>
-    <code>
-     KEY:HUSH_PUPPY
-    </code>
+    <code>KEY:HUSH_PUPPY</code>
     - Hush Puppy
     <br/>
-    <code>
-     KEY:HVYARMALTHST
-    </code>
+    <code>KEY:HVYARMALTHST</code>
     - Altherian Steel
     <br/>
-    <code>
-     KEY:HV5_HVN_ESCP_PD
-    </code>
+    <code>KEY:HV5_HVN_ESCP_PD</code>
     - HV-5 Haven Escape Pod (PL
 6)
     <br/>
-    <code>
-     KEY:HYPNOSIS_LENSES
-    </code>
+    <code>KEY:HYPNOSIS_LENSES</code>
     - Hypnosis
     <br/>
-    <code>
-     KEY:ICE
-    </code>
+    <code>KEY:ICE</code>
     - Ice
     <br/>
-    <code>
-     KEY:ICE_BLAST_AMMO
-    </code>
+    <code>KEY:ICE_BLAST_AMMO</code>
     - Icy Blast
     <br/>
-    <code>
-     KEY:ICE_BLAST_MELEE
-    </code>
+    <code>KEY:ICE_BLAST_MELEE</code>
     - Icy Blast
     <br/>
-    <code>
-     KEY:ICE_BLAST_RANGED
-    </code>
+    <code>KEY:ICE_BLAST_RANGED</code>
     - Icy Blast
     <br/>
-    <code>
-     KEY:ICE_BR_A
-    </code>
+    <code>KEY:ICE_BR_A</code>
     - Icy Burst
     <br/>
-    <code>
-     KEY:ICE_BR_M
-    </code>
+    <code>KEY:ICE_BR_M</code>
     - Icy Burst
     <br/>
-    <code>
-     KEY:ICE_BR_R
-    </code>
+    <code>KEY:ICE_BR_R</code>
     - Icy Burst
     <br/>
-    <code>
-     KEY:ICEWD
-    </code>
+    <code>KEY:ICEWD</code>
     - Icewood
     <br/>
-    <code>
-     KEY:ILLUMINATOR
-    </code>
+    <code>KEY:ILLUMINATOR</code>
     - Illuminator
     <br/>
-    <code>
-     KEY:ILLUMINATOR
-    </code>
+    <code>KEY:ILLUMINATOR</code>
     - #Illuminator
     <br/>
-    <code>
-     KEY:IMPCT
-    </code>
+    <code>KEY:IMPCT</code>
     - Impact
     <br/>
-    <code>
-     KEY:IMPROVED_HANDLING
-    </code>
+    <code>KEY:IMPROVED_HANDLING</code>
     - Improved handling
     <br/>
-    <code>
-     KEY:INSERT_ANTI_STAB
-    </code>
+    <code>KEY:INSERT_ANTI_STAB</code>
     - Anti Stab Insert
     <br/>
-    <code>
-     KEY:INSERT_BUOYANCY
-    </code>
+    <code>KEY:INSERT_BUOYANCY</code>
     - Buoyancy Insert
     <br/>
-    <code>
-     KEY:INSERT_FLEX_TRAUMA
-    </code>
+    <code>KEY:INSERT_FLEX_TRAUMA</code>
     - Flexible Trauma Insert
     <br/>
-    <code>
-     KEY:INSERT_HVY_CERAMIC
-    </code>
+    <code>KEY:INSERT_HVY_CERAMIC</code>
     - Heavy Ceramic Insert
     <br/>
-    <code>
-     KEY:INSERT_LT_CERAMIC
-    </code>
+    <code>KEY:INSERT_LT_CERAMIC</code>
     - Light Ceramic Insert
     <br/>
-    <code>
-     KEY:INSERT_MED_CERAMIC
-    </code>
+    <code>KEY:INSERT_MED_CERAMIC</code>
     - Medium Ceramic Insert
     <br/>
-    <code>
-     KEY:INSERT_STEEL_TRAUMA
-    </code>
+    <code>KEY:INSERT_STEEL_TRAUMA</code>
     - Steel Trauma Insert
     <br/>
-    <code>
-     KEY:INSERT_TITAN_TRAUMA
-    </code>
+    <code>KEY:INSERT_TITAN_TRAUMA</code>
     - Titanium Trauma Insert
     <br/>
-    <code>
-     KEY:INSTMW
-    </code>
+    <code>KEY:INSTMW</code>
     - Masterwork - Instruments
     <br/>
-    <code>
-     KEY:INSULATED
-    </code>
+    <code>KEY:INSULATED</code>
     - Insulated
     <br/>
-    <code>
-     KEY:INT_EQ_GDGT_AMR
-    </code>
+    <code>KEY:INT_EQ_GDGT_AMR</code>
     - Integrated Equipment
 Gadget
     <br/>
-    <code>
-     KEY:INT_EQ_GDGT_WPN
-    </code>
+    <code>KEY:INT_EQ_GDGT_WPN</code>
     - Integrated Equipment
 Gadget
     <br/>
-    <code>
-     KEY:INT_WPN_GDGT
-    </code>
+    <code>KEY:INT_WPN_GDGT</code>
     - Integrated Weapon Gadget
     <br/>
-    <code>
-     KEY:INVULN
-    </code>
+    <code>KEY:INVULN</code>
     - Invulnerability
     <br/>
-    <code>
-     KEY:INVULN_GRT_5E
-    </code>
+    <code>KEY:INVULN_GRT_5E</code>
     - Greater Invulnerability (+6)
     <br/>
-    <code>
-     KEY:INVULN_GRT_10E
-    </code>
+    <code>KEY:INVULN_GRT_10E</code>
     - Greater Invulnerability
 (+7)
     <br/>
-    <code>
-     KEY:INVULN_GRT_10M
-    </code>
+    <code>KEY:INVULN_GRT_10M</code>
     - Greater Invulnerability
 (+4)
     <br/>
-    <code>
-     KEY:INVULN_GRT_15M
-    </code>
+    <code>KEY:INVULN_GRT_15M</code>
     - Greater Invulnerability
 (+5)
     <br/>
-    <code>
-     KEY:IRIS_LENSES
-    </code>
+    <code>KEY:IRIS_LENSES</code>
     - Iris
     <br/>
-    <code>
-     KEY:IRON
-    </code>
+    <code>KEY:IRON</code>
     - Iron
     <br/>
-    <code>
-     KEY:IRON_PLATED
-    </code>
+    <code>KEY:IRON_PLATED</code>
     - Iron Plated
     <br/>
-    <code>
-     KEY:IRONWOOD
-    </code>
+    <code>KEY:IRONWOOD</code>
     - Ironwood
     <br/>
-    <code>
-     KEY:IRONWOOD_PLUS
-    </code>
+    <code>KEY:IRONWOOD_PLUS</code>
     - Ironwood (+1)
     <br/>
-    <code>
-     KEY:INT_EQ_GDGT_AMR
-    </code>
+    <code>KEY:INT_EQ_GDGT_AMR</code>
     - Integrated Equipment
 Gadget
     <br/>
-    <code>
-     KEY:INT_EQ_GDGT_WPN
-    </code>
+    <code>KEY:INT_EQ_GDGT_WPN</code>
     - Integrated Equipment
 Gadget
     <br/>
-    <code>
-     KEY:INT_WPN_GDGT
-    </code>
+    <code>KEY:INT_WPN_GDGT</code>
     - Integrated Weapon Gadget
     <br/>
-    <code>
-     KEY:INVULN
-    </code>
+    <code>KEY:INVULN</code>
     - Invulnerability
     <br/>
-    <code>
-     KEY:JETPACK
-    </code>
+    <code>KEY:JETPACK</code>
     - Jetpack (PL6)
     <br/>
-    <code>
-     KEY:JETASSSTWNGS
-    </code>
+    <code>KEY:JETASSSTWNGS</code>
     - Jet-Assist Wings (PL7)
     <br/>
-    <code>
-     KEY:KAHLES_SIGHT
-    </code>
+    <code>KEY:KAHLES_SIGHT</code>
     - Kahles ZF69
     <br/>
-    <code>
-     KEY:KARMIC
-    </code>
+    <code>KEY:KARMIC</code>
     - Karmic
     <br/>
-    <code>
-     KEY:KEEN
-    </code>
+    <code>KEY:KEEN</code>
     - Keen
     <br/>
-    <code>
-     KEY:KICHAN
-    </code>
+    <code>KEY:KICHAN</code>
     - Ki Channel
     <br/>
-    <code>
-     KEY:KIFOC
-    </code>
+    <code>KEY:KIFOC</code>
     - Ki Focus
     <br/>
-    <code>
-     KEY:KNOCKBACK
-    </code>
+    <code>KEY:KNOCKBACK</code>
     - Knockback
     <br/>
-    <code>
-     KEY:LANDI
-    </code>
+    <code>KEY:LANDI</code>
     - Landing
     <br/>
-    <code>
-     KEY:LANDING
-    </code>
+    <code>KEY:LANDING</code>
     - Landing
     <br/>
-    <code>
-     KEY:LASER_MOUNT
-    </code>
+    <code>KEY:LASER_MOUNT</code>
     - Laser mount
     <br/>
-    <code>
-     KEY:LASER_SIGHT
-    </code>
+    <code>KEY:LASER_SIGHT</code>
     - Laser Sight
     <br/>
-    <code>
-     KEY:LAW_A
-    </code>
+    <code>KEY:LAW_A</code>
     - Axiomatic, Lawful
     <br/>
-    <code>
-     KEY:LAW_M
-    </code>
+    <code>KEY:LAW_M</code>
     - Axiomatic, Lawful
     <br/>
-    <code>
-     KEY:LAWFUL_MELEE
-    </code>
+    <code>KEY:LAWFUL_MELEE</code>
     - Lawful
     <br/>
-    <code>
-     KEY:LAW_POWER_AMMO
-    </code>
+    <code>KEY:LAW_POWER_AMMO</code>
     - Axiomatic Power
     <br/>
-    <code>
-     KEY:LAW_POWER_MELEE
-    </code>
+    <code>KEY:LAW_POWER_MELEE</code>
     - Axiomatic Power
     <br/>
-    <code>
-     KEY:LAW_POWER_RANGED
-    </code>
+    <code>KEY:LAW_POWER_RANGED</code>
     - Axiomatic Power
     <br/>
-    <code>
-     KEY:LAW_R
-    </code>
+    <code>KEY:LAW_R</code>
     - Axiomatic, Lawful
     <br/>
-    <code>
-     KEY:LAWFUL_MELEE
-    </code>
+    <code>KEY:LAWFUL_MELEE</code>
     - Lawful
     <br/>
-    <code>
-     KEY:LAWFUL_RANGED
-    </code>
+    <code>KEY:LAWFUL_RANGED</code>
     - Lawful
     <br/>
-    <code>
-     KEY:LCD_LENSES
-    </code>
+    <code>KEY:LCD_LENSES</code>
     - LCD
     <br/>
-    <code>
-     KEY:LEATHER
-    </code>
+    <code>KEY:LEATHER</code>
     - Leather
     <br/>
-    <code>
-     KEY:LEGENDWA
-    </code>
+    <code>KEY:LEGENDWA</code>
     - Legendary 2 - Weapon
     <br/>
-    <code>
-     KEY:LEGENDWB
-    </code>
+    <code>KEY:LEGENDWB</code>
     - Legendary 3 - Weapon
     <br/>
-    <code>
-     KEY:LEGENDWC
-    </code>
+    <code>KEY:LEGENDWC</code>
     - Legendary 4 - Weapon
     <br/>
-    <code>
-     KEY:LEGENDWD
-    </code>
+    <code>KEY:LEGENDWD</code>
     - Legendary 5 - Weapon
     <br/>
-    <code>
-     KEY:LEGENDAFA
-    </code>
+    <code>KEY:LEGENDAFA</code>
     - Fitted Legendary 2 -
 Armor.Shield
     <br/>
-    <code>
-     KEY:LEGENDAFB
-    </code>
+    <code>KEY:LEGENDAFB</code>
     - Fitted Legendary 3 -
 Armor.Shield
     <br/>
-    <code>
-     KEY:LEGENDAFC
-    </code>
+    <code>KEY:LEGENDAFC</code>
     - Fitted Legendary 4 -
 Armor.Shield
     <br/>
-    <code>
-     KEY:LEGENDAFD
-    </code>
+    <code>KEY:LEGENDAFD</code>
     - Fitted Legendary 5 -
 Armor.Shield
     <br/>
-    <code>
-     KEY:LEGENDANA
-    </code>
+    <code>KEY:LEGENDANA</code>
     - Nimble Legendary 2 -
 Armor.Shield
     <br/>
-    <code>
-     KEY:LEGENDANB
-    </code>
+    <code>KEY:LEGENDANB</code>
     - Nimble Legendary 3 -
 Armor.Shield
     <br/>
-    <code>
-     KEY:LEGENDANC
-    </code>
+    <code>KEY:LEGENDANC</code>
     - Nimble Legendary 4 -
 Armor.Shield
     <br/>
-    <code>
-     KEY:LEGENDAND
-    </code>
+    <code>KEY:LEGENDAND</code>
     - Nimble Legendary 5 -
 Armor.Shield
     <br/>
-    <code>
-     KEY:LEGENDAPA
-    </code>
+    <code>KEY:LEGENDAPA</code>
     - Proof Legendary 2 - Armor.Shield
     <br/>
-    <code>
-     KEY:LEGENDAPB
-    </code>
+    <code>KEY:LEGENDAPB</code>
     - Proof Legendary 3 - Armor.Shield
     <br/>
-    <code>
-     KEY:LEGENDAPC
-    </code>
+    <code>KEY:LEGENDAPC</code>
     - Proof Legendary 4 - Armor.Shield
     <br/>
-    <code>
-     KEY:LEGENDAPD
-    </code>
+    <code>KEY:LEGENDAPD</code>
     - Proof Legendary 5 - Armor.Shield
     <br/>
-    <code>
-     KEY:LF_SPPRT_SYSTEM
-    </code>
+    <code>KEY:LF_SPPRT_SYSTEM</code>
     - Life Support System
     <br/>
-    <code>
-     KEY:LGHT_FORTFCTN
-    </code>
+    <code>KEY:LGHT_FORTFCTN</code>
     - Light Fortification (PL7)
     <br/>
-    <code>
-     KEY:Linguist_BP_PFF
-    </code>
+    <code>KEY:Linguist_BP_PFF</code>
     - Linguist
     <br/>
-    <code>
-     KEY:LINKED
-    </code>
+    <code>KEY:LINKED</code>
     - Linked
     <br/>
-    <code>
-     KEY:LNGBRL_L
-    </code>
+    <code>KEY:LNGBRL_L</code>
     - Lengthened Barrel
     <br/>
-    <code>
-     KEY:LNGBRL_P
-    </code>
+    <code>KEY:LNGBRL_P</code>
     - Lengthened Barrel
     <br/>
-    <code>
-     KEY:LNKED
-    </code>
+    <code>KEY:LNKED</code>
     - Linked
     <br/>
-    <code>
-     KEY:Lock_G
-    </code>
+    <code>KEY:Lock_G</code>
     - Locked Gauntlets
     <br/>
-    <code>
-     KEY:LOCKPICK_SET
-    </code>
+    <code>KEY:LOCKPICK_SET</code>
     - Lockpick set
     <br/>
-    <code>
-     KEY:LRG_AVNG_ELCT_SCM
-    </code>
+    <code>KEY:LRG_AVNG_ELCT_SCM</code>
     - Avenger Electro-Scimitar (PL
 8)
     <br/>
-    <code>
-     KEY:LRG_LK8_AMRPCG_PK
-    </code>
+    <code>KEY:LRG_LK8_AMRPCG_PK</code>
     - LK8 Armor-Piercing Pike (PL
 6)
     <br/>
-    <code>
-     KEY:LRG_MCH
-    </code>
+    <code>KEY:LRG_MCH</code>
     - Large Mecha
     <br/>
-    <code>
-     KEY:LRG_PS15_PNTR_CLW
-    </code>
+    <code>KEY:LRG_PS15_PNTR_CLW</code>
     - PS-15 Panther Claws (PL
 5)
     <br/>
-    <code>
-     KEY:LRG_PS25_TIGR_CLW
-    </code>
+    <code>KEY:LRG_PS25_TIGR_CLW</code>
     - PS-25 Tiger Claws (PL 7)
     <br/>
-    <code>
-     KEY:LRG_PTHN_ELCT_WHP
-    </code>
+    <code>KEY:LRG_PTHN_ELCT_WHP</code>
     - XJ-A Python Electro-Whip (PL
 7)
     <br/>
-    <code>
-     KEY:LRG_QUAD_MCH
-    </code>
+    <code>KEY:LRG_QUAD_MCH</code>
     - Quadrupedal
     <br/>
-    <code>
-     KEY:LRG_RP91_RPR_LSCT
-    </code>
+    <code>KEY:LRG_RP91_RPR_LSCT</code>
     - RP-91 Reaper Laser Scythe (PL
 8)
     <br/>
-    <code>
-     KEY:LRG_THNDRB_SHK_RD
-    </code>
+    <code>KEY:LRG_THNDRB_SHK_RD</code>
     - Thunderbolt Shock Rod (PL
 5)
     <br/>
-    <code>
-     KEY:LSR_SIGHT
-    </code>
+    <code>KEY:LSR_SIGHT</code>
     - Laser Sight
     <br/>
-    <code>
-     KEY:LSR_SIGHT
-    </code>
+    <code>KEY:LSR_SIGHT</code>
     - #Laser Sight
     <br/>
-    <code>
-     KEY:LTMEDARMALTHST
-    </code>
+    <code>KEY:LTMEDARMALTHST</code>
     - Altherian Steel
     <br/>
-    <code>
-     KEY:LT5_LNGSHT_MSSDRV
-    </code>
+    <code>KEY:LT5_LNGSHT_MSSDRV</code>
     - LT-5 Longshot Mass Driver (PL
 8)
     <br/>
-    <code>
-     KEY:LUCKY
-    </code>
+    <code>KEY:LUCKY</code>
     - Lucky
     <br/>
-    <code>
-     KEY:LUMINSTONE
-    </code>
+    <code>KEY:LUMINSTONE</code>
     - Luminstone
     <br/>
-    <code>
-     KEY:LX10_ANTISHCK
-    </code>
+    <code>KEY:LX10_ANTISHCK</code>
     - LX-10 Antishock Array (PL6)
     <br/>
-    <code>
-     KEY:LX20_ANTISHCK
-    </code>
+    <code>KEY:LX20_ANTISHCK</code>
     - LX-20 Antishock Array (PL7)
     <br/>
-    <code>
-     KEY:M9_BRRGE_CHAINGUN
-    </code>
+    <code>KEY:M9_BRRGE_CHAINGUN</code>
     - M-9 Barrage Chaingun (PL
 5)
     <br/>
-    <code>
-     KEY:M21_COMET_AUTOLSR
-    </code>
+    <code>KEY:M21_COMET_AUTOLSR</code>
     - M-21 Comet Autolaser (PL
 6)
     <br/>
-    <code>
-     KEY:M53_FRST_RCKTLNCH
-    </code>
+    <code>KEY:M53_FRST_RCKTLNCH</code>
     - M-53 Firestar Rocket Launcher
 (PL 5)
     <br/>
-    <code>
-     KEY:M55_CRUD_RCKTLNCH
-    </code>
+    <code>KEY:M55_CRUD_RCKTLNCH</code>
     - M-55 Crud Rocket Launcher (PL
 5)
     <br/>
-    <code>
-     KEY:M70_EMP_RCKTLNCHR
-    </code>
+    <code>KEY:M70_EMP_RCKTLNCHR</code>
     - M-70 EMP Rocket Launcher (PL
 6)
     <br/>
-    <code>
-     KEY:M75_CRKT_RCKTLNCH
-    </code>
+    <code>KEY:M75_CRKT_RCKTLNCH</code>
     - M-75 Cricket Rocket Launcher
 (PL 6)
     <br/>
-    <code>
-     KEY:M87_TALN_MSSLLNCH
-    </code>
+    <code>KEY:M87_TALN_MSSLLNCH</code>
     - M-87 Talon Missile Launcher
 (PL 5)
     <br/>
-    <code>
-     KEY:MACHINE_PISTOL
-    </code>
+    <code>KEY:MACHINE_PISTOL</code>
     - Machine pistol
     <br/>
-    <code>
-     KEY:MAG_ENH_FUR_ARMOR
-    </code>
+    <code>KEY:MAG_ENH_FUR_ARMOR</code>
     - Magic Enhanced Fur
     <br/>
-    <code>
-     KEY:MAG_ENH_FUR_CLOTHING
-    </code>
+    <code>KEY:MAG_ENH_FUR_CLOTHING</code>
     - Magic Enhanced Fur
     <br/>
-    <code>
-     KEY:MAGETUNE
-    </code>
+    <code>KEY:MAGETUNE</code>
     - Mage Tuned
     <br/>
-    <code>
-     KEY:MAGIC_BOX
-    </code>
+    <code>KEY:MAGIC_BOX</code>
     - Magic box
     <br/>
-    <code>
-     KEY:MAGIC_COST
-    </code>
+    <code>KEY:MAGIC_COST</code>
     - Magical Enhancment Cost
     <br/>
-    <code>
-     KEY:MAGIC_ENHANCE_1
-    </code>
+    <code>KEY:MAGIC_ENHANCE_1</code>
     - Magical Enhancments (+1)
     <br/>
-    <code>
-     KEY:MAGIC_ENHANCE_2
-    </code>
+    <code>KEY:MAGIC_ENHANCE_2</code>
     - Magical Enhancments (+2)
     <br/>
-    <code>
-     KEY:MAGIC_ENHANCE_3
-    </code>
+    <code>KEY:MAGIC_ENHANCE_3</code>
     - Magical Enhancments (+3)
     <br/>
-    <code>
-     KEY:MAGIC_ENHANCE_4
-    </code>
+    <code>KEY:MAGIC_ENHANCE_4</code>
     - Magical Enhancments (+4)
     <br/>
-    <code>
-     KEY:MAGIC_ENHANCE_5
-    </code>
+    <code>KEY:MAGIC_ENHANCE_5</code>
     - Magical Enhancments (+5)
     <br/>
-    <code>
-     KEY:MAGIC_ENHANCE_6
-    </code>
+    <code>KEY:MAGIC_ENHANCE_6</code>
     - Magical Enhancments (+6)
     <br/>
-    <code>
-     KEY:MAGIC_ENHANCE_7
-    </code>
+    <code>KEY:MAGIC_ENHANCE_7</code>
     - Magical Enhancments (+7)
     <br/>
-    <code>
-     KEY:MAGIC_ENHANCE_8
-    </code>
+    <code>KEY:MAGIC_ENHANCE_8</code>
     - Magical Enhancments (+8)
     <br/>
-    <code>
-     KEY:MAGIC_ENHANCE_9
-    </code>
+    <code>KEY:MAGIC_ENHANCE_9</code>
     - Magical Enhancments (+9)
     <br/>
-    <code>
-     KEY:MAGIC_ENHANCE_10
-    </code>
+    <code>KEY:MAGIC_ENHANCE_10</code>
     - Magical Enhancments (+10)
     <br/>
-    <code>
-     KEY:MAGNET_EYES_LENSES
-    </code>
+    <code>KEY:MAGNET_EYES_LENSES</code>
     - Magnet eyes
     <br/>
-    <code>
-     KEY:MANAWALL
-    </code>
+    <code>KEY:MANAWALL</code>
     - Manawall Crushing
     <br/>
-    <code>
-     KEY:MANAWALLELD
-    </code>
+    <code>KEY:MANAWALLELD</code>
     - Manawall Crushing (Eldritch)
     <br/>
-    <code>
-     KEY:MANEU
-    </code>
+    <code>KEY:MANEU</code>
     - Maneuvering
     <br/>
-    <code>
-     KEY:MANEUGR
-    </code>
+    <code>KEY:MANEUGR</code>
     - Maneuvering (Greater)
     <br/>
-    <code>
-     KEY:MANIF_SHLD
-    </code>
+    <code>KEY:MANIF_SHLD</code>
     - Manifester
     <br/>
-    <code>
-     KEY:MANIF_WPN_M
-    </code>
+    <code>KEY:MANIF_WPN_M</code>
     - Manifester
     <br/>
-    <code>
-     KEY:MANIF_WPN_R
-    </code>
+    <code>KEY:MANIF_WPN_R</code>
     - Manifester
     <br/>
-    <code>
-     KEY:MARK_I_STANDARD_PALMPRINT_ID
-    </code>
+    <code>KEY:MARK_I_STANDARD_PALMPRINT_ID</code>
     - Mark I Standard
 Palmprint ID
     <br/>
-    <code>
-     KEY:MASTERCRAFT_ARMR_1
-    </code>
+    <code>KEY:MASTERCRAFT_ARMR_1</code>
     - Mastercraft +1
     <br/>
-    <code>
-     KEY:MASTERCRAFT_ARMR_2
-    </code>
+    <code>KEY:MASTERCRAFT_ARMR_2</code>
     - Mastercraft +2
     <br/>
-    <code>
-     KEY:MASTERCRAFT_ARMR_3
-    </code>
+    <code>KEY:MASTERCRAFT_ARMR_3</code>
     - Mastercraft +3
     <br/>
-    <code>
-     KEY:MASTERCRAFT_SHLD_1
-    </code>
+    <code>KEY:MASTERCRAFT_SHLD_1</code>
     - Mastercraft +1
     <br/>
-    <code>
-     KEY:MASTERCRAFT_SHLD_2
-    </code>
+    <code>KEY:MASTERCRAFT_SHLD_2</code>
     - Mastercraft +2
     <br/>
-    <code>
-     KEY:MASTERCRAFT_SHLD_3
-    </code>
+    <code>KEY:MASTERCRAFT_SHLD_3</code>
     - Mastercraft +3
     <br/>
-    <code>
-     KEY:MASTERCRAFT_TOOL_1
-    </code>
+    <code>KEY:MASTERCRAFT_TOOL_1</code>
     - Mastercraft +1
     <br/>
-    <code>
-     KEY:MASTERCRAFT_TOOL_2
-    </code>
+    <code>KEY:MASTERCRAFT_TOOL_2</code>
     - Mastercraft +2
     <br/>
-    <code>
-     KEY:MASTERCRAFT_TOOL_3
-    </code>
+    <code>KEY:MASTERCRAFT_TOOL_3</code>
     - Mastercraft +3
     <br/>
-    <code>
-     KEY:MASTERCRAFT_WEAP_DAM_1
-    </code>
+    <code>KEY:MASTERCRAFT_WEAP_DAM_1</code>
     - Mastercraft +1
 Damage
     <br/>
-    <code>
-     KEY:MASTERCRAFT_WEAP_DAM_2
-    </code>
+    <code>KEY:MASTERCRAFT_WEAP_DAM_2</code>
     - Mastercraft +2
 Damage
     <br/>
-    <code>
-     KEY:MASTERCRAFT_WEAP_DAM_3
-    </code>
+    <code>KEY:MASTERCRAFT_WEAP_DAM_3</code>
     - Mastercraft +3
 Damage
     <br/>
-    <code>
-     KEY:MASTERCRAFT_WEAP_HIT_1
-    </code>
+    <code>KEY:MASTERCRAFT_WEAP_HIT_1</code>
     - Mastercraft +1 To
 Hit
     <br/>
-    <code>
-     KEY:MASTERCRAFT_WEAP_HIT_2
-    </code>
+    <code>KEY:MASTERCRAFT_WEAP_HIT_2</code>
     - Mastercraft +2 To
 Hit
     <br/>
-    <code>
-     KEY:MASTERCRAFT_WEAP_HIT_3
-    </code>
+    <code>KEY:MASTERCRAFT_WEAP_HIT_3</code>
     - Mastercraft +3 To
 Hit
     <br/>
-    <code>
-     KEY:MATCH_GRADE_WEAPON
-    </code>
+    <code>KEY:MATCH_GRADE_WEAPON</code>
     - Match grade weapon
     <br/>
-    <code>
-     KEY:MDFNS_CLOAK_SCRN
-    </code>
+    <code>KEY:MDFNS_CLOAK_SCRN</code>
     - Cloaking Screen
     <br/>
-    <code>
-     KEY:MDFNS_DISPLACER
-    </code>
+    <code>KEY:MDFNS_DISPLACER</code>
     - Displacer
     <br/>
-    <code>
-     KEY:MDFNS_MGNT_FLD
-    </code>
+    <code>KEY:MDFNS_MGNT_FLD</code>
     - Magnetic Field
     <br/>
-    <code>
-     KEY:MDFNS_PRTCL_FLD
-    </code>
+    <code>KEY:MDFNS_PRTCL_FLD</code>
     - Particle Field
     <br/>
-    <code>
-     KEY:MDFNS_STLTH_SCRN
-    </code>
+    <code>KEY:MDFNS_STLTH_SCRN</code>
     - Stealth Screen
     <br/>
-    <code>
-     KEY:MECHA_M300_RHINO_MSSCNN
-    </code>
+    <code>KEY:MECHA_M300_RHINO_MSSCNN</code>
     - M-300 Rhino Mass Cannon
 (PL 7)
     <br/>
-    <code>
-     KEY:MEDICAL_SUITE
-    </code>
+    <code>KEY:MEDICAL_SUITE</code>
     - Medical Suite
     <br/>
-    <code>
-     KEY:MEDM_FORTFCTN
-    </code>
+    <code>KEY:MEDM_FORTFCTN</code>
     - Medium Fortification (PL8)
     <br/>
-    <code>
-     KEY:MEGATANM
-    </code>
+    <code>KEY:MEGATANM</code>
     - Megatanium (PL 8)
     <br/>
-    <code>
-     KEY:MEGATANM_ARMR
-    </code>
+    <code>KEY:MEGATANM_ARMR</code>
     - Megatanium Armor (PL8)
     <br/>
-    <code>
-     KEY:MEMORY_CACHE_WATCH
-    </code>
+    <code>KEY:MEMORY_CACHE_WATCH</code>
     - Memory cache
     <br/>
-    <code>
-     KEY:MERC_A
-    </code>
+    <code>KEY:MERC_A</code>
     - Merciful
     <br/>
-    <code>
-     KEY:MERC_M
-    </code>
+    <code>KEY:MERC_M</code>
     - Merciful
     <br/>
-    <code>
-     KEY:MERC_R
-    </code>
+    <code>KEY:MERC_R</code>
     - Merciful
     <br/>
-    <code>
-     KEY:MERCIFUL_MELEE
-    </code>
+    <code>KEY:MERCIFUL_MELEE</code>
     - Merciful
     <br/>
-    <code>
-     KEY:MERCIFUL_RANGED
-    </code>
+    <code>KEY:MERCIFUL_RANGED</code>
     - Merciful
     <br/>
-    <code>
-     KEY:MI_CLE
-    </code>
+    <code>KEY:MI_CLE</code>
     - Mighty Cleaving
     <br/>
-    <code>
-     KEY:MIGHTY_CLEAVE
-    </code>
+    <code>KEY:MIGHTY_CLEAVE</code>
     - Mighty Cleaving
     <br/>
-    <code>
-     KEY:MINDCRU
-    </code>
+    <code>KEY:MINDCRU</code>
     - Mindcrusher
     <br/>
-    <code>
-     KEY:MINDFEED
-    </code>
+    <code>KEY:MINDFEED</code>
     - Mind Feeder
     <br/>
-    <code>
-     KEY:MITHRAL_ARMR_HVY
-    </code>
+    <code>KEY:MITHRAL_ARMR_HVY</code>
     - Mithral (Armor/Heavy)
     <br/>
-    <code>
-     KEY:MITHRAL_ARMR_LT
-    </code>
+    <code>KEY:MITHRAL_ARMR_LT</code>
     - Mithral (Armor/Light)
     <br/>
-    <code>
-     KEY:MITHRAL_ARMR_MED
-    </code>
+    <code>KEY:MITHRAL_ARMR_MED</code>
     - Mithral (Armor/Medium)
     <br/>
-    <code>
-     KEY:MITHRAL_ITEM
-    </code>
+    <code>KEY:MITHRAL_ITEM</code>
     - Mithral
 (Weapon/Ammo/Instrument)
     <br/>
-    <code>
-     KEY:MITHRAL_PLATED
-    </code>
+    <code>KEY:MITHRAL_PLATED</code>
     - Mithral Plated
     <br/>
-    <code>
-     KEY:MITHRAL_SHLD
-    </code>
+    <code>KEY:MITHRAL_SHLD</code>
     - Mithral (Shield)
     <br/>
-    <code>
-     KEY:MLTPL_US_ITM_GDGT
-    </code>
+    <code>KEY:MLTPL_US_ITM_GDGT</code>
     - Multiple Use Item Gadget
     <br/>
-    <code>
-     KEY:MMARK
-    </code>
+    <code>KEY:MMARK</code>
     - Maker's Mark
     <br/>
-    <code>
-     KEY:MND_ARMR
-    </code>
+    <code>KEY:MND_ARMR</code>
     - Mindarmor
     <br/>
-    <code>
-     KEY:MND_CRSHR
-    </code>
+    <code>KEY:MND_CRSHR</code>
     - Mindcrusher
     <br/>
-    <code>
-     KEY:MND_FDR
-    </code>
+    <code>KEY:MND_FDR</code>
     - Mind Feeder
     <br/>
-    <code>
-     KEY:MNDARMR
-    </code>
+    <code>KEY:MNDARMR</code>
     - Mindarmor
     <br/>
-    <code>
-     KEY:MNFSTR_S
-    </code>
+    <code>KEY:MNFSTR_S</code>
     - Manifester
     <br/>
-    <code>
-     KEY:MNFSTR_W
-    </code>
+    <code>KEY:MNFSTR_W</code>
     - Manifester
     <br/>
-    <code>
-     KEY:MNTL_ADBL
-    </code>
+    <code>KEY:MNTL_ADBL</code>
     - Mentally Audible
     <br/>
-    <code>
-     KEY:MNTRZD_GDGT_EQP
-    </code>
+    <code>KEY:MNTRZD_GDGT_EQP</code>
     - Miniaturized Gadget
     <br/>
-    <code>
-     KEY:MNTRZD_GDGT_WPN
-    </code>
+    <code>KEY:MNTRZD_GDGT_WPN</code>
     - Miniaturized Gadget
     <br/>
-    <code>
-     KEY:MOBILITY_ARMR_LT
-    </code>
+    <code>KEY:MOBILITY_ARMR_LT</code>
     - Mobility [Light Armor]
     <br/>
-    <code>
-     KEY:MOBILITY_ARMR_MED
-    </code>
+    <code>KEY:MOBILITY_ARMR_MED</code>
     - Mobility [Medium Armor]
     <br/>
-    <code>
-     KEY:MOBILITY_ARMR_HVY
-    </code>
+    <code>KEY:MOBILITY_ARMR_HVY</code>
     - Mobility [Heavy Armor]
     <br/>
-    <code>
-     KEY:MOUNT_BAG_OF_BONES
-    </code>
+    <code>KEY:MOUNT_BAG_OF_BONES</code>
     - Mount Quality (Bag of
 Bones)
     <br/>
-    <code>
-     KEY:MOUNT_CHARGER
-    </code>
+    <code>KEY:MOUNT_CHARGER</code>
     - Mount Quality (Charger)
     <br/>
-    <code>
-     KEY:MOUNT_COURSER
-    </code>
+    <code>KEY:MOUNT_COURSER</code>
     - Mount Quality (Courser)
     <br/>
-    <code>
-     KEY:MOUNT_FLIGHTY
-    </code>
+    <code>KEY:MOUNT_FLIGHTY</code>
     - Mount Quality (Flighty)
     <br/>
-    <code>
-     KEY:MOUNT_NAG
-    </code>
+    <code>KEY:MOUNT_NAG</code>
     - Mount Quality (Nag)
     <br/>
-    <code>
-     KEY:MOUNT_NOBLE_STEED
-    </code>
+    <code>KEY:MOUNT_NOBLE_STEED</code>
     - Mount Quality (Noble
 Steed)
     <br/>
-    <code>
-     KEY:MOUNT_OLD_NAG
-    </code>
+    <code>KEY:MOUNT_OLD_NAG</code>
     - Mount Quality (Old Nag)
     <br/>
-    <code>
-     KEY:MOUNT_RACER
-    </code>
+    <code>KEY:MOUNT_RACER</code>
     - Mount Quality (Racer)
     <br/>
-    <code>
-     KEY:MOUNT_SCP_RFL
-    </code>
+    <code>KEY:MOUNT_SCP_RFL</code>
     - Rifle Scope Mount
     <br/>
-    <code>
-     KEY:MOUNT_STEED
-    </code>
+    <code>KEY:MOUNT_STEED</code>
     - Mount Quality (Steed)
     <br/>
-    <code>
-     KEY:MOVESIL
-    </code>
+    <code>KEY:MOVESIL</code>
     - Moving Silently
     <br/>
-    <code>
-     KEY:MRPH_MTL_ALL_GDGT
-    </code>
+    <code>KEY:MRPH_MTL_ALL_GDGT</code>
     - Morphic Metal Alloy
 Gadget
     <br/>
-    <code>
-     KEY:MTHRL
-    </code>
+    <code>KEY:MTHRL</code>
     - Mithral
     <span class="new">
      (deprecated)
     </span>
     <br/>
-    <code>
-     KEY:MTHRL_MDHV
-    </code>
+    <code>KEY:MTHRL_MDHV</code>
     - Mithral
     <span class="new">
      (deprecated)
     </span>
     <br/>
-    <code>
-     KEY:MULTIPART
-    </code>
+    <code>KEY:MULTIPART</code>
     - Multipart
     <br/>
-    <code>
-     KEY:MUT_SECOND_WIND
-    </code>
+    <code>KEY:MUT_SECOND_WIND</code>
     - Second Wind
     <br/>
-    <code>
-     KEY:MWORKA
-    </code>
+    <code>KEY:MWORKA</code>
     - Masterwork (Armor)
     <br/>
-    <code>
-     KEY:MWORKI
-    </code>
+    <code>KEY:MWORKI</code>
     - Masterwork (Instrument)
     <br/>
-    <code>
-     KEY:MWORKT
-    </code>
+    <code>KEY:MWORKT</code>
     - Masterwork (Tool)
     <br/>
-    <code>
-     KEY:MWORKW
-    </code>
+    <code>KEY:MWORKW</code>
     - Masterwork (Weapon/Ammo)
     <br/>
-    <code>
-     KEY:NAKAMURA_ANGR
-    </code>
+    <code>KEY:NAKAMURA_ANGR</code>
     - Nakamura Blade / Personality
 (Angry) /
     <br/>
-    <code>
-     KEY:NAKAMURA_BLDT
-    </code>
+    <code>KEY:NAKAMURA_BLDT</code>
     - Nakamura Blade / Personality
 (Bloodthirsty) /
     <br/>
-    <code>
-     KEY:NAKAMURA_IMPT
-    </code>
+    <code>KEY:NAKAMURA_IMPT</code>
     - Nakamura Blade / Personality
 (Impatient) /
     <br/>
-    <code>
-     KEY:NAKAMURA_INST
-    </code>
+    <code>KEY:NAKAMURA_INST</code>
     - Nakamura Blade / Personality
 (Insightful) /
     <br/>
-    <code>
-     KEY:NAKAMURA_PCLV
-    </code>
+    <code>KEY:NAKAMURA_PCLV</code>
     - Nakamura Blade / Personality
 (Peace Loving) /
     <br/>
-    <code>
-     KEY:NAKAMURA_PTNT
-    </code>
+    <code>KEY:NAKAMURA_PTNT</code>
     - Nakamura Blade / Personality
 (Patient) /
     <br/>
-    <code>
-     KEY:NAKAMURA_STHG
-    </code>
+    <code>KEY:NAKAMURA_STHG</code>
     - Nakamura Blade / Personality
 (Soothing) /
     <br/>
-    <code>
-     KEY:NAKAMURA_VLNT
-    </code>
+    <code>KEY:NAKAMURA_VLNT</code>
     - Nakamura Blade / Personality
 (Violent) /
     <br/>
-    <code>
-     KEY:NANOREPAIR_UNIT
-    </code>
+    <code>KEY:NANOREPAIR_UNIT</code>
     - Nanorepair Unit (PL 8)
     <br/>
-    <code>
-     KEY:NEAC_FDOL
-    </code>
+    <code>KEY:NEAC_FDOL</code>
     - Fuzzy Dice of Luck
     <br/>
-    <code>
-     KEY:NEAC_FIG_HUM
-    </code>
+    <code>KEY:NEAC_FIG_HUM</code>
     - Dashboard Figurine [humorous]
     <br/>
-    <code>
-     KEY:NEAC_FIG_MON
-    </code>
+    <code>KEY:NEAC_FIG_MON</code>
     - Dashboard Figurine
 [monstrous]
     <br/>
-    <code>
-     KEY:NEAC_FIG_REL
-    </code>
+    <code>KEY:NEAC_FIG_REL</code>
     - Dashboard Figurine
 [religious]
     <br/>
-    <code>
-     KEY:NEG_GRV_BOOST_GDGT
-    </code>
+    <code>KEY:NEG_GRV_BOOST_GDGT</code>
     - Neg-grav Boosters
 Gadget
     <br/>
-    <code>
-     KEY:NEGATING
-    </code>
+    <code>KEY:NEGATING</code>
     - Negating
     <br/>
-    <code>
-     KEY:NEOVLCNM
-    </code>
+    <code>KEY:NEOVLCNM</code>
     - Neovulcanium (PL 7)
     <br/>
-    <code>
-     KEY:NEOVLCNM_ARMR
-    </code>
+    <code>KEY:NEOVLCNM_ARMR</code>
     - Neovulcanium Armor (PL7)
     <br/>
-    <code>
-     KEY:NEUTRONT
-    </code>
+    <code>KEY:NEUTRONT</code>
     - Neutronite (PL7)
     <br/>
-    <code>
-     KEY:NITROUS_OXIDE_SYSTEM
-    </code>
+    <code>KEY:NITROUS_OXIDE_SYSTEM</code>
     - Nitrous oxide system
     <br/>
-    <code>
-     KEY:NKP_PUMA_PPUP_TRT
-    </code>
+    <code>KEY:NKP_PUMA_PPUP_TRT</code>
     - NKP Puma Pop-Up Turret (PL
 6)
     <br/>
-    <code>
-     KEY:NON_SINUSOIDAL
-    </code>
+    <code>KEY:NON_SINUSOIDAL</code>
     - Non-sinusoidal transmission
     <br/>
-    <code>
-     KEY:NONHUMANOID
-    </code>
+    <code>KEY:NONHUMANOID</code>
     - Nonhumanoid (Armor)
     <br/>
-    <code>
-     KEY:NONLETHAL
-    </code>
+    <code>KEY:NONLETHAL</code>
     - Nonlethal
     <br/>
-    <code>
-     KEY:OIL_SLICK
-    </code>
+    <code>KEY:OIL_SLICK</code>
     - Oil slick
     <br/>
-    <code>
-     KEY:OPTICAL_SCOPE
-    </code>
+    <code>KEY:OPTICAL_SCOPE</code>
     - Optical Scope
     <br/>
-    <code>
-     KEY:ORCL_TG_SYS1
-    </code>
+    <code>KEY:ORCL_TG_SYS1</code>
     - Oracle Targeting System Mk 1
 (PL6)
     <br/>
-    <code>
-     KEY:ORCL_TG_SYS2
-    </code>
+    <code>KEY:ORCL_TG_SYS2</code>
     - Oracle Targeting System Mk 2
 (PL6)
     <br/>
-    <code>
-     KEY:ORCL_TG_SYS3
-    </code>
+    <code>KEY:ORCL_TG_SYS3</code>
     - Oracle Targeting System Mk 3
 (PL6)
     <br/>
-    <code>
-     KEY:ORCL_TG_SYS4
-    </code>
+    <code>KEY:ORCL_TG_SYS4</code>
     - Oracle Targeting System Mk 4
 (PL6)
     <br/>
-    <code>
-     KEY:ORCL_TG_SYS5
-    </code>
+    <code>KEY:ORCL_TG_SYS5</code>
     - Oracle Targeting System Mk 5
 (PL6)
     <br/>
-    <code>
-     KEY:OTHER_DIRECTIONAL_GLASSES
-    </code>
+    <code>KEY:OTHER_DIRECTIONAL_GLASSES</code>
     - Other directional
 glasses
     <br/>
-    <code>
-     KEY:OUTERSHELL
-    </code>
+    <code>KEY:OUTERSHELL</code>
     - Outershell
     <br/>
-    <code>
-     KEY:PAPER
-    </code>
+    <code>KEY:PAPER</code>
     - Paper
     <br/>
-    <code>
-     KEY:PARCHMENT
-    </code>
+    <code>KEY:PARCHMENT</code>
     - Parchment
     <br/>
-    <code>
-     KEY:PARRYING
-    </code>
+    <code>KEY:PARRYING</code>
     - Parrying
     <br/>
-    <code>
-     KEY:PKNIFE
-    </code>
+    <code>KEY:PKNIFE</code>
     - Popknife
     <br/>
-    <code>
-     KEY:PERF_BAL
-    </code>
+    <code>KEY:PERF_BAL</code>
     - Perfect Balance - Weapon
     <br/>
-    <code>
-     KEY:PERF_EDGE
-    </code>
+    <code>KEY:PERF_EDGE</code>
     - Perfect Edge
     <br/>
-    <code>
-     KEY:PHASING
-    </code>
+    <code>KEY:PHASING</code>
     - Phasing
     <br/>
-    <code>
-     KEY:PHONE_REMOTE_CONTROL
-    </code>
+    <code>KEY:PHONE_REMOTE_CONTROL</code>
     - Remote Control
     <br/>
-    <code>
-     KEY:PHONE_SHOE
-    </code>
+    <code>KEY:PHONE_SHOE</code>
     - Phone
     <br/>
-    <code>
-     KEY:PHONE_SLIP_AWAY_UNIT
-    </code>
+    <code>KEY:PHONE_SLIP_AWAY_UNIT</code>
     - Slip-Away Unit
     <br/>
-    <code>
-     KEY:PIEZO_BUG
-    </code>
+    <code>KEY:PIEZO_BUG</code>
     - Piezo-bug
     <br/>
-    <code>
-     KEY:PKIN_A
-    </code>
+    <code>KEY:PKIN_A</code>
     - Psychokinetic
     <br/>
-    <code>
-     KEY:PKIN_BR_A
-    </code>
+    <code>KEY:PKIN_BR_A</code>
     - Psychokinetic Burst
     <br/>
-    <code>
-     KEY:PKIN_BR_M
-    </code>
+    <code>KEY:PKIN_BR_M</code>
     - Psychokinetic Burst
     <br/>
-    <code>
-     KEY:PKIN_BR_R
-    </code>
+    <code>KEY:PKIN_BR_R</code>
     - Psychokinetic Burst
     <br/>
-    <code>
-     KEY:PKIN_M
-    </code>
+    <code>KEY:PKIN_M</code>
     - Psychokinetic
     <br/>
-    <code>
-     KEY:PKIN_R
-    </code>
+    <code>KEY:PKIN_R</code>
     - Psychokinetic
     <br/>
-    <code>
-     KEY:PLAS_EFF_MAT
-    </code>
+    <code>KEY:PLAS_EFF_MAT</code>
     - Plasma Efficiency Matrix
     <br/>
-    <code>
-     KEY:PLASTIC_HARD
-    </code>
+    <code>KEY:PLASTIC_HARD</code>
     - Hard Plastic
     <br/>
-    <code>
-     KEY:PLASTIC_SOFT
-    </code>
+    <code>KEY:PLASTIC_SOFT</code>
     - Soft Plastic
     <br/>
-    <code>
-     KEY:PLUS1A
-    </code>
+    <code>KEY:PLUS1A</code>
     - +1 (Enhancement to Armor)
     <br/>
-    <code>
-     KEY:PLUS1S
-    </code>
+    <code>KEY:PLUS1S</code>
     - +1 (Enhancement to Shield)
     <br/>
-    <code>
-     KEY:PLUS1W
-    </code>
+    <code>KEY:PLUS1W</code>
     - +1 (Enhancement to Weapon
     <br/>
-    <code>
-     KEY:PLUS1W
-    </code>
+    <code>KEY:PLUS1W</code>
     - +1 (Enhancement to Weapon or
 Ammunition)
     <br/>
-    <code>
-     KEY:PLUS2A
-    </code>
+    <code>KEY:PLUS2A</code>
     - +2 (Enhancement to Armor)
     <br/>
-    <code>
-     KEY:PLUS2S
-    </code>
+    <code>KEY:PLUS2S</code>
     - +2 (Enhancement to Shield)
     <br/>
-    <code>
-     KEY:PLUS2W
-    </code>
+    <code>KEY:PLUS2W</code>
     - +2 (Enhancement to Weapon)
     <br/>
-    <code>
-     KEY:PLUS2W
-    </code>
+    <code>KEY:PLUS2W</code>
     - +2 (Enhancement to Weapon or
 Ammunition)
     <br/>
-    <code>
-     KEY:PLUS3A
-    </code>
+    <code>KEY:PLUS3A</code>
     - +3 (Enhancement to Armor)
     <br/>
-    <code>
-     KEY:PLUS3S
-    </code>
+    <code>KEY:PLUS3S</code>
     - +3 (Enhancement to Shield)
     <br/>
-    <code>
-     KEY:PLUS3W
-    </code>
+    <code>KEY:PLUS3W</code>
     - +3 (Enhancement to Weapon)
     <br/>
-    <code>
-     KEY:PLUS3W
-    </code>
+    <code>KEY:PLUS3W</code>
     - +3 (Enhancement to Weapon or
 Ammunition)
     <br/>
-    <code>
-     KEY:PLUS4A
-    </code>
+    <code>KEY:PLUS4A</code>
     - +4 (Enhancement to Armor)
     <br/>
-    <code>
-     KEY:PLUS4S
-    </code>
+    <code>KEY:PLUS4S</code>
     - +4 (Enhancement to Shield)
     <br/>
-    <code>
-     KEY:PLUS4W
-    </code>
+    <code>KEY:PLUS4W</code>
     - +4 (Enhancement to Weapon)
     <br/>
-    <code>
-     KEY:PLUS4W
-    </code>
+    <code>KEY:PLUS4W</code>
     - +4 (Enhancement to Weapon or
 Ammunition)
     <br/>
-    <code>
-     KEY:PLUS5A
-    </code>
+    <code>KEY:PLUS5A</code>
     - +5 (Enhancement to Armor)
     <br/>
-    <code>
-     KEY:PLUS5S
-    </code>
+    <code>KEY:PLUS5S</code>
     - +5 (Enhancement to Shield)
     <br/>
-    <code>
-     KEY:PLUS5W
-    </code>
+    <code>KEY:PLUS5W</code>
     - +5 (Enhancement to Weapon)
     <br/>
-    <code>
-     KEY:PLUS5W
-    </code>
+    <code>KEY:PLUS5W</code>
     - +5 (Enhancement to Weapon or
 Ammunition)
     <br/>
-    <code>
-     KEY:PLUS_6_ARMR
-    </code>
+    <code>KEY:PLUS_6_ARMR</code>
     - +6 (Enhancement to Armor)
     <br/>
-    <code>
-     KEY:PLUS_6_SHLD
-    </code>
+    <code>KEY:PLUS_6_SHLD</code>
     - +6 (Enhancement to Shield)
     <br/>
-    <code>
-     KEY:PLUS_6_WEAP
-    </code>
+    <code>KEY:PLUS_6_WEAP</code>
     - +6 (Enhancement to Weapon or
 Ammunition)
     <br/>
-    <code>
-     KEY:PLUS_7_ARMR
-    </code>
+    <code>KEY:PLUS_7_ARMR</code>
     - +7 (Enhancement to Armor)
     <br/>
-    <code>
-     KEY:PLUS_7_SHLD
-    </code>
+    <code>KEY:PLUS_7_SHLD</code>
     - +7 (Enhancement to Shield)
     <br/>
-    <code>
-     KEY:PLUS_7_WEAP
-    </code>
+    <code>KEY:PLUS_7_WEAP</code>
     - +7 (Enhancement to Weapon or
 Ammunition)
     <br/>
-    <code>
-     KEY:PLUS_8_ARMR
-    </code>
+    <code>KEY:PLUS_8_ARMR</code>
     - +8 (Enhancement to Armor)
     <br/>
-    <code>
-     KEY:PLUS_8_SHLD
-    </code>
+    <code>KEY:PLUS_8_SHLD</code>
     - +8 (Enhancement to Shield)
     <br/>
-    <code>
-     KEY:PLUS_8_WEAP
-    </code>
+    <code>KEY:PLUS_8_WEAP</code>
     - +8 (Enhancement to Weapon or
 Ammunition)
     <br/>
-    <code>
-     KEY:PLUS_9_ARMR
-    </code>
+    <code>KEY:PLUS_9_ARMR</code>
     - +9 (Enhancement to Armor)
     <br/>
-    <code>
-     KEY:PLUS_9_SHLD
-    </code>
+    <code>KEY:PLUS_9_SHLD</code>
     - +9 (Enhancement to Shield)
     <br/>
-    <code>
-     KEY:PLUS_9_WEAP
-    </code>
+    <code>KEY:PLUS_9_WEAP</code>
     - +9 (Enhancement to Weapon or
 Ammunition)
     <br/>
-    <code>
-     KEY:PLUS_10_ARMR
-    </code>
+    <code>KEY:PLUS_10_ARMR</code>
     - +10 (Enhancement to Armor)
     <br/>
-    <code>
-     KEY:PLUS_10_SHLD
-    </code>
+    <code>KEY:PLUS_10_SHLD</code>
     - +10 (Enhancement to Shield)
     <br/>
-    <code>
-     KEY:PLUS_10_WEAP
-    </code>
+    <code>KEY:PLUS_10_WEAP</code>
     - +10 (Enhancement to Weapon or
 Ammunition)
     <br/>
-    <code>
-     KEY:PNT_ON_LCD_GDGT_AMR
-    </code>
+    <code>KEY:PNT_ON_LCD_GDGT_AMR</code>
     - Paint-On LCD Gadget
     <br/>
-    <code>
-     KEY:PNT_ON_LCD_GDGT_EQP
-    </code>
+    <code>KEY:PNT_ON_LCD_GDGT_EQP</code>
     - Paint-On LCD Gadget
     <br/>
-    <code>
-     KEY:PNT_ON_LCD_GDGT_WPN
-    </code>
+    <code>KEY:PNT_ON_LCD_GDGT_WPN</code>
     - Paint-On LCD Gadget
     <br/>
-    <code>
-     KEY:POISON_SPIKE_WATCH
-    </code>
+    <code>KEY:POISON_SPIKE_WATCH</code>
     - Poison spike
     <br/>
-    <code>
-     KEY:POISON1
-    </code>
+    <code>KEY:POISON1</code>
     - Poisonwarding (+1)
     <br/>
-    <code>
-     KEY:POISON2
-    </code>
+    <code>KEY:POISON2</code>
     - Poisonwarding (+2)
     <br/>
-    <code>
-     KEY:POISON3
-    </code>
+    <code>KEY:POISON3</code>
     - Poisonwarding (+3)
     <br/>
-    <code>
-     KEY:POISON4
-    </code>
+    <code>KEY:POISON4</code>
     - Poisonwarding (+4)
     <br/>
-    <code>
-     KEY:POISON5
-    </code>
+    <code>KEY:POISON5</code>
     - Poisonwarding (+5)
     <br/>
-    <code>
-     KEY:POISONST
-    </code>
+    <code>KEY:POISONST</code>
     - Potion Storing
     <br/>
-    <code>
-     KEY:POLYGRAPH_EARIMPLANT
-    </code>
+    <code>KEY:POLYGRAPH_EARIMPLANT</code>
     - Polygraph/Voice Stress
 Analyzer
     <br/>
-    <code>
-     KEY:POP_UP_SHIELD
-    </code>
+    <code>KEY:POP_UP_SHIELD</code>
     - Pop-up shield
     <br/>
-    <code>
-     KEY:PORTABLE_PC
-    </code>
+    <code>KEY:PORTABLE_PC</code>
     - Portable PC
     <br/>
-    <code>
-     KEY:Potion(Oil of Shillelagh)
-    </code>
+    <code>KEY:Potion(Oil of Shillelagh)</code>
     - Potion (Oil of
 Shillelagh)
     <br/>
-    <code>
-     KEY:Potion(Oil of Bless Weapon)
-    </code>
+    <code>KEY:Potion(Oil of Bless Weapon)</code>
     - Potion (Oil of Bless
 Weapon)
     <br/>
-    <code>
-     KEY:Potion (Darkness)
-    </code>
+    <code>KEY:Potion (Darkness)</code>
     - Potion (Darkvision)
     <br/>
-    <code>
-     KEY:POWER STORING
-    </code>
+    <code>KEY:POWER STORING</code>
     - Power Storing
     <br/>
-    <code>
-     KEY:PRHNSL_APPNDG_GDGT
-    </code>
+    <code>KEY:PRHNSL_APPNDG_GDGT</code>
     - Prehensile Appendage
 Gadget
     <br/>
-    <code>
-     KEY:PROPS_SUITE
-    </code>
+    <code>KEY:PROPS_SUITE</code>
     - Props Suite
     <br/>
-    <code>
-     KEY:PROTEUS_PACKAGE
-    </code>
+    <code>KEY:PROTEUS_PACKAGE</code>
     - Proteus package
     <br/>
-    <code>
-     KEY:PSIARMFORH
-    </code>
+    <code>KEY:PSIARMFORH</code>
     - #Reinforcement (Heavy) -
 Armor.Shield
     <br/>
-    <code>
-     KEY:PSIARMFORL
-    </code>
+    <code>KEY:PSIARMFORL</code>
     - #Reinforcement (Light) -
 Armor.Shield
     <br/>
-    <code>
-     KEY:PSIARMFORM
-    </code>
+    <code>KEY:PSIARMFORM</code>
     - #Reinforcement (Moderate) -
 Armor.Shield
     <br/>
-    <code>
-     KEY:PSIBANE
-    </code>
+    <code>KEY:PSIBANE</code>
     - Psibane
     <br/>
-    <code>
-     KEY:PSIBANE_A
-    </code>
+    <code>KEY:PSIBANE_A</code>
     - Psibane
     <br/>
-    <code>
-     KEY:PSIBANE_M
-    </code>
+    <code>KEY:PSIBANE_M</code>
     - Psibane
     <br/>
-    <code>
-     KEY:PSIBANE_R
-    </code>
+    <code>KEY:PSIBANE_R</code>
     - Psibane
     <br/>
-    <code>
-     KEY:PSIBLADE
-    </code>
+    <code>KEY:PSIBLADE</code>
     - Psionic Blade
     <br/>
-    <code>
-     KEY:PSYCHIC
-    </code>
+    <code>KEY:PSYCHIC</code>
     - Psychic
     <br/>
-    <code>
-     KEY:PWR_CRWL
-    </code>
+    <code>KEY:PWR_CRWL</code>
     - |Power Effect (Single Use/Use
 Activated)
     <br/>
-    <code>
-     KEY:PWR_DRJ
-    </code>
+    <code>KEY:PWR_DRJ</code>
     - |Power Effect (50 Charges/Power
 Trigger)
     <br/>
-    <code>
-     KEY:PWR_PCWN_1
-    </code>
+    <code>KEY:PWR_PCWN_1</code>
     - |Power Effect (Power Trigger/1st
 Power)
     <br/>
-    <code>
-     KEY:PWR_PCWN_2
-    </code>
+    <code>KEY:PWR_PCWN_2</code>
     - |Power Effect (Power Trigger/2nd
 Power)
     <br/>
-    <code>
-     KEY:PWR_PCWN_3
-    </code>
+    <code>KEY:PWR_PCWN_3</code>
     - |Power Effect (Power Trigger/3+
 Power)
     <br/>
-    <code>
-     KEY:PWR_PS
-    </code>
+    <code>KEY:PWR_PS</code>
     - |Power Effect (Single
 Use/Completion)
     <br/>
-    <code>
-     KEY:PWR_PT
-    </code>
+    <code>KEY:PWR_PT</code>
     - |Power Effect (Single Use/Use
 Activated)
     <br/>
-    <code>
-     KEY:PWR_PT_P
-    </code>
+    <code>KEY:PWR_PT_P</code>
     - |Power Effect (Single Use/Use
 Activated/Personal)
     <br/>
-    <code>
-     KEY:PWR_RST
-    </code>
+    <code>KEY:PWR_RST</code>
     - Power Resistance
     <br/>
-    <code>
-     KEY:PWRRST_13
-    </code>
+    <code>KEY:PWRRST_13</code>
     - Power Resistance (13)
     <br/>
-    <code>
-     KEY:PWRRST_15
-    </code>
+    <code>KEY:PWRRST_15</code>
     - Power Resistance (15)
     <br/>
-    <code>
-     KEY:PWRRST_17
-    </code>
+    <code>KEY:PWRRST_17</code>
     - Power Resistance (17)
     <br/>
-    <code>
-     KEY:PWRRST_19
-    </code>
+    <code>KEY:PWRRST_19</code>
     - Power Resistance (19)
     <br/>
-    <code>
-     KEY:PWRSTOR
-    </code>
+    <code>KEY:PWRSTOR</code>
     - Power Storing
     <br/>
-    <code>
-     KEY:QUICKN
-    </code>
+    <code>KEY:QUICKN</code>
     - Quickness
     <br/>
-    <code>
-     KEY:QUICKNESS
-    </code>
+    <code>KEY:QUICKNESS</code>
     - Quickness
     <br/>
-    <code>
-     KEY:RADIANT
-    </code>
+    <code>KEY:RADIANT</code>
     - Radiant
     <br/>
-    <code>
-     KEY:RAGE_FLAW
-    </code>
+    <code>KEY:RAGE_FLAW</code>
     - Rage
     <br/>
-    <code>
-     KEY:RAZORS_EDGE
-    </code>
+    <code>KEY:RAZORS_EDGE</code>
     - Razor's edge
     <br/>
-    <code>
-     KEY:REDEEMING
-    </code>
+    <code>KEY:REDEEMING</code>
     - Redeeming
     <br/>
-    <code>
-     KEY:REACTIVE_ARMR
-    </code>
+    <code>KEY:REACTIVE_ARMR</code>
     - Reactive Armor (PL8)
     <br/>
-    <code>
-     KEY:REF_SPR_MOD
-    </code>
+    <code>KEY:REF_SPR_MOD</code>
     - Reflecting Spread Module
     <br/>
-    <code>
-     KEY:REFLC
-    </code>
+    <code>KEY:REFLC</code>
     - Reflecting
     <br/>
-    <code>
-     KEY:REFLECT_GRT
-    </code>
+    <code>KEY:REFLECT_GRT</code>
     - Greater Reflection
     <br/>
-    <code>
-     KEY:REINFORCED
-    </code>
+    <code>KEY:REINFORCED</code>
     - Reinforced - Armor
     <br/>
-    <code>
-     KEY:REINFORCED
-    </code>
+    <code>KEY:REINFORCED</code>
     - Reinforced - Weapon
     <br/>
-    <code>
-     KEY:REINFORCED_TIRES
-    </code>
+    <code>KEY:REINFORCED_TIRES</code>
     - Reinforced tires
     <br/>
-    <code>
-     KEY:REINFRCD_ARMR
-    </code>
+    <code>KEY:REINFRCD_ARMR</code>
     - Reinforced - Armor
     <br/>
-    <code>
-     KEY:REINFRCD_WEAP
-    </code>
+    <code>KEY:REINFRCD_WEAP</code>
     - Reinforced - Weapon
     <br/>
-    <code>
-     KEY:REMOTE_CONTROL
-    </code>
+    <code>KEY:REMOTE_CONTROL</code>
     - Remote control
     <br/>
-    <code>
-     KEY:REMOTE_SHUTDOWN_SYS
-    </code>
+    <code>KEY:REMOTE_SHUTDOWN_SYS</code>
     - Remote Shutdown System
     <br/>
-    <code>
-     KEY:RES_ACD_GRT
-    </code>
+    <code>KEY:RES_ACD_GRT</code>
     - Acid Resistance (Greater)
     <br/>
-    <code>
-     KEY:RES_CLD_GRT
-    </code>
+    <code>KEY:RES_CLD_GRT</code>
     - Cold Resistance (Greater)
     <br/>
-    <code>
-     KEY:RES_ELE_GRT
-    </code>
+    <code>KEY:RES_ELE_GRT</code>
     - Electricity Resistance
 (Greater)
     <br/>
-    <code>
-     KEY:RES_FR_GRT
-    </code>
+    <code>KEY:RES_FR_GRT</code>
     - Fire Resistance (Greater)
     <br/>
-    <code>
-     KEY:RES_SNC_GRT
-    </code>
+    <code>KEY:RES_SNC_GRT</code>
     - Sonic Resistance (Greater)
     <br/>
-    <code>
-     KEY:RESILIUM_ARMR
-    </code>
+    <code>KEY:RESILIUM_ARMR</code>
     - Resilium Armor (PL6)
     <br/>
-    <code>
-     KEY:RETRN
-    </code>
+    <code>KEY:RETRN</code>
     - Returning
     <br/>
-    <code>
-     KEY:RETURNING
-    </code>
+    <code>KEY:RETURNING</code>
     - Returning
     <br/>
-    <code>
-     KEY:REVOLVING_LICENSE_PLATE
-    </code>
+    <code>KEY:REVOLVING_LICENSE_PLATE</code>
     - Revolving license
 plate
     <br/>
-    <code>
-     KEY:RGFD_LSR_SCP_GDGT
-    </code>
+    <code>KEY:RGFD_LSR_SCP_GDGT</code>
     - Rangefinding Laser Scope
 Gadget
     <br/>
-    <code>
-     KEY:RING
-    </code>
+    <code>KEY:RING</code>
     - Ring
     <br/>
-    <code>
-     KEY:RINGFinerQuality
-    </code>
+    <code>KEY:RINGFinerQuality</code>
     - Finer Quality
     <br/>
-    <code>
-     KEY:RINGHighQuality
-    </code>
+    <code>KEY:RINGHighQuality</code>
     - High Quality
     <br/>
-    <code>
-     KEY:RINGPoisonDrip
-    </code>
+    <code>KEY:RINGPoisonDrip</code>
     - Poison Dripper
     <br/>
-    <code>
-     KEY:RINGPoisonNeedle
-    </code>
+    <code>KEY:RINGPoisonNeedle</code>
     - Poison Needle
     <br/>
-    <code>
-     KEY:RINGPoisonSquirt
-    </code>
+    <code>KEY:RINGPoisonSquirt</code>
     - Poison Squirter
     <br/>
-    <code>
-     KEY:RJTTHRST_BTS
-    </code>
+    <code>KEY:RJTTHRST_BTS</code>
     - Ramjet Thruster Boots (PL8)
     <br/>
-    <code>
-     KEY:RNFRC_HVY
-    </code>
+    <code>KEY:RNFRC_HVY</code>
     - Reinforcement (Heavy)
     <br/>
-    <code>
-     KEY:RNFRC_LGHT
-    </code>
+    <code>KEY:RNFRC_LGHT</code>
     - Reinforcement (Light)
     <br/>
-    <code>
-     KEY:RNFRC_MOD
-    </code>
+    <code>KEY:RNFRC_MOD</code>
     - Reinforcement (Moderate)
     <br/>
-    <code>
-     KEY:RNGED
-    </code>
+    <code>KEY:RNGED</code>
     - Ranged
     <br/>
-    <code>
-     KEY:RNGD
-    </code>
+    <code>KEY:RNGD</code>
     - Ranged
     <br/>
-    <code>
-     KEY:ROBOT_FLY_05
-    </code>
+    <code>KEY:ROBOT_FLY_05</code>
     - +5 Speed
     <br/>
-    <code>
-     KEY:ROBOT_FLY_10
-    </code>
+    <code>KEY:ROBOT_FLY_10</code>
     - +10 Speed
     <br/>
-    <code>
-     KEY:ROBOT_FLY_15
-    </code>
+    <code>KEY:ROBOT_FLY_15</code>
     - +15 Speed
     <br/>
-    <code>
-     KEY:ROBOT_FLY_20
-    </code>
+    <code>KEY:ROBOT_FLY_20</code>
     - +20 Speed
     <br/>
-    <code>
-     KEY:ROBOT_FLY_25
-    </code>
+    <code>KEY:ROBOT_FLY_25</code>
     - +25 Speed
     <br/>
-    <code>
-     KEY:ROBOT_FLY_30
-    </code>
+    <code>KEY:ROBOT_FLY_30</code>
     - +30 Speed
     <br/>
-    <code>
-     KEY:ROBOT_FLY_35
-    </code>
+    <code>KEY:ROBOT_FLY_35</code>
     - +35 Speed
     <br/>
-    <code>
-     KEY:ROBOT_FLY_40
-    </code>
+    <code>KEY:ROBOT_FLY_40</code>
     - +40 Speed
     <br/>
-    <code>
-     KEY:ROBOT_SPEED_05
-    </code>
+    <code>KEY:ROBOT_SPEED_05</code>
     - +5 Speed
     <br/>
-    <code>
-     KEY:ROBOT_SPEED_10
-    </code>
+    <code>KEY:ROBOT_SPEED_10</code>
     - +10 Speed
     <br/>
-    <code>
-     KEY:ROBOT_SPEED_15
-    </code>
+    <code>KEY:ROBOT_SPEED_15</code>
     - +15 Speed
     <br/>
-    <code>
-     KEY:ROBOT_SPEED_20
-    </code>
+    <code>KEY:ROBOT_SPEED_20</code>
     - +20 Speed
     <br/>
-    <code>
-     KEY:ROBOT_SPEED_25
-    </code>
+    <code>KEY:ROBOT_SPEED_25</code>
     - +25 Speed
     <br/>
-    <code>
-     KEY:ROBOT_SPEED_30
-    </code>
+    <code>KEY:ROBOT_SPEED_30</code>
     - +30 Speed
     <br/>
-    <code>
-     KEY:ROBOT_SWIM_05
-    </code>
+    <code>KEY:ROBOT_SWIM_05</code>
     - +5 Speed
     <br/>
-    <code>
-     KEY:ROBOT_SWIM_10
-    </code>
+    <code>KEY:ROBOT_SWIM_10</code>
     - +10 Speed
     <br/>
-    <code>
-     KEY:ROBOT_SWIM_15
-    </code>
+    <code>KEY:ROBOT_SWIM_15</code>
     - +15 Speed
     <br/>
-    <code>
-     KEY:ROBOT_SWIM_20
-    </code>
+    <code>KEY:ROBOT_SWIM_20</code>
     - +20 Speed
     <br/>
-    <code>
-     KEY:ROCKET_LAUNCHER
-    </code>
+    <code>KEY:ROCKET_LAUNCHER</code>
     - Rocket launcher
     <br/>
-    <code>
-     KEY:ROGUEFR
-    </code>
+    <code>KEY:ROGUEFR</code>
     - Roguefriend
     <br/>
-    <code>
-     KEY:ROLLER_ICE_BLADES_SHOE
-    </code>
+    <code>KEY:ROLLER_ICE_BLADES_SHOE</code>
     - Roller/ice blades
     <br/>
-    <code>
-     KEY:ROPE
-    </code>
+    <code>KEY:ROPE</code>
     - Rope
     <br/>
-    <code>
-     KEY:ROTARY_SAW_WATCH
-    </code>
+    <code>KEY:ROTARY_SAW_WATCH</code>
     - Rotary saw
     <br/>
-    <code>
-     KEY:RST_ACD
-    </code>
+    <code>KEY:RST_ACD</code>
     - Acid Resistance
     <br/>
-    <code>
-     KEY:RST_ACD_IMP
-    </code>
+    <code>KEY:RST_ACD_IMP</code>
     - Acid Resistance (Improved)
     <br/>
-    <code>
-     KEY:RST_CLD
-    </code>
+    <code>KEY:RST_CLD</code>
     - Cold Resistance
     <br/>
-    <code>
-     KEY:RST_CLD_IMP
-    </code>
+    <code>KEY:RST_CLD_IMP</code>
     - Cold Resistance (Improved)
     <br/>
-    <code>
-     KEY:RST_ELE
-    </code>
+    <code>KEY:RST_ELE</code>
     - Electricity Resistance Lightning
 Resistance
     <br/>
-    <code>
-     KEY:RST_ELE_IMP
-    </code>
+    <code>KEY:RST_ELE_IMP</code>
     - Electricity Resistance
 (Improved)
     <br/>
-    <code>
-     KEY:RST_FR
-    </code>
+    <code>KEY:RST_FR</code>
     - Fire Resistance
     <br/>
-    <code>
-     KEY:RST_FR_IMP
-    </code>
+    <code>KEY:RST_FR_IMP</code>
     - Fire Resistance (Improved)
     <br/>
-    <code>
-     KEY:RST_SNC
-    </code>
+    <code>KEY:RST_SNC</code>
     - Sonic Resistance
     <br/>
-    <code>
-     KEY:RST_SNC_IMP
-    </code>
+    <code>KEY:RST_SNC_IMP</code>
     - Sonic Resistance (Improved)
     <br/>
-    <code>
-     KEY:RUBBER_ROUND
-    </code>
+    <code>KEY:RUBBER_ROUND</code>
     - Rubber Round
     <br/>
-    <code>
-     KEY:RWT
-    </code>
+    <code>KEY:RWT</code>
     - Reduced Weight
     <br/>
-    <code>
-     KEY:SAFE_PASSAGE
-    </code>
+    <code>KEY:SAFE_PASSAGE</code>
     - Safe passage
     <br/>
-    <code>
-     KEY:SAR_GMWLARM
-    </code>
+    <code>KEY:SAR_GMWLARM</code>
     - GMW Sarishan Steel (Lg)
     <br/>
-    <code>
-     KEY:SAR_GMWLSHD
-    </code>
+    <code>KEY:SAR_GMWLSHD</code>
     - GMW Sarishan Steel (Lg)
     <br/>
-    <code>
-     KEY:SAR_GMWLWEAP
-    </code>
+    <code>KEY:SAR_GMWLWEAP</code>
     - GMW Sarishan Steel (Lg)
     <br/>
-    <code>
-     KEY:SAR_GMWSARM
-    </code>
+    <code>KEY:SAR_GMWSARM</code>
     - GMW Sarishan Steel (Sm)
     <br/>
-    <code>
-     KEY:SAR_GMWSSHD
-    </code>
+    <code>KEY:SAR_GMWSSHD</code>
     - GMW Sarishan Steel (Sm)
     <br/>
-    <code>
-     KEY:SAR_GMWSWEAP
-    </code>
+    <code>KEY:SAR_GMWSWEAP</code>
     - GMW Sarishan Steel (Sm)
     <br/>
-    <code>
-     KEY:SAR_GMWMARM
-    </code>
+    <code>KEY:SAR_GMWMARM</code>
     - GMW Sarishan Steel (Med)
     <br/>
-    <code>
-     KEY:SAR_GMWMSHD
-    </code>
+    <code>KEY:SAR_GMWMSHD</code>
     - GMW Sarishan Steel (Med)
     <br/>
-    <code>
-     KEY:SAR_GMWMWEAP
-    </code>
+    <code>KEY:SAR_GMWMWEAP</code>
     - GMW Sarishan Steel (Med)
     <br/>
-    <code>
-     KEY:SARISH_GMWLBRD
-    </code>
+    <code>KEY:SARISH_GMWLBRD</code>
     - GMW Sarishan Steel (Lg)
     <br/>
-    <code>
-     KEY:SARISH_GMWMBRD
-    </code>
+    <code>KEY:SARISH_GMWMBRD</code>
     - GMW Sarishan Steel (Med)
     <br/>
-    <code>
-     KEY:SARISH_LARM
-    </code>
+    <code>KEY:SARISH_LARM</code>
     - Sarishan Steel (Lg)
     <br/>
-    <code>
-     KEY:SARISH_LBRD
-    </code>
+    <code>KEY:SARISH_LBRD</code>
     - Sarishan Steel (Lg)
     <br/>
-    <code>
-     KEY:SARISH_LSHD
-    </code>
+    <code>KEY:SARISH_LSHD</code>
     - Sarishan Steel (Lg
     <br/>
-    <code>
-     KEY:SARISH_LWEAP
-    </code>
+    <code>KEY:SARISH_LWEAP</code>
     - Sarishan Steel (Lg)
     <br/>
-    <code>
-     KEY:SARISH_MARM
-    </code>
+    <code>KEY:SARISH_MARM</code>
     - Sarishan Steel (Med)
     <br/>
-    <code>
-     KEY:SARISH_MBRD
-    </code>
+    <code>KEY:SARISH_MBRD</code>
     - Sarishan Steel (Med)
     <br/>
-    <code>
-     KEY:SARISH_MSHD
-    </code>
+    <code>KEY:SARISH_MSHD</code>
     - Sarishan Steel (Med)
     <br/>
-    <code>
-     KEY:SARISH_MWEAP
-    </code>
+    <code>KEY:SARISH_MWEAP</code>
     - Sarishan Steel (Med)
     <br/>
-    <code>
-     KEY:SARISH_SARM
-    </code>
+    <code>KEY:SARISH_SARM</code>
     - Sarishan Steel (Sm)
     <br/>
-    <code>
-     KEY:SARISH_SSHD
-    </code>
+    <code>KEY:SARISH_SSHD</code>
     - Sarishan Steel (Sm)
     <br/>
-    <code>
-     KEY:SARISH_SWEAP
-    </code>
+    <code>KEY:SARISH_SWEAP</code>
     - Sarishan Steel (Sm)
     <br/>
-    <code>
-     KEY:SAS_AIR_FINLTERS
-    </code>
+    <code>KEY:SAS_AIR_FINLTERS</code>
     - Air Filters
     <br/>
-    <code>
-     KEY:SAS_AQUATIC_GEAR
-    </code>
+    <code>KEY:SAS_AQUATIC_GEAR</code>
     - Aquatic Gear
     <br/>
-    <code>
-     KEY:SAS_CLIMBING_CLAWS
-    </code>
+    <code>KEY:SAS_CLIMBING_CLAWS</code>
     - Climbing Claws
     <br/>
-    <code>
-     KEY:SAS_ELEM_FIELD
-    </code>
+    <code>KEY:SAS_ELEM_FIELD</code>
     - Electrical Field
     <br/>
-    <code>
-     KEY:SAS_ELEM_RES_ACID_5
-    </code>
+    <code>KEY:SAS_ELEM_RES_ACID_5</code>
     - Elemental Resistance (Acid
 5)
     <br/>
-    <code>
-     KEY:SAS_ELEM_RES_ACID_10
-    </code>
+    <code>KEY:SAS_ELEM_RES_ACID_10</code>
     - Elemental Resistance (Acid
 10)
     <br/>
-    <code>
-     KEY:SAS_ELEM_RES_FIRE_5
-    </code>
+    <code>KEY:SAS_ELEM_RES_FIRE_5</code>
     - Elemental Resistance (Fire
 5)
     <br/>
-    <code>
-     KEY:SAS_ELEM_RES_FIRE_10
-    </code>
+    <code>KEY:SAS_ELEM_RES_FIRE_10</code>
     - Elemental Resistance (Fire
 10)
     <br/>
-    <code>
-     KEY:SAS_ELEM_RES_COLD_5
-    </code>
+    <code>KEY:SAS_ELEM_RES_COLD_5</code>
     - Elemental Resistance (Cold
 5)
     <br/>
-    <code>
-     KEY:SAS_ELEM_RES_COLD_10
-    </code>
+    <code>KEY:SAS_ELEM_RES_COLD_10</code>
     - Elemental Resistance (Cold
 10)
     <br/>
-    <code>
-     KEY:SAS_ELEM_RES_ELEC_5
-    </code>
+    <code>KEY:SAS_ELEM_RES_ELEC_5</code>
     - Elemental Resistance
 (Electricity 5)
     <br/>
-    <code>
-     KEY:SAS_ELEM_RES_ELEC_10
-    </code>
+    <code>KEY:SAS_ELEM_RES_ELEC_10</code>
     - Elemental Resistance
 (Electricity 10)
     <br/>
-    <code>
-     KEY:SAS_ELEM_RES_SONIC_5
-    </code>
+    <code>KEY:SAS_ELEM_RES_SONIC_5</code>
     - Elemental Resistance (Sonic
 5)
     <br/>
-    <code>
-     KEY:SAS_ELEM_RES_SONIC_10
-    </code>
+    <code>KEY:SAS_ELEM_RES_SONIC_10</code>
     - Elemental Resistance
 (Sonic 10)
     <br/>
-    <code>
-     KEY:SAS_HEAVY_SHIELDING
-    </code>
+    <code>KEY:SAS_HEAVY_SHIELDING</code>
     - Heavy Shielding
     <br/>
-    <code>
-     KEY:SAS_INTERNAL_CHRONOMETER
-    </code>
+    <code>KEY:SAS_INTERNAL_CHRONOMETER</code>
     - Internal
 Chronometer
     <br/>
-    <code>
-     KEY:SAS_NIGHT_OWL_LENSES
-    </code>
+    <code>KEY:SAS_NIGHT_OWL_LENSES</code>
     - Lenses of the Night
 Owl
     <br/>
-    <code>
-     KEY:SAS_NOISE_BAFFLERS
-    </code>
+    <code>KEY:SAS_NOISE_BAFFLERS</code>
     - Noise Bafflers
     <br/>
-    <code>
-     KEY:SAS_ORNAMENTATION
-    </code>
+    <code>KEY:SAS_ORNAMENTATION</code>
     - Ornamentation
     <br/>
-    <code>
-     KEY:SAS_PARTING_GAUNTLETS
-    </code>
+    <code>KEY:SAS_PARTING_GAUNTLETS</code>
     - Parting Gauntlets
     <br/>
-    <code>
-     KEY:SAS_REINFORCED_STRUCTURE
-    </code>
+    <code>KEY:SAS_REINFORCED_STRUCTURE</code>
     - Reinforced
 Structure
     <br/>
-    <code>
-     KEY:SAS_SERVO_ARTICULATION_2
-    </code>
+    <code>KEY:SAS_SERVO_ARTICULATION_2</code>
     - Servomotor Articulation
 (2)
     <br/>
-    <code>
-     KEY:SAS_SERVO_ARTICULATION_4
-    </code>
+    <code>KEY:SAS_SERVO_ARTICULATION_4</code>
     - Servomotor Articulation
 (4)
     <br/>
-    <code>
-     KEY:SAS_SERVO_ARTICULATION_6
-    </code>
+    <code>KEY:SAS_SERVO_ARTICULATION_6</code>
     - Servomotor Articulation
 (6)
     <br/>
-    <code>
-     KEY:SAS_SERVO_ARTICULATION_8
-    </code>
+    <code>KEY:SAS_SERVO_ARTICULATION_8</code>
     - Servomotor Articulation
 (8)
     <br/>
-    <code>
-     KEY:SAS_SERVO_ARTICULATION_10
-    </code>
+    <code>KEY:SAS_SERVO_ARTICULATION_10</code>
     - Servomotor
 Articulation (10)
     <br/>
-    <code>
-     KEY:SAS_SNAP_SHIELD
-    </code>
+    <code>KEY:SAS_SNAP_SHIELD</code>
     - Snap Shield
     <br/>
-    <code>
-     KEY:SAS_SOUND_GATHERERS
-    </code>
+    <code>KEY:SAS_SOUND_GATHERERS</code>
     - Sound Gatherers
     <br/>
-    <code>
-     KEY:SAS_SPEED_ENHANCERS_5
-    </code>
+    <code>KEY:SAS_SPEED_ENHANCERS_5</code>
     - Speed Enhancers (+5
 ft.)
     <br/>
-    <code>
-     KEY:SAS_SPEED_ENHANCERS_10
-    </code>
+    <code>KEY:SAS_SPEED_ENHANCERS_10</code>
     - Speed Enhancers (+10
 ft.)
     <br/>
-    <code>
-     KEY:SAS_STRENGTH_BOOSTING_2
-    </code>
+    <code>KEY:SAS_STRENGTH_BOOSTING_2</code>
     - Strength Boosting
 (+2)
     <br/>
-    <code>
-     KEY:SAS_STRENGTH_BOOSTING_4
-    </code>
+    <code>KEY:SAS_STRENGTH_BOOSTING_4</code>
     - Strength Boosting
 (+4)
     <br/>
-    <code>
-     KEY:SAS_STRENGTH_BOOSTING_6
-    </code>
+    <code>KEY:SAS_STRENGTH_BOOSTING_6</code>
     - Strength Boosting
 (+6)
     <br/>
-    <code>
-     KEY:SAT_DTALNK_GDGT
-    </code>
+    <code>KEY:SAT_DTALNK_GDGT</code>
     - Satellite Datalink Gadget
     <br/>
-    <code>
-     KEY:SAWBRL
-    </code>
+    <code>KEY:SAWBRL</code>
     - Sawed-Off Barrel
     <br/>
-    <code>
-     KEY:SBALH1
-    </code>
+    <code>KEY:SBALH1</code>
     - Superb Balancex1 [Heavy Armo]
     <br/>
-    <code>
-     KEY:SBALH2
-    </code>
+    <code>KEY:SBALH2</code>
     - Superb Balancex2 [Heavy Armor]
     <br/>
-    <code>
-     KEY:SBALL1
-    </code>
+    <code>KEY:SBALL1</code>
     - Superb Balancex1 [Light Armor]
     <br/>
-    <code>
-     KEY:SBALL2
-    </code>
+    <code>KEY:SBALL2</code>
     - Superb Balancex2 [Light Armor]
     <br/>
-    <code>
-     KEY:SBALM1
-    </code>
+    <code>KEY:SBALM1</code>
     - Superb Balancex1 [Medium Armor]
     <br/>
-    <code>
-     KEY:SBALM2
-    </code>
+    <code>KEY:SBALM2</code>
     - Superb Balancex2 [Medium Armor]
     <br/>
-    <code>
-     KEY:SCP_ELE_OP
-    </code>
+    <code>KEY:SCP_ELE_OP</code>
     - Scope (Electro-optical)
     <br/>
-    <code>
-     KEY:SCP_STD
-    </code>
+    <code>KEY:SCP_STD</code>
     - Scope (Standard)
     <br/>
-    <code>
-     KEY:SCP_STD
-    </code>
+    <code>KEY:SCP_STD</code>
     - #Scope (Standard)
     <br/>
-    <code>
-     KEY:SCROLL
-    </code>
+    <code>KEY:SCROLL</code>
     - SCROLL
     <br/>
-    <code>
-     KEY:Scroll (Analayze Dweomer)
-    </code>
+    <code>KEY:Scroll (Analayze Dweomer)</code>
     - Scroll (Analyze
 Dweomer)
     <br/>
-    <code>
-     KEY:Scroll (Banishement/Arcane)
-    </code>
+    <code>KEY:Scroll (Banishement/Arcane)</code>
     - Scroll
 (Banishment/Arcane)
     <br/>
-    <code>
-     KEY:SCROLL_ARCANE
-    </code>
+    <code>KEY:SCROLL_ARCANE</code>
     - SCROLL (Arcane)
     <br/>
-    <code>
-     KEY:SCROLL_ARCANE
-    </code>
+    <code>KEY:SCROLL_ARCANE</code>
     - |Spell Effect (Arcane
 Scroll)
     <br/>
-    <code>
-     KEY:SCROLL_ARCANE_EPIC
-    </code>
+    <code>KEY:SCROLL_ARCANE_EPIC</code>
     - |Spell Effect (Single
 Use/Completion)
     <br/>
-    <code>
-     KEY:Scroll (Control Water/Divine)
-    </code>
+    <code>KEY:Scroll (Control Water/Divine)</code>
     - Scroll (Control
 Water)
     <br/>
-    <code>
-     KEY:Scroll (Control Weather/Arcane)
-    </code>
+    <code>KEY:Scroll (Control Weather/Arcane)</code>
     - Scroll (Control
 Weather/Arcane/Lvl 7)
     <br/>
-    <code>
-     KEY:SCROLL_DIVINE
-    </code>
+    <code>KEY:SCROLL_DIVINE</code>
     - SCROLL (Divine)
     <br/>
-    <code>
-     KEY:SCROLL_DIVINE
-    </code>
+    <code>KEY:SCROLL_DIVINE</code>
     - |Spell Effect (Divine
 Scroll)
     <br/>
-    <code>
-     KEY:SCROLL_DIVINE_EPIC
-    </code>
+    <code>KEY:SCROLL_DIVINE_EPIC</code>
     - |Spell Effect (Single
 Use/Completion)
     <br/>
-    <code>
-     KEY:Scroll (Gate/Arcane)
-    </code>
+    <code>KEY:Scroll (Gate/Arcane)</code>
     - Scroll (Gate)
     <br/>
-    <code>
-     KEY:Scroll (Ice Storm)
-    </code>
+    <code>KEY:Scroll (Ice Storm)</code>
     - Scroll (Ice
 Storm/Arcane)
     <br/>
-    <code>
-     KEY:SCROLL_MAJOR
-    </code>
+    <code>KEY:SCROLL_MAJOR</code>
     - SCROLL (Major)
     <br/>
-    <code>
-     KEY:SCROLL_MEDIUM
-    </code>
+    <code>KEY:SCROLL_MEDIUM</code>
     - SCROLL (Medium)
     <br/>
-    <code>
-     KEY:SCROLL_MINOR
-    </code>
+    <code>KEY:SCROLL_MINOR</code>
     - SCROLL (Minor)
     <br/>
-    <code>
-     KEY:Scroll (Protection from Energy/Arcane)
-    </code>
+    <code>KEY:Scroll (Protection from Energy/Arcane)</code>
     - Scroll
 (Protection from Energy)
     <br/>
-    <code>
-     KEY:Scroll (Stone Shape/Arcane)
-    </code>
+    <code>KEY:Scroll (Stone Shape/Arcane)</code>
     - Scroll (Stone
 Shape)
     <br/>
-    <code>
-     KEY:Scroll (Summon Monster IX/Arcane)
-    </code>
+    <code>KEY:Scroll (Summon Monster IX/Arcane)</code>
     - Scroll (Summon
 Monster IX)
     <br/>
-    <code>
-     KEY:Scroll (Tongues/Arcane)
-    </code>
+    <code>KEY:Scroll (Tongues/Arcane)</code>
     - Scroll (Tongues)
     <br/>
-    <code>
-     KEY:Scroll (Wall of Stone/Arcane)
-    </code>
+    <code>KEY:Scroll (Wall of Stone/Arcane)</code>
     - Scroll (Wall of
 Stone)
     <br/>
-    <code>
-     KEY:SDA_POWER_OF_NATURE
-    </code>
+    <code>KEY:SDA_POWER_OF_NATURE</code>
     - Power of Nature
     <br/>
-    <code>
-     KEY:SDA_UNDEAD_MASTERY
-    </code>
+    <code>KEY:SDA_UNDEAD_MASTERY</code>
     - Undead Mastery
     <br/>
-    <code>
-     KEY:SE_1COMPLET_WP
-    </code>
+    <code>KEY:SE_1COMPLET_WP</code>
     - |Spell Effect
 (Single/Completion)
     <br/>
-    <code>
-     KEY:SEALED_LENSES
-    </code>
+    <code>KEY:SEALED_LENSES</code>
     - Sealed lenses
     <br/>
-    <code>
-     KEY:SEAT_HLDMNSTR
-    </code>
+    <code>KEY:SEAT_HLDMNSTR</code>
     - Seat of Hold Monster
     <br/>
-    <code>
-     KEY:SEAT_SAFETY
-    </code>
+    <code>KEY:SEAT_SAFETY</code>
     - Seats of Safety
     <br/>
-    <code>
-     KEY:SECCOMP
-    </code>
+    <code>KEY:SECCOMP</code>
     - Secret Compartment
     <br/>
-    <code>
-     KEY:SEEING
-    </code>
+    <code>KEY:SEEING</code>
     - Seeking
     <br/>
-    <code>
-     KEY:SEEK
-    </code>
+    <code>KEY:SEEK</code>
     - Seeking
     <br/>
-    <code>
-     KEY:SERRATED
-    </code>
+    <code>KEY:SERRATED</code>
     - Serrated
     <br/>
-    <code>
-     KEY:SF_CAMO
-    </code>
+    <code>KEY:SF_CAMO</code>
     - Camouflage
     <br/>
-    <code>
-     KEY:SF_DATA
-    </code>
+    <code>KEY:SF_DATA</code>
     - Program
     <br/>
-    <code>
-     KEY:SF_ELECSCOPE
-    </code>
+    <code>KEY:SF_ELECSCOPE</code>
     - Electronic Scope
     <br/>
-    <code>
-     KEY:SF_KNBLD_WEAP
-    </code>
+    <code>KEY:SF_KNBLD_WEAP</code>
     - Keenblade
     <br/>
-    <code>
-     KEY:SF_LASERSIGHT
-    </code>
+    <code>KEY:SF_LASERSIGHT</code>
     - Laser Sight
     <br/>
-    <code>
-     KEY:SF_SECURITY
-    </code>
+    <code>KEY:SF_SECURITY</code>
     - Sevurity Upgrade
     <br/>
-    <code>
-     KEY:SF_SILENCER
-    </code>
+    <code>KEY:SF_SILENCER</code>
     - Silencer
     <br/>
-    <code>
-     KEY:SF_SPELLWARE_1
-    </code>
+    <code>KEY:SF_SPELLWARE_1</code>
     - Spellware_1st_lev
     <br/>
-    <code>
-     KEY:SF_SPELLWARE_2
-    </code>
+    <code>KEY:SF_SPELLWARE_2</code>
     - Spellware_2nd_lev
     <br/>
-    <code>
-     KEY:SF_SPELLWARE_3
-    </code>
+    <code>KEY:SF_SPELLWARE_3</code>
     - Spellware_3rd_lev
     <br/>
-    <code>
-     KEY:SF_SPELLWARE_4
-    </code>
+    <code>KEY:SF_SPELLWARE_4</code>
     - Spellware_4th_lev
     <br/>
-    <code>
-     KEY:SF_SPELLWARE_5
-    </code>
+    <code>KEY:SF_SPELLWARE_5</code>
     - Spellware_5th_lev
     <br/>
-    <code>
-     KEY:SF_SPELLWARE_6
-    </code>
+    <code>KEY:SF_SPELLWARE_6</code>
     - Spellware_6th_lev
     <br/>
-    <code>
-     KEY:SF_SPELLWARE_7
-    </code>
+    <code>KEY:SF_SPELLWARE_7</code>
     - Spellware_7th_lev
     <br/>
-    <code>
-     KEY:SF_SPELLWARE_8
-    </code>
+    <code>KEY:SF_SPELLWARE_8</code>
     - Spellware_8th_lev
     <br/>
-    <code>
-     KEY:SF_SPELLWARE_9
-    </code>
+    <code>KEY:SF_SPELLWARE_9</code>
     - Spellware_9th_lev
     <br/>
-    <code>
-     KEY:SF_TOOLSMW
-    </code>
+    <code>KEY:SF_TOOLSMW</code>
     - Masterwork
     <br/>
-    <code>
-     KEY:SF_TOOLSNM
-    </code>
+    <code>KEY:SF_TOOLSNM</code>
     - Normal
     <br/>
-    <code>
-     KEY:SF_TOOLSSP
-    </code>
+    <code>KEY:SF_TOOLSSP</code>
     - Specialized
     <br/>
-    <code>
-     KEY:SF_TOOLSSPM
-    </code>
+    <code>KEY:SF_TOOLSSPM</code>
     - Specialized Masterwork
     <br/>
-    <code>
-     KEY:SHADOW
-    </code>
+    <code>KEY:SHADOW</code>
     - Shadow
     <br/>
-    <code>
-     KEY:SHCOR
-    </code>
+    <code>KEY:SHCOR</code>
     - Shock Core
     <br/>
-    <code>
-     KEY:SHDW
-    </code>
+    <code>KEY:SHDW</code>
     - Shadow
     <br/>
-    <code>
-     KEY:SHDW_GRT
-    </code>
+    <code>KEY:SHDW_GRT</code>
     - Shadow (Greater)
     <br/>
-    <code>
-     KEY:SHDW_IMP
-    </code>
+    <code>KEY:SHDW_IMP</code>
     - Shadow (Improved)
     <br/>
-    <code>
-     KEY:SHIELDALTHST
-    </code>
+    <code>KEY:SHIELDALTHST</code>
     - Altherian Steel
     <br/>
-    <code>
-     KEY:SHK_BR_A
-    </code>
+    <code>KEY:SHK_BR_A</code>
     - Shocking Burst
     <br/>
-    <code>
-     KEY:SHK_BR_M
-    </code>
+    <code>KEY:SHK_BR_M</code>
     - Shocking Burst
     <br/>
-    <code>
-     KEY:SHK_BR_R
-    </code>
+    <code>KEY:SHK_BR_R</code>
     - Shocking Burst
     <br/>
-    <code>
-     KEY:SHLDPIERC_A
-    </code>
+    <code>KEY:SHLDPIERC_A</code>
     - Shield Piercing - Ammunition
     <br/>
-    <code>
-     KEY:SHLDPIERC_R
-    </code>
+    <code>KEY:SHLDPIERC_R</code>
     - Shield Piercing -
 Weapon.Ranged
     <br/>
-    <code>
-     KEY:SHOCK_A
-    </code>
+    <code>KEY:SHOCK_A</code>
     - Shock
     <br/>
-    <code>
-     KEY:SHOCK_BLAST_AMMO
-    </code>
+    <code>KEY:SHOCK_BLAST_AMMO</code>
     - Lightning Blast
     <br/>
-    <code>
-     KEY:SHOCK_BLAST_MELEE
-    </code>
+    <code>KEY:SHOCK_BLAST_MELEE</code>
     - Lightning Blast
     <br/>
-    <code>
-     KEY:SHOCK_BLAST_RANGED
-    </code>
+    <code>KEY:SHOCK_BLAST_RANGED</code>
     - Lightning Blast
     <br/>
-    <code>
-     KEY:SHOCK_M
-    </code>
+    <code>KEY:SHOCK_M</code>
     - Shock
     <br/>
-    <code>
-     KEY:SHOCK_MELEE
-    </code>
+    <code>KEY:SHOCK_MELEE</code>
     - Shock
     <br/>
-    <code>
-     KEY:SHOCK_R
-    </code>
+    <code>KEY:SHOCK_R</code>
     - Shock
     <br/>
-    <code>
-     KEY:SHOCK_RANGED
-    </code>
+    <code>KEY:SHOCK_RANGED</code>
     - Shock
     <br/>
-    <code>
-     KEY:SHOCK_TIP_SHOE
-    </code>
+    <code>KEY:SHOCK_TIP_SHOE</code>
     - Shock tip
     <br/>
-    <code>
-     KEY:SHTBRL_L
-    </code>
+    <code>KEY:SHTBRL_L</code>
     - Shortened Barrel
     <br/>
-    <code>
-     KEY:SHTBRL_P
-    </code>
+    <code>KEY:SHTBRL_P</code>
     - Shortened Barrel
     <br/>
-    <code>
-     KEY:SIGHT
-    </code>
+    <code>KEY:SIGHT</code>
     - Sight
     <br/>
-    <code>
-     KEY:SILENCED_REVOLVER
-    </code>
+    <code>KEY:SILENCED_REVOLVER</code>
     - Silenced revolver
     <br/>
-    <code>
-     KEY:SILENCER
-    </code>
+    <code>KEY:SILENCER</code>
     - Silencer
     <br/>
-    <code>
-     KEY:SILENT_MOVES
-    </code>
+    <code>KEY:SILENT_MOVES</code>
     - Silent Moves
     <br/>
-    <code>
-     KEY:SILK
-    </code>
+    <code>KEY:SILK</code>
     - Silk
     <br/>
-    <code>
-     KEY:SILVER
-    </code>
+    <code>KEY:SILVER</code>
     - Silver
     <br/>
-    <code>
-     KEY:SILVER_AMMO
-    </code>
+    <code>KEY:SILVER_AMMO</code>
     - Silver
     <br/>
-    <code>
-     KEY:SKILLCHIP1
-    </code>
+    <code>KEY:SKILLCHIP1</code>
     - Skill Software
     <br/>
-    <code>
-     KEY:SKILLCHIP2
-    </code>
+    <code>KEY:SKILLCHIP2</code>
     - Skill Software
     <br/>
-    <code>
-     KEY:SKILLCHIP3
-    </code>
+    <code>KEY:SKILLCHIP3</code>
     - Skill Software
     <br/>
-    <code>
-     KEY:SKILLCHIP4
-    </code>
+    <code>KEY:SKILLCHIP4</code>
     - Skill Software
     <br/>
-    <code>
-     KEY:SKILLCHIP5
-    </code>
+    <code>KEY:SKILLCHIP5</code>
     - Skill Software
     <br/>
-    <code>
-     KEY:SKILLCHIP6
-    </code>
+    <code>KEY:SKILLCHIP6</code>
     - Skill Software
     <br/>
-    <code>
-     KEY:SKILLCHIP7
-    </code>
+    <code>KEY:SKILLCHIP7</code>
     - Skill Software
     <br/>
-    <code>
-     KEY:SKILLCHIP8
-    </code>
+    <code>KEY:SKILLCHIP8</code>
     - Skill Software
     <br/>
-    <code>
-     KEY:SKILLIMPLANT
-    </code>
+    <code>KEY:SKILLIMPLANT</code>
     - Skill Implant
     <br/>
-    <code>
-     KEY:SKILLNET4A
-    </code>
+    <code>KEY:SKILLNET4A</code>
     - Skill Software 1
     <br/>
-    <code>
-     KEY:SKILLNET4B
-    </code>
+    <code>KEY:SKILLNET4B</code>
     - Skill Software 2
     <br/>
-    <code>
-     KEY:SKILLNET4C
-    </code>
+    <code>KEY:SKILLNET4C</code>
     - Skill Software 3
     <br/>
-    <code>
-     KEY:SKILLNET4D
-    </code>
+    <code>KEY:SKILLNET4D</code>
     - Skill Software 4
     <br/>
-    <code>
-     KEY:SKILLNET8A
-    </code>
+    <code>KEY:SKILLNET8A</code>
     - Skill Software 1
     <br/>
-    <code>
-     KEY:SKILLNET8B
-    </code>
+    <code>KEY:SKILLNET8B</code>
     - Skill Software 2
     <br/>
-    <code>
-     KEY:SKILLNET8C
-    </code>
+    <code>KEY:SKILLNET8C</code>
     - Skill Software 3
     <br/>
-    <code>
-     KEY:SKILLNET8D
-    </code>
+    <code>KEY:SKILLNET8D</code>
     - Skill Software 4
     <br/>
-    <code>
-     KEY:SKILLNET12A
-    </code>
+    <code>KEY:SKILLNET12A</code>
     - Skill Software 1
     <br/>
-    <code>
-     KEY:SKILLNET12B
-    </code>
+    <code>KEY:SKILLNET12B</code>
     - Skill Software 2
     <br/>
-    <code>
-     KEY:SKILLNET12C
-    </code>
+    <code>KEY:SKILLNET12C</code>
     - Skill Software 3
     <br/>
-    <code>
-     KEY:SKILLNET12D
-    </code>
+    <code>KEY:SKILLNET12D</code>
     - Skill Software 4
     <br/>
-    <code>
-     KEY:SKILLPROGIT4
-    </code>
+    <code>KEY:SKILLPROGIT4</code>
     - Skill Software 1
     <br/>
-    <code>
-     KEY:SKILLPROGIT8
-    </code>
+    <code>KEY:SKILLPROGIT8</code>
     - Skill Software 1
     <br/>
-    <code>
-     KEY:SKILLPROGIT12
-    </code>
+    <code>KEY:SKILLPROGIT12</code>
     - Skill Software 1
     <br/>
-    <code>
-     KEY:SKL_DISABLE_DEVICE_MP
-    </code>
+    <code>KEY:SKL_DISABLE_DEVICE_MP</code>
     - Disable Device
     <br/>
-    <code>
-     KEY:SL_FDR
-    </code>
+    <code>KEY:SL_FDR</code>
     - Soul Feeder
     <br/>
-    <code>
-     KEY:SLF_RPRNG_GDGT
-    </code>
+    <code>KEY:SLF_RPRNG_GDGT</code>
     - Self-Repairing Gadget -
 Armor
     <br/>
-    <code>
-     KEY:SLF_RPRNG_GDGT_EQM
-    </code>
+    <code>KEY:SLF_RPRNG_GDGT_EQM</code>
     - Self-Repairing Gadget -
 Goods
     <br/>
-    <code>
-     KEY:SLICK
-    </code>
+    <code>KEY:SLICK</code>
     - Slick
     <br/>
-    <code>
-     KEY:SLK
-    </code>
+    <code>KEY:SLK</code>
     - Slick
     <br/>
-    <code>
-     KEY:SLK_GRT
-    </code>
+    <code>KEY:SLK_GRT</code>
     - Slick (Greater)
     <br/>
-    <code>
-     KEY:SLK_IMP
-    </code>
+    <code>KEY:SLK_IMP</code>
     - Slick (Improved)
     <br/>
-    <code>
-     KEY:SLNT_MV
-    </code>
+    <code>KEY:SLNT_MV</code>
     - Silent moves
     <br/>
-    <code>
-     KEY:SLNT_MV_GRT
-    </code>
+    <code>KEY:SLNT_MV_GRT</code>
     - Silent moves (Greater)
     <br/>
-    <code>
-     KEY:SLNT_MV_IM
-    </code>
+    <code>KEY:SLNT_MV_IM</code>
     - Silent moves (Improved)
     <br/>
-    <code>
-     KEY:SLVR
-    </code>
+    <code>KEY:SLVR</code>
     - Silvered
     <br/>
-    <code>
-     KEY:SMART_LINK
-    </code>
+    <code>KEY:SMART_LINK</code>
     - Smart Link
     <br/>
-    <code>
-     KEY:SMITE
-    </code>
+    <code>KEY:SMITE</code>
     - Smiting
     <br/>
-    <code>
-     KEY:SMOKE_SCREEN
-    </code>
+    <code>KEY:SMOKE_SCREEN</code>
     - Smoke screen
     <br/>
-    <code>
-     KEY:SND_SPPRSSR_GDGT_EQP
-    </code>
+    <code>KEY:SND_SPPRSSR_GDGT_EQP</code>
     - Sound Suppressor
 Gadget
     <br/>
-    <code>
-     KEY:SND_SPPRSSR_GDGT_WPN
-    </code>
+    <code>KEY:SND_SPPRSSR_GDGT_WPN</code>
     - Sound Suppressor
 Gadget
     <br/>
-    <code>
-     KEY:SNSR_ACHILLES
-    </code>
+    <code>KEY:SNSR_ACHILLES</code>
     - Achilles Targeting Software
     <br/>
-    <code>
-     KEY:SNSR_BFFLNG_GDGT
-    </code>
+    <code>KEY:SNSR_BFFLNG_GDGT</code>
     - Sensor Baffling Gadget
     <br/>
-    <code>
-     KEY:SNSR_CLASS_1
-    </code>
+    <code>KEY:SNSR_CLASS_1</code>
     - Class I Sensor Array
     <br/>
-    <code>
-     KEY:SNSR_CLASS_2
-    </code>
+    <code>KEY:SNSR_CLASS_2</code>
     - Class II Sensor Array
     <br/>
-    <code>
-     KEY:SNSR_CLASS_3
-    </code>
+    <code>KEY:SNSR_CLASS_3</code>
     - Class III Sensor Array
     <br/>
-    <code>
-     KEY:SNSR_CLASS_4
-    </code>
+    <code>KEY:SNSR_CLASS_4</code>
     - Class IV Sensor Array
     <br/>
-    <code>
-     KEY:SNSR_CLASS_5
-    </code>
+    <code>KEY:SNSR_CLASS_5</code>
     - Class V Sensor Array
     <br/>
-    <code>
-     KEY:SNSR_CLASS_6
-    </code>
+    <code>KEY:SNSR_CLASS_6</code>
     - Class VI Sensor Array
     <br/>
-    <code>
-     KEY:SNSR_CLASS_7
-    </code>
+    <code>KEY:SNSR_CLASS_7</code>
     - Class VII Sensor Array
     <br/>
-    <code>
-     KEY:SNSR_CLASS_8
-    </code>
+    <code>KEY:SNSR_CLASS_8</code>
     - Class VIII Sensor Array
     <br/>
-    <code>
-     KEY:SNSR_CLASS_9
-    </code>
+    <code>KEY:SNSR_CLASS_9</code>
     - Class IX Sensor Array
     <br/>
-    <code>
-     KEY:SNSR_IMP_TRGT_SYS
-    </code>
+    <code>KEY:SNSR_IMP_TRGT_SYS</code>
     - Improved Targeting
 System
     <br/>
-    <code>
-     KEY:SNSR_TRGT_SYS
-    </code>
+    <code>KEY:SNSR_TRGT_SYS</code>
     - Targeting System
     <br/>
-    <code>
-     KEY:SONIC_BLAST_AMMO
-    </code>
+    <code>KEY:SONIC_BLAST_AMMO</code>
     - Sonic Blast
     <br/>
-    <code>
-     KEY:SONIC_BLAST_MELEE
-    </code>
+    <code>KEY:SONIC_BLAST_MELEE</code>
     - Sonic Blast
     <br/>
-    <code>
-     KEY:SONIC_BLAST_RANGED
-    </code>
+    <code>KEY:SONIC_BLAST_RANGED</code>
     - Sonic Blast
     <br/>
-    <code>
-     KEY:SONIC_RES
-    </code>
+    <code>KEY:SONIC_RES</code>
     - Sonic Resistance
     <br/>
-    <code>
-     KEY:SONIC_WARD
-    </code>
+    <code>KEY:SONIC_WARD</code>
     - Sonic Warding
     <br/>
-    <code>
-     KEY:SOULBREAK
-    </code>
+    <code>KEY:SOULBREAK</code>
     - Soulbreaker
     <br/>
-    <code>
-     KEY:SPACE_SKIN
-    </code>
+    <code>KEY:SPACE_SKIN</code>
     - Space Skin (PL 6)
     <br/>
-    <code>
-     KEY:SPEED
-    </code>
+    <code>KEY:SPEED</code>
     - Speed
     <br/>
-    <code>
-     KEY:SPEED_LD
-    </code>
+    <code>KEY:SPEED_LD</code>
     - Speed Loader
     <br/>
-    <code>
-     KEY:SPELL_RES_13
-    </code>
+    <code>KEY:SPELL_RES_13</code>
     - Spell Resistance (SR 13)
     <br/>
-    <code>
-     KEY:SPELL_RES_15
-    </code>
+    <code>KEY:SPELL_RES_15</code>
     - Spell Resistance (SR 15)
     <br/>
-    <code>
-     KEY:SPELL_RES_17
-    </code>
+    <code>KEY:SPELL_RES_17</code>
     - Spell Resistance (SR 17)
     <br/>
-    <code>
-     KEY:SPELL_RES_19
-    </code>
+    <code>KEY:SPELL_RES_19</code>
     - Spell Resistance (SR 19)
     <br/>
-    <code>
-     KEY:SPELL_RES_21
-    </code>
+    <code>KEY:SPELL_RES_21</code>
     - Greater Spell Resistance (SR
 21)
     <br/>
-    <code>
-     KEY:SPELL_RES_23
-    </code>
+    <code>KEY:SPELL_RES_23</code>
     - Greater Spell Resistance (SR
 23)
     <br/>
-    <code>
-     KEY:SPELL_RES_25
-    </code>
+    <code>KEY:SPELL_RES_25</code>
     - Greater Spell Resistance (SR
 25)
     <br/>
-    <code>
-     KEY:SPELL_RES_27
-    </code>
+    <code>KEY:SPELL_RES_27</code>
     - Greater Spell Resistance (SR
 27)
     <br/>
-    <code>
-     KEY:SPELLFOCUS
-    </code>
+    <code>KEY:SPELLFOCUS</code>
     - Spell Focus Value
     <br/>
-    <code>
-     KEY:SPELLMATERIAL
-    </code>
+    <code>KEY:SPELLMATERIAL</code>
     - Spell Material Component
 Value
     <br/>
-    <code>
-     KEY:SPELLW1
-    </code>
+    <code>KEY:SPELLW1</code>
     - Spellwarding (+1)
     <br/>
-    <code>
-     KEY:SPELLW2
-    </code>
+    <code>KEY:SPELLW2</code>
     - Spellwarding (+2)
     <br/>
-    <code>
-     KEY:SPELLW3
-    </code>
+    <code>KEY:SPELLW3</code>
     - Spellwarding (+3)
     <br/>
-    <code>
-     KEY:SPELLW4
-    </code>
+    <code>KEY:SPELLW4</code>
     - Spellwarding (+4)
     <br/>
-    <code>
-     KEY:SPELLW5
-    </code>
+    <code>KEY:SPELLW5</code>
     - Spellwarding (+5)
     <br/>
-    <code>
-     KEY:SPIKE_A
-    </code>
+    <code>KEY:SPIKE_A</code>
     - Armor Spikes
     <br/>
-    <code>
-     KEY:SPIKE_DROPPER
-    </code>
+    <code>KEY:SPIKE_DROPPER</code>
     - Spike dropper
     <br/>
-    <code>
-     KEY:SPIKE_S
-    </code>
+    <code>KEY:SPIKE_S</code>
     - Shield Spikes
     <br/>
-    <code>
-     KEY:SPIKE_SB
-    </code>
+    <code>KEY:SPIKE_SB</code>
     - Shield Bash
     <br/>
-    <code>
-     KEY:SPL_1USE
-    </code>
+    <code>KEY:SPL_1USE</code>
     - Spell Effect (Single Use/Use
 Activated)
     <br/>
-    <code>
-     KEY:SPL_1USE
-    </code>
+    <code>KEY:SPL_1USE</code>
     - |Spell Effect (Single Use/Use
 Activated)
     <br/>
-    <code>
-     KEY:SPL_ACT
-    </code>
+    <code>KEY:SPL_ACT</code>
     - Spell Effect (Use Activated)
     <br/>
-    <code>
-     KEY:SPL_ACT_RING
-    </code>
+    <code>KEY:SPL_ACT_RING</code>
     - |Spell Effect (Use Activated
 Ring)
     <br/>
-    <code>
-     KEY:SPL_CHRG
-    </code>
+    <code>KEY:SPL_CHRG</code>
     - Spell Effect (50 Charges/Spell
 Trigger)
     <br/>
-    <code>
-     KEY:SPL_CHRG
-    </code>
+    <code>KEY:SPL_CHRG</code>
     - |Spell Effect (50 Charges/Spell
 Trigger)
     <br/>
-    <code>
-     KEY:SPL_CMD
-    </code>
+    <code>KEY:SPL_CMD</code>
     - Spell Effect (Command Word)
     <br/>
-    <code>
-     KEY:SPL_CON_ROUND
-    </code>
+    <code>KEY:SPL_CON_ROUND</code>
     - |Spell Effect (Continuous/Spell
 duration measured in rounds)
     <br/>
-    <code>
-     KEY:SPL_CON_MINUTES
-    </code>
+    <code>KEY:SPL_CON_MINUTES</code>
     - |Spell Effect (Continuous/Spell
 duration 1 minute/level)
     <br/>
-    <code>
-     KEY:SPL_CON_HOURS
-    </code>
+    <code>KEY:SPL_CON_HOURS</code>
     - |Spell Effect (Continuous/Spell
 duration 10 minutes/level)
     <br/>
-    <code>
-     KEY:SPL_CON_DAYS
-    </code>
+    <code>KEY:SPL_CON_DAYS</code>
     - |Spell Effect (Continuous/Spell
 duration 24-hours or more)
     <br/>
-    <code>
-     KEY:SPL_RST
-    </code>
+    <code>KEY:SPL_RST</code>
     - Spell Resistance
     <span class="new">
      (deprecated)
     </span>
     <br/>
-    <code>
-     KEY:SPL_STR
-    </code>
+    <code>KEY:SPL_STR</code>
     - Spell Storing
     <br/>
-    <code>
-     KEY:SPONSOR
-    </code>
+    <code>KEY:SPONSOR</code>
     - Sponsorship
     <br/>
-    <code>
-     KEY:SPPRSSN
-    </code>
+    <code>KEY:SPPRSSN</code>
     - Suppression
     <br/>
-    <code>
-     KEY:SPPRSS_FN57
-    </code>
+    <code>KEY:SPPRSS_FN57</code>
     - FN Five-seveN Suppressor
     <br/>
-    <code>
-     KEY:SPPRSS_MAC10
-    </code>
+    <code>KEY:SPPRSS_MAC10</code>
     - Ingram MAC-10 Suppressor
     <br/>
-    <code>
-     KEY:SPPRSS_MAC11
-    </code>
+    <code>KEY:SPPRSS_MAC11</code>
     - Ingram MAC-11 Suppressor
     <br/>
-    <code>
-     KEY:SPPRSS_OTS02
-    </code>
+    <code>KEY:SPPRSS_OTS02</code>
     - OTs-02 Kiparis Suppressor
     <br/>
-    <code>
-     KEY:SPPRSS_PIS
-    </code>
+    <code>KEY:SPPRSS_PIS</code>
     - Suppressor (Pistol)
     <br/>
-    <code>
-     KEY:SPPRSS_RFL
-    </code>
+    <code>KEY:SPPRSS_RFL</code>
     - Suppressor (Rifle)
     <br/>
-    <code>
-     KEY:SPPRSS_RFL
-    </code>
+    <code>KEY:SPPRSS_RFL</code>
     - #Suppressor (Rifle)
     <br/>
-    <code>
-     KEY:SPPRSS_SCH21
-    </code>
+    <code>KEY:SPPRSS_SCH21</code>
     - SCH-21 Gorda Suppressor
 Barrel
     <br/>
-    <code>
-     KEY:SPPRSS_MPI69
-    </code>
+    <code>KEY:SPPRSS_MPI69</code>
     - Steyr MPi69 Suppressor
     <br/>
-    <code>
-     KEY:SPPRSS_MPI81
-    </code>
+    <code>KEY:SPPRSS_MPI81</code>
     - Steyr MPi81 Suppressor
     <br/>
-    <code>
-     KEY:SPPRSS_PGM_UR
-    </code>
+    <code>KEY:SPPRSS_PGM_UR</code>
     - Silenced Barrel
     <br/>
-    <code>
-     KEY:SPRNG_LDD_GDGT
-    </code>
+    <code>KEY:SPRNG_LDD_GDGT</code>
     - Spring Loaded Gadget
     <br/>
-    <code>
-     KEY:STARLIGHT_LENSES
-    </code>
+    <code>KEY:STARLIGHT_LENSES</code>
     - Starlight lenses
     <br/>
-    <code>
-     KEY:STEALTH_SUITE
-    </code>
+    <code>KEY:STEALTH_SUITE</code>
     - Stealth Suite (PL 6)
     <br/>
-    <code>
-     KEY:STEEL
-    </code>
+    <code>KEY:STEEL</code>
     - Mundane (Weapon/Ammo)
     <br/>
-    <code>
-     KEY:STEEL
-    </code>
+    <code>KEY:STEEL</code>
     - Steel
     <br/>
-    <code>
-     KEY:STN_MDL_GDGT_12
-    </code>
+    <code>KEY:STN_MDL_GDGT_12</code>
     - Stun Module Gadget (Fort DC
 12)
     <br/>
-    <code>
-     KEY:STN_MDL_GDGT_15
-    </code>
+    <code>KEY:STN_MDL_GDGT_15</code>
     - Stun Module Gadget (Fort DC
 15)
     <br/>
-    <code>
-     KEY:STN_MDL_GDGT_18
-    </code>
+    <code>KEY:STN_MDL_GDGT_18</code>
     - Stun Module Gadget (Fort DC
 18)
     <br/>
-    <code>
-     KEY:STONE
-    </code>
+    <code>KEY:STONE</code>
     - Stone
     <br/>
-    <code>
-     KEY:STOR_CMPRT_GDGT_AMR
-    </code>
+    <code>KEY:STOR_CMPRT_GDGT_AMR</code>
     - Storage Compartment
 Gadget
     <br/>
-    <code>
-     KEY:STOR_CMPRT_GDGT_EQP
-    </code>
+    <code>KEY:STOR_CMPRT_GDGT_EQP</code>
     - Storage Compartment
 Gadget
     <br/>
-    <code>
-     KEY:STRCTRL_ENHNCMT
-    </code>
+    <code>KEY:STRCTRL_ENHNCMT</code>
     - Structural Enhancement (PL
 7)
     <br/>
-    <code>
-     KEY:STRCTRL_ENHNCMT2
-    </code>
+    <code>KEY:STRCTRL_ENHNCMT2</code>
     - Structural Enhancement (PL
 7)
     <br/>
-    <code>
-     KEY:STWL_STUNTMN
-    </code>
+    <code>KEY:STWL_STUNTMN</code>
     - Stuntman's Steering Wheel
     <br/>
-    <code>
-     KEY:SUBMACHINE_GUN
-    </code>
+    <code>KEY:SUBMACHINE_GUN</code>
     - Submachine gun
     <br/>
-    <code>
-     KEY:SUBSONIC_AMMO
-    </code>
+    <code>KEY:SUBSONIC_AMMO</code>
     - Subsonic
     <br/>
-    <code>
-     KEY:SUCTION_SHOE
-    </code>
+    <code>KEY:SUCTION_SHOE</code>
     - Suction
     <br/>
-    <code>
-     KEY:Sunblade (Bastard)
-    </code>
+    <code>KEY:Sunblade (Bastard)</code>
     - Sun Blade (Bastard)
     <br/>
-    <code>
-     KEY:Sunblade (Short)
-    </code>
+    <code>KEY:Sunblade (Short)</code>
     - Sun Blade (Short)
     <br/>
-    <code>
-     KEY:SUNDERER
-    </code>
+    <code>KEY:SUNDERER</code>
     - Sunderer
     <br/>
-    <code>
-     KEY:SUPPRESS_A
-    </code>
+    <code>KEY:SUPPRESS_A</code>
     - Suppression
     <br/>
-    <code>
-     KEY:SUPPRESS_M
-    </code>
+    <code>KEY:SUPPRESS_M</code>
     - Suppression
     <br/>
-    <code>
-     KEY:SUPPRESS_R
-    </code>
+    <code>KEY:SUPPRESS_R</code>
     - Suppression
     <br/>
-    <code>
-     KEY:SUPPRESSION
-    </code>
+    <code>KEY:SUPPRESSION</code>
     - Suppression
     <br/>
-    <code>
-     KEY:SURVEILLANCE
-    </code>
+    <code>KEY:SURVEILLANCE</code>
     - Surveillance
     <br/>
-    <code>
-     KEY:SURVEILLANCE_SUITE
-    </code>
+    <code>KEY:SURVEILLANCE_SUITE</code>
     - Surveillance Suite
     <br/>
-    <code>
-     KEY:SUSAT_SIGHT
-    </code>
+    <code>KEY:SUSAT_SIGHT</code>
     - SUSAT
     <br/>
-    <code>
-     KEY:T_PSIBLADE
-    </code>
+    <code>KEY:T_PSIBLADE</code>
     - Thrown Psiblade
     <br/>
-    <code>
-     KEY:T95_CVLCD_CHAINGN
-    </code>
+    <code>KEY:T95_CVLCD_CHAINGN</code>
     - T-95 Cavalcade Chaingun (PL
 6)
     <br/>
-    <code>
-     KEY:TACTICAL_OUTERSHELL
-    </code>
+    <code>KEY:TACTICAL_OUTERSHELL</code>
     - Tactical Outershell
     <br/>
-    <code>
-     KEY:TASSLE
-    </code>
+    <code>KEY:TASSLE</code>
     - Tassel
     <br/>
-    <code>
-     KEY:TATTOO_ARCANE
-    </code>
+    <code>KEY:TATTOO_ARCANE</code>
     - |Spell Effect (Arcane
 Tattoo)
     <br/>
-    <code>
-     KEY:TATTOO_DIVINE
-    </code>
+    <code>KEY:TATTOO_DIVINE</code>
     - |Spell Effect (Divine
 Tattoo)
     <br/>
-    <code>
-     KEY:TATTOO_PSIONIC
-    </code>
+    <code>KEY:TATTOO_PSIONIC</code>
     - |Power Effect (Psionic
 Tattoo)
     <br/>
-    <code>
-     KEY:TELE
-    </code>
+    <code>KEY:TELE</code>
     - Telescoping
     <br/>
-    <code>
-     KEY:TELESCOPIC_LENSES
-    </code>
+    <code>KEY:TELESCOPIC_LENSES</code>
     - Telescopic lenses
     <br/>
-    <code>
-     KEY:TELESCOPIC_SIGHT
-    </code>
+    <code>KEY:TELESCOPIC_SIGHT</code>
     - Telescopic Sight
     <br/>
-    <code>
-     KEY:THGHT_BSTN
-    </code>
+    <code>KEY:THGHT_BSTN</code>
     - Thought Bastion
     <br/>
-    <code>
-     KEY:THERMPGRAPHIC_LENSES
-    </code>
+    <code>KEY:THERMPGRAPHIC_LENSES</code>
     - Thermpgraphic lenses
     <br/>
-    <code>
-     KEY:THNDR_A
-    </code>
+    <code>KEY:THNDR_A</code>
     - Thundering
     <br/>
-    <code>
-     KEY:THNDR_M
-    </code>
+    <code>KEY:THNDR_M</code>
     - Thundering
     <br/>
-    <code>
-     KEY:THUNDER_MELEE
-    </code>
+    <code>KEY:THUNDER_MELEE</code>
     - Thundering
     <br/>
-    <code>
-     KEY:THNDR_R
-    </code>
+    <code>KEY:THNDR_R</code>
     - Thundering
     <br/>
-    <code>
-     KEY:THUNDER_RANGED
-    </code>
+    <code>KEY:THUNDER_RANGED</code>
     - Thundering
     <br/>
-    <code>
-     KEY:THROW
-    </code>
+    <code>KEY:THROW</code>
     - Throwing
     <br/>
-    <code>
-     KEY:THROWN_AMMO
-    </code>
+    <code>KEY:THROWN_AMMO</code>
     - Thrown Ammunition
     <br/>
-    <code>
-     KEY:THRUSTER_BTS
-    </code>
+    <code>KEY:THRUSTER_BTS</code>
     - Thruster Boots (PL7)
     <br/>
-    <code>
-     KEY:TIME_BTTRS
-    </code>
+    <code>KEY:TIME_BTTRS</code>
     - Time Buttress
     <br/>
-    <code>
-     KEY:TIMEBUT
-    </code>
+    <code>KEY:TIMEBUT</code>
     - Time Buttress
     <br/>
-    <code>
-     KEY:TIRE_IMPVS
-    </code>
+    <code>KEY:TIRE_IMPVS</code>
     - Impervious Tires
     <br/>
-    <code>
-     KEY:TIRE_REINFLT
-    </code>
+    <code>KEY:TIRE_REINFLT</code>
     - Reinflating Tires
     <br/>
-    <code>
-     KEY:TIRE_SLASHER
-    </code>
+    <code>KEY:TIRE_SLASHER</code>
     - Tire slasher
     <br/>
-    <code>
-     KEY:TIRE_ZEPHYR
-    </code>
+    <code>KEY:TIRE_ZEPHYR</code>
     - Zephyr Tires
     <br/>
-    <code>
-     KEY:TLPRT_MAG_GDGT
-    </code>
+    <code>KEY:TLPRT_MAG_GDGT</code>
     - Teleporting Magazine Gadget
     <br/>
-    <code>
-     KEY:TOOLSGRMW
-    </code>
+    <code>KEY:TOOLSGRMW</code>
     - Greater Mastercraft
     <br/>
-    <code>
-     KEY:TOOLSMW
-    </code>
+    <code>KEY:TOOLSMW</code>
     - Masterwork - Tools
     <br/>
-    <code>
-     KEY:TPORTING
-    </code>
+    <code>KEY:TPORTING</code>
     - Teleporting
     <br/>
-    <code>
-     KEY:TRACER_AMMO
-    </code>
+    <code>KEY:TRACER_AMMO</code>
     - Tracer
     <br/>
-    <code>
-     KEY:TRACKING_MODIFICATION_PALMPRINT_ID
-    </code>
+    <code>KEY:TRACKING_MODIFICATION_PALMPRINT_ID</code>
     - Tracking
 Modification Palmprint ID
     <br/>
-    <code>
-     KEY:TRANSLATOR_LENSES
-    </code>
+    <code>KEY:TRANSLATOR_LENSES</code>
     - Translator lenses
     <br/>
-    <code>
-     KEY:TRANSMITTER_LENSES
-    </code>
+    <code>KEY:TRANSMITTER_LENSES</code>
     - Transmitter lenses
     <br/>
-    <code>
-     KEY:TRANSSTEEL
-    </code>
+    <code>KEY:TRANSSTEEL</code>
     - Transparent Steel
     <br/>
-    <code>
-     KEY:TRAP
-    </code>
+    <code>KEY:TRAP</code>
     - Trap
     <br/>
-    <code>
-     KEY:TRAPW1
-    </code>
+    <code>KEY:TRAPW1</code>
     - Trapwarding (+1)
     <br/>
-    <code>
-     KEY:TRAPW2
-    </code>
+    <code>KEY:TRAPW2</code>
     - Trapwarding (+2)
     <br/>
-    <code>
-     KEY:TRAPW3
-    </code>
+    <code>KEY:TRAPW3</code>
     - Trapwarding (+3)
     <br/>
-    <code>
-     KEY:TRAPW4
-    </code>
+    <code>KEY:TRAPW4</code>
     - Trapwarding (+4)
     <br/>
-    <code>
-     KEY:TRAPW5
-    </code>
+    <code>KEY:TRAPW5</code>
     - Trapwarding (+5)
     <br/>
-    <code>
-     KEY:TREADS_SHOE
-    </code>
+    <code>KEY:TREADS_SHOE</code>
     - Treads
     <br/>
-    <code>
-     KEY:TRI_FERENCE_PHOTOGRAPHY
-    </code>
+    <code>KEY:TRI_FERENCE_PHOTOGRAPHY</code>
     - Tri-ference
 photography
     <br/>
-    <code>
-     KEY:TRIPLE_THROW
-    </code>
+    <code>KEY:TRIPLE_THROW</code>
     - Triple Throw
     <br/>
-    <code>
-     KEY:TSNM_480_PLSM_CNN
-    </code>
+    <code>KEY:TSNM_480_PLSM_CNN</code>
     - Tsunami 480 Plasma Cannon (PL
 7)
     <br/>
-    <code>
-     KEY:TUBULAR_SPACE_FRAME
-    </code>
+    <code>KEY:TUBULAR_SPACE_FRAME</code>
     - Tubular space frame
     <br/>
-    <code>
-     KEY:TUMBLE
-    </code>
+    <code>KEY:TUMBLE</code>
     - Tumbling
     <br/>
-    <code>
-     KEY:TYPHN_240_LSR_CNN
-    </code>
+    <code>KEY:TYPHN_240_LSR_CNN</code>
     - Typhoon 240 Laser Cannon (PL
 6)
     <br/>
-    <code>
-     KEY:ULTRLT_CMPSTN_GDGT
-    </code>
+    <code>KEY:ULTRLT_CMPSTN_GDGT</code>
     - Ultralight Composition
 Gadget
     <br/>
-    <code>
-     KEY:UNCANNY
-    </code>
+    <code>KEY:UNCANNY</code>
     - Uncanny Protection
     <br/>
-    <code>
-     KEY:UNDEAD
-    </code>
+    <code>KEY:UNDEAD</code>
     - Undead controlling
     <br/>
-    <code>
-     KEY:UNERRING_ACCURACY
-    </code>
+    <code>KEY:UNERRING_ACCURACY</code>
     - Unerring Accuracy
     <br/>
-    <code>
-     KEY:UNHLY_A
-    </code>
+    <code>KEY:UNHLY_A</code>
     - Unholy
     <br/>
-    <code>
-     KEY:UNHLY_M
-    </code>
+    <code>KEY:UNHLY_M</code>
     - Unholy
     <br/>
-    <code>
-     KEY:UNHLY_R
-    </code>
+    <code>KEY:UNHLY_R</code>
     - Unholy
     <br/>
-    <code>
-     KEY:UNHOLY_POWER_AMMO
-    </code>
+    <code>KEY:UNHOLY_POWER_AMMO</code>
     - Unholy Power
     <br/>
-    <code>
-     KEY:UNHOLY_POWER_MELEE
-    </code>
+    <code>KEY:UNHOLY_POWER_MELEE</code>
     - Unholy Power
     <br/>
-    <code>
-     KEY:UNHOLY_POWER_RANGED
-    </code>
+    <code>KEY:UNHOLY_POWER_RANGED</code>
     - Unholy Power
     <br/>
-    <code>
-     KEY:UNRELIABLE
-    </code>
+    <code>KEY:UNRELIABLE</code>
     - Unreliable
     <br/>
-    <code>
-     KEY:UNRULY
-    </code>
+    <code>KEY:UNRULY</code>
     - Unruly
     <br/>
-    <code>
-     KEY:UPGRADE
-    </code>
+    <code>KEY:UPGRADE</code>
     - Upgrade
     <br/>
-    <code>
-     KEY:VANADIUM
-    </code>
+    <code>KEY:VANADIUM</code>
     - Vanadium (PL6)
     <br/>
-    <code>
-     KEY:VANISH
-    </code>
+    <code>KEY:VANISH</code>
     - Vanishing
     <br/>
-    <code>
-     KEY:VANISHING
-    </code>
+    <code>KEY:VANISHING</code>
     - Vanishing
     <br/>
-    <code>
-     KEY:VAR_AMMNTN_GDGT
-    </code>
+    <code>KEY:VAR_AMMNTN_GDGT</code>
     - Variable Ammunition Gadget
     <br/>
-    <code>
-     KEY:VAR_CHRG_GDGT
-    </code>
+    <code>KEY:VAR_CHRG_GDGT</code>
     - Variable Charge Gadget
     <br/>
-    <code>
-     KEY:VC_RCGNTN_SYS_GDGT
-    </code>
+    <code>KEY:VC_RCGNTN_SYS_GDGT</code>
     - Voice Recognition System
 Gadget
     <br/>
-    <code>
-     KEY:VHCL_ALUMISTEEL_ARMR
-    </code>
+    <code>KEY:VHCL_ALUMISTEEL_ARMR</code>
     - Alumisteel Armor
 (PL5)
     <br/>
-    <code>
-     KEY:VHCL_DURAPLASTC_ARMR
-    </code>
+    <code>KEY:VHCL_DURAPLASTC_ARMR</code>
     - Duraplastic Armor
 (PL5)
     <br/>
-    <code>
-     KEY:VHCL_DURALLOY_ARMR
-    </code>
+    <code>KEY:VHCL_DURALLOY_ARMR</code>
     - Duralloy Armor (PL6)
     <br/>
-    <code>
-     KEY:VHCL_RESILIUM_ARMR
-    </code>
+    <code>KEY:VHCL_RESILIUM_ARMR</code>
     - Resilium Armor (PL6)
     <br/>
-    <code>
-     KEY:VHCL_CRSTL_CRBN_ARMR
-    </code>
+    <code>KEY:VHCL_CRSTL_CRBN_ARMR</code>
     - Crystal Carbon Armor
 (PL7)
     <br/>
-    <code>
-     KEY:VHCL_MEGATANIUM_ARMR
-    </code>
+    <code>KEY:VHCL_MEGATANIUM_ARMR</code>
     - Megatanium Armor
 (PL8)
     <br/>
-    <code>
-     KEY:VHCL_NEOVULCANM_ARMR
-    </code>
+    <code>KEY:VHCL_NEOVULCANM_ARMR</code>
     - Neovulcanium Armor
 (PL7)
     <br/>
-    <code>
-     KEY:VHCL_REACTIVE_ARMR
-    </code>
+    <code>KEY:VHCL_REACTIVE_ARMR</code>
     - Reactive Armor (PL8)
     <br/>
-    <code>
-     KEY:VICIOU
-    </code>
+    <code>KEY:VICIOU</code>
     - Vicious
     <br/>
-    <code>
-     KEY:VID_SCP_GDGT
-    </code>
+    <code>KEY:VID_SCP_GDGT</code>
     - Video Scope Gadget
     <br/>
-    <code>
-     KEY:VOICE_ACTIVATED_COMMAND
-    </code>
+    <code>KEY:VOICE_ACTIVATED_COMMAND</code>
     - Voice Activated Command
 System
     <br/>
-    <code>
-     KEY:VORPAL
-    </code>
+    <code>KEY:VORPAL</code>
     - Vorpal
     <br/>
-    <code>
-     KEY:WALL
-    </code>
+    <code>KEY:WALL</code>
     - Wall
     <br/>
-    <code>
-     KEY:WAND
-    </code>
+    <code>KEY:WAND</code>
     - Wand
     <br/>
-    <code>
-     KEY:WARNING_SIGNAL_IDCARD
-    </code>
+    <code>KEY:WARNING_SIGNAL_IDCARD</code>
     - Warning Signal
     <br/>
-    <code>
-     KEY:WARPTH_RCLLSS_RFL
-    </code>
+    <code>KEY:WARPTH_RCLLSS_RFL</code>
     - Warpath Recoilless Rifle (PL
 5)
     <br/>
-    <code>
-     KEY:WaterbaneArm
-    </code>
+    <code>KEY:WaterbaneArm</code>
     - Waterbane - Armor
     <br/>
-    <code>
-     KEY:WaterbaneWeap
-    </code>
+    <code>KEY:WaterbaneWeap</code>
     - Waterbane - Weapon
     <br/>
-    <code>
-     KEY:WAX
-    </code>
+    <code>KEY:WAX</code>
     - Wax
     <br/>
-    <code>
-     KEY:WEAPALTHST
-    </code>
+    <code>KEY:WEAPALTHST</code>
     - Altherian Steel
     <br/>
-    <code>
-     KEY:WEAPALTHST
-    </code>
+    <code>KEY:WEAPALTHST</code>
     - Altherian Steel
     <br/>
-    <code>
-     KEY:WEAPGRMW
-    </code>
+    <code>KEY:WEAPGRMW</code>
     - Greater Mastercraft
     <br/>
-    <code>
-     KEY:WEAPMW
-    </code>
+    <code>KEY:WEAPMW</code>
     - Masterwork - Weapon
     <br/>
-    <code>
-     KEY:WEAPON_ACCURIZING
-    </code>
+    <code>KEY:WEAPON_ACCURIZING</code>
     - Weapon accurizing
     <br/>
-    <code>
-     KEY:WHITE_PHOSPHOR
-    </code>
+    <code>KEY:WHITE_PHOSPHOR</code>
     - White Phosphorous
     <br/>
-    <code>
-     KEY:WILD_A
-    </code>
+    <code>KEY:WILD_A</code>
     - Wild
     <br/>
-    <code>
-     KEY:WILD_S
-    </code>
+    <code>KEY:WILD_S</code>
     - Wild
     <br/>
-    <code>
-     KEY:WIND_RESISTANCE_REDUCTION_1
-    </code>
+    <code>KEY:WIND_RESISTANCE_REDUCTION_1</code>
     - Wind resistance
 reduction (+1)
     <br/>
-    <code>
-     KEY:WIND_RESISTANCE_REDUCTION_2
-    </code>
+    <code>KEY:WIND_RESISTANCE_REDUCTION_2</code>
     - Wind resistance
 reduction (+2)
     <br/>
-    <code>
-     KEY:WNDW_DCPTN
-    </code>
+    <code>KEY:WNDW_DCPTN</code>
     - Windows of Deception
     <br/>
-    <code>
-     KEY:WOOD
-    </code>
+    <code>KEY:WOOD</code>
     - Mundane (Weapon/Ammo)
     <br/>
-    <code>
-     KEY:WOOD
-    </code>
+    <code>KEY:WOOD</code>
     - Wood
     <br/>
-    <code>
-     KEY:WOOD_PLATED
-    </code>
+    <code>KEY:WOOD_PLATED</code>
     - Wood Plated
     <br/>
-    <code>
-     KEY:WOUND
-    </code>
+    <code>KEY:WOUND</code>
     - Wounding
     <br/>
-    <code>
-     KEY:WOUNDING
-    </code>
+    <code>KEY:WOUNDING</code>
     - Wounding
     <br/>
-    <code>
-     KEY:WPNBAL
-    </code>
+    <code>KEY:WPNBAL</code>
     - Weapon Balancing
     <br/>
-    <code>
-     KEY:WPNDBLD
-    </code>
+    <code>KEY:WPNDBLD</code>
     - Blinding
     <br/>
-    <code>
-     KEY:WPNDBLK
-    </code>
+    <code>KEY:WPNDBLK</code>
     - Blinking
     <br/>
-    <code>
-     KEY:WPNDBCL
-    </code>
+    <code>KEY:WPNDBCL</code>
     - Celestial Bone
     <br/>
-    <code>
-     KEY:WPNDFL1
-    </code>
+    <code>KEY:WPNDFL1</code>
     - Deflecting +1
     <br/>
-    <code>
-     KEY:WPNDFL2
-    </code>
+    <code>KEY:WPNDFL2</code>
     - Deflecting +2
     <br/>
-    <code>
-     KEY:WPNDFL3
-    </code>
+    <code>KEY:WPNDFL3</code>
     - Deflecting +3
     <br/>
-    <code>
-     KEY:WPNDFL4
-    </code>
+    <code>KEY:WPNDFL4</code>
     - Deflecting +4
     <br/>
-    <code>
-     KEY:WPNDPRS
-    </code>
+    <code>KEY:WPNDPRS</code>
     - Persuading
     <br/>
-    <code>
-     KEY:X_RAY_LENSES
-    </code>
+    <code>KEY:X_RAY_LENSES</code>
     - X ray lenses
     <br/>
-    <code>
-     KEY:XP_MGZN_GDGT
-    </code>
+    <code>KEY:XP_MGZN_GDGT</code>
     - Expanded Magazine Gadget
     <br/>
-    <code>
-     KEY:ZERO_G_STABILZR
-    </code>
+    <code>KEY:ZERO_G_STABILZR</code>
     - Zero-G Stabilizer (PL
 7)
     <br/>

--- a/docs/listfilepages/globalfilestagpages/globalfilesother.html
+++ b/docs/listfilepages/globalfilestagpages/globalfilesother.html
@@ -143,13 +143,9 @@ be handled one of two ways.
      </li>
      <li>
       Used in conjunction with the
-      <code>
-       CHOOSE
-      </code>
+      <code>CHOOSE</code>
       tag,
-      <code>
-       %LIST
-      </code>
+      <code>%LIST</code>
       can be used with this tag to provide the
 required choice.
      </li>
@@ -165,18 +161,14 @@ a matching ability.
      PRExxx
     </a>
     tags unless they use the
-    <code>
-     %LIST
-    </code>
+    <code>%LIST</code>
     parameter. ABILITY tags qualified with PRExxx
 tags will not be added unless the character meets the
 prerequisites.
    </li>
    <li>
     For specific infomation on the
-    <code>
-     .CLEAR
-    </code>
+    <code>.CLEAR</code>
     tag, read
 the
     <a href="#clear">
@@ -211,90 +203,70 @@ activate a chooser inside of a feat being granted.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ABILITY:FEAT|AUTOMATIC|Empower
-Spell
-   </code>
+   <code>ABILITY:FEAT|AUTOMATIC|Empower
+Spell</code>
   </p>
   <p class="indent3">
    Adds the empower spell feat as an Auto feat.
   </p>
   <p class="indent2">
-   <code>
-    ABILITY:FEAT|AUTOMATIC|TYPE=SpecialFu
-   </code>
+   <code>ABILITY:FEAT|AUTOMATIC|TYPE=SpecialFu</code>
   </p>
   <p class="indent3">
    Adds all feats with SpecialFu Type.
   </p>
   <p class="indent2">
-   <code>
-    ABILITY:Special Ability|AUTOMATIC|Monkey
-Fu Mastery
-   </code>
+   <code>ABILITY:Special Ability|AUTOMATIC|Monkey
+Fu Mastery</code>
   </p>
   <p class="indent3">
    Adds the Monkey Fu Mastery 'Special Ability' and
 lists it as Automatic nature (if visible).
   </p>
   <p class="indent2">
-   <code>
-    ABILITY:CLASSFEATURE|VIRTUAL|Stunning
-Fist
-   </code>
+   <code>ABILITY:CLASSFEATURE|VIRTUAL|Stunning
+Fist</code>
   </p>
   <p class="indent3">
    Adds the Stunning Fist ability as a virtual
 class feature.
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:WEAPONPROFS|LIST &lt;tab&gt;
-ABILITY:FEAT|AUTOMATIC|Weapon Focus (%LIST)
-   </code>
+   <code>CHOOSE:WEAPONPROFS|LIST &lt;tab&gt;
+ABILITY:FEAT|AUTOMATIC|Weapon Focus (%LIST)</code>
   </p>
   <p class="indent3">
    The feat "Weapon Focus" is granted as an
 automatic feat with the weapon chosen with the
-   <code>
-    CHOOSE
-   </code>
+   <code>CHOOSE</code>
    tag.
   </p>
   <p class="indent2">
-   <code>
-    ABILITY:FEAT|AUTOMATIC|.CLEAR
-   </code>
+   <code>ABILITY:FEAT|AUTOMATIC|.CLEAR</code>
   </p>
   <p class="indent3">
    Clears all automatic feats from the
 character.
   </p>
   <p class="indent2">
-   <code>
-    ABILITY:FEAT|VIRTUAL|.CLEAR.Empower
-Spell
-   </code>
+   <code>ABILITY:FEAT|VIRTUAL|.CLEAR.Empower
+Spell</code>
   </p>
   <p class="indent3">
    Clears the empower spell feat as an virtual
 feat.
   </p>
   <p class="indent2">
-   <code>
-    ABILITY:FEAT|AUTOMATIC|Toughness|Track
-   </code>
+   <code>ABILITY:FEAT|AUTOMATIC|Toughness|Track</code>
   </p>
   <p class="indent3">
    Example of granting more than one feat. This
 grants 'Track' and 'Toughness' as automatic feats
   </p>
   <p class="indent2">
-   <code>
-    ABILITY:Special Ability|AUTOMATIC|Wild
+   <code>ABILITY:Special Ability|AUTOMATIC|Wild
 Shape(Small Animal)|Wild Shape(Medium
-Animal)|PREVARGTEQ:DruidWildShape,4
-   </code>
+Animal)|PREVARGTEQ:DruidWildShape,4</code>
   </p>
   <p class="indent3">
    Grants the Special Ability 'Wild Shape (Small
@@ -303,11 +275,9 @@ once the variable 'DruidWildShape' equals or is greater than
 '4'
   </p>
   <p class="indent2">
-   <code>
-    ABILITY:Special Ability|AUTOMATIC|Wild
+   <code>ABILITY:Special Ability|AUTOMATIC|Wild
 Shape(Small Animal,Medium
-Animal)|PREVARGTEQ:DruidWildShape,4
-   </code>
+Animal)|PREVARGTEQ:DruidWildShape,4</code>
   </p>
   <p class="indent3">
    This shows an example of Abilities with
@@ -317,11 +287,9 @@ and grants the Special Ability 'Wild Shape (Small Animal)' and
 Comma delimiter.
   </p>
   <p class="indent2">
-   <code>
-    ABILITY:Special Ability|AUTOMATIC|%LIST
+   <code>ABILITY:Special Ability|AUTOMATIC|%LIST
 &lt;tab&gt; CHOOSE:ABILITYSELECTION|Special
-Ability|TYPE=CuteBunnies &lt;tab&gt; MULT:YES
-   </code>
+Ability|TYPE=CuteBunnies &lt;tab&gt; MULT:YES</code>
   </p>
   <p class="indent3">
    Would grant automatically, a Choice of type
@@ -365,9 +333,7 @@ type, that are granted as free armor proficiencies.
    </li>
    <li>
     When including the
-    <code>
-     ARMORTYPE=
-    </code>
+    <code>ARMORTYPE=</code>
     sub-tag you may use
 a period-delimted (.) list of armor types. This will grant the
 character proficiency with armor that meet all of the listed armor
@@ -384,37 +350,29 @@ pipe-delimited (|) syntax.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    AUTO:ARMORPROF|ARMORTYPE=Light
-   </code>
+   <code>AUTO:ARMORPROF|ARMORTYPE=Light</code>
   </p>
   <p class="indent3">
    All Light armors are given as free armor
 proficiencies.
   </p>
   <p class="indent2">
-   <code>
-    AUTO:ARMORPROF|Leather
-   </code>
+   <code>AUTO:ARMORPROF|Leather</code>
   </p>
   <p class="indent3">
    Leather armor is given as a free armor
 proficiency.
   </p>
   <p class="indent2">
-   <code>
-    AUTO:ARMORPROF|ARMORTYPE=Light|ARMORTYPE=Medium
-   </code>
+   <code>AUTO:ARMORPROF|ARMORTYPE=Light|ARMORTYPE=Medium</code>
   </p>
   <p class="indent3">
    Light and Medium Armor is given as a free armor
 proficiency.
   </p>
   <p class="indent2">
-   <code>
-    AUTO:ARMORPROF|Dwarven
-Plate|PRERACE:1,Dwarf
-   </code>
+   <code>AUTO:ARMORPROF|Dwarven
+Plate|PRERACE:1,Dwarf</code>
   </p>
   <p class="indent3">
    Dwarven Plate is given as a free armor
@@ -455,9 +413,7 @@ to the character for free.
 pipe-delimited (|) syntax.
    </li>
    <li>
-    <code>
-     AUTO:EQUIP
-    </code>
+    <code>AUTO:EQUIP</code>
     won't take (%)LIST or (%)CHOICE for
 substitution.
    </li>
@@ -468,9 +424,7 @@ substitution.
    </strong>
    The equipment added is
 marked on the GUI just as feats added by the
-   <code>
-    AUTO:FEAT
-   </code>
+   <code>AUTO:FEAT</code>
    tag, i.e. are yellow, and can't be removed. Additionally, the
 equipment must be added to the Equipment Set just as any other
 Equipment the PC has to come out on the OS.
@@ -499,20 +453,16 @@ class level lines. It can be used on a class line.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    AUTO:EQUIP|Flurry of
-Blows|PRECLASS:1,Monk=1|
-   </code>
+   <code>AUTO:EQUIP|Flurry of
+Blows|PRECLASS:1,Monk=1|</code>
   </p>
   <p class="indent3">
    The item "Flurry of Blows" is granted as a free
 equipment item if the character has a level of Monk.
   </p>
   <p class="indent2">
-   <code>
-    AUTO:EQUIP|Flurry of
-Blows|PREMULT:2,[PRESTAT:1,DEX=15],[PRECLASS:1,Monk=1]
-   </code>
+   <code>AUTO:EQUIP|Flurry of
+Blows|PREMULT:2,[PRESTAT:1,DEX=15],[PRECLASS:1,Monk=1]</code>
   </p>
   <p class="indent3">
    The item "Flurry of Blows" is granted as a free
@@ -537,34 +487,24 @@ of 15 or better.
    <li style="list-style: none; display: inline">
     <ul class="incremental">
      <li>
-      <code>
-       AUTO:FEAT
-      </code>
+      <code>AUTO:FEAT</code>
       is deprecated. Use
       <a href="#ability">
-       <code>
-        ABILITY:FEAT|AUTOMATIC|
-       </code>
+       <code>ABILITY:FEAT|AUTOMATIC|</code>
       </a>
       instead.
      </li>
      <li>
       All
-      <code>
-       FEAT
-      </code>
+      <code>FEAT</code>
       tags have been
       <strong>
        deprecated
       </strong>
       and replaced by the
-      <code>
-       ABILITY
-      </code>
+      <code>ABILITY</code>
       system, which is more general. The
-      <code>
-       ABILITY
-      </code>
+      <code>ABILITY</code>
       system can model feats, racial features, class
 features, traits, flaws, temporary bonuses, and so on, all using a
 common format.
@@ -613,13 +553,9 @@ be handled one of two ways.
       </li>
       <li>
        Used in conjunction with the
-       <code>
-        CHOOSE
-       </code>
+       <code>CHOOSE</code>
        tag,
-       <code>
-        %LIST
-       </code>
+       <code>%LIST</code>
        can be used with this tag to provide the
 required choice.
       </li>
@@ -657,33 +593,25 @@ activate a chooser inside of a feat being granted.
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     AUTO:FEAT|Dodge|PRESTAT:1,DEX=13
-    </code>
+    <code>AUTO:FEAT|Dodge|PRESTAT:1,DEX=13</code>
    </p>
    <p class="indent3">
     The feat "Dodge" is granted as an automatic feat
 if the character's dexterity is 13 or higher.
    </p>
    <p class="indent2">
-    <code>
-     CHOOSE:WEAPONPROFICIENCY|LIST &lt;tab&gt;
-AUTO:FEAT|Weapon Focus (%LIST)
-    </code>
+    <code>CHOOSE:WEAPONPROFICIENCY|LIST &lt;tab&gt;
+AUTO:FEAT|Weapon Focus (%LIST)</code>
    </p>
    <p class="indent3">
     The feat "Weapon Focus" is granted as an
 automatic feat with the weapon chosen with the
-    <code>
-     CHOOSE
-    </code>
+    <code>CHOOSE</code>
     tag.
    </p>
    <p class="indent2">
-    <code>
-     AUTO:FEAT|.CLEAR.Dodge &lt;tab&gt;
-AUTO:FEAT|Alertness
-    </code>
+    <code>AUTO:FEAT|.CLEAR.Dodge &lt;tab&gt;
+AUTO:FEAT|Alertness</code>
    </p>
    <p class="indent3">
     The feat "Dodge" is cleared and the feat
@@ -754,33 +682,23 @@ type, that are granted as free language.
    </li>
    <li>
     When including the
-    <code>
-     TYPE=
-    </code>
+    <code>TYPE=</code>
     sub-tag you may use a
 period-delimited (.) list of language types. This will grant the
 character any Language with the listed types.
    </li>
    <li>
     Use of
-    <code>
-     %LIST
-    </code>
+    <code>%LIST</code>
     will insert the result of a
-    <code>
-     CHOOSE
-    </code>
+    <code>CHOOSE</code>
     tag.
    </li>
    <li>
-    <code>
-     .CLEAR
-    </code>
+    <code>.CLEAR</code>
     will clear all languages granted by
 previous
-    <code>
-     AUTO:LANG
-    </code>
+    <code>AUTO:LANG</code>
     tags.
    </li>
    <li>
@@ -794,27 +712,21 @@ pipe-delimited (|) syntax.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    AUTO:LANG|Common
-   </code>
+   <code>AUTO:LANG|Common</code>
   </p>
   <p class="indent3">
    Common is granted as a free language to the
 character.
   </p>
   <p class="indent2">
-   <code>
-    AUTO:LANG|TYPE=Latin
-   </code>
+   <code>AUTO:LANG|TYPE=Latin</code>
   </p>
   <p class="indent3">
    Latin-type Languages are given as free languages
 .
   </p>
   <p class="indent2">
-   <code>
-    AUTO:LANG|Draconic|PREFEAT:1,Dodge
-   </code>
+   <code>AUTO:LANG|Draconic|PREFEAT:1,Dodge</code>
   </p>
   <p class="indent3">
    The Draconic language is granted as a free
@@ -857,9 +769,7 @@ type, that are granted as free shield proficiencies.
    </li>
    <li>
     When including the
-    <code>
-     SHIELDTYPE=
-    </code>
+    <code>SHIELDTYPE=</code>
     sub-tag you may use
 a period-delimted (.) list of shield types. This will grant the
 character proficiency with shields that meet all of the listed
@@ -876,18 +786,14 @@ pipe-delimited (|) syntax.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    AUTO:SHIELDPROF|SHIELDTYPE=Buckler
-   </code>
+   <code>AUTO:SHIELDPROF|SHIELDTYPE=Buckler</code>
   </p>
   <p class="indent3">
    Buckler shield is given as a free shield
 proficiency.
   </p>
   <p class="indent2">
-   <code>
-    AUTO:SHIELDPROF|SHIELDTYPE=Buckler|SHIELDTYPE=Light|SHIELDTYPE=Heavy
-   </code>
+   <code>AUTO:SHIELDPROF|SHIELDTYPE=Buckler|SHIELDTYPE=Light|SHIELDTYPE=Heavy</code>
   </p>
   <p class="indent3">
    Buckler, Light, and Heavy Shields are given as
@@ -948,22 +854,16 @@ proficiency type.
    </li>
    <li>
     When including the
-    <code>
-     TYPE=Text
-    </code>
+    <code>TYPE=Text</code>
     or
-    <code>
-     TYPE,Text
-    </code>
+    <code>TYPE,Text</code>
     sub-tag you may use a period-delimted (.)
 list of weapon types. This will grant the character proficiency
 with weapons that meet all of the listed weapon types.
    </li>
    <li>
     When using the
-    <code>
-     DEITYWEAPONS
-    </code>
+    <code>DEITYWEAPONS</code>
     sub-tag, all of the
 deity's favored weapons, except for natural weapons, are added. If
 the deity specifies "ALL" or "ANY" for its favored weapon, no
@@ -980,83 +880,65 @@ pipe-delimited (|) syntax.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    AUTO:WEAPONPROF|Longsword|Shortbow
-(Composite)
-   </code>
+   <code>AUTO:WEAPONPROF|Longsword|Shortbow
+(Composite)</code>
   </p>
   <p class="indent3">
    The "Longsword" and "Shortbow (Composite)" are
 given as free weapon proficiencies.
   </p>
   <p class="indent2">
-   <code>
-    AUTO:WEAPONPROF|TYPE.Simple
-   </code>
+   <code>AUTO:WEAPONPROF|TYPE.Simple</code>
   </p>
   <p class="indent3">
    All "Simple" weapons are given as free weapon
 proficiencies.
   </p>
   <p class="indent2">
-   <code>
-    AUTO:WEAPONPROF|TYPE.Simple|TYPE.Martial
-   </code>
+   <code>AUTO:WEAPONPROF|TYPE.Simple|TYPE.Martial</code>
   </p>
   <p class="indent3">
    All "Simple" and "Martial" weapons are given as
 free weapon proficiencies.
   </p>
   <p class="indent2">
-   <code>
-    AUTO:WEAPONPROF|TYPE.Ranged|TYPE.Piercing|TYPE.Simple
-   </code>
+   <code>AUTO:WEAPONPROF|TYPE.Ranged|TYPE.Piercing|TYPE.Simple</code>
   </p>
   <p class="indent3">
    All "Ranged", "Piercing" and "Simple" weapons
 are given as free weapon proficiencies.
   </p>
   <p class="indent2">
-   <code>
-    AUTO:WEAPONPROF|TYPE.Martial.Slashing
-   </code>
+   <code>AUTO:WEAPONPROF|TYPE.Martial.Slashing</code>
   </p>
   <p class="indent3">
    All "Martial" weapons that are "Slashing" type
 are given as free weapon proficiencies.
   </p>
   <p class="indent2">
-   <code>
-    AUTO:WEAPONPROF|TYPE.Martial.Slashing.Melee
-   </code>
+   <code>AUTO:WEAPONPROF|TYPE.Martial.Slashing.Melee</code>
   </p>
   <p class="indent3">
    All "Melee" type "Martial" weapons that are
 "Slashing" type are given as free weapon proficiencies.
   </p>
   <p class="indent2">
-   <code>
-    AUTO:WEAPONPROF|DEITYWEAPONS
-   </code>
+   <code>AUTO:WEAPONPROF|DEITYWEAPONS</code>
   </p>
   <p class="indent3">
    All favored weapons of the character's deity are
 given as free weapon proficiencies.
   </p>
   <p class="indent2">
-   <code>
-    AUTO:WEAPONPROF|TYPE=NoProfReq|Longspear|Javelin
-   </code>
+   <code>AUTO:WEAPONPROF|TYPE=NoProfReq|Longspear|Javelin</code>
   </p>
   <p class="indent3">
    All "NoProfReq" and "Longspear" and "Javelin"
 weapons are given as free weapon proficiencies.
   </p>
   <p class="indent2">
-   <code>
-    CLASS:Rogue.MOD &lt;tab&gt;
-AUTO:WEAPONPROF|Gladius
-   </code>
+   <code>CLASS:Rogue.MOD &lt;tab&gt;
+AUTO:WEAPONPROF|Gladius</code>
   </p>
   <p class="indent3">
    Modified the Rogue Class to include the Gladius
@@ -1141,46 +1023,36 @@ classes the character possesses.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CSKILL:Listen|Spot
-   </code>
+   <code>CSKILL:Listen|Spot</code>
   </p>
   <p class="indent3">
    The "Listen" and "Spot" skills are made class
 skills.
   </p>
   <p class="indent2">
-   <code>
-    CSKILL:Search|TYPE.Knowledge
-   </code>
+   <code>CSKILL:Search|TYPE.Knowledge</code>
   </p>
   <p class="indent3">
    The "Search" and "Knowledge" type skills are
 made class skills.
   </p>
   <p class="indent2">
-   <code>
-    CSKILL:ALL
-   </code>
+   <code>CSKILL:ALL</code>
   </p>
   <p class="indent3">
    All skills are made class skills.
   </p>
   <p class="indent2">
-   <code>
-    CSKILL:LIST
-   </code>
+   <code>CSKILL:LIST</code>
   </p>
   <p class="indent3">
    Skills selected in the associated choice are
 made class skills. (In Abilities and Feats)
   </p>
   <p class="indent2">
-   <code>
-    CLASS:Sorcerer.MOD &lt;tab&gt;
+   <code>CLASS:Sorcerer.MOD &lt;tab&gt;
 CSKILL:.CLEAR.Scry &lt;tab&gt;
-CSKILL:Drive|TYPE.Knowledge|Perform
-   </code>
+CSKILL:Drive|TYPE.Knowledge|Perform</code>
   </p>
   <p class="indent3">
    Modifies the Class Sorcerer, droping the class
@@ -1188,23 +1060,19 @@ skill "Scry" and adding "Drive, Perform and all TYPE.Knowledge"
 skills.
   </p>
   <p class="indent2">
-   <code>
-    CLASS:Blackguard.MOD &lt;tab&gt;
+   <code>CLASS:Blackguard.MOD &lt;tab&gt;
 CSKILL:.CLEAR &lt;tab&gt;
 CSKILL:Concentration|TYPE.Craft|Diplomacy|Heal|Intimidate|Knowledge
-(Religion)|TYPE.Profession|Climb|Jump|Listen|Spot|Swim|Pilot
-   </code>
+(Religion)|TYPE.Profession|Climb|Jump|Listen|Spot|Swim|Pilot</code>
   </p>
   <p class="indent3">
    Modified Class that removes all class skills in
 the object previously, then adds in the specific list.
   </p>
   <p class="indent2">
-   <code>
-    CLASS:Blackguard.MOD &lt;tab&gt;
+   <code>CLASS:Blackguard.MOD &lt;tab&gt;
 CSKILL:.CLEAR.Handle Animal|.CLEAR.Ride|Heal &lt;tab&gt;
-CSKILL:Pilot
-   </code>
+CSKILL:Pilot</code>
   </p>
   <p class="indent3">
    Modified Class that removes only Handle Animal
@@ -1256,41 +1124,33 @@ cross-class skills.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CCSKILL:Listen|Spot
-   </code>
+   <code>CCSKILL:Listen|Spot</code>
   </p>
   <p class="indent3">
    The "Listen" and "Spot" skills are made
 cross-class skills.
   </p>
   <p class="indent2">
-   <code>
-    CCSKILL:Search|TYPE.Knowledge
-   </code>
+   <code>CCSKILL:Search|TYPE.Knowledge</code>
   </p>
   <p class="indent3">
    The "Search" and "Knowledge" type skills are
 made cross-class skills.
   </p>
   <p class="indent2">
-   <code>
-    CCSKILL:LIST
-   </code>
+   <code>CCSKILL:LIST</code>
   </p>
   <p class="indent3">
    Skills selected in the associated choice are
 made cross-class skills.
   </p>
   <p class="indent2">
-   <code>
-    CLASS:Blackguard.MOD &lt;tab&gt;
+   <code>CLASS:Blackguard.MOD &lt;tab&gt;
 STARTSKILLPTS:2 &lt;tab&gt; CSKILL:.CLEAR|Handle Animal|Ride
 &lt;tab&gt;
 CSKILL:Concentration|TYPE.Craft|Diplomacy|Heal|Intimidate|Knowledge
 (Religion)|TYPE.Profession|Climb|Jump|Listen|Spot|Swim|Pilot
-&lt;tab&gt; CCSKILL:Handle Animal|Ride
-   </code>
+&lt;tab&gt; CCSKILL:Handle Animal|Ride</code>
   </p>
   <p class="indent3">
    Modified Class that changes all of these Tags
@@ -1350,19 +1210,15 @@ category.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHANGEPROF:Urgrosh (Dwarven),Waraxe
-(Dwarven)=Martial
-   </code>
+   <code>CHANGEPROF:Urgrosh (Dwarven),Waraxe
+(Dwarven)=Martial</code>
   </p>
   <p class="indent3">
    Changes the above weapons to be Martial weapons
 for proficiency purposes.
   </p>
   <p class="indent2">
-   <code>
-    CHANGEPROF:TYPE.Hammer=Simple
-   </code>
+   <code>CHANGEPROF:TYPE.Hammer=Simple</code>
   </p>
   <p class="indent3">
    Changes all weapons of TYPE Hammer to be Simple
@@ -1431,16 +1287,12 @@ companions for the specified companion type.
    </li>
    <li>
     PRExxx tags can be added at the end of
-    <code>
-     COMPANIONLIST
-    </code>
+    <code>COMPANIONLIST</code>
     tags, PRExxx tags are checked against
 the master.
    </li>
    <li>
-    <code>
-     FOLLOWERADJUSTMENT
-    </code>
+    <code>FOLLOWERADJUSTMENT</code>
     will modify the masters
 effective level when determining the benefits gained from the
 companion creature.
@@ -1452,9 +1304,7 @@ companion creature.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    COMPANIONLIST:Familiar|Bat,Cat,Hawk,Lizard,Owl,Rat,Raven,Snake(Tiny/Viper),Toad,Weasel
-   </code>
+   <code>COMPANIONLIST:Familiar|Bat,Cat,Hawk,Lizard,Owl,Rat,Raven,Snake(Tiny/Viper),Toad,Weasel</code>
   </p>
   <p class="indent3">
    Would build the list consisting of the Bat, Cat,
@@ -1462,38 +1312,30 @@ Hawk, Lizard, Owl, Rat, Raven, Snake(Tiny/Viper), Toad, and Weasel
 and make them available to be familiars.
   </p>
   <p class="indent2">
-   <code>
-    COMPANIONLIST:Pet|RACETYPE=Animal
-   </code>
+   <code>COMPANIONLIST:Pet|RACETYPE=Animal</code>
   </p>
   <p class="indent3">
    Would build a list of all animals and make them
 available to be a Pet.
   </p>
   <p class="indent2">
-   <code>
-    COMPANIONLIST:Pet|RACESUBTYPE=Fire
-   </code>
+   <code>COMPANIONLIST:Pet|RACESUBTYPE=Fire</code>
   </p>
   <p class="indent3">
    Would build a list of all creatures with a race
 subtype of 'Fire' and make them available to be a Pet.
   </p>
   <p class="indent2">
-   <code>
-    COMPANIONLIST:Familiar|Quasit|PREFEAT:1,Special
-Familiar|PREALIGN:CE
-   </code>
+   <code>COMPANIONLIST:Familiar|Quasit|PREFEAT:1,Special
+Familiar|PREALIGN:CE</code>
   </p>
   <p class="indent3">
    A Quasit can be chosen as a Familiar but only if
 the master is evil and has the Special Familiar feat.
   </p>
   <p class="indent2">
-   <code>
-    COMPANIONLIST:Animal
-Companion|Ape|FOLLOWERADJUSTMENT:-3
-   </code>
+   <code>COMPANIONLIST:Animal
+Companion|Ape|FOLLOWERADJUSTMENT:-3</code>
   </p>
   <p class="indent3">
    An Ape companion to a 4th level master gains the
@@ -1549,9 +1391,7 @@ such as the undead's lack of a constitution score.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DEFINE:LOCK.CON|10
-   </code>
+   <code>DEFINE:LOCK.CON|10</code>
   </p>
   <p class="indent3">
    Constitution is set to 10 and an asterisk is
@@ -1564,13 +1404,9 @@ tag:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DEFINE:LOCK.CON|10
-   </code>
+   <code>DEFINE:LOCK.CON|10</code>
    becomes
-   <code>
-    DEFINESTAT:LOCK|CON|10
-   </code>
+   <code>DEFINESTAT:LOCK|CON|10</code>
   </p>
   <hr/>
   <p class="lstdep">
@@ -1615,9 +1451,7 @@ DEFINE:LOCK
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DEFINE:UNLOCK.CON
-   </code>
+   <code>DEFINE:UNLOCK.CON</code>
   </p>
   <p class="indent3">
    Constitution is unlocked.
@@ -1629,13 +1463,9 @@ tag:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DEFINE:UNLOCK.CON
-   </code>
+   <code>DEFINE:UNLOCK.CON</code>
    becomes
-   <code>
-    DEFINESTAT:UNLOCK|CON
-   </code>
+   <code>DEFINESTAT:UNLOCK|CON</code>
   </p>
   <hr/>
   <p class="lstnew">
@@ -1711,9 +1541,7 @@ Formula
     <ul>
      <li>
       Using
-      <code>
-       LOCK
-      </code>
+      <code>LOCK</code>
       will lock the designated ability score
 (y) to the value (z) regardless of any other bonuses to that
 ability score except for those applied by the
@@ -1724,22 +1552,16 @@ ability score except for those applied by the
      </li>
      <li>
       Using
-      <code>
-       UNLOCK
-      </code>
+      <code>UNLOCK</code>
       will unlock the designated ability
 score (y) that has previously been locked.
      </li>
      <li>
       The
-      <code>
-       UNLOCK
-      </code>
+      <code>UNLOCK</code>
       sub-tag will not affect an ability
 score that has been designated as a "nonstat". (see
-      <code>
-       NONSTAT
-      </code>
+      <code>NONSTAT</code>
       below).
      </li>
     </ul>
@@ -1754,18 +1576,14 @@ initialized during character creation.
      </li>
      <li>
       Using
-      <code>
-       NONSTAT
-      </code>
+      <code>NONSTAT</code>
       will change an ability score to a
 non-stat, causing it to be shown as an asterisk (*) on output
 sheets and prohibiting any bonuses from being applied.
      </li>
      <li>
       Using
-      <code>
-       STAT
-      </code>
+      <code>STAT</code>
       will change an ability score that has
 been previously designated as a nonstat back to a stat without
 affecting its locked/unlocked state.
@@ -1774,17 +1592,13 @@ affecting its locked/unlocked state.
    </li>
    <li>
     Using
-    <code>
-     MINVALUE
-    </code>
+    <code>MINVALUE</code>
     defines the minimum value (z) for
 the designated ability score (y).
    </li>
    <li>
     Using
-    <code>
-     MAXVALUE
-    </code>
+    <code>MAXVALUE</code>
     defines the maximum value (z) for
 the designated ability score (y).
    </li>
@@ -1795,26 +1609,20 @@ the designated ability score (y).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DEFINESTAT:LOCK|INT|10
-   </code>
+   <code>DEFINESTAT:LOCK|INT|10</code>
   </p>
   <p class="indent3">
    Locks the stat "Intelligence" to 10.
   </p>
   <p class="indent2">
-   <code>
-    DEFINESTAT:UNLOCK|INT
-   </code>
+   <code>DEFINESTAT:UNLOCK|INT</code>
   </p>
   <p class="indent3">
    Unlocks previously locked stat
 "Intelligence".
   </p>
   <p class="indent2">
-   <code>
-    DEFINESTAT:NONSTAT|INT
-   </code>
+   <code>DEFINESTAT:NONSTAT|INT</code>
   </p>
   <p class="indent3">
    Changes the ability score "Intelligence" to a
@@ -1822,9 +1630,7 @@ non-stat, causing it to appear on the output sheet as an
 asterisk.
   </p>
   <p class="indent2">
-   <code>
-    DEFINESTAT:STAT|INT
-   </code>
+   <code>DEFINESTAT:STAT|INT</code>
   </p>
   <p class="indent3">
    Changes the ability score "Intelligence" that
@@ -1832,18 +1638,14 @@ has been previously changed to a non-stat back to a normal
 stat.
   </p>
   <p class="indent2">
-   <code>
-    DEFINESTAT:MINVALUE|INT|3
-   </code>
+   <code>DEFINESTAT:MINVALUE|INT|3</code>
   </p>
   <p class="indent3">
    The creature cannot have an "Intelligence" less
 than 3.
   </p>
   <p class="indent2">
-   <code>
-    DEFINESTAT:MAXVALUE|INT|10
-   </code>
+   <code>DEFINESTAT:MAXVALUE|INT|10</code>
   </p>
   <p class="indent3">
    The creature cannot have an "Intelligence" more
@@ -1912,54 +1714,38 @@ description)
   <ul class="indent1">
    <li>
     The
-    <code>
-     DESC
-    </code>
+    <code>DESC</code>
     tags provides a description appropriate
 for the object it is attached to, i.e. ability, deity, domain,
 equipment, feat, or spell.
    </li>
    <li>
     PRExxx tags can be used with the
-    <code>
-     DESC
-    </code>
+    <code>DESC</code>
     tag.
    </li>
    <li>
     Multiple
-    <code>
-     DESC
-    </code>
+    <code>DESC</code>
     tags per line are allowed with all
 qualifying
-    <code>
-     DESC
-    </code>
+    <code>DESC</code>
     tags being concatonated for output and
 separated by spaces.
    </li>
    <li>
-    <code>
-     .CLEAR
-    </code>
+    <code>.CLEAR</code>
     will clear all
-    <code>
-     DESC
-    </code>
+    <code>DESC</code>
     tags.
    </li>
    <li>
-    <code>
-     .CLEAR.(regular expression match)
-    </code>
+    <code>.CLEAR.(regular expression match)</code>
     will clear
 specific instances.
    </li>
    <li>
-    <code>
-     DESC
-    </code>
+    <code>DESC</code>
     tags now take variable substitution.
     <br/>
     <ul>
@@ -1967,14 +1753,10 @@ specific instances.
       Within the text a percent-sign (%) followed by a number (#)
 will substitute the #th variable from the variable list associated
 with the
-      <code>
-       DESC
-      </code>
+      <code>DESC</code>
       . For example, %1 will substitute the
 first variable into that position in the
-      <code>
-       DESC
-      </code>
+      <code>DESC</code>
      </li>
      <li>
       Variables are specified at the end of the descriptive text and
@@ -1997,34 +1779,24 @@ list:
     <br/>
     <ul>
      <li>
-      <code>
-       %CHOICE
-      </code>
+      <code>%CHOICE</code>
       - Will replace the first associated choice
 in the object.
      </li>
      <li>
-      <code>
-       %FEAT
-      </code>
+      <code>%FEAT</code>
       - Will substitute the descriptions of feats
 within the object that match the associated preqrequisites.
      </li>
      <li>
-      <code>
-       %LIST
-      </code>
+      <code>%LIST</code>
       - Will substitute all choices comma
 separated into that parameter.
      </li>
      <li>
-      <code>
-       %NAME
-      </code>
+      <code>%NAME</code>
       - The name of the object this
-      <code>
-       DESC
-      </code>
+      <code>DESC</code>
       tag is in.
      </li>
     </ul>
@@ -2055,19 +1827,13 @@ structures using things like character groups "[a-zA-Z]" match any
 alphabetic character or groupings "(bat|super)man" match batman or
 superman and many many more. So, for example, you could clear all
 DESC tags by doing
-      <code>
-       DESC:.CLEAR..*
-      </code>
+      <code>DESC:.CLEAR..*</code>
       , or clear all
 exceptional abilities by doing
-      <code>
-       DESC:.CLEAR.\(Ex\)
-      </code>
+      <code>DESC:.CLEAR.\(Ex\)</code>
       , or
 clear everything that's non-numeric with
-      <code>
-       DESC:.CLEAR.[A-Za-z]
-      </code>
+      <code>DESC:.CLEAR.[A-Za-z]</code>
       .
      </li>
     </ul>
@@ -2079,70 +1845,56 @@ clear everything that's non-numeric with
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DESC:This domain grants the turn code
-monkey speech into english
-   </code>
+   <code>DESC:This domain grants the turn code
+monkey speech into english</code>
   </p>
   <p class="indent3">
    The domain description.
   </p>
   <p class="indent2">
-   <code>
-    DESC:This is a description of the
-item.
-   </code>
+   <code>DESC:This is a description of the
+item.</code>
   </p>
   <p class="indent3">
    Adds a description for the equipment.
   </p>
   <p class="indent2">
-   <code>
-    DESC:This is sample text for the example
-purposes
-   </code>
+   <code>DESC:This is sample text for the example
+purposes</code>
   </p>
   <p class="indent3">
    Adds feat description.
   </p>
   <p class="indent2">
-   <code>
-    DESC:Kick Butt (level
-3)|PRELEVEL:3
-   </code>
+   <code>DESC:Kick Butt (level
+3)|PRELEVEL:3</code>
   </p>
   <p class="indent3">
    Adds feat description only if the PC is level 3
 or higher.
   </p>
   <p class="indent2">
-   <code>
-    DESC:Assembly ~ 1
+   <code>DESC:Assembly ~ 1
 table|PREVAREQ:AssemblyTables,1
     <br/>
     DESC:Assembly ~ %1
-tables|AssemblyTables|PREVARGTEQ:AssemblyTables,2
-   </code>
+tables|AssemblyTables|PREVARGTEQ:AssemblyTables,2</code>
   </p>
   <p class="indent3">
    Adds a feat description which is dependent upon
 the value of the variable AssemblyTables.
   </p>
   <p class="indent2">
-   <code>
-    DESC:You get a +2 bonus on all %1 saving
-throws|%CHOICE
-   </code>
+   <code>DESC:You get a +2 bonus on all %1 saving
+throws|%CHOICE</code>
   </p>
   <p class="indent3">
    Adds feat description and replaces %1 with the
 first choice made.
   </p>
   <p class="indent2">
-   <code>
-    DESC:Bardic Music %1/day
-(%2)|BardicMusicTimes|%FEAT=TYPE.BardicMusic
-   </code>
+   <code>DESC:Bardic Music %1/day
+(%2)|BardicMusicTimes|%FEAT=TYPE.BardicMusic</code>
   </p>
   <p class="indent3">
    The variable "BardicMusicTimes" is substituted
@@ -2151,62 +1903,50 @@ with type "BardicMusic" are concatenated and substituted for
 "%2".
   </p>
   <p class="indent2">
-   <code>
-    DESC:You get a +3 bonus on all checks
-involving %1|%LIST.
-   </code>
+   <code>DESC:You get a +3 bonus on all checks
+involving %1|%LIST.</code>
   </p>
   <p class="indent3">
    Adds feat description replaces %LIST with all
 choices made.
   </p>
   <p class="indent2">
-   <code>
-    DESC:%3 Sneak Attacks per day for +%1d%2
-damage|SneakAttack|SneakAttackDie|SneakAttackTimes
-   </code>
+   <code>DESC:%3 Sneak Attacks per day for +%1d%2
+damage|SneakAttack|SneakAttackDie|SneakAttackTimes</code>
   </p>
   <p class="indent3">
    Adds feat description substituting the variables
 from the positions specified.
   </p>
   <p class="indent2">
-   <code>
-    Advanced Combat Martial Arts.MOD
+   <code>Advanced Combat Martial Arts.MOD
 &lt;tab&gt; DESC:.CLEAR &lt;tab&gt; DESC:When the character scores
 a critical hit on an opponent with an unarmed strike, the character
-deals triple damage
-   </code>
+deals triple damage</code>
   </p>
   <p class="indent3">
    Changes the feat description, substituting the
 specified.
   </p>
   <p class="indent2">
-   <code>
-    DESC:Toasts the monsters with
-fire
-   </code>
+   <code>DESC:Toasts the monsters with
+fire</code>
   </p>
   <p class="indent3">
    What the spell does.
   </p>
   <p class="indent2">
-   <code>
-    DESC:Target is prone for (CASTERLEVEL)
-rounds.
-   </code>
+   <code>DESC:Target is prone for (CASTERLEVEL)
+rounds.</code>
   </p>
   <p class="indent3">
    If the value of CASTERLEVEL is equal to 3 then
 this would output: "Target is prone for 3 rounds.".
   </p>
   <p class="indent2">
-   <code>
-    Maximize Power.MOD &lt;tab&gt; DESC:.CLEAR
+   <code>Maximize Power.MOD &lt;tab&gt; DESC:.CLEAR
 &lt;tab&gt; DESC:You can manifest powers to maximum
-effect.
-   </code>
+effect.</code>
   </p>
   <p class="indent3">
    Replaces the standard spell DESC with the
@@ -2247,9 +1987,7 @@ description. Default is NO.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DESCISPI:YES
-   </code>
+   <code>DESCISPI:YES</code>
   </p>
   <p class="indent3">
    It will bold and italicize the description of an
@@ -2332,17 +2070,13 @@ prerequisites.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DR:10/+1
-   </code>
+   <code>DR:10/+1</code>
   </p>
   <p class="indent3">
    Grants DR of 10/+1 on output.
   </p>
   <p class="indent2">
-   <code>
-    DR:2/-|PRESTAT:1,CON=18
-   </code>
+   <code>DR:2/-|PRESTAT:1,CON=18</code>
   </p>
   <p class="indent3">
    Grants DR of 2/- if the character has a
@@ -2413,9 +2147,7 @@ Domains.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    FOLLOWERS:Familiar|1
-   </code>
+   <code>FOLLOWERS:Familiar|1</code>
   </p>
   <p class="indent3">
    A character is allowed only 1 companion of type
@@ -2461,9 +2193,7 @@ of kit).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    KIT:1|Wizard1|Illusionist1
-   </code>
+   <code>KIT:1|Wizard1|Illusionist1</code>
   </p>
   <p class="indent3">
    Offers a choice of the Wizard1 or Illusionist1
@@ -2504,9 +2234,7 @@ movement types the race has.
   </p>
   <p class="sidebar0">
    Note: Each race should always have a
-   <code>
-    MOVE
-   </code>
+   <code>MOVE</code>
    entry as this is required for other objects to
 later adjust the movement.
   </p>
@@ -2516,9 +2244,7 @@ later adjust the movement.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    MOVE:Walk,30,Fly,10
-   </code>
+   <code>MOVE:Walk,30,Fly,10</code>
   </p>
   <p class="indent3">
    This would grant a walking speed of 30 ft per
@@ -2530,10 +2256,8 @@ round and a flying speed of 10 feet per round
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    This can be used anywhere except Equipment
-and Equipment Mod files.
-   </code>
+   <code>This can be used anywhere except Equipment
+and Equipment Mod files.</code>
   </p>
   <hr/>
   <p class="indent0">
@@ -2590,18 +2314,14 @@ assumed
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    MOVECLONE:Walk,Fly,*2
-   </code>
+   <code>MOVECLONE:Walk,Fly,*2</code>
   </p>
   <p class="indent3">
    Create the "Fly" movement type and set it equal
 to "Walk" multiplied by 2.
   </p>
   <p class="indent2">
-   <code>
-    MOVECLONE:Walk,Tunnel,/3
-   </code>
+   <code>MOVECLONE:Walk,Tunnel,/3</code>
   </p>
   <p class="indent3">
    Create "Tunnel" movement type and set it equal
@@ -2640,9 +2360,7 @@ Identity. The Default is "NO".
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    NAMEISPI:YES
-   </code>
+   <code>NAMEISPI:YES</code>
   </p>
   <p class="indent3">
    The name is the Product Identity
@@ -2725,9 +2443,7 @@ must be present.
    </li>
    <li>
     For multiple attacks included in the same
-    <code>
-     NATURALATTACKS
-    </code>
+    <code>NATURALATTACKS</code>
     tag, the first is treated as a primary
 weapon and the second is treated as a secondary attack.
    </li>
@@ -2761,24 +2477,16 @@ otherwise, the attacks will always be size "Medium".
    </li>
    <li>
     The
-    <code>
-     NATURALATTACKS
-    </code>
+    <code>NATURALATTACKS</code>
     tag creates a proficiency for
 the attacks on the fly which allows the use of the
-    <code>
-     BONUS:WEAPONPROF
-    </code>
+    <code>BONUS:WEAPONPROF</code>
     tag to effect it. For example, if you
 used the
-    <code>
-     NATURALATTACKS
-    </code>
+    <code>NATURALATTACKS</code>
     tag to create a Bite attack
 you could then use
-    <code>
-     BONUS:WEAPONPROF=Bite|DAMAGE,TOHIT|2
-    </code>
+    <code>BONUS:WEAPONPROF=Bite|DAMAGE,TOHIT|2</code>
     to add 2 to the
 attack and damage rolls.
    </li>
@@ -2789,17 +2497,13 @@ attack and damage rolls.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    NATURALATTACKS:Claw,Weapon.Natural.Melee.Piercing.Slashing,*2,1d4|Bite,Weapon.Natural.Melee.Bludgeoning.Piercing.Slashing,*1,1d6
-   </code>
+   <code>NATURALATTACKS:Claw,Weapon.Natural.Melee.Piercing.Slashing,*2,1d4|Bite,Weapon.Natural.Melee.Bludgeoning.Piercing.Slashing,*1,1d6</code>
   </p>
   <p class="indent3">
    Race has 2 Claw attacks and a Bite attack.
   </p>
   <p class="indent2">
-   <code>
-    NATURALATTACKS:Slam,Weapon.Natural.Melee.Bludgeoning,*1,2d4,SPROP=plus 1d4 acid and grab
-   </code>
+   <code>NATURALATTACKS:Slam,Weapon.Natural.Melee.Bludgeoning,*1,2d4,SPROP=plus 1d4 acid and grab</code>
   </p>
   <p class="indent3">
    Race has a single slam attack that has the extra
@@ -2851,17 +2555,13 @@ to appear on the output sheet)
    </li>
    <li>
     The
-    <code>
-     [NAME]
-    </code>
+    <code>[NAME]</code>
     tag, when used, will be replaced by the
 parenthetical text in the object's name.
    </li>
    <li>
     If the
-    <code>
-     [NAME]
-    </code>
+    <code>[NAME]</code>
     tag is used where there is no
 parenthetical text the object name itself is output.
    </li>
@@ -2879,55 +2579,43 @@ sacrificing the preferred name of the object.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    OUTPUTNAME:Jason's [NAME]
-   </code>
+   <code>OUTPUTNAME:Jason's [NAME]</code>
   </p>
   <p class="indent3">
    LST entry "Magic Spell" will output as "Jason's
 Magic Spell"
   </p>
   <p class="indent2">
-   <code>
-    OUTPUTNAME:[NAME] Elf
-   </code>
+   <code>OUTPUTNAME:[NAME] Elf</code>
   </p>
   <p class="indent3">
    LST entry "Elf (Gray)" will output as "Gray
 Elf".
   </p>
   <p class="indent2">
-   <code>
-    OUTPUTNAME:Huge Water Elemental
-   </code>
+   <code>OUTPUTNAME:Huge Water Elemental</code>
   </p>
   <p class="indent3">
    LST entry "Elemental (Water/Huge)" will output
 as "Huge Water Elemental".
   </p>
   <p class="indent2">
-   <code>
-    OUTPUTNAME:Formian [NAME]
-   </code>
+   <code>OUTPUTNAME:Formian [NAME]</code>
   </p>
   <p class="indent3">
    LST entry "Formian (Queen)" will output as
 "Formian Queen".
   </p>
   <p class="indent2">
-   <code>
-    OUTPUTNAME:Potion of [NAME]
-   </code>
+   <code>OUTPUTNAME:Potion of [NAME]</code>
   </p>
   <p class="indent3">
    LST entry "Potion (Glibness)" will output as
 "Potion of Glibness".
   </p>
   <p class="indent2">
-   <code>
-    Clenched Fist.MOD &lt;tab&gt;
-OUTPUTNAME:Big [NAME]
-   </code>
+   <code>Clenched Fist.MOD &lt;tab&gt;
+OUTPUTNAME:Big [NAME]</code>
   </p>
   <p class="indent3">
    This spell will output as "Big Clenched
@@ -3041,39 +2729,31 @@ selection for the character.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    QUALIFY:ABILITY=FEAT|Mounted
-Combat|Ride-By Attack
-   </code>
+   <code>QUALIFY:ABILITY=FEAT|Mounted
+Combat|Ride-By Attack</code>
   </p>
   <p class="indent3">
    The character would be able to take the above
 feats whether they meet the prereqs or not.
   </p>
   <p class="indent2">
-   <code>
-    QUALIFY:FEAT|Mounted Combat|Ride-By
-Attack
-   </code>
+   <code>QUALIFY:FEAT|Mounted Combat|Ride-By
+Attack</code>
   </p>
   <p class="indent3">
    The character would be able to take the above
 feats whether they meet the prereqs or not.
   </p>
   <p class="indent2">
-   <code>
-    QUALIFY:CLASS|Monk
-   </code>
+   <code>QUALIFY:CLASS|Monk</code>
   </p>
   <p class="indent3">
    The character would be able to take the Monk
 class whether they meet the prereqs or not.
   </p>
   <p class="indent2">
-   <code>
-    QUALIFY:CLASS|Battle
-Mind|Telepath
-   </code>
+   <code>QUALIFY:CLASS|Battle
+Mind|Telepath</code>
   </p>
   <p class="indent3">
    The character would be able to take either the
@@ -3132,18 +2812,14 @@ selections to allow)
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    REGION:1|Region1|Region2|Region3
-   </code>
+   <code>REGION:1|Region1|Region2|Region3</code>
   </p>
   <p class="indent3">
    Will allow the choice of Region1, Region2, or
 Region3 as the character's region.
   </p>
   <p class="indent2">
-   <code>
-    REGION:1|Timbuktu
-   </code>
+   <code>REGION:1|Timbuktu</code>
   </p>
   <p class="indent3">
    The PC is from the "Timbuktu" region.
@@ -3167,21 +2843,15 @@ Region3 as the character's region.
     <ul class="incremental">
      <li>
       All
-      <code>
-       FEAT
-      </code>
+      <code>FEAT</code>
       tags have been
       <strong>
        deprecated
       </strong>
       and replaced by the
-      <code>
-       ABILITY
-      </code>
+      <code>ABILITY</code>
       system, which is more general. The
-      <code>
-       ABILITY
-      </code>
+      <code>ABILITY</code>
       system can model feats, racial features, class
 features, traits, flaws, temporary bonuses, and so on, all using a
 common format.
@@ -3257,9 +2927,7 @@ variable (y).
     </li>
     <li>
      When
-     <code>
-      ALL
-     </code>
+     <code>ALL</code>
      is used for (x), all indicated feats are
 removed without prompting.
     </li>
@@ -3270,27 +2938,21 @@ removed without prompting.
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     REMOVE:FEAT|Alertness
-    </code>
+    <code>REMOVE:FEAT|Alertness</code>
    </p>
    <p class="indent3">
     Removes the Alertness feat, no choice is
 presented, the feat is simply removed.
    </p>
    <p class="indent2">
-    <code>
-     REMOVE:FEAT|TYPE.Fighter
-    </code>
+    <code>REMOVE:FEAT|TYPE.Fighter</code>
    </p>
    <p class="indent3">
     Presents a list of Fighter type feats and allows
 the removal of up to 3.
    </p>
    <p class="indent2">
-    <code>
-     REMOVE:FEAT|2|CHOICE
-    </code>
+    <code>REMOVE:FEAT|2|CHOICE</code>
    </p>
    <p class="indent3">
     Presents a list of all feats the character has
@@ -3298,9 +2960,7 @@ and allows the removal of 2 of them. If a feat has a cost
 associated with it, it returns that cost to the feat pool.
    </p>
    <p class="indent2">
-    <code>
-     REMOVE:FEAT|ALL|CLASS.Paladin
-    </code>
+    <code>REMOVE:FEAT|ALL|CLASS.Paladin</code>
    </p>
    <p class="indent3">
     Removes all feats that have been granted/taken
@@ -3368,52 +3028,36 @@ has.
    </li>
    <li>
     The
-    <code>
-     %
-    </code>
+    <code>%</code>
     tag will fill in a number from a variable
 listed after a pipe
-    <code>
-     |
-    </code>
+    <code>|</code>
     .
    </li>
    <li>
     This can be done numerous times, with each successive percent
 sign
-    <code>
-     %
-    </code>
+    <code>%</code>
     relating to the next variable listed after
 another pipe
-    <code>
-     |
-    </code>
+    <code>|</code>
     .
    </li>
    <li>
     This can be specified via number of
-    <code>
-     %#
-    </code>
+    <code>%#</code>
     , with each
 successive numbered
-    <code>
-     %
-    </code>
+    <code>%</code>
     relating to the next variable
 listed after another pipe
-    <code>
-     |
-    </code>
+    <code>|</code>
     . The count starts at zero
 and counts up.
    </li>
    <li>
     Each variable needs to be defined (via the global
-    <code>
-     DEFINE
-    </code>
+    <code>DEFINE</code>
     tag.)
    </li>
    <li>
@@ -3421,58 +3065,40 @@ and counts up.
 or formula equals zero.
    </li>
    <li>
-    <code>
-     SAB:.CLEAR
-    </code>
+    <code>SAB:.CLEAR</code>
     can be used in conjunction with the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     but does not support cross-level
 interactions.
    </li>
    <li>
-    <code>
-     SAB:.CLEAR
-    </code>
+    <code>SAB:.CLEAR</code>
     will only clear a previous
-    <code>
-     SAB
-    </code>
+    <code>SAB</code>
     in the same object (class, template, etc.). It
 will not clear them across objects.
    </li>
    <li>
-    <code>
-     SAB:.CLEAR.Text
-    </code>
+    <code>SAB:.CLEAR.Text</code>
     must include the exact text of the
 Special Ability to be removed but only the exact text up to the
 first open-parentheses. The
-    <code>
-     CLEAR
-    </code>
+    <code>CLEAR</code>
     and Replace tags
 should be at the end of the line, so the new and old tags are
 not.
    </li>
    <li>
     SAB tags can be qualified with
-    <code>
-     [PRExxx](globalfilesprexxx.html)
-    </code>
+    <code>[PRExxx](globalfilesprexxx.html)</code>
     tags.
    </li>
    <li>
     SAB tags can be used with
-    <code>
-     %CHOICE
-    </code>
+    <code>%CHOICE</code>
     tags to display
 the result of a
-    <code>
-     CHOOSE
-    </code>
+    <code>CHOOSE</code>
     result.
    </li>
   </ul>
@@ -3482,9 +3108,7 @@ the result of a
   <ol>
    <li>
     <p>
-     <code>
-      SAB:Fire in the Hole
-     </code>
+     <code>SAB:Fire in the Hole</code>
     </p>
     <p>
      Grants the special ability "Fire in the Hole".
@@ -3492,42 +3116,28 @@ the result of a
    </li>
    <li>
     <p>
-     <code>
-      SAB:Sneak Attack +%d%|Sneak Attack|Sneak Attack
-Die
-     </code>
+     <code>SAB:Sneak Attack +%d%|Sneak Attack|Sneak Attack
+Die</code>
     </p>
     <p>
      If the PC's
-     <code>
-      Sneak Attack
-     </code>
+     <code>Sneak Attack</code>
      variable had value
-     <code>
-      2
-     </code>
+     <code>2</code>
      , and the PC's
-     <code>
-      Sneak Attack Die
-     </code>
+     <code>Sneak Attack Die</code>
      variable
 had value
-     <code>
-      6
-     </code>
+     <code>6</code>
      , this would grant the special ability
-     <code>
-      Sneak Attack +2d6
-     </code>
+     <code>Sneak Attack +2d6</code>
      .
     </p>
    </li>
    <li>
     <p>
-     <code>
-      SAB:.CLEAR.+1d6 to natural weapons →
-SAB:+1d8 to natural weapons
-     </code>
+     <code>SAB:.CLEAR.+1d6 to natural weapons →
+SAB:+1d8 to natural weapons</code>
     </p>
     <p>
      Clears the "Natural Weapons" value and makes it +1d8
@@ -3536,9 +3146,7 @@ instead.
    </li>
    <li>
     <p>
-     <code>
-      SAB:Banana toss|PRERACE:monkey
-     </code>
+     <code>SAB:Banana toss|PRERACE:monkey</code>
     </p>
     <p>
      Grants the special ability "Banana toss" if the character's race
@@ -3547,29 +3155,19 @@ is "monkey".
    </li>
    <li>
     <p>
-     <code>
-      SAB:Banana toss via elemental power of (%CHOICE)
+     <code>SAB:Banana toss via elemental power of (%CHOICE)
 → STACK:NO → MULT:YES
-→ CHOOSE:Air|Earth|Fire|Water
-     </code>
+→ CHOOSE:Air|Earth|Fire|Water</code>
     </p>
     <p>
      Offers a Choice between the elemental powers of
-     <code>
-      Air
-     </code>
+     <code>Air</code>
      ,
-     <code>
-      Earth
-     </code>
+     <code>Earth</code>
      ,
-     <code>
-      Fire
-     </code>
+     <code>Fire</code>
      and
-     <code>
-      Water
-     </code>
+     <code>Water</code>
      for banana tossing. The same ability may be
 taken multiple times, but a different element must be chosen each
 time.
@@ -3577,15 +3175,11 @@ time.
    </li>
    <li>
     <p>
-     <code>
-      SAB:.CLEAR.Poison
-     </code>
+     <code>SAB:.CLEAR.Poison</code>
     </p>
     <p>
      Clears the
-     <code>
-      Poison
-     </code>
+     <code>Poison</code>
      value and replaces it with
 nothing.
     </p>
@@ -3599,23 +3193,17 @@ nothing.
      :
     </p>
     <pre>
-<code> CLASS:Basketweaver        
+<code>CLASS:Basketweaver        
  1  →  SAB:Basket Toss
  5  →  SAB:.CLEAR.Basket Toss  →  SAB:Greater Basket Toss</code>
 </pre>
     <p>
      Replaces the
-     <code>
-      Basket Toss
-     </code>
+     <code>Basket Toss</code>
      ability with the
-     <code>
-      Greater Basket Toss
-     </code>
+     <code>Greater Basket Toss</code>
      ability at
-     <code>
-      Basketweaver
-     </code>
+     <code>Basketweaver</code>
      class level 5.
     </p>
    </li>
@@ -3634,18 +3222,12 @@ nothing.
 </pre>
     <p>
      Another way of replacing the
-     <code>
-      Basket Toss
-     </code>
+     <code>Basket Toss</code>
      ability
 with the
-     <code>
-      Greater Basket Toss
-     </code>
+     <code>Greater Basket Toss</code>
      ability at
-     <code>
-      Basketweaver
-     </code>
+     <code>Basketweaver</code>
      class level 5.
     </p>
    </li>
@@ -3655,9 +3237,7 @@ with the
   </h4>
   <p>
    The
-   <code>
-    SAB
-   </code>
+   <code>SAB</code>
    tag has no effect on calculations. Its sole
 purpose is to display a short ability description under the
    <i>
@@ -3665,9 +3245,7 @@ purpose is to display a short ability description under the
    </i>
    section of the character sheet. An example
 for
-   <code>
-    SAB:Plays nice with others.
-   </code>
+   <code>SAB:Plays nice with others.</code>
    is shown below.
   </p>
   <p>
@@ -3675,9 +3253,7 @@ for
   </p>
   <p>
    The
-   <code>
-    ASPECT
-   </code>
+   <code>ASPECT</code>
    tag can be used to display similar
 pieces of text in the other boxes,
    <em>
@@ -3697,24 +3273,18 @@ Modifiers
   <ul>
    <li>
     Conditional combat bonus:
-    <code>
-     ASPECT:CombatBonus|+2 to attack
-and damage vs. elves.
-    </code>
+    <code>ASPECT:CombatBonus|+2 to attack
+and damage vs. elves.</code>
    </li>
    <li>
     Conditional saving throw bonus:
-    <code>
-     ASPECT:SaveBonus|-2
-penalty on saving throws vs. fear effects.
-    </code>
+    <code>ASPECT:SaveBonus|-2
+penalty on saving throws vs. fear effects.</code>
    </li>
    <li>
     Conditional skill bonus:
-    <code>
-     ASPECT:SkillBonus|+2 Competence
-bonus on Climb checks when climbing trees.
-    </code>
+    <code>ASPECT:SkillBonus|+2 Competence
+bonus on Climb checks when climbing trees.</code>
    </li>
   </ul>
   <p>
@@ -3763,9 +3333,7 @@ object is taken.
    </li>
    <li>
     This tag is used in conjunction with a
-    <code>
-     CHOOSE
-    </code>
+    <code>CHOOSE</code>
     tag
 that does not already have an integrated number for "choices" to be
 made.
@@ -3776,9 +3344,7 @@ is one (1).
    </li>
    <li>
     Tag is ignored when used in conjunction with
-    <code>
-     CHOOSE:NOCHOICE
-    </code>
+    <code>CHOOSE:NOCHOICE</code>
     .
    </li>
   </ul>
@@ -3788,19 +3354,15 @@ is one (1).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SELECT:3 &lt;tab&gt;
-CHOOSE:SKILLS
-   </code>
+   <code>SELECT:3 &lt;tab&gt;
+CHOOSE:SKILLS</code>
   </p>
   <p class="indent3">
    Allows the selection of "3" skills selected from
 the list of skills currently held by the character.
   </p>
   <p class="indent2">
-   <code>
-    SELECT:INT
-   </code>
+   <code>SELECT:INT</code>
   </p>
   <p class="indent3">
    Allows a number of choices equal to the
@@ -3866,20 +3428,16 @@ by PRExxx tags.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    Super
-Foo&lt;tab&gt;SERVESAS:ABILITY=FEAT|Endurance|Diehard
-   </code>
+   <code>Super
+Foo&lt;tab&gt;SERVESAS:ABILITY=FEAT|Endurance|Diehard</code>
   </p>
   <p class="indent3">
    Allows a character with the feat "Super Foo" to
 pass a prerequisite of "Endurance" or "Diehard".
   </p>
   <p class="indent2">
-   <code>
-    Super Warrior &lt;tab&gt;
-SERVESAS:CLASS|Warrior|Barbarian
-   </code>
+   <code>Super Warrior &lt;tab&gt;
+SERVESAS:CLASS|Warrior|Barbarian</code>
   </p>
   <p class="indent3">
    Allows a character with class levels of "Super
@@ -3957,22 +3515,16 @@ objects, PCGen will sort by
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    Enlarge
-Spell&lt;tab&gt;SORTKEY:Metamagic~Enlarge Spell
-   </code>
+   <code>Enlarge
+Spell&lt;tab&gt;SORTKEY:Metamagic~Enlarge Spell</code>
   </p>
   <p class="indent2">
-   <code>
-    Quicken
-Spell&lt;tab&gt;SORTKEY:11-MetaMagic~Quicken Spell
-   </code>
+   <code>Quicken
+Spell&lt;tab&gt;SORTKEY:11-MetaMagic~Quicken Spell</code>
   </p>
   <p class="indent2">
-   <code>
-    Early Feat&lt;tab&gt;SORTKEY:Z-Me
-last
-   </code>
+   <code>Early Feat&lt;tab&gt;SORTKEY:Z-Me
+last</code>
   </p>
   <p class="indent3">
    Would Display as
@@ -4017,25 +3569,19 @@ Source Name)
    </li>
    <li>
     This tag is used on its own line, with other
-    <code>
-     SOURCExxx
-    </code>
+    <code>SOURCExxx</code>
     tags, or on individual object lines.
    </li>
    <li>
     When used on its own line the
-    <code>
-     SOURCELONG
-    </code>
+    <code>SOURCELONG</code>
     tag will
 be used by all objects which follow it.
    </li>
    <li>
     When used on individual object lines it applies to that object
 and overrides any stand alone
-    <code>
-     SOURCELONG
-    </code>
+    <code>SOURCELONG</code>
     tag on lines
 which preceeded it.
    </li>
@@ -4046,10 +3592,8 @@ which preceeded it.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SOURCELONG:Core Rulebook I (Foo
-Handbook)
-   </code>
+   <code>SOURCELONG:Core Rulebook I (Foo
+Handbook)</code>
   </p>
   <p class="indent3">
    The long source name for this file is "Core
@@ -4091,9 +3635,7 @@ object. This tag is optional.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SOURCELINK:http://www.d20srd.org/srd/spells/aid.htm
-   </code>
+   <code>SOURCELINK:http://www.d20srd.org/srd/spells/aid.htm</code>
   </p>
   <p class="indent3">
    Provides the following active URL:
@@ -4102,9 +3644,7 @@ object. This tag is optional.
    </a>
   </p>
   <p class="indent2">
-   <code>
-    SOURCELINK:http://paizo.com/prd/spells/aid.html
-   </code>
+   <code>SOURCELINK:http://paizo.com/prd/spells/aid.html</code>
   </p>
   <p class="indent3">
    Provides the following active URL:
@@ -4145,19 +3685,15 @@ the SOURCE information requires its presence.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SOURCEPAGE:p.102
-   </code>
+   <code>SOURCEPAGE:p.102</code>
   </p>
   <p class="indent3">
    Further information can be found on page 102 of
 the source.
   </p>
   <p class="indent2">
-   <code>
-    CLASS:Strong.MOD &lt;tab&gt; SOURCEPAGE:p.
-28
-   </code>
+   <code>CLASS:Strong.MOD &lt;tab&gt; SOURCEPAGE:p.
+28</code>
   </p>
   <p class="indent3">
    Further information can be found on page 28 of
@@ -4194,25 +3730,19 @@ Source Name)
    </li>
    <li>
     This tag is used on its own line, with other
-    <code>
-     SOURCExxx
-    </code>
+    <code>SOURCExxx</code>
     tags, or on individual object lines.
    </li>
    <li>
     When used on its own line the
-    <code>
-     SOURCESHORT
-    </code>
+    <code>SOURCESHORT</code>
     tag will
 be used by all objects which follow it.
    </li>
    <li>
     When used on individual object lines it applies to that object
 and overrides any stand alone
-    <code>
-     SOURCESHORT
-    </code>
+    <code>SOURCESHORT</code>
     tag on lines
 which preceeded it.
    </li>
@@ -4223,9 +3753,7 @@ which preceeded it.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SOURCESHORT:FHB
-   </code>
+   <code>SOURCESHORT:FHB</code>
   </p>
   <p class="indent3">
    The short source name for this file is
@@ -4263,25 +3791,19 @@ product/book.
    </li>
    <li>
     This tag is used on its own line, with other
-    <code>
-     SOURCExxx
-    </code>
+    <code>SOURCExxx</code>
     tags, or on individual object lines.
    </li>
    <li>
     When used on its own line the
-    <code>
-     SOURCEWEB
-    </code>
+    <code>SOURCEWEB</code>
     tag will
 be used by all objects which follow it.
    </li>
    <li>
     When used on individual object lines it applies to that object
 and overrides any stand alone
-    <code>
-     SOURCEWEB
-    </code>
+    <code>SOURCEWEB</code>
     tag on lines
 which preceeded it.
    </li>
@@ -4292,9 +3814,7 @@ which preceeded it.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SOURCEWEB:http://www.foogames.com/product.php?products=654321
-   </code>
+   <code>SOURCEWEB:http://www.foogames.com/product.php?products=654321</code>
   </p>
   <p class="indent3">
    The web site for this source is
@@ -4369,44 +3889,36 @@ names.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SPELLKNOWN:CLASS|Arawnite
+   <code>SPELLKNOWN:CLASS|Arawnite
 Guardian=0|Create Water,Detect Magical Aura,Light,Mending,Read
-Magic,Resistance,Virtue
-   </code>
+Magic,Resistance,Virtue</code>
   </p>
   <p class="indent3">
    This is the character's known spell's for the
 Arawnite Guardian class.
   </p>
   <p class="indent2">
-   <code>
-    1 &lt;tab&gt; SPELLKNOWN:CLASS|Trundlefolk
+   <code>1 &lt;tab&gt; SPELLKNOWN:CLASS|Trundlefolk
 Shaman=0|Create Water,Cure Minor Wounds,Detect
-Magic,Guidance,Mending,Purify Food and Drink
-   </code>
+Magic,Guidance,Mending,Purify Food and Drink</code>
   </p>
   <p class="indent3">
    This is the character's known spell's for the
 first level Trundlefolk Shaman class.
   </p>
   <p class="indent2">
-   <code>
-    SPELLKNOWN:CLASS|SPELLCASTER.Psionic=7|Hypercognition
-   </code>
+   <code>SPELLKNOWN:CLASS|SPELLCASTER.Psionic=7|Hypercognition</code>
   </p>
   <p class="indent3">
    The Hypercognition power is added to the
 character's Psionic spallcasting classes.
   </p>
   <p class="indent2">
-   <code>
-    SUBCLASSLEVEL:1 &lt;tab&gt;
+   <code>SUBCLASSLEVEL:1 &lt;tab&gt;
 SPELLKNOWN:CLASS|Holy Warrior=1|Bless,Bless Water,Bless
 Weapon,Create Water,Cure Light Wounds,Detect Poison,Detect
 Undead,Divine Favor,Endure Elements,Magic Weapon,Protection from
-Evil,Read Magic,Resistance,Virtue
-   </code>
+Evil,Read Magic,Resistance,Virtue</code>
   </p>
   <p class="indent3">
    This is the character's known spell's for the
@@ -4483,13 +3995,9 @@ tag
    </li>
    <li>
     The
-    <code>
-     SPELLCASTER
-    </code>
+    <code>SPELLCASTER</code>
     subtag is used only with the
-    <code>
-     CLASS
-    </code>
+    <code>CLASS</code>
     subtag.
    </li>
    <li>
@@ -4503,70 +4011,58 @@ names.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SPELLLEVEL:DOMAIN|Cold=1|Endure
+   <code>SPELLLEVEL:DOMAIN|Cold=1|Endure
 Elements|Cold=2|Chill Metal|Cold=3|Sleet Storm|Cold=4|Wall of
 Ice|Cold=5|Cone of Cold|Cold=6|Freezing Sphere|Cold=7|Control
-Weather|Cold=8|Finger of Death|Cold=9|Elemental Swarm
-   </code>
+Weather|Cold=8|Finger of Death|Cold=9|Elemental Swarm</code>
   </p>
   <p class="indent3">
    This is the character's spell's for the Cold
 domain.
   </p>
   <p class="indent2">
-   <code>
-    SPELLLEVEL:CLASS|Arawnite
+   <code>SPELLLEVEL:CLASS|Arawnite
 Guardian=0|Create Water,Detect Magical Aura,Light,Mending,Read
-Magic,Resistance,Virtue
-   </code>
+Magic,Resistance,Virtue</code>
   </p>
   <p class="indent3">
    This is the character's spell's for the Arawnite
 Guardian class.
   </p>
   <p class="indent2">
-   <code>
-    SPELLLEVEL:CLASS|SPELLCASTER.Psionic=7|Hypercognition
-   </code>
+   <code>SPELLLEVEL:CLASS|SPELLCASTER.Psionic=7|Hypercognition</code>
   </p>
   <p class="indent3">
    The Hypercognition power is added to the
 character's Psionic spallcasting classes.
   </p>
   <p class="indent2">
-   <code>
-    1 &lt;tab&gt; SPELLLEVEL:CLASS|Trundlefolk
+   <code>1 &lt;tab&gt; SPELLLEVEL:CLASS|Trundlefolk
 Shaman=0|Create Water,Cure Minor Wounds,Detect
-Magic,Guidance,Mending,Purify Food and Drink
-   </code>
+Magic,Guidance,Mending,Purify Food and Drink</code>
   </p>
   <p class="indent3">
    This is the character's spell's for the first
 level Trundlefolk Shaman class.
   </p>
   <p class="indent2">
-   <code>
-    SUBCLASSLEVEL:1 &lt;tab&gt;
+   <code>SUBCLASSLEVEL:1 &lt;tab&gt;
 SPELLLEVEL:CLASS|Holy Warrior=1|Bless,Bless Water,Bless
 Weapon,Create Water,Cure Light Wounds,Detect Poison,Detect
 Undead,Divine Favor,Endure Elements,Magic Weapon,Protection from
-Evil,Read Magic,Resistance,Virtue
-   </code>
+Evil,Read Magic,Resistance,Virtue</code>
   </p>
   <p class="indent3">
    This is the character's spell's for the first
 level subclass Holy Warrior class.
   </p>
   <p class="indent2">
-   <code>
-    The Dead &lt;tab&gt; NAMEISPI:NO
+   <code>The Dead &lt;tab&gt; NAMEISPI:NO
 &lt;tab&gt; SPELLLEVEL:DOMAIN|The Dead=1|Detect Return|The
 Dead=2|Consecrate|The Dead=3|Negative Energy Protection|The
 Dead=4|Touch of Return|The Dead=5|Hallow|The Dead=6|Heal|The
 Dead=7|Greater Restoration|The Dead=8|Greater Return|The
-Dead=9|Imprison Soul
-   </code>
+Dead=9|Imprison Soul</code>
   </p>
   <p class="indent3">
    This is the character's spell's for the
@@ -4662,54 +4158,38 @@ Spellbook Names
     .
    </li>
    <li>
-    <code>
-     TIMES
-    </code>
+    <code>TIMES</code>
     is an optional parameter and if not present
 will default to 1.
    </li>
    <li>
-    <code>
-     TIMEUNIT
-    </code>
+    <code>TIMEUNIT</code>
     can be any unit of time, e.g. Day, Week,
 Month, Encounter, etc., but is optional and if not present will
 default to "Day".
    </li>
    <li>
-    <code>
-     CASTERLEVEL
-    </code>
+    <code>CASTERLEVEL</code>
     is an optional parameter and if not
 present will default to 1.
    </li>
    <li>
     There should never be more than one
-    <code>
-     TIMES
-    </code>
+    <code>TIMES</code>
     and
-    <code>
-     CASTERLEVEL
-    </code>
+    <code>CASTERLEVEL</code>
     tag used within a
-    <code>
-     SPELLS
-    </code>
+    <code>SPELLS</code>
     tag.
    </li>
    <li>
     You can apply PRExxx tags to the
-    <code>
-     SPELLS
-    </code>
+    <code>SPELLS</code>
     tag.
     <ul>
      <li>
       If a
-      <code>
-       SPELLS
-      </code>
+      <code>SPELLS</code>
       tag requires multiple PRExxx tags they
 are pipe-delimited ("|").
      </li>
@@ -4732,17 +4212,13 @@ using parentheses "( )".
    </li>
    <li>
     Because the
-    <code>
-     SPELLS
-    </code>
+    <code>SPELLS</code>
     tag is not associated with any
 one class the variable "CL" will not work in it.
    </li>
    <li>
     Use of
-    <code>
-     .CLEARALL
-    </code>
+    <code>.CLEARALL</code>
     will clear all spell-like
 abilities for the character/creature.
    </li>
@@ -4753,10 +4229,8 @@ abilities for the character/creature.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SPELLS:Innate|TIMES=3|CASTERLEVEL=(max(TL,1))|Acid
-Arrow,12+CHA|PRESTAT:1,CHA=12
-   </code>
+   <code>SPELLS:Innate|TIMES=3|CASTERLEVEL=(max(TL,1))|Acid
+Arrow,12+CHA|PRESTAT:1,CHA=12</code>
   </p>
   <p class="indent3">
    "Acid Arrow" is granted as an "Innate" spell 3
@@ -4765,10 +4239,8 @@ DC is 12+CHA, and the Caster level is the character's level
 (minimum 1).
   </p>
   <p class="indent2">
-   <code>
-    SPELLS:Innate|TIMES=ATWILL|CASTERLEVEL=TL|Fireball|Cure Light
-Wounds
-   </code>
+   <code>SPELLS:Innate|TIMES=ATWILL|CASTERLEVEL=TL|Fireball|Cure Light
+Wounds</code>
   </p>
   <p class="indent3">
    Grants "Fireball" and "Cure Light Wounds" at
@@ -4776,19 +4248,15 @@ will with a caster level equal to your hitdice in the spellbook
 "Innate"
   </p>
   <p class="indent2">
-   <code>
-    SPELLS:Innate|Charm Person,15
-   </code>
+   <code>SPELLS:Innate|Charm Person,15</code>
   </p>
   <p class="indent3">
    Grants "Charm Person" once per day, first level
 with a DC of 15 in the spellbook "Innate"
   </p>
   <p class="indent2">
-   <code>
-    SPELLS:Dragon|CASTERLEVEL=18|Death
-Ward|PRESTAT:1,WIS=20|PREALIGN:LG,NG,CG
-   </code>
+   <code>SPELLS:Dragon|CASTERLEVEL=18|Death
+Ward|PRESTAT:1,WIS=20|PREALIGN:LG,NG,CG</code>
   </p>
   <p class="indent3">
    Grants "Death Ward" once per day with a caster
@@ -4796,10 +4264,8 @@ level of 18 in spellbook "Dragon" requiring a Wisdom of 20 and any
 good alignment.
   </p>
   <p class="indent2">
-   <code>
-    SPELLS:Innate|TIMES=5|TIMEUNIT=Week|Wall
-of Stone
-   </code>
+   <code>SPELLS:Innate|TIMES=5|TIMEUNIT=Week|Wall
+of Stone</code>
   </p>
   <p class="indent3">
    Grants "Wall of Stone", 5 times per week at 1st
@@ -4837,9 +4303,7 @@ feat/class/template/etc. bestows.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SR:TL+10
-   </code>
+   <code>SR:TL+10</code>
   </p>
   <p class="indent3">
    This would set the Spell Resistance to be the
@@ -4882,18 +4346,14 @@ modifiers applied.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    STAT.STR.NOTEMP
-   </code>
+   <code>STAT.STR.NOTEMP</code>
   </p>
   <p class="indent3">
    This would output the character's unmodified
 strength score when used.
   </p>
   <p class="indent2">
-   <code>
-    STAT.INT.NOTEMP
-   </code>
+   <code>STAT.INT.NOTEMP</code>
   </p>
   <p class="indent3">
    This would output the character's unmodified
@@ -4935,9 +4395,7 @@ modifiers applied.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SR:STAT.INT.NOTEMP
-   </code>
+   <code>SR:STAT.INT.NOTEMP</code>
   </p>
   <p class="indent3">
    This would set the character's spell resistance
@@ -4982,10 +4440,8 @@ Bonus Sub-Tab.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TEMPDESC:This bonus can be applied when
-the character is in an underground environment.
-   </code>
+   <code>TEMPDESC:This bonus can be applied when
+the character is in an underground environment.</code>
   </p>
   <p class="indent3">
    Describes the conditions needed for the bonus to
@@ -5030,9 +4486,7 @@ PREAPPLY tag.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TEMPLATE:Lycanthrope.REMOVE
-   </code>
+   <code>TEMPLATE:Lycanthrope.REMOVE</code>
   </p>
   <p class="indent3">
    Removes the "Lycanthrope" template..
@@ -5061,9 +4515,7 @@ PREAPPLY tag.
      <li>
       The 'damage by size category' syntax, with multiple arguments, now
 takes as many arguments as there are size categories in the
-      <code>
-       sizeAdjustment.lst
-      </code>
+      <code>sizeAdjustment.lst</code>
       .
       <em>
        Typically
@@ -5073,9 +4525,7 @@ takes as many arguments as there are size categories in the
        exactly
       </em>
       nine arguments, ignoring
-      <code>
-       sizeAdjustment.lst
-      </code>
+      <code>sizeAdjustment.lst</code>
       .)
      </li>
     </ul>
@@ -5086,50 +4536,36 @@ takes as many arguments as there are size categories in the
   </h4>
   <ul class="incremental">
    <li>
-    <code>
-     UDAM:XdY
-    </code>
+    <code>UDAM:XdY</code>
     <ul class="incremental">
      <li>
       Sets the character's unarmed attack damage to
-      <code>
-       XdY
-      </code>
+      <code>XdY</code>
       regardless of the character's current size.
      </li>
     </ul>
    </li>
    <li>
-    <code>
-     UDAM:XdY,XdY, ... ,XdY
-    </code>
+    <code>UDAM:XdY,XdY, ... ,XdY</code>
     <ul class="incremental">
      <li>
       Sets the character's unarmed attack damage by size.
      </li>
      <li>
       The arguments
-      <code>
-       XdY
-      </code>
+      <code>XdY</code>
       are in ascending order of size.
      </li>
      <li>
       The number of arguments
-      <code>
-       XdY
-      </code>
+      <code>XdY</code>
       must match the number of sizes listed in the game mode's
-      <code>
-       sizeAdjustment.lst
-      </code>
+      <code>sizeAdjustment.lst</code>
       .
      </li>
      <li>
       For the
-      <code>
-       35e
-      </code>
+      <code>35e</code>
       game mode, there are nine sizes -
       <em>
        fine, diminutive, tiny, small, medium, large, huge, gargantuan, colossal,
@@ -5145,28 +4581,18 @@ colossal+
   </h4>
   <ol class="incremental">
    <li>
-    <code>
-     UDAM:1d3
-    </code>
+    <code>UDAM:1d3</code>
     - sets un-armed damage to be
-    <code>
-     1d3
-    </code>
+    <code>1d3</code>
     , no matter what size the creature is.
    </li>
    <li>
-    <code>
-     UDAM:1,1d2,1d3,1d4,1d6,1d8,1d10,1d12,2d8
-    </code>
+    <code>UDAM:1,1d2,1d3,1d4,1d6,1d8,1d10,1d12,2d8</code>
     - sets a damage
 progression for nine creature sizes, increasing from
-    <code>
-     1
-    </code>
+    <code>1</code>
     point at the smallest size, to
-    <code>
-     2d8
-    </code>
+    <code>2d8</code>
     at the largest size.
    </li>
   </ol>
@@ -5207,9 +4633,7 @@ with the UDAM tag on the same line.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    UMULT:2
-   </code>
+   <code>UMULT:2</code>
   </p>
   <p class="indent3">
    This set unarmed damage critical multiplier as
@@ -5295,9 +4719,7 @@ negate both the encumbrance and armor penalties.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    UNENCUMBEREDMOVE:HeavyLoad|HeavyArmor
-   </code>
+   <code>UNENCUMBEREDMOVE:HeavyLoad|HeavyArmor</code>
   </p>
   <p class="indent3">
    This is used in the Race entry for Dwarves,
@@ -5322,34 +4744,24 @@ and heavy loads.
    <li style="list-style: none; display: inline">
     <ul class="incremental">
      <li>
-      <code>
-       VFEAT
-      </code>
+      <code>VFEAT</code>
       is deprecated. Use
       <a href="#ability">
-       <code>
-        ABILITY:FEAT|VIRTUAL|
-       </code>
+       <code>ABILITY:FEAT|VIRTUAL|</code>
       </a>
       instead.
      </li>
      <li>
       All
-      <code>
-       FEAT
-      </code>
+      <code>FEAT</code>
       tags have been
       <strong>
        deprecated
       </strong>
       and replaced by the
-      <code>
-       ABILITY
-      </code>
+      <code>ABILITY</code>
       system, which is more general. The
-      <code>
-       ABILITY
-      </code>
+      <code>ABILITY</code>
       system can model feats, racial features, class
 features, traits, flaws, temporary bonuses, and so on, all using a
 common format.
@@ -5406,13 +4818,9 @@ be handled one of two ways.
       </li>
       <li>
        Used in conjunction with the
-       <code>
-        CHOOSE
-       </code>
+       <code>CHOOSE</code>
        tag,
-       <code>
-        %LIST
-       </code>
+       <code>%LIST</code>
        can be used with this tag to provide the
 required choice.
       </li>
@@ -5464,51 +4872,39 @@ activate a chooser inside of a feat being granted.
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     VFEAT:Simple Weapon Proficiency
-    </code>
+    <code>VFEAT:Simple Weapon Proficiency</code>
    </p>
    <p class="indent3">
     The character gains "Simple Weapon Proficiency"
 as a virtual feat.
    </p>
    <p class="indent2">
-    <code>
-     VFEAT:Alertness|Blind Fight
-    </code>
+    <code>VFEAT:Alertness|Blind Fight</code>
    </p>
    <p class="indent3">
     The character gains "Alertness" and "Blind
 Fight" as virtual feats.
    </p>
    <p class="indent2">
-    <code>
-     VFEAT:Weapon Focus(Greatsword)
-    </code>
+    <code>VFEAT:Weapon Focus(Greatsword)</code>
    </p>
    <p class="indent3">
     The character gains "Weapon Focus(Greatsword)"
 as a virtual feat.
    </p>
    <p class="indent2">
-    <code>
-     CHOOSE:WEAPONPROFS|LIST &lt;tab&gt;
-VFEAT:Weapon Focus (%LIST)
-    </code>
+    <code>CHOOSE:WEAPONPROFS|LIST &lt;tab&gt;
+VFEAT:Weapon Focus (%LIST)</code>
    </p>
    <p class="indent3">
     The feat "Weapon Focus" is granted as a virtual
 feat with the weapon chosen with the
-    <code>
-     CHOOSE
-    </code>
+    <code>CHOOSE</code>
     tag.
    </p>
    <p class="indent2">
-    <code>
-     VFEAT:Banana Barrage|PRECLASS:1,Ninja
-Monkey=1
-    </code>
+    <code>VFEAT:Banana Barrage|PRECLASS:1,Ninja
+Monkey=1</code>
    </p>
    <p class="indent3">
     The character gains "Banana Barrage" as a
@@ -5579,56 +4975,44 @@ vision.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    VISION:Low-light
-   </code>
+   <code>VISION:Low-light</code>
   </p>
   <p class="indent3">
    This gives the "Low-Light" vision mode to the
 PC.
   </p>
   <p class="indent2">
-   <code>
-    VISION:Darkvision (60')
-   </code>
+   <code>VISION:Darkvision (60')</code>
   </p>
   <p class="indent3">
    This gives the "Dark" vision mode of 60 foot to
 the PC.
   </p>
   <p class="indent2">
-   <code>
-    VISION:Darkvision (10*TL)
-   </code>
+   <code>VISION:Darkvision (10*TL)</code>
   </p>
   <p class="indent3">
    This gives the "Dark" vision mode of 10 x their
 total level to the PC.
   </p>
   <p class="indent2">
-   <code>
-    VISION:Darkvision
-(120')|Low-light
-   </code>
+   <code>VISION:Darkvision
+(120')|Low-light</code>
   </p>
   <p class="indent3">
    This gives the "Dark" vision mode of 120 foot
 and the "Low-Light" vision mode to the PC.
   </p>
   <p class="indent2">
-   <code>
-    VISION:.CLEAR.Low-light
-   </code>
+   <code>VISION:.CLEAR.Low-light</code>
   </p>
   <p class="indent3">
    Removes the Low-light vision from the
 character
   </p>
   <p class="indent2">
-   <code>
-    VISION:Darkvision
-(0')&lt;tab&gt;BONUS:VISION|Darkvision|30
-   </code>
+   <code>VISION:Darkvision
+(0')&lt;tab&gt;BONUS:VISION|Darkvision|30</code>
   </p>
   <p class="indent3">
    If character does not have Darkvision, receives
@@ -5674,31 +5058,23 @@ abilities.)
     Modifies an existing LST object.
    </li>
    <li>
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     is appended to the end of the first tag on an
 object line as follows:
     <ul>
      <li>
-      <code>
-       &lt;object name&gt;.MOD
-      </code>
+      <code>&lt;object name&gt;.MOD</code>
       for dieties, domains,
 equipment (including weapons, armor, and shields), eqmods, feats,
 languages, race, skill, spell, and templates.
      </li>
      <li>
-      <code>
-       CLASS:&lt;class name&gt;.MOD
-      </code>
+      <code>CLASS:&lt;class name&gt;.MOD</code>
       for classes.
      </li>
      <li>
-      <code>
-       CATEGORY=&lt;category name&gt;|&lt;ability name or
-key&gt;.MOD
-      </code>
+      <code>CATEGORY=&lt;category name&gt;|&lt;ability name or
+key&gt;.MOD</code>
       for abilities.
      </li>
     </ul>
@@ -5709,107 +5085,63 @@ i.e. case sensitive.
    </li>
    <li>
     Any tags that follow the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag are added to the
 list of tags already in the object.
    </li>
    <li>
     If only one tag is allowed, such as
-    <code>
-     HD
-    </code>
+    <code>HD</code>
     for classes
 or
-    <code>
-     COST
-    </code>
+    <code>COST</code>
     in equipment, the new tag will replace the tag
 in the original entry.
    </li>
    <li>
     If more than one tag is allowed, most notably
-    <code>
-     BONUS
-    </code>
+    <code>BONUS</code>
     statements, then the new tag will be added to
 the other tags in the object.
    </li>
    <li>
     When modifying an object to remove or replace a numerical
-    <code>
-     BONUS
-    </code>
+    <code>BONUS</code>
     , you must duplicate the original
-    <code>
-     BONUS
-    </code>
+    <code>BONUS</code>
     with the number or formula used for the
 numerical bonus multiplied by "-1".
    </li>
    <li>
     The order of operations is: Native line,
-    <code>
-     COPY
-    </code>
+    <code>COPY</code>
     ,
-    <code>
-     MOD
-    </code>
+    <code>MOD</code>
     , then
-    <code>
-     FORGET
-    </code>
+    <code>FORGET</code>
     , but the order of
 operation is also controlled by the
-    <code>
-     RANK
-    </code>
+    <code>RANK</code>
     tag in the
 PCC file.
     <ul>
      <li>
       Given:
-      <code>
-       1.MOD
-      </code>
-      <code>
-       1.FORGET
-      </code>
-      <code>
-       2.COPY
-      </code>
-      <code>
-       2.Blank
-      </code>
-      <code>
-       2.MOD
-      </code>
-      <code>
-       3.MOD
-      </code>
+      <code>1.MOD</code>
+      <code>1.FORGET</code>
+      <code>2.COPY</code>
+      <code>2.Blank</code>
+      <code>2.MOD</code>
+      <code>3.MOD</code>
      </li>
      <li>
       Order of processing is:
-      <code>
-       2.Blank
-      </code>
-      <code>
-       2.COPY
-      </code>
-      <code>
-       1.MOD
-      </code>
-      <code>
-       2.MOD
-      </code>
-      <code>
-       3.MOD
-      </code>
-      <code>
-       1.FORGET
-      </code>
+      <code>2.Blank</code>
+      <code>2.COPY</code>
+      <code>1.MOD</code>
+      <code>2.MOD</code>
+      <code>3.MOD</code>
+      <code>1.FORGET</code>
      </li>
     </ul>
    </li>
@@ -5824,9 +5156,7 @@ Behavior:
   </p>
   <p class="indent2">
    When modifying a LST Object with the
-   <code>
-    .MOD
-   </code>
+   <code>.MOD</code>
    tag, there are four ways in which tags are
 modified internally by PCGen: Modification by Overwriting Data,
 Modification by Selective Overwriting, Modification by Appending
@@ -5838,127 +5168,95 @@ below.
   </p>
   <p class="indent3">
    Initial LST Object:
-   <code>
-    &lt;lst object&gt;
-&lt;tab&gt; LSTFILETAG:A
-   </code>
+   <code>&lt;lst object&gt;
+&lt;tab&gt; LSTFILETAG:A</code>
   </p>
   <p class="indent3">
    Modified By:
-   <code>
-    &lt;lst object&gt;.MOD
-&lt;tab&gt; LSTFILETAG:B
-   </code>
+   <code>&lt;lst object&gt;.MOD
+&lt;tab&gt; LSTFILETAG:B</code>
   </p>
   <p class="indent3">
    Results In:
-   <code>
-    &lt;lst object&gt; &lt;tab&gt;
-LSTFILETAG:B
-   </code>
+   <code>&lt;lst object&gt; &lt;tab&gt;
+LSTFILETAG:B</code>
   </p>
   <p class="indent2">
    Modification by Selective Overwriting Data
   </p>
   <p class="indent3">
    Initial LST Object:
-   <code>
-    &lt;lst object&gt;
-&lt;tab&gt; LSTFILETAG:A|A1
-   </code>
+   <code>&lt;lst object&gt;
+&lt;tab&gt; LSTFILETAG:A|A1</code>
   </p>
   <p class="indent3">
    Modified By:
-   <code>
-    &lt;lst object&gt;.MOD
-&lt;tab&gt; LSTFILETAG:A|A2
-   </code>
+   <code>&lt;lst object&gt;.MOD
+&lt;tab&gt; LSTFILETAG:A|A2</code>
   </p>
   <p class="indent3">
    Results In:
-   <code>
-    &lt;lst object&gt; &lt;tab&gt;
-LSTFILETAG:A|A2
-   </code>
+   <code>&lt;lst object&gt; &lt;tab&gt;
+LSTFILETAG:A|A2</code>
   </p>
   <p class="indent2">
    While
   </p>
   <p class="indent3">
    Initial LST Object:
-   <code>
-    &lt;lst object&gt;
-&lt;tab&gt; LSTFILETAG:A|A1
-   </code>
+   <code>&lt;lst object&gt;
+&lt;tab&gt; LSTFILETAG:A|A1</code>
   </p>
   <p class="indent3">
    Modified By:
-   <code>
-    &lt;lst object&gt;.MOD
-&lt;tab&gt; LSTFILETAG:B|B1
-   </code>
+   <code>&lt;lst object&gt;.MOD
+&lt;tab&gt; LSTFILETAG:B|B1</code>
   </p>
   <p class="indent3">
    Results In:
-   <code>
-    &lt;lst object&gt; &lt;tab&gt;
-LSTFILETAG:B|B1
-   </code>
+   <code>&lt;lst object&gt; &lt;tab&gt;
+LSTFILETAG:B|B1</code>
   </p>
   <p class="indent2">
    Modification by Appending Data
   </p>
   <p class="indent3">
    Initial LST Object:
-   <code>
-    &lt;lst object&gt;
-&lt;tab&gt; LSTFILETAG:A
-   </code>
+   <code>&lt;lst object&gt;
+&lt;tab&gt; LSTFILETAG:A</code>
   </p>
   <p class="indent3">
    Modified By:
-   <code>
-    &lt;lst object&gt;.MOD
-&lt;tab&gt; LSTFILETAG:B
-   </code>
+   <code>&lt;lst object&gt;.MOD
+&lt;tab&gt; LSTFILETAG:B</code>
   </p>
   <p class="indent3">
    Is Equivalent To:
-   <code>
-    &lt;lst object&gt;
-&lt;tab&gt; LSTFILETAG:A,B
-   </code>
+   <code>&lt;lst object&gt;
+&lt;tab&gt; LSTFILETAG:A,B</code>
   </p>
   <p class="indent2">
    Modification by Separate LST Tags
   </p>
   <p class="indent3">
    Initial LST Object:
-   <code>
-    &lt;lst object&gt;
-&lt;tab&gt; LSTFILETAG:A
-   </code>
+   <code>&lt;lst object&gt;
+&lt;tab&gt; LSTFILETAG:A</code>
   </p>
   <p class="indent3">
    Modified By:
-   <code>
-    &lt;lst object&gt;.MOD
-&lt;tab&gt; LSTFILETAG:B
-   </code>
+   <code>&lt;lst object&gt;.MOD
+&lt;tab&gt; LSTFILETAG:B</code>
   </p>
   <p class="indent3">
    Is Equivalent To:
-   <code>
-    &lt;lst object&gt;
-&lt;tab&gt; LSTFILETAG:A &lt;tab&gt; LSTFILETAG:B
-   </code>
+   <code>&lt;lst object&gt;
+&lt;tab&gt; LSTFILETAG:A &lt;tab&gt; LSTFILETAG:B</code>
   </p>
   <p class="indent3">
    But is Not Equivalent To:
-   <code>
-    &lt;lst
-object&gt; &lt;tab&gt; LSTFILETAG:A,B
-   </code>
+   <code>&lt;lst
+object&gt; &lt;tab&gt; LSTFILETAG:A,B</code>
   </p>
   <p class="sidebar1">
    NOTE:The actual separator used in the
@@ -5972,9 +5270,7 @@ modification syntax.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    Human.MOD
-   </code>
+   <code>Human.MOD</code>
   </p>
   <p class="indent3">
    Modifies the
@@ -5988,10 +5284,8 @@ modification syntax.
    file)
   </p>
   <p class="indent2">
-   <code>
-    Dagger.MOD &lt;tab&gt; DESC:Short and
-pointy
-   </code>
+   <code>Dagger.MOD &lt;tab&gt; DESC:Short and
+pointy</code>
   </p>
   <p class="indent3">
    Replaces the description of the
@@ -6005,9 +5299,7 @@ pointy
    file)
   </p>
   <p class="indent2">
-   <code>
-    CLASS:Ranger.MOD
-   </code>
+   <code>CLASS:Ranger.MOD</code>
   </p>
   <p class="indent3">
    Modifies the
@@ -6021,10 +5313,8 @@ pointy
    file)
   </p>
   <p class="indent2">
-   <code>
-    Acid Arrow.MOD &lt;tab&gt; OUTPUTNAME:My
-Acid Arrow
-   </code>
+   <code>Acid Arrow.MOD &lt;tab&gt; OUTPUTNAME:My
+Acid Arrow</code>
   </p>
   <p class="indent3">
    Renames the
@@ -6038,10 +5328,8 @@ Acid Arrow
    (in a spells.lst file)
   </p>
   <p class="indent2">
-   <code>
-    Resistance.MOD &lt;tab&gt;
-BONUS:CHECKS|Fortitude,Reflex,Will|1|TYPE=Resistance|PREAPPLY:ANYPC
-   </code>
+   <code>Resistance.MOD &lt;tab&gt;
+BONUS:CHECKS|Fortitude,Reflex,Will|1|TYPE=Resistance|PREAPPLY:ANYPC</code>
   </p>
   <p class="indent3">
    Adds a saving throw temporary bonus function to
@@ -6052,11 +5340,9 @@ the
    spell
   </p>
   <p class="indent2">
-   <code>
-    CLASS:Arcane Archer.MOD &lt;tab&gt;
+   <code>CLASS:Arcane Archer.MOD &lt;tab&gt;
 BONUS:CHECKS|BASE.Will|-1*(CL/3) &lt;tab&gt;
-BONUS:CHECKS|BASE.Will|CL/2+2
-   </code>
+BONUS:CHECKS|BASE.Will|CL/2+2</code>
   </p>
   <p class="indent3">
    Modifies the
@@ -6068,9 +5354,7 @@ first removing the original "Will" bonus and then adding the new
 bonus.
   </p>
   <p class="indent2">
-   <code>
-    Skill Focus.MOD
-   </code>
+   <code>Skill Focus.MOD</code>
   </p>
   <p class="indent3">
    Modifies the
@@ -6084,9 +5368,7 @@ bonus.
    file)
   </p>
   <p class="indent2">
-   <code>
-    BOWSTR.MOD
-   </code>
+   <code>BOWSTR.MOD</code>
   </p>
   <p class="indent3">
    Modifies the
@@ -6100,10 +5382,8 @@ bonus.
    file)
   </p>
   <p class="indent2">
-   <code>
-    CATEGORY=Mutation|Weak Immune
-System.MOD
-   </code>
+   <code>CATEGORY=Mutation|Weak Immune
+System.MOD</code>
   </p>
   <p class="indent3">
    Modifies an ability of the category "Mutation",
@@ -6165,9 +5445,7 @@ properties as the original object.
    <li>
     When copying abilities you reference the ability by its
 "category", i.e.
-    <code>
-     CATEGORY=&lt;category&gt;
-    </code>
+    <code>CATEGORY=&lt;category&gt;</code>
     , and its
 name, or "key".
    </li>
@@ -6178,115 +5456,69 @@ i.e. case sensitive.
    <li>
     Copying a "class" requires that the object include the
 beginning
-    <code>
-     CLASS:
-    </code>
+    <code>CLASS:</code>
     tag.
    </li>
    <li>
     Tags following the
-    <code>
-     .COPY
-    </code>
+    <code>.COPY</code>
     line modify the new
 object in the same way the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     tag modifies
 objects.
    </li>
    <li>
     Any tags that follow the
-    <code>
-     .COPY
-    </code>
+    <code>.COPY</code>
     tag are added to
 the list of tags already in the object.
    </li>
    <li>
     If only one tag is allowed, such as
-    <code>
-     HD
-    </code>
+    <code>HD</code>
     for classes
 or
-    <code>
-     COST
-    </code>
+    <code>COST</code>
     in equipment, the new tag will replace the tag
 in the original entry.
    </li>
    <li>
     If more than one tag is allowed, most notably
-    <code>
-     BONUS
-    </code>
+    <code>BONUS</code>
     statements, then the new tag will be added to
 the other tags in the object.
    </li>
    <li>
     The order of operations is: Native line,
-    <code>
-     COPY
-    </code>
+    <code>COPY</code>
     ,
-    <code>
-     MOD
-    </code>
+    <code>MOD</code>
     , then
-    <code>
-     FORGET
-    </code>
+    <code>FORGET</code>
     , but the order of
 operation is also controlled by the
-    <code>
-     RANK
-    </code>
+    <code>RANK</code>
     tag in the
 PCC file.
     <ul>
      <li>
       Given:
-      <code>
-       1.MOD
-      </code>
-      <code>
-       1.FORGET
-      </code>
-      <code>
-       2.COPY
-      </code>
-      <code>
-       2.Blank
-      </code>
-      <code>
-       2.MOD
-      </code>
-      <code>
-       3.MOD
-      </code>
+      <code>1.MOD</code>
+      <code>1.FORGET</code>
+      <code>2.COPY</code>
+      <code>2.Blank</code>
+      <code>2.MOD</code>
+      <code>3.MOD</code>
      </li>
      <li>
       Order of processing is:
-      <code>
-       2.Blank
-      </code>
-      <code>
-       2.COPY
-      </code>
-      <code>
-       1.MOD
-      </code>
-      <code>
-       2.MOD
-      </code>
-      <code>
-       3.MOD
-      </code>
-      <code>
-       1.FORGET
-      </code>
+      <code>2.Blank</code>
+      <code>2.COPY</code>
+      <code>1.MOD</code>
+      <code>2.MOD</code>
+      <code>3.MOD</code>
+      <code>1.FORGET</code>
      </li>
     </ul>
    </li>
@@ -6305,52 +5537,40 @@ Spellcasting, Favored Enemies, etc.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    Human.COPY=Aboriginee
-   </code>
+   <code>Human.COPY=Aboriginee</code>
   </p>
   <p class="indent3">
    Creates a new race called Aboriginee based on
 the Human race.
   </p>
   <p class="indent2">
-   <code>
-    Dagger.COPY=Hunting Knife
-   </code>
+   <code>Dagger.COPY=Hunting Knife</code>
   </p>
   <p class="indent3">
    Creates a new weapon called Hunting Knife based
 on the weapon Dagger.
   </p>
   <p class="indent2">
-   <code>
-    CLASS:Ranger.COPY=Woodsman
-   </code>
+   <code>CLASS:Ranger.COPY=Woodsman</code>
   </p>
   <p class="indent3">
    Creates a new class called the Woodsman based on
 the Ranger class.
   </p>
   <p class="indent2">
-   <code>
-    Skill Focus.COPY=Heighten
-Knowledge
-   </code>
+   <code>Skill Focus.COPY=Heighten
+Knowledge</code>
   </p>
   <p class="indent3">
    Creates a new feat called Heighten Knowledge
 based on the Skill Focus feat.
   </p>
   <p class="indent2">
-   <code>
-    CATEGORY=(foo)|(key).COPY
-   </code>
+   <code>CATEGORY=(foo)|(key).COPY</code>
   </p>
   <p class="indent3">
    The new syntax to be used to
-   <code>
-    .COPY
-   </code>
+   <code>.COPY</code>
    an ability.
   </p>
   <hr/>
@@ -6388,13 +5608,9 @@ of object being cleared, Optional))
   <ul class="indent2">
    <li>
     This tag is used in conjunction with the
-    <code>
-     .MOD
-    </code>
+    <code>.MOD</code>
     and
-    <code>
-     .COPY
-    </code>
+    <code>.COPY</code>
     tags and may not be used for "Run-Time"
 changes.
    </li>
@@ -6407,17 +5623,13 @@ changes.
    </li>
    <li>
     Tags that can have multiple items, such as
-    <code>
-     TYPE
-    </code>
+    <code>TYPE</code>
     ,
 or tags that can be used multiple times can be eliminated.
    </li>
    <li>
     The
-    <code>
-     .CLEAR
-    </code>
+    <code>.CLEAR</code>
     syntax has not yet been standardized as
 many of the other tags have been and there are at least 2
 variations on how it can be used.
@@ -6425,9 +5637,7 @@ variations on how it can be used.
   </ul>
   <p class="sidebar1">
    Note: Although listed as global,
-   <code>
-    .CLEAR
-   </code>
+   <code>.CLEAR</code>
    will not work with all tags. Some
 experimentation may be required to see which usage is required with
 which tags.
@@ -6438,9 +5648,7 @@ which tags.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TAG:.CLEAR
-   </code>
+   <code>TAG:.CLEAR</code>
   </p>
   <p class="indent3">
    This syntax clears all the values of the
@@ -6450,16 +5658,12 @@ sequential manner and if the two tags order is swapped the new
 value will be cleared as well as the original values.
   </p>
   <p class="indent2">
-   <code>
-    TAG:.CLEAR.&lt;Values to be
-cleared&gt;
-   </code>
+   <code>TAG:.CLEAR.&lt;Values to be
+cleared&gt;</code>
   </p>
   <p class="indent3">
    The items which follow the
-   <code>
-    .CLEAR.
-   </code>
+   <code>.CLEAR.</code>
    are cleared.
   </p>
   <p class="indent1">
@@ -6468,28 +5672,20 @@ cleared&gt;
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    .CLEAR
-   </code>
+   <code>.CLEAR</code>
    is not supported on the
-   <code>
-    CHOICE
-   </code>
+   <code>CHOICE</code>
    tag, allowing the removal of the tag from the
 item. Two ways to do that are:
   </p>
   <ul class="indent2" style="list-style: lower-alpha">
    <li>
-    <code>
-     MULT:NO
-    </code>
+    <code>MULT:NO</code>
     - makes it a single feat, choice not
 supported.
    </li>
    <li>
-    <code>
-     CHOOSE:NOCHOICE
-    </code>
+    <code>CHOOSE:NOCHOICE</code>
     - no popup, but selectable
 multiple times.
    </li>
@@ -6500,10 +5696,8 @@ multiple times.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CLASS:Ranger.MOD &lt;tab&gt;
-CSKILL:.CLEAR.Animal Empathy
-   </code>
+   <code>CLASS:Ranger.MOD &lt;tab&gt;
+CSKILL:.CLEAR.Animal Empathy</code>
   </p>
   <p class="indent3">
    Modifies the
@@ -6518,11 +5712,9 @@ CSKILL:.CLEAR.Animal Empathy
   </p>
   <blockquote class="indent2">
    <p class="tagindent1">
-    <code>
-     Dagger.COPY=Hunting Knife &lt;tab&gt;
+    <code>Dagger.COPY=Hunting Knife &lt;tab&gt;
 TYPE:.CLEAR &lt;tab&gt;
-TYPE:Weapon.Melee.Finesseable.Exotic.Standard.Piercing.Slashing.Dagger
-    </code>
+TYPE:Weapon.Melee.Finesseable.Exotic.Standard.Piercing.Slashing.Dagger</code>
    </p>
   </blockquote>
   <p class="indent3">
@@ -6534,22 +5726,16 @@ TYPE:Weapon.Melee.Finesseable.Exotic.Standard.Piercing.Slashing.Dagger
 weapon and then adds back the desired types.
   </p>
   <p class="indent2">
-   <code>
-    Acid Arrow.MOD &lt;tab&gt; SCHOOL:.CLEAR
-&lt;tab&gt; SCHOOL:Lesser Conjuration
-   </code>
+   <code>Acid Arrow.MOD &lt;tab&gt; SCHOOL:.CLEAR
+&lt;tab&gt; SCHOOL:Lesser Conjuration</code>
   </p>
   <p class="indent3">
    Modifies the Acid Arrow spell by eliminating the
 original value of the
-   <code>
-    SCHOOL
-   </code>
+   <code>SCHOOL</code>
    tag and then sets the new
 value with a second
-   <code>
-    SCHOOL
-   </code>
+   <code>SCHOOL</code>
    tag.
   </p>
   <p class="indent1">
@@ -6559,13 +5745,9 @@ value with a second
   </p>
   <p class="indent2">
    In conjunction with
-   <code>
-    .MOD
-   </code>
+   <code>.MOD</code>
    and
-   <code>
-    .COPY
-   </code>
+   <code>.COPY</code>
   </p>
   <hr/>
   <h2>
@@ -6609,9 +5791,7 @@ abilities.)
    <li>
     When forgeting abilities you reference the ability by its
 "category", i.e.
-    <code>
-     CATEGORY=&lt;category&gt;
-    </code>
+    <code>CATEGORY=&lt;category&gt;</code>
     , and its
 name, or "key".
    </li>
@@ -6625,73 +5805,39 @@ i.e. case sensitive.
    <li>
     Forgeting a "class" requires that the object include the
 beginning
-    <code>
-     CLASS:
-    </code>
+    <code>CLASS:</code>
     tag.
    </li>
    <li>
     The order of operations is: Native line,
-    <code>
-     COPY
-    </code>
+    <code>COPY</code>
     ,
-    <code>
-     MOD
-    </code>
+    <code>MOD</code>
     , then
-    <code>
-     FORGET
-    </code>
+    <code>FORGET</code>
     , but the order of
 operation is also controlled by the
-    <code>
-     RANK
-    </code>
+    <code>RANK</code>
     tag in the
 PCC file.
     <ul>
      <li>
       Given:
-      <code>
-       1.MOD
-      </code>
-      <code>
-       1.FORGET
-      </code>
-      <code>
-       2.COPY
-      </code>
-      <code>
-       2.Blank
-      </code>
-      <code>
-       2.MOD
-      </code>
-      <code>
-       3.MOD
-      </code>
+      <code>1.MOD</code>
+      <code>1.FORGET</code>
+      <code>2.COPY</code>
+      <code>2.Blank</code>
+      <code>2.MOD</code>
+      <code>3.MOD</code>
      </li>
      <li>
       Order of processing is:
-      <code>
-       2.Blank
-      </code>
-      <code>
-       2.COPY
-      </code>
-      <code>
-       1.MOD
-      </code>
-      <code>
-       2.MOD
-      </code>
-      <code>
-       3.MOD
-      </code>
-      <code>
-       1.FORGET
-      </code>
+      <code>2.Blank</code>
+      <code>2.COPY</code>
+      <code>1.MOD</code>
+      <code>2.MOD</code>
+      <code>3.MOD</code>
+      <code>1.FORGET</code>
      </li>
     </ul>
    </li>
@@ -6702,42 +5848,32 @@ PCC file.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    Human.FORGET
-   </code>
+   <code>Human.FORGET</code>
   </p>
   <p class="indent3">
    Removes the Human race (in a race.lst file)
   </p>
   <p class="indent2">
-   <code>
-    Dagger.FORGET
-   </code>
+   <code>Dagger.FORGET</code>
   </p>
   <p class="indent3">
    Removes the Dagger weapon (in equipment.lst
 file)
   </p>
   <p class="indent2">
-   <code>
-    CLASS:Ranger.FORGET
-   </code>
+   <code>CLASS:Ranger.FORGET</code>
   </p>
   <p class="indent3">
    Removes the Ranger class (in class.lst)
   </p>
   <p class="indent2">
-   <code>
-    Skill Focus.FORGET
-   </code>
+   <code>Skill Focus.FORGET</code>
   </p>
   <p class="indent3">
    Removes the Skill Focus feat (in feat.lst)
   </p>
   <p class="indent2">
-   <code>
-    CATEGORY=(foo)|(key).FORGET
-   </code>
+   <code>CATEGORY=(foo)|(key).FORGET</code>
   </p>
   <p class="indent3">
    The new syntax to be used to .FORGET an
@@ -6795,9 +5931,7 @@ the qualifiers has the following effect:
       </strong>
       - Will return a list of all LST objects of
 the type requested by the
-      <code>
-       CHOOSE
-      </code>
+      <code>CHOOSE</code>
       tag, e.g. Template,
 Race, Equipment, Domain, etc.
      </li>
@@ -6807,9 +5941,7 @@ Race, Equipment, Domain, etc.
       </strong>
       - Will return a list of all LST objects
 already taken by the Player Character of the type requested by the
-      <code>
-       CHOOSE
-      </code>
+      <code>CHOOSE</code>
       tag, e.g. Template, Race, Equipment, Domain,
 etc.
      </li>
@@ -6819,9 +5951,7 @@ etc.
       </strong>
       - Will return a list of all LST
 objects of the type requested by the
-      <code>
-       CHOOSE
-      </code>
+      <code>CHOOSE</code>
       tag, e.g.
 Template, Race, Equipment, Domain, etc., that the player character
 is otherwise qualified for.
@@ -6831,9 +5961,7 @@ is otherwise qualified for.
    <li>
     Qualifiers can be logically negated by prefacing with the
 exclamation point (!), i.e.
-    <code>
-     !PC
-    </code>
+    <code>!PC</code>
     is a valid usage.
    </li>
    <li>
@@ -6892,25 +6020,19 @@ Name:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRERACE:%
-   </code>
+   <code>PRERACE:%</code>
   </p>
   <p class="indent3">
    Match any race in a race.lst file
   </p>
   <p class="indent2">
-   <code>
-    Level %
-   </code>
+   <code>Level %</code>
   </p>
   <p class="indent3">
    Any Level
   </p>
   <p class="indent2">
-   <code>
-    Knowledge%
-   </code>
+   <code>Knowledge%</code>
   </p>
   <p class="indent3">
    Any Knowledge skills

--- a/docs/listfilepages/globalfilestagpages/globalfilesprexxx.html
+++ b/docs/listfilepages/globalfilestagpages/globalfilesprexxx.html
@@ -71,9 +71,7 @@ when using PRExxx tags.
    <li>
     When using PRExxx tags as part of a class, the level will be
 tested before any new level is fully applied. This means that
-    <code>
-     PREPCLEVEL:MAX=1
-    </code>
+    <code>PREPCLEVEL:MAX=1</code>
     will pass when adding a second level
 to a first level character as that character is not yet level
 2.
@@ -87,9 +85,7 @@ whether the prerequisite is passed or not.
    </li>
    <li>
     There is a
-    <code>
-     PRE:.CLEAR
-    </code>
+    <code>PRE:.CLEAR</code>
     tag. Be aware that it will
 clear all PRExxx tags from an object and you will need to re-enter
 those PRExxx tags that you want to keep.
@@ -107,28 +103,20 @@ those PRExxx tags that you want to keep.
   <p>
    Logical negation of any pre-requisite is obtained by pre-pending
 an exclamation mark,
-   <code>
-    !
-   </code>
+   <code>!</code>
    , to the
-   <code>
-    PRE
-   </code>
+   <code>PRE</code>
    tag.
   </p>
   <ul>
    <li>
-    <code>
-     PREALIGN:LG
-    </code>
+    <code>PREALIGN:LG</code>
     ,
     <strong>
      without
     </strong>
     the
-    <code>
-     !
-    </code>
+    <code>!</code>
     , requires that the character's alignment
     <strong>
      is
@@ -136,17 +124,13 @@ an exclamation mark,
     lawful good.
    </li>
    <li>
-    <code>
-     !PREALIGN:LG
-    </code>
+    <code>!PREALIGN:LG</code>
     ,
     <strong>
      with
     </strong>
     the
-    <code>
-     !
-    </code>
+    <code>!</code>
     , requires that the character
     <strong>
      is not
@@ -159,22 +143,16 @@ an exclamation mark,
   </h4>
   <p>
    Use
-   <code>
-    PREMULT:1,[sub_prereq1],[sub_prereq2]...
-   </code>
+   <code>PREMULT:1,[sub_prereq1],[sub_prereq2]...</code>
    to
 require
    <strong>
     at least one
    </strong>
    of the sub-prerequisites
-   <code>
-    [sub_prereq1]
-   </code>
+   <code>[sub_prereq1]</code>
    ,
-   <code>
-    [sub_prereq2]
-   </code>
+   <code>[sub_prereq2]</code>
    , ... to be
 true.
   </p>
@@ -182,9 +160,7 @@ true.
    <li>
     <p>
      2-variable OR:
-     <code>
-      PREMULT:1,[PREALIGN:LG],[PREGENDER:M]
-     </code>
+     <code>PREMULT:1,[PREALIGN:LG],[PREGENDER:M]</code>
     </p>
     <p>
      Must have lawful good alignment OR male gender.
@@ -193,9 +169,7 @@ true.
    <li>
     <p>
      3-variable OR:
-     <code>
-      PREMULT:1,[PREALIGN:LG],[PREGENDER:M],[PREATT:10]
-     </code>
+     <code>PREMULT:1,[PREALIGN:LG],[PREGENDER:M],[PREATT:10]</code>
     </p>
     <p>
      Must have lawful good alignment OR male gender OR a base attack
@@ -208,25 +182,17 @@ bonus of at least 10.
   </h4>
   <p>
    Use
-   <code>
-    PREMULT:N,[sub_prereq1],[sub_prereq2]...
-   </code>
+   <code>PREMULT:N,[sub_prereq1],[sub_prereq2]...</code>
    , where
-   <code>
-    N
-   </code>
+   <code>N</code>
    is the number of sub-prerequisites, to require that
    <strong>
     all
    </strong>
    of the sub-prerequisites
-   <code>
-    [sub_prereq1]
-   </code>
+   <code>[sub_prereq1]</code>
    ,
-   <code>
-    [sub_prereq2]
-   </code>
+   <code>[sub_prereq2]</code>
    , ... are
 true.
   </p>
@@ -234,9 +200,7 @@ true.
    <li>
     <p>
      2-variable AND:
-     <code>
-      PREMULT:2,[PREALIGN:LG],[PREGENDER:M]
-     </code>
+     <code>PREMULT:2,[PREALIGN:LG],[PREGENDER:M]</code>
     </p>
     <p>
      Must have lawful good alignment AND male gender.
@@ -245,9 +209,7 @@ true.
    <li>
     <p>
      3-variable AND:
-     <code>
-      PREMULT:3,[PREALIGN:LG],[PREGENDER:M],[PREATT:10]
-     </code>
+     <code>PREMULT:3,[PREALIGN:LG],[PREGENDER:M],[PREATT:10]</code>
     </p>
     <p>
      Must have lawful good alignment AND male gender AND a base
@@ -260,39 +222,25 @@ attack bonus of at least 10.
   </h4>
   <p>
    The
-   <code>
-    NOR
-   </code>
+   <code>NOR</code>
    (
-   <code>
-    not OR
-   </code>
+   <code>not OR</code>
    ) and
-   <code>
-    NAND
-   </code>
+   <code>NAND</code>
    (
-   <code>
-    not AND
-   </code>
+   <code>not AND</code>
    ) functions are produced by
 prefixing
-   <code>
-    !
-   </code>
+   <code>!</code>
    , giving the
-   <code>
-    !PREMULT
-   </code>
+   <code>!PREMULT</code>
    tag.
   </p>
   <ul>
    <li>
     <p>
      2-variable NOR:
-     <code>
-      !PREMULT:1,[PREALIGN:LG],[PREGENDER:M]
-     </code>
+     <code>!PREMULT:1,[PREALIGN:LG],[PREGENDER:M]</code>
     </p>
     <p>
      Must NOT have (lawful good alignment OR male gender).
@@ -301,9 +249,7 @@ prefixing
    <li>
     <p>
      2-variable NAND:
-     <code>
-      !PREMULT:2,[PREALIGN:LG],[PREGENDER:M]
-     </code>
+     <code>!PREMULT:2,[PREALIGN:LG],[PREGENDER:M]</code>
     </p>
     <p>
      Must NOT have (lawful good alignment AND male gender).
@@ -315,18 +261,12 @@ prefixing
   </h4>
   <p>
    It is possible to nest the
-   <code>
-    PREMULT
-   </code>
+   <code>PREMULT</code>
    tag within other
-   <code>
-    PREMULT
-   </code>
+   <code>PREMULT</code>
    tags, allowing logic functions like
-   <code>
-    (A
-OR B) AND (C OR D)
-   </code>
+   <code>(A
+OR B) AND (C OR D)</code>
    to be realised.
   </p>
   <h3 id="comparison-operators">
@@ -339,39 +279,27 @@ operators.
   </p>
   <ul>
    <li>
-    <code>
-     EQ
-    </code>
+    <code>EQ</code>
     - equals
    </li>
    <li>
-    <code>
-     GT
-    </code>
+    <code>GT</code>
     - greater than
    </li>
    <li>
-    <code>
-     GTEQ
-    </code>
+    <code>GTEQ</code>
     - greater than or equal to
    </li>
    <li>
-    <code>
-     LT
-    </code>
+    <code>LT</code>
     - less than
    </li>
    <li>
-    <code>
-     LTEQ
-    </code>
+    <code>LTEQ</code>
     - less than or equal to
    </li>
    <li>
-    <code>
-     NEQ
-    </code>
+    <code>NEQ</code>
     - not equal to
    </li>
   </ul>
@@ -380,39 +308,25 @@ operators.
   </p>
   <ul>
    <li>
-    <code>
-     PREBASESIZE
-    </code>
+    <code>PREBASESIZE</code>
    </li>
    <li>
-    <code>
-     PREHANDS
-    </code>
+    <code>PREHANDS</code>
    </li>
    <li>
-    <code>
-     PRELEGS
-    </code>
+    <code>PRELEGS</code>
    </li>
    <li>
-    <code>
-     PREREACH
-    </code>
+    <code>PREREACH</code>
    </li>
    <li>
-    <code>
-     PRESIZE
-    </code>
+    <code>PRESIZE</code>
    </li>
    <li>
-    <code>
-     PRESR
-    </code>
+    <code>PRESR</code>
    </li>
    <li>
-    <code>
-     PREVAR
-    </code>
+    <code>PREVAR</code>
    </li>
   </ul>
   <p>
@@ -422,24 +336,16 @@ operators.
 name
    </strong>
    . i.e.
-   <code>
-    PREVARNEQ
-   </code>
+   <code>PREVARNEQ</code>
    or
-   <code>
-    PREREACHLTEQ
-   </code>
+   <code>PREREACHLTEQ</code>
    .
   </p>
   <p>
    (Not as
-   <code>
-    PREVAR:EQ
-   </code>
+   <code>PREVAR:EQ</code>
    or
-   <code>
-    PREREACH:LTEQ
-   </code>
+   <code>PREREACH:LTEQ</code>
    .)
   </p>
   <hr/>
@@ -449,13 +355,9 @@ name
   <p>
    <em>
     Require that the character has at least
-    <code>
-     N
-    </code>
+    <code>N</code>
     abilities from a given
-    <code>
-     ability_category
-    </code>
+    <code>ability_category</code>
     . A type of
 ability can be specified, or individual abilities can be specified
 by name.
@@ -470,18 +372,12 @@ by name.
     <ul>
      <li>
       The syntax
-      <code>
-       PREABILITY:N,CATEGORY=ability_category,ALL
-      </code>
+      <code>PREABILITY:N,CATEGORY=ability_category,ALL</code>
       was
 deleted. (Formerly used to require
-      <code>
-       N
-      </code>
+      <code>N</code>
       abilities from
-      <code>
-       ability_category
-      </code>
+      <code>ability_category</code>
       . Removed because it was too
 broad.)
      </li>
@@ -503,65 +399,43 @@ PREABILITY.
   <ol>
    <li>
     <p>
-     <code>
-      PREABILITY:N,CATEGORY=ability_category,TYPE.ability_type_1,TYPE.ability_type_2,...
-     </code>
+     <code>PREABILITY:N,CATEGORY=ability_category,TYPE.ability_type_1,TYPE.ability_type_2,...</code>
     </p>
     <p>
      Requires the character to have at least
-     <code>
-      N
-     </code>
+     <code>N</code>
      abilities
 from
-     <code>
-      ability_category
-     </code>
+     <code>ability_category</code>
      , of the specific type(s)
-     <code>
-      ability_type_1
-     </code>
+     <code>ability_type_1</code>
      ,
-     <code>
-      ability_type_2
-     </code>
+     <code>ability_type_2</code>
      , and so
 on.
     </p>
    </li>
    <li>
     <p>
-     <code>
-      PREABILITY:N,CATEGORY=ability_category,ability_name_1,ability_name_2,...
-     </code>
+     <code>PREABILITY:N,CATEGORY=ability_category,ability_name_1,ability_name_2,...</code>
     </p>
     <p>
      Requires the character to have at least
-     <code>
-      N
-     </code>
+     <code>N</code>
      abilities
 from a specific list of abilities:
-     <code>
-      ability_name_1
-     </code>
+     <code>ability_name_1</code>
      ,
-     <code>
-      ability_name_2
-     </code>
+     <code>ability_name_2</code>
      , and so on.
     </p>
    </li>
   </ol>
   <p>
    It is possible to combine the
-   <code>
-    TYPE.ability_type1
-   </code>
+   <code>TYPE.ability_type1</code>
    and the
-   <code>
-    ability_name_1
-   </code>
+   <code>ability_name_1</code>
    syntax:
   </p>
   <pre>
@@ -575,9 +449,7 @@ from a specific list of abilities:
    <li>
     <p>
      The
-     <code>
-      CATEGORY
-     </code>
+     <code>CATEGORY</code>
      tag will only accept "parent"
 categories.
     </p>
@@ -585,34 +457,26 @@ categories.
    <li>
     <p>
      Square brackets around an ability name,
-     <code>
-      [ability_name_1]
-     </code>
+     <code>[ability_name_1]</code>
      , means that the character must
      <strong>
       not
      </strong>
      have
-     <code>
-      ability_name_1
-     </code>
+     <code>ability_name_1</code>
      .
     </p>
    </li>
    <li>
     <p>
      Square brackets around an ability type,
-     <code>
-      [TYPE.ability_type_1]
-     </code>
+     <code>[TYPE.ability_type_1]</code>
      , means that the character must
      <strong>
       not
      </strong>
      have any ability of the type
-     <code>
-      ability_type_1
-     </code>
+     <code>ability_type_1</code>
      .
     </p>
    </li>
@@ -628,15 +492,11 @@ categories.
     <ul>
      <li>
       <p>
-       <code>
-        PREABILITY:1,CATEGORY=Feat,Dodge
-       </code>
+       <code>PREABILITY:1,CATEGORY=Feat,Dodge</code>
       </p>
       <p>
        Requires the
-       <code>
-        Dodge
-       </code>
+       <code>Dodge</code>
        feat. (Prerequisite for
        <a href="http://www.d20srd.org/srd/feats.htm#mobility">
         d20 SRD
@@ -647,19 +507,13 @@ Mobility
      </li>
      <li>
       <p>
-       <code>
-        PREABILITY:2,CATEGORY=Feat,Dodge,Mobility
-       </code>
+       <code>PREABILITY:2,CATEGORY=Feat,Dodge,Mobility</code>
       </p>
       <p>
        Requires two of the
-       <code>
-        Dodge
-       </code>
+       <code>Dodge</code>
        and
-       <code>
-        Mobility
-       </code>
+       <code>Mobility</code>
        feats, i.e. both are required. (Prerequisite for
        <a href="http://www.d20srd.org/srd/feats.htm#springAttack">
         d20 SRD Spring
@@ -670,10 +524,8 @@ Attack
      </li>
      <li>
       <p>
-       <code>
-        PREABILITY:2,CATEGORY=Feat,Improved Disarm,Improved
-Feint,Improved Trip
-       </code>
+       <code>PREABILITY:2,CATEGORY=Feat,Improved Disarm,Improved
+Feint,Improved Trip</code>
       </p>
       <p>
        Requires any two of the three feats specified.
@@ -688,29 +540,21 @@ Feint,Improved Trip
     <ul>
      <li>
       <p>
-       <code>
-        PREABILITY:1,Category=Feat,TYPE.SpellFocus
-       </code>
+       <code>PREABILITY:1,Category=Feat,TYPE.SpellFocus</code>
       </p>
       <p>
        Requires at least one
-       <code>
-        SpellFocus
-       </code>
+       <code>SpellFocus</code>
        type feat.
       </p>
      </li>
      <li>
       <p>
-       <code>
-        PREABILITY:3,Category=Feat,TYPE.Metamagic
-       </code>
+       <code>PREABILITY:3,Category=Feat,TYPE.Metamagic</code>
       </p>
       <p>
        Requires at least three
-       <code>
-        Metamagic
-       </code>
+       <code>Metamagic</code>
        type feats.
       </p>
      </li>
@@ -723,10 +567,8 @@ Feint,Improved Trip
     <ul>
      <li>
       <p>
-       <code>
-        PREABILITY:1,Category=SpecialQuality,[Night
-Vision]
-       </code>
+       <code>PREABILITY:1,Category=SpecialQuality,[Night
+Vision]</code>
       </p>
       <p>
        Requires that the creature does
@@ -734,47 +576,35 @@ Vision]
         not
        </strong>
        have the
-       <code>
-        Night Vision
-       </code>
+       <code>Night Vision</code>
        special quality.
       </p>
       <p>
        Note that the
-       <code>
-        !
-       </code>
+       <code>!</code>
        syntax could also be used, i.e.
       </p>
       <p>
-       <code>
-        !PREABILITY:1,Category=SpecialQuality,Night
-Vision
-       </code>
+       <code>!PREABILITY:1,Category=SpecialQuality,Night
+Vision</code>
        .
       </p>
      </li>
      <li>
       <p>
-       <code>
-        PREABILITY:1,CATEGORY=Feat,Power Attack,[Weapon
-Finesse]
-       </code>
+       <code>PREABILITY:1,CATEGORY=Feat,Power Attack,[Weapon
+Finesse]</code>
       </p>
       <p>
        Requires that the creature has the
-       <code>
-        Power Attack
-       </code>
+       <code>Power Attack</code>
        feat, and does
        <strong>
         not
        </strong>
        have the
-       <code>
-        Weapon
-Finesse
-       </code>
+       <code>Weapon
+Finesse</code>
        feat.
       </p>
      </li>
@@ -846,35 +676,27 @@ Middle Age, Old, and Venerable.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PREAGESET:1,Old
-   </code>
+   <code>PREAGESET:1,Old</code>
   </p>
   <p class="indent3">
    Requires the PC to be "Old" or "Venerable".
   </p>
   <p class="indent2">
-   <code>
-    PREAGESET:1,Venerable
-   </code>
+   <code>PREAGESET:1,Venerable</code>
   </p>
   <p class="indent3">
    Requires the PC to be "Venerable".
   </p>
   <p class="indent2">
-   <code>
-    !PREAGESET:1,Venerable
-   </code>
+   <code>!PREAGESET:1,Venerable</code>
   </p>
   <p class="indent3">
    Requires the PC to be younger than
 "Venerable".
   </p>
   <p class="indent2">
-   <code>
-    PREMULT:2,[PREAGESET:1,Middle
-Age],[!PREAGESET:1,Old]
-   </code>
+   <code>PREMULT:2,[PREAGESET:1,Middle
+Age],[!PREAGESET:1,Old]</code>
   </p>
   <p class="indent3">
    Requires the PC to be "Middle Age" but not
@@ -953,34 +775,26 @@ Deity's Alignment.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PREALIGN:LG,NG,CG
-   </code>
+   <code>PREALIGN:LG,NG,CG</code>
   </p>
   <p class="indent3">
    Requires any Good alignment.
   </p>
   <p class="indent2">
-   <code>
-    PREALIGN:2,5,8
-   </code>
+   <code>PREALIGN:2,5,8</code>
   </p>
   <p class="indent3">
    Requires any evil alignment.
   </p>
   <p class="indent2">
-   <code>
-    PREALIGN:LG,Deity
-   </code>
+   <code>PREALIGN:LG,Deity</code>
   </p>
   <p class="indent3">
    Requires Lawful Good or the character's chosen
 Deity's alignment.
   </p>
   <p class="indent2">
-   <code>
-    !PREALIGN:LG,NG,CG
-   </code>
+   <code>!PREALIGN:LG,NG,CG</code>
   </p>
   <p class="indent3">
    Requires the PC not be of "Good" alignment.
@@ -1032,32 +846,24 @@ type name).
    <li>
     Requires that the included qualifications be met by the target
 before the associated
-    <code>
-     BONUS
-    </code>
+    <code>BONUS</code>
     will be applied to that
 target.
    </li>
    <li>
-    <code>
-     PREAPPLY
-    </code>
+    <code>PREAPPLY</code>
     works
     <strong>
      ONLY
     </strong>
     at the end of
 a
-    <code>
-     BONUS
-    </code>
+    <code>BONUS</code>
     tag.
    </li>
    <li>
     Bonuses with
-    <code>
-     PREAPPLY
-    </code>
+    <code>PREAPPLY</code>
     tags will only appear in the
     <em>
      Temporary Bonuses Tab
@@ -1080,17 +886,11 @@ a
    </li>
    <li>
     All LST objects containing
-    <code>
-     BONUS
-    </code>
+    <code>BONUS</code>
     tags with
-    <code>
-     ANYPC
-    </code>
+    <code>ANYPC</code>
     as the target of a
-    <code>
-     PREAPPLY
-    </code>
+    <code>PREAPPLY</code>
     tag
 will always show up on the
     <em>
@@ -1100,9 +900,7 @@ will always show up on the
    </li>
    <li>
     Use of the
-    <code>
-     ANYPC
-    </code>
+    <code>ANYPC</code>
     subtag allows for bonuses to be
 granted without the character needing to have added the containing
 object to his character, or to allow for conditional/situational
@@ -1110,9 +908,7 @@ bonuses on LST objects that have been added to the character.
    </li>
    <li>
     LST objects that can include a
-    <code>
-     PREAPPLY:ANYPC
-    </code>
+    <code>PREAPPLY:ANYPC</code>
     tag
 include:
     <ul>
@@ -1135,14 +931,10 @@ include:
    </li>
    <li>
     Spells with
-    <code>
-     PREAPPLY
-    </code>
+    <code>PREAPPLY</code>
     tags with weapon types will
 be treated as containing
-    <code>
-     ANYPC
-    </code>
+    <code>ANYPC</code>
     subtag and will appear
 in the
     <em>
@@ -1166,36 +958,28 @@ Bonus Tab
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PREAPPLY:ANYPC
-   </code>
+   <code>PREAPPLY:ANYPC</code>
   </p>
   <p class="indent3">
    This allows the bonus granted to be applied to
 any character.
   </p>
   <p class="indent2">
-   <code>
-    PREAPPLY:PC
-   </code>
+   <code>PREAPPLY:PC</code>
   </p>
   <p class="indent3">
    This allows the bonus granted to be applied to
 the PC to which the granting LST object is attached.
   </p>
   <p class="indent2">
-   <code>
-    PREAPPLY:Ranged;Melee
-   </code>
+   <code>PREAPPLY:Ranged;Melee</code>
   </p>
   <p class="indent3">
    This allows the bonus granted to be applied to
 either ranged or melee weapons.
   </p>
   <p class="indent2">
-   <code>
-    PREAPPLY:Weapon,Blunt
-   </code>
+   <code>PREAPPLY:Weapon,Blunt</code>
   </p>
   <p class="indent3">
    This allows the bonus granted to be applied to
@@ -1208,13 +992,9 @@ tag:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:COMBAT|AC|2|PREAPPLY:PC
-   </code>
+   <code>BONUS:COMBAT|AC|2|PREAPPLY:PC</code>
    becomes
-   <code>
-    TEMPBONUS:PC|COMBAT|AC|2
-   </code>
+   <code>TEMPBONUS:PC|COMBAT|AC|2</code>
   </p>
   <hr/>
   <p class="lststatus">
@@ -1279,37 +1059,29 @@ with).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PREARMORTYPE:1,Chainmail,Full
-Plate
-   </code>
+   <code>PREARMORTYPE:1,Chainmail,Full
+Plate</code>
   </p>
   <p class="indent3">
    Character must have either "Chainmail" or "Full
 Plate" armor equipped.
   </p>
   <p class="indent2">
-   <code>
-    PREARMORTYPE:1,Leather Armor%
-   </code>
+   <code>PREARMORTYPE:1,Leather Armor%</code>
   </p>
   <p class="indent3">
    The "%" allows for items named Leather Armor
 (Masterwork), Leather Armor (+1) etc.
   </p>
   <p class="indent2">
-   <code>
-    PREARMORTYPE:1,TYPE.Medium
-   </code>
+   <code>PREARMORTYPE:1,TYPE.Medium</code>
   </p>
   <p class="indent3">
    Character must have a Medium type armor
 equipped.
   </p>
   <p class="indent2">
-   <code>
-    PREARMORTYPE:1,LIST
-   </code>
+   <code>PREARMORTYPE:1,LIST</code>
   </p>
   <p class="indent3">
    Character must be proficient in the armor
@@ -1350,9 +1122,7 @@ bonus.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PREATT:6
-   </code>
+   <code>PREATT:6</code>
   </p>
   <p class="indent3">
    This would apply only if the PC had minimum base
@@ -1371,45 +1141,29 @@ or in a particular range of size categories.
   </h4>
   <p>
    Changed:
-   <code>
-    size
-   </code>
+   <code>size</code>
    used to be specified as the size name
 in words, i.e.
-   <code>
-    Small
-   </code>
+   <code>Small</code>
    . Now is is specified as the
-   <code>
-    SIZENAME
-   </code>
+   <code>SIZENAME</code>
    , i.e.
-   <code>
-    S
-   </code>
+   <code>S</code>
    .
   </p>
   <h4 id="syntax">
    Syntax
   </h4>
   <p>
-   <code>
-    PREBASESIZEoperator:size
-   </code>
+   <code>PREBASESIZEoperator:size</code>
   </p>
   <p>
-   <code>
-    operator
-   </code>
+   <code>operator</code>
    and
-   <code>
-    size
-   </code>
+   <code>size</code>
    are as per the
    <a href="#presize">
-    <code>
-     PRESIZE
-    </code>
+    <code>PRESIZE</code>
     tag
    </a>
    .
@@ -1420,9 +1174,7 @@ in words, i.e.
   <p>
    As per the
    <a href="#presize">
-    <code>
-     PRESIZE
-    </code>
+    <code>PRESIZE</code>
     tag
    </a>
   </p>
@@ -1457,9 +1209,7 @@ text.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PREBIRTHPLACE:Klamath
-   </code>
+   <code>PREBIRTHPLACE:Klamath</code>
   </p>
   <p class="indent3">
    Character must have been born in "Klamath".
@@ -1641,18 +1391,14 @@ number the associated check must be greater than or equal to).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRECHECK:1,Fortitude=5,Reflex=3
-   </code>
+   <code>PRECHECK:1,Fortitude=5,Reflex=3</code>
   </p>
   <p class="indent3">
    Would succeed if Fortitude meets or exceeds 5 or
 Reflex meets or exceeds 3.
   </p>
   <p class="indent2">
-   <code>
-    PRECHECK:2,Fortitude=5,Reflex=3,Willpower=4
-   </code>
+   <code>PRECHECK:2,Fortitude=5,Reflex=3,Willpower=4</code>
   </p>
   <p class="indent3">
    Would succeed if any 2 of the 3 three listed
@@ -1701,9 +1447,7 @@ to).
 Checks are usually only those from class advancement (no stat
 modifiers, magic, etc.), but follow anything defined with
 "
-   <code>
-    BONUS:CHECKS|BASE.Name|
-   </code>
+   <code>BONUS:CHECKS|BASE.Name|</code>
    ".
   </p>
   <p class="indent1">
@@ -1712,18 +1456,14 @@ modifiers, magic, etc.), but follow anything defined with
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRECHECKBASE:2,Fortitude=3,Reflex=3
-   </code>
+   <code>PRECHECKBASE:2,Fortitude=3,Reflex=3</code>
   </p>
   <p class="indent3">
    Would succeed if both Fortitude meets or exceeds
 3 and Reflex meets or exceeds 3.
   </p>
   <p class="indent2">
-   <code>
-    PRECHECKBASE:1,Fortitude=5,Reflex=3
-   </code>
+   <code>PRECHECKBASE:1,Fortitude=5,Reflex=3</code>
   </p>
   <p class="indent3">
    Would succeed if Fortitude meets or exceeds 5 or
@@ -1765,9 +1505,7 @@ Tab
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRECITY:Klamath
-   </code>
+   <code>PRECITY:Klamath</code>
   </p>
   <p class="indent3">
    Character must currently reside in
@@ -1844,18 +1582,14 @@ Name)
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRECLASS:2,Wizard=5,Sorcerer=6,Cleric=7
-   </code>
+   <code>PRECLASS:2,Wizard=5,Sorcerer=6,Cleric=7</code>
   </p>
   <p class="indent3">
    Multi-classed character must be at least
 Wiz5/Sor6, Wiz5/Clr7 or Sor6/Clr7.
   </p>
   <p class="indent2">
-   <code>
-    PRECLASS:1,SPELLCASTER=2
-   </code>
+   <code>PRECLASS:1,SPELLCASTER=2</code>
   </p>
   <p class="indent3">
    Character must have 2 levels in any spellcasting
@@ -1864,18 +1598,14 @@ PCGen does not treat manifesting differently from spellcasting.
 Spellcaster and manifester can be considered interchangeable.
   </p>
   <p class="indent2">
-   <code>
-    PRECLASS:1,SPELLCASTER.Arcane=2
-   </code>
+   <code>PRECLASS:1,SPELLCASTER.Arcane=2</code>
   </p>
   <p class="indent3">
    Character must have 2 levels in any arcane
 spellcasting class.
   </p>
   <p class="indent2">
-   <code>
-    PRECLASS:1,SPELLCASTER.Divine=6,SPELLCASTER.Psionic=3
-   </code>
+   <code>PRECLASS:1,SPELLCASTER.Divine=6,SPELLCASTER.Psionic=3</code>
   </p>
   <p class="indent3">
    Character must have 6 levels in any divine
@@ -1883,102 +1613,80 @@ spellcasting class or 3 levels in any psionic manifesting
 class.
   </p>
   <p class="indent2">
-   <code>
-    PRECLASS:2,TYPE.Base=5,TYPE.Prestige=1
-   </code>
+   <code>PRECLASS:2,TYPE.Base=5,TYPE.Prestige=1</code>
   </p>
   <p class="indent3">
    Character must have 5 levels in any Base class
 and 1 level in any Prestige class.
   </p>
   <p class="indent2">
-   <code>
-    PRECLASS:2,ANY
-   </code>
+   <code>PRECLASS:2,ANY</code>
   </p>
   <p class="indent3">
    Multi-classed character must be at least two
 Classes.
   </p>
   <p class="indent2">
-   <code>
-    PRECLASS:1,ANY
-   </code>
+   <code>PRECLASS:1,ANY</code>
   </p>
   <p class="indent3">
    Character must have 1 level in any class.
   </p>
   <p class="indent2">
-   <code>
-    PREMULT:1,[PREFEAT:1,Blood of the
-Fey],[PRECLASS:1,Fey-Touched=1]
-   </code>
+   <code>PREMULT:1,[PREFEAT:1,Blood of the
+Fey],[PRECLASS:1,Fey-Touched=1]</code>
   </p>
   <p class="indent3">
    Character must have 1 level in Fey-Touched class
 or feat Blood of the Fey.
   </p>
   <p class="indent2">
-   <code>
-    PRECLASS:1,Jack o' the Green=5
-!PREFEAT:1,TYPE.LASlipperyEel
-   </code>
+   <code>PRECLASS:1,Jack o' the Green=5
+!PREFEAT:1,TYPE.LASlipperyEel</code>
   </p>
   <p class="indent3">
    Character must have 5 levels in Jack o' the
 Green class and not have the feat LASlipperyEel.
   </p>
   <p class="indent2">
-   <code>
-    !PRECLASS:1,SPELLCASTER.Arcane=1
-   </code>
+   <code>!PRECLASS:1,SPELLCASTER.Arcane=1</code>
   </p>
   <p class="indent3">
    Character must not have 1 level in
 SPELLCASTER.Arcane class.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:COMBAT|AC|1|PRECLASS:1,Shaper=10
-   </code>
+   <code>BONUS:COMBAT|AC|1|PRECLASS:1,Shaper=10</code>
   </p>
   <p class="indent3">
    Character adds 1 to armor class if 10 levels in
 Shaper Class.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:WEAPON|TOHIT|4|TYPE=Luck|PRECLASS:1,Wizard=1,Sorcerer=1
-   </code>
+   <code>BONUS:WEAPON|TOHIT|4|TYPE=Luck|PRECLASS:1,Wizard=1,Sorcerer=1</code>
   </p>
   <p class="indent3">
    Character adds 4 to To-Hit from luck if 1 level
 in either Wizard/Sorcerer Class.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:CASTERLEVEL|Minstrel|CL-3|PRECLASS:1,Minstrel=4
-   </code>
+   <code>BONUS:CASTERLEVEL|Minstrel|CL-3|PRECLASS:1,Minstrel=4</code>
   </p>
   <p class="indent3">
    Character adds CL-3 bonus to Casterlevel if 4
 levels in Minstrel Class.
   </p>
   <p class="indent2">
-   <code>
-    SA:Damage reduction 1/opposed
-alignment|PRECLASS:1,Shaper=10
-   </code>
+   <code>SA:Damage reduction 1/opposed
+alignment|PRECLASS:1,Shaper=10</code>
   </p>
   <p class="indent3">
    SA: will fire with 10 levels of Shaper
 Class.
   </p>
   <p class="indent2">
-   <code>
-    SA:Spy|PREMULT:2,[PRECLASS:1,Aradil's
-Eye=5],[PRECLASSLEVELMAX:1,Aradil's Eye=9]
-   </code>
+   <code>SA:Spy|PREMULT:2,[PRECLASS:1,Aradil's
+Eye=5],[PRECLASSLEVELMAX:1,Aradil's Eye=9]</code>
   </p>
   <p class="indent3">
    SA: will fire with 5 levels of Aradil's Eye
@@ -2048,16 +1756,12 @@ name)
 the RSRD are "Base", "PC", or "Prestige".
    </li>
    <li>
-    <code>
-     SPELLCASTER
-    </code>
+    <code>SPELLCASTER</code>
     will check against all spellcasting
 classes.
    </li>
    <li>
-    <code>
-     SPELLCASTER.Text
-    </code>
+    <code>SPELLCASTER.Text</code>
     will check against spellcaster
 types, e.g. Arcane or Divine.
    </li>
@@ -2068,9 +1772,7 @@ types, e.g. Arcane or Divine.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRECLASSLEVELMAX:2,Fighter=2,SPELLCASTER=2
-   </code>
+   <code>PRECLASSLEVELMAX:2,Fighter=2,SPELLCASTER=2</code>
   </p>
   <p class="indent3">
    Character cannot have more than 2 levels of
@@ -2135,18 +1837,14 @@ text must match the entry exactly.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRECSKILL:1,Spot,Listen
-   </code>
+   <code>PRECSKILL:1,Spot,Listen</code>
   </p>
   <p class="indent3">
    Character must have either "Spot" or "Listen" as
 a Class Skill.
   </p>
   <p class="indent2">
-   <code>
-    PRECSKILL:2,TYPE.Spy
-   </code>
+   <code>PRECSKILL:2,TYPE.Spy</code>
   </p>
   <p class="indent3">
    Character must have two "Spy" skills as Class
@@ -2211,44 +1909,34 @@ pantheon name.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PREDEITY:1,Y
-   </code>
+   <code>PREDEITY:1,Y</code>
   </p>
   <p class="indent3">
    Character must have a deity chosen.
   </p>
   <p class="indent2">
-   <code>
-    PREDEITY:1,N
-   </code>
+   <code>PREDEITY:1,N</code>
   </p>
   <p class="indent3">
    Character must NOT have a deity chosen.
   </p>
   <p class="indent2">
-   <code>
-    PREDEITY:1,Zeus,Odin
-   </code>
+   <code>PREDEITY:1,Zeus,Odin</code>
   </p>
   <p class="indent3">
    Character must have chosen either "Zeus" or
 "Odin".
   </p>
   <p class="indent2">
-   <code>
-    PREDEITY:1,Zeus,PANTHEON.Celtic,Odin
-   </code>
+   <code>PREDEITY:1,Zeus,PANTHEON.Celtic,Odin</code>
   </p>
   <p class="indent3">
    Character must have chosen either "Zeus", "Odin"
 or a deity in the "Celtic" pantheon.
   </p>
   <p class="indent2">
-   <code>
-    CLASS:Druid.MOD &lt;tab&gt;
-PREDEITY:1.Saluwe,Yarris,Belisarda,Fire Dragon
-   </code>
+   <code>CLASS:Druid.MOD &lt;tab&gt;
+PREDEITY:1.Saluwe,Yarris,Belisarda,Fire Dragon</code>
   </p>
   <p class="indent3">
    Character must have chosen either "Saluwe"
@@ -2324,18 +2012,14 @@ Deity's Alignment.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PREDEITYALIGN:0
-   </code>
+   <code>PREDEITYALIGN:0</code>
   </p>
   <p class="indent3">
    Character must have chosen a Lawful Good
 deity.
   </p>
   <p class="indent2">
-   <code>
-    PREDEITYALIGN:LG,NG,CG
-   </code>
+   <code>PREDEITYALIGN:LG,NG,CG</code>
   </p>
   <p class="indent3">
    Character must have chosen a deity of any Good
@@ -2384,9 +2068,7 @@ domains that the PC has selected for itself.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PREDEITYDOMAIN:1,Good,Law
-   </code>
+   <code>PREDEITYDOMAIN:1,Good,Law</code>
   </p>
   <p class="indent3">
    Character must have chosen of deity with either
@@ -2439,18 +2121,14 @@ itself.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PREDOMAIN:1,Good,Law
-   </code>
+   <code>PREDOMAIN:1,Good,Law</code>
   </p>
   <p class="indent3">
    Character must have 1 of the two listed
 domains.
   </p>
   <p class="indent2">
-   <code>
-    PREDOMAIN:2,ANY
-   </code>
+   <code>PREDOMAIN:2,ANY</code>
   </p>
   <p class="indent3">
    Character must have 2 domains of any type.
@@ -2501,18 +2179,14 @@ Resistance.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PREDR:1,+1=10
-   </code>
+   <code>PREDR:1,+1=10</code>
   </p>
   <p class="indent3">
    Must have DR of 10/+1 or greater (but DR Type
 must be +1).
   </p>
   <p class="indent2">
-   <code>
-    PREDR:1,-=10,+1=10,+2=10,+3=10,+4=10,+5=10,Silver=10
-   </code>
+   <code>PREDR:1,-=10,+1=10,+2=10,+3=10,+4=10,+5=10,Silver=10</code>
   </p>
   <p class="indent3">
    Must have DR of 10 or greater of any type
@@ -2580,61 +2254,47 @@ delimited (.) list. (e.g. TYPE=Heavy.Armor for "Heavy Armor")
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PREEQUIP:1,Leather Armor
-   </code>
+   <code>PREEQUIP:1,Leather Armor</code>
   </p>
   <p class="indent3">
    Must have Leather Armor (only) equipped.
   </p>
   <p class="indent2">
-   <code>
-    PREEQUIP:1,Leather Armor%
-   </code>
+   <code>PREEQUIP:1,Leather Armor%</code>
   </p>
   <p class="indent3">
    The "%" allows for items named Leather Armor
 (Masterwork), Leather Armor (+1) etc.
   </p>
   <p class="indent2">
-   <code>
-    PREEQUIP:1,TYPE=Armor
-   </code>
+   <code>PREEQUIP:1,TYPE=Armor</code>
   </p>
   <p class="indent3">
    Must have some type of armor equipped.
   </p>
   <p class="indent2">
-   <code>
-    PREEQUIP:2,TYPE=Armor,Sword
-(Long)%
-   </code>
+   <code>PREEQUIP:2,TYPE=Armor,Sword
+(Long)%</code>
   </p>
   <p class="indent3">
    Must be equipped with any Sword (Long), as well
 as any type of armor.
   </p>
   <p class="indent2">
-   <code>
-    PREEQUIP:2,TYPE=Armor,TYPE=Shield
-   </code>
+   <code>PREEQUIP:2,TYPE=Armor,TYPE=Shield</code>
   </p>
   <p class="indent3">
    Must be equipped with any Armor and any
 Shield.
   </p>
   <p class="indent2">
-   <code>
-    PREEQUIP:1,WIELDCATEGORY=TwoHanded
-   </code>
+   <code>PREEQUIP:1,WIELDCATEGORY=TwoHanded</code>
   </p>
   <p class="indent3">
    Must be equipped with a two handed weapon.
   </p>
   <p class="indent2">
-   <code>
-    PREEQUIP:1,TYPE=Armor.Heavy,TYPE=Armor.Light
-   </code>
+   <code>PREEQUIP:1,TYPE=Armor.Heavy,TYPE=Armor.Light</code>
   </p>
   <p class="indent3">
    Must have equipped Heavy Armor or Light
@@ -2694,36 +2354,28 @@ can be more than one if can have more than one Primary hand.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PREEQUIPPRIMARY:1,Dagger
-   </code>
+   <code>PREEQUIPPRIMARY:1,Dagger</code>
   </p>
   <p class="indent3">
    Must have a dagger equipped in the primary
 hand.
   </p>
   <p class="indent2">
-   <code>
-    PREEQUIPPRIMARY:1,Dagger%
-   </code>
+   <code>PREEQUIPPRIMARY:1,Dagger%</code>
   </p>
   <p class="indent3">
    The "%" allows for items named Dagger
 (Masterwork), Dagger (Punching), etc.
   </p>
   <p class="indent2">
-   <code>
-    PREEQUIPPRIMARY:1,TYPE=Slashing
-   </code>
+   <code>PREEQUIPPRIMARY:1,TYPE=Slashing</code>
   </p>
   <p class="indent3">
    Must have some type of slashing weapon equipped
 in the primary hand.
   </p>
   <p class="indent2">
-   <code>
-    PREEQUIPPRIMARY:1,WIELDCATEGORY=OneHanded
-   </code>
+   <code>PREEQUIPPRIMARY:1,WIELDCATEGORY=OneHanded</code>
   </p>
   <p class="indent3">
    Must have a one handed weapon equipped in the
@@ -2783,36 +2435,28 @@ can be more than one if can have more than one Secondary hand.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PREEQUIPSECONDARY:1,Dagger
-   </code>
+   <code>PREEQUIPSECONDARY:1,Dagger</code>
   </p>
   <p class="indent3">
    Must have a dagger equipped in the secondary
 hand.
   </p>
   <p class="indent2">
-   <code>
-    PREEQUIPSECONDARY:1,Dagger%
-   </code>
+   <code>PREEQUIPSECONDARY:1,Dagger%</code>
   </p>
   <p class="indent3">
    The "%" allows for items named Dagger
 (Masterwork), Dagger (Punching), etc.
   </p>
   <p class="indent2">
-   <code>
-    PREEQUIPSECONDARY:1,TYPE=Slashing
-   </code>
+   <code>PREEQUIPSECONDARY:1,TYPE=Slashing</code>
   </p>
   <p class="indent3">
    Must have some type of slashing weapon equipped
 in the secondary hand.
   </p>
   <p class="indent2">
-   <code>
-    PREEQUIPSECONDARY:1,WIELDCATEGORY=Light
-   </code>
+   <code>PREEQUIPSECONDARY:1,WIELDCATEGORY=Light</code>
   </p>
   <p class="indent3">
    Must have a light weapon equipped in the
@@ -2870,27 +2514,21 @@ style.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PREEQUIPBOTH:1,Quarterstaff
-   </code>
+   <code>PREEQUIPBOTH:1,Quarterstaff</code>
   </p>
   <p class="indent3">
    Must have a Quarterstaff equipped in both
 hands.
   </p>
   <p class="indent2">
-   <code>
-    PREEQUIPBOTH:1,Sword (Great%
-   </code>
+   <code>PREEQUIPBOTH:1,Sword (Great%</code>
   </p>
   <p class="indent3">
    The "%" allows for items named Sword
 (Great/Masterwork) etc.
   </p>
   <p class="indent2">
-   <code>
-    PREEQUIPBOTH:1,TYPE=Slashing
-   </code>
+   <code>PREEQUIPBOTH:1,TYPE=Slashing</code>
   </p>
   <p class="indent3">
    Must have a slashing type weapon equipped in
@@ -2949,20 +2587,16 @@ style.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PREEQUIPTWOWEAPON:1,Sword
-(Short)
-   </code>
+   <code>PREEQUIPTWOWEAPON:1,Sword
+(Short)</code>
   </p>
   <p class="indent3">
    Must have a Sword (Short) equipped as one of two
 weapons for two weapon fighting.
   </p>
   <p class="indent2">
-   <code>
-    PREEQUIPTWOWEAPON:1,Sword
-(Short%
-   </code>
+   <code>PREEQUIPTWOWEAPON:1,Sword
+(Short%</code>
   </p>
   <p class="indent3">
    Must have a Sword (Short) equipped as one of two
@@ -2970,18 +2604,14 @@ weapons and allows for items named Sword (Short/Masterwork)
 etc.
   </p>
   <p class="indent2">
-   <code>
-    PREEQUIPTWOWEAPON:1,TYPE=Slashing
-   </code>
+   <code>PREEQUIPTWOWEAPON:1,TYPE=Slashing</code>
   </p>
   <p class="indent3">
    Must have a "Slashing" type weapon equipped as
 one of two weapons for two weapon fighting.
   </p>
   <p class="indent2">
-   <code>
-    PREEQUIPTWOWEAPON:1,WIELDCATEGORY=Light
-   </code>
+   <code>PREEQUIPTWOWEAPON:1,WIELDCATEGORY=Light</code>
   </p>
   <p class="indent3">
    Must have a light weapon equipped for two weapon
@@ -3005,34 +2635,24 @@ fighting.
    <li style="list-style: none; display: inline">
     <ul class="incremental">
      <li>
-      <code>
-       PREFEAT
-      </code>
+      <code>PREFEAT</code>
       is deprecated. Use
       <a href="#preability">
-       <code>
-        PREABILITY
-       </code>
+       <code>PREABILITY</code>
       </a>
       instead.
      </li>
      <li>
       All
-      <code>
-       FEAT
-      </code>
+      <code>FEAT</code>
       tags have been
       <strong>
        deprecated
       </strong>
       and replaced by the
-      <code>
-       ABILITY
-      </code>
+      <code>ABILITY</code>
       system, which is more general. The
-      <code>
-       ABILITY
-      </code>
+      <code>ABILITY</code>
       system can model feats, racial features, class
 features, traits, flaws, temporary bonuses, and so on, all using a
 common format.
@@ -3106,33 +2726,21 @@ space between the name of the feat and the parentheses.
     </li>
     <li>
      Use of the
-     <code>
-      (TYPE=&lt;text&gt;)
-     </code>
+     <code>(TYPE=&lt;text&gt;)</code>
      syntax with feats
 with multiple instances, e.g.
-     <code>
-      Weapon Focus(TYPE=Bow)
-     </code>
+     <code>Weapon Focus(TYPE=Bow)</code>
      ,
 though allowed, is only supported for feats with internal choosers
 for
-     <code>
-      DOMAIN
-     </code>
+     <code>DOMAIN</code>
      ,
-     <code>
-      SKILL
-     </code>
+     <code>SKILL</code>
      ,
-     <code>
-      SPELL
-     </code>
+     <code>SPELL</code>
      ,
 and
-     <code>
-      WEAPONPROF
-     </code>
+     <code>WEAPONPROF</code>
      types.
     </li>
    </ul>
@@ -3142,87 +2750,69 @@ and
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     PREFEAT:1,Dodge,Combat Reflexes
-    </code>
+    <code>PREFEAT:1,Dodge,Combat Reflexes</code>
    </p>
    <p class="indent3">
     Character must have either "Dodge" or "Combat
 Reflexes".
    </p>
    <p class="indent2">
-    <code>
-     PREFEAT:2,CHECKMULT,Spell Focus
-    </code>
+    <code>PREFEAT:2,CHECKMULT,Spell Focus</code>
    </p>
    <p class="indent3">
     Character must have "Spell Focus" for two
 schools.
    </p>
    <p class="indent2">
-    <code>
-     PREFEAT:2,CHECKMULT,Spell Focus,[Spell
-Focus(Enchantment)]
-    </code>
+    <code>PREFEAT:2,CHECKMULT,Spell Focus,[Spell
+Focus(Enchantment)]</code>
    </p>
    <p class="indent3">
     Character must have "Spell Focus" for two
 schools, but not the "Enchantment" school.
    </p>
    <p class="indent2">
-    <code>
-     PREFEAT:2,Weapon Focus(TYPE=Bow),Weapon
-Focus(Longsword)
-    </code>
+    <code>PREFEAT:2,Weapon Focus(TYPE=Bow),Weapon
+Focus(Longsword)</code>
    </p>
    <p class="indent3">
     Character must have both "Weapon
 Focus(Longsword)" and any one "Bow" type "Weapon Focus".
    </p>
    <p class="indent2">
-    <code>
-     PREFEAT:2,CHECKMULT,Weapon
-Focus(TYPE=Sword)
-    </code>
+    <code>PREFEAT:2,CHECKMULT,Weapon
+Focus(TYPE=Sword)</code>
    </p>
    <p class="indent3">
     Character must have two "Sword" type "Weapon
 Focus" feats.
    </p>
    <p class="indent2">
-    <code>
-     PREFEAT:2,Skill Focus(Spot),Skill
-Focus(Listen),Skill Focus(Search)
-    </code>
+    <code>PREFEAT:2,Skill Focus(Spot),Skill
+Focus(Listen),Skill Focus(Search)</code>
    </p>
    <p class="indent3">
     Character must have any two of "Skill
 Focus(Spot)", "Skill Focus(Listen)", or "Skill Focus(Search)".
    </p>
    <p class="indent2">
-    <code>
-     PREFEAT:2,TYPE=ItemCreation
-    </code>
+    <code>PREFEAT:2,TYPE=ItemCreation</code>
    </p>
    <p class="indent3">
     Character must have any two "ItemCreation" type
 feats.
    </p>
    <p class="indent2">
-    <code>
-     PREFEAT:1,Skill
-Focus(Knowledge%)
-    </code>
+    <code>PREFEAT:1,Skill
+Focus(Knowledge%)</code>
    </p>
    <p class="indent3">
     Character must have one "Skill Focus" feat for a
 "Knowledge" sub-type skill.
    </p>
    <p class="indent2">
-    <code>
-     Magecraft (Charismatic).MOD &lt;tab&gt;
-!PREFEAT:1,Untapped Potential
-    </code>
+    <code>Magecraft (Charismatic).MOD &lt;tab&gt;
+!PREFEAT:1,Untapped Potential</code>
    </p>
    <p class="indent3">
     Character must not (!) have one feat called
@@ -3264,9 +2854,7 @@ None, and Other.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PREGENDER:M
-   </code>
+   <code>PREGENDER:M</code>
   </p>
   <p class="indent3">
    Character's gender must start with "M".
@@ -3345,9 +2933,7 @@ prerequisite.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PREHANDSGT:2
-   </code>
+   <code>PREHANDSGT:2</code>
   </p>
   <p class="indent3">
    Character must have a number of hands greater
@@ -3401,36 +2987,28 @@ Monster Classes only.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PREHD:MIN=1,MAX=3
-   </code>
+   <code>PREHD:MIN=1,MAX=3</code>
   </p>
   <p class="indent3">
    The character must have one, two, or three
 racial hit die monster levels.
   </p>
   <p class="indent2">
-   <code>
-    PREHD:MIN=4
-   </code>
+   <code>PREHD:MIN=4</code>
   </p>
   <p class="indent3">
    The character must have four or more racial hit
 die or monster levels.
   </p>
   <p class="indent2">
-   <code>
-    PREHD:MAX=4
-   </code>
+   <code>PREHD:MAX=4</code>
   </p>
   <p class="indent3">
    The character must have four or fewer racial hit
 die monster levels.
   </p>
   <p class="indent2">
-   <code>
-    !PREHD:MIN=5,MAX=7
-   </code>
+   <code>!PREHD:MIN=5,MAX=7</code>
   </p>
   <p class="indent3">
    Character must have between 0-4 OR 7 or greater
@@ -3471,9 +3049,7 @@ prerequisite.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PREHP:50
-   </code>
+   <code>PREHP:50</code>
   </p>
   <p class="indent3">
    The character must have at least 50 hp.
@@ -3529,27 +3105,21 @@ assignment.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PREITEM:1,Sword (Long),Sword
-(Short)
-   </code>
+   <code>PREITEM:1,Sword (Long),Sword
+(Short)</code>
   </p>
   <p class="indent3">
    Character must possess either a "long sword" or
 a "short sword".
   </p>
   <p class="indent2">
-   <code>
-    PREITEM:2,TYPE=Armor,TYPE=Armor
-   </code>
+   <code>PREITEM:2,TYPE=Armor,TYPE=Armor</code>
   </p>
   <p class="indent3">
    Character must possess two sets of armor.
   </p>
   <p class="indent2">
-   <code>
-    PREITEM:1,TYPE=Natural
-   </code>
+   <code>PREITEM:1,TYPE=Natural</code>
   </p>
   <p class="indent3">
    Character must possess one natural item.
@@ -3592,9 +3162,7 @@ Name)
    </li>
    <li>
     The Kit name is taken from the
-    <code>
-     STARTPACK
-    </code>
+    <code>STARTPACK</code>
     tag for
 the target kit.
    </li>
@@ -3611,36 +3179,28 @@ the target kit.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PREKIT:1,Starting Gold
-   </code>
+   <code>PREKIT:1,Starting Gold</code>
   </p>
   <p class="indent3">
    Makes sure the character has the 'Starting Gold'
 kit.
   </p>
   <p class="indent2">
-   <code>
-    PREKIT:2,Flumph Abilities,Flumph
-Skills
-   </code>
+   <code>PREKIT:2,Flumph Abilities,Flumph
+Skills</code>
   </p>
   <p class="indent3">
    Makes sure the character has both kits
   </p>
   <p class="indent2">
-   <code>
-    PREKIT:1,Alchemist's Kit
-   </code>
+   <code>PREKIT:1,Alchemist's Kit</code>
   </p>
   <p class="indent3">
    Makes sure the character does not have the
 Alchemist's Kit
   </p>
   <p class="indent2">
-   <code>
-    PREKIT:1,Dragon Age%
-   </code>
+   <code>PREKIT:1,Dragon Age%</code>
   </p>
   <p class="indent3">
    Will match both 'Dragon Age 01 ~ Wyrmling' and
@@ -3693,45 +3253,35 @@ prerequisite.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRELANG:1,Dwarven,Elven
-   </code>
+   <code>PRELANG:1,Dwarven,Elven</code>
   </p>
   <p class="indent3">
    Character must be able to speak either "Dwarven"
 or "Elven".
   </p>
   <p class="indent2">
-   <code>
-    PRELANG:2,Dwarven,Elven
-   </code>
+   <code>PRELANG:2,Dwarven,Elven</code>
   </p>
   <p class="indent3">
    Character must be able to speak both "Dwarven"
 and "Elven".
   </p>
   <p class="indent2">
-   <code>
-    PRELANG:2,Dwarven,Elven,Halfling
-   </code>
+   <code>PRELANG:2,Dwarven,Elven,Halfling</code>
   </p>
   <p class="indent3">
    Character must be able to speak any two of
 "Dwarven", "Elven" or "Halfling".
   </p>
   <p class="indent2">
-   <code>
-    PRELANG:3,ANY
-   </code>
+   <code>PRELANG:3,ANY</code>
   </p>
   <p class="indent3">
    Character must be able to speak any three
 languages.
   </p>
   <p class="indent2">
-   <code>
-    PRELANG:4,TYPE=Spoken
-   </code>
+   <code>PRELANG:4,TYPE=Spoken</code>
   </p>
   <p class="indent3">
    Character must be able to speak any four
@@ -3811,9 +3361,7 @@ prerequisite.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRELEGSGTEQ:4
-   </code>
+   <code>PRELEGSGTEQ:4</code>
   </p>
   <p class="indent3">
    Character must have at least 4 legs.
@@ -3866,34 +3414,26 @@ to qualify.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRELEVEL:MIN=5
-   </code>
+   <code>PRELEVEL:MIN=5</code>
   </p>
   <p class="indent3">
    Character must be at least 5th level.
   </p>
   <p class="indent2">
-   <code>
-    PRELEVEL:MAX=5
-   </code>
+   <code>PRELEVEL:MAX=5</code>
   </p>
   <p class="indent3">
    Character must be no greater than 5th level.
   </p>
   <p class="indent2">
-   <code>
-    PRELEVEL:MIN=5,MAX=10
-   </code>
+   <code>PRELEVEL:MIN=5,MAX=10</code>
   </p>
   <p class="indent3">
    Character must be at least 5th level but no
 greater than 10th level.
   </p>
   <p class="indent2">
-   <code>
-    !PRELEVEL:MIN=3,MAX=6
-   </code>
+   <code>!PRELEVEL:MIN=3,MAX=6</code>
   </p>
   <p class="indent3">
    Character must NOT be 3rd, 4th, 5th or 6th
@@ -3935,9 +3475,7 @@ some very bad exceptions in the code.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRELEVELMAX:10
-   </code>
+   <code>PRELEVELMAX:10</code>
   </p>
   <p class="indent3">
    Character cannot be over level 10.
@@ -3990,26 +3528,20 @@ minimum movement rate for the associated movement type).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PREMOVE:1,Walk=30,Fly=20
-   </code>
+   <code>PREMOVE:1,Walk=30,Fly=20</code>
   </p>
   <p class="indent3">
    Character must be able to either walk at speed
 30 OR fly at speed 20
   </p>
   <p class="indent2">
-   <code>
-    PREMOVE:1,Swim=10
-   </code>
+   <code>PREMOVE:1,Swim=10</code>
   </p>
   <p class="indent3">
    Character must be able to swim at speed 10
   </p>
   <p class="indent2">
-   <code>
-    PREMOVE:2,Walk=30,Climb=15
-   </code>
+   <code>PREMOVE:2,Walk=30,Climb=15</code>
   </p>
   <p class="indent3">
    Character must be able to walk at speed 30 AND
@@ -4060,38 +3592,30 @@ PRExxx tags.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PREMULT:1,[PRERACE:Gnome],[PRECLASS:1,Cleric=1]
-   </code>
+   <code>PREMULT:1,[PRERACE:Gnome],[PRECLASS:1,Cleric=1]</code>
   </p>
   <p class="indent3">
    Character must be either a "Gnome" or a
 "Cleric".
   </p>
   <p class="indent2">
-   <code>
-    PREMULT:1,[PRERACE:Gnome],[PREMULT:2,[PRESIZEGTEQ:M],[PREFEAT:1,Alertness]]
-   </code>
+   <code>PREMULT:1,[PRERACE:Gnome],[PREMULT:2,[PRESIZEGTEQ:M],[PREFEAT:1,Alertness]]</code>
   </p>
   <p class="indent3">
    Character must be "Gnome" OR a medium sized or
 larger creature with the "Alertness" feat.
   </p>
   <p class="indent2">
-   <code>
-    PREMULT:1,[!PRERACE:%],[PRERACE:Bunch of
-Rocks]
-   </code>
+   <code>PREMULT:1,[!PRERACE:%],[PRERACE:Bunch of
+Rocks]</code>
   </p>
   <p class="indent3">
    Character only be from a "Bunch of Rocks".
   </p>
   <p class="indent2">
-   <code>
-    Stamina.MOD &lt;tab&gt; PRE:.CLEAR
+   <code>Stamina.MOD &lt;tab&gt; PRE:.CLEAR
 &lt;tab&gt; PREMULT:1,[PREFEAT:1,Robust],[PRECLASS:1,Super
-Soldier=1]
-   </code>
+Soldier=1]</code>
   </p>
   <p class="indent3">
    The Stamna feat is modified to remove all PRE
@@ -4151,9 +3675,7 @@ classes.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PREPCLEVEL:MAX=1
-   </code>
+   <code>PREPCLEVEL:MAX=1</code>
   </p>
   <p class="indent3">
    Character must be no greater than 1st level.
@@ -4162,34 +3684,26 @@ level character. A character with racial hitdice (monster levels)
 but only 1 or no character class levels will still qualify.
   </p>
   <p class="indent2">
-   <code>
-    PREPCLEVEL:MIN=5
-   </code>
+   <code>PREPCLEVEL:MIN=5</code>
   </p>
   <p class="indent3">
    Character must be at least 5th level.
   </p>
   <p class="indent2">
-   <code>
-    PREPCLEVEL:MAX=5
-   </code>
+   <code>PREPCLEVEL:MAX=5</code>
   </p>
   <p class="indent3">
    Character must be no greater than 5th level.
   </p>
   <p class="indent2">
-   <code>
-    PREPCLEVEL:MIN=5,MAX=10
-   </code>
+   <code>PREPCLEVEL:MIN=5,MAX=10</code>
   </p>
   <p class="indent3">
    Character must be at least 5th level but no
 greater than 10th level.
   </p>
   <p class="indent2">
-   <code>
-    !PREPCLEVEL:MIN=2,MAX=4
-   </code>
+   <code>!PREPCLEVEL:MIN=2,MAX=4</code>
   </p>
   <p class="indent3">
    Character must NOT be 2nd, 3rd or 4th level.
@@ -4245,18 +3759,14 @@ unecessary.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PREPOINTBUYMETHOD:1,Standard
-   </code>
+   <code>PREPOINTBUYMETHOD:1,Standard</code>
   </p>
   <p class="indent3">
    Sets a prerequisite of "Standard" for the
 point-buy saved method.
   </p>
   <p class="indent2">
-   <code>
-    PREPOINTBUYMETHOD:1,Standard,High-powered
-   </code>
+   <code>PREPOINTBUYMETHOD:1,Standard,High-powered</code>
   </p>
   <p class="indent3">
    Sets a prerequisite of "Standard" or
@@ -4309,19 +3819,15 @@ name of a Armor Prof).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PREPROFWITHARMOR:1,Chainmail,Full
-Plate
-   </code>
+   <code>PREPROFWITHARMOR:1,Chainmail,Full
+Plate</code>
   </p>
   <p class="indent3">
    Character must be proficient with either
 "Chainmail" or "Full Plate".
   </p>
   <p class="indent2">
-   <code>
-    PREPROFWITHARMOR:1,TYPE.Medium
-   </code>
+   <code>PREPROFWITHARMOR:1,TYPE.Medium</code>
   </p>
   <p class="indent3">
    Character must be proficient with Medium
@@ -4374,19 +3880,15 @@ name of a shield proficiency).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PREPROFWITHSHIELD:1,Buckler,Large
-Shield
-   </code>
+   <code>PREPROFWITHSHIELD:1,Buckler,Large
+Shield</code>
   </p>
   <p class="indent3">
    Character must be proficient with either
 "Buckler" or "Large Shield".
   </p>
   <p class="indent2">
-   <code>
-    PREPROFWITHSHIELD:1,TYPE.Tower
-   </code>
+   <code>PREPROFWITHSHIELD:1,TYPE.Tower</code>
   </p>
   <p class="indent3">
    Character must be proficient with Tower
@@ -4482,97 +3984,75 @@ assignment.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRERACE:1,Dwarf,Elf,Human
-   </code>
+   <code>PRERACE:1,Dwarf,Elf,Human</code>
   </p>
   <p class="indent3">
    Character must be a "Dwarf", "Elf" or
 "Human".
   </p>
   <p class="indent2">
-   <code>
-    PRERACE:1,Elf%,[Elf (aquatic)]
-   </code>
+   <code>PRERACE:1,Elf%,[Elf (aquatic)]</code>
   </p>
   <p class="indent3">
    Character must be one of the "Elf" races, except
 "Elf (aquatic)".
   </p>
   <p class="indent2">
-   <code>
-    PRERACE:1,TYPE=Dire
-   </code>
+   <code>PRERACE:1,TYPE=Dire</code>
   </p>
   <p class="indent3">
    Character's race type must be "Dire".
   </p>
   <p class="indent2">
-   <code>
-    PRERACE:1,RACETYPE=Giant
-   </code>
+   <code>PRERACE:1,RACETYPE=Giant</code>
   </p>
   <p class="indent3">
    Character's race type must be "Giant".
   </p>
   <p class="indent2">
-   <code>
-    !PRERACE:1,RACETYPE=Outsider
-   </code>
+   <code>!PRERACE:1,RACETYPE=Outsider</code>
   </p>
   <p class="indent3">
    Character's race type must not be
 "Outsider".
   </p>
   <p class="indent2">
-   <code>
-    PRERACE:1,RACESUBTYPE=Incorporeal
-   </code>
+   <code>PRERACE:1,RACESUBTYPE=Incorporeal</code>
   </p>
   <p class="indent3">
    Character must have the "Incorporeal"
 subtype.
   </p>
   <p class="indent2">
-   <code>
-    PRERACE:2,RACETYPE=Undead,RACESUBTYPE=Incorporeal
-   </code>
+   <code>PRERACE:2,RACETYPE=Undead,RACESUBTYPE=Incorporeal</code>
   </p>
   <p class="indent3">
    Character must have both a race type of "Undead"
 and a subtype of "Incorporeal".
   </p>
   <p class="indent2">
-   <code>
-    PRERACE:1,%
-   </code>
+   <code>PRERACE:1,%</code>
   </p>
   <p class="indent3">
    This will pass if any race has been chosen but
 will fail if no race has been selected.
   </p>
   <p class="indent2">
-   <code>
-    !PRERACE:1,%
-   </code>
+   <code>!PRERACE:1,%</code>
   </p>
   <p class="indent3">
    This will pass if no race has been selected.
   </p>
   <p class="indent2">
-   <code>
-    PRERACE:TYPE=Humanoid
-   </code>
+   <code>PRERACE:TYPE=Humanoid</code>
   </p>
   <p class="indent3">
    This will pass if a humanoid race has been
 selected.
   </p>
   <p class="indent2">
-   <code>
-    CLASS:Sorcerer.MOD &lt;tab&gt;
-!PRERACE:Human
-   </code>
+   <code>CLASS:Sorcerer.MOD &lt;tab&gt;
+!PRERACE:Human</code>
   </p>
   <p class="indent3">
    This will pass if no Human race has been
@@ -4654,18 +4134,14 @@ reach to be compared to).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PREREACH:10
-   </code>
+   <code>PREREACH:10</code>
   </p>
   <p class="indent3">
    Character must have at least a reach of 10
 ft..
   </p>
   <p class="indent2">
-   <code>
-    PREREACHEQ:5
-   </code>
+   <code>PREREACHEQ:5</code>
   </p>
   <p class="indent3">
    Character must have a reach of exactly 5
@@ -4703,9 +4179,7 @@ text.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PREREGION:Slithe
-   </code>
+   <code>PREREGION:Slithe</code>
   </p>
   <p class="indent3">
    Character must hail from the "Slithe"
@@ -4747,9 +4221,7 @@ name)
    <li>
     The rule name must have been defined and match the variable
 (
-    <code>
-     VAR
-    </code>
+    <code>VAR</code>
     ) entry in the
     <em>
      system/gameModes/rules.lst
@@ -4771,9 +4243,7 @@ Rules
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRERULE:1,SYS_WTPSK
-   </code>
+   <code>PRERULE:1,SYS_WTPSK</code>
   </p>
   <p class="indent3">
    The rule WeightPenaltyToSkill must be checked
@@ -4815,9 +4285,7 @@ prerequisite.
    </li>
    <li>
     Special abilities applied by the
-    <code>
-     SAB
-    </code>
+    <code>SAB</code>
     tag will
 satisfy this prerequisite.
    </li>
@@ -4828,20 +4296,16 @@ satisfy this prerequisite.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRESA:1,Turn undead,Rebuke undead,Smite
-Evil
-   </code>
+   <code>PRESA:1,Turn undead,Rebuke undead,Smite
+Evil</code>
   </p>
   <p class="indent3">
    Character must have any one of "Turn Undead",
 "Rebuke Undead" or "Smite Evil".
   </p>
   <p class="indent2">
-   <code>
-    CLASS:Mystic Theurge.MOD &lt;tab&gt;
-!PRESA:1,Theurgy
-   </code>
+   <code>CLASS:Mystic Theurge.MOD &lt;tab&gt;
+!PRESA:1,Theurgy</code>
   </p>
   <p class="indent3">
    Character must not have any Special Abilities of
@@ -4862,43 +4326,25 @@ particular range of size categories.
    Syntax
   </h4>
   <p>
-   <code>
-    PRESIZEoperator:size
-   </code>
+   <code>PRESIZEoperator:size</code>
   </p>
   <p>
-   <code>
-    operator
-   </code>
+   <code>operator</code>
    is a comparison operator from the list
-   <code>
-    EQ
-   </code>
+   <code>EQ</code>
    ,
-   <code>
-    LT
-   </code>
+   <code>LT</code>
    ,
-   <code>
-    LTEQ
-   </code>
+   <code>LTEQ</code>
    ,
-   <code>
-    GT
-   </code>
+   <code>GT</code>
    ,
-   <code>
-    GTEQ
-   </code>
+   <code>GTEQ</code>
    , or
-   <code>
-    NEQ
-   </code>
+   <code>NEQ</code>
    . The
 comparison operator is written as part of the tag name, i.e.
-   <code>
-    PRESIZELTEQ
-   </code>
+   <code>PRESIZELTEQ</code>
    . See
    <a href="#comparison-operators">
     comparison operators
@@ -4908,102 +4354,66 @@ comparison operator is written as part of the tag name, i.e.
   </p>
   <p>
    The
-   <code>
-    operator
-   </code>
+   <code>operator</code>
    is written as part of the tag name,
 i.e.
-   <code>
-    PRESIZENEQ
-   </code>
+   <code>PRESIZENEQ</code>
    or
-   <code>
-    PRESIZEGTEQ
-   </code>
+   <code>PRESIZEGTEQ</code>
    .
   </p>
   <p>
-   <code>
-    size
-   </code>
+   <code>size</code>
    is one of the
-   <code>
-    SIZENAME
-   </code>
+   <code>SIZENAME</code>
    s defined
 in the "game mode", i.e.
-   <code>
-    /system/gameModes/35e/sizeAdjustment.lst
-   </code>
+   <code>/system/gameModes/35e/sizeAdjustment.lst</code>
    . For the
-   <code>
-    35e
-   </code>
+   <code>35e</code>
    game mode the
-   <code>
-    SIZENAMES
-   </code>
+   <code>SIZENAMES</code>
    are:
   </p>
   <ul>
    <li>
-    <code>
-     F
-    </code>
+    <code>F</code>
     - fine
    </li>
    <li>
-    <code>
-     D
-    </code>
+    <code>D</code>
     - diminutive
    </li>
    <li>
-    <code>
-     T
-    </code>
+    <code>T</code>
     - tiny
    </li>
    <li>
-    <code>
-     S
-    </code>
+    <code>S</code>
     - small
    </li>
    <li>
-    <code>
-     M
-    </code>
+    <code>M</code>
     - medium
    </li>
    <li>
-    <code>
-     L
-    </code>
+    <code>L</code>
     - large
    </li>
    <li>
-    <code>
-     H
-    </code>
+    <code>H</code>
     - huge
    </li>
    <li>
-    <code>
-     G
-    </code>
+    <code>G</code>
     - gargantuan
    </li>
    <li>
-    <code>
-     C
-    </code>
+    <code>C</code>
     - colossal
    </li>
    <li>
-    <code>
-     P
-    </code>
+    <code>P</code>
     - larger than colossal
    </li>
   </ul>
@@ -5013,9 +4423,7 @@ in the "game mode", i.e.
   <ol>
    <li>
     <p>
-     <code>
-      PRESIZEGTEQ:S
-     </code>
+     <code>PRESIZEGTEQ:S</code>
     </p>
     <p>
      Require the character is at least small-sized.
@@ -5023,9 +4431,7 @@ in the "game mode", i.e.
    </li>
    <li>
     <p>
-     <code>
-      PRESIZELT:S
-     </code>
+     <code>PRESIZELT:S</code>
     </p>
     <p>
      Require that the character is fine, diminutive, or tiny.
@@ -5033,18 +4439,14 @@ in the "game mode", i.e.
    </li>
    <li>
     <p>
-     <code>
-      PREMULT:2,[PRESIZEGTEQ:S],[PRESIZELTEQ:L]
-     </code>
+     <code>PREMULT:2,[PRESIZEGTEQ:S],[PRESIZELTEQ:L]</code>
     </p>
     <p>
      Require the character to be small, medium, or large.
     </p>
     <p>
      Alternately,
-     <code>
-      PREMULT:1,[PRESIZEEQ:S],[PRESIZEEQ:M],[PRESIZEEQ:L]
-     </code>
+     <code>PREMULT:1,[PRESIZEEQ:S],[PRESIZEEQ:M],[PRESIZEEQ:L]</code>
      would do the same thing.
     </p>
    </li>
@@ -5099,9 +4501,7 @@ name)
    <li>
     If you require multiples of a particular type of skill, you
 need to include a
-    <code>
-     TYPE.Text
-    </code>
+    <code>TYPE.Text</code>
     sub-tag for each instance
 in the comma delimited list.
    </li>
@@ -5117,28 +4517,22 @@ parentheses because the text must match the entry exactly.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRESKILL:1,Spot=10,Listen=10
-   </code>
+   <code>PRESKILL:1,Spot=10,Listen=10</code>
   </p>
   <p class="indent3">
    Character must have at least 10 ranks in either
 "Spot" or "Listen".
   </p>
   <p class="indent2">
-   <code>
-    PRESKILL:2,TYPE.Spy=2,TYPE.Spy=2
-   </code>
+   <code>PRESKILL:2,TYPE.Spy=2,TYPE.Spy=2</code>
   </p>
   <p class="indent3">
    Character must have two "Spy" skills with at
 least two ranks in each of them.
   </p>
   <p class="indent2">
-   <code>
-    PRESKILL:3,Appraise=3,Decipher
-Script=3,Knowledge (TYPE=Other)=3
-   </code>
+   <code>PRESKILL:3,Appraise=3,Decipher
+Script=3,Knowledge (TYPE=Other)=3</code>
   </p>
   <p class="indent3">
    Character must have three skills with at least
@@ -5224,9 +4618,7 @@ in some files but not all.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRESKILLMULT:1,Spot=10,Listen=10
-   </code>
+   <code>PRESKILLMULT:1,Spot=10,Listen=10</code>
   </p>
   <p class="indent3">
    Character must have a Spot or Listen at 10 or
@@ -5287,9 +4679,7 @@ Variable, or Formula (Skill ranks)
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRESKILLSIT:1,SKILL=Spot,Woodlands=10
-   </code>
+   <code>PRESKILLSIT:1,SKILL=Spot,Woodlands=10</code>
   </p>
   <p class="indent3">
    Character must have at least 10 ranks in "Spot
@@ -5345,9 +4735,7 @@ must equal y.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRESKILLTOT:Spot,Listen,Search=30
-   </code>
+   <code>PRESKILLTOT:Spot,Listen,Search=30</code>
   </p>
   <p class="indent3">
    Character must have a total of 30 non-bonus
@@ -5391,10 +4779,8 @@ name of a spell).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRESPELL:1,Magic Missile,Lightning
-Bolt
-   </code>
+   <code>PRESPELL:1,Magic Missile,Lightning
+Bolt</code>
   </p>
   <p class="indent3">
    Character must have either Magic Missile OR
@@ -5435,18 +4821,14 @@ Lightning Bolt in their spell list.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRESPELLBOOK:YES
-   </code>
+   <code>PRESPELLBOOK:YES</code>
   </p>
   <p class="indent3">
    At least one of the character's classes must use
 spell books.
   </p>
   <p class="indent2">
-   <code>
-    PRESPELLBOOK:NO
-   </code>
+   <code>PRESPELLBOOK:NO</code>
   </p>
   <p class="indent3">
    None of the character's classes can use spell
@@ -5514,45 +4896,35 @@ meet all the requirements), then this prerequisite is met.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRESPELLCAST:MEMORIZE=Y
-   </code>
+   <code>PRESPELLCAST:MEMORIZE=Y</code>
   </p>
   <p class="indent3">
    Character's class must have to memorize
 spells.
   </p>
   <p class="indent2">
-   <code>
-    PRESPELLCAST:MEMORIZE=N
-   </code>
+   <code>PRESPELLCAST:MEMORIZE=N</code>
   </p>
   <p class="indent3">
    Character's class must NOT have to memorize
 spells.
   </p>
   <p class="indent2">
-   <code>
-    PRESPELLCAST:TYPE=Arcane
-   </code>
+   <code>PRESPELLCAST:TYPE=Arcane</code>
   </p>
   <p class="indent3">
    Character must be able to cast arcane
 spells.
   </p>
   <p class="indent2">
-   <code>
-    PRESPELLCAST:TYPE=Divine
-   </code>
+   <code>PRESPELLCAST:TYPE=Divine</code>
   </p>
   <p class="indent3">
    Character must be able to cast divine
 spells.
   </p>
   <p class="indent2">
-   <code>
-    PRESPELLCAST:TYPE=Arcane,TYPE=Divine
-   </code>
+   <code>PRESPELLCAST:TYPE=Arcane,TYPE=Divine</code>
   </p>
   <p class="indent3">
    Character must be able to cast arcane/divine
@@ -5603,9 +4975,7 @@ Acid, Sonic, Evil, Good, Mind-Affecting, etc.)
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRESPELLDESCRIPTOR:4,Mind-Affecting=3
-   </code>
+   <code>PRESPELLDESCRIPTOR:4,Mind-Affecting=3</code>
   </p>
   <p class="indent3">
    Character must have at least four 3rd level or
@@ -5617,9 +4987,7 @@ higher Mind-Affecting spells to meet the requirement.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRESPELLDESCRIPTOR:y,x,z
-   </code>
+   <code>PRESPELLDESCRIPTOR:y,x,z</code>
   </p>
   <hr/>
   <p class="lststatus">
@@ -5675,9 +5043,7 @@ a comma-delimited (",") list.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRESPELLSCHOOL:3,Necromancy=2
-   </code>
+   <code>PRESPELLSCHOOL:3,Necromancy=2</code>
   </p>
   <p class="indent3">
    Character must have at least three 2nd level or
@@ -5737,9 +5103,7 @@ as a comma-delimited (",") list.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRESPELLSCHOOLSUB:3,Creation=2
-   </code>
+   <code>PRESPELLSCHOOLSUB:3,Creation=2</code>
   </p>
   <p class="indent3">
    Character must have at least three 2nd level
@@ -5821,28 +5185,22 @@ is required
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRESPELLTYPE:4,Arcane=5
-   </code>
+   <code>PRESPELLTYPE:4,Arcane=5</code>
   </p>
   <p class="indent3">
    Character must have at least four 5th level
 arcane spells to meet the requirement.
   </p>
   <p class="indent2">
-   <code>
-    PRESPELLTYPE:1,Arcane=3,Divine=3,Psionic=3
-   </code>
+   <code>PRESPELLTYPE:1,Arcane=3,Divine=3,Psionic=3</code>
   </p>
   <p class="indent3">
    Character must have at least one 3rd level spell
 from any of the "Arcane", "Divine", or "Psionic" types.
   </p>
   <p class="indent2">
-   <code>
-    PRESPELLTYPE:1,Arcane=3 &lt;tab&gt;
-PRESPELLTYPE:1,Divine=3
-   </code>
+   <code>PRESPELLTYPE:1,Arcane=3 &lt;tab&gt;
+PRESPELLTYPE:1,Divine=3</code>
   </p>
   <p class="indent3">
    Character must have at least one 3rd level
@@ -5922,18 +5280,14 @@ including SR from equipment) a prerequisite.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRESRGTEQ:10
-   </code>
+   <code>PRESRGTEQ:10</code>
   </p>
   <p class="indent3">
    Character must have spell resistance of 10 or
 greater.
   </p>
   <p class="indent2">
-   <code>
-    PRESREQ:10
-   </code>
+   <code>PRESREQ:10</code>
   </p>
   <p class="indent3">
    Character must have spell resistance of exactly
@@ -5984,45 +5338,35 @@ minimum value of the stat).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRESTAT:1,STR=18
-   </code>
+   <code>PRESTAT:1,STR=18</code>
   </p>
   <p class="indent3">
    Character must have an 18 Strength to meet the
 requirement.
   </p>
   <p class="indent2">
-   <code>
-    PRESTAT:1,STR=18,WIS=18
-   </code>
+   <code>PRESTAT:1,STR=18,WIS=18</code>
   </p>
   <p class="indent3">
    Either STR or WIS at 18 - one of the two listed
 must meet the requirements.
   </p>
   <p class="indent2">
-   <code>
-    PRESTAT:2,STR=18,WIS=18
-   </code>
+   <code>PRESTAT:2,STR=18,WIS=18</code>
   </p>
   <p class="indent3">
    BOTH STR and WIS at 18 - two of the two listed
 must meet the requirements.
   </p>
   <p class="indent2">
-   <code>
-    PRESTAT:1,STR=15,WIS=13
-   </code>
+   <code>PRESTAT:1,STR=15,WIS=13</code>
   </p>
   <p class="indent3">
    Either STR at 15 or WIS at 13 - one of the two
 listed must meet the requirements.
   </p>
   <p class="indent2">
-   <code>
-    PRESTAT:2,STR=13,INT=10,CHA=13
-   </code>
+   <code>PRESTAT:2,STR=13,INT=10,CHA=13</code>
   </p>
   <p class="indent3">
    Either STR at 13, INT at 10 or CHA at 13 - two
@@ -6065,9 +5409,7 @@ of the three listed must meet the requirements.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRESUBCLASS:1,Evoker,Abjurer,Enchanter,Illusionist
-   </code>
+   <code>PRESUBCLASS:1,Evoker,Abjurer,Enchanter,Illusionist</code>
   </p>
   <p class="indent3">
    Character must be one of the listed
@@ -6116,18 +5458,14 @@ list matches, the prerequisite is met.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRETEMPLATE:1,Celestial,Fiendish
-   </code>
+   <code>PRETEMPLATE:1,Celestial,Fiendish</code>
   </p>
   <p class="indent3">
    Character must be either "Celestial" or
 "Fiendish".
   </p>
   <p class="indent2">
-   <code>
-    PRETEMPLATE:1,Feral%
-   </code>
+   <code>PRETEMPLATE:1,Feral%</code>
   </p>
   <p class="indent3">
    Character must be any subrace of Feral.
@@ -6172,10 +5510,8 @@ but alerts the player to the additional pre-requisites.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRETEXT:Character must make a sacrifice of
-bananas to the Monkey God.
-   </code>
+   <code>PRETEXT:Character must make a sacrifice of
+bananas to the Monkey God.</code>
   </p>
   <p class="indent3">
    Explains what additional requirements are needed
@@ -6216,9 +5552,7 @@ considers both the base attack bonu and the epic attack bonus.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRETOTALAB:21
-   </code>
+   <code>PRETOTALAB:21</code>
   </p>
   <p class="indent3">
    Required total attack bonus is 21.
@@ -6260,9 +5594,7 @@ etc.
    </li>
    <li>
     See the
-    <code>
-     PRETYPE
-    </code>
+    <code>PRETYPE</code>
     entry in
     <a href="../datafilestagpages/datafilesequipment.html#pretype">
      Equipment
@@ -6290,26 +5622,20 @@ type template.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRETYPE:1,Elemental,Fey,Outsider
-   </code>
+   <code>PRETYPE:1,Elemental,Fey,Outsider</code>
   </p>
   <p class="indent3">
    Type must either "Elemental", "Fey" or
 "Outsider".
   </p>
   <p class="indent2">
-   <code>
-    PRETYPE:2,Humanoid,Undead
-   </code>
+   <code>PRETYPE:2,Humanoid,Undead</code>
   </p>
   <p class="indent3">
    Character must be an "Undead Humanoid".
   </p>
   <p class="indent2">
-   <code>
-    PRETYPE:1,Heavy
-   </code>
+   <code>PRETYPE:1,Heavy</code>
   </p>
   <p class="indent3">
    Object must have the type "Heavy".
@@ -6346,9 +5672,7 @@ bonus.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PREUATT:4
-   </code>
+   <code>PREUATT:4</code>
   </p>
   <p class="indent3">
    This would apply only if the PC had minimum
@@ -6360,9 +5684,7 @@ unarmed attack bonus of 4.
   </h3>
   <p>
    Requires that a
-   <code>
-    VAR
-   </code>
+   <code>VAR</code>
    variable has a certain value or
 range of values.
   </p>
@@ -6373,43 +5695,25 @@ range of values.
    Syntax
   </h4>
   <p>
-   <code>
-    PREVARoperator:varname,value
-   </code>
+   <code>PREVARoperator:varname,value</code>
   </p>
   <p>
-   <code>
-    operator
-   </code>
+   <code>operator</code>
    is a comparison operator from the list
-   <code>
-    EQ
-   </code>
+   <code>EQ</code>
    ,
-   <code>
-    LT
-   </code>
+   <code>LT</code>
    ,
-   <code>
-    LTEQ
-   </code>
+   <code>LTEQ</code>
    ,
-   <code>
-    GT
-   </code>
+   <code>GT</code>
    ,
-   <code>
-    GTEQ
-   </code>
+   <code>GTEQ</code>
    , or
-   <code>
-    NEQ
-   </code>
+   <code>NEQ</code>
    . The
 comparison operator is written as part of the tag name, i.e.
-   <code>
-    PREVARLTEQ
-   </code>
+   <code>PREVARLTEQ</code>
    . See
    <a href="#comparison-operators">
     comparison operators
@@ -6418,23 +5722,15 @@ comparison operator is written as part of the tag name, i.e.
 details.
   </p>
   <p>
-   <code>
-    varname
-   </code>
+   <code>varname</code>
    is the name of a variable - as used in a
-   <code>
-    DEFINE:
-   </code>
+   <code>DEFINE:</code>
    or
-   <code>
-    BONUS:VAR
-   </code>
+   <code>BONUS:VAR</code>
    statement.
   </p>
   <p>
-   <code>
-    value
-   </code>
+   <code>value</code>
    is the value the variable is to be compared
 to.
   </p>
@@ -6444,9 +5740,7 @@ to.
   <ol>
    <li>
     <p>
-     <code>
-      PREVARGT:Rage,4
-     </code>
+     <code>PREVARGT:Rage,4</code>
     </p>
     <p>
      Character must must have a variable 'Rage' with a value greater
@@ -6455,9 +5749,7 @@ than four.
    </li>
    <li>
     <p>
-     <code>
-      PREVARGT:SneakAttack,5
-     </code>
+     <code>PREVARGT:SneakAttack,5</code>
     </p>
     <p>
      Character must have a variable 'Sneak Attack' with a value
@@ -6466,9 +5758,7 @@ greater than five.
    </li>
    <li>
     <p>
-     <code>
-      PREVARGT:SneakAttack,5,Rage,4
-     </code>
+     <code>PREVARGT:SneakAttack,5,Rage,4</code>
     </p>
     <p>
      Character must have a variable 'SneakAttack' with a value
@@ -6535,27 +5825,21 @@ type.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PREVISION:2,Normal=ANY,Darkvision=ANY
-   </code>
+   <code>PREVISION:2,Normal=ANY,Darkvision=ANY</code>
   </p>
   <p class="indent3">
    Character must have both Normal and
 Darkvision.
   </p>
   <p class="indent2">
-   <code>
-    PREVISION:1,Blindsight=30,Darkvision=30
-   </code>
+   <code>PREVISION:1,Blindsight=30,Darkvision=30</code>
   </p>
   <p class="indent3">
    Character must have either Blindsight or
 Darkvision at at least 30.
   </p>
   <p class="indent2">
-   <code>
-    PREVISION:1,Low-Light=ANY
-   </code>
+   <code>PREVISION:1,Low-Light=ANY</code>
   </p>
   <p class="indent3">
    Character must have low-light vision to any
@@ -6623,37 +5907,29 @@ results.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PREWEAPONPROF:2,Kama,Katana
-   </code>
+   <code>PREWEAPONPROF:2,Kama,Katana</code>
   </p>
   <p class="indent3">
    Character must have proficiency with both the
 "Kama" and the "Katana".
   </p>
   <p class="indent2">
-   <code>
-    PREWEAPONPROF:1,TYPE.Exotic
-   </code>
+   <code>PREWEAPONPROF:1,TYPE.Exotic</code>
   </p>
   <p class="indent3">
    Character must have a weapon proficiency of type
 "Exotic".
   </p>
   <p class="indent2">
-   <code>
-    PREWEAPONPROF:1,TYPE.Martial,Chain
-(Spiked)
-   </code>
+   <code>PREWEAPONPROF:1,TYPE.Martial,Chain
+(Spiked)</code>
   </p>
   <p class="indent3">
    Character must have either a weapon proficiency
 of type "Martial" or proficiency with "Chain (Spiked)".
   </p>
   <p class="indent2">
-   <code>
-    PREWEAPONPROF:1,DEITYWEAPON
-   </code>
+   <code>PREWEAPONPROF:1,DEITYWEAPON</code>
   </p>
   <p class="indent3">
    Character must have proficiency with one of the
@@ -6693,9 +5969,7 @@ Name:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRE:.CLEAR
-   </code>
+   <code>PRE:.CLEAR</code>
   </p>
   <p class="indent3">
    Clears all prerequisites.
@@ -6732,16 +6006,12 @@ some but not all prereqs.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    QUALIFY:Whirlwind Attack
-   </code>
+   <code>QUALIFY:Whirlwind Attack</code>
    (In
 Template)
   </p>
   <p class="indent2">
-   <code>
-    PRESTAT:Q:1,DEX=13
-   </code>
+   <code>PRESTAT:Q:1,DEX=13</code>
    (In Whirlwind
 Attack Feat)
   </p>

--- a/docs/listfilepages/globalfilestagpages/globalfilestype.html
+++ b/docs/listfilepages/globalfilestagpages/globalfilestype.html
@@ -29,9 +29,7 @@
   </h1>
   <p>
    The LST file tag
-   <code>
-    TYPE
-   </code>
+   <code>TYPE</code>
    has many uses within the
 PCGen, most commonly it is used to sort objects by type within the
 display or to identify a group of objects to another object that
@@ -188,9 +186,7 @@ multiclassing.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TYPE:Base.PC
-   </code>
+   <code>TYPE:Base.PC</code>
   </p>
   <p class="indent3">
    The class will appear if the "Base" or "PC"
@@ -213,32 +209,22 @@ filter options are selected.
    RSRD
   </p>
   <p class="indent3">
-   <code>
-    PC
-   </code>
+   <code>PC</code>
   </p>
   <p class="indent3">
-   <code>
-    NPC
-   </code>
+   <code>NPC</code>
   </p>
   <p class="indent3">
-   <code>
-    Prestige
-   </code>
+   <code>Prestige</code>
   </p>
   <p class="indent3">
-   <code>
-    Monster
-   </code>
+   <code>Monster</code>
   </p>
   <p class="indent2">
    MSRD
   </p>
   <p class="indent3">
-   <code>
-    Advanced
-   </code>
+   <code>Advanced</code>
   </p>
   <hr/>
   <h2>
@@ -273,9 +259,7 @@ on the resources tab.
    <li>
     Companion Modifiers can be composed of several lines, each
 requiring the
-    <code>
-     TYPE
-    </code>
+    <code>TYPE</code>
     tag.
    </li>
    <li>
@@ -301,9 +285,7 @@ normally not recommended.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TYPE:Familiar
-   </code>
+   <code>TYPE:Familiar</code>
   </p>
   <p class="indent3">
    Defines the creature as a "Familiar" for
@@ -315,19 +297,13 @@ resources tab display purposes.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    Familiar
-   </code>
+   <code>Familiar</code>
   </p>
   <p class="indent2">
-   <code>
-    Animal Companion
-   </code>
+   <code>Animal Companion</code>
   </p>
   <p class="indent2">
-   <code>
-    Special Mount
-   </code>
+   <code>Special Mount</code>
   </p>
   <hr/>
   <h2>
@@ -368,17 +344,13 @@ belongs to.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TYPE:Good
-   </code>
+   <code>TYPE:Good</code>
   </p>
   <p class="indent3">
    The deity belongs to the "Good" type.
   </p>
   <p class="indent2">
-   <code>
-    TYPE:Good.Chaotic
-   </code>
+   <code>TYPE:Good.Chaotic</code>
   </p>
   <p class="indent3">
    The deity belongs to the "Good" and "Chaotic"
@@ -411,22 +383,16 @@ Type)
   <ul class="indent2">
    <li>
     The
-    <code>
-     TYPE
-    </code>
+    <code>TYPE</code>
     tag is used for many filtering and PRExxx
 tags. Please follow the conventions used in the Players Rules for
 the
-    <code>
-     TYPE
-    </code>
+    <code>TYPE</code>
     tag.
    </li>
    <li>
     The
-    <code>
-     TYPE
-    </code>
+    <code>TYPE</code>
     tag may also be used to identify which
 "slot" the item will be equiped to. See
     <a href="#equipslottypes">
@@ -441,20 +407,16 @@ the
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TYPE:Weapon.Simple.Melee.Slashing.Metal
-   </code>
+   <code>TYPE:Weapon.Simple.Melee.Slashing.Metal</code>
   </p>
   <p class="indent3">
    Item is a Simple Melee Slashing Metal
 Weapon.
   </p>
   <p class="indent2">
-   <code>
-    Scythe.MOD &lt;tab&gt; TYPE:.CLEAR
+   <code>Scythe.MOD &lt;tab&gt; TYPE:.CLEAR
 &lt;tab&gt;
-TYPE:Weapon.Exotic.Melee.Piercing.Slashing.Standard
-   </code>
+TYPE:Weapon.Exotic.Melee.Piercing.Slashing.Standard</code>
   </p>
   <p class="indent3">
    Modifying the Scythe to have a few more
@@ -494,84 +456,52 @@ is no limit on how many such items can be equipped.
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     Eyegear
-    </code>
+    <code>Eyegear</code>
    </p>
    <p class="indent2">
-    <code>
-     Headgear
-    </code>
+    <code>Headgear</code>
    </p>
    <p class="indent2">
-    <code>
-     Amulet
-    </code>
+    <code>Amulet</code>
    </p>
    <p class="indent2">
-    <code>
-     Armor
-    </code>
+    <code>Armor</code>
    </p>
    <p class="indent2">
-    <code>
-     Robe
-    </code>
+    <code>Robe</code>
    </p>
    <p class="indent2">
-    <code>
-     Cape
-    </code>
+    <code>Cape</code>
    </p>
    <p class="indent2">
-    <code>
-     Shirt
-    </code>
+    <code>Shirt</code>
    </p>
    <p class="indent2">
-    <code>
-     Clothing
-    </code>
+    <code>Clothing</code>
    </p>
    <p class="indent2">
-    <code>
-     Belt
-    </code>
+    <code>Belt</code>
    </p>
    <p class="indent2">
-    <code>
-     Shield
-    </code>
+    <code>Shield</code>
    </p>
    <p class="indent2">
-    <code>
-     Bracer
-    </code>
+    <code>Bracer</code>
    </p>
    <p class="indent2">
-    <code>
-     Glove
-    </code>
+    <code>Glove</code>
    </p>
    <p class="indent2">
-    <code>
-     Weapon
-    </code>
+    <code>Weapon</code>
    </p>
    <p class="indent2">
-    <code>
-     Ring
-    </code>
+    <code>Ring</code>
    </p>
    <p class="indent2">
-    <code>
-     Legwear
-    </code>
+    <code>Legwear</code>
    </p>
    <p class="indent2">
-    <code>
-     Boot
-    </code>
+    <code>Boot</code>
    </p>
    <p class="indent1">
     <strong>
@@ -579,28 +509,20 @@ is no limit on how many such items can be equipped.
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     PsionicTattoo
-    </code>
+    <code>PsionicTattoo</code>
     - used in SRD and
 RSRD
    </p>
    <p class="indent2">
-    <code>
-     Tattoo
-    </code>
+    <code>Tattoo</code>
     - used in MSRD
    </p>
    <p class="indent2">
-    <code>
-     Transportation
-    </code>
+    <code>Transportation</code>
     - used in MSRD
    </p>
    <p class="indent2">
-    <code>
-     Vehicle
-    </code>
+    <code>Vehicle</code>
     - used in Spycraft
    </p>
    <p class="indent0">
@@ -614,38 +536,26 @@ the Equipment List but are instead listed in a separate block
 labeled Money.
    </p>
    <p class="indent2">
-    <code>
-     Coin
-    </code>
+    <code>Coin</code>
    </p>
    <p class="indent2">
-    <code>
-     Gem
-    </code>
+    <code>Gem</code>
    </p>
    <p class="indent1">
     The following types trigger special blocks for
 these types of equipment and are mutually exclusive.
    </p>
    <p class="indent2">
-    <code>
-     Armor
-    </code>
+    <code>Armor</code>
    </p>
    <p class="indent2">
-    <code>
-     Ammunition
-    </code>
+    <code>Ammunition</code>
    </p>
    <p class="indent2">
-    <code>
-     Shield
-    </code>
+    <code>Shield</code>
    </p>
    <p class="indent2">
-    <code>
-     Weapon
-    </code>
+    <code>Weapon</code>
    </p>
    <p class="indent1">
     The following is used to identify Equipment
@@ -655,9 +565,7 @@ is used in some newer stat block formats. Examples might include a
 wand of Fireballs, a Thunderstone and a Tanglefoot Bag.
    </p>
    <p class="indent2">
-    <code>
-     OffensiveGear
-    </code>
+    <code>OffensiveGear</code>
    </p>
    <p class="indent1">
     The following is used to identify Equipment
@@ -667,24 +575,18 @@ used in some newer stat block formats. Examples might include a
 Cloak of Displacement and a Ring of Invisibility.
    </p>
    <p class="indent2">
-    <code>
-     DefensiveGear
-    </code>
+    <code>DefensiveGear</code>
    </p>
    <p class="indent1">
     The following is used to identify Equipment
 which can be used to cast illumination. The item should also
 contain certain
-    <code>
-     QUALITY
-    </code>
+    <code>QUALITY</code>
     tags which define the
 brightness and duration of the light source.
    </p>
    <p class="indent2">
-    <code>
-     LightSource
-    </code>
+    <code>LightSource</code>
    </p>
    <p class="indent0">
     <strong>
@@ -693,34 +595,24 @@ brightness and duration of the light source.
    </p>
    <p class="indent1">
     All items of type
-    <code>
-     Weapon
-    </code>
+    <code>Weapon</code>
     must also
 have at least one of the types
-    <code>
-     Melee
-    </code>
+    <code>Melee</code>
     or
-    <code>
-     Ranged
-    </code>
+    <code>Ranged</code>
     .
    </p>
    <p class="indent1">
     The type
-    <code>
-     Thrown
-    </code>
+    <code>Thrown</code>
     is designates a
 weapon as a thrown weapon and activates a second output block
 showing the weapons Ranged statistics.
    </p>
    <p class="indent1">
     The type
-    <code>
-     Double
-    </code>
+    <code>Double</code>
     designates a weapon
 as a double weapon and activates the three
     <a href="../datafilestagpages/datafilesequipment.html#altcritmult">
@@ -745,73 +637,47 @@ as a double weapon and activates the three
     tag.
    </p>
    <p class="indent2">
-    <code>
-     Bludgeoning
-    </code>
+    <code>Bludgeoning</code>
    </p>
    <p class="indent2">
-    <code>
-     Piercing
-    </code>
+    <code>Piercing</code>
    </p>
    <p class="indent2">
-    <code>
-     Slashing
-    </code>
+    <code>Slashing</code>
    </p>
    <p class="indent2">
-    <code>
-     Fire
-    </code>
+    <code>Fire</code>
    </p>
    <p class="indent2">
-    <code>
-     Acid
-    </code>
+    <code>Acid</code>
    </p>
    <p class="indent2">
-    <code>
-     Electricity
-    </code>
+    <code>Electricity</code>
    </p>
    <p class="indent2">
-    <code>
-     Cold
-    </code>
+    <code>Cold</code>
    </p>
    <p class="indent2">
-    <code>
-     Poison
-    </code>
+    <code>Poison</code>
    </p>
    <p class="indent2">
-    <code>
-     Sonic
-     <br/>
-    </code>
+    <code>Sonic
+     <br/></code>
    </p>
    <p class="indent1">
     Additional MSRD Weapon Damage Types:
    </p>
    <p class="indent2">
-    <code>
-     Ballistic
-    </code>
+    <code>Ballistic</code>
    </p>
    <p class="indent2">
-    <code>
-     Concussion
-    </code>
+    <code>Concussion</code>
    </p>
    <p class="indent2">
-    <code>
-     Radiation
-    </code>
+    <code>Radiation</code>
    </p>
    <p class="indent2">
-    <code>
-     Disintegration
-    </code>
+    <code>Disintegration</code>
    </p>
    <p class="indent0">
     <strong>
@@ -819,9 +685,7 @@ as a double weapon and activates the three
     </strong>
    </p>
    <p class="indent1">
-    <code>
-     Container
-    </code>
+    <code>Container</code>
     designates the item is a
 container and activates the
     <a href="../datafilestagpages/datafilesequipment.html#contains">
@@ -866,13 +730,9 @@ modifier has in order for that modifier to be applied.
    </li>
    <li>
     Used in conjunction with
-    <code>
-     PRETYPE
-    </code>
+    <code>PRETYPE</code>
     and
-    <code>
-     ITYPE
-    </code>
+    <code>ITYPE</code>
     .
    </li>
   </ul>
@@ -882,19 +742,15 @@ modifier has in order for that modifier to be applied.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TYPE:Armor.Shield
-   </code>
+   <code>TYPE:Armor.Shield</code>
   </p>
   <p class="indent3">
    Item is of the "Armor" &amp; "Shield" types.
   </p>
   <p class="indent2">
-   <code>
-    EDF Combat Armor.MOD &lt;tab&gt;
+   <code>EDF Combat Armor.MOD &lt;tab&gt;
 TYPE:.CLEAR &lt;tab&gt;
-TYPE:Armor.Medium.Suit.Tactical.PL6
-   </code>
+TYPE:Armor.Medium.Suit.Tactical.PL6</code>
   </p>
   <p class="indent3">
    Modifies the item is of the "Armor" "Medium"
@@ -906,9 +762,7 @@ TYPE:Armor.Medium.Suit.Tactical.PL6
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BaseMaterial
-   </code>
+   <code>BaseMaterial</code>
   </p>
   <p class="indent3">
    The BaseMaterial TYPE is used to identify
@@ -951,19 +805,15 @@ assigned to the feat or ability.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TYPE:General.Fighter
-   </code>
+   <code>TYPE:General.Fighter</code>
   </p>
   <p class="indent3">
    This Feat is part of the "General" and "Fighter"
 feat types.
   </p>
   <p class="indent2">
-   <code>
-    Acrobatic.MOD &lt;tab&gt; TYPE:.CLEAR
-&lt;tab&gt; TYPE:General.Fast.Pugilist.Rustler.Showman
-   </code>
+   <code>Acrobatic.MOD &lt;tab&gt; TYPE:.CLEAR
+&lt;tab&gt; TYPE:General.Fast.Pugilist.Rustler.Showman</code>
   </p>
   <p class="indent3">
    Modification of the Acrobatic Class to be
@@ -971,10 +821,8 @@ feat types.
 types.
   </p>
   <p class="indent2">
-   <code>
-    Charm.MOD &lt;tab&gt;
-TYPE:Efficacious
-   </code>
+   <code>Charm.MOD &lt;tab&gt;
+TYPE:Efficacious</code>
   </p>
   <p class="indent3">
    This modification adds the "Efficacious" feat
@@ -1002,19 +850,13 @@ a selection.
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     General
-    </code>
+    <code>General</code>
    </p>
    <p class="indent2">
-    <code>
-     ItemCreation
-    </code>
+    <code>ItemCreation</code>
    </p>
    <p class="indent2">
-    <code>
-     Metamagic
-    </code>
+    <code>Metamagic</code>
    </p>
    <p class="indent0">
     <strong>
@@ -1023,29 +865,19 @@ Types
     </strong>
    </p>
    <p class="indent2">
-    <code>
-     Fighter
-    </code>
+    <code>Fighter</code>
    </p>
    <p class="indent2">
-    <code>
-     Wizard
-    </code>
+    <code>Wizard</code>
    </p>
    <p class="indent2">
-    <code>
-     FavoredEnemy
-    </code>
+    <code>FavoredEnemy</code>
    </p>
    <p class="indent2">
-    <code>
-     Turning
-    </code>
+    <code>Turning</code>
    </p>
    <p class="indent2">
-    <code>
-     RogueAbilities
-    </code>
+    <code>RogueAbilities</code>
    </p>
    <p class="indent0">
     <strong>
@@ -1065,14 +897,10 @@ the type the output sheet will list the ability in the Special
 Attacks block or the Special Qualities block.
    </p>
    <p class="indent2">
-    <code>
-     SpecialAttack
-    </code>
+    <code>SpecialAttack</code>
    </p>
    <p class="indent2">
-    <code>
-     SpecialQuality
-    </code>
+    <code>SpecialQuality</code>
    </p>
    <p class="indent1">
     Abilities designated as Extraordinary,
@@ -1085,24 +913,16 @@ using a type rather than having the abbreviation be part of the
 name this makes it optional.
    </p>
    <p class="indent2">
-    <code>
-     Extraordinary
-    </code>
+    <code>Extraordinary</code>
    </p>
    <p class="indent2">
-    <code>
-     SpellLike
-    </code>
+    <code>SpellLike</code>
    </p>
    <p class="indent2">
-    <code>
-     Supernatural
-    </code>
+    <code>Supernatural</code>
    </p>
    <p class="indent2">
-    <code>
-     PsiLike
-    </code>
+    <code>PsiLike</code>
    </p>
    <p class="indent1">
     The following type identifies the Feat or
@@ -1110,9 +930,7 @@ Ability as one which provides an alternate attack or modifies a
 standard attack. This is used in some newer stat block formats.
    </p>
    <p class="indent2">
-    <code>
-     AttackOption
-    </code>
+    <code>AttackOption</code>
    </p>
    <p class="indent1">
     The following type identifies the Feat or
@@ -1120,9 +938,7 @@ Ability as one which represents an Aura or continuous area of
 effect ability. This is used in some newer stat block formats.
    </p>
    <p class="indent2">
-    <code>
-     Aura
-    </code>
+    <code>Aura</code>
    </p>
    <p class="indent1">
     The following type identifies the Feat or
@@ -1131,9 +947,7 @@ used in some newer stat block formats where the ability is listed
 with languages.
    </p>
    <p class="indent2">
-    <code>
-     Communicate
-    </code>
+    <code>Communicate</code>
    </p>
    <p class="indent1">
     The following type identifies the Feat or
@@ -1142,9 +956,7 @@ AC or HP effecting abilities. This is used in some newer stat block
 formats.
    </p>
    <p class="indent2">
-    <code>
-     Defensive
-    </code>
+    <code>Defensive</code>
    </p>
    <p class="indent1">
     The followng type identifies the Feat or Ability
@@ -1152,9 +964,7 @@ as one which represent a specific immunity. This is used in some
 newer stat block formats.
    </p>
    <p class="indent2">
-    <code>
-     Immunity
-    </code>
+    <code>Immunity</code>
    </p>
    <p class="indent1">
     The following type identifies the Feat or
@@ -1163,9 +973,7 @@ defensive benefit. This is used in some newer stat block formats
 where the ability is listed with AC details.
    </p>
    <p class="indent2">
-    <code>
-     ModifyAC
-    </code>
+    <code>ModifyAC</code>
    </p>
    <p class="indent1">
     The following type identifies the Feat or
@@ -1174,9 +982,7 @@ related to hit points. This is used in some newer stat block
 formats where the ability is listed with hit points.
    </p>
    <p class="indent2">
-    <code>
-     ModifyHP
-    </code>
+    <code>ModifyHP</code>
    </p>
    <p class="indent1">
     The following type identifies the Feat or
@@ -1185,9 +991,7 @@ modifies the movement rate. This is used in some newer stat block
 formats where the ability is listed with movement rates.
    </p>
    <p class="indent2">
-    <code>
-     ModifyMovement
-    </code>
+    <code>ModifyMovement</code>
    </p>
    <p class="indent1">
     The following type identifies the Feat or
@@ -1195,9 +999,7 @@ Ability as one which represent a specific resistance. This is used
 in some newer stat block formats.
    </p>
    <p class="indent2">
-    <code>
-     Resistance
-    </code>
+    <code>Resistance</code>
    </p>
    <p class="indent1">
     The following type identifies the Feat or
@@ -1206,9 +1008,7 @@ more saving throws. This is used in some newer stat block formats
 where the bonus is listed with saving throws.
    </p>
    <p class="indent2">
-    <code>
-     SaveBonus
-    </code>
+    <code>SaveBonus</code>
    </p>
    <p class="indent1">
     The following type identifies the Feat or
@@ -1216,9 +1016,7 @@ Ability as one which represent a specific special sense or
 perception. This is used in some newer stat block formats.
    </p>
    <p class="indent2">
-    <code>
-     Sense
-    </code>
+    <code>Sense</code>
    </p>
    <p class="indent1">
     The following type identifies the Feat or
@@ -1226,9 +1024,7 @@ Ability as one which represent a specific weakness. This is used in
 some newer stat block formats.
    </p>
    <p class="indent2">
-    <code>
-     Weakness
-    </code>
+    <code>Weakness</code>
    </p>
   </blockquote>
   <hr/>
@@ -1265,18 +1061,14 @@ types that languages are.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TYPE:Spoken.Written.Read
-   </code>
+   <code>TYPE:Spoken.Written.Read</code>
   </p>
   <p class="indent3">
    Language is "Spoken", "Written" and "Read".
   </p>
   <p class="indent2">
-   <code>
-    Celestial &lt;tab&gt;
-TYPE:Spoken
-   </code>
+   <code>Celestial &lt;tab&gt;
+TYPE:Spoken</code>
   </p>
   <p class="indent3">
    Language Celestial is "Spoken", not "Written" or
@@ -1288,19 +1080,13 @@ TYPE:Spoken
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    Read
-   </code>
+   <code>Read</code>
   </p>
   <p class="indent2">
-   <code>
-    Spoken
-   </code>
+   <code>Spoken</code>
   </p>
   <p class="indent2">
-   <code>
-    Written
-   </code>
+   <code>Written</code>
   </p>
   <hr/>
   <h2>
@@ -1339,9 +1125,7 @@ file.
    </li>
    <li>
     The
-    <code>
-     TYPE
-    </code>
+    <code>TYPE</code>
     tag is used to set the source display
 tree in the Sources Tab.
    </li>
@@ -1350,9 +1134,7 @@ tree in the Sources Tab.
    </li>
    <li>
     PCC
-    <code>
-     TYPE
-    </code>
+    <code>TYPE</code>
     tags cannot have more than three type
 elements as follows:
     <ul class="indent2">
@@ -1387,9 +1169,7 @@ same order in every file.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TYPE:Foo Games.Core Rules.Core
-   </code>
+   <code>TYPE:Foo Games.Core Rules.Core</code>
   </p>
   <hr/>
   <h2>
@@ -1436,9 +1216,7 @@ Plant, Shapechanger, Undead, and Vermin
      Note:
     </strong>
     In the past, the
-    <code>
-     TYPE
-    </code>
+    <code>TYPE</code>
     tag
 in race files has been used to set the races Creature Type as
 defined in the game rules. This function is now being performed by
@@ -1447,9 +1225,7 @@ the
      RACETYPE
     </a>
     tag and the use of the
-    <code>
-     TYPE
-    </code>
+    <code>TYPE</code>
     tag to set this is being
 phased out.
    </li>
@@ -1460,9 +1236,7 @@ phased out.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TYPE:Outsider
-   </code>
+   <code>TYPE:Outsider</code>
   </p>
   <p class="indent3">
    The race is of the "Outsider" type.
@@ -1473,8 +1247,7 @@ phased out.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    Aberration
+   <code>Aberration
     <br/>
     Animal
     <br/>
@@ -1506,8 +1279,7 @@ phased out.
     <br/>
     Undead
     <br/>
-    Vermin
-   </code>
+    Vermin</code>
   </p>
   <hr/>
   <h2>
@@ -1549,20 +1321,16 @@ list.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TYPE:Charisma.Perform
-   </code>
+   <code>TYPE:Charisma.Perform</code>
   </p>
   <p class="indent3">
    This skill belongs to the "Charisma" and
 "Perform" types.
   </p>
   <p class="indent2">
-   <code>
-    Craft (Electronic - class skill).MOD
+   <code>Craft (Electronic - class skill).MOD
 &lt;tab&gt; TYPE:.CLEAR &lt;tab&gt;
-TYPE:Scientist_Skills.Terraformer_Skills
-   </code>
+TYPE:Scientist_Skills.Terraformer_Skills</code>
   </p>
   <p class="indent3">
    This skill is modified to be in the
@@ -1580,8 +1348,7 @@ ability
    </strong>
   </p>
   <p class="indent3">
-   <code>
-    Strength
+   <code>Strength
     <br/>
     Dexterity
     <br/>
@@ -1591,8 +1358,7 @@ ability
     <br/>
     Wisdom
     <br/>
-    Charisma
-   </code>
+    Charisma</code>
   </p>
   <p class="indent2">
    <strong>
@@ -1601,13 +1367,11 @@ type
    </strong>
   </p>
   <p class="indent3">
-   <code>
-    Craft
+   <code>Craft
     <br/>
     Knowledge
     <br/>
-    Perform
-   </code>
+    Perform</code>
   </p>
   <hr/>
   <h2>
@@ -1648,9 +1412,7 @@ delimiter.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TYPE:Arcane.Divine
-   </code>
+   <code>TYPE:Arcane.Divine</code>
   </p>
   <p class="indent3">
    Spell is both "Arcane" and "Divine".
@@ -1661,19 +1423,13 @@ delimiter.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    Arcane
-   </code>
+   <code>Arcane</code>
   </p>
   <p class="indent2">
-   <code>
-    Divine
-   </code>
+   <code>Divine</code>
   </p>
   <p class="indent2">
-   <code>
-    Psionic
-   </code>
+   <code>Psionic</code>
   </p>
   <hr/>
   <h2>
@@ -1715,9 +1471,7 @@ period-delimiter.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TYPE:DefaultMonster
-   </code>
+   <code>TYPE:DefaultMonster</code>
   </p>
   <p class="indent3">
    Kit is a "DefaultMonster" kit.
@@ -1728,29 +1482,19 @@ period-delimiter.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DefaultMonster
-   </code>
+   <code>DefaultMonster</code>
   </p>
   <p class="indent2">
-   <code>
-    Treasure
-   </code>
+   <code>Treasure</code>
   </p>
   <p class="indent2">
-   <code>
-    NPC
-   </code>
+   <code>NPC</code>
   </p>
   <p class="indent2">
-   <code>
-    PC
-   </code>
+   <code>PC</code>
   </p>
   <p class="indent2">
-   <code>
-    StartingKit
-   </code>
+   <code>StartingKit</code>
   </p>
   <hr/>
   <h2>
@@ -1789,9 +1533,7 @@ to race, such as the Rangers Favored Enemy
      Note:
     </strong>
     In the past, the
-    <code>
-     TYPE
-    </code>
+    <code>TYPE</code>
     tag
 in tTemplate files have been used to alter the races Creature Type
 as defined in the game rules. This function is now being performed
@@ -1800,9 +1542,7 @@ by the
      RACETYPE
     </a>
     tag and the use of
-    <code>
-     TYPE
-    </code>
+    <code>TYPE</code>
     to alter this is being phased
 out.
    </li>
@@ -1813,9 +1553,7 @@ out.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TYPE:Outsider
-   </code>
+   <code>TYPE:Outsider</code>
   </p>
   <p class="indent3">
    Is a "Outsider" if this template is
@@ -1868,9 +1606,7 @@ bonuses.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TYPE:Simple
-   </code>
+   <code>TYPE:Simple</code>
   </p>
   <p class="indent3">
    Characters with "Simple" weapon proficiency can

--- a/docs/listfilepages/globalfilestagpages/globalfilesvariables.html
+++ b/docs/listfilepages/globalfilestagpages/globalfilesvariables.html
@@ -259,9 +259,7 @@ File.
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:PC.Prestige
-     </code>
+     <code>TYPE:PC.Prestige</code>
     </p>
     <p>
      <strong>
@@ -269,17 +267,11 @@ File.
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:General
-     </code>
+     <code>TYPE:General</code>
      <br/>
-     <code>
-      TYPE:General.Fighter
-     </code>
+     <code>TYPE:General.Fighter</code>
      <br/>
-     <code>
-      TYPE:Order
-     </code>
+     <code>TYPE:Order</code>
     </p>
     <p>
      <strong>
@@ -287,29 +279,17 @@ File.
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Class.Hidden
-     </code>
+     <code>TYPE:Class.Hidden</code>
      <br/>
-     <code>
-      TYPE:Class.Hidden.AncientHealing
-     </code>
+     <code>TYPE:Class.Hidden.AncientHealing</code>
      <br/>
-     <code>
-      TYPE:Class.Hidden.RadiantEnlightenment
-     </code>
+     <code>TYPE:Class.Hidden.RadiantEnlightenment</code>
      <br/>
-     <code>
-      TYPE:Class.Hidden.SecretEnlightenment
-     </code>
+     <code>TYPE:Class.Hidden.SecretEnlightenment</code>
      <br/>
-     <code>
-      TYPE:Class.Hidden.TeutonicKnightCombat
-     </code>
+     <code>TYPE:Class.Hidden.TeutonicKnightCombat</code>
      <br/>
-     <code>
-      TYPE:Internal
-     </code>
+     <code>TYPE:Internal</code>
     </p>
     <p>
      <strong>
@@ -318,17 +298,11 @@ File.
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Animal
-     </code>
+     <code>TYPE:Animal</code>
      <br/>
-     <code>
-      TYPE:Undead
-     </code>
+     <code>TYPE:Undead</code>
      <br/>
-     <code>
-      TYPE:Vermin
-     </code>
+     <code>TYPE:Vermin</code>
      <br/>
     </p>
     <p>
@@ -337,9 +311,7 @@ File.
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:None
-     </code>
+     <code>TYPE:None</code>
     </p>
     <p>
      <strong>
@@ -347,9 +319,7 @@ File.
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Divine
-     </code>
+     <code>TYPE:Divine</code>
     </p>
     <p>
      <strong>
@@ -357,9 +327,7 @@ File.
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:KnighthoodAPG
-     </code>
+     <code>TYPE:KnighthoodAPG</code>
     </p>
    </blockquote>
    <p class="indent1">
@@ -377,17 +345,11 @@ Group (APG) - Honor and Corruption (35e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:General
-     </code>
+     <code>TYPE:General</code>
      <br/>
-     <code>
-      TYPE:Metamagic
-     </code>
+     <code>TYPE:Metamagic</code>
      <br/>
-     <code>
-      TYPE:Rogue
-     </code>
+     <code>TYPE:Rogue</code>
     </p>
     <p>
      <strong>
@@ -395,13 +357,9 @@ Group (APG) - Honor and Corruption (35e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Subclass.Hidden.KnightHP
-     </code>
+     <code>TYPE:Subclass.Hidden.KnightHP</code>
      <br/>
-     <code>
-      TYPE:Subclass.Hidden.ScoundrelHP
-     </code>
+     <code>TYPE:Subclass.Hidden.ScoundrelHP</code>
     </p>
     <p>
      <strong>
@@ -409,9 +367,7 @@ Group (APG) - Honor and Corruption (35e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Humanoid
-     </code>
+     <code>TYPE:Humanoid</code>
      <br/>
     </p>
    </blockquote>
@@ -431,13 +387,9 @@ Group (APG) - Honor and Corruption (35e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:PC.Prestige
-     </code>
+     <code>TYPE:PC.Prestige</code>
      <br/>
-     <code>
-      TYPE:NPC.Base
-     </code>
+     <code>TYPE:NPC.Base</code>
     </p>
     <p>
      <strong>
@@ -445,9 +397,7 @@ Group (APG) - Honor and Corruption (35e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:General
-     </code>
+     <code>TYPE:General</code>
     </p>
     <p>
      <strong>
@@ -455,9 +405,7 @@ Group (APG) - Honor and Corruption (35e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Intelligence.Knowledge
-     </code>
+     <code>TYPE:Intelligence.Knowledge</code>
     </p>
     <p>
      <strong>
@@ -465,9 +413,7 @@ Group (APG) - Honor and Corruption (35e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Undead
-     </code>
+     <code>TYPE:Undead</code>
     </p>
     <p>
      <strong>
@@ -475,13 +421,9 @@ Group (APG) - Honor and Corruption (35e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Arquebus
-     </code>
+     <code>TYPE:Arquebus</code>
      <br/>
-     <code>
-      TYPE:Cannon
-     </code>
+     <code>TYPE:Cannon</code>
     </p>
     <p>
      <strong>
@@ -489,13 +431,9 @@ Group (APG) - Honor and Corruption (35e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Weapon.Arquebus.Ranged.Projectile
-     </code>
+     <code>TYPE:Weapon.Arquebus.Ranged.Projectile</code>
      <br/>
-     <code>
-      TYPE:Weapon.Cannon.Ranged.Projectile
-     </code>
+     <code>TYPE:Weapon.Cannon.Ranged.Projectile</code>
     </p>
    </blockquote>
    <hr/>
@@ -514,13 +452,9 @@ Group (APG) - Honor and Corruption (35e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Base.PC
-     </code>
+     <code>TYPE:Base.PC</code>
      <br/>
-     <code>
-      TYPE:PC.Prestige
-     </code>
+     <code>TYPE:PC.Prestige</code>
     </p>
     <p>
      <strong>
@@ -528,9 +462,7 @@ Group (APG) - Honor and Corruption (35e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Weapon.Slashing.Melee
-     </code>
+     <code>TYPE:Weapon.Slashing.Melee</code>
     </p>
     <p>
      <strong>
@@ -538,161 +470,83 @@ Group (APG) - Honor and Corruption (35e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Armor.Light.Suit.Specific.Nonmetal
-     </code>
+     <code>TYPE:Armor.Light.Suit.Specific.Nonmetal</code>
      <br/>
-     <code>
-      TYPE:Enhancement.Ammunition.SpecificArrow.Individual
-     </code>
+     <code>TYPE:Enhancement.Ammunition.SpecificArrow.Individual</code>
      <br/>
-     <code>
-      TYPE:Enhancement.Shield.Heavy.Specific
-     </code>
+     <code>TYPE:Enhancement.Shield.Heavy.Specific</code>
      <br/>
-     <code>
-      TYPE:Enhancement.Weapon.Melee.Martial.Specific.Bashing.Mace
-     </code>
+     <code>TYPE:Enhancement.Weapon.Melee.Martial.Specific.Bashing.Mace</code>
      <br/>
-     <code>
-      TYPE:Enhancement.Weapon.Melee.Martial.Specific.Slashing.Sword
-     </code>
+     <code>TYPE:Enhancement.Weapon.Melee.Martial.Specific.Slashing.Sword</code>
      <br/>
-     <code>
-      TYPE:Goods
-     </code>
+     <code>TYPE:Goods</code>
      <br/>
-     <code>
-      TYPE:Goods.Alchemical.Consumable
-     </code>
+     <code>TYPE:Goods.Alchemical.Consumable</code>
      <br/>
-     <code>
-      TYPE:Goods.Book
-     </code>
+     <code>TYPE:Goods.Book</code>
      <br/>
-     <code>
-      TYPE:Goods.Boot
-     </code>
+     <code>TYPE:Goods.Boot</code>
      <br/>
-     <code>
-      TYPE:Goods.Container
-     </code>
+     <code>TYPE:Goods.Container</code>
      <br/>
-     <code>
-      TYPE:Goods.Food
-     </code>
+     <code>TYPE:Goods.Food</code>
      <br/>
-     <code>
-      TYPE:Goods.Glove
-     </code>
+     <code>TYPE:Goods.Glove</code>
      <br/>
-     <code>
-      TYPE:Goods.Poison
-     </code>
+     <code>TYPE:Goods.Poison</code>
      <br/>
-     <code>
-      TYPE:Goods.Tools.Instrument.Percussion.Resizable.Weapon.Melee.Exotic.Slashing
-     </code>
+     <code>TYPE:Goods.Tools.Instrument.Percussion.Resizable.Weapon.Melee.Exotic.Slashing</code>
      <br/>
-     <code>
-      TYPE:Goods.Tools.Instrument.Wind.Resizable.Weapon.Melee.Simple.Bashing
-     </code>
+     <code>TYPE:Goods.Tools.Instrument.Wind.Resizable.Weapon.Melee.Simple.Bashing</code>
      <br/>
-     <code>
-      TYPE:Goods.Tools.SurgeryTools
-     </code>
+     <code>TYPE:Goods.Tools.SurgeryTools</code>
      <br/>
-     <code>
-      TYPE:Goods.Weapon.Melee
-     </code>
+     <code>TYPE:Goods.Weapon.Melee</code>
      <br/>
-     <code>
-      TYPE:Magic.Artifact
-     </code>
+     <code>TYPE:Magic.Artifact</code>
      <br/>
-     <code>
-      TYPE:Magic.Artifact.Armor.Light.Suit.Specific.Nonmetal
-     </code>
+     <code>TYPE:Magic.Artifact.Armor.Light.Suit.Specific.Nonmetal</code>
      <br/>
-     <code>
-      TYPE:Magic.Artifact.Armor.Medium.Suit.Specific
-     </code>
+     <code>TYPE:Magic.Artifact.Armor.Medium.Suit.Specific</code>
      <br/>
-     <code>
-      TYPE:Magic.Artifact.Enhancement.Shield.Heavy.Specific
-     </code>
+     <code>TYPE:Magic.Artifact.Enhancement.Shield.Heavy.Specific</code>
      <br/>
-     <code>
-      TYPE:Magic.Artifact.Enhancement.Weapon.Melee.Martial.Specific.Slashing.Sword
-     </code>
+     <code>TYPE:Magic.Artifact.Enhancement.Weapon.Melee.Martial.Specific.Slashing.Sword</code>
      <br/>
-     <code>
-      TYPE:Magic.Artifact.Enhancement.Weapon.Melee.Simple.Specific.Bludgeoning.Mace
-     </code>
+     <code>TYPE:Magic.Artifact.Enhancement.Weapon.Melee.Simple.Specific.Bludgeoning.Mace</code>
      <br/>
-     <code>
-      TYPE:Magic.Potion.Consumable
-     </code>
+     <code>TYPE:Magic.Potion.Consumable</code>
      <br/>
-     <code>
-      TYPE:Magic.Ring
-     </code>
+     <code>TYPE:Magic.Ring</code>
      <br/>
-     <code>
-      TYPE:Magic.Staff
-     </code>
+     <code>TYPE:Magic.Staff</code>
      <br/>
-     <code>
-      TYPE:Magic.Wand
-     </code>
+     <code>TYPE:Magic.Wand</code>
      <br/>
-     <code>
-      TYPE:Magic.Wondrous
-     </code>
+     <code>TYPE:Magic.Wondrous</code>
      <br/>
-     <code>
-      TYPE:Magic.Wondrous.Amulet
-     </code>
+     <code>TYPE:Magic.Wondrous.Amulet</code>
      <br/>
-     <code>
-      TYPE:Magic.Wondrous.Boot
-     </code>
+     <code>TYPE:Magic.Wondrous.Boot</code>
      <br/>
-     <code>
-      TYPE:Magic.Wondrous.Bracelet
-     </code>
+     <code>TYPE:Magic.Wondrous.Bracelet</code>
      <br/>
-     <code>
-      TYPE:Magic.Wondrous.Headgear
-     </code>
+     <code>TYPE:Magic.Wondrous.Headgear</code>
      <br/>
-     <code>
-      TYPE:Shield.Buckler.Standard
-     </code>
+     <code>TYPE:Shield.Buckler.Standard</code>
      <br/>
-     <code>
-      TYPE:Shield.Heavy.Standard
-     </code>
+     <code>TYPE:Shield.Heavy.Standard</code>
      <br/>
-     <code>
-      TYPE:Weapon.Exotic.Melee.Standard.Slashing.Sword
-     </code>
+     <code>TYPE:Weapon.Exotic.Melee.Standard.Slashing.Sword</code>
      <br/>
-     <code>
-      TYPE:Weapon.Exotic.Ranged.Standard.Thrown
-     </code>
+     <code>TYPE:Weapon.Exotic.Ranged.Standard.Thrown</code>
      <br/>
-     <code>
-      TYPE:Weapon.Melee.Exotic.Reach.Finesseable.Subdual.Slashing
-     </code>
+     <code>TYPE:Weapon.Melee.Exotic.Reach.Finesseable.Subdual.Slashing</code>
      <br/>
-     <code>
-      TYPE:Weapon.Melee.Finesseable.Martial.Standard.Piercing.Sword
-     </code>
+     <code>TYPE:Weapon.Melee.Finesseable.Martial.Standard.Piercing.Sword</code>
      <br/>
-     <code>
-      TYPE:Weapon.Melee.Finesseable.Ranged.Thrown.Simple.Standard.Piercing.Slashing.Dagger
-     </code>
+     <code>TYPE:Weapon.Melee.Finesseable.Ranged.Thrown.Simple.Standard.Piercing.Slashing.Dagger</code>
     </p>
     <p>
      <strong>
@@ -700,17 +554,11 @@ Group (APG) - Honor and Corruption (35e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Clerical
-     </code>
+     <code>TYPE:Clerical</code>
      <br/>
-     <code>
-      TYPE:Fighter
-     </code>
+     <code>TYPE:Fighter</code>
      <br/>
-     <code>
-      TYPE:General
-     </code>
+     <code>TYPE:General</code>
     </p>
     <p>
      <strong>
@@ -718,9 +566,7 @@ Group (APG) - Honor and Corruption (35e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Flaw
-     </code>
+     <code>TYPE:Flaw</code>
     </p>
     <p>
      <strong>
@@ -728,21 +574,13 @@ Group (APG) - Honor and Corruption (35e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:BenevolentSpirit
-     </code>
+     <code>TYPE:BenevolentSpirit</code>
      <br/>
-     <code>
-      TYPE:Class.Hidden
-     </code>
+     <code>TYPE:Class.Hidden</code>
      <br/>
-     <code>
-      TYPE:HearthMagic
-     </code>
+     <code>TYPE:HearthMagic</code>
      <br/>
-     <code>
-      TYPE:ShalraekuZarakku
-     </code>
+     <code>TYPE:ShalraekuZarakku</code>
     </p>
     <p>
      <strong>
@@ -750,13 +588,9 @@ Group (APG) - Honor and Corruption (35e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Read.Written.Spoken
-     </code>
+     <code>TYPE:Read.Written.Spoken</code>
      <br/>
-     <code>
-      TYPE:Spoken
-     </code>
+     <code>TYPE:Spoken</code>
     </p>
     <p>
      <strong>
@@ -764,9 +598,7 @@ Group (APG) - Honor and Corruption (35e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Humanoid
-     </code>
+     <code>TYPE:Humanoid</code>
     </p>
     <p>
      <strong>
@@ -774,25 +606,15 @@ Group (APG) - Honor and Corruption (35e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Animal
-     </code>
+     <code>TYPE:Animal</code>
      <br/>
-     <code>
-      TYPE:Humanoid
-     </code>
+     <code>TYPE:Humanoid</code>
      <br/>
-     <code>
-      TYPE:Plant
-     </code>
+     <code>TYPE:Plant</code>
      <br/>
-     <code>
-      TYPE:Undead
-     </code>
+     <code>TYPE:Undead</code>
      <br/>
-     <code>
-      TYPE:Vermin
-     </code>
+     <code>TYPE:Vermin</code>
     </p>
     <p>
      <strong>
@@ -800,21 +622,13 @@ Group (APG) - Honor and Corruption (35e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:HearthMagic
-     </code>
+     <code>TYPE:HearthMagic</code>
      <br/>
-     <code>
-      TYPE:Intelligence.Craft
-     </code>
+     <code>TYPE:Intelligence.Craft</code>
      <br/>
-     <code>
-      TYPE:Intelligence.Knowledge
-     </code>
+     <code>TYPE:Intelligence.Knowledge</code>
      <br/>
-     <code>
-      TYPE:Wisdom.Profession
-     </code>
+     <code>TYPE:Wisdom.Profession</code>
     </p>
     <p>
      <strong>
@@ -822,17 +636,11 @@ Group (APG) - Honor and Corruption (35e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Arcane
-     </code>
+     <code>TYPE:Arcane</code>
      <br/>
-     <code>
-      TYPE:Arcane.Divine
-     </code>
+     <code>TYPE:Arcane.Divine</code>
      <br/>
-     <code>
-      TYPE:Divine
-     </code>
+     <code>TYPE:Divine</code>
     </p>
     <p>
      <strong>
@@ -840,13 +648,9 @@ Group (APG) - Honor and Corruption (35e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Exotic
-     </code>
+     <code>TYPE:Exotic</code>
      <br/>
-     <code>
-      TYPE:Simple
-     </code>
+     <code>TYPE:Simple</code>
     </p>
    </blockquote>
    <hr/>
@@ -863,9 +667,7 @@ Faeries (3e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:PC.Prestige
-     </code>
+     <code>TYPE:PC.Prestige</code>
     </p>
     <p>
      <strong>
@@ -873,25 +675,15 @@ Faeries (3e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Fey
-     </code>
+     <code>TYPE:Fey</code>
      <br/>
-     <code>
-      TYPE:General
-     </code>
+     <code>TYPE:General</code>
      <br/>
-     <code>
-      TYPE:ItemCreation
-     </code>
+     <code>TYPE:ItemCreation</code>
      <br/>
-     <code>
-      TYPE:Metamagic
-     </code>
+     <code>TYPE:Metamagic</code>
      <br/>
-     <code>
-      TYPE:Special
-     </code>
+     <code>TYPE:Special</code>
     </p>
     <p>
      <strong>
@@ -899,9 +691,7 @@ Faeries (3e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:AspectOfNature
-     </code>
+     <code>TYPE:AspectOfNature</code>
     </p>
     <p>
      <strong>
@@ -909,27 +699,19 @@ Faeries (3e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:FaerieRacialTrait
-     </code>
+     <code>TYPE:FaerieRacialTrait</code>
      <br/>
     </p>
     <p>
-     <code>
-      TYPE:FeyArts
-     </code>
+     <code>TYPE:FeyArts</code>
      <br/>
     </p>
     <p>
-     <code>
-      TYPE:Special.RacialTraitCost
-     </code>
+     <code>TYPE:Special.RacialTraitCost</code>
      <br/>
     </p>
     <p>
-     <code>
-      TYPE:Special.UncannyDodge
-     </code>
+     <code>TYPE:Special.UncannyDodge</code>
     </p>
     <p>
      <strong>
@@ -937,9 +719,7 @@ Faeries (3e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Spoken
-     </code>
+     <code>TYPE:Spoken</code>
     </p>
     <p>
      <strong>
@@ -947,9 +727,7 @@ Faeries (3e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Intelligence.Knowledge
-     </code>
+     <code>TYPE:Intelligence.Knowledge</code>
     </p>
     <p>
      <strong>
@@ -957,13 +735,9 @@ Faeries (3e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Arcane
-     </code>
+     <code>TYPE:Arcane</code>
      <br/>
-     <code>
-      TYPE:Divine
-     </code>
+     <code>TYPE:Divine</code>
     </p>
     <p>
      <strong>
@@ -971,17 +745,11 @@ Faeries (3e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Fey
-     </code>
+     <code>TYPE:Fey</code>
      <br/>
-     <code>
-      TYPE:Humanoid
-     </code>
+     <code>TYPE:Humanoid</code>
      <br/>
-     <code>
-      TYPE:Giant
-     </code>
+     <code>TYPE:Giant</code>
     </p>
    </blockquote>
    <hr/>
@@ -998,105 +766,55 @@ Pulp Fantasy (Modern)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:
-     </code>
+     <code>TYPE:</code>
      <br/>
-     <code>
-      TYPE:AddTalent.FastTalent.ToughTalent.SmartTalent.DedicatedTalent.CharismaticTalent
-     </code>
+     <code>TYPE:AddTalent.FastTalent.ToughTalent.SmartTalent.DedicatedTalent.CharismaticTalent</code>
      <br/>
-     <code>
-      TYPE:AddTalent.StrongTalent.FastTalent.SmartTalent.DedicatedTalent.CharismaticTalent
-     </code>
+     <code>TYPE:AddTalent.StrongTalent.FastTalent.SmartTalent.DedicatedTalent.CharismaticTalent</code>
      <br/>
-     <code>
-      TYPE:AddTalent.StrongTalent.FastTalent.ToughTalent.SmartTalent.CharismaticTalent
-     </code>
+     <code>TYPE:AddTalent.StrongTalent.FastTalent.ToughTalent.SmartTalent.CharismaticTalent</code>
      <br/>
-     <code>
-      TYPE:AddTalent.StrongTalent.FastTalent.ToughTalent.SmartTalent.DedicatedTalent
-     </code>
+     <code>TYPE:AddTalent.StrongTalent.FastTalent.ToughTalent.SmartTalent.DedicatedTalent</code>
      <br/>
-     <code>
-      TYPE:AddTalent.StrongTalent.ToughTalent.SmartTalent.DedicatedTalent.CharismaticTalent
-     </code>
+     <code>TYPE:AddTalent.StrongTalent.ToughTalent.SmartTalent.DedicatedTalent.CharismaticTalent</code>
      <br/>
-     <code>
-      TYPE:CharismaticPlus
-     </code>
+     <code>TYPE:CharismaticPlus</code>
      <br/>
-     <code>
-      TYPE:DedicatedPlus
-     </code>
+     <code>TYPE:DedicatedPlus</code>
      <br/>
-     <code>
-      TYPE:Talent.CharismaticTalent.Authority
-     </code>
+     <code>TYPE:Talent.CharismaticTalent.Authority</code>
      <br/>
-     <code>
-      TYPE:Talent.CharismaticTalent.ByGraceOfFortune
-     </code>
+     <code>TYPE:Talent.CharismaticTalent.ByGraceOfFortune</code>
      <br/>
-     <code>
-      TYPE:Talent.DedicatedTalent.Attentive
-     </code>
+     <code>TYPE:Talent.DedicatedTalent.Attentive</code>
      <br/>
-     <code>
-      TYPE:Talent.FastTalent.Elusive
-     </code>
+     <code>TYPE:Talent.FastTalent.Elusive</code>
      <br/>
-     <code>
-      TYPE:Talent.FastTalent.InstinctiveResponse
-     </code>
+     <code>TYPE:Talent.FastTalent.InstinctiveResponse</code>
      <br/>
-     <code>
-      TYPE:Talent.FastTalent.NeedForSpeed
-     </code>
+     <code>TYPE:Talent.FastTalent.NeedForSpeed</code>
      <br/>
-     <code>
-      TYPE:Talent.FastTalent.Precision
-     </code>
+     <code>TYPE:Talent.FastTalent.Precision</code>
      <br/>
-     <code>
-      TYPE:Talent.SmartTalent.BrainsOverBrawn
-     </code>
+     <code>TYPE:Talent.SmartTalent.BrainsOverBrawn</code>
      <br/>
-     <code>
-      TYPE:Talent.SmartTalent.Deduction
-     </code>
+     <code>TYPE:Talent.SmartTalent.Deduction</code>
      <br/>
-     <code>
-      TYPE:Talent.SmartTalent.FastLearner
-     </code>
+     <code>TYPE:Talent.SmartTalent.FastLearner</code>
      <br/>
-     <code>
-      TYPE:Talent.SmartTalent.MechanicalAptitude
-     </code>
+     <code>TYPE:Talent.SmartTalent.MechanicalAptitude</code>
      <br/>
-     <code>
-      TYPE:Talent.SmartTalent.Prodigy
-     </code>
+     <code>TYPE:Talent.SmartTalent.Prodigy</code>
      <br/>
-     <code>
-      TYPE:Talent.SmartTalent.Research
-     </code>
+     <code>TYPE:Talent.SmartTalent.Research</code>
      <br/>
-     <code>
-      TYPE:Talent.StrongTalent.Brawler
-     </code>
+     <code>TYPE:Talent.StrongTalent.Brawler</code>
      <br/>
-     <code>
-      TYPE:Talent.StrongTalent.Soldiery
-     </code>
+     <code>TYPE:Talent.StrongTalent.Soldiery</code>
      <br/>
-     <code>
-      TYPE:Talent.ToughTalent.Rage
-     </code>
+     <code>TYPE:Talent.ToughTalent.Rage</code>
      <br/>
-     <code>
-      TYPE:Talent.ToughTalent.Survivalist
-     </code>
+     <code>TYPE:Talent.ToughTalent.Survivalist</code>
     </p>
     <p>
      <strong>
@@ -1104,9 +822,7 @@ Pulp Fantasy (Modern)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Advanced.PC
-     </code>
+     <code>TYPE:Advanced.PC</code>
     </p>
     <p>
      <strong>
@@ -1114,9 +830,7 @@ Pulp Fantasy (Modern)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Monster
-     </code>
+     <code>TYPE:Monster</code>
     </p>
     <p>
      <strong>
@@ -1124,61 +838,33 @@ Pulp Fantasy (Modern)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Gadget
-     </code>
+     <code>TYPE:Gadget</code>
      <br/>
-     <code>
-      TYPE:Goods.Boot
-     </code>
+     <code>TYPE:Goods.Boot</code>
      <br/>
-     <code>
-      TYPE:Goods.General
-     </code>
+     <code>TYPE:Goods.General</code>
      <br/>
-     <code>
-      TYPE:Goods.Clothing
-     </code>
+     <code>TYPE:Goods.Clothing</code>
      <br/>
-     <code>
-      TYPE:Goods.Clothing.Belt
-     </code>
+     <code>TYPE:Goods.Clothing.Belt</code>
      <br/>
-     <code>
-      TYPE:Goods.Container.General
-     </code>
+     <code>TYPE:Goods.Container.General</code>
      <br/>
-     <code>
-      TYPE:Goods.General
-     </code>
+     <code>TYPE:Goods.General</code>
      <br/>
-     <code>
-      TYPE:Goods.Headgear
-     </code>
+     <code>TYPE:Goods.Headgear</code>
      <br/>
-     <code>
-      TYPE:Goods.Tools
-     </code>
+     <code>TYPE:Goods.Tools</code>
      <br/>
-     <code>
-      TYPE:Goods.Tools.Consumer
-     </code>
+     <code>TYPE:Goods.Tools.Consumer</code>
      <br/>
-     <code>
-      TYPE:Goods.Tools.Consumer.Photo
-     </code>
+     <code>TYPE:Goods.Tools.Consumer.Photo</code>
      <br/>
-     <code>
-      TYPE:Goods.Tools.Medical
-     </code>
+     <code>TYPE:Goods.Tools.Medical</code>
      <br/>
-     <code>
-      TYPE:Goods.Tools.Medical.Consumable
-     </code>
+     <code>TYPE:Goods.Tools.Medical.Consumable</code>
      <br/>
-     <code>
-      TYPE:Goods.WeaponAccessory.Consumable
-     </code>
+     <code>TYPE:Goods.WeaponAccessory.Consumable</code>
     </p>
     <p>
      <strong>
@@ -1186,17 +872,11 @@ Pulp Fantasy (Modern)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Armor.Light.Suit.Tactical
-     </code>
+     <code>TYPE:Armor.Light.Suit.Tactical</code>
      <br/>
-     <code>
-      TYPE:Armor.Medium.Suit.Tactical
-     </code>
+     <code>TYPE:Armor.Medium.Suit.Tactical</code>
      <br/>
-     <code>
-      TYPE:Armor.Heavy.Suit.Tactical
-     </code>
+     <code>TYPE:Armor.Heavy.Suit.Tactical</code>
     </p>
     <p>
      <strong>
@@ -1204,9 +884,7 @@ Pulp Fantasy (Modern)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Goods.Poison.Consumable
-     </code>
+     <code>TYPE:Goods.Poison.Consumable</code>
     </p>
     <p>
      <strong>
@@ -1214,33 +892,19 @@ Pulp Fantasy (Modern)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Goods.Transportation.Civilian.Aircraft
-     </code>
+     <code>TYPE:Goods.Transportation.Civilian.Aircraft</code>
      <br/>
-     <code>
-      TYPE:Goods.Transportation.Civilian.Car
-     </code>
+     <code>TYPE:Goods.Transportation.Civilian.Car</code>
      <br/>
-     <code>
-      TYPE:Goods.Transportation.Civilian.Motorcycle
-     </code>
+     <code>TYPE:Goods.Transportation.Civilian.Motorcycle</code>
      <br/>
-     <code>
-      TYPE:Goods.Transportation.Military.Aircraft
-     </code>
+     <code>TYPE:Goods.Transportation.Military.Aircraft</code>
      <br/>
-     <code>
-      TYPE:Goods.Transportation.Military.Armored
-     </code>
+     <code>TYPE:Goods.Transportation.Military.Armored</code>
      <br/>
-     <code>
-      TYPE:Goods.Transportation.Military.Motorcycle.Tracked
-     </code>
+     <code>TYPE:Goods.Transportation.Military.Motorcycle.Tracked</code>
      <br/>
-     <code>
-      TYPE:Goods.Transportation.Military.U-boat
-     </code>
+     <code>TYPE:Goods.Transportation.Military.U-boat</code>
     </p>
     <p>
      <strong>
@@ -1249,9 +913,7 @@ File.
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Explosive.Slashing
-     </code>
+     <code>TYPE:Explosive.Slashing</code>
     </p>
     <p>
      <strong>
@@ -1259,13 +921,9 @@ File.
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Ammunition.Standard.Metal.Bullet
-     </code>
+     <code>TYPE:Ammunition.Standard.Metal.Bullet</code>
      <br/>
-     <code>
-      TYPE:Ammunition.Standard.Metal.Bullet.Individual
-     </code>
+     <code>TYPE:Ammunition.Standard.Metal.Bullet.Individual</code>
     </p>
     <p>
      <strong>
@@ -1273,9 +931,7 @@ File.
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Weapon.Natural.Melee.Simple.Unarmed.Mystic.Bludgeoning.Finesseable
-     </code>
+     <code>TYPE:Weapon.Natural.Melee.Simple.Unarmed.Mystic.Bludgeoning.Finesseable</code>
     </p>
     <p>
      <strong>
@@ -1283,41 +939,23 @@ File.
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Weapon.Ranged.Standard.Firearm.Pistol.Ballistic.Personal.Semiauto.Container.Projectile
-     </code>
+     <code>TYPE:Weapon.Ranged.Standard.Firearm.Pistol.Ballistic.Personal.Semiauto.Container.Projectile</code>
      <br/>
-     <code>
-      TYPE:Weapon.Ranged.Standard.Firearm.Longarm.Ballistic.Personal.Semiauto.Container.Projectile
-     </code>
+     <code>TYPE:Weapon.Ranged.Standard.Firearm.Longarm.Ballistic.Personal.Semiauto.Container.Projectile</code>
      <br/>
-     <code>
-      TYPE:Weapon.Ranged.Standard.Firearm.Longarm.Ballistic.Personal.Semiauto.Automatic.Container.Projectile
-     </code>
+     <code>TYPE:Weapon.Ranged.Standard.Firearm.Longarm.Ballistic.Personal.Semiauto.Automatic.Container.Projectile</code>
      <br/>
-     <code>
-      TYPE:Weapon.Ranged.Standard.Firearm.Heavy.Ballistic.Exotic.Automatic.Container.Projectile
-     </code>
+     <code>TYPE:Weapon.Ranged.Standard.Firearm.Heavy.Ballistic.Exotic.Automatic.Container.Projectile</code>
      <br/>
-     <code>
-      TYPE:Weapon.Ranged.Standard.Firearm.Heavy.Ballistic.Exotic
-     </code>
+     <code>TYPE:Weapon.Ranged.Standard.Firearm.Heavy.Ballistic.Exotic</code>
      <br/>
-     <code>
-      TYPE:Weapon.Ranged.Standard.Cannon.Vehicle.Ballistic.Exotic.Automatic
-     </code>
+     <code>TYPE:Weapon.Ranged.Standard.Cannon.Vehicle.Ballistic.Exotic.Automatic</code>
      <br/>
-     <code>
-      TYPE:Weapon.Ranged.Standard.Cannon.Vehicle.Ballistic.Exotic.Semiauto
-     </code>
+     <code>TYPE:Weapon.Ranged.Standard.Cannon.Vehicle.Ballistic.Exotic.Semiauto</code>
      <br/>
-     <code>
-      TYPE:Weapon.Ranged.Standard.Cannon.Vehicle.Concussion.Exotic.Semiauto
-     </code>
+     <code>TYPE:Weapon.Ranged.Standard.Cannon.Vehicle.Concussion.Exotic.Semiauto</code>
      <br/>
-     <code>
-      TYPE:Weapons.Ranged.Standard.Archaic.Piercing.Wooden.Container
-     </code>
+     <code>TYPE:Weapons.Ranged.Standard.Archaic.Piercing.Wooden.Container</code>
     </p>
     <p>
      <strong>
@@ -1325,9 +963,7 @@ File.
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Gadget
-     </code>
+     <code>TYPE:Gadget</code>
     </p>
     <p>
      <strong>
@@ -1335,29 +971,17 @@ File.
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:General.Ambassador
-     </code>
+     <code>TYPE:General.Ambassador</code>
      <br/>
-     <code>
-      TYPE:General.Driver
-     </code>
+     <code>TYPE:General.Driver</code>
      <br/>
-     <code>
-      TYPE:General.Explorer
-     </code>
+     <code>TYPE:General.Explorer</code>
      <br/>
-     <code>
-      TYPE:General.Mystery_Man.Operator
-     </code>
+     <code>TYPE:General.Mystery_Man.Operator</code>
      <br/>
-     <code>
-      TYPE:General.Operator
-     </code>
+     <code>TYPE:General.Operator</code>
      <br/>
-     <code>
-      TYPE:General.Smart.Explorer
-     </code>
+     <code>TYPE:General.Smart.Explorer</code>
     </p>
     <p>
      <strong>
@@ -1365,117 +989,61 @@ File.
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:AddWealth
-     </code>
+     <code>TYPE:AddWealth</code>
      <br/>
-     <code>
-      TYPE:AmbassadorAbility
-     </code>
+     <code>TYPE:AmbassadorAbility</code>
      <br/>
-     <code>
-      TYPE:BrawlerAbility
-     </code>
+     <code>TYPE:BrawlerAbility</code>
      <br/>
-     <code>
-      TYPE:CombatAceAbility
-     </code>
+     <code>TYPE:CombatAceAbility</code>
      <br/>
-     <code>
-      TYPE:CrossTraining
-     </code>
+     <code>TYPE:CrossTraining</code>
      <br/>
-     <code>
-      TYPE:DetectiveAbility
-     </code>
+     <code>TYPE:DetectiveAbility</code>
      <br/>
-     <code>
-      TYPE:DriverAbility
-     </code>
+     <code>TYPE:DriverAbility</code>
      <br/>
-     <code>
-      TYPE:EclecticSelections
-     </code>
+     <code>TYPE:EclecticSelections</code>
      <br/>
-     <code>
-      TYPE:ExplorerAbility
-     </code>
+     <code>TYPE:ExplorerAbility</code>
      <br/>
-     <code>
-      TYPE:FastLearnerLevel
-     </code>
+     <code>TYPE:FastLearnerLevel</code>
      <br/>
-     <code>
-      TYPE:GManAbility
-     </code>
+     <code>TYPE:GManAbility</code>
      <br/>
-     <code>
-      TYPE:HeirWorkaround
-     </code>
+     <code>TYPE:HeirWorkaround</code>
      <br/>
-     <code>
-      TYPE:MoveReputationOne
-     </code>
+     <code>TYPE:MoveReputationOne</code>
      <br/>
-     <code>
-      TYPE:MoveReputationTwo
-     </code>
+     <code>TYPE:MoveReputationTwo</code>
      <br/>
-     <code>
-      TYPE:MoveReputationThree
-     </code>
+     <code>TYPE:MoveReputationThree</code>
      <br/>
-     <code>
-      TYPE:MysteryManAbility
-     </code>
+     <code>TYPE:MysteryManAbility</code>
      <br/>
-     <code>
-      TYPE:MysticAbility
-     </code>
+     <code>TYPE:MysticAbility</code>
      <br/>
-     <code>
-      TYPE:NewsHoundAbility
-     </code>
+     <code>TYPE:NewsHoundAbility</code>
      <br/>
-     <code>
-      TYPE:OperatorAbility
-     </code>
+     <code>TYPE:OperatorAbility</code>
      <br/>
-     <code>
-      TYPE:RelicHunterAbility
-     </code>
+     <code>TYPE:RelicHunterAbility</code>
      <br/>
-     <code>
-      TYPE:ScientistAbility
-     </code>
+     <code>TYPE:ScientistAbility</code>
      <br/>
-     <code>
-      TYPE:ShadowyAvengerAbility
-     </code>
+     <code>TYPE:ShadowyAvengerAbility</code>
      <br/>
-     <code>
-      TYPE:SidekickBonus
-     </code>
+     <code>TYPE:SidekickBonus</code>
      <br/>
-     <code>
-      TYPE:SignatureKitChoice
-     </code>
+     <code>TYPE:SignatureKitChoice</code>
      <br/>
-     <code>
-      TYPE:Special.Hunter.Operator
-     </code>
+     <code>TYPE:Special.Hunter.Operator</code>
      <br/>
-     <code>
-      TYPE:SpyAbility
-     </code>
+     <code>TYPE:SpyAbility</code>
      <br/>
-     <code>
-      TYPE:WeirdInventorAbility
-     </code>
+     <code>TYPE:WeirdInventorAbility</code>
      <br/>
-     <code>
-      TYPE:X-Training
-     </code>
+     <code>TYPE:X-Training</code>
     </p>
     <p>
      <strong>
@@ -1483,221 +1051,113 @@ File.
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Adventurer.Athlete.Circus_Performer.Explorer.Mystic_PF.Scientist.Soldier
-     </code>
+     <code>TYPE:Adventurer.Athlete.Circus_Performer.Explorer.Mystic_PF.Scientist.Soldier</code>
      <br/>
-     <code>
-      TYPE:Adventurer.Athlete.Criminal.Investigative.Military.Rural.CombatAce.Daredevil.Detective.Driver.Explorer.G_Man.Gangster.Mystery_Man.Soldier
-     </code>
+     <code>TYPE:Adventurer.Athlete.Criminal.Investigative.Military.Rural.CombatAce.Daredevil.Detective.Driver.Explorer.G_Man.Gangster.Mystery_Man.Soldier</code>
      <br/>
-     <code>
-      TYPE:Adventurer.Criminal.Investigative.Law_Enforcement.Military.Rural.Brawler.Detective.Mystery_Man.Scientist
-     </code>
+     <code>TYPE:Adventurer.Criminal.Investigative.Law_Enforcement.Military.Rural.Brawler.Detective.Mystery_Man.Scientist</code>
      <br/>
-     <code>
-      TYPE:Ambassador.Bureaucrat.Detective.Explorer.Mystery_Man.Relic_Hunter.Scientist.World_Traveller
-     </code>
+     <code>TYPE:Ambassador.Bureaucrat.Detective.Explorer.Mystery_Man.Relic_Hunter.Scientist.World_Traveller</code>
      <br/>
-     <code>
-      TYPE:Ambassador.Daredevil.Detective.Driver.Explorer.Mystery_Man.Relic_Hunter.Shadowy_Avenger.Operator
-     </code>
+     <code>TYPE:Ambassador.Daredevil.Detective.Driver.Explorer.Mystery_Man.Relic_Hunter.Shadowy_Avenger.Operator</code>
      <br/>
-     <code>
-      TYPE:Ambassador.Gangster
-     </code>
+     <code>TYPE:Ambassador.Gangster</code>
      <br/>
-     <code>
-      TYPE:Ambassador.Operator
-     </code>
+     <code>TYPE:Ambassador.Operator</code>
      <br/>
-     <code>
-      TYPE:Ambassador.Operator.Politician.World_Traveller
-     </code>
+     <code>TYPE:Ambassador.Operator.Politician.World_Traveller</code>
      <br/>
-     <code>
-      TYPE:Antiques_Dealer.Explorer.Scientist
-     </code>
+     <code>TYPE:Antiques_Dealer.Explorer.Scientist</code>
      <br/>
-     <code>
-      TYPE:Antiques_Dealer.Fortuneteller.World_Traveller.Ambassador.Explorer.Scientist
-     </code>
+     <code>TYPE:Antiques_Dealer.Fortuneteller.World_Traveller.Ambassador.Explorer.Scientist</code>
      <br/>
-     <code>
-      TYPE:Brawler.CombatAce.Daredevil.Driver.G_Man.Gangster.Law_Enforcement.Military.Shadowy_Avenger.Soldier
-     </code>
+     <code>TYPE:Brawler.CombatAce.Daredevil.Driver.G_Man.Gangster.Law_Enforcement.Military.Shadowy_Avenger.Soldier</code>
      <br/>
-     <code>
-      TYPE:Brawler.CombatAce.Explorer.Gangster
-     </code>
+     <code>TYPE:Brawler.CombatAce.Explorer.Gangster</code>
      <br/>
-     <code>
-      TYPE:Brawler.Daredevil.Detective.Explorer.Gangster.Mystery_Man.Soldier
-     </code>
+     <code>TYPE:Brawler.Daredevil.Detective.Explorer.Gangster.Mystery_Man.Soldier</code>
      <br/>
-     <code>
-      TYPE:Brawler.Daredevil.Detective.Mystery_Man.Soldier
-     </code>
+     <code>TYPE:Brawler.Daredevil.Detective.Mystery_Man.Soldier</code>
      <br/>
-     <code>
-      TYPE:Brawler.Daredevil.Explorer.Gangster.Mystery_Man.Soldier
-     </code>
+     <code>TYPE:Brawler.Daredevil.Explorer.Gangster.Mystery_Man.Soldier</code>
      <br/>
-     <code>
-      TYPE:Brawler.Detective.Mystery_Man.Soldier
-     </code>
+     <code>TYPE:Brawler.Detective.Mystery_Man.Soldier</code>
      <br/>
-     <code>
-      TYPE:Brawler.G_Man.Operator
-     </code>
+     <code>TYPE:Brawler.G_Man.Operator</code>
      <br/>
-     <code>
-      TYPE:Brawler.Mystic_PF
-     </code>
+     <code>TYPE:Brawler.Mystic_PF</code>
      <br/>
-     <code>
-      TYPE:Bureaucrat.Fortuneteller.Politician.World_Traveller.Ambassador.Driver.Explorer.Gangster.Relic_Hunter.Scientist
-     </code>
+     <code>TYPE:Bureaucrat.Fortuneteller.Politician.World_Traveller.Ambassador.Driver.Explorer.Gangster.Relic_Hunter.Scientist</code>
      <br/>
-     <code>
-      TYPE:Circus_Performer.Daredevil.Mystic_PF.Relic_Hunter.Shadowy_Avenger
-     </code>
+     <code>TYPE:Circus_Performer.Daredevil.Mystic_PF.Relic_Hunter.Shadowy_Avenger</code>
      <br/>
-     <code>
-      TYPE:CombatAce.Daredevil
-     </code>
+     <code>TYPE:CombatAce.Daredevil</code>
      <br/>
-     <code>
-      TYPE:CombatAce.Explorer.G_Man
-     </code>
+     <code>TYPE:CombatAce.Explorer.G_Man</code>
      <br/>
-     <code>
-      TYPE:CombatAce.Mystery_Man.Shadowy_Avenger.Operator
-     </code>
+     <code>TYPE:CombatAce.Mystery_Man.Shadowy_Avenger.Operator</code>
      <br/>
-     <code>
-      TYPE:Craftsperson.CombatAce.Driver.Scientist
-     </code>
+     <code>TYPE:Craftsperson.CombatAce.Driver.Scientist</code>
      <br/>
-     <code>
-      TYPE:Craftsperson.Driver
-     </code>
+     <code>TYPE:Craftsperson.Driver</code>
      <br/>
-     <code>
-      TYPE:Daredevil.Detective.Mystery_Man.Soldier
-     </code>
+     <code>TYPE:Daredevil.Detective.Mystery_Man.Soldier</code>
      <br/>
-     <code>
-      TYPE:Daredevil.Driver.Explorer.Gangster
-     </code>
+     <code>TYPE:Daredevil.Driver.Explorer.Gangster</code>
      <br/>
-     <code>
-      TYPE:Daredevil.Driver.G_Man
-     </code>
+     <code>TYPE:Daredevil.Driver.G_Man</code>
      <br/>
-     <code>
-      TYPE:Daredevil.Explorer.Relic_Hunter.Shadowy_Avenger.Operator
-     </code>
+     <code>TYPE:Daredevil.Explorer.Relic_Hunter.Shadowy_Avenger.Operator</code>
      <br/>
-     <code>
-      TYPE:Daredevil.G_Man
-     </code>
+     <code>TYPE:Daredevil.G_Man</code>
      <br/>
-     <code>
-      TYPE:Daredevil.Scientist
-     </code>
+     <code>TYPE:Daredevil.Scientist</code>
      <br/>
-     <code>
-      TYPE:Daredevil.Shadowy_Avenger.Operator
-     </code>
+     <code>TYPE:Daredevil.Shadowy_Avenger.Operator</code>
      <br/>
-     <code>
-      TYPE:Detective.Mystery_Man
-     </code>
+     <code>TYPE:Detective.Mystery_Man</code>
      <br/>
-     <code>
-      TYPE:Driver.G_Man.Gangster
-     </code>
+     <code>TYPE:Driver.G_Man.Gangster</code>
      <br/>
-     <code>
-      TYPE:Escape_Artist.Fortuneteller.Stage_Magician.Gangster.Shadowy_Avenger
-     </code>
+     <code>TYPE:Escape_Artist.Fortuneteller.Stage_Magician.Gangster.Shadowy_Avenger</code>
      <br/>
-     <code>
-      TYPE:Escape_Artist.Stage_Magician.Daredevil.Explorer
-     </code>
+     <code>TYPE:Escape_Artist.Stage_Magician.Daredevil.Explorer</code>
      <br/>
-     <code>
-      TYPE:Explorer.G_Man.Mystic_PF.Soldier.Operator
-     </code>
+     <code>TYPE:Explorer.G_Man.Mystic_PF.Soldier.Operator</code>
      <br/>
-     <code>
-      TYPE:Explorer.G_Man.Soldier.Operator
-     </code>
+     <code>TYPE:Explorer.G_Man.Soldier.Operator</code>
      <br/>
-     <code>
-      TYPE:Explorer.Mystery_Man
-     </code>
+     <code>TYPE:Explorer.Mystery_Man</code>
      <br/>
-     <code>
-      TYPE:Explorer.Operator
-     </code>
+     <code>TYPE:Explorer.Operator</code>
      <br/>
-     <code>
-      TYPE:Gangster.Operator
-     </code>
+     <code>TYPE:Gangster.Operator</code>
      <br/>
-     <code>
-      TYPE:Gangster.Politician.Relic_Hunter
-     </code>
+     <code>TYPE:Gangster.Politician.Relic_Hunter</code>
      <br/>
-     <code>
-      TYPE:Gangster.Relic_Hunter.Shadowy_Avenger
-     </code>
+     <code>TYPE:Gangster.Relic_Hunter.Shadowy_Avenger</code>
      <br/>
-     <code>
-      TYPE:General
-     </code>
+     <code>TYPE:General</code>
      <br/>
-     <code>
-      TYPE:Hunter.Detective.Mystery_Man.Scientist.Operator
-     </code>
+     <code>TYPE:Hunter.Detective.Mystery_Man.Scientist.Operator</code>
      <br/>
-     <code>
-      TYPE:Hunter.Gangster.Relic_Hunter
-     </code>
+     <code>TYPE:Hunter.Gangster.Relic_Hunter</code>
      <br/>
-     <code>
-      TYPE:Hunter.Relic_Hunter.World_Traveller
-     </code>
+     <code>TYPE:Hunter.Relic_Hunter.World_Traveller</code>
      <br/>
-     <code>
-      TYPE:Hunter.Soldier.Operator
-     </code>
+     <code>TYPE:Hunter.Soldier.Operator</code>
      <br/>
-     <code>
-      TYPE:Mystery_Man
-     </code>
+     <code>TYPE:Mystery_Man</code>
      <br/>
-     <code>
-      TYPE:Mystic_PF.Shadowy_Avenger.Soldier.Operator
-     </code>
+     <code>TYPE:Mystic_PF.Shadowy_Avenger.Soldier.Operator</code>
      <br/>
-     <code>
-      TYPE:Operator
-     </code>
+     <code>TYPE:Operator</code>
      <br/>
-     <code>
-      TYPE:Relic_Hunter.Scientist.Shadowy_Avenger.Operator
-     </code>
+     <code>TYPE:Relic_Hunter.Scientist.Shadowy_Avenger.Operator</code>
      <br/>
-     <code>
-      TYPE:Soldier
-     </code>
+     <code>TYPE:Soldier</code>
      <br/>
-     <code>
-      TYPE:World_Traveller.Gangster
-     </code>
+     <code>TYPE:World_Traveller.Gangster</code>
     </p>
     <p>
      <strong>
@@ -1705,165 +1165,85 @@ File.
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Antiques_Dealer_Skills.Bureaucrat_Skills.Craftsperson_Skills.Engineer_Skills.Fortuneteller_Skills.Politician_Skills
-     </code>
+     <code>TYPE:Antiques_Dealer_Skills.Bureaucrat_Skills.Craftsperson_Skills.Engineer_Skills.Fortuneteller_Skills.Politician_Skills</code>
      <br/>
-     <code>
-      TYPE:Antiques_Dealer_Skills.Bureaucrat_Skills.Domestic_Skills.Fortuneteller_Skills.Politician_Skills.World_Traveller_Skills
-     </code>
+     <code>TYPE:Antiques_Dealer_Skills.Bureaucrat_Skills.Domestic_Skills.Fortuneteller_Skills.Politician_Skills.World_Traveller_Skills</code>
      <br/>
-     <code>
-      TYPE:Antiques_Dealer_Skills.Circus_Performer_Skills.Fortuneteller_Skills.Outcast_Skills
-     </code>
+     <code>TYPE:Antiques_Dealer_Skills.Circus_Performer_Skills.Fortuneteller_Skills.Outcast_Skills</code>
      <br/>
-     <code>
-      TYPE:Antiques_Dealer_Skills.Craftsperson_Skills.Domestic_Skills.Engineer_Skills.Laborer_Skills
-     </code>
+     <code>TYPE:Antiques_Dealer_Skills.Craftsperson_Skills.Domestic_Skills.Engineer_Skills.Laborer_Skills</code>
      <br/>
-     <code>
-      TYPE:Artist_Skills.Bureaucrat_Skills.Domestic_Skills.Escape_Artist_Skills.Fortuneteller_Skills.Politician_Skills.Stage_Magician_Skills.World_Traveller_Skills
-     </code>
+     <code>TYPE:Artist_Skills.Bureaucrat_Skills.Domestic_Skills.Escape_Artist_Skills.Fortuneteller_Skills.Politician_Skills.Stage_Magician_Skills.World_Traveller_Skills</code>
      <br/>
-     <code>
-      TYPE:Artist_Skills.Bureaucrat_Skills.Domestic_Skills.Politician_Skills
-     </code>
+     <code>TYPE:Artist_Skills.Bureaucrat_Skills.Domestic_Skills.Politician_Skills</code>
      <br/>
-     <code>
-      TYPE:Artist_Skills.Bureaucrat_Skills.Heir_Skills
-     </code>
+     <code>TYPE:Artist_Skills.Bureaucrat_Skills.Heir_Skills</code>
      <br/>
-     <code>
-      TYPE:Artist_Skills.Bureaucrat_Skills.Politician_Skills
-     </code>
+     <code>TYPE:Artist_Skills.Bureaucrat_Skills.Politician_Skills</code>
      <br/>
-     <code>
-      TYPE:Artist_Skills.Circus_Performer_Skills.Heir_Skills
-     </code>
+     <code>TYPE:Artist_Skills.Circus_Performer_Skills.Heir_Skills</code>
      <br/>
-     <code>
-      TYPE:Artist_Skills.Craftsperson_Skills.Heir_Skills
-     </code>
+     <code>TYPE:Artist_Skills.Craftsperson_Skills.Heir_Skills</code>
      <br/>
-     <code>
-      TYPE:Artist_Skills.Domestic_Skills
-     </code>
+     <code>TYPE:Artist_Skills.Domestic_Skills</code>
      <br/>
-     <code>
-      TYPE:Artist_Skills.Heir_Skills
-     </code>
+     <code>TYPE:Artist_Skills.Heir_Skills</code>
      <br/>
-     <code>
-      TYPE:Artist_Skills.Outcast_Skills
-     </code>
+     <code>TYPE:Artist_Skills.Outcast_Skills</code>
      <br/>
-     <code>
-      TYPE:Artist_Skills.Stage_Magician_Skills
-     </code>
+     <code>TYPE:Artist_Skills.Stage_Magician_Skills</code>
      <br/>
-     <code>
-      TYPE:Bureaucrat_Skills.Circus_Performer_Skills.Domestic_Skills.Escape_Artist_Skills.Heir_Skills.Politician_Skills.World_Traveller_Skills
-     </code>
+     <code>TYPE:Bureaucrat_Skills.Circus_Performer_Skills.Domestic_Skills.Escape_Artist_Skills.Heir_Skills.Politician_Skills.World_Traveller_Skills</code>
      <br/>
-     <code>
-      TYPE:Bureaucrat_Skills.Circus_Performer_Skills.Escape_Artist_Skills.Heir_Skills.Politician_Skills.World_Traveller_Skills
-     </code>
+     <code>TYPE:Bureaucrat_Skills.Circus_Performer_Skills.Escape_Artist_Skills.Heir_Skills.Politician_Skills.World_Traveller_Skills</code>
      <br/>
-     <code>
-      TYPE:Bureaucrat_Skills.Domestic_Skills.Fortuneteller_Skills.Politician_Skills
-     </code>
+     <code>TYPE:Bureaucrat_Skills.Domestic_Skills.Fortuneteller_Skills.Politician_Skills</code>
      <br/>
-     <code>
-      TYPE:Bureaucrat_Skills.Domestic_Skills.Heir_Skills.Politician_Skills
-     </code>
+     <code>TYPE:Bureaucrat_Skills.Domestic_Skills.Heir_Skills.Politician_Skills</code>
      <br/>
-     <code>
-      TYPE:Bureaucrat_Skills.Heir_Skills.Politician_Skills.World_Traveller_Skills
-     </code>
+     <code>TYPE:Bureaucrat_Skills.Heir_Skills.Politician_Skills.World_Traveller_Skills</code>
      <br/>
-     <code>
-      TYPE:Bureaucrat_Skills.Politician_Skills
-     </code>
+     <code>TYPE:Bureaucrat_Skills.Politician_Skills</code>
      <br/>
-     <code>
-      TYPE:Circus_Performer_Skills.Domestic_Skills.Laborer_Skills
-     </code>
+     <code>TYPE:Circus_Performer_Skills.Domestic_Skills.Laborer_Skills</code>
      <br/>
-     <code>
-      TYPE:Circus_Performer_Skills.Escape_Artist_Skills.Laborer_Skills
-     </code>
+     <code>TYPE:Circus_Performer_Skills.Escape_Artist_Skills.Laborer_Skills</code>
      <br/>
-     <code>
-      TYPE:Craftsperson_Skills.Engineer_Skills.Escape_Artist_Skills.Laborer_Skills.Stage_Magician_Skills
-     </code>
+     <code>TYPE:Craftsperson_Skills.Engineer_Skills.Escape_Artist_Skills.Laborer_Skills.Stage_Magician_Skills</code>
      <br/>
-     <code>
-      TYPE:Craftsperson_Skills.Engineer_Skills.Laborer_Skills
-     </code>
+     <code>TYPE:Craftsperson_Skills.Engineer_Skills.Laborer_Skills</code>
      <br/>
-     <code>
-      TYPE:Craftsperson_Skills.Escape_Artist_Skills.Stage_Magician_Skills
-     </code>
+     <code>TYPE:Craftsperson_Skills.Escape_Artist_Skills.Stage_Magician_Skills</code>
      <br/>
-     <code>
-      TYPE:Craftsperson_Skills.Outcast_Skills
-     </code>
+     <code>TYPE:Craftsperson_Skills.Outcast_Skills</code>
      <br/>
-     <code>
-      TYPE:Craftsperson_Skills.Stage_Magician_Skills
-     </code>
+     <code>TYPE:Craftsperson_Skills.Stage_Magician_Skills</code>
      <br/>
-     <code>
-      TYPE:Domestic_Skills.Engineer_Skills.Laborer_Skills.World_Traveller_Skills
-     </code>
+     <code>TYPE:Domestic_Skills.Engineer_Skills.Laborer_Skills.World_Traveller_Skills</code>
      <br/>
-     <code>
-      TYPE:Domestic_Skills.Laborer_Skills.Politician_Skills
-     </code>
+     <code>TYPE:Domestic_Skills.Laborer_Skills.Politician_Skills</code>
      <br/>
-     <code>
-      TYPE:Domestic_Skills.Outcast_Skills.Stage_Magician_Skills
-     </code>
+     <code>TYPE:Domestic_Skills.Outcast_Skills.Stage_Magician_Skills</code>
      <br/>
-     <code>
-      TYPE:Domestic_Skills.Stage_Magician_Skills
-     </code>
+     <code>TYPE:Domestic_Skills.Stage_Magician_Skills</code>
      <br/>
-     <code>
-      TYPE:Escape_Artist_Skills.Fortuneteller_Skills.Stage_Magician_Skills
-     </code>
+     <code>TYPE:Escape_Artist_Skills.Fortuneteller_Skills.Stage_Magician_Skills</code>
      <br/>
-     <code>
-      TYPE:Fortuneteller_Skills.Politician_Skills
-     </code>
+     <code>TYPE:Fortuneteller_Skills.Politician_Skills</code>
      <br/>
-     <code>
-      TYPE:Heir_Skills.Laborer_Skills
-     </code>
+     <code>TYPE:Heir_Skills.Laborer_Skills</code>
      <br/>
-     <code>
-      TYPE:Hunter_Skills.Outcast_Skills.World_Traveller_Skills
-     </code>
+     <code>TYPE:Hunter_Skills.Outcast_Skills.World_Traveller_Skills</code>
      <br/>
-     <code>
-      TYPE:Occupation_Skill.Engineer_Skills
-     </code>
+     <code>TYPE:Occupation_Skill.Engineer_Skills</code>
      <br/>
-     <code>
-      TYPE:Occupation_Skill.Academic_Skills.Adventurer_Skills.Antiques_Dealer_Skills.Artist_Skills.Circus_Performer_Skills.Escape_Artist_Skills.Fortuneteller_Skills
-     </code>
+     <code>TYPE:Occupation_Skill.Academic_Skills.Adventurer_Skills.Antiques_Dealer_Skills.Artist_Skills.Circus_Performer_Skills.Escape_Artist_Skills.Fortuneteller_Skills</code>
      <br/>
-     <code>
-      TYPE:Politician_Skills
-     </code>
+     <code>TYPE:Politician_Skills</code>
      <br/>
-     <code>
-      TYPE:Stage_Magician_Skills
-     </code>
+     <code>TYPE:Stage_Magician_Skills</code>
      <br/>
-     <code>
-      TYPE:World_Traveller_Skills
-     </code>
+     <code>TYPE:World_Traveller_Skills</code>
     </p>
     <p>
      <strong>
@@ -1871,65 +1251,35 @@ File.
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Spoken.Caddoan
-     </code>
+     <code>TYPE:Spoken.Caddoan</code>
      <br/>
-     <code>
-      TYPE:Spoken.Iroquoian
-     </code>
+     <code>TYPE:Spoken.Iroquoian</code>
      <br/>
-     <code>
-      TYPE:Spoken.Muskogean
-     </code>
+     <code>TYPE:Spoken.Muskogean</code>
      <br/>
-     <code>
-      TYPE:Spoken.Sahaptian
-     </code>
+     <code>TYPE:Spoken.Sahaptian</code>
      <br/>
-     <code>
-      TYPE:Spoken.Signaling
-     </code>
+     <code>TYPE:Spoken.Signaling</code>
      <br/>
-     <code>
-      TYPE:Spoken.Siouian
-     </code>
+     <code>TYPE:Spoken.Siouian</code>
      <br/>
-     <code>
-      TYPE:Spoken.Uto-Aztecan
-     </code>
+     <code>TYPE:Spoken.Uto-Aztecan</code>
      <br/>
-     <code>
-      TYPE:Written.Braille
-     </code>
+     <code>TYPE:Written.Braille</code>
      <br/>
-     <code>
-      TYPE:Written.Caddoan
-     </code>
+     <code>TYPE:Written.Caddoan</code>
     </p>
-    <code>
-     TYPE:Written.Iroquoian
-    </code>
+    <code>TYPE:Written.Iroquoian</code>
     <br/>
-    <code>
-     TYPE:Written.Muskogean
-    </code>
+    <code>TYPE:Written.Muskogean</code>
     <br/>
-    <code>
-     TYPE:Written.Sahaptian
-    </code>
+    <code>TYPE:Written.Sahaptian</code>
     <br/>
-    <code>
-     TYPE:Written.Signaling
-    </code>
+    <code>TYPE:Written.Signaling</code>
     <br/>
-    <code>
-     TYPE:Written.Siouian
-    </code>
+    <code>TYPE:Written.Siouian</code>
     <br/>
-    <code>
-     TYPE:Written.Uto-Aztecan
-    </code>
+    <code>TYPE:Written.Uto-Aztecan</code>
     <br/>
     <p>
      <strong>
@@ -1937,9 +1287,7 @@ File.
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Animal
-     </code>
+     <code>TYPE:Animal</code>
     </p>
     <p>
      <strong>
@@ -1947,17 +1295,11 @@ File.
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Intelligence
-     </code>
+     <code>TYPE:Intelligence</code>
      <br/>
-     <code>
-      TYPE:Intelligence.Knowledge
-     </code>
+     <code>TYPE:Intelligence.Knowledge</code>
      <br/>
-     <code>
-      TYPE:Intelligence.Knowledge.Science
-     </code>
+     <code>TYPE:Intelligence.Knowledge.Science</code>
     </p>
     <p>
      <strong>
@@ -1965,17 +1307,11 @@ File.
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Archaic
-     </code>
+     <code>TYPE:Archaic</code>
      <br/>
-     <code>
-      TYPE:ExoticFirearms
-     </code>
+     <code>TYPE:ExoticFirearms</code>
      <br/>
-     <code>
-      TYPE:PersonalFirearm
-     </code>
+     <code>TYPE:PersonalFirearm</code>
     </p>
    </blockquote>
    <hr/>
@@ -1992,13 +1328,9 @@ and Minions (35e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Monster
-     </code>
+     <code>TYPE:Monster</code>
      <br/>
-     <code>
-      TYPE:PC.Prestige
-     </code>
+     <code>TYPE:PC.Prestige</code>
     </p>
     <p>
      <strong>
@@ -2006,17 +1338,11 @@ and Minions (35e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Goods.Alchemical.Consumable.Flask
-     </code>
+     <code>TYPE:Goods.Alchemical.Consumable.Flask</code>
      <br/>
-     <code>
-      TYPE:Goods.General
-     </code>
+     <code>TYPE:Goods.General</code>
      <br/>
-     <code>
-      TYPE:Goods.Trade
-     </code>
+     <code>TYPE:Goods.Trade</code>
     </p>
     <p>
      <strong>
@@ -2024,25 +1350,17 @@ and Minions (35e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:SpecialQuality.Extraordinary
-     </code>
+     <code>TYPE:SpecialQuality.Extraordinary</code>
      <br/>
-     <code>
-      TYPE:SpecialQuality.Supernatural
-     </code>
+     <code>TYPE:SpecialQuality.Supernatural</code>
      <br/>
     </p>
     <p>
-     <code>
-      TYPE:SpecialAttack.Extraordinary
-     </code>
+     <code>TYPE:SpecialAttack.Extraordinary</code>
      <br/>
     </p>
     <p>
-     <code>
-      TYPE:SpecialQuality.Extraordinary
-     </code>
+     <code>TYPE:SpecialQuality.Extraordinary</code>
      <br/>
     </p>
     <p>
@@ -2051,9 +1369,7 @@ and Minions (35e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Spoken
-     </code>
+     <code>TYPE:Spoken</code>
     </p>
     <p>
      <strong>
@@ -2061,15 +1377,11 @@ and Minions (35e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Monstrous Humanoid
-     </code>
+     <code>TYPE:Monstrous Humanoid</code>
      <br/>
     </p>
     <p>
-     <code>
-      TYPE:Magical Beast
-     </code>
+     <code>TYPE:Magical Beast</code>
     </p>
     <p>
      <strong>
@@ -2077,9 +1389,7 @@ and Minions (35e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Intelligence.Knowledge
-     </code>
+     <code>TYPE:Intelligence.Knowledge</code>
     </p>
     <p>
      <strong>
@@ -2087,13 +1397,9 @@ and Minions (35e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Arcane
-     </code>
+     <code>TYPE:Arcane</code>
      <br/>
-     <code>
-      TYPE:Divine
-     </code>
+     <code>TYPE:Divine</code>
     </p>
     <p>
      <strong>
@@ -2101,17 +1407,11 @@ and Minions (35e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Fey
-     </code>
+     <code>TYPE:Fey</code>
      <br/>
-     <code>
-      TYPE:Humanoid
-     </code>
+     <code>TYPE:Humanoid</code>
      <br/>
-     <code>
-      TYPE:Giant
-     </code>
+     <code>TYPE:Giant</code>
     </p>
    </blockquote>
    <hr/>
@@ -2129,13 +1429,9 @@ File.
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Weapon.Melee.Martial.Specific.Slashing.Sword
-     </code>
+     <code>TYPE:Weapon.Melee.Martial.Specific.Slashing.Sword</code>
      <br/>
-     <code>
-      TYPE:Weapon.Melee.Ranged.Simple.Thrown.Specific.Piercing.Slashing.Dagger
-     </code>
+     <code>TYPE:Weapon.Melee.Ranged.Simple.Thrown.Specific.Piercing.Slashing.Dagger</code>
     </p>
     <p>
      <strong>
@@ -2143,17 +1439,11 @@ File.
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Weapon
-     </code>
+     <code>TYPE:Weapon</code>
      <br/>
-     <code>
-      TYPE:Ammunition
-     </code>
+     <code>TYPE:Ammunition</code>
      <br/>
-     <code>
-      TYPE:Armor
-     </code>
+     <code>TYPE:Armor</code>
     </p>
    </blockquote>
    <hr/>
@@ -2170,9 +1460,7 @@ Spells (35e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Arcane.Divine
-     </code>
+     <code>TYPE:Arcane.Divine</code>
     </p>
    </blockquote>
    <p class="indent1">
@@ -2188,9 +1476,7 @@ Spellbinder's Sourcebook (35e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Arcane.Divine
-     </code>
+     <code>TYPE:Arcane.Divine</code>
     </p>
     <p>
      <strong>
@@ -2198,9 +1484,7 @@ Spellbinder's Sourcebook (35e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Magical Beast
-     </code>
+     <code>TYPE:Magical Beast</code>
     </p>
    </blockquote>
    <p class="indent1">
@@ -2216,9 +1500,7 @@ Spellbinder's Sourcebook II (35e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Arcane.Divine
-     </code>
+     <code>TYPE:Arcane.Divine</code>
     </p>
    </blockquote>
    <p class="indent1">
@@ -2235,33 +1517,19 @@ File.
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Talent.StrongTalent.Brute.HeavyLoad.Hurling.LikeRock.Might
-     </code>
+     <code>TYPE:Talent.StrongTalent.Brute.HeavyLoad.Hurling.LikeRock.Might</code>
      <br/>
-     <code>
-      TYPE:Talent.FastTalent.Elusive.Finesse.NeedSpeed.QuickerThanEye
-     </code>
+     <code>TYPE:Talent.FastTalent.Elusive.Finesse.NeedSpeed.QuickerThanEye</code>
      <br/>
-     <code>
-      TYPE:Talent.ToughTalent.FXResistance.ToxinResistance
-     </code>
+     <code>TYPE:Talent.ToughTalent.FXResistance.ToxinResistance</code>
      <br/>
-     <code>
-      TYPE:Talent.SmartTalent.FastLearner.QuickThinking.Tactician
-     </code>
+     <code>TYPE:Talent.SmartTalent.FastLearner.QuickThinking.Tactician</code>
      <br/>
-     <code>
-      TYPE:Talent.DedicatedTalent.AnimalAffinity.AnimalFriendship.Oracle.Selfless.Virtue
-     </code>
+     <code>TYPE:Talent.DedicatedTalent.AnimalAffinity.AnimalFriendship.Oracle.Selfless.Virtue</code>
      <br/>
-     <code>
-      TYPE:Efficacious
-     </code>
+     <code>TYPE:Efficacious</code>
      <br/>
-     <code>
-      TYPE:Talent.CharismaticTalent.Efficacious.Facetious.Intimidating.Pulchritudinous
-     </code>
+     <code>TYPE:Talent.CharismaticTalent.Efficacious.Facetious.Intimidating.Pulchritudinous</code>
     </p>
    </blockquote>
    <hr/>
@@ -2278,29 +1546,17 @@ Dawningstar (35e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Talent.StrongTalent.HeavyGravityResistance.StrongRage.ThrowingArm.StrongPlus
-     </code>
+     <code>TYPE:Talent.StrongTalent.HeavyGravityResistance.StrongRage.ThrowingArm.StrongPlus</code>
      <br/>
-     <code>
-      TYPE:Talent.FastTalent.Footwork.Sharpshooter.FastPlus
-     </code>
+     <code>TYPE:Talent.FastTalent.Footwork.Sharpshooter.FastPlus</code>
      <br/>
-     <code>
-      TYPE:Talent.ToughTalent.ToughRage.RadiationResistnace.StunResistance.ToughPlus
-     </code>
+     <code>TYPE:Talent.ToughTalent.ToughRage.RadiationResistnace.StunResistance.ToughPlus</code>
      <br/>
-     <code>
-      TYPE:Talent.SmartTalent.Investigation.Navigation.Scholar.Xenotech.SmartPlus
-     </code>
+     <code>TYPE:Talent.SmartTalent.Investigation.Navigation.Scholar.Xenotech.SmartPlus</code>
      <br/>
-     <code>
-      TYPE:Talent.DedicatedTalent.Survival.SwornEnemy.RebuilderSwornEnemy.Treatment.DedicatedPlus
-     </code>
+     <code>TYPE:Talent.DedicatedTalent.Survival.SwornEnemy.RebuilderSwornEnemy.Treatment.DedicatedPlus</code>
      <br/>
-     <code>
-      TYPE:Talent.CharismaticTalent.AnimalHusbandry.Command.Diplomatic.Mercantile.CharismaticPlus
-     </code>
+     <code>TYPE:Talent.CharismaticTalent.AnimalHusbandry.Command.Diplomatic.Mercantile.CharismaticPlus</code>
     </p>
     <p>
      <strong>
@@ -2308,9 +1564,7 @@ Dawningstar (35e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:PC.Advanced
-     </code>
+     <code>TYPE:PC.Advanced</code>
     </p>
     <p>
      <strong>
@@ -2318,9 +1572,7 @@ Dawningstar (35e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:PC.Prestige.Advanced
-     </code>
+     <code>TYPE:PC.Prestige.Advanced</code>
     </p>
     <p>
      <strong>
@@ -2328,9 +1580,7 @@ Dawningstar (35e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:PC.Race
-     </code>
+     <code>TYPE:PC.Race</code>
     </p>
     <p>
      <strong>
@@ -2338,9 +1588,7 @@ Dawningstar (35e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:SpecialMount
-     </code>
+     <code>TYPE:SpecialMount</code>
     </p>
     <p>
      <strong>
@@ -2348,57 +1596,31 @@ Dawningstar (35e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Goods.Tools.Masterwork.Resizable
-     </code>
+     <code>TYPE:Goods.Tools.Masterwork.Resizable</code>
      <br/>
-     <code>
-      TYPE:Goods.General.PL2.PL5.PL6
-     </code>
+     <code>TYPE:Goods.General.PL2.PL5.PL6</code>
      <br/>
-     <code>
-      TYPE:Cybernetics.PL6
-     </code>
+     <code>TYPE:Cybernetics.PL6</code>
      <br/>
-     <code>
-      TYPE:Cybernetics.Weapon.Ranged.Laser.Fire.Piercing
-     </code>
+     <code>TYPE:Cybernetics.Weapon.Ranged.Laser.Fire.Piercing</code>
      <br/>
-     <code>
-      TYPE:Goods.Tools.Electronic
-     </code>
+     <code>TYPE:Goods.Tools.Electronic</code>
      <br/>
-     <code>
-      TYPE:Goods.Transportation.Civilian.Motorcycles.Truck.Wheel.Aircraft
-     </code>
+     <code>TYPE:Goods.Transportation.Civilian.Motorcycles.Truck.Wheel.Aircraft</code>
      <br/>
-     <code>
-      TYPE:Goods.Transportation.Military.Wheel.Track.Aircraft
-     </code>
+     <code>TYPE:Goods.Transportation.Military.Wheel.Track.Aircraft</code>
      <br/>
-     <code>
-      TYPE:Ammunition.Standard.Bullet.Energy.Gyrojet.Missile
-     </code>
+     <code>TYPE:Ammunition.Standard.Bullet.Energy.Gyrojet.Missile</code>
      <br/>
-     <code>
-      TYPE:Goods.Transportaiton.Mecha.Superstructure.PL6.PL7
-     </code>
+     <code>TYPE:Goods.Transportaiton.Mecha.Superstructure.PL6.PL7</code>
      <br/>
-     <code>
-      TYPE:Goods.Transportation.Starship.Mediumweight.HeavyDestroyer
-     </code>
+     <code>TYPE:Goods.Transportation.Starship.Mediumweight.HeavyDestroyer</code>
      <br/>
-     <code>
-      TYPE:Goods.Transportation.Starship.Ultralight.AtmosphericShuttle
-     </code>
+     <code>TYPE:Goods.Transportation.Starship.Ultralight.AtmosphericShuttle</code>
      <br/>
-     <code>
-      TYPE:Goods.Transportation.Starship.Superheavy.EvacuationShip.Spacestation
-     </code>
+     <code>TYPE:Goods.Transportation.Starship.Superheavy.EvacuationShip.Spacestation</code>
      <br/>
-     <code>
-      TYPE:Goods.Transportation.Starship.Light.Frigate.Scout
-     </code>
+     <code>TYPE:Goods.Transportation.Starship.Light.Frigate.Scout</code>
     </p>
     <p>
      <strong>
@@ -2406,17 +1628,11 @@ Dawningstar (35e)
      </strong>
     </p>
     <p>
-     <code>
-      TYPE:Weapon
-     </code>
+     <code>TYPE:Weapon</code>
      <br/>
-     <code>
-      TYPE:Ammunition
-     </code>
+     <code>TYPE:Ammunition</code>
      <br/>
-     <code>
-      TYPE:Armor
-     </code>
+     <code>TYPE:Armor</code>
     </p>
    </blockquote>
   </blockquote>

--- a/docs/listfilepages/listfileLSTwalkthrough.html
+++ b/docs/listfilepages/listfileLSTwalkthrough.html
@@ -182,129 +182,93 @@ Campaign Information Tags
    Sample PCC FIles:
   </p>
   <p class="indent2">
-   <code>
-    CAMPAIGN:
-   </code>
+   <code>CAMPAIGN:</code>
    - Name of Campaign
 Displayed in data load window.
   </p>
   <p class="indent2">
-   <code>
-    GAMEMODE:3e
-   </code>
+   <code>GAMEMODE:3e</code>
    - Designates the Game
 Mode.
   </p>
   <p class="indent2">
-   <code>
-    TYPE:Dominant Game Publisher.SRD
-   </code>
+   <code>TYPE:Dominant Game Publisher.SRD</code>
    -
 Type will be used for sorting.
   </p>
   <p class="indent2">
-   <code>
-    RANK: 1
-   </code>
+   <code>RANK: 1</code>
    - Rank indicates priority
 in sorting.
   </p>
   <p class="indent2">
-   <code>
-    GENRE:
-   </code>
+   <code>GENRE:</code>
    - This tells PCGen what
 genre this is, used to filter sources.
   </p>
   <p class="indent2">
-   <code>
-    BOOKTYPE:
-   </code>
+   <code>BOOKTYPE:</code>
    - Identifies the source
 book type for use in prerequisites for loading other source
 book.
   </p>
   <p class="indent2">
-   <code>
-    SETTING:
-   </code>
+   <code>SETTING:</code>
    - Identifies the setting
 of which this source is part.
   </p>
   <p class="indent2">
-   <code>
-    !PRECAMPAIGN:1,BOOKTYPE=Core Rules
-   </code>
+   <code>!PRECAMPAIGN:1,BOOKTYPE=Core Rules</code>
    - Established the prerequisite for loading.
   </p>
   <p class="indent2">
-   <code>
-    PUBNAMELONG:The Full Name of the
-Source
-   </code>
+   <code>PUBNAMELONG:The Full Name of the
+Source</code>
    &lt; - Long name for the publisher of the material
 (used in some displays).
   </p>
   <p class="indent2">
-   <code>
-    PUBNAMESHORT:Source
-   </code>
+   <code>PUBNAMESHORT:Source</code>
    - Short name
 for the publisher of the material (used in some displays).
   </p>
   <p class="indent2">
-   <code>
-    PUBNAMEWEB:http://www.mywebsite.com
-   </code>
+   <code>PUBNAMEWEB:http://www.mywebsite.com</code>
    - Website for the publisher's site).
   </p>
   <p class="indent2">
-   <code>
-    SOURCELONG:The Full Name of the
-Source
-   </code>
+   <code>SOURCELONG:The Full Name of the
+Source</code>
    &lt; - Long title (used in some displays).
   </p>
   <p class="indent2">
-   <code>
-    SOURCESHORT:Source
-   </code>
+   <code>SOURCESHORT:Source</code>
    - Short title
 (used in some displays).
   </p>
   <p class="indent2">
-   <code>
-    SOURCEWEB:http://www.mywebsite.com
-   </code>
+   <code>SOURCEWEB:http://www.mywebsite.com</code>
    - Website for the source (typically the publisher's general
 site).
   </p>
   <p class="indent2">
-   <code>
-    ISOGL:YES
-   </code>
+   <code>ISOGL:YES</code>
    - If the source uses the
 open gaming license (OGL) See OGL FAQ.
   </p>
   <p class="indent2">
-   <code>
-    COPYRIGHT:Open Game License v 1.0a
-Copyright 2000, WotC etc.
-   </code>
+   <code>COPYRIGHT:Open Game License v 1.0a
+Copyright 2000, WotC etc.</code>
    - Copyright Terms.
   </p>
   <p class="indent2">
-   <code>
-    COPYRIGHT:Full Name of the Source
-Copyright 2003, Company Name, Authors Names
-   </code>
+   <code>COPYRIGHT:Full Name of the Source
+Copyright 2003, Company Name, Authors Names</code>
    - Copyright
 Owner.
   </p>
   <p class="indent2">
-   <code>
-    [LST Type]:[LST File Name]
-   </code>
+   <code>[LST Type]:[LST File Name]</code>
    - Call a
 LST file.
   </p>
@@ -382,9 +346,7 @@ object.
 PCC file with the following:
   </p>
   <p class="indent1">
-   <code>
-    PCC:myPCC.pcc
-   </code>
+   <code>PCC:myPCC.pcc</code>
    .
   </p>
   <p class="indent0">
@@ -397,9 +359,7 @@ objects named
 would have the following line in your PCC file.
   </p>
   <p class="indent1">
-   <code>
-    CLASS:myfirstclass.lst
-   </code>
+   <code>CLASS:myfirstclass.lst</code>
   </p>
   <p class="indent0">
    For a complete listing of LST file types and the
@@ -433,9 +393,7 @@ the file
 the following line:
   </p>
   <p class="indent1">
-   <code>
-    SPELL:@/d20ogl/srd/srdspells.lst
-   </code>
+   <code>SPELL:@/d20ogl/srd/srdspells.lst</code>
   </p>
   <p class="indent0">
    The "@" symbol tells PCGen to start at the top
@@ -447,9 +405,7 @@ of the
 down.
   </p>
   <p class="indent1">
-   <code>
-    CLASS:&amp;/complete_monkey/complete_monkey_classes.lst
-   </code>
+   <code>CLASS:&amp;/complete_monkey/complete_monkey_classes.lst</code>
   </p>
   <p class="indent0">
    The "&amp;" symbol tells PCGen to start at the
@@ -475,22 +431,16 @@ path down.
   <p class="indent0">
    You can include or exclude specific information
 from any LST file by using the
-   <code>
-    INCLUDE
-   </code>
+   <code>INCLUDE</code>
    or
-   <code>
-    EXCLUDE
-   </code>
+   <code>EXCLUDE</code>
    tags.
   </p>
   <p class="indent0">
    Examples:
   </p>
   <p class="indent1">
-   <code>
-    CLASS:myfirstclass.lst|@/d20ogl/srd/srdclassesbase.lst|(INCLUDE:Fighter)
-   </code>
+   <code>CLASS:myfirstclass.lst|@/d20ogl/srd/srdclassesbase.lst|(INCLUDE:Fighter)</code>
   </p>
   <p class="indent2">
    Loads the classes in
@@ -501,9 +451,7 @@ from any LST file by using the
 classes.
   </p>
   <p class="indent1">
-   <code>
-    CLASS:myfirstclass.lst|(EXCLUDE:Monk|Sorcerer)|@/d20ogl/srd/srdclassesbase.lst
-   </code>
+   <code>CLASS:myfirstclass.lst|(EXCLUDE:Monk|Sorcerer)|@/d20ogl/srd/srdclassesbase.lst</code>
   </p>
   <p class="indent2">
    Load all classes in
@@ -528,9 +476,7 @@ PCC file tags in PCGen's
   <p class="indent0">
    Because LST files are called from PCC files they
 have little in the way of a header, just a
-   <code>
-    SOURCExxx
-   </code>
+   <code>SOURCExxx</code>
    tag, which provides information used on character sheets and
 displays.
   </p>
@@ -611,19 +557,13 @@ Simian and the written only language Peel.
    Here is the header block:
   </p>
   <p class="indent1">
-   <code>
-    SOURCELONG:PCGen Documentation
-   </code>
+   <code>SOURCELONG:PCGen Documentation</code>
   </p>
   <p class="indent2">
-   <code>
-    SOURCESHORT:P-Doc
-   </code>
+   <code>SOURCESHORT:P-Doc</code>
   </p>
   <p class="indent2">
-   <code>
-    SOURCEWEB:http://www.pcgen.org
-   </code>
+   <code>SOURCEWEB:http://www.pcgen.org</code>
   </p>
   <p class="indent0">
    Here the header tells us in detail where the
@@ -641,24 +581,16 @@ on your keyboard) or whitespace. Entries are on separate lines.
    And here are the two working tags:
   </p>
   <p class="indent1">
-   <code>
-    Simian
-   </code>
+   <code>Simian</code>
   </p>
   <p class="indent2">
-   <code>
-    TYPE:Spoken
-   </code>
+   <code>TYPE:Spoken</code>
   </p>
   <p class="indent1">
-   <code>
-    Peel
-   </code>
+   <code>Peel</code>
   </p>
   <p class="indent2">
-   <code>
-    TYPE:Written
-   </code>
+   <code>TYPE:Written</code>
   </p>
   <p class="indent0">
    You can refer to the srdlanguages.lst for a
@@ -676,19 +608,13 @@ simple, like a Mighty Sling.
    First, the header block:
   </p>
   <p class="indent1">
-   <code>
-    SOURCELONG:PCGen Documentation
-   </code>
+   <code>SOURCELONG:PCGen Documentation</code>
   </p>
   <p class="indent2">
-   <code>
-    SOURCESHORT:P-Doc
-   </code>
+   <code>SOURCESHORT:P-Doc</code>
   </p>
   <p class="indent2">
-   <code>
-    SOURCEWEB:http://www.pcgen.org
-   </code>
+   <code>SOURCEWEB:http://www.pcgen.org</code>
   </p>
   <p class="indent0">
    Then comes the actual code. In order we list the
@@ -708,59 +634,37 @@ references your new weapon and then have your PCC load it.
 into a separate line
   </p>
   <p class="indent1">
-   <code>
-    Sling (+1 Mighty)
-   </code>
+   <code>Sling (+1 Mighty)</code>
   </p>
   <p class="indent2">
-   <code>
-    TYPE:Weapon.Simple.Ranged.Standard.Bludgeoning
-   </code>
+   <code>TYPE:Weapon.Simple.Ranged.Standard.Bludgeoning</code>
   </p>
   <p class="indent2">
-   <code>
-    COST:0
-   </code>
+   <code>COST:0</code>
   </p>
   <p class="indent2">
-   <code>
-    WT:0
-   </code>
+   <code>WT:0</code>
   </p>
   <p class="indent2">
-   <code>
-    PROFICIENCY:Sling
-   </code>
+   <code>PROFICIENCY:Sling</code>
   </p>
   <p class="indent2">
-   <code>
-    CRITMULT:x2
-   </code>
+   <code>CRITMULT:x2</code>
   </p>
   <p class="indent2">
-   <code>
-    CRITRANGE:1
-   </code>
+   <code>CRITRANGE:1</code>
   </p>
   <p class="indent2">
-   <code>
-    DAMAGE:1d4
-   </code>
+   <code>DAMAGE:1d4</code>
   </p>
   <p class="indent2">
-   <code>
-    RANGE:50
-   </code>
+   <code>RANGE:50</code>
   </p>
   <p class="indent2">
-   <code>
-    SIZE:S
-   </code>
+   <code>SIZE:S</code>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:WEAPON|DAMAGE|STRMIN1
-   </code>
+   <code>BONUS:WEAPON|DAMAGE|STRMIN1</code>
   </p>
   <p class="indent0">
    Looking at this you might notice the source page
@@ -781,9 +685,7 @@ as the user has a strength bonus of at least +1. A mighty +2 sling
 would be identical except for the tag
   </p>
   <p class="indent1">
-   <code>
-    BONUS:WEAPON|DAMAGE|STRMIN2
-   </code>
+   <code>BONUS:WEAPON|DAMAGE|STRMIN2</code>
   </p>
   <p class="indent0">
    Now lets do something a bit more and create some
@@ -793,49 +695,31 @@ start by copying the plate armor from the srdequiparmorshields.lst
 file.
   </p>
   <p class="indent1">
-   <code>
-    Full Plate
-   </code>
+   <code>Full Plate</code>
   </p>
   <p class="indent2">
-   <code>
-    TYPE:Armor.Heavy.Suit.Standard.Metal
-   </code>
+   <code>TYPE:Armor.Heavy.Suit.Standard.Metal</code>
   </p>
   <p class="indent2">
-   <code>
-    COST:1500
-   </code>
+   <code>COST:1500</code>
   </p>
   <p class="indent2">
-   <code>
-    WT:50
-   </code>
+   <code>WT:50</code>
   </p>
   <p class="indent2">
-   <code>
-    ACCHECK:-6
-   </code>
+   <code>ACCHECK:-6</code>
   </p>
   <p class="indent2">
-   <code>
-    MAXDEX:1
-   </code>
+   <code>MAXDEX:1</code>
   </p>
   <p class="indent2">
-   <code>
-    SOURCEPAGE:Chap.7, Armor
-   </code>
+   <code>SOURCEPAGE:Chap.7, Armor</code>
   </p>
   <p class="indent2">
-   <code>
-    SPELLFAILURE:35
-   </code>
+   <code>SPELLFAILURE:35</code>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:COMBAT|AC|8|TYPE=Armor.REPLACE
-   </code>
+   <code>BONUS:COMBAT|AC|8|TYPE=Armor.REPLACE</code>
   </p>
   <p class="indent0">
    Looking at it you can see how its tags work and
@@ -852,99 +736,77 @@ srdequiparmorsheildspecific.lst
   <table class="w67">
    <tr>
     <td colspan="2">
-     <code>
-      Red Dragon Armor
-     </code>
+     <code>Red Dragon Armor</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      PROFICIENCY:Full Plate
-     </code>
+     <code>PROFICIENCY:Full Plate</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      TYPE:Magic.Armor.Heavy.Standard.Suit.Specific
-     </code>
+     <code>TYPE:Magic.Armor.Heavy.Standard.Suit.Specific</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      COST:16650
-     </code>
+     <code>COST:16650</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      WT:50
-     </code>
+     <code>WT:50</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      ACCHECK:-5
-     </code>
+     <code>ACCHECK:-5</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      MAXDEX:1
-     </code>
+     <code>MAXDEX:1</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      SPELLFAILURE:35
-     </code>
+     <code>SPELLFAILURE:35</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      BONUS:COMBAT|AC|10|TYPE=Armor.REPLACE
-     </code>
+     <code>BONUS:COMBAT|AC|10|TYPE=Armor.REPLACE</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      SAB:Fire Resistance +5
-     </code>
+     <code>SAB:Fire Resistance +5</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      SAB:Immune to Red Dragon Fear
-     </code>
+     <code>SAB:Immune to Red Dragon Fear</code>
     </td>
    </tr>
   </table>
@@ -1019,29 +881,19 @@ the Bastard Sword can use it one handed.
    file we get:
   </p>
   <p class="indent1">
-   <code>
-    SOURCELONG:PCGen Documentation
-   </code>
+   <code>SOURCELONG:PCGen Documentation</code>
   </p>
   <p class="indent2">
-   <code>
-    SOURCESHORT:P-Doc
-   </code>
+   <code>SOURCESHORT:P-Doc</code>
   </p>
   <p class="indent2">
-   <code>
-    SOURCEWEB:http://www.pcgen.org
-   </code>
+   <code>SOURCEWEB:http://www.pcgen.org</code>
   </p>
   <p class="indent1">
-   <code>
-    Sword (Bastard)
-   </code>
+   <code>Sword (Bastard)</code>
   </p>
   <p class="indent2">
-   <code>
-    TYPE:Martial.Exotic.Sword
-   </code>
+   <code>TYPE:Martial.Exotic.Sword</code>
   </p>
   <p class="indent0">
    So you see the weapon's name, the type, and the
@@ -1084,46 +936,36 @@ of the srdfeats.lst and pull alertness.
   <table class="w67">
    <tr>
     <td colspan="2">
-     <code>
-      Alertness
-     </code>
+     <code>Alertness</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      TYPE:General
-     </code>
+     <code>TYPE:General</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      DESC:See Text
-     </code>
+     <code>DESC:See Text</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      BONUS:SKILL|Listen,Spot|2
-     </code>
+     <code>BONUS:SKILL|Listen,Spot|2</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      SOURCEPAGE:Chap.5, Feat
-Descriptions
-     </code>
+     <code>SOURCEPAGE:Chap.5, Feat
+Descriptions</code>
     </td>
    </tr>
   </table>
@@ -1140,91 +982,71 @@ or just not addressed.
   <table class="w67">
    <tr>
     <td colspan="2">
-     <code>
-      Weapon Specialization
-     </code>
+     <code>Weapon Specialization</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      TYPE:Special.Fighter
-     </code>
+     <code>TYPE:Special.Fighter</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      PREFEAT:1,Weapon Focus
-     </code>
+     <code>PREFEAT:1,Weapon Focus</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      PREVARGTEQ:WeapSpecQualify,1
-     </code>
+     <code>PREVARGTEQ:WeapSpecQualify,1</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      DESC:See Text
-     </code>
+     <code>DESC:See Text</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      MULT:YES
-     </code>
+     <code>MULT:YES</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      CHOOSE:FEAT=Weapon Focus|1
-     </code>
+     <code>CHOOSE:FEAT=Weapon Focus|1</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      BONUS:WEAPONPROF=%LIST|DAMAGE|2|TYPE=NotRanged
-     </code>
+     <code>BONUS:WEAPONPROF=%LIST|DAMAGE|2|TYPE=NotRanged</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      BONUS:WEAPONPROF=%LIST|DAMAGE-SHORTRANGE|2
-     </code>
+     <code>BONUS:WEAPONPROF=%LIST|DAMAGE-SHORTRANGE|2</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      SOURCEPAGE:Chap.5, Feat
-Descriptions
-     </code>
+     <code>SOURCEPAGE:Chap.5, Feat
+Descriptions</code>
     </td>
    </tr>
   </table>
@@ -1251,176 +1073,138 @@ be found in the srdracesphb.lst file.
   <table class="w67">
    <tr>
     <td colspan="2">
-     <code>
-      Elf
-     </code>
+     <code>Elf</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      FAVCLASS:Wizard
-     </code>
+     <code>FAVCLASS:Wizard</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      STARTFEATS:1
-     </code>
+     <code>STARTFEATS:1</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      SIZE:M
-     </code>
+     <code>SIZE:M</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      MOVE:Walk,30
-     </code>
+     <code>MOVE:Walk,30</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      REACH:5
-     </code>
+     <code>REACH:5</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      VISION:Low-light
-     </code>
+     <code>VISION:Low-light</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      LANGAUTO:Common,Elven
-     </code>
+     <code>LANGAUTO:Common,Elven</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      LANGBONUS:Draconic,Gnoll,Gnome,Goblin,Orc,Sylvan
-     </code>
+     <code>LANGBONUS:Draconic,Gnoll,Gnome,Goblin,Orc,Sylvan</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      WEAPONAUTO:Shortbow|Longbow|Longbow
-(Composite)|Shortbow (Composite)
-     </code>
+     <code>WEAPONAUTO:Shortbow|Longbow|Longbow
+(Composite)|Shortbow (Composite)</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      WEAPONBONUS:Rapier|Longsword
-     </code>
+     <code>WEAPONBONUS:Rapier|Longsword</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      BONUS:SKILL|Listen,Search,Spot|2|TYPE=Racial
-     </code>
+     <code>BONUS:SKILL|Listen,Search,Spot|2|TYPE=Racial</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      BONUS:STAT|DEX|2
-     </code>
+     <code>BONUS:STAT|DEX|2</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      BONUS:STAT|CON|-2
-     </code>
+     <code>BONUS:STAT|CON|-2</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      SAB:Immunity to magic sleep spells and
-effects
-     </code>
+     <code>SAB:Immunity to magic sleep spells and
+effects</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      SAB:+2 racial saving throw bonus against
-Enchantment spells or effects
-     </code>
+     <code>SAB:+2 racial saving throw bonus against
+Enchantment spells or effects</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      SAB:An elf who merely passes within 5 feet of
+     <code>SAB:An elf who merely passes within 5 feet of
 a secret or concealed door is entitled to a Search check to notice
-it as if she were actively looking for the door
-     </code>
+it as if she were actively looking for the door</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      TYPE:Humanoid
-     </code>
+     <code>TYPE:Humanoid</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      SOURCEPAGE:Chap.2, Elves
-     </code>
+     <code>SOURCEPAGE:Chap.2, Elves</code>
     </td>
    </tr>
   </table>
@@ -1466,162 +1250,124 @@ monster classes.
 our standard header.
   </p>
   <p class="indent1">
-   <code>
-    SOURCELONG:PCGen Documentation
-   </code>
+   <code>SOURCELONG:PCGen Documentation</code>
   </p>
   <p class="indent2">
-   <code>
-    SOURCESHORT:P-Doc
-   </code>
+   <code>SOURCESHORT:P-Doc</code>
   </p>
   <p class="indent2">
-   <code>
-    SOURCEWEB:http://www.pcgen.org/
-   </code>
+   <code>SOURCEWEB:http://www.pcgen.org/</code>
   </p>
   <table class="w67">
    <tr>
     <td colspan="2">
-     <code>
-      Silverback
-     </code>
+     <code>Silverback</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      FAVCLASS:Ranger
-     </code>
+     <code>FAVCLASS:Ranger</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      STARTFEATS:1
-     </code>
+     <code>STARTFEATS:1</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      SIZE:L
-     </code>
+     <code>SIZE:L</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      MOVE:Walk,30
-     </code>
+     <code>MOVE:Walk,30</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      REACH:10
-     </code>
+     <code>REACH:10</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      VISION:Darkvision (60')
-     </code>
+     <code>VISION:Darkvision (60')</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      LANGAUTO:Common,Simian
-     </code>
+     <code>LANGAUTO:Common,Simian</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      LANGBONUS:Draconic,Gnoll,Gnome,Goblin,Orc,Sylvan,Elven
-     </code>
+     <code>LANGBONUS:Draconic,Gnoll,Gnome,Goblin,Orc,Sylvan,Elven</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      BONUS:SKILL|Handle Animal,Diplomacy,Sense
-Motive|2|TYPE=Racial
-     </code>
+     <code>BONUS:SKILL|Handle Animal,Diplomacy,Sense
+Motive|2|TYPE=Racial</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      BONUS:STAT|STR|2
-     </code>
+     <code>BONUS:STAT|STR|2</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      BONUS:STAT|INT|1
-     </code>
+     <code>BONUS:STAT|INT|1</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      BONUS:STAT|DEX|-1
-     </code>
+     <code>BONUS:STAT|DEX|-1</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      NATURALATTACKS:Claw,Weapon.Natural.Melee.Piercing.Slashing,*2,1d6
-     </code>
+     <code>NATURALATTACKS:Claw,Weapon.Natural.Melee.Piercing.Slashing,*2,1d6</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      SAB:Immunity to charm
-     </code>
+     <code>SAB:Immunity to charm</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      TYPE:Humanoid
-     </code>
+     <code>TYPE:Humanoid</code>
     </td>
    </tr>
   </table>
@@ -1670,133 +1416,103 @@ line and the indentions list the tags that fall on that line.
   <table class="w67">
    <tr>
     <td colspan="2">
-     <code>
-      CLASS:Warrior
-     </code>
+     <code>CLASS:Warrior</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      CLASS:Warrior
-     </code>
+     <code>CLASS:Warrior</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      HD:8
-     </code>
+     <code>HD:8</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      TYPE:NPC
-     </code>
+     <code>TYPE:NPC</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      ABB:War
-     </code>
+     <code>ABB:War</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      SOURCEPAGE:Chap.2, Classes, NPC
-Classes
-     </code>
+     <code>SOURCEPAGE:Chap.2, Classes, NPC
+Classes</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      BONUS:CHECKS|BASE.Fortitude|CL/2+2
-     </code>
+     <code>BONUS:CHECKS|BASE.Fortitude|CL/2+2</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      BONUS:CHECKS|BASE.Reflex,BASE.Willpower|CL/3
-     </code>
+     <code>BONUS:CHECKS|BASE.Reflex,BASE.Willpower|CL/3</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      BONUS:COMBAT|BAB|CL
-     </code>
+     <code>BONUS:COMBAT|BAB|CL</code>
     </td>
    </tr>
   </table>
   <table class="w67">
    <tr>
     <td colspan="2">
-     <code>
-      CLASS:Warrior
-     </code>
+     <code>CLASS:Warrior</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      STARTSKILLPTS:2
-     </code>
+     <code>STARTSKILLPTS:2</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      CSKILL:Climb|Handle
-Animal|Intimidate|Jump|Ride|Swim
-     </code>
+     <code>CSKILL:Climb|Handle
+Animal|Intimidate|Jump|Ride|Swim</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
-     <code>
-      1
-     </code>
+     <code>1</code>
     </td>
     <td class="w90">
-     <code>
-      WEAPONAUTO:SIMPLE|MARTIAL
-     </code>
+     <code>WEAPONAUTO:SIMPLE|MARTIAL</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      AUTO:FEAT|:Simple Weapon Proficiency|Armor
+     <code>AUTO:FEAT|:Simple Weapon Proficiency|Armor
 Proficiency (Light)|Armor Proficiency (Medium)|Armor Proficiency
-(Heavy)|Shield Proficiency|Martial Weapon Proficiency
-     </code>
+(Heavy)|Shield Proficiency|Martial Weapon Proficiency</code>
     </td>
    </tr>
   </table>
@@ -1829,176 +1545,128 @@ srdbaseclasses.lst file:
   <table class="w67">
    <tr>
     <td class="w10">
-     <code>
-      1
-     </code>
+     <code>1</code>
     </td>
     <td class="w90">
-     <code>
-      ADD:FEAT(TYPE=Fighter)
-     </code>
+     <code>ADD:FEAT(TYPE=Fighter)</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      WEAPONAUTO:SIMPLE|MARTIAL AUTO:FEAT|:Armor
+     <code>WEAPONAUTO:SIMPLE|MARTIAL AUTO:FEAT|:Armor
 Proficiency (Light)|Armor Proficiency
       <br/>
       (Medium)|Armor Proficiency (Heavy)|Shield Proficiency|Simple Weapon
-Proficiency
-     </code>
+Proficiency</code>
     </td>
    </tr>
   </table>
   <table class="w67">
    <tr>
     <td class="w10">
-     <code>
-      2
-     </code>
+     <code>2</code>
     </td>
     <td class="w90">
-     <code>
-      ADD:FEAT(TYPE=Fighter)
-     </code>
+     <code>ADD:FEAT(TYPE=Fighter)</code>
     </td>
    </tr>
   </table>
   <table class="w67">
    <tr>
     <td class="w10">
-     <code>
-      4
-     </code>
+     <code>4</code>
     </td>
     <td class="w90">
-     <code>
-      DEFINE:WeapSpecQualify|1
-     </code>
+     <code>DEFINE:WeapSpecQualify|1</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      ADD:FEAT(TYPE=Fighter)
-     </code>
+     <code>ADD:FEAT(TYPE=Fighter)</code>
     </td>
    </tr>
   </table>
   <table class="w67">
    <tr>
     <td class="w10">
-     <code>
-      6
-     </code>
+     <code>6</code>
     </td>
     <td class="w90">
-     <code>
-      ADD:FEAT(TYPE=Fighter)
-     </code>
+     <code>ADD:FEAT(TYPE=Fighter)</code>
     </td>
    </tr>
   </table>
   <table class="w67">
    <tr>
     <td class="w10">
-     <code>
-      8
-     </code>
+     <code>8</code>
     </td>
     <td class="w90">
-     <code>
-      ADD:FEAT(TYPE=Fighter)
-     </code>
+     <code>ADD:FEAT(TYPE=Fighter)</code>
     </td>
    </tr>
   </table>
   <table class="w67">
    <tr>
     <td class="w10">
-     <code>
-      10
-     </code>
+     <code>10</code>
     </td>
     <td class="w90">
-     <code>
-      ADD:FEAT(TYPE=Fighter)
-     </code>
+     <code>ADD:FEAT(TYPE=Fighter)</code>
     </td>
    </tr>
   </table>
   <table class="w67">
    <tr>
     <td class="w10">
-     <code>
-      12
-     </code>
+     <code>12</code>
     </td>
     <td class="w90">
-     <code>
-      ADD:FEAT(TYPE=Fighter)
-     </code>
+     <code>ADD:FEAT(TYPE=Fighter)</code>
     </td>
    </tr>
   </table>
   <table class="w67">
    <tr>
     <td class="w10">
-     <code>
-      14
-     </code>
+     <code>14</code>
     </td>
     <td class="w90">
-     <code>
-      ADD:FEAT(TYPE=Fighter)
-     </code>
+     <code>ADD:FEAT(TYPE=Fighter)</code>
     </td>
    </tr>
   </table>
   <table class="w67">
    <tr>
     <td class="w10">
-     <code>
-      16
-     </code>
+     <code>16</code>
     </td>
     <td class="w90">
-     <code>
-      ADD:FEAT(TYPE=Fighter)
-     </code>
+     <code>ADD:FEAT(TYPE=Fighter)</code>
     </td>
    </tr>
   </table>
   <table class="w67">
    <tr>
     <td class="w10">
-     <code>
-      18
-     </code>
+     <code>18</code>
     </td>
     <td class="w90">
-     <code>
-      ADD:FEAT(TYPE=Fighter)
-     </code>
+     <code>ADD:FEAT(TYPE=Fighter)</code>
     </td>
    </tr>
   </table>
   <table class="w67">
    <tr>
     <td class="w10">
-     <code>
-      20
-     </code>
+     <code>20</code>
     </td>
     <td class="w90">
-     <code>
-      ADD:FEAT(TYPE=Fighter)
-     </code>
+     <code>ADD:FEAT(TYPE=Fighter)</code>
     </td>
    </tr>
   </table>
@@ -2020,108 +1688,84 @@ bard.
   <table class="w67">
    <tr>
     <td colspan="2">
-     <code>
-      CLASS:Bard
-     </code>
+     <code>CLASS:Bard</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      HD:6
-     </code>
+     <code>HD:6</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      SPELLSTAT:CHA
-     </code>
+     <code>SPELLSTAT:CHA</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      SPELLTYPE:Arcane
-     </code>
+     <code>SPELLTYPE:Arcane</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      TYPE:Base.PC
-     </code>
+     <code>TYPE:Base.PC</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      ABB:Brd
-     </code>
+     <code>ABB:Brd</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      MEMORIZE:NO
-     </code>
+     <code>MEMORIZE:NO</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      SOURCEPAGE:Chap.3, Bard
-     </code>
+     <code>SOURCEPAGE:Chap.3, Bard</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      LANGAUTO:Literacy
-     </code>
+     <code>LANGAUTO:Literacy</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      BONUS:CHECKS|BASE.Fortitude|CL/3
-     </code>
+     <code>BONUS:CHECKS|BASE.Fortitude|CL/3</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      BONUS:CHECKS|BASE.Reflex,BASE.Willpower|CL/2+2
-     </code>
+     <code>BONUS:CHECKS|BASE.Reflex,BASE.Willpower|CL/2+2</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      BONUS:COMBAT|BAB|CL*3/4
-     </code>
+     <code>BONUS:COMBAT|BAB|CL*3/4</code>
     </td>
    </tr>
   </table>
@@ -2133,18 +1777,14 @@ as the prime stat without memorizing spells.
   <table class="w67">
    <tr>
     <td colspan="2">
-     <code>
-      CLASS:Bard
-     </code>
+     <code>CLASS:Bard</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      PREALIGN:3,4,5,6,7,8
-     </code>
+     <code>PREALIGN:3,4,5,6,7,8</code>
     </td>
    </tr>
   </table>
@@ -2157,32 +1797,26 @@ evil respectively.
   <table class="w67">
    <tr>
     <td colspan="2">
-     <code>
-      CLASS:Bard
-     </code>
+     <code>CLASS:Bard</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      STARTSKILLPTS:4
-     </code>
+     <code>STARTSKILLPTS:4</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      CSKILL:Alchemy|Appraise|Balance|Bluff|Climb|Concentration|TYPE.Craft|
+     <code>CSKILL:Alchemy|Appraise|Balance|Bluff|Climb|Concentration|TYPE.Craft|
 Decipher Script|Diplomacy|Disguise|Escape Artist|Gather
 Information|Hide| Intuit Direction|Jump|TYPE.Knowledge|Listen|Move
 Silently|Perform|Pick Pocket| TYPE.Profession|Scry|Sense
 Motive|Speak Language|Spellcraft|Swim|Tumble|Use Magic
-Device
-     </code>
+Device</code>
     </td>
    </tr>
   </table>
@@ -2193,109 +1827,85 @@ along.
   <table class="w67">
    <tr>
     <td class="w10">
-     <code>
-      1
-     </code>
+     <code>1</code>
     </td>
     <td class="w90">
-     <code>
-      CAST:2
-     </code>
+     <code>CAST:2</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      KNOWN:4
-     </code>
+     <code>KNOWN:4</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      SAB:Bardic music
-%/day|BardicMusic
-     </code>
+     <code>SAB:Bardic music
+%/day|BardicMusic</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      SAB:Bardic knowledge
-(+%)|BardicKnowledge
-     </code>
+     <code>SAB:Bardic knowledge
+(+%)|BardicKnowledge</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      BONUS:VAR|BardicMusic|CL=Bard
-     </code>
+     <code>BONUS:VAR|BardicMusic|CL=Bard</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      BONUS:VAR|BardicKnowledge|CL=Bard+INT
-     </code>
+     <code>BONUS:VAR|BardicKnowledge|CL=Bard+INT</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      DEFINE:BardicKnowledge|0
-     </code>
+     <code>DEFINE:BardicKnowledge|0</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      DEFINE:BardicMusic|0
-     </code>
+     <code>DEFINE:BardicMusic|0</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      WEAPONAUTO:SIMPLE
-     </code>
+     <code>WEAPONAUTO:SIMPLE</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      WEAPONBONUS:Longbow|Longbow(Composite)|Longsword|Rapier|Sap|Shortbow
-(Composite)|Sword (Short)|Shortbow|Whip
-     </code>
+     <code>WEAPONBONUS:Longbow|Longbow(Composite)|Longsword|Rapier|Sap|Shortbow
+(Composite)|Sword (Short)|Shortbow|Whip</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      AUTO:FEAT|:Armor Proficiency (Light)|Armor
+     <code>AUTO:FEAT|:Armor Proficiency (Light)|Armor
 Proficiency (Medium)|Shield Proficiency|Simple Weapon
-Proficiency
-     </code>
+Proficiency</code>
     </td>
    </tr>
   </table>
@@ -2316,23 +1926,17 @@ is done with the Bardic Knowledge bonus.
   <table class="w67">
    <tr>
     <td class="w10">
-     <code>
-      2
-     </code>
+     <code>2</code>
     </td>
     <td class="w90">
-     <code>
-      CAST:3,0
-     </code>
+     <code>CAST:3,0</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      KNOWN:5,2
-     </code>
+     <code>KNOWN:5,2</code>
     </td>
    </tr>
   </table>
@@ -2348,46 +1952,34 @@ know 2 of them.
   <table class="w67">
    <tr>
     <td class="w10">
-     <code>
-      3
-     </code>
+     <code>3</code>
     </td>
     <td class="w90">
-     <code>
-      CAST:3,1
-     </code>
+     <code>CAST:3,1</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      KNOWN:6,3
-     </code>
+     <code>KNOWN:6,3</code>
     </td>
    </tr>
   </table>
   <table class="w67">
    <tr>
     <td class="w10">
-     <code>
-      4
-     </code>
+     <code>4</code>
     </td>
     <td class="w90">
-     <code>
-      CAST:3,2,0
-     </code>
+     <code>CAST:3,2,0</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      KNOWN:6,3,2
-     </code>
+     <code>KNOWN:6,3,2</code>
     </td>
    </tr>
    <tr>
@@ -2420,23 +2012,17 @@ know 2 of them.
    </tr>
    <tr>
     <td class="w10">
-     <code>
-      20
-     </code>
+     <code>20</code>
     </td>
     <td class="w90">
-     <code>
-      CAST:4,4,4,4,4,4,4
-     </code>
+     <code>CAST:4,4,4,4,4,4,4</code>
     </td>
    </tr>
    <tr>
     <td class="w10">
     </td>
     <td class="w90">
-     <code>
-      KNOWN:6,5,5,5,5,5,4
-     </code>
+     <code>KNOWN:6,5,5,5,5,5,4</code>
     </td>
    </tr>
   </table>

--- a/docs/listfilepages/listfileimportanttoknow.html
+++ b/docs/listfilepages/listfileimportanttoknow.html
@@ -429,50 +429,34 @@ of the publisher/source material
   </p>
   <p>
    In the PCC file, the
-   <code>
-    SOURCExxx
-   </code>
+   <code>SOURCExxx</code>
    tags must be on
 separate lines:
   </p>
   <p class="indent2">
-   <code>
-    SOURCELONG:Dominant Game Publisher -
-System Reference Document
-   </code>
+   <code>SOURCELONG:Dominant Game Publisher -
+System Reference Document</code>
   </p>
   <p class="indent2">
-   <code>
-    SOURCESHORT:SRD
-   </code>
+   <code>SOURCESHORT:SRD</code>
   </p>
   <p class="indent2">
-   <code>
-    SOURCEWEB:HTTP://www.rpgpublisher.com/
-   </code>
+   <code>SOURCEWEB:HTTP://www.rpgpublisher.com/</code>
   </p>
   <p>
    In LST files, the
-   <code>
-    SORCExxx
-   </code>
+   <code>SORCExxx</code>
    tags must be on one
 line, separated by a tab delimiter:
   </p>
   <blockquote class="indent2">
    <p class="tagindent2">
-    <code>
-     SOURCELONG:Dominant Game Publisher -
-System Reference Document
-    </code>
+    <code>SOURCELONG:Dominant Game Publisher -
+System Reference Document</code>
     &lt;tab&gt;
-    <code>
-     SOURCESHORT:SRD
-    </code>
+    <code>SOURCESHORT:SRD</code>
     &lt;tab&gt;
-    <code>
-     SOURCEWEB:HTTP://www.rpgpublisher.com/
-    </code>
+    <code>SOURCEWEB:HTTP://www.rpgpublisher.com/</code>
    </p>
   </blockquote>
   <hr/>

--- a/docs/listfilepages/lstfileclass/lfc_lesson00_homebrew.html
+++ b/docs/listfilepages/lstfileclass/lfc_lesson00_homebrew.html
@@ -166,9 +166,7 @@ you will not include the angle brackets in your tags.
   <p class="indent0">
    2) Coding examples and PCGen tags are identified
 by
-   <code>
-    &lt;code&gt;
-   </code>
+   <code>&lt;code&gt;</code>
    style.
   </p>
   <p class="indent0">
@@ -187,9 +185,7 @@ i.e. deity, feat, weapon, etc., the object name will be formated as
    </span>
    text, except for when the object
 is part of a
-   <code>
-    &lt;code&gt;
-   </code>
+   <code>&lt;code&gt;</code>
    example.
   </p>
   <hr/>

--- a/docs/listfilepages/lstfileclass/lfc_lesson01_pcc.html
+++ b/docs/listfilepages/lstfileclass/lfc_lesson01_pcc.html
@@ -42,8 +42,7 @@ creation)
    </strong>
   </p>
   <p class="indent1">
-   <code>
-    <a href="../datafilestagpages/datafilespcc.html#campaign">
+   <code><a href="../datafilestagpages/datafilespcc.html#campaign">
      CAMPAIGN
     </a>
     ,
@@ -81,8 +80,7 @@ creation)
     ,
     <a href="../datafilestagpages/datafilespcc.html#infotext">
      INFOTEXT
-    </a>
-   </code>
+    </a></code>
   </p>
   <p>
    This lesson will discuss what a PCC is, and what it uses to tell
@@ -136,11 +134,9 @@ which files it needs to load.
   </p>
   <hr/>
   <p>
-   <code>
-    <strong>
+   <code><strong>
      CAMPAIGN:
-    </strong>
-   </code>
+    </strong></code>
    The name used for the
 set of sources in the PCC
   </p>
@@ -151,9 +147,7 @@ memory object, and then define parts of it, we HAVE to name the
 campaign for PCGen on the FIRST LINE of the file. No other tag
 lines can come before it. We tell PCGen the name of the campaign by
 using the CAMPAIGN tag. So I put "
-   <code>
-    CAMPAIGN:My Stuff
-   </code>
+   <code>CAMPAIGN:My Stuff</code>
    "
 right at the very top. When PCGen lists my campaign, it will
 display 'My stuff' in the source tab.
@@ -161,9 +155,7 @@ display 'My stuff' in the source tab.
   <hr/>
   <p>
    <strong>
-    <code>
-     GAMEMODE:
-    </code>
+    <code>GAMEMODE:</code>
    </strong>
    what game mode the
 campaign is designed for.
@@ -174,18 +166,14 @@ want this campaign to run in. We use the GAMEMODE tag to tell PCGen
 which GameMode to run in. Since I want to run it in the normal
 gamemode that comes with PCGen, I'm going to use '3e' So I put
 "
-   <code>
-    GAMEMODE:3e
-   </code>
+   <code>GAMEMODE:3e</code>
    " on my second line. Note that this MUST
 be the second line in the file.
   </p>
   <hr/>
   <p>
    <strong>
-    <code>
-     RANK:
-    </code>
+    <code>RANK:</code>
    </strong>
    Loading order.
   </p>
@@ -203,9 +191,7 @@ simple route for the moment. :)
 this one _only_ so I don't have to think about the other sources in
 PCGen (and make it easier for my group to load the same stuff). I'm
 going to make it
-   <code>
-    RANK:1
-   </code>
+   <code>RANK:1</code>
    . It should now load before any
 other source with a higher RANK number.
   </p>
@@ -218,11 +204,9 @@ depth in another lesson...
   </p>
   <hr/>
   <p>
-   <code>
-    <strong>
+   <code><strong>
      TYPE:
-    </strong>
-   </code>
+    </strong></code>
    Displaying on the Source
 tab.
   </p>
@@ -236,15 +220,12 @@ then type of book, and then anything else necessary. So I'll enter
   </p>
   <p>
    My file now looks like this (between the
-   <code>
-    -----
-   </code>
+   <code>-----</code>
    lines is the actual file):
   </p>
   <blockquote>
    <p>
-    <code>
-     -----------
+    <code>-----------
      <br/>
      CAMPAIGN:My Stuff
      <br/>
@@ -254,8 +235,7 @@ then type of book, and then anything else necessary. So I'll enter
      <br/>
      TYPE:PCGenLstMonkey.Campaign Setting.My World
      <br/>
-     -----------
-    </code>
+     -----------</code>
    </p>
   </blockquote>
   <p>
@@ -277,11 +257,9 @@ if you expanded the tree fully would be:
   </blockquote>
   <hr/>
   <p>
-   <code>
-    <strong>
+   <code><strong>
      SOURCExxx:
-    </strong>
-   </code>
+    </strong></code>
    Identifying the source
 material.
   </p>
@@ -298,32 +276,22 @@ be:
   </p>
   <blockquote>
    <p>
-    <code>
-     SOURCELONG:PCGenLstMonkey
-     <br/>
-    </code>
-    <code>
-     SOURCESHORT:PCGLM
-     <br/>
-    </code>
-    <code>
-     SOURCEWEB:http://www.mystuffcampaign.com
-    </code>
+    <code>SOURCELONG:PCGenLstMonkey
+     <br/></code>
+    <code>SOURCESHORT:PCGLM
+     <br/></code>
+    <code>SOURCEWEB:http://www.mystuffcampaign.com</code>
    </p>
   </blockquote>
   <hr/>
   <p>
    <strong>
-    <code>
-     ISOGL
-    </code>
+    <code>ISOGL</code>
    </strong>
    and
-   <code>
-    <strong>
+   <code><strong>
      COPYRIGHT:
-    </strong>
-   </code>
+    </strong></code>
    OGL Section 15
 information.
   </p>
@@ -334,9 +302,7 @@ community, the ISOGL tag. This is used to indicate whether or not
 the source falls under the OGL license (most do... It's really hard
 work for it not to).  So we'll enter it this way:
 "
-   <code>
-    ISOGL:YES
-   </code>
+   <code>ISOGL:YES</code>
    ". This will trigger the program to insert
 the information from the next tag we cover into the OGL (Open
 Gaming License) that we display on startup.
@@ -350,17 +316,13 @@ will look like this:
   </p>
   <blockquote>
    <p>
-    <code>
-     COPYRIGHT:PCGenLstMonkey Copyright 2003
-    </code>
+    <code>COPYRIGHT:PCGenLstMonkey Copyright 2003</code>
    </p>
   </blockquote>
   <hr/>
   <p>
    <strong>
-    <code>
-     INFOTEXT:
-    </code>
+    <code>INFOTEXT:</code>
    </strong>
    further information for
 the user.
@@ -374,11 +336,9 @@ read like this:
   </p>
   <blockquote>
    <p>
-    <code>
-     INFOTEXT:This data set contains all the information
+    <code>INFOTEXT:This data set contains all the information
 necessary to create a character for the mystuff campaign
-world
-    </code>
+world</code>
    </p>
   </blockquote>
   <p>

--- a/docs/listfilepages/lstfileclass/lfc_lesson02_pcc.html
+++ b/docs/listfilepages/lstfileclass/lfc_lesson02_pcc.html
@@ -43,8 +43,7 @@ calling)
    </strong>
   </p>
   <p class="indent1">
-   <code>
-    <a href="../datafilestagpages/datafilespcc.html#deity">
+   <code><a href="../datafilestagpages/datafilespcc.html#deity">
      DEITY
     </a>
     ,
@@ -112,8 +111,7 @@ calling)
      EXCLUDE
     </a>
     ,
-#
-   </code>
+#</code>
   </p>
   <hr/>
   <h2>
@@ -157,8 +155,7 @@ building on lesson #1 here.):
   </p>
   <blockquote>
    <p>
-    <code>
-     -------------------------------
+    <code>-------------------------------
      <br/>
      CAMPAIGN:My Stuff
      <br/>
@@ -213,8 +210,7 @@ to
      <br/>
      WEAPONPROF:mystuffweaponprofs.lst
      <br/>
-     -------------------------------
-    </code>
+     -------------------------------</code>
    </p>
   </blockquote>
   <p>
@@ -302,10 +298,8 @@ another race tag for that file, but on the end I put
   </p>
   <blockquote>
    <p>
-    <code>
-     RACE:@/data/d20ogl/fantasyflightgames/legendsandlairs/mythicraces/mythicracesraces.lst|
-(EXCLUDE:Fairy|Anaema)
-    </code>
+    <code>RACE:@/data/d20ogl/fantasyflightgames/legendsandlairs/mythicraces/mythicracesraces.lst|
+(EXCLUDE:Fairy|Anaema)</code>
    </p>
   </blockquote>
   <p>
@@ -317,10 +311,8 @@ INCLUDE tag. I enter another feat tag, and at the end I put
   </p>
   <blockquote>
    <p>
-    <code>
-     FEAT:@/data/d20ogl/swordandsorcerystudios/scarredlands/relicsrituals/relicsritualsfeats.lst|
-(INCLUDE:Hide Spell)
-    </code>
+    <code>FEAT:@/data/d20ogl/swordandsorcerystudios/scarredlands/relicsrituals/relicsritualsfeats.lst|
+(INCLUDE:Hide Spell)</code>
    </p>
   </blockquote>
   <hr/>
@@ -345,8 +337,7 @@ files".
   </p>
   <blockquote>
    <p>
-    <code>
-     -------------------------------
+    <code>-------------------------------
      <br/>
      CAMPAIGN:My Stuff
      <br/>
@@ -415,8 +406,7 @@ to
      <br/>
      elicsritualsfeats.lst|(INCLUDE:Hide Spell)
      <br/>
-     -------------------------------
-    </code>
+     -------------------------------</code>
    </p>
   </blockquote>
   <p>

--- a/docs/listfilepages/lstfileclass/lfc_lesson03_race1.html
+++ b/docs/listfilepages/lstfileclass/lfc_lesson03_race1.html
@@ -44,8 +44,7 @@
    </strong>
   </p>
   <p class="indent1">
-   <code>
-    <a href="../datafilestagpages/datafilesraces.html">
+   <code><a href="../datafilestagpages/datafilesraces.html">
      OUTPUTNAME
     </a>
     ,
@@ -75,8 +74,7 @@
     ,
     <a href="../datafilestagpages/datafilesraces.html#move">
      MOVE
-    </a>
-   </code>
+    </a></code>
   </p>
   <hr/>
   <p>
@@ -414,9 +412,7 @@ Therefore we would name it "Angel (Solar)".
   <hr/>
   <p>
    <strong>
-    <code>
-     OUTPUTNAME
-    </code>
+    <code>OUTPUTNAME</code>
    </strong>
   </p>
   <p>
@@ -442,9 +438,7 @@ entering the tag like this:
   </p>
   <blockquote>
    <p>
-    <code>
-     OUTPUTNAME:[NAME]
-    </code>
+    <code>OUTPUTNAME:[NAME]</code>
    </p>
   </blockquote>
   <p>
@@ -453,11 +447,9 @@ OUTPUTNAME tag on this one.
   </p>
   <hr/>
   <p>
-   <code>
-    <strong>
+   <code><strong>
      SIZE
-    </strong>
-   </code>
+    </strong></code>
   </p>
   <p>
    Every creature has a size.  The size tag uses the first
@@ -468,38 +460,28 @@ D (Diminutive), T (Tiny), S (Small), M (Medium), L (Large), H
   <p>
    The Solar is a Large creature so on that line we'll enter a
 couple tabs and then put "
-   <code>
-    SIZE:L
-   </code>
+   <code>SIZE:L</code>
    ". The Ninja Monkey is
 man-sized (Medium), so we'll put "
-   <code>
-    SIZE:M
-   </code>
+   <code>SIZE:M</code>
    " on that
 line.
   </p>
   <hr/>
   <p>
-   <code>
-    <strong>
+   <code><strong>
      RACETYPE/RACESUBTYPE
-    </strong>
-   </code>
+    </strong></code>
   </p>
   <p>
    After the creature's size the next information is the race type.
 For the Solar it is listed as Outsider (Good). The information in
 the brackets after the type lists all the subtypes for the monster,
 in this case Good. We will enter "
-   <code>
-    RACETYPE:Outsider
-   </code>
+   <code>RACETYPE:Outsider</code>
    "
 put in a tab and enter "
-   <code>
-    RACESUBTYPE:Good
-   </code>
+   <code>RACESUBTYPE:Good</code>
    ".
   </p>
   <p>
@@ -508,9 +490,7 @@ subtypes.
   </p>
   <blockquote>
    <p>
-    <code>
-     RACETYPE:Monstrous Humanoid
-    </code>
+    <code>RACETYPE:Monstrous Humanoid</code>
    </p>
   </blockquote>
   <p class="sidebar">
@@ -521,18 +501,14 @@ subtypes.
    The Solar changes subtypes in the RSRD to Outsider (Angel,
 Extraplanar, Good). Therefore we need to change our subtype entry
 to read
-   <code>
-    RACESUBTYPE:Angel|Extraplanar|Good
-   </code>
+   <code>RACESUBTYPE:Angel|Extraplanar|Good</code>
    .
   </p>
   <hr/>
   <p>
-   <code>
-    <strong>
+   <code><strong>
      TYPE
-    </strong>
-   </code>
+    </strong></code>
   </p>
   <p>
    <strong>
@@ -540,9 +516,7 @@ to read
    </strong>
    This use of TYPE has been deprecated and
 is replaced with
-   <code>
-    RACETYPE/RACESUBTYPE
-   </code>
+   <code>RACETYPE/RACESUBTYPE</code>
    .
   </p>
   <p>
@@ -553,26 +527,20 @@ etc.).
   <p>
    The Solar is an Outsider so our tag would read
 "
-   <code>
-    TYPE:Outsider
-   </code>
+   <code>TYPE:Outsider</code>
    ".
   </p>
   <p>
    The Ninja monkey is a Monstrous Humanoid so our tag would be
 "
-   <code>
-    TYPE:Monstrous Humanoid
-   </code>
+   <code>TYPE:Monstrous Humanoid</code>
    ".
   </p>
   <hr/>
   <p>
-   <code>
-    <strong>
+   <code><strong>
      MONSTERCLASS
-    </strong>
-   </code>
+    </strong></code>
   </p>
   <p>
    The MONSTERCLASS tag is used by the program when the "Default
@@ -594,27 +562,21 @@ file) to grant the race the appropriate spellcasting levels.
    The Solar is an Outsider with 22 HD, and he casts spells as a
 20th level cleric, so his tag would be
 "
-   <code>
-    MONSTERCLASS:Solar:22
-   </code>
+   <code>MONSTERCLASS:Solar:22</code>
    "
   </p>
   <p>
    For the Ninja Monkey, he's a Monstrous Humanoid and has 4 HD and
 no spellcasting ability, so the tag for him would read
 "
-   <code>
-    MONSTERCLASS:Monstrous Humanoid:4
-   </code>
+   <code>MONSTERCLASS:Monstrous Humanoid:4</code>
    ".
   </p>
   <hr/>
   <p>
-   <code>
-    <strong>
+   <code><strong>
      HITDICE
-    </strong>
-   </code>
+    </strong></code>
   </p>
   <p>
    <strong>
@@ -634,25 +596,19 @@ the top of each race listing.
   <p>
    The Solar has 22d8 hit points, so would have
 "
-   <code>
-    HITDICE:22,8
-   </code>
+   <code>HITDICE:22,8</code>
    " for this tag.
   </p>
   <p>
    The ninja monkey has 4d8 hit points, so would have
 "
-   <code>
-    HITDICE:4,8
-   </code>
+   <code>HITDICE:4,8</code>
    " for this tag.
   </p>
   <hr/>
   <p>
    <strong>
-    <code>
-     MOVE
-    </code>
+    <code>MOVE</code>
    </strong>
   </p>
   <p>
@@ -669,9 +625,7 @@ a tab or two between the last tag and this new one):
   </p>
   <blockquote>
    <p>
-    <code>
-     MOVE:Walk,50,Fly,150
-    </code>
+    <code>MOVE:Walk,50,Fly,150</code>
    </p>
   </blockquote>
   <p>
@@ -680,9 +634,7 @@ rate of 20, so the tag for his line would be:
   </p>
   <blockquote>
    <p>
-    <code>
-     MOVE:Walk,30,Climb,20
-    </code>
+    <code>MOVE:Walk,30,Climb,20</code>
    </p>
   </blockquote>
   <hr/>

--- a/docs/listfilepages/lstfileclass/lfc_lesson04_race2.html
+++ b/docs/listfilepages/lstfileclass/lfc_lesson04_race2.html
@@ -42,8 +42,7 @@
    </strong>
   </p>
   <p class="indent1">
-   <code>
-    <a href="../globalfilestagpages/globalfilesbonus.html#combatac">
+   <code><a href="../globalfilestagpages/globalfilesbonus.html#combatac">
      BONUS:COMBAT|AC
     </a>
     ,
@@ -73,8 +72,7 @@
     ,
     <a href="../globalfilestagpages/globalfilesother.html#autoweaponprof">
      AUTO:WEAPONPROF
-    </a>
-   </code>
+    </a></code>
   </p>
   <p>
    Not much to say before we jump into things this time. This is a
@@ -83,9 +81,7 @@ continuation from lesson #3 in our look at creating race files.
   <hr/>
   <p>
    <strong>
-    <code>
-     BONUS:COMBAT|AC
-    </code>
+    <code>BONUS:COMBAT|AC</code>
    </strong>
   </p>
   <p>
@@ -105,29 +101,21 @@ for the race. Looking at the entry for the Solar: "AC:35 (-1 size,
    We would enter the bonus from natural armor for the Solar using
 the following tag
 "
-   <code>
-    BONUS:COMBAT|AC|21|TYPE=NaturalArmor.REPLACE
-   </code>
+   <code>BONUS:COMBAT|AC|21|TYPE=NaturalArmor.REPLACE</code>
    ". Quite
 the tag, eh? :P
   </p>
   <p>
    To break it down a bit further, "
-   <code>
-    BONUS:COMBAT|AC
-   </code>
+   <code>BONUS:COMBAT|AC</code>
    "
 directs PCGen to apply the bonus to the character's/monster's AC.
 "21" is the value of the bonus to be applied of course. The
 "
-   <code>
-    TYPE=whatever
-   </code>
+   <code>TYPE=whatever</code>
    " sets the type of bonus for stacking
 purposes. It should be noted that "
-   <code>
-    TYPE=NaturalArmor
-   </code>
+   <code>TYPE=NaturalArmor</code>
    "
 is a special type in that it causes the program to separate those
 bonuses out from other AC bonuses when sent to the output
@@ -151,14 +139,10 @@ program assumes it will stack with anything.
     Example:
     <br/>
     "
-    <code>
-     BONUS:COMBAT|AC|2
-    </code>
+    <code>BONUS:COMBAT|AC|2</code>
     " and
 "
-    <code>
-     BONUS:COMBAT|AC|1
-    </code>
+    <code>BONUS:COMBAT|AC|1</code>
     " will stack for a total bonus to
 the AC of +3.
    </p>
@@ -174,51 +158,37 @@ choose and apply the largest of them.
     Examples:
     <br/>
     a) "
-    <code>
-     BONUS:COMBAT|AC|2|TYPE=NaturalArmor
-    </code>
+    <code>BONUS:COMBAT|AC|2|TYPE=NaturalArmor</code>
     "
     <br/>
     and "
-    <code>
-     BONUS:COMBAT|AC|1|TYPE=Deflection
-    </code>
+    <code>BONUS:COMBAT|AC|1|TYPE=Deflection</code>
     "
     <br/>
     will stack for a total bonus to the AC of +3.
    </p>
    <p>
     b) "
-    <code>
-     BONUS:COMBAT|AC|2|TYPE=NaturalArmor
-    </code>
+    <code>BONUS:COMBAT|AC|2|TYPE=NaturalArmor</code>
     "
     <br/>
     and "
-    <code>
-     BONUS:COMBAT|AC|1|TYPE=NaturalArmor
-    </code>
+    <code>BONUS:COMBAT|AC|1|TYPE=NaturalArmor</code>
     "
     <br/>
     will not stack and there will be a total bonus to the AC of +2.
    </p>
    <p>
     c) "
-    <code>
-     BONUS:COMBAT|AC|2|TYPE=NaturalArmor
-    </code>
+    <code>BONUS:COMBAT|AC|2|TYPE=NaturalArmor</code>
     "
     <br/>
     and "
-    <code>
-     BONUS:COMBAT|AC|1|TYPE=NaturalArmor
-    </code>
+    <code>BONUS:COMBAT|AC|1|TYPE=NaturalArmor</code>
     "
     <br/>
     and "
-    <code>
-     BONUS:COMBAT|AC|1|TYPE=Deflection
-    </code>
+    <code>BONUS:COMBAT|AC|1|TYPE=Deflection</code>
     "
     <br/>
     will give you a total bonus to ac of +3.
@@ -226,14 +196,10 @@ choose and apply the largest of them.
   </blockquote>
   <p>
    3) When you use the "
-   <code>
-    .REPLACE
-   </code>
+   <code>.REPLACE</code>
    " suffix, the program
 takes all like bonuses that have "
-   <code>
-    .REPLACE
-   </code>
+   <code>.REPLACE</code>
    " appended
 and adds them together, and THEN compares that result to all other
 like bonuses to determine which to use.
@@ -243,16 +209,12 @@ like bonuses to determine which to use.
     Examples:
     <br/>
     a) "
-    <code>
-     BONUS:COMBAT|AC|2|TYPE=NaturalArmor.REPLACE
-    </code>
+    <code>BONUS:COMBAT|AC|2|TYPE=NaturalArmor.REPLACE</code>
     "
     <br/>
     and
 "
-    <code>
-     BONUS:COMBAT|AC|1|TYPE=NaturalArmor.REPLACE
-    </code>
+    <code>BONUS:COMBAT|AC|1|TYPE=NaturalArmor.REPLACE</code>
     "
     <br/>
     will stack and there will be a total bonus to the AC of +3.
@@ -260,22 +222,16 @@ like bonuses to determine which to use.
    <p>
     b)
 "
-    <code>
-     BONUS:COMBAT|AC|2|TYPE=NaturalArmor.REPLACE
-    </code>
+    <code>BONUS:COMBAT|AC|2|TYPE=NaturalArmor.REPLACE</code>
     "
     <br/>
     and
 "
-    <code>
-     BONUS:COMBAT|AC|2|TYPE=NaturalArmor.REPLACE
-    </code>
+    <code>BONUS:COMBAT|AC|2|TYPE=NaturalArmor.REPLACE</code>
     "
     <br/>
     and"
-    <code>
-     BONUS:COMBAT|AC|1|TYPE=NaturalArmor
-    </code>
+    <code>BONUS:COMBAT|AC|1|TYPE=NaturalArmor</code>
     "
     <br/>
     will give you a total bonus to ac of +4.
@@ -298,9 +254,7 @@ having a thick pelt. The tag for that would be:
   </p>
   <blockquote>
    <p>
-    <code>
-     BONUS:COMBAT|AC|2|TYPE=NaturalArmor.REPLACE
-    </code>
+    <code>BONUS:COMBAT|AC|2|TYPE=NaturalArmor.REPLACE</code>
    </p>
   </blockquote>
   <p>
@@ -317,18 +271,14 @@ this would be:
   </p>
   <blockquote>
    <p>
-    <code>
-     BONUS:COMBAT|AC|2|TYPE=Divine
-    </code>
+    <code>BONUS:COMBAT|AC|2|TYPE=Divine</code>
     ".
    </p>
   </blockquote>
   <hr/>
   <p>
    <strong>
-    <code>
-     BONUS:COMBAT|BAB
-    </code>
+    <code>BONUS:COMBAT|BAB</code>
    </strong>
   </p>
   <p>
@@ -364,26 +314,20 @@ that affect BAB, so our BAB total is 35-5-9-1+1=21.
   <p>
    These values are only used when you are creating a "default
 monster" so we will append the
-   <code>
-    PREDEFAULTMONSTER:Y
-   </code>
+   <code>PREDEFAULTMONSTER:Y</code>
    tag
 to the bonus. This basically tells the program not to apply the
 bonus unless the user has selected "Use Default Monsters" in the
 preferences tab. This BAB bonus is also the base for the race and
 needs to stack with feats and other things that actually modify the
 base BAB, so we'll give it a "
-   <code>
-    TYPE=Base.REPLACE
-   </code>
+   <code>TYPE=Base.REPLACE</code>
    ". Our
 tag will look like this:
   </p>
   <blockquote>
    <p>
-    <code>
-     BONUS:COMBAT|BAB|21|PREDEFAULTMONSTER:Y|TYPE=Base.REPLACE
-    </code>
+    <code>BONUS:COMBAT|BAB|21|PREDEFAULTMONSTER:Y|TYPE=Base.REPLACE</code>
    </p>
   </blockquote>
   <p>
@@ -394,9 +338,7 @@ other stuff. The tag for this will be:
   </p>
   <blockquote>
    <p>
-    <code>
-     BONUS:COMBAT|BAB|5|PREDEFAULTMONSTER:Y|TYPE=Base.REPLACE
-    </code>
+    <code>BONUS:COMBAT|BAB|5|PREDEFAULTMONSTER:Y|TYPE=Base.REPLACE</code>
    </p>
   </blockquote>
   <p class="sidebar">
@@ -409,11 +351,9 @@ so no calculation is needed.
   </p>
   <hr/>
   <p>
-   <code>
-    <strong>
+   <code><strong>
      NATURALATTACKS
-    </strong>
-   </code>
+    </strong></code>
   </p>
   <p>
    The NATURALATTACKS tag is what we use to define non-equipment
@@ -477,9 +417,7 @@ secondary attack. The tag for the ninja monkey would look thus:
   </p>
   <blockquote>
    <p>
-    <code>
-     NATURALATTACKS:Claw,Weapon.Natural.Melee.Piercing.Slashing,*2,1d4|Bite,Weapon.Natural.Melee.Piercing.Slashing.Bludgeoning,*1,1d8
-    </code>
+    <code>NATURALATTACKS:Claw,Weapon.Natural.Melee.Piercing.Slashing,*2,1d4|Bite,Weapon.Natural.Melee.Piercing.Slashing.Bludgeoning,*1,1d8</code>
    </p>
   </blockquote>
   <p>
@@ -492,9 +430,7 @@ click on it and change the location to "Carried").
   <hr/>
   <p>
    <strong>
-    <code>
-     FACE
-    </code>
+    <code>FACE</code>
    </strong>
   </p>
   <p>
@@ -506,23 +442,17 @@ the correct value on the character sheet.
   </p>
   <p>
    We use the
-   <code>
-    FACE
-   </code>
+   <code>FACE</code>
    tag to define this
 characteristic.  The format is
 "
-   <code>
-    FACE:width,length
-   </code>
+   <code>FACE:width,length</code>
    ".
   </p>
   <p>
    Both the Solar and the Ninja Monkey have a face of 5 ft. by 5
 ft. so we will enter "
-   <code>
-    FACE:5,5
-   </code>
+   <code>FACE:5,5</code>
    " to both entries.
   </p>
   <p>
@@ -537,18 +467,14 @@ would need to enter 2.5 for 2 1/2.
    <br/>
    In the revised rules, face is called Space and is represented by a
 single number. We continue to use the
-   <code>
-    FACE
-   </code>
+   <code>FACE</code>
    tag and
 enter just the one number.
   </p>
   <hr/>
   <p>
    <strong>
-    <code>
-     REACH
-    </code>
+    <code>REACH</code>
    </strong>
   </p>
   <p>
@@ -564,16 +490,12 @@ format is "REACH:distance".
   <p>
    A Solar has a reach of 10 feet since it is a large creature, so
 on it's line we'll enter "
-   <code>
-    REACH:10
-   </code>
+   <code>REACH:10</code>
    ".  The 
 Ninja Monkey is a medium size creature (w/o tentacles  :p) so
 it will get the standard reach for a medium-size creature of 5
 feet.  "
-   <code>
-    REACH:5
-   </code>
+   <code>REACH:5</code>
    " goes on his line.
   </p>
   <hr/>
@@ -592,9 +514,7 @@ being used instead.
    When a racial entry lists weapons (other than natural) or armor
 the race is considered to come with the mentioned equipment. 
 To grant equipment automatically we use the
-   <code>
-    AUTO:EQUIP
-   </code>
+   <code>AUTO:EQUIP</code>
    tag.  Despite it's name, it doesn't actually equip the gear,
 it only puts in in the "owned gear" list (for lack of a better
 term).  The user creating the creature will have to go to the
@@ -605,14 +525,10 @@ gear tab and actually equip it.
 (such as "+5 Vorpal Greatsword").  You can get around this by
 creating a different name for a piece of equipment ("Solar
 Greatsword") and using
-   <code>
-    OUTPUTNAME
-   </code>
+   <code>OUTPUTNAME</code>
    in the equipment
 .lst (
-   <code>
-    OUTPUTNAME:+5 Vorpal Greatsword
-   </code>
+   <code>OUTPUTNAME:+5 Vorpal Greatsword</code>
    ).  We'll
 cover this in more detail when we go over equipment.
   </p>
@@ -625,27 +541,21 @@ and use the names "Solar Longsword" and "Solar Longbow".
   <p>
    The tag granting these pieces of equipment to the Solar would
 thus be "
-   <code>
-    AUTO:EQUIP|Solar Greatsword|Solar 
-Longbow
-   </code>
+   <code>AUTO:EQUIP|Solar Greatsword|Solar 
+Longbow</code>
    ".
   </p>
   <p>
    For the Ninja Monkey I think I'll give him Leather armor and a
 regular dagger.  The tag for this would be 
 "
-   <code>
-    AUTO:EQUIP|Leather|Dagger
-   </code>
+   <code>AUTO:EQUIP|Leather|Dagger</code>
    ".
   </p>
   <hr/>
   <p>
    <strong>
-    <code>
-     AUTO:ARMORPROF
-    </code>
+    <code>AUTO:ARMORPROF</code>
    </strong>
   </p>
   <p>
@@ -654,18 +564,12 @@ proficient with the type of armor in that class and all lesser
 types.  So if an entry is shown for a Medium type armor, the
 race would be proficient with Medium *and* light armors.  To
 grant these proficiencies, we use the
-   <code>
-    AUTO:ARMORPROF
-   </code>
+   <code>AUTO:ARMORPROF</code>
    tag.  This tag is the same in format as the
-   <code>
-    AUTO:EQUIP
-   </code>
+   <code>AUTO:EQUIP</code>
    tag.  It will take armors by name and
 grant only proficiency with that type, or by
-   <code>
-    TYPE
-   </code>
+   <code>TYPE</code>
    and grant proficiency to every type of armor in
 that selection.
   </p>
@@ -676,26 +580,20 @@ skip this tag for them.
   <p>
    The Ninja Monkey has Leather armor (which is Light) so we'll put
 in a tag of "
-   <code>
-    AUTO:ARMORPROF|TYPE=Light
-   </code>
+   <code>AUTO:ARMORPROF|TYPE=Light</code>
    " for them.
   </p>
   <hr/>
   <p>
-   <code>
-    <strong>
+   <code><strong>
      AUTO:WEAPONPROF
-    </strong>
-   </code>
+    </strong></code>
   </p>
   <p>
    When a race has a weapon (or weapons) other than natural ones
 listed they are considered to be proficient with them.  To
 grant these weapon proficiencies, we use the
-   <code>
-    AUTO:WEAPONPROF
-   </code>
+   <code>AUTO:WEAPONPROF</code>
    tag.  It has the same format as
 the last two tags we covered.  Note that you need to put the
 appropriate proficiency name in this tag, NOT the weapon name.
@@ -703,18 +601,14 @@ appropriate proficiency name in this tag, NOT the weapon name.
   <p>
    Since the Solar uses a greatsword and a composite longbow, the
 entry for them is  "
-   <code>
-    AUTO:WEAPONPROF|Greatsword|Longbow
-(Composite)
-   </code>
+   <code>AUTO:WEAPONPROF|Greatsword|Longbow
+(Composite)</code>
    ".
   </p>
   <p>
    The Ninja Monkey only has a dagger, so the entry for him will be
 "
-   <code>
-    AUTO:WEAPONPROF|Dagger
-   </code>
+   <code>AUTO:WEAPONPROF|Dagger</code>
    ".
   </p>
   <p class="sidebar">

--- a/docs/listfilepages/lstfileclass/lfc_lesson05_race3.html
+++ b/docs/listfilepages/lstfileclass/lfc_lesson05_race3.html
@@ -42,8 +42,7 @@
    </strong>
   </p>
   <p class="indent1">
-   <code>
-    <a href="../globalfilestagpages/globalfilesother.html#sab">
+   <code><a href="../globalfilestagpages/globalfilesother.html#sab">
      SA
     </a>
     ,
@@ -77,8 +76,7 @@
     ,
     <a href="../globalfilestagpages/globalfilesbonus.html#stat">
      BONUS:STAT
-    </a>
-   </code>
+    </a></code>
   </p>
   <hr/>
   <p>
@@ -92,11 +90,9 @@ documentation for more information.
   </p>
   <hr/>
   <p>
-   <code>
-    <strong>
+   <code><strong>
      SA
-    </strong>
-   </code>
+    </strong></code>
   </p>
   <p>
    This is the tag we use for any special abilities, attacks or
@@ -117,8 +113,7 @@ should list. So his set of SA
   </p>
   <blockquote>
    <p>
-    <code>
-     SA:Aura of Menace (Su)
+    <code>SA:Aura of Menace (Su)
      <br/>
      SA:Magic Circle against Evil (Su)
      <br/>
@@ -132,8 +127,7 @@ should list. So his set of SA
      <br/>
      SA:Fire resistance 20 (Ex)
      <br/>
-     SA:Keen Vision (Ex)
-    </code>
+     SA:Keen Vision (Ex)</code>
    </p>
   </blockquote>
   <p>
@@ -143,11 +137,9 @@ areas. So we would put:
   </p>
   <blockquote>
    <p>
-    <code>
-     SA:Posion Immunity (Ex)
+    <code>SA:Posion Immunity (Ex)
      <br/>
-     SA:+2 to Hide in forested areas
-    </code>
+     SA:+2 to Hide in forested areas</code>
    </p>
   </blockquote>
   <p class="sidebar">
@@ -158,8 +150,7 @@ areas. So we would put:
    The Solar's special abilities have changed a little in 3.5. His
 tags would look like:
    <br/>
-   <code>
-    SA:Spell-Like Abilities
+   <code>SA:Spell-Like Abilities
     <br/>
     SA:Immunity to petrification/cold/acid (Ex)
     <br/>
@@ -172,15 +163,12 @@ tags would look like:
     SA:Resistance to Electricity 10 (Ex)
     <br/>
     SA:Tongues (Su)
-    <br/>
-   </code>
+    <br/></code>
   </p>
   <hr/>
   <p>
    <strong>
-    <code>
-     FEAT
-    </code>
+    <code>FEAT</code>
    </strong>
   </p>
   <p>
@@ -193,15 +181,11 @@ be found in the file xsrd_feats_hidden.lst.  Basically they
 are exactly like normal feats except they are not visible in the
 GUI so you can't select them as a feat choice for your
 character.  We use the "
-   <code>
-    FEAT
-   </code>
+   <code>FEAT</code>
    " to grant these
 abilities to a monster. It should be noted that only a single
 "
-   <code>
-    FEAT
-   </code>
+   <code>FEAT</code>
    " tag can be present in a race line so if
 multiple feats need to be granted they should be separated with a
 "|" (pipe) character.
@@ -213,28 +197,20 @@ We could code this like so:
   </p>
   <blockquote>
    <p>
-    <code>
-     FEAT:Rage&lt;tab&gt;BONUS:VAR|RageTimesLvl,RagePowerLvl|HD
-    </code>
+    <code>FEAT:Rage&lt;tab&gt;BONUS:VAR|RageTimesLvl,RagePowerLvl|HD</code>
    </p>
   </blockquote>
   <hr/>
   <p>
    <strong>
-    <code>
-     VFEAT
-    </code>
+    <code>VFEAT</code>
    </strong>
   </p>
   <p>
    Similar to the
-   <code>
-    FEAT
-   </code>
+   <code>FEAT</code>
    tag, the
-   <code>
-    VFEAT
-   </code>
+   <code>VFEAT</code>
    is
 used to grant feats to a creature.  It is generally used to
 grant bonus feats particularly ones that a creature may not
@@ -252,10 +228,8 @@ feats as bonus feats.  We would therefore enter:
   </p>
   <blockquote>
    <p>
-    <code>
-     VFEAT:Multidexterity&lt;tab&gt;VFEAT:Multiweapon
-Fighting
-    </code>
+    <code>VFEAT:Multidexterity&lt;tab&gt;VFEAT:Multiweapon
+Fighting</code>
    </p>
   </blockquote>
   <p class="sidebar">
@@ -272,9 +246,7 @@ Fighting feats as bonus feats in 3.5.
   <hr/>
   <p>
    <strong>
-    <code>
-     VISION
-    </code>
+    <code>VISION</code>
    </strong>
   </p>
   <p>
@@ -296,9 +268,7 @@ be:
   </p>
   <blockquote>
    <p>
-    <code>
-     VISION:Darkvision (60')|Low-light
-    </code>
+    <code>VISION:Darkvision (60')|Low-light</code>
    </p>
   </blockquote>
   <p>
@@ -309,18 +279,14 @@ a range of 60 feet.  Their tag will read:
   </p>
   <blockquote>
    <p>
-    <code>
-     VISION:Darkvision (60')
-    </code>
+    <code>VISION:Darkvision (60')</code>
    </p>
   </blockquote>
   <hr/>
   <p>
-   <code>
-    <strong>
+   <code><strong>
      SR
-    </strong>
-   </code>
+    </strong></code>
   </p>
   <p>
    For races that have Spell Resistance, we use the SR tag. This
@@ -330,9 +296,7 @@ better SR with more levels. So SR:12 is valid as is SR:11+TL.
   <p>
    The Solar has a spell resistance of 32, so we would enter
 "
-   <code>
-    SR:32
-   </code>
+   <code>SR:32</code>
    " for him.
   </p>
   <p>
@@ -340,11 +304,9 @@ better SR with more levels. So SR:12 is valid as is SR:11+TL.
   </p>
   <hr/>
   <p>
-   <code>
-    <strong>
+   <code><strong>
      DR
-    </strong>
-   </code>
+    </strong></code>
   </p>
   <p>
    To indicate Damage Reduction for races we use the DR tag. It
@@ -360,18 +322,14 @@ in the second position.
    The Solar has a damage reduction of 35 and only a +4 or better
 weapon can get through it, so the tag would read
 "
-   <code>
-    DR:35/+4
-   </code>
+   <code>DR:35/+4</code>
    ".
   </p>
   <p>
    The Ninja Monkey has a very strong connection with the earth and
 gains a small damage reduction of 3 with no special weapons that
 can ignore it, so the tag would be "
-   <code>
-    DR:3/-
-   </code>
+   <code>DR:3/-</code>
    ".
   </p>
   <p class="sidebar">
@@ -382,19 +340,15 @@ can ignore it, so the tag would be "
    In the RSRD the Solar has a damage reduction of 15/epic and evil so
 we would instead enter:
    <br/>
-   <code>
-    DR:15/epic and evil
-   </code>
+   <code>DR:15/epic and evil</code>
    <br/>
    The Ninja Monkey's DR remains unchanged.
   </p>
   <hr/>
   <p>
-   <code>
-    <strong>
+   <code><strong>
      TEMPLATE
-    </strong>
-   </code>
+    </strong></code>
   </p>
   <p>
    We use templates (and the "TEMPLATE" tag) to apply all the
@@ -412,17 +366,13 @@ tag for each template you wish to apply.
   <p>
    The Solar is an outsider so we would add a
 "
-   <code>
-    TEMPLATE:Outsider
-   </code>
+   <code>TEMPLATE:Outsider</code>
    " to his listing.
   </p>
   <p>
    The Ninja Monkey is a Monstrous Humanoid and would get
 "
-   <code>
-    TEMPLATE:Monstrous Humanoid
-   </code>
+   <code>TEMPLATE:Monstrous Humanoid</code>
    ".
   </p>
   <p>
@@ -438,9 +388,7 @@ without a corporeal form.
   <hr/>
   <p>
    <strong>
-    <code>
-     BONUS:CHECKS
-    </code>
+    <code>BONUS:CHECKS</code>
    </strong>
   </p>
   <p>
@@ -471,30 +419,22 @@ mod)-1 (epic bonus)=12. His Reflex Save bonus would be 18 (final)-5
   </p>
   <p>
    The tag we use to enter these values is
-   <code>
-    BONUS:CHECKS
-   </code>
+   <code>BONUS:CHECKS</code>
    . This tag has two forms. The first is
 "
-   <code>
-    BONUS:CHECKS|checkname|#
-   </code>
+   <code>BONUS:CHECKS|checkname|#</code>
    " which would add "#" as
 bonus that would appear in the "Misc" box on the output sheet. The
 second form (and the one we will use in our race files almost
 always) is "
-   <code>
-    BONUS:CHECKS|BASE.checkname|#
-   </code>
+   <code>BONUS:CHECKS|BASE.checkname|#</code>
    ", which adds
 to the base bonus and makes it appear in the "Base Save" column on
 the output sheets. If the bonus is the same for multiple checks,
 you can do them in one tag by separating them with a comma like
 this
 "
-   <code>
-    BONUS:CHECKS|BASE.checkname1,BASE.checkname2|#
-   </code>
+   <code>BONUS:CHECKS|BASE.checkname1,BASE.checkname2|#</code>
    ".
   </p>
   <p>
@@ -502,17 +442,13 @@ this
 we can use one tag instead of three. Like the BAB, these values are
 only to be used for default monsters, so we'll use the
 "
-   <code>
-    PREDEFAULTMONSTER:Y
-   </code>
+   <code>PREDEFAULTMONSTER:Y</code>
    " suffix with it. The tag for the
 Solar would thus be:
   </p>
   <blockquote>
    <p>
-    <code>
-     BONUS:CHECKS|BASE.Fortitude,BASE.Reflex,BASE.Willpower|12|PREDEFAULTMONSTER:Y
-    </code>
+    <code>BONUS:CHECKS|BASE.Fortitude,BASE.Reflex,BASE.Willpower|12|PREDEFAULTMONSTER:Y</code>
    </p>
   </blockquote>
   <p>
@@ -523,13 +459,9 @@ need to use two tags. The tags would be:
   </p>
   <blockquote>
    <p>
-    <code>
-     BONUS:CHECKS|BASE.Reflex|5|PREDEFAULTMONSTER:Y
-    </code>
+    <code>BONUS:CHECKS|BASE.Reflex|5|PREDEFAULTMONSTER:Y</code>
     <br/>
-    <code>
-     BONUS:CHECKS|BASE.Fortitude,BASE.Willpower|2|PREDEFAULTMONSTER:Y
-    </code>
+    <code>BONUS:CHECKS|BASE.Fortitude,BASE.Willpower|2|PREDEFAULTMONSTER:Y</code>
    </p>
   </blockquote>
   <p class="sidebar">
@@ -541,20 +473,14 @@ need to use two tags. The tags would be:
 Monstrous Humanoid. Therefore in the RSRD it would have base saves
 of Fort +1, Ref +4, Will +4. In LST code this would be:
    <br/>
-   <code>
-    BONUS:CHECKS|BASE.Fortitude|1|PREDEFAULTMONSTER:Y
-   </code>
+   <code>BONUS:CHECKS|BASE.Fortitude|1|PREDEFAULTMONSTER:Y</code>
    <br/>
-   <code>
-    BONUS:CHECKS|BASE.Reflex,BASE.Willpower|4|PREDEFAULTMONSTER:Y
-   </code>
+   <code>BONUS:CHECKS|BASE.Reflex,BASE.Willpower|4|PREDEFAULTMONSTER:Y</code>
   </p>
   <hr/>
   <p>
    <strong>
-    <code>
-     BONUS:STAT
-    </code>
+    <code>BONUS:STAT</code>
    </strong>
   </p>
   <p>
@@ -575,26 +501,18 @@ more to make it even.  (For the Solar these values would be
 STR 18, DEX 10, CON 10,  INT 12, WIS 14, CHA 14 with INT, WIS
 and CHA being odd). Now that we have the non-monster values, we can
 put  them into the
-   <code>
-    BONUS:STAT
-   </code>
+   <code>BONUS:STAT</code>
    tag.
   </p>
   <p>
    To designate which stat gets the bonus we use the
 abbreviations.  So for strength it would be
-   <code>
-    BONUS:STAT|STR|#
-   </code>
+   <code>BONUS:STAT|STR|#</code>
    .   Like the
-   <code>
-    BONUS:SKILL
-   </code>
+   <code>BONUS:SKILL</code>
    tag, you can apply the same bonus to more
 than one stat at once by making a comma separated list such as
-   <code>
-    BONUS:STAT|STR,CON|#
-   </code>
+   <code>BONUS:STAT|STR,CON|#</code>
    .  One last note, if the
 final stat value is 10 then there is no  need to add a bonus
 tag for it.
@@ -604,9 +522,7 @@ tag for it.
 stats for default monsters we add one more tag,  lumping
 together all the stats that were odd and adding a
 "
-   <code>
-    PREDEFAULTMONSTER:Y
-   </code>
+   <code>PREDEFAULTMONSTER:Y</code>
    ".
   </p>
   <p>
@@ -623,8 +539,7 @@ lets put together the stat bonuses for the Solar:
   </p>
   <blockquote>
    <p>
-    <code>
-     BONUS:STAT|STR|18
+    <code>BONUS:STAT|STR|18
      <br/>
      BONUS:STAT|DEX,CON|10
      <br/>
@@ -632,8 +547,7 @@ lets put together the stat bonuses for the Solar:
      <br/>
      BONUS:STAT|WIS,CHA|14
      <br/>
-     BONUS:STAT|INT,WIS,CHA|1|PREDEFAULTMONSTER:Y
-    </code>
+     BONUS:STAT|INT,WIS,CHA|1|PREDEFAULTMONSTER:Y</code>
    </p>
   </blockquote>
   <p>
@@ -646,15 +560,13 @@ tags  in the race file would be:
   </p>
   <blockquote>
    <p>
-    <code>
-     BONUS:STAT|STR|6
+    <code>BONUS:STAT|STR|6
      <br/>
      BONUS:STAT|DEX|8
      <br/>
      BONUS:STAT|CON,WIS|4
      <br/>
-     BONUS:STAT|STR,INT,WIS|1|PREDEFAULTMONSTER:Y.
-    </code>
+     BONUS:STAT|STR,INT,WIS|1|PREDEFAULTMONSTER:Y.</code>
    </p>
   </blockquote>
   <hr/>

--- a/docs/listfilepages/lstfileclass/lfc_lesson06_race4.html
+++ b/docs/listfilepages/lstfileclass/lfc_lesson06_race4.html
@@ -43,8 +43,7 @@
    </strong>
   </p>
   <p class="indent1">
-   <code>
-    <a href="../datafilestagpages/datafilesraces.html#moncskill">
+   <code><a href="../datafilestagpages/datafilesraces.html#moncskill">
      MONCSKILL
     </a>
     ,
@@ -99,8 +98,7 @@ MFEAT,
     ,
     <a href="../globalfilestagpages/globalfilesother.html#sourcepage">
      SOURCEPAGE
-    </a>
-   </code>
+    </a></code>
   </p>
   <p>
    This will be the final lesson on creating "monster" race files.
@@ -115,17 +113,13 @@ dive right in.
   <hr/>
   <p>
    <strong>
-    <code>
-     MONCSKILL
-    </code>
+    <code>MONCSKILL</code>
    </strong>
   </p>
   <p>
    To define the skills that are considered class skill for each
 race we use the
-   <code>
-    MONCSKILL
-   </code>
+   <code>MONCSKILL</code>
    tag.  Following the tag
 is a list of the race's class skills, separated by the pipe ("|")
 character.
@@ -141,11 +135,9 @@ there is a class skill for that race.
   </p>
   <blockquote>
    <p>
-    <code>
-     MONCSKILL:Concentration|Escape
+    <code>MONCSKILL:Concentration|Escape
 Artist|Hide|TYPE.Knowledge|TYPE.Craft|Listen|Move
-Silently|Search|Sense Motive|Spellcraft|Spot
-    </code>
+Silently|Search|Sense Motive|Spellcraft|Spot</code>
    </p>
   </blockquote>
   <p>
@@ -157,10 +149,8 @@ racial skills since they may choose from among all of them.
   </p>
   <blockquote>
    <p>
-    <code>
-     MONCSKILL:Balance|Hide|Jump|Listen|Move
-Silently|Spot
-    </code>
+    <code>MONCSKILL:Balance|Hide|Jump|Listen|Move
+Silently|Spot</code>
    </p>
   </blockquote>
   <p class="sidebar">
@@ -188,9 +178,7 @@ it since they have a racial bonus to Balance.
   <hr/>
   <p>
    <strong>
-    <code>
-     BONUS:SKILLRANK
-    </code>
+    <code>BONUS:SKILLRANK</code>
    </strong>
   </p>
   <p>
@@ -225,9 +213,7 @@ would be:
   </p>
   <blockquote>
    <p>
-    <code>
-     BONUS:SKILLRANK|Concentration|11|PREDEFAULTMONSTER:Y
-    </code>
+    <code>BONUS:SKILLRANK|Concentration|11|PREDEFAULTMONSTER:Y</code>
    </p>
   </blockquote>
   <p>
@@ -250,10 +236,8 @@ several others) would be:
   </p>
   <blockquote>
    <p>
-    <code>
-     BONUS:SKILLRANK|Escape Artist,Hide,Listen,Move
-Silently,Sense Motive,Spot|25|PREDEFAULTMONSTER:Y
-    </code>
+    <code>BONUS:SKILLRANK|Escape Artist,Hide,Listen,Move
+Silently,Sense Motive,Spot|25|PREDEFAULTMONSTER:Y</code>
    </p>
   </blockquote>
   <p>
@@ -266,9 +250,7 @@ listing all of the  skills of the selected type and allow them
 to pick five of them and then assign the appropriate number
 of  ranks to those skills.  I use an
 "
-   <code>
-    ADD:FEAT(TYPE=FiveKnowledge22,TYPE=FiveCraft22)
-   </code>
+   <code>ADD:FEAT(TYPE=FiveKnowledge22,TYPE=FiveCraft22)</code>
    " tag
 in this race file to  start the feat chooser.
   </p>
@@ -295,10 +277,8 @@ be:
   </p>
   <blockquote>
    <p>
-    <code>
-     BONUS:SKILLRANK|Balance,Hide,Jump,Listen,Move
-Silently,Spot|5|PREDEFAULTMONSTER:Y
-    </code>
+    <code>BONUS:SKILLRANK|Balance,Hide,Jump,Listen,Move
+Silently,Spot|5|PREDEFAULTMONSTER:Y</code>
    </p>
   </blockquote>
   <p class="sidebar">
@@ -330,9 +310,7 @@ Silently|4|PREDEFAULTMONSTER:Y
   <hr/>
   <p>
    <strong>
-    <code>
-     BONUS:SKILL
-    </code>
+    <code>BONUS:SKILL</code>
    </strong>
   </p>
   <p>
@@ -347,25 +325,19 @@ however so we do not need to enter them in the race file.
   </p>
   <p>
    We apply these racial skill bonuses using the
-   <code>
-    BONUS:SKILL
-   </code>
+   <code>BONUS:SKILL</code>
    tag.  You can use this tag for a
 single skill, or multiple ones separated by commas as long as the
 bonus value is the same for each skill.  If there are two
 skills with two different bonus values, you have to use two
 separate
-   <code>
-    BONUS:SKILL
-   </code>
+   <code>BONUS:SKILL</code>
    tags.
   </p>
   <p>
    To indicate that these are Racial bonuses we add
 "
-   <code>
-    |TYPE=Racial
-   </code>
+   <code>|TYPE=Racial</code>
    " to the end of the tags.
   </p>
   <p>
@@ -379,9 +351,7 @@ be:
   </p>
   <blockquote>
    <p>
-    <code>
-     BONUS:SKILL|Balance,Jump|4|TYPE=Racial
-    </code>
+    <code>BONUS:SKILL|Balance,Jump|4|TYPE=Racial</code>
    </p>
   </blockquote>
   <p class="sidebar">
@@ -395,9 +365,7 @@ in the RSRD.
   <hr/>
   <p>
    <strong>
-    <code>
-     MFEAT
-    </code>
+    <code>MFEAT</code>
    </strong>
    (
    <span class="new">
@@ -416,14 +384,10 @@ being used instead.
   </p>
   <p>
    To grant racial feats we use the
-   <code>
-    MFEAT
-   </code>
+   <code>MFEAT</code>
    tag. 
 This is very similar to the
-   <code>
-    MONCSKILL
-   </code>
+   <code>MONCSKILL</code>
    tag in that the
 tag is followed by a list (of feats instead of skills) separated by
 the pipe character.
@@ -435,9 +399,7 @@ section of their listing.
   <p>
    A couple of things to pay special attention to when entering
 feats using the
-   <code>
-    MFEAT
-   </code>
+   <code>MFEAT</code>
    tag:  Often a race will
 have a feat multiple times, but with a different target, such as
 Weapon Focus with their claws and their bite.  This would be
@@ -454,10 +416,8 @@ reference a feat with a target, in any kind of .lst file.
   </p>
   <blockquote>
    <p>
-    <code>
-     MFEAT:Cleave|Dodge|Great Cleave|Improved
-Initiative|Mobility|Power Attack
-    </code>
+    <code>MFEAT:Cleave|Dodge|Great Cleave|Improved
+Initiative|Mobility|Power Attack</code>
    </p>
   </blockquote>
   <p class="sidebar">
@@ -480,11 +440,9 @@ coded as:
   </p>
   <hr/>
   <p>
-   <code>
-    <strong>
+   <code><strong>
      CR
-    </strong>
-   </code>
+    </strong></code>
   </p>
   <p>
    The CR tag is used to set the challenge rating for the race. It
@@ -495,17 +453,13 @@ rating of 4 would get a "CR:4" tag. One with a challenge rating of
   <p>
    The Solar has a challenge rating of 19, so the tag would read
 "
-   <code>
-    CR:19
-   </code>
+   <code>CR:19</code>
    ".
   </p>
   <p>
    The Ninja Monkey has a challenge rating of 2, so his tag would
 read "
-   <code>
-    CR:2
-   </code>
+   <code>CR:2</code>
    ".
   </p>
   <p class="sidebar">
@@ -519,9 +473,7 @@ read "
   <hr/>
   <p>
    <strong>
-    <code>
-     PREALIGN
-    </code>
+    <code>PREALIGN</code>
    </strong>
   </p>
   <p>
@@ -555,9 +507,7 @@ LG,LN,LE,NG,TN,NE,CG,CN,CE.
   <p>
    Since the Solars must be of good alignment, the tag for them
 will read "
-   <code>
-    PREALIGN:0,3,6
-   </code>
+   <code>PREALIGN:0,3,6</code>
    ".
   </p>
   <p>
@@ -566,11 +516,9 @@ so we will simply not put in a PREALIGN tag for them.
   </p>
   <hr/>
   <p>
-   <code>
-    <strong>
+   <code><strong>
      HITDICEADVANCEMENT
-    </strong>
-   </code>
+    </strong></code>
   </p>
   <p>
    We use the HITDICEADVANCEMENT tag for those races that change
@@ -588,9 +536,7 @@ this tag should be left out.
    The solar shows an advance of 22-33 for Large size and 34-66 for
 Huge. So the tag for him will be
 "
-   <code>
-    HITDICEADVANCEMENT:33,66
-   </code>
+   <code>HITDICEADVANCEMENT:33,66</code>
    "
   </p>
   <p>
@@ -599,11 +545,9 @@ get no HITDICEADVANCEMENT tag.
   </p>
   <hr/>
   <p>
-   <code>
-    <strong>
+   <code><strong>
      LEVELADJUSTMENT
-    </strong>
-   </code>
+    </strong></code>
   </p>
   <p>
    The LEVELADJUSTMENT tag is used for those races that might
@@ -618,17 +562,13 @@ level adjustment.
    The Ninja Monkey, due to his several small special abilities
 would get a +2 level adjustment, so his tag would read
 "
-   <code>
-    LEVELADJUSTMENT:2
-   </code>
+   <code>LEVELADJUSTMENT:2</code>
    ".
   </p>
   <hr/>
   <p>
    <strong>
-    <code>
-     FAVCLASS
-    </code>
+    <code>FAVCLASS</code>
    </strong>
   </p>
   <p>
@@ -642,17 +582,13 @@ enter:
   </p>
   <blockquote>
    <p>
-    <code>
-     FAVCLASS:Monk
-    </code>
+    <code>FAVCLASS:Monk</code>
    </p>
   </blockquote>
   <hr/>
   <p>
    <strong>
-    <code>
-     LANGAUTO
-    </code>
+    <code>LANGAUTO</code>
    </strong>
   </p>
   <p>
@@ -671,9 +607,7 @@ this:
   </p>
   <blockquote>
    <p>
-    <code>
-     LANGAUTO:Celestial,Infernal,Draconic
-    </code>
+    <code>LANGAUTO:Celestial,Infernal,Draconic</code>
    </p>
   </blockquote>
   <p>
@@ -683,17 +617,13 @@ so their tag will look like this:
   </p>
   <blockquote>
    <p>
-    <code>
-     LANGAUTO:Common,Monkey
-    </code>
+    <code>LANGAUTO:Common,Monkey</code>
    </p>
   </blockquote>
   <hr/>
   <p>
    <strong>
-    <code>
-     LANGBONUS
-    </code>
+    <code>LANGBONUS</code>
    </strong>
   </p>
   <p>
@@ -701,9 +631,7 @@ so their tag will look like this:
 number of bonus languages that the creature can pick from when
 spending its Int-based language picks.  The tag for this works
 just like the
-   <code>
-    LANGAUTO
-   </code>
+   <code>LANGAUTO</code>
    tag.
   </p>
   <p>
@@ -716,17 +644,13 @@ as their bonus languages.
   </p>
   <blockquote>
    <p>
-    <code>
-     LANGBONUS:Elven,Goblin,Sylvan
-    </code>
+    <code>LANGBONUS:Elven,Goblin,Sylvan</code>
    </p>
   </blockquote>
   <hr/>
   <p>
    <strong>
-    <code>
-     LEGS
-    </code>
+    <code>LEGS</code>
    </strong>
   </p>
   <p>
@@ -739,18 +663,14 @@ to just refer to the pictures provided. :p
   <p>
    Both the Solar and our Ninja Monkey have two legs, so the tag
 for both races will be "
-   <code>
-    LEGS:2
-   </code>
+   <code>LEGS:2</code>
    ".
   </p>
   <hr/>
   <p>
-   <code>
-    <strong>
+   <code><strong>
      HANDS
-    </strong>
-   </code>
+    </strong></code>
   </p>
   <p>
    The HANDS tag is used to denote the number of hands a creature
@@ -764,24 +684,18 @@ a race's natural attacks.
   <p>
    The Solar and our Ninja Monkey both have two hands, so our tag
 for both races would be "
-   <code>
-    HANDS:2
-   </code>
+   <code>HANDS:2</code>
    "
   </p>
   <hr/>
   <p>
-   <code>
-    <strong>
+   <code><strong>
      SPELLS
-    </strong>
-   </code>
+    </strong></code>
   </p>
   <p>
    The
-   <code>
-    SPELLS
-   </code>
+   <code>SPELLS</code>
    tag is used to grant innate spellcasting
 (and some spell-like abilities). We use it for spell-like abilities
 when they grant the full spell effect. If it is restricted in some
@@ -792,18 +706,12 @@ certain creature, etc.), we simply list it as an SA.
    Alternately, you can create a version of the spell with the
 modifications the race needs included in the description.  The
 spell should be added with no
-   <code>
-    CLASS
-   </code>
+   <code>CLASS</code>
    or
-   <code>
-    DOMAIN
-   </code>
+   <code>DOMAIN</code>
    tags.  Once the spell is created you can
 use the
-   <code>
-    SPELLS
-   </code>
+   <code>SPELLS</code>
    as normal.
   </p>
   <p>
@@ -821,8 +729,7 @@ would be:
   </p>
   <blockquote>
    <p>
-    <code>
-     SPELLS:Innate|TIMES=-1|CASTERLEVEL=20|Aid|Animate
+    <code>SPELLS:Innate|TIMES=-1|CASTERLEVEL=20|Aid|Animate
 Objects|Commune|Continual Flame|Dimensional Anchor|Greater
 Dispelling|Holy Smite,21|Imprisonment|Improved Invisibility (Self
 Only)|Lesser Restoration|Remove Curse|Remove Disease|Remove
@@ -833,8 +740,7 @@ Barrier,23|Earthquake,25|Heal|Permanency|Resurrection|Shapechange,
      <br/>
      SPELLS:Innate|TIMES=1|CASTERLEVEL=20|Greater Restoration|Mass
 Charm,25|Power Word (Blind),25|Power Word (Kill),26|Power Word
-(Stun),24|Prismatic Spray,24|Symbol,24|Wish
-    </code>
+(Stun),24|Prismatic Spray,24|Symbol,24|Wish</code>
    </p>
   </blockquote>
   <p>
@@ -845,18 +751,14 @@ blank.  The tag would then look like:
   </p>
   <blockquote>
    <p>
-    <code>
-     SPELLS:Innate|TIMES=-1|Pass Without Trace
-    </code>
+    <code>SPELLS:Innate|TIMES=-1|Pass Without Trace</code>
    </p>
   </blockquote>
   <hr/>
   <p>
-   <code>
-    <strong>
+   <code><strong>
      SOURCEPAGE
-    </strong>
-   </code>
+    </strong></code>
   </p>
   <p>
    This is just what it seems, where we indicate the page from the
@@ -874,17 +776,13 @@ would be the filename, so SOURCEPAGE:&lt;filename&gt;/
   <p>
    For the solar, we pulled him from the SRD so his tag would be
 "
-   <code>
-    SOURCEPAGE:srdmonstersc.rtf
-   </code>
+   <code>SOURCEPAGE:srdmonstersc.rtf</code>
    ".
   </p>
   <p>
    The Ninja Money is from my custom races file, so Il make the tag
 for him "
-   <code>
-    SOURCEPAGE:customraces.txt
-   </code>
+   <code>SOURCEPAGE:customraces.txt</code>
    ".
   </p>
   <hr/>

--- a/docs/listfilepages/lstfileclass/lfc_lesson07_spells.html
+++ b/docs/listfilepages/lstfileclass/lfc_lesson07_spells.html
@@ -54,8 +54,7 @@
    </strong>
   </p>
   <p class="indent1">
-   <code>
-    <a href="../datafilestagpages/datafilesspells.html#school">
+   <code><a href="../datafilestagpages/datafilesspells.html#school">
      SCHOOL
     </a>
     ,
@@ -121,8 +120,7 @@
     ,
     <a href="../datafilestagpages/datafilesspells.html#xpcost">
      XPCOST
-    </a>
-   </code>
+    </a></code>
   </p>
   <p>
    Please notice the
@@ -164,9 +162,7 @@ information (applying a spell to a character) will come later.
    </strong>
   </p>
   <p class="indent1">
-   <code>
-    SCHOOL, SUBSCHOOL, DESCRIPTOR
-   </code>
+   <code>SCHOOL, SUBSCHOOL, DESCRIPTOR</code>
   </p>
   <p>
    The line below the spell name is usually in this format:
@@ -178,9 +174,7 @@ information (applying a spell to a character) will come later.
    Note that I mention "Descriptors" in plural. There generally is
 only one School and Subschool, but many spells have more than one
 descriptor.
-   <code>
-    DESCRIPTOR
-   </code>
+   <code>DESCRIPTOR</code>
    can contain a pipe-delimited
 (|) list of descriptors, so put a pipe between more than one
 descriptor.
@@ -195,11 +189,9 @@ a School and 2 descriptors.
   </p>
   <blockquote>
    <p>
-    <code>
-     SCHOOL:Evocation
+    <code>SCHOOL:Evocation
      <br/>
-     DESCRIPTOR:Evil|Sonic
-    </code>
+     DESCRIPTOR:Evil|Sonic</code>
    </p>
   </blockquote>
   <p>
@@ -213,13 +205,11 @@ Sonic]
   </p>
   <blockquote>
    <p>
-    <code>
-     SCHOOL:Enchantment
+    <code>SCHOOL:Enchantment
      <br/>
      SUBSCHOOL:Compulsion
      <br/>
-     DESCRIPTOR:Mind-Affecting|Sonic
-    </code>
+     DESCRIPTOR:Mind-Affecting|Sonic</code>
    </p>
   </blockquote>
   <p>
@@ -238,9 +228,7 @@ DESCRIPTOR.
    </strong>
   </p>
   <p class="indent1">
-   <code>
-    CLASSES, DOMAINS, TYPE
-   </code>
+   <code>CLASSES, DOMAINS, TYPE</code>
   </p>
   <p>
    This is only part of the way of linking. If adding a new spell,
@@ -268,13 +256,11 @@ tags. Our example from
   </p>
   <blockquote>
    <p>
-    <code>
-     Blasphamy
+    <code>Blasphamy
      <br/>
      CLASSES:Cleric=7
      <br/>
-     DOMAINS:Evil=7
-    </code>
+     DOMAINS:Evil=7</code>
    </p>
   </blockquote>
   <p>
@@ -283,9 +269,7 @@ get:
   </p>
   <blockquote>
    <p>
-    <code>
-     TYPE:Divine.
-    </code>
+    <code>TYPE:Divine.</code>
    </p>
   </blockquote>
   <p>
@@ -306,13 +290,11 @@ example:
   </p>
   <blockquote>
    <p>
-    <code>
-     Antimagic Field
+    <code>Antimagic Field
      <br/>
      CLASSES:Cleric=8|Sorcerer,Wizard=6
      <br/>
-     DOMAINS:Magic,Protection=6
-    </code>
+     DOMAINS:Magic,Protection=6</code>
    </p>
   </blockquote>
   <p>
@@ -321,9 +303,7 @@ the next tag would be:
   </p>
   <blockquote>
    <p>
-    <code>
-     TYPE:Arcane.Divine
-    </code>
+    <code>TYPE:Arcane.Divine</code>
    </p>
   </blockquote>
   <p>
@@ -344,9 +324,7 @@ etc. but those are global tags not normally used in a
    </strong>
   </p>
   <p class="indent1">
-   <code>
-    COMPS, CASTTIME
-   </code>
+   <code>COMPS, CASTTIME</code>
   </p>
   <p>
    This section is easy, especially for those people that like to
@@ -364,11 +342,9 @@ cut and paste. For the following spell information:
   </p>
   <blockquote>
    <p>
-    <code>
-     COMPS:V
+    <code>COMPS:V
      <br/>
-     CASTTIME:1 standard action
-    </code>
+     CASTTIME:1 standard action</code>
    </p>
   </blockquote>
   <p>
@@ -384,9 +360,7 @@ cut and paste. For the following spell information:
    </strong>
   </p>
   <p class="indent1">
-   <code>
-    RANGE, DURATION, TARGETAREA
-   </code>
+   <code>RANGE, DURATION, TARGETAREA</code>
   </p>
   <p>
    Ok, the first two are easy.
@@ -411,9 +385,7 @@ put in the word for the range.
 bit of code that will do math functions. Such math functions must
 be encapsulated within a set of parentheses (). The character
 casterlevel can be used in these calculations by using the variable
-   <code>
-    CASTERLEVEL
-   </code>
+   <code>CASTERLEVEL</code>
    as part of the math function. Everything
 in the parentheses is reduced to a number. For normal parentheses,
 like those used for "(D)" where spellcaster can end the spell
@@ -457,14 +429,12 @@ you
   </p>
   <blockquote>
    <p>
-    <code>
-     RANGE:40 ft.
+    <code>RANGE:40 ft.
      <br/>
      TARGETAREA:Nonevil creatures in a 40-ft.-radius spread centered on
 you
      <br/>
-     DURATION:Instantaneous
-    </code>
+     DURATION:Instantaneous</code>
    </p>
   </blockquote>
   <p>
@@ -491,14 +461,12 @@ object
   </p>
   <blockquote>
    <p>
-    <code>
-     RANGE:Close
+    <code>RANGE:Close
      <br/>
      TARGETAREA:One location [ up to (CASETERLEVEL*10) cubes] or one
 object
      <br/>
-     DURATION:(CASTERLEVEL*2) hours [D]
-    </code>
+     DURATION:(CASTERLEVEL*2) hours [D]</code>
    </p>
   </blockquote>
   <hr/>
@@ -511,9 +479,7 @@ object
    </strong>
   </p>
   <p class="indent1">
-   <code>
-    SAVEINFO, SPELLRES
-   </code>
+   <code>SAVEINFO, SPELLRES</code>
   </p>
   <p>
    Again, this is easy copy/paste stuff.
@@ -533,11 +499,9 @@ object
   </p>
   <blockquote>
    <p>
-    <code>
-     SAVEINFO:None or Will negates; see text
+    <code>SAVEINFO:None or Will negates; see text
      <br/>
-     SPELLRES:Yes
-    </code>
+     SPELLRES:Yes</code>
    </p>
   </blockquote>
   <hr/>
@@ -550,21 +514,13 @@ object
    </strong>
   </p>
   <p class="indent1">
-   <code>
-    DESC
-   </code>
+   <code>DESC</code>
    ,
-   <code>
-    VARIANTS
-   </code>
+   <code>VARIANTS</code>
    ,
-   <code>
-    COST
-   </code>
+   <code>COST</code>
    ,
-   <code>
-    XPCOST
-   </code>
+   <code>XPCOST</code>
   </p>
   <p>
    These tags are from the spells description, and require some
@@ -572,9 +528,7 @@ judgment calls.
   </p>
   <p class="indent1">
    1)
-   <code>
-    DESC
-   </code>
+   <code>DESC</code>
    is usually pulled from the
 "one-liners" in spell descriptions, such as those found in the RSRD
    <span class="lstfile">
@@ -588,9 +542,7 @@ descriptions to less than 50 characters long.
   </p>
   <p class="indent1">
    2)
-   <code>
-    VARIANTS
-   </code>
+   <code>VARIANTS</code>
    are taken from the
 description, where the caster makes a decision on how a spell works
 when casting, such as Fire Seeds, where the caster uses either
@@ -604,18 +556,14 @@ casting.
   </p>
   <p class="indent1">
    3)
-   <code>
-    COST
-   </code>
+   <code>COST</code>
    gives the specific cost of
 material components, usually listed at end of the spell
 description.
   </p>
   <p class="indent1">
    4)
-   <code>
-    XPCOST
-   </code>
+   <code>XPCOST</code>
    gives the xp cost, when
 one exists, when casting the related spell. As with the material
 component cost, the xp cost is typically listed at the end of the
@@ -630,10 +578,8 @@ spell description.
   </p>
   <blockquote>
    <p>
-    <code>
-     DESC:Kills, paralyzes, weakens, or dazes nonevil
-subjects.
-    </code>
+    <code>DESC:Kills, paralyzes, weakens, or dazes nonevil
+subjects.</code>
    </p>
   </blockquote>
   <p>
@@ -671,11 +617,9 @@ supplies (cost 1,000 gp).
   </p>
   <blockquote>
    <p>
-    <code>
-     DESC:Duplicate awakens when original dies.
+    <code>DESC:Duplicate awakens when original dies.
      <br/>
-     COST:1500
-    </code>
+     COST:1500</code>
    </p>
   </blockquote>
   <p>
@@ -700,17 +644,13 @@ creation costs).
   </blockquote>
   <blockquote>
    <p>
-    <code>
-     XPCOST:100
-    </code>
+    <code>XPCOST:100</code>
    </p>
   </blockquote>
   <hr/>
   <p>
    Throw in a
-   <code>
-    SOURCEPAGE
-   </code>
+   <code>SOURCEPAGE</code>
    tag, and basically, that is a
 spell, minus any Temp bonus tags for applying spell effects to
 characters.

--- a/docs/listfilepages/lstfileclass/lfc_lesson08_biosettings.html
+++ b/docs/listfilepages/lstfileclass/lfc_lesson08_biosettings.html
@@ -41,8 +41,7 @@
    </strong>
   </p>
   <p class="indent1">
-   <code>
-    <a href="../systemfilestagpages/systemfilesbiosettingslist.html#ageset">
+   <code><a href="../systemfilestagpages/systemfilesbiosettingslist.html#ageset">
      AGESET
     </a>
     ,
@@ -104,15 +103,12 @@
     ,
     <a href="../systemfilestagpages/systemfilesbiosettingslist.html#skintone">
      SKINTONE
-    </a>
-   </code>
+    </a></code>
   </p>
   <hr/>
   <p>
    <strong>
-    <code>
-     AGESET
-    </code>
+    <code>AGESET</code>
    </strong>
   </p>
   <p>
@@ -125,9 +121,7 @@ adulthood, your first ageset tag would probably look like this:
   </p>
   <blockquote>
    <p>
-    <code>
-     AGESET:0|Adult
-    </code>
+    <code>AGESET:0|Adult</code>
    </p>
   </blockquote>
   <p>
@@ -139,13 +133,11 @@ line for that age group looks like this:
   </p>
   <blockquote>
    <p>
-    <code>
-     AGESET:1|Middle Age &lt;tab&gt;
+    <code>AGESET:1|Middle Age &lt;tab&gt;
      <br/>
      BONUS:STAT|STR,CON,DEX|-1 &lt;tab&gt;
      <br/>
-     BONUS:STAT|INT,WIS,CHA|1
-    </code>
+     BONUS:STAT|INT,WIS,CHA|1</code>
    </p>
   </blockquote>
   <p>
@@ -158,9 +150,7 @@ your character.
   <hr/>
   <p>
    <strong>
-    <code>
-     RACENAME
-    </code>
+    <code>RACENAME</code>
    </strong>
   </p>
   <p>
@@ -185,9 +175,7 @@ affected by whatever information follows this RACENAME tag.
   <hr/>
   <p>
    <strong>
-    <code>
-     BASEAGEADD
-    </code>
+    <code>BASEAGEADD</code>
    </strong>
   </p>
   <p>
@@ -211,9 +199,7 @@ between 1 and 24 to add to the character's base age.
   <hr/>
   <p>
    <strong>
-    <code>
-     CLASS
-    </code>
+    <code>CLASS</code>
    </strong>
   </p>
   <p>
@@ -238,20 +224,16 @@ like:
   </p>
   <blockquote>
    <p>
-    <code>
-     RACENAME:Human% &lt;tab&gt;
+    <code>RACENAME:Human% &lt;tab&gt;
      <br/>
      CLASS:Barbarian,Rogue,Sorcerer[BASEAGEADD:1d4]|Bard,Fighter,Paladin,Ranger[B
-ASEAGEADD:1d6]|Cleric,Druid,Monk,Wizard[BASEAGEADD:2d6]
-    </code>
+ASEAGEADD:1d6]|Cleric,Druid,Monk,Wizard[BASEAGEADD:2d6]</code>
    </p>
   </blockquote>
   <hr/>
   <p>
    <strong>
-    <code>
-     BASEHT
-    </code>
+    <code>BASEHT</code>
    </strong>
   </p>
   <p>
@@ -270,9 +252,7 @@ BASEHT:1.6.
   <hr/>
   <p>
    <strong>
-    <code>
-     HTDIEROLL
-    </code>
+    <code>HTDIEROLL</code>
    </strong>
   </p>
   <p>
@@ -290,9 +270,7 @@ like 1d12, etc.
   <hr/>
   <p>
    <strong>
-    <code>
-     BASEWT
-    </code>
+    <code>BASEWT</code>
    </strong>
   </p>
   <p>
@@ -309,9 +287,7 @@ properly.
   <hr/>
   <p>
    <strong>
-    <code>
-     WTDIEROLL
-    </code>
+    <code>WTDIEROLL</code>
    </strong>
   </p>
   <p>
@@ -329,9 +305,7 @@ like 1d12, etc.
   <hr/>
   <p>
    <strong>
-    <code>
-     TOTALWT
-    </code>
+    <code>TOTALWT</code>
    </strong>
   </p>
   <p>
@@ -348,9 +322,7 @@ the random height and weight rolls.
   <hr/>
   <p>
    <strong>
-    <code>
-     SEX
-    </code>
+    <code>SEX</code>
    </strong>
   </p>
   <p>
@@ -364,20 +336,16 @@ The sub-tags are separated by pipes within the brackets.
   </p>
   <blockquote>
    <p>
-    <code>
-     RACENAME:Human%
+    <code>RACENAME:Human%
      <br/>
      SEX:Male[BASEHT:58|HTDIEROLL:2d10|BASEWT:120|WTDIEROLL:2d4|TOTALWT:BASEWT+(HTDIEROLL*WTDIEROLL)]Female[BASEHT:53|HTDIEROLL:2d10|BASEWT:85|WTDIEROLL
-:2d4|TOTALWT:BASEWT+(HTDIEROLL*WTDIEROLL)]
-    </code>
+:2d4|TOTALWT:BASEWT+(HTDIEROLL*WTDIEROLL)]</code>
    </p>
   </blockquote>
   <hr/>
   <p>
    <strong>
-    <code>
-     BASEAGE
-    </code>
+    <code>BASEAGE</code>
    </strong>
   </p>
   <p>
@@ -393,17 +361,13 @@ see:
   </p>
   <blockquote>
    <p>
-    <code>
-     BASEAGE:35
-    </code>
+    <code>BASEAGE:35</code>
    </p>
   </blockquote>
   <hr/>
   <p>
    <strong>
-    <code>
-     MAXAGE
-    </code>
+    <code>MAXAGE</code>
    </strong>
   </p>
   <p>
@@ -419,17 +383,13 @@ see:
   </p>
   <blockquote>
    <p>
-    <code>
-     MAXAGE:55
-    </code>
+    <code>MAXAGE:55</code>
    </p>
   </blockquote>
   <hr/>
   <p>
    <strong>
-    <code>
-     AGEDIEROLL
-    </code>
+    <code>AGEDIEROLL</code>
    </strong>
   </p>
   <p>
@@ -444,17 +404,13 @@ our tag would look like:
   </p>
   <blockquote>
    <p>
-    <code>
-     AGEDIEROLL:1d20
-    </code>
+    <code>AGEDIEROLL:1d20</code>
    </p>
   </blockquote>
   <hr/>
   <p>
    <strong>
-    <code>
-     HAIR
-    </code>
+    <code>HAIR</code>
    </strong>
   </p>
   <p>
@@ -464,18 +420,14 @@ wish may be used as a hair color.
   </p>
   <blockquote>
    <p>
-    <code>
-     RACENAME:Human% &lt;tab&gt;
-EYES:Hazel|Blue|Brown|Grey|Violet
-    </code>
+    <code>RACENAME:Human% &lt;tab&gt;
+EYES:Hazel|Blue|Brown|Grey|Violet</code>
    </p>
   </blockquote>
   <hr/>
   <p>
    <strong>
-    <code>
-     SKINTONE
-    </code>
+    <code>SKINTONE</code>
    </strong>
   </p>
   <p>
@@ -485,10 +437,8 @@ you wish may be used as a skintone color.
   </p>
   <blockquote>
    <p>
-    <code>
-     RACENAME:Human% &lt;tab&gt;
-SKINTONE:Bronze|Yellow|Red|Pink|Vermillion
-    </code>
+    <code>RACENAME:Human% &lt;tab&gt;
+SKINTONE:Bronze|Yellow|Red|Pink|Vermillion</code>
    </p>
   </blockquote>
   <p>
@@ -497,14 +447,12 @@ SKINTONE:Bronze|Yellow|Red|Pink|Vermillion
   </p>
   <blockquote>
    <p>
-    <code>
-     RACENAME:Human% &lt;tab&gt; HAIR:Blonde|White|Salt &amp;
+    <code>RACENAME:Human% &lt;tab&gt; HAIR:Blonde|White|Salt &amp;
 Pepper|Plaid
      <br/>
      EYES:Hazel|Blue|Brown|Grey|Violet
      <br/>
-     SKINTONE:Bronze|Yellow|Red|Pink|Vermillion
-    </code>
+     SKINTONE:Bronze|Yellow|Red|Pink|Vermillion</code>
    </p>
   </blockquote>
   <p>
@@ -516,8 +464,7 @@ from the SRD would be:
   </p>
   <blockquote>
    <p>
-    <code>
-     AGESET:1|Middle Age BONUS:STAT|STR,CON,DEX|-1
+    <code>AGESET:1|Middle Age BONUS:STAT|STR,CON,DEX|-1
      <br/>
      BONUS:STAT|INT,WIS,CHA|1
      <br/>
@@ -535,8 +482,7 @@ from the SRD would be:
      <br/>
      AGEDIEROLL:(1d10+1d4)
      <br/>
-     RACENAME:Halfling% BASEAGE:50 MAXAGE:74 AGEDIEROLL:4d6
-    </code>
+     RACENAME:Halfling% BASEAGE:50 MAXAGE:74 AGEDIEROLL:4d6</code>
    </p>
   </blockquote>
   <hr/>

--- a/docs/listfilepages/lstfileclass/lfc_lesson09_weaponprofs.html
+++ b/docs/listfilepages/lstfileclass/lfc_lesson09_weaponprofs.html
@@ -41,8 +41,7 @@
    </strong>
   </p>
   <p class="indent1">
-   <code>
-    <a href="../datafilestagpages/datafilesweaponproficiencies.html#type">
+   <code><a href="../datafilestagpages/datafilesweaponproficiencies.html#type">
      TYPE
     </a>
     ,
@@ -53,8 +52,7 @@
     <a href="../datafilestagpages/datafilesweaponproficiencies.html#hands">
      IFLARGERTHANWEAPON
     </a>
-    .
-   </code>
+    .</code>
   </p>
   <p class="indent1">
    The weapon proficiency files are used to set up
@@ -81,9 +79,7 @@ is the name of a weapon proficiency.
   <hr/>
   <p>
    <strong>
-    <code>
-     TYPE
-    </code>
+    <code>TYPE</code>
    </strong>
   </p>
   <p>
@@ -107,9 +103,7 @@ TYPE.
   <hr/>
   <p>
    <strong>
-    <code>
-     HANDS
-    </code>
+    <code>HANDS</code>
    </strong>
   </p>
   <p>
@@ -121,13 +115,9 @@ for a creature that had three hands and required all three to wield
 it properly.
   </p>
   <p>
-   <code>
-    HANDS:1
-   </code>
+   <code>HANDS:1</code>
    and
-   <code>
-    HANDS:2
-   </code>
+   <code>HANDS:2</code>
    are examples of
 the use of this tag.
   </p>
@@ -139,9 +129,7 @@ flag, described below
   <hr/>
   <p>
    <strong>
-    <code>
-     IFLARGERTHANWEAPON
-    </code>
+    <code>IFLARGERTHANWEAPON</code>
    </strong>
   </p>
   <p>
@@ -161,12 +149,10 @@ well):
   <blockquote>
    <p>
     <br/>
-    <code>
-     Bastard Sword (Exotic) TYPE:Exotic
+    <code>Bastard Sword (Exotic) TYPE:Exotic
 HANDS:1IFLARGERTHANWEAPON
      <br/>
-     Bastard Sword (Martial) TYPE:Martial HANDS:2
-    </code>
+     Bastard Sword (Martial) TYPE:Martial HANDS:2</code>
    </p>
   </blockquote>
   <p>

--- a/docs/listfilepages/lstfileclass/lfc_lesson10_languages.html
+++ b/docs/listfilepages/lstfileclass/lfc_lesson10_languages.html
@@ -54,11 +54,9 @@
    </strong>
   </p>
   <p class="indent1">
-   <code>
-    <a href="../datafilestagpages/datafileslanguages.html#type">
+   <code><a href="../datafilestagpages/datafileslanguages.html#type">
      TYPE
-    </a>
-   </code>
+    </a></code>
   </p>
   <hr/>
   <p>
@@ -76,14 +74,10 @@ the language name and a TYPE tag for each one.
   </p>
   <p>
    The language LST files are where the
-   <code>
-    CHOOSE:LANG
-   </code>
+   <code>CHOOSE:LANG</code>
    tag generates its list from when it is invoked. This file also
 tells PCGen, in conjunction with the
-   <code>
-    LANGBONUS
-   </code>
+   <code>LANGBONUS</code>
    tag,
 what languages are available for races to choose from as bonus
 languages based on their primary language stat.
@@ -101,16 +95,12 @@ at the beginning of the line is the name of a language.
   <hr/>
   <p>
    <strong>
-    <code>
-     TYPE
-    </code>
+    <code>TYPE</code>
    </strong>
   </p>
   <p>
    The
-   <code>
-    TYPE
-   </code>
+   <code>TYPE</code>
    tag is used to set the type/group of the
 language. It may take multiple types delimited by periods. The
 types used are usually Spoken, Read, and Written. Some
@@ -118,13 +108,11 @@ examples:
   </p>
   <blockquote>
    <p>
-    <code>
-     English TYPE:Spoken.Read.Written
+    <code>English TYPE:Spoken.Read.Written
      <br/>
      Sign Language TYPE:Spoken.Read
      <br/>
-     Trade Pidgin TYPE:Spoken
-    </code>
+     Trade Pidgin TYPE:Spoken</code>
    </p>
   </blockquote>
   <hr/>

--- a/docs/listfilepages/lstfileclass/lfc_lesson11_kits_default_monster.html
+++ b/docs/listfilepages/lstfileclass/lfc_lesson11_kits_default_monster.html
@@ -54,8 +54,7 @@
    </strong>
   </p>
   <p class="indent1">
-   <code>
-    <a href="../datafilestagpages/datafilesstartingkits.html#startpack">
+   <code><a href="../datafilestagpages/datafilesstartingkits.html#startpack">
      STARTPACK
     </a>
     ,
@@ -101,8 +100,7 @@
     </a>
     <a href="../datafilestagpages/datafilesstartingkits.html#free">
      FREE
-    </a>
-   </code>
+    </a></code>
   </p>
   <hr/>
   <p>
@@ -120,13 +118,9 @@ syntax than other LST files you may already be familiar with.
   </p>
   <p>
    The format for a Kit file is each Kit starts with a
-   <code>
-    STARTPACK
-   </code>
+   <code>STARTPACK</code>
    tag and ends when the code sees another
-   <code>
-    STARTPACK
-   </code>
+   <code>STARTPACK</code>
    tag or the end of file.  Most tags in a
 Kit file appear one to a line as opposed to tab separated as in
 other list files.  However, there are some tags which require
@@ -155,9 +149,7 @@ examples in this lesson as well.
   <p>
    <a href="../datafilestagpages/datafilesstartingkits.html#startpack">
     <strong>
-     <code>
-      STARTPACK
-     </code>
+     <code>STARTPACK</code>
     </strong>
    </a>
   </p>
@@ -171,9 +163,7 @@ beginning of a new Kit.  By convention we use "Default
   </p>
   <blockquote>
    <p>
-    <code>
-     STARTPACK:Default Angel (Solar)
-    </code>
+    <code>STARTPACK:Default Angel (Solar)</code>
    </p>
   </blockquote>
   <p>
@@ -181,24 +171,18 @@ beginning of a new Kit.  By convention we use "Default
   </p>
   <blockquote>
    <p>
-    <code>
-     STARTPACK:Default Ninja Monkey
-    </code>
+    <code>STARTPACK:Default Ninja Monkey</code>
    </p>
   </blockquote>
   <hr/>
   <p>
    <strong>
-    <code>
-     PRExxx
-    </code>
+    <code>PRExxx</code>
    </strong>
   </p>
   <p>
    Several items can appear on a
-   <code>
-    STARTPACK
-   </code>
+   <code>STARTPACK</code>
    line. One
 of those things is a prereq for anyone to be able to take that
 kit.  All global prereqs are allowable on this line.
@@ -212,46 +196,34 @@ don't want those pesky Ninja Monkeys selecting our Default Angel
   <p>
    To do this we will add a
    <a href="../globalfilestagpages/globalfilesprexxx.html#prerace">
-    <code>
-     PRERACE
-    </code>
+    <code>PRERACE</code>
    </a>
    tag to the
-   <code>
-    STARTPACK
-   </code>
+   <code>STARTPACK</code>
    line we started above. So we
 enter a few tabs and type:
   </p>
   <blockquote>
    <p>
-    <code>
-     PRERACE:1,Angel (Solar)
-    </code>
+    <code>PRERACE:1,Angel (Solar)</code>
    </p>
   </blockquote>
   <p>
    However, we also want to allow new characters without a race to
 select this Kit. To do this we need to add a new tag to the
 prereq.  To have multiple prereqs we need to use the
-   <code>
-    PREMULT
-   </code>
+   <code>PREMULT</code>
    .  To specify that only a character
 without a race can select the Kit we use the syntax
 "
-   <code>
-    !PRERACE:%
-   </code>
+   <code>!PRERACE:%</code>
    ".   So the final tag for the Solar
 would be:
   </p>
   <blockquote>
    <p>
-    <code>
-     PREMULT:1,[PRERACE:1,Angel
-(Solar)],[!PRERACE:1,%]
-    </code>
+    <code>PREMULT:1,[PRERACE:1,Angel
+(Solar)],[!PRERACE:1,%]</code>
    </p>
   </blockquote>
   <p>
@@ -259,19 +231,15 @@ would be:
   </p>
   <blockquote>
    <p>
-    <code>
-     PREMULT:1,[PRERACE:1,Ninja
-Monkey],[!PRERACE:1,%]
-    </code>
+    <code>PREMULT:1,[PRERACE:1,Ninja
+Monkey],[!PRERACE:1,%]</code>
    </p>
   </blockquote>
   <hr/>
   <p>
    <a href="../datafilestagpages/datafilesstartingkits.html#equipbuy">
     <strong>
-     <code>
-      EQUIPBUY
-     </code>
+     <code>EQUIPBUY</code>
     </strong>
    </a>
   </p>
@@ -284,34 +252,26 @@ in the race write up for free so we generally want to set this to
   </p>
   <p>
    The code to do this would be (also on the
-   <code>
-    STARTPACK
-   </code>
+   <code>STARTPACK</code>
    line):
   </p>
   <blockquote>
    <p>
-    <code>
-     EQUIPBUY:0
-    </code>
+    <code>EQUIPBUY:0</code>
    </p>
   </blockquote>
   <hr/>
   <p>
    <a href="../datafilestagpages/datafilesstartingkits.html#visible">
     <strong>
-     <code>
-      VISIBLE
-     </code>
+     <code>VISIBLE</code>
     </strong>
    </a>
   </p>
   <p>
    This tag allows us to control the visibility of the Kit in the
 user interface.  This tag is also specified on the
-   <code>
-    STARTPACK
-   </code>
+   <code>STARTPACK</code>
    line. We want anyone who is qualified (met
 the prerequisites we specified earlier) to take the kit to see it
 so we will enter "QUALIFY" as the visibility. We could also specify
@@ -319,26 +279,20 @@ so we will enter "QUALIFY" as the visibility. We could also specify
   </p>
   <blockquote>
    <p>
-    <code>
-     VISIBLE:QUALIFY
-    </code>
+    <code>VISIBLE:QUALIFY</code>
    </p>
   </blockquote>
   <hr/>
   <p>
    <a href="../datafilestagpages/datafilesstartingkits.html#race">
     <strong>
-     <code>
-      RACE
-     </code>
+     <code>RACE</code>
     </strong>
    </a>
   </p>
   <p>
    The next tag we will cover is the
-   <code>
-    RACE
-   </code>
+   <code>RACE</code>
    tag. 
 As you may have guessed this allows us to set the race of the
 character applying the kit.  Now because setting a character's
@@ -350,17 +304,13 @@ the Kit).
   <p>
    This brings up an important point to note, any kit line can be
 qualified with a
-   <code>
-    PREXXX
-   </code>
+   <code>PREXXX</code>
    tag.  In our case we will
 use part of the prereq we entered for race above.
   </p>
   <blockquote>
    <p>
-    <code>
-     RACE:Angel (Solar)&lt;tab&gt;!PRERACE:1,%
-    </code>
+    <code>RACE:Angel (Solar)&lt;tab&gt;!PRERACE:1,%</code>
    </p>
   </blockquote>
   <p>
@@ -373,9 +323,7 @@ race selected.  For the Ninja Monkey just replace Angel
   <p>
    <a href="../datafilestagpages/datafilesstartingkits.html#name">
     <strong>
-     <code>
-      NAME
-     </code>
+     <code>NAME</code>
     </strong>
    </a>
   </p>
@@ -383,25 +331,19 @@ race selected.  For the Ninja Monkey just replace Angel
    Generally, we set the name of the monster character to the name
 of the monster exactly as it appears in the source.  We use
 the
-   <code>
-    NAME
-   </code>
+   <code>NAME</code>
    to accomplish that.
   </p>
   <blockquote>
    <p>
-    <code>
-     NAME:Solar
-    </code>
+    <code>NAME:Solar</code>
    </p>
   </blockquote>
   <hr/>
   <p>
    <a href="../datafilestagpages/datafilesstartingkits.html#gender">
     <strong>
-     <code>
-      GENDER
-     </code>
+     <code>GENDER</code>
     </strong>
    </a>
   </p>
@@ -413,22 +355,16 @@ specify a particular gender so we will skip this tag for them
   <p>
    Just to illustrate if you wanted to create a special female
 version of the Solar you could specify
-   <code>
-    GENDER:Female
-   </code>
+   <code>GENDER:Female</code>
    on either the
-   <code>
-    NAME
-   </code>
+   <code>NAME</code>
    line or on its own line.
   </p>
   <hr/>
   <p>
    <a href="../datafilestagpages/datafilesstartingkits.html#align">
     <strong>
-     <code>
-      ALIGN
-     </code>
+     <code>ALIGN</code>
     </strong>
    </a>
   </p>
@@ -444,9 +380,7 @@ can code that in a Kit as follows:
   </p>
   <blockquote>
    <p>
-    <code>
-     ALIGN:LG|NG|CG
-    </code>
+    <code>ALIGN:LG|NG|CG</code>
    </p>
   </blockquote>
   <p>
@@ -462,18 +396,14 @@ our Default Ninja Monkey.
   </p>
   <blockquote>
    <p>
-    <code>
-     ALIGN:CG
-    </code>
+    <code>ALIGN:CG</code>
    </p>
   </blockquote>
   <hr/>
   <p>
    <a href="../datafilestagpages/datafilesstartingkits.html#stat">
     <strong>
-     <code>
-      STAT
-     </code>
+     <code>STAT</code>
     </strong>
    </a>
   </p>
@@ -492,17 +422,13 @@ preference will be used.
   </p>
   <p>
    Returning to our examples the
-   <code>
-    STAT
-   </code>
+   <code>STAT</code>
    line for the
 Solar would look like:
   </p>
   <blockquote>
    <p>
-    <code>
-     STAT:STR=10|DEX=10|CON=10|INT=11|WIS=11|CHA=11
-    </code>
+    <code>STAT:STR=10|DEX=10|CON=10|INT=11|WIS=11|CHA=11</code>
    </p>
   </blockquote>
   <p>
@@ -511,42 +437,32 @@ Wis 15, Cha 10 so our stat line looks like:
   </p>
   <blockquote>
    <p>
-    <code>
-     STAT:STR=11|DEX=10|CON=10|INT=11|WIS=11|CHA=10
-    </code>
+    <code>STAT:STR=11|DEX=10|CON=10|INT=11|WIS=11|CHA=10</code>
    </p>
   </blockquote>
   <hr/>
   <p>
    <a href="../datafilestagpages/datafilesstartingkits.html#skill">
     <strong>
-     <code>
-      SKILL
-     </code>
+     <code>SKILL</code>
     </strong>
    </a>
    /
    <a href="../datafilestagpages/datafilesstartingkits.html#rank">
     <strong>
-     <code>
-      RANK
-     </code>
+     <code>RANK</code>
     </strong>
    </a>
    /
    <a href="../datafilestagpages/datafilesstartingkits.html#count">
     <strong>
-     <code>
-      COUNT
-     </code>
+     <code>COUNT</code>
     </strong>
    </a>
    /
    <a href="../datafilestagpages/datafilesstartingkits.html#free">
     <strong>
-     <code>
-      FREE
-     </code>
+     <code>FREE</code>
     </strong>
    </a>
   </p>
@@ -555,23 +471,17 @@ Wis 15, Cha 10 so our stat line looks like:
 to buy skill ranks in a skill for the character applying the kit.
 All of the comments under the section for
    <a href="../globalfilestagpages/globalfilesbonus.html#skillrank">
-    <code>
-     BONUS:SKILLRANK
-    </code>
+    <code>BONUS:SKILLRANK</code>
    </a>
    apply here as well, except that the workaround for skills which
 require a choice is not required. To handle a choice of skills in a
 default kit we enter all the choices separated by a pipe (|)
 character. We then use the special tag
-   <code>
-    COUNT
-   </code>
+   <code>COUNT</code>
    to
 specify how many choices from the list the character should get.
 You can specify specific skills or types of skills like
-   <code>
-    TYPE=Knowledge
-   </code>
+   <code>TYPE=Knowledge</code>
    .
   </p>
   <p>
@@ -581,9 +491,7 @@ to buy the listed skills. Occasionally a source will grant more
 ranks than the monster can actually pay for. In these cases you
 have two options. You can either not grant the ranks and note that
 the source appears to be in error or you can use the
-   <code>
-    FREE:YES
-   </code>
+   <code>FREE:YES</code>
    tag on the
    <strong>
     SKILL
@@ -604,15 +512,12 @@ Rank" setting in the PCGen preferences.
    With all that being said our we would add the following lines to
 our Solar kit (each SKILL/RANK pair should be on a new line,
 replace
-   <code>
-    TAB
-   </code>
+   <code>TAB</code>
    with a real tab character):
   </p>
   <blockquote>
    <p>
-    <code>
-     SKILL:Diplomacy &lt;tab&gt; RANK:23
+    <code>SKILL:Diplomacy &lt;tab&gt; RANK:23
      <br/>
      SKILL:Concentration &lt;tab&gt; RANK:25
      <br/>
@@ -634,8 +539,7 @@ replace
      <br/>
      SKILL:TYPE=Knowledge|TYPE=Craft &lt;tab&gt; RANK:25
 &lt;tab&gt; COUNT:5
-     <br/>
-    </code>
+     <br/></code>
    </p>
   </blockquote>
   <p>
@@ -643,46 +547,36 @@ replace
   </p>
   <blockquote>
    <p>
-    <code>
-     SKILL:Hide &lt;tab&gt; RANK:4
+    <code>SKILL:Hide &lt;tab&gt; RANK:4
      <br/>
      SKILL:Listen &lt;tab&gt; RANK:3
      <br/>
      SKILL:Move Silently &lt;tab&gt; RANK:4
      <br/>
      SKILL:Spot &lt;tab&gt; RANK:3
-     <br/>
-    </code>
+     <br/></code>
    </p>
   </blockquote>
   <hr/>
   <p>
    <a href="../datafilestagpages/datafilesstartingkits.html#feat">
     <strong>
-     <code>
-      FEAT
-     </code>
+     <code>FEAT</code>
     </strong>
    </a>
    /
    <a href="../datafilestagpages/datafilesstartingkits.html#free">
     <strong>
-     <code>
-      FREE
-     </code>
+     <code>FREE</code>
     </strong>
    </a>
   </p>
   <p>
    The
-   <code>
-    FEAT
-   </code>
+   <code>FEAT</code>
    tag is a very simple one. It simply lists
 each feat a creature gets one to a line. The
-   <code>
-    FREE:YES
-   </code>
+   <code>FREE:YES</code>
    tag can be added to the
    <strong>
     FEAT
@@ -701,8 +595,7 @@ has more feats than it should for its HD.
   </p>
   <blockquote>
    <p>
-    <code>
-     FEAT:Cleave
+    <code>FEAT:Cleave
      <br/>
      FEAT:Dodge
      <br/>
@@ -713,61 +606,46 @@ has more feats than it should for its HD.
      FEAT:Mobility
      <br/>
      FEAT:Power Attack
-     <br/>
-    </code>
+     <br/></code>
    </p>
   </blockquote>
   <hr/>
   <p>
    <a href="../datafilestagpages/datafilesstartingkits.html#gear">
     <strong>
-     <code>
-      GEAR
-     </code>
+     <code>GEAR</code>
     </strong>
    </a>
    /
    <a href="../datafilestagpages/datafilesstartingkits.html#eqmod">
     <strong>
-     <code>
-      EQMOD
-     </code>
+     <code>EQMOD</code>
     </strong>
    </a>
    /
    <a href="../datafilestagpages/datafilesstartingkits.html#size">
     <strong>
-     <code>
-      SIZE
-     </code>
+     <code>SIZE</code>
     </strong>
    </a>
    /
    <a href="../datafilestagpages/datafilesstartingkits.html#location">
     <strong>
-     <code>
-      LOCATION
-     </code>
+     <code>LOCATION</code>
     </strong>
    </a>
   </p>
   <p>
    The last set of tags we need to cover to complete our Solar and
 Ninja Monkey examples are the
-   <code>
-    GEAR
-   </code>
+   <code>GEAR</code>
    tags.  The
 Solar gets two pieces of equipment by default, a +5 dancing vorpal
 greatsword and a +2 mighty (+5 Str) composite longbow.  To
 enter this into the kit we first grant the base item with the
-   <code>
-    GEAR
-   </code>
+   <code>GEAR</code>
    tag like so:
-   <code>
-    GEAR:Greatsword
-   </code>
+   <code>GEAR:Greatsword</code>
    .
   </p>
   <p>
@@ -797,9 +675,7 @@ the following code to the
    </strong>
    line we created
 earlier:
-   <code>
-    EQMOD:MWORKW.PLUS5W.DANCE.VORPAL
-   </code>
+   <code>EQMOD:MWORKW.PLUS5W.DANCE.VORPAL</code>
    .
   </p>
   <p>
@@ -808,23 +684,15 @@ the creature we are creating.  By default, PCGen creates all
 items at Medium size.  Our Solar however is a Large size
 creature so we want his greatsword to be Large as well.  We
 can do this with the
-   <code>
-    SIZE
-   </code>
+   <code>SIZE</code>
    tag.  The
-   <code>
-    SIZE
-   </code>
+   <code>SIZE</code>
    tag takes the single character abbreviation for
 size or a special tag
-   <code>
-    PC
-   </code>
+   <code>PC</code>
    to size the item to whatever
 size the character is.  We will add the
-   <code>
-    SIZE:PC
-   </code>
+   <code>SIZE:PC</code>
    tag to our
    <strong>
     GEAR
@@ -838,22 +706,16 @@ not equip the item the gear will be added to the character as a
 possession but will not be used.  This could be useful for
 items left in the monster's lair but in our case we actually want
 the Solar to use its greatsword.  To do this we use the
-   <code>
-    LOCATION
-   </code>
+   <code>LOCATION</code>
    tag.  This tag uses the same locations
 as you would see in the user interface when equipping an
 item.  A greatsword is a two-handed weapon so it can only be
 equipped to one place "Both Hands".  We add the tag
-   <code>
-    LOCATION:Both Hands
-   </code>
+   <code>LOCATION:Both Hands</code>
    .  For items that are not
 weapons that can only be equipped to one place on the body (like a
 ring) you can simply specify "Equipped" in the
-   <code>
-    LOCATION
-   </code>
+   <code>LOCATION</code>
    tag and PCGen will equip it to the correct
 location.
   </p>
@@ -863,14 +725,12 @@ equipment will look like this:
   </p>
   <blockquote>
    <p>
-    <code>
-     GEAR:Greatsword &lt;tab&gt;
+    <code>GEAR:Greatsword &lt;tab&gt;
 EQMOD:MWORKW.PLUS5W.DANCE.VORPAL &lt;tab&gt; SIZE:PC &lt;tab&gt;
 LOCATION:Both Hands
      <br/>
      GEAR:Longbow (Composite) &lt;tab&gt; EQMOD:MWORKW.BOWSTR|5.PLUS2W
-&lt;tab&gt; SIZE:PC &lt;tab&gt; LOCATION:Carried
-    </code>
+&lt;tab&gt; SIZE:PC &lt;tab&gt; LOCATION:Carried</code>
    </p>
   </blockquote>
   <hr/>

--- a/docs/listfilepages/lstfileclass/lfc_lesson12_feat1.html
+++ b/docs/listfilepages/lstfileclass/lfc_lesson12_feat1.html
@@ -43,8 +43,7 @@
    </strong>
   </p>
   <p class="indent1">
-   <code>
-    <a href="../globalfilestagpages/globalfilesother.html#outputname">
+   <code><a href="../globalfilestagpages/globalfilesother.html#outputname">
      OUTPUTNAME
     </a>
     ,
@@ -98,8 +97,7 @@
     ,
     <a href="../globalfilestagpages/globalfilesother.html#sourceshort">
      SOURCEPAGE
-    </a>
-   </code>
+    </a></code>
   </p>
   <hr/>
   <p>
@@ -174,9 +172,7 @@ characters in it to get around the issues.
    So, as an example of OUTPUTNAME use, if we wanted the name on
 output to be "Critical (Improved)", we could cause it to happen by
 entering
-   <code>
-    OUTPUTNAME:Critical (Improved)
-   </code>
+   <code>OUTPUTNAME:Critical (Improved)</code>
    . Note that
 there is a preference setting that turns off output names so the
 user may not see it if they have elected to turn them off.
@@ -196,9 +192,7 @@ skip an OUTPUTNAME tag on this one.
 first and most obvious is to set the feat type as indicated by the
 source. Another use of it is for internal program use to group a
 set of feats together for later selection by an
-   <code>
-    ADD:FEAT(TYPE=type)
-   </code>
+   <code>ADD:FEAT(TYPE=type)</code>
    tag elsewhere. This is especially
 useful when you have several benefits that a PC can choose from.
 These TYPEs can also be used in separating feats for display in
@@ -224,9 +218,7 @@ those listed above are just ones you might commonly see.
   <p>
    Looking at the RSRD, Improved Critical is a General feat and a
 Fighter feat, so we enter
-   <code>
-    TYPE:General.Fighter
-   </code>
+   <code>TYPE:General.Fighter</code>
   </p>
   <hr/>
   <p>
@@ -269,9 +261,7 @@ UI.
 section of a data source, it should be VISIBLE:YES (or leave out
 the VISIBLE tag so it defaults to YES). If it's not listed as a
 feat in the source, it should be
-   <code>
-    VISIBLE:NO
-   </code>
+   <code>VISIBLE:NO</code>
    . The
 EXPORT and DISPLAY options are used for special cases where we need
 to something very strange... :)
@@ -300,9 +290,7 @@ feat also.
   <p>
    According to the RSRD, Improved Critical can be taken more than
 once, so we'll use
-   <code>
-    MULT:YES
-   </code>
+   <code>MULT:YES</code>
    .
   </p>
   <hr/>
@@ -324,9 +312,7 @@ you in the "Special" section of the feat description.
    According to the RSRD, Improved Critical does not stack with
 itself (you can take it again but must choose a different weapon)
 so we need to put
-   <code>
-    STACK:NO
-   </code>
+   <code>STACK:NO</code>
    in the feat line.
   </p>
   <hr/>
@@ -438,11 +424,9 @@ shorter) text from the DESC tag will be displayed.
   </p>
   <p>
    For the Improved Critical feat we would enter
-   <code>
-    BENEFIT:When
+   <code>BENEFIT:When
 using the weapon you selected, your threat range is
-doubled.
-   </code>
+doubled.</code>
   </p>
   <p>
    Note that it is quite common to leave this tag out so as to
@@ -480,10 +464,8 @@ practice CMP has adopted for this tag).
   </p>
   <p>
    Since we are using the RSRD for our example, the tag would be
-   <code>
-    SOURCELONG:Revised (v.3.5) System Reference
-Document
-   </code>
+   <code>SOURCELONG:Revised (v.3.5) System Reference
+Document</code>
   </p>
   <hr/>
   <p>
@@ -520,9 +502,7 @@ tag is encountered, or it may be placed on each feat line.
   </p>
   <p>
    In the case of the RSRD, the tag would be
-   <code>
-    SOURCEWEB:http://www.wizards.com/default.asp?x=d20/article/srd35
-   </code>
+   <code>SOURCEWEB:http://www.wizards.com/default.asp?x=d20/article/srd35</code>
   </p>
   <hr/>
   <p>
@@ -538,20 +518,14 @@ using the SOURCEPAGE output token.
   </p>
   <p>
    When you are going from an OGL book the format is usually
-   <code>
-    SOURCEPAGE:p.#
-   </code>
+   <code>SOURCEPAGE:p.#</code>
    . If you are working from an online
 document such as the SRD, it would be the filename, so
-   <code>
-    SOURCEPAGE:&lt;filename&gt;
-   </code>
+   <code>SOURCEPAGE:&lt;filename&gt;</code>
   </p>
   <p>
    Since we are working from the RSRD, our tag will look like
-   <code>
-    SOURCEPAGE:Feats.rtf
-   </code>
+   <code>SOURCEPAGE:Feats.rtf</code>
   </p>
   <hr/>
   <p>
@@ -568,8 +542,7 @@ feat so far (new lines should tab characters):
   </p>
   <blockquote>
    <p>
-    <code>
-     Improved Critical
+    <code>Improved Critical
      <br/>
      TYPE:General.Fighter
      <br/>
@@ -594,8 +567,7 @@ doubled.
       http://www.wizards.com/default.asp?x=d20/article/srd35
      </a>
      <br/>
-     SOURCEPAGE:Feats.rtf
-    </code>
+     SOURCEPAGE:Feats.rtf</code>
    </p>
   </blockquote>
   <p>

--- a/docs/listfilepages/lstfileclass/lfc_lesson13_feat2.html
+++ b/docs/listfilepages/lstfileclass/lfc_lesson13_feat2.html
@@ -274,18 +274,14 @@ follows:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PREALIGN:LG,CG
-   </code>
+   <code>PREALIGN:LG,CG</code>
   </p>
   <p class="indent3">
    Must be Lawful Good or Chaotic Good
 alignment
   </p>
   <p class="indent2">
-   <code>
-    PREALIGN:Deity
-   </code>
+   <code>PREALIGN:Deity</code>
   </p>
   <p class="indent3">
    Character's alignment must match that of their
@@ -313,9 +309,7 @@ standard format. It takes the form of PREATT:#.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PREATT:3
-   </code>
+   <code>PREATT:3</code>
   </p>
   <p class="indent3">
    Characters BAB must be 3 or greater
@@ -349,9 +343,7 @@ the ones defined in your gamemode files or the tag will fail.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRECHECKBASE:1,Fortitude=1,Reflex=3
-   </code>
+   <code>PRECHECKBASE:1,Fortitude=1,Reflex=3</code>
   </p>
   <p class="indent3">
    Would evaluate as true if the character's base
@@ -359,9 +351,7 @@ Fortitude meets or exceeds 5 or their base Reflex meets or exceeds
 3
   </p>
   <p class="indent2">
-   <code>
-    PRECHECK:2,Fortitude=2,Will=2,Reflex=2
-   </code>
+   <code>PRECHECK:2,Fortitude=2,Will=2,Reflex=2</code>
   </p>
   <p class="indent3">
    Would evaluate as true if any 2 of the 3 three
@@ -392,26 +382,20 @@ or SPELLCASTER.Divine).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRECLASS:1,Fighter=3
-   </code>
+   <code>PRECLASS:1,Fighter=3</code>
   </p>
   <p class="indent3">
    Must have three levels in the Fighter class
   </p>
   <p class="indent2">
-   <code>
-    PRECLASS:2,TYPE.Prestige=1,SPELLCASTER=3
-   </code>
+   <code>PRECLASS:2,TYPE.Prestige=1,SPELLCASTER=3</code>
   </p>
   <p class="indent3">
    Must have one Prestige level and three levels in
 a spellcasting class
   </p>
   <p class="indent2">
-   <code>
-    PRECLASS:1,SPELLCASTER.Arcane=1
-   </code>
+   <code>PRECLASS:1,SPELLCASTER.Arcane=1</code>
   </p>
   <p class="indent3">
    Must have one level in an arcane casting
@@ -447,18 +431,14 @@ game mode files.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PREEQUIP:1,Longsword
-   </code>
+   <code>PREEQUIP:1,Longsword</code>
   </p>
   <p class="indent3">
    Must have an item with the exact name "Longsword
 equipped.
   </p>
   <p class="indent2">
-   <code>
-    PREEQUIP:2,TYPE=Armor,TYPE=Shield
-   </code>
+   <code>PREEQUIP:2,TYPE=Armor,TYPE=Shield</code>
   </p>
   <p class="indent3">
    Must have both a piece of equipment with "Armor"
@@ -466,9 +446,7 @@ contained in its TYPE tag and one with "Shield" contained in its
 TYPE tag equipped.
   </p>
   <p class="indent2">
-   <code>
-    PREEQUIP:1,WIELDCATEGORY=OneHanded
-   </code>
+   <code>PREEQUIP:1,WIELDCATEGORY=OneHanded</code>
   </p>
   <p class="indent3">
    Must have a weapon equipped that has a wield
@@ -517,45 +495,35 @@ name (with no space in between).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PREFEAT:1,Dodge,Combat Reflexes
-   </code>
+   <code>PREFEAT:1,Dodge,Combat Reflexes</code>
   </p>
   <p class="indent3">
    Must have the Dodge feat or the Combat Reflexes
 feat
   </p>
   <p class="indent2">
-   <code>
-    PREFEAT:2,TYPE=Fighter
-   </code>
+   <code>PREFEAT:2,TYPE=Fighter</code>
   </p>
   <p class="indent3">
    Must have two feats with a type of Fighter
   </p>
   <p class="indent2">
-   <code>
-    PREFEAT:2,CHECKMULT,Spell Focus
-   </code>
+   <code>PREFEAT:2,CHECKMULT,Spell Focus</code>
   </p>
   <p class="indent3">
    Must have any two Spell Focus feats
   </p>
   <p class="indent2">
-   <code>
-    PREFEAT:1,Spell
-Focus(Evocation)
-   </code>
+   <code>PREFEAT:1,Spell
+Focus(Evocation)</code>
   </p>
   <p class="indent3">
    Must have Spell Focus in the Evocation
 school
   </p>
   <p class="indent2">
-   <code>
-    PREFEAT:2,CHECKMULT,Spell Focus,[Spell
-Focus(Evocation)
-   </code>
+   <code>PREFEAT:2,CHECKMULT,Spell Focus,[Spell
+Focus(Evocation)</code>
   </p>
   <p class="indent3">
    Must have two Spell Focus feats, and *not* have
@@ -585,20 +553,14 @@ definition file). If you use the name option you may use a wildcard
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PREITEM:1,Longsword
-   </code>
+   <code>PREITEM:1,Longsword</code>
   </p>
   <p class="indent3">
-   <code>
-    Must have an item named
-"Longsword"
-   </code>
+   <code>Must have an item named
+"Longsword"</code>
   </p>
   <p class="indent2">
-   <code>
-    PREITEM:1,Longsword %
-   </code>
+   <code>PREITEM:1,Longsword %</code>
   </p>
   <p class="indent3">
    Must have an item that has Longsword as the
@@ -606,17 +568,13 @@ beginning of the name. This would match "Longsword +1" and
 "Longsword (Soulstealer)" but not "Soulstealer Longsword"
   </p>
   <p class="indent2">
-   <code>
-    PREITEM:2,Longsword,Shortsword
-   </code>
+   <code>PREITEM:2,Longsword,Shortsword</code>
   </p>
   <p class="indent3">
    Must have a "Longsword" and a "Shortsword"
   </p>
   <p class="indent2">
-   <code>
-    PREITEM:2,TYPE=Sword,TYPE=Sword
-   </code>
+   <code>PREITEM:2,TYPE=Sword,TYPE=Sword</code>
   </p>
   <p class="indent3">
    Must have two different items that have "Sword"
@@ -643,9 +601,7 @@ the PRExxx.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRELEVEL:4
-   </code>
+   <code>PRELEVEL:4</code>
   </p>
   <p class="indent3">
    Character must have at least four levels between
@@ -676,9 +632,7 @@ show in red on your feat list in the GUI).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRELEVELMAX:3
-   </code>
+   <code>PRELEVELMAX:3</code>
   </p>
   <p class="indent3">
    Character may not have more than three character
@@ -702,18 +656,14 @@ PREMOVE:#,&lt;movementtype&gt;=&lt;movementrate&gt;,etc.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PREMOVE:1,Climb=10,Brachiate=10
-   </code>
+   <code>PREMOVE:1,Climb=10,Brachiate=10</code>
   </p>
   <p class="indent3">
    Character must have a Climb movement rate of 10'
 or more or a Brachiate movement rate of 10' or more
   </p>
   <p class="indent2">
-   <code>
-    PREMOVE:2,Walk=30,Fly=30
-   </code>
+   <code>PREMOVE:2,Walk=30,Fly=30</code>
   </p>
   <p class="indent3">
    Character must have both a Walk movement rate of
@@ -747,17 +697,13 @@ the other bracketed PRExxx conditions you need to meet.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PREMULT:1,[PREFEAT:1,Dodge],[PRESTAT:1,DEX=15]
-   </code>
+   <code>PREMULT:1,[PREFEAT:1,Dodge],[PRESTAT:1,DEX=15]</code>
   </p>
   <p class="indent3">
    Must have the Dodge feat or a Dex of 15
   </p>
   <p class="indent2">
-   <code>
-    PREMULT:1,[PREMULT:2,[PREATT:3],[PRESTAT:1,STR=15]],[PREFEAT:1,CombatExpertise]
-   </code>
+   <code>PREMULT:1,[PREMULT:2,[PREATT:3],[PRESTAT:1,STR=15]],[PREFEAT:1,CombatExpertise]</code>
   </p>
   <p class="indent3">
    Must have Strength of 15 and a base attack bonus
@@ -791,34 +737,26 @@ brackets around it.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRERACE:1,Dwarf
-   </code>
+   <code>PRERACE:1,Dwarf</code>
   </p>
   <p class="indent3">
    Must be a Dwarf
   </p>
   <p class="indent2">
-   <code>
-    PRERACE:2,RACETYPE=Undead,RACESUBTYPE=Incorporeal
-   </code>
+   <code>PRERACE:2,RACETYPE=Undead,RACESUBTYPE=Incorporeal</code>
   </p>
   <p class="indent3">
    Must have both a race type of "Undead" and a
 subtype of "Incorporeal"
   </p>
   <p class="indent2">
-   <code>
-    PRERACE:1,RACETYPE=Giant
-   </code>
+   <code>PRERACE:1,RACETYPE=Giant</code>
   </p>
   <p class="indent3">
    Must have a race type of "Giant"
   </p>
   <p class="indent2">
-   <code>
-    PRERACE:1,Elf%,[Elf (High)]
-   </code>
+   <code>PRERACE:1,Elf%,[Elf (High)]</code>
   </p>
   <p class="indent3">
    Must be one of the "Elf" races, except
@@ -873,17 +811,13 @@ It is PRESIZE&lt;suffix&gt;:&lt;sizeidentifier&gt;
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRESIZEEQ:L
-   </code>
+   <code>PRESIZEEQ:L</code>
   </p>
   <p class="indent3">
    MUst be Large size
   </p>
   <p class="indent2">
-   <code>
-    PRESIZEGTEQ:H
-   </code>
+   <code>PRESIZEGTEQ:H</code>
   </p>
   <p class="indent3">
    Must be of Huge size or greater
@@ -911,27 +845,21 @@ specify the skills by exact name or by TYPE.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRESKILL:1,Spot=10
-   </code>
+   <code>PRESKILL:1,Spot=10</code>
   </p>
   <p class="indent3">
    Must have ten ranks in the Spot skill
   </p>
   <p class="indent2">
-   <code>
-    PRESKILL:1,Spot,Listen=10
-   </code>
+   <code>PRESKILL:1,Spot,Listen=10</code>
   </p>
   <p class="indent3">
    Must have ten ranks in the Spot or Listen
 skill
   </p>
   <p class="indent2">
-   <code>
-    PRESKILL:2,TYPE.Perform,Perform
-(Dance)=5
-   </code>
+   <code>PRESKILL:2,TYPE.Perform,Perform
+(Dance)=5</code>
   </p>
   <p class="indent3">
    Must have 5 ranks in Perform (Dance) and 5 ranks
@@ -965,18 +893,14 @@ PRESPELLTYPE:&lt;spelltype&gt;,&lt;numberofspells&gt;,&lt;spelllevel&gt;.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRESPELLTYPE:Arcane,2,3
-   </code>
+   <code>PRESPELLTYPE:Arcane,2,3</code>
   </p>
   <p class="indent3">
    Must know at least two third level Arcane
 spells
   </p>
   <p class="indent2">
-   <code>
-    PRESPELLTYPE:Divine,1,4
-   </code>
+   <code>PRESPELLTYPE:Divine,1,4</code>
   </p>
   <p class="indent3">
    Must know at least one fourth level Divine
@@ -1007,26 +931,20 @@ the above mentioned game mode file.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRESTAT:1,STR=15
-   </code>
+   <code>PRESTAT:1,STR=15</code>
   </p>
   <p class="indent3">
    Must have a strength of at least 15
   </p>
   <p class="indent2">
-   <code>
-    PRESTAT:2,STR=12,DEX=13
-   </code>
+   <code>PRESTAT:2,STR=12,DEX=13</code>
   </p>
   <p class="indent3">
    Must have a strength of 12 or more *and* a
 dexterity of 13 or more
   </p>
   <p class="indent2">
-   <code>
-    PRESTAT:1,INT=12,WIS=12
-   </code>
+   <code>PRESTAT:1,INT=12,WIS=12</code>
   </p>
   <p class="indent3">
    Must have an intelligence of 12 or more *or* a
@@ -1059,10 +977,8 @@ template.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PRETEXT:Must be a member of the Church of
-the Ninja Monkey
-   </code>
+   <code>PRETEXT:Must be a member of the Church of
+the Ninja Monkey</code>
   </p>
   <hr/>
   <p class="indent1">
@@ -1098,25 +1014,19 @@ PREVAR&lt;suffix&gt;:&lt;varname&gt;,&lt;value&gt;
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PREVARLT:SPELLFAILURE,10
-   </code>
+   <code>PREVARLT:SPELLFAILURE,10</code>
   </p>
   <p class="indent3">
    Spell failure must be less than ten
   </p>
   <p class="indent2">
-   <code>
-    PREVARGTEQ:RageTimes,2
-   </code>
+   <code>PREVARGTEQ:RageTimes,2</code>
   </p>
   <p class="indent3">
    RageTimes variable must be two or more
   </p>
   <p class="indent2">
-   <code>
-    PREVARGT:TurnUndeadTimes,2,SneakAttack,3
-   </code>
+   <code>PREVARGT:TurnUndeadTimes,2,SneakAttack,3</code>
   </p>
   <p class="indent3">
    TurnUneadTimes variable must be greater than two
@@ -1146,8 +1056,7 @@ characters):
   </p>
   <blockquote>
    <p>
-    <code>
-     Improved Critical
+    <code>Improved Critical
      <br/>
      TYPE:General.Fighter
      <br/>
@@ -1171,8 +1080,7 @@ doubled.
      <br/>
      SOURCEWEB:http://www.wizards.com/default.asp?x=d20/article/srd35
      <br/>
-     SOURCEPAGE:Feats.rtf
-    </code>
+     SOURCEPAGE:Feats.rtf</code>
    </p>
   </blockquote>
   <p class="indent1">

--- a/docs/listfilepages/lstfileclass/lfc_lesson14_deities.html
+++ b/docs/listfilepages/lstfileclass/lfc_lesson14_deities.html
@@ -48,8 +48,7 @@ Gwaith)
    </b>
   </p>
   <p class="indent1">
-   <code>
-    <a href="../datafilestagpages/datafilesdeities.html#domains">
+   <code><a href="../datafilestagpages/datafilesdeities.html#domains">
      DOMAINS
     </a>
     ,
@@ -83,8 +82,7 @@ Gwaith)
     ,
     <a href="../globalfilestagpages/globalfilesother.html#sourcepage">
      SOURCEPAGE
-    </a>
-   </code>
+    </a></code>
   </p>
   <hr/>
   <p class="indent0">
@@ -306,15 +304,11 @@ of a deity. This means that the entries into our data file begin as
 follows:
   </p>
   <p class="indent1">
-   <code>
-    MoSaT
-   </code>
+   <code>MoSaT</code>
    &lt;TAB&gt;
   </p>
   <p class="indent1">
-   <code>
-    Thalia
-   </code>
+   <code>Thalia</code>
    &lt;TAB&gt;
   </p>
   <hr/>
@@ -325,9 +319,7 @@ follows:
    <strong>
     Tag Format:
    </strong>
-   <code>
-    DOMAINS:&lt;domain list&gt;
-   </code>
+   <code>DOMAINS:&lt;domain list&gt;</code>
   </p>
   <p class="indent0">
    This tag sets the domains the deity makes
@@ -341,35 +333,25 @@ important that the domains listed must be defined in a
 When making your own deity, you may include as many domains as you
 wish, though prudence may dictate limiting the number for if a
 deity has all domains, which can be done by simply using
-   <code>
-    ALL
-   </code>
+   <code>ALL</code>
    as the sole argument, there is no need for
 additional deities, and what fun would that be.
   </p>
   <p class="indent0">
    The
-   <code>
-    PRExxx
-   </code>
+   <code>PRExxx</code>
    tag may be used as an
 optional tag added at the end of the domain list, separated by a
 pipe (|). These prerequisites are checked against the divine caster
 to determine if he/she is allowed to select the domains listed in
 that particular
-   <code>
-    DOMAINS
-   </code>
+   <code>DOMAINS</code>
    tag. Typically, the
-   <code>
-    PREALIGN
-   </code>
+   <code>PREALIGN</code>
    tag is used to restrict what alignments a
 cleric/class with access to domains can be to have access to the
 domains. For more depth on
-   <code>
-    PREALIGN
-   </code>
+   <code>PREALIGN</code>
    syntax and usage
 itself, scroll down a bit. It can be used by itself on the line
 (with slightly different meaning for the user) and is explained
@@ -377,9 +359,7 @@ more in depth there.
   </p>
   <p class="indent0">
    PCGen provides some flexibility in how the
-   <code>
-    DOMAINS
-   </code>
+   <code>DOMAINS</code>
    tags are applied, allowing some fairly complex
 application, but most usage of this tag is fairly simple so you
 might just skip over the next paragraph. On the other, if you wish
@@ -388,60 +368,38 @@ started.
   </p>
   <p class="indent0">
    When using the
-   <code>
-    PRExxx
-   </code>
+   <code>PRExxx</code>
    tags at the
 end of the
-   <code>
-    DOMAINS
-   </code>
+   <code>DOMAINS</code>
    tag, all domains listed in that tag
 will be restricted if the
-   <code>
-    PRExxx
-   </code>
+   <code>PRExxx</code>
    tag isn't satisfied.
 Fortunately, PCGen allows the placement of multiple
-   <code>
-    DOMAINS
-   </code>
+   <code>DOMAINS</code>
    tags in the same deity line, and each
-   <code>
-    DOMAINS
-   </code>
+   <code>DOMAINS</code>
    tag can have its own
-   <code>
-    PRExxx
-   </code>
+   <code>PRExxx</code>
    tag,
 or none at all. With multiple
-   <code>
-    DOMAINS
-   </code>
+   <code>DOMAINS</code>
    tags, the
-   <code>
-    PRExxx
-   </code>
+   <code>PRExxx</code>
    tags are applied only to the domains included
 in that specific
-   <code>
-    DOMAINS
-   </code>
+   <code>DOMAINS</code>
    tag but all domains included
 in each
-   <code>
-    DOMAINS
-   </code>
+   <code>DOMAINS</code>
    tags are made available to the divine
 caster, that is if the appropriate prerequisites have been
 satisfied.
   </p>
   <p class="indent0">
    At this point we are ready to build the
-   <code>
-    DOMAINS
-   </code>
+   <code>DOMAINS</code>
    tags for our two example deities.
   </p>
   <p class="indent0">
@@ -462,9 +420,7 @@ having the domains of
     Animal
    </span>
    , so this tag will appear as
-   <code>
-    DOMAINS:Chaos,Knowledge,Animal
-   </code>
+   <code>DOMAINS:Chaos,Knowledge,Animal</code>
    . If we wish to restrict
 the selection of the
    <span class="lstobj">
@@ -472,17 +428,11 @@ the selection of the
    </span>
    domain to
 only those divine casters who are chaotic, we can break the
-   <code>
-    DOMAINS
-   </code>
+   <code>DOMAINS</code>
    tag into the following two tags:
-   <code>
-    DOMAINS:Chaos|PREALIGN:CG,CN
-   </code>
+   <code>DOMAINS:Chaos|PREALIGN:CG,CN</code>
    &lt;tab&gt;
-   <code>
-    DOMAINS:Knowledge,Animal
-   </code>
+   <code>DOMAINS:Knowledge,Animal</code>
    .
   </p>
   <p class="indent0">
@@ -503,9 +453,7 @@ having the domains of
     Poetry
    </span>
    , so this tag will appear as
-   <code>
-    DOMAINS:Good,Knowledge,Poetry
-   </code>
+   <code>DOMAINS:Good,Knowledge,Poetry</code>
    . If we wish to restrict
 the selection of the
    <span class="lstobj">
@@ -513,17 +461,11 @@ the selection of the
    </span>
    domain to
 only those divine casters who are good, we can break the
-   <code>
-    DOMAINS
-   </code>
+   <code>DOMAINS</code>
    tag into the following two tags:
-   <code>
-    DOMAINS:Good|PREALIGN:LG,NG,CG
-   </code>
+   <code>DOMAINS:Good|PREALIGN:LG,NG,CG</code>
    &lt;tab&gt;
-   <code>
-    DOMAINS:Knowledge,Poetry
-   </code>
+   <code>DOMAINS:Knowledge,Poetry</code>
   </p>
   <p class="indent0">
    <strong>
@@ -531,78 +473,48 @@ only those divine casters who are good, we can break the
    </strong>
   </p>
   <p class="indent1">
-   <code>
-    MoSaT
-   </code>
+   <code>MoSaT</code>
    &lt;TAB&gt; . . .
 &lt;TAB&gt;
-   <code>
-    DOMAINS:Chaos,Knowledge,Animal
-   </code>
+   <code>DOMAINS:Chaos,Knowledge,Animal</code>
    (without the
-   <code>
-    PRExxx
-   </code>
+   <code>PRExxx</code>
    tags.)
   </p>
   <p class="indent1">
-   <code>
-    MoSaT
-   </code>
+   <code>MoSaT</code>
    &lt;TAB&gt; . . . &lt;TAB&gt;
-   <code>
-    DOMAINS:Chaos|PREALIGN:CG,CN
-   </code>
+   <code>DOMAINS:Chaos|PREALIGN:CG,CN</code>
    &lt;tab&gt;
-   <code>
-    DOMAINS:Knowledge,Animal
-   </code>
+   <code>DOMAINS:Knowledge,Animal</code>
    (With the
-   <code>
-    PRExxx
-   </code>
+   <code>PRExxx</code>
    tag.)
   </p>
   <p class="indent1">
-   <code>
-    Thalia
-   </code>
+   <code>Thalia</code>
    &lt;TAB&gt; . . . &lt;TAB
 &gt;
-   <code>
-    DOMAINS:Good,Knowledge,Poetry
-   </code>
+   <code>DOMAINS:Good,Knowledge,Poetry</code>
    (without
-   <code>
-    PRExxx
-   </code>
+   <code>PRExxx</code>
    tags.)
   </p>
   <p class="indent1">
-   <code>
-    Thalia
-   </code>
+   <code>Thalia</code>
    &lt;TAB&gt; . . .
 &lt;TAB&gt;
-   <code>
-    DOMAINS:Good|PREALIGN:LG,NG,CG
-   </code>
+   <code>DOMAINS:Good|PREALIGN:LG,NG,CG</code>
    &lt;tab&gt;
-   <code>
-    DOMAINS:Knowledge,Poetry
-   </code>
+   <code>DOMAINS:Knowledge,Poetry</code>
    (with
-   <code>
-    PRExxx
-   </code>
+   <code>PRExxx</code>
    tags.)
   </p>
   <hr/>
   <p class="indent0">
    <strong>
-    <code>
-     ALIGN
-    </code>
+    <code>ALIGN</code>
    </strong>
   </p>
   <p class="indent0">
@@ -610,55 +522,33 @@ only those divine casters who are good, we can break the
     Tag
 Format:
    </strong>
-   <code>
-    ALIGN:&lt;alignment&gt;
-   </code>
+   <code>ALIGN:&lt;alignment&gt;</code>
   </p>
   <p class="indent0">
    This tag identifies the alignment of the deity.
 The generally accepted entries in the text field are
-   <code>
-    LG
-   </code>
+   <code>LG</code>
    ,
-   <code>
-    NG
-   </code>
+   <code>NG</code>
    ,
-   <code>
-    CG
-   </code>
+   <code>CG</code>
    ,
-   <code>
-    LN
-   </code>
+   <code>LN</code>
    ,
-   <code>
-    TN
-   </code>
+   <code>TN</code>
    ,
-   <code>
-    CN
-   </code>
+   <code>CN</code>
    ,
-   <code>
-    LE
-   </code>
+   <code>LE</code>
    ,
-   <code>
-    NE
-   </code>
+   <code>NE</code>
    and
-   <code>
-    CE
-   </code>
+   <code>CE</code>
    representing the following alignments: Lawful
 Good, Neutral Good, Chaotic Good, Lawful Neutral, True Neutral,
 Chaotic Neutral, Lawful Evil, Neutral Evil and Chaotic Evil. This
 tag isn't strictly necessary, but is used in
-   <code>
-    PREDEITYALIGN
-   </code>
+   <code>PREDEITYALIGN</code>
    tag, and a few other places, so we are
 including it with the critical tags.
   </p>
@@ -681,52 +571,36 @@ abbreviations, we get the tag implementations listed below.
    </strong>
   </p>
   <p class="indent1">
-   <code>
-    MoSaT
-   </code>
+   <code>MoSaT</code>
    &lt;TAB&gt; . . . &lt;TAB&gt;
-   <code>
-    ALIGN:CG
-   </code>
+   <code>ALIGN:CG</code>
   </p>
   <p class="indent1">
-   <code>
-    Thalia
-   </code>
+   <code>Thalia</code>
    &lt;TAB&gt; . . .
 &lt;TAB&gt;
-   <code>
-    ALIGN:NG
-   </code>
+   <code>ALIGN:NG</code>
   </p>
   <hr/>
   <p class="indent0">
    <strong>
-    <code>
-     PREALIGN
-    </code>
+    <code>PREALIGN</code>
    </strong>
   </p>
   <p class="indent0">
    <strong>
     Tag Format:
    </strong>
-   <code>
-    PREALIGN:&lt;alignment abbreviation&gt;
-   </code>
+   <code>PREALIGN:&lt;alignment abbreviation&gt;</code>
   </p>
   <p class="indent0">
    This tag establishes a restriction, based on the
 electing character's alignment, on which deities may be selected.
 This tag, in conjunction with the
-   <code>
-    DOMAINS
-   </code>
+   <code>DOMAINS</code>
    tag,
 replaces the functionality of the
-   <code>
-    FOLLOWERALIGN
-   </code>
+   <code>FOLLOWERALIGN</code>
    tag,
 which, as it has been deprecated, isn't being covered in this
 class.
@@ -735,41 +609,23 @@ class.
    The argument for this tag is a comma-delimited
 list of alignments by abbreviation. The accepted entries in the
 text field are
-   <code>
-    LG
-   </code>
+   <code>LG</code>
    ,
-   <code>
-    NG
-   </code>
+   <code>NG</code>
    ,
-   <code>
-    CG
-   </code>
+   <code>CG</code>
    ,
-   <code>
-    LN
-   </code>
+   <code>LN</code>
    ,
-   <code>
-    TN
-   </code>
+   <code>TN</code>
    ,
-   <code>
-    CN
-   </code>
+   <code>CN</code>
    ,
-   <code>
-    LE
-   </code>
+   <code>LE</code>
    ,
-   <code>
-    LN
-   </code>
+   <code>LN</code>
    and
-   <code>
-    CE
-   </code>
+   <code>CE</code>
    representing the following
 alignments: Lawful Good, Neutral Good, Chaotic Good, Lawful
 Neutral, True Neutral, Chaotic Neutral, Lawful Evil, Neutral Evil
@@ -780,9 +636,7 @@ and Chaotic Evil. These abbreviations are defined in the
    file in the Game
 Mode section of the PCGen documentation. There is one additional
 'alignment' which can be included. That is
-   <code>
-    Deity
-   </code>
+   <code>Deity</code>
    ,
 which simply refers back to the selected deity's own alignment.
   </p>
@@ -801,39 +655,27 @@ listed below.
    </strong>
   </p>
   <p class="indent1">
-   <code>
-    MoSaT
-   </code>
+   <code>MoSaT</code>
    &lt;TAB&gt; . . . &lt;TAB&gt;
-   <code>
-    PREALIGN:NG,CG,CN
-   </code>
+   <code>PREALIGN:NG,CG,CN</code>
   </p>
   <p class="indent1">
-   <code>
-    Thalia
-   </code>
+   <code>Thalia</code>
    &lt;TAB&gt; . . .
 &lt;TAB&gt;
-   <code>
-    PREALIGN:LG,NG,TN,CG
-   </code>
+   <code>PREALIGN:LG,NG,TN,CG</code>
   </p>
   <hr/>
   <p class="indent0">
-   <code>
-    <strong>
+   <code><strong>
      DEITYWEAP
-    </strong>
-   </code>
+    </strong></code>
   </p>
   <p class="indent0">
    <strong>
     Tag Format:
    </strong>
-   <code>
-    DEITYWEAP:&lt;favored weapon&gt;
-   </code>
+   <code>DEITYWEAP:&lt;favored weapon&gt;</code>
   </p>
   <p class="indent0">
    This tag provides the deity's favored weapon.
@@ -888,23 +730,15 @@ implementation of this tag for our deities is shown below.
    </strong>
   </p>
   <p class="indent1">
-   <code>
-    MoSaT
-   </code>
+   <code>MoSaT</code>
    &lt;TAB&gt; . . . &lt;TAB&gt;
-   <code>
-    DEITYWEAP:Tiger Claws
-   </code>
+   <code>DEITYWEAP:Tiger Claws</code>
   </p>
   <p class="indent1">
-   <code>
-    Thalia
-   </code>
+   <code>Thalia</code>
    &lt;TAB&gt; . . .
 &lt;TAB&gt;
-   <code>
-    DEITYWEAP:Shepherd's Crook
-   </code>
+   <code>DEITYWEAP:Shepherd's Crook</code>
   </p>
   <hr/>
   <p class="indent0">
@@ -930,19 +764,15 @@ implement.
   </p>
   <hr/>
   <p class="indent0">
-   <code>
-    <strong>
+   <code><strong>
      PANTHEON
-    </strong>
-   </code>
+    </strong></code>
   </p>
   <p class="indent0">
    <strong>
     Tag Format:
    </strong>
-   <code>
-    PANTHEON:&lt;pantheon name&gt;
-   </code>
+   <code>PANTHEON:&lt;pantheon name&gt;</code>
   </p>
   <p class="indent0">
    This tag establishes the pantheon to which the
@@ -972,39 +802,27 @@ implementation listed below.
    </strong>
   </p>
   <p class="indent1">
-   <code>
-    MoSaT
-   </code>
+   <code>MoSaT</code>
    &lt;TAB&gt; . . . &lt;TAB&gt;
-   <code>
-    PANTHEON:BoD
-   </code>
+   <code>PANTHEON:BoD</code>
   </p>
   <p class="indent1">
-   <code>
-    Thalia
-   </code>
+   <code>Thalia</code>
    &lt;TAB&gt; . . .
 &lt;TAB&gt;
-   <code>
-    PANTHEON:Olympia
-   </code>
+   <code>PANTHEON:Olympia</code>
   </p>
   <hr/>
   <p class="indent0">
    <strong>
-    <code>
-     TITLE
-    </code>
+    <code>TITLE</code>
    </strong>
   </p>
   <p class="indent0">
    <strong>
     Tag Format:
    </strong>
-   <code>
-    TITLE:&lt;descriptive title&gt;
-   </code>
+   <code>TITLE:&lt;descriptive title&gt;</code>
   </p>
   <p class="indent0">
    This tag provides the deity's descriptive title,
@@ -1028,39 +846,27 @@ below.
    </strong>
   </p>
   <p class="indent1">
-   <code>
-    MoSaT
-   </code>
+   <code>MoSaT</code>
    &lt;TAB&gt; . . . &lt;TAB&gt;
-   <code>
-    TITLE:The CONTENTed One
-   </code>
+   <code>TITLE:The CONTENTed One</code>
   </p>
   <p class="indent1">
-   <code>
-    Thalia
-   </code>
+   <code>Thalia</code>
    &lt;TAB&gt; . . .
 &lt;TAB&gt;
-   <code>
-    TITLE:The Flourishing One
-   </code>
+   <code>TITLE:The Flourishing One</code>
   </p>
   <hr/>
   <p class="indent0">
-   <code>
-    <strong>
+   <code><strong>
      APPEARANCE
-    </strong>
-   </code>
+    </strong></code>
   </p>
   <p class="indent0">
    <strong>
     Tag Format:
    </strong>
-   <code>
-    APPEARANCE:&lt;descriptive appearance&gt;
-   </code>
+   <code>APPEARANCE:&lt;descriptive appearance&gt;</code>
   </p>
   <p class="indent0">
    This tag provides the deity's descriptive
@@ -1077,41 +883,29 @@ implementation of this tag for each deity below.
    </strong>
   </p>
   <p class="indent1">
-   <code>
-    MoSaT
-   </code>
+   <code>MoSaT</code>
    &lt;TAB&gt; . . . &lt;TAB&gt;
-   <code>
-    APPEARANCE:He is usually seen as a small simian stooped over
-a wireless keyboard typing madly.
-   </code>
+   <code>APPEARANCE:He is usually seen as a small simian stooped over
+a wireless keyboard typing madly.</code>
   </p>
   <p class="indent1">
-   <code>
-    Thalia
-   </code>
+   <code>Thalia</code>
    &lt;TAB&gt; . . .
 &lt;TAB&gt;
-   <code>
-    APPEARANCE:She is sometimes seen with a crown of
-ivy and a Shepherd's crook
-   </code>
+   <code>APPEARANCE:She is sometimes seen with a crown of
+ivy and a Shepherd's crook</code>
   </p>
   <hr/>
   <p class="indent0">
-   <code>
-    <strong>
+   <code><strong>
      WORSHIPPERS
-    </strong>
-   </code>
+    </strong></code>
   </p>
   <p class="indent0">
    <strong>
     Tag Format:
    </strong>
-   <code>
-    WORSHIPPERS:&lt;typical worshipers&gt;
-   </code>
+   <code>WORSHIPPERS:&lt;typical worshipers&gt;</code>
   </p>
   <p class="indent0">
    This tag provides a list of the deity's typical
@@ -1129,9 +923,7 @@ see the implementation of this tag in the examples below.
   </p>
   <p class="sidebar1">
    NOTE: The astute student will note that the
-   <code>
-    WORSHIPPERS
-   </code>
+   <code>WORSHIPPERS</code>
    tag is misspelled. That may be so but that
 is the way the tag is in fact spelled within the program, so please
 conform to the misspelling ... at least until we can fix it in the
@@ -1143,24 +935,16 @@ code base.
    </strong>
   </p>
   <p class="indent1">
-   <code>
-    MoSaT
-   </code>
+   <code>MoSaT</code>
    &lt;TAB&gt; . . . &lt;TAB&gt;
-   <code>
-    WORSHIPPERS:LST Monkeys
-   </code>
+   <code>WORSHIPPERS:LST Monkeys</code>
   </p>
   <p class="indent1">
-   <code>
-    Thalia
-   </code>
+   <code>Thalia</code>
    &lt;TAB&gt; . . .
 &lt;TAB&gt;
-   <code>
-    WORSHIPPERS:Comedians and Pastoral
-Poets
-   </code>
+   <code>WORSHIPPERS:Comedians and Pastoral
+Poets</code>
   </p>
   <hr/>
   <p class="indent0">
@@ -1191,18 +975,14 @@ on your own!
   <hr/>
   <p>
    <strong>
-    <code>
-     DESCISIP
-    </code>
+    <code>DESCISIP</code>
    </strong>
   </p>
   <p class="indent0">
    <strong>
     Tag Format:
    </strong>
-   <code>
-    DESCIP:&lt;YES or NO&gt;
-   </code>
+   <code>DESCIP:&lt;YES or NO&gt;</code>
   </p>
   <p class="indent0">
    This tag is used to identify the deity
@@ -1227,13 +1007,9 @@ can help to clarify any confusion.
    As for this tag itself, it is fairly simple to
 implement as the argument for the tag is a simple boolean and will
 take only
-   <code>
-    YES
-   </code>
+   <code>YES</code>
    or
-   <code>
-    NO
-   </code>
+   <code>NO</code>
    as values. For our
 sample deities, the first created as an example in the
    <span class="lstfile">
@@ -1242,41 +1018,31 @@ sample deities, the first created as an example in the
    file, and the other created
 out-of-thin-air for this lst class, the descriptions are not PI;
 therefore, we would implement this tag as
-   <code>
-    DESCISPI:NO
-   </code>
+   <code>DESCISPI:NO</code>
    .
 Or we would if it was really necessary for if the tag is not
 included PCGen defaults to
-   <code>
-    NO
-   </code>
+   <code>NO</code>
    so we won't actually
 include the tag in our deity file.
   </p>
   <hr/>
   <p class="indent0">
    <strong>
-    <code>
-     SOURCEPAGE
-    </code>
+    <code>SOURCEPAGE</code>
    </strong>
   </p>
   <p class="indent0">
    <strong>
     Tag Format:
    </strong>
-   <code>
-    SOURCEPAGE:&lt;source page number&gt;
-   </code>
+   <code>SOURCEPAGE:&lt;source page number&gt;</code>
   </p>
   <p class="indent0">
    Simply put, this tag provides the specific page
 reference within the source from which the deity information was
 taken. The source page text generally takes the form of
-   <code>
-    &lt;p.#&gt;
-   </code>
+   <code>&lt;p.#&gt;</code>
    with the pound sign (#) being replaced by
 the page number on which the deity information can be found within
 the source material. For our sample deity
@@ -1288,13 +1054,9 @@ the source material. For our sample deity
     my_deity.lst
    </span>
    file so our
-   <code>
-    SOURCEPAGE
-   </code>
+   <code>SOURCEPAGE</code>
    tag will take the form of
-   <code>
-    SOURCEPAGE:my_deity.lst
-   </code>
+   <code>SOURCEPAGE:my_deity.lst</code>
    . As
 for
    <span class="lstobj">
@@ -1304,9 +1066,7 @@ for
 deity, there is no source page, but many functions and filters in
 PCGen use it, so it is good to include it. Therefore, we will
 include the tag with an
-   <code>
-    n/a
-   </code>
+   <code>n/a</code>
    for the source page.
   </p>
   <p class="indent0">
@@ -1315,24 +1075,16 @@ include the tag with an
    </strong>
   </p>
   <p class="indent1">
-   <code>
-    MoSaT
-   </code>
+   <code>MoSaT</code>
    &lt;tab&gt; . . .
 &lt;tab&gt;
-   <code>
-    SOURCEPAGE:my_deity.lst
-   </code>
+   <code>SOURCEPAGE:my_deity.lst</code>
   </p>
   <p class="indent1">
-   <code>
-    Thalia
-   </code>
+   <code>Thalia</code>
    &lt;tab&gt; . . .
 &lt;tab&gt;
-   <code>
-    SOURCEPAGE:n/a
-   </code>
+   <code>SOURCEPAGE:n/a</code>
   </p>
   <hr/>
   <h3>
@@ -1344,129 +1096,83 @@ single line and the tags in the order that I feel makes most
 sense.):
   </p>
   <p class="indent2">
-   <code>
-    MoSaT&lt;tab&gt;
-   </code>
+   <code>MoSaT&lt;tab&gt;</code>
   </p>
   <p class="indent2">
-   <code>
-    TITLE:The CONTENTed
-One&lt;tab&gt;
-   </code>
+   <code>TITLE:The CONTENTed
+One&lt;tab&gt;</code>
   </p>
   <p class="indent2">
-   <code>
-    PANTHEON:BoD&lt;tab&gt;
-   </code>
+   <code>PANTHEON:BoD&lt;tab&gt;</code>
   </p>
   <p class="indent2">
-   <code>
-    ALIGN:CG&lt;tab&gt;
-   </code>
+   <code>ALIGN:CG&lt;tab&gt;</code>
   </p>
   <p class="indent2">
-   <code>
-    PREALIGN:NG,CG,CN&lt;tab&gt;
-   </code>
+   <code>PREALIGN:NG,CG,CN&lt;tab&gt;</code>
   </p>
   <p class="indent2">
-   <code>
-    DOMAINS:Chaos|PREALIGN:CG,CN&lt;tab&gt;
-   </code>
+   <code>DOMAINS:Chaos|PREALIGN:CG,CN&lt;tab&gt;</code>
   </p>
   <p class="indent2">
-   <code>
-    DOMAINS:Knowledge,Animal&lt;tab&gt;
-   </code>
+   <code>DOMAINS:Knowledge,Animal&lt;tab&gt;</code>
   </p>
   <p class="indent2">
-   <code>
-    DEITYWEAP:Tiger
-Claws&lt;tab&gt;
-   </code>
+   <code>DEITYWEAP:Tiger
+Claws&lt;tab&gt;</code>
   </p>
   <p class="indent2">
-   <code>
-    APPEARANCE:He is usually seen as a small
-simian
-   </code>
+   <code>APPEARANCE:He is usually seen as a small
+simian</code>
   </p>
   <p class="indent3">
-   <code>
-    stooped over a wireless keyboard typing
-madly.&lt;tab&gt;
-   </code>
+   <code>stooped over a wireless keyboard typing
+madly.&lt;tab&gt;</code>
   </p>
   <p class="indent2">
-   <code>
-    WORSHIPPERS:LST
-Monkeys&lt;tab&gt;
-   </code>
+   <code>WORSHIPPERS:LST
+Monkeys&lt;tab&gt;</code>
   </p>
   <p class="indent2">
-   <code>
-    SOURCEPAGE:my_deity.lst
-   </code>
+   <code>SOURCEPAGE:my_deity.lst</code>
   </p>
   <p class="indent2">
-   <code>
-    Thalia&lt;tab&gt;
-   </code>
+   <code>Thalia&lt;tab&gt;</code>
   </p>
   <p class="indent2">
-   <code>
-    TITLE:The Flourishing
-One&lt;tab&gt;
-   </code>
+   <code>TITLE:The Flourishing
+One&lt;tab&gt;</code>
   </p>
   <p class="indent2">
-   <code>
-    PANTHEON:Olympia&lt;tab&gt;
-   </code>
+   <code>PANTHEON:Olympia&lt;tab&gt;</code>
   </p>
   <p class="indent2">
-   <code>
-    ALIGN:NG&lt;tab&gt;
-   </code>
+   <code>ALIGN:NG&lt;tab&gt;</code>
   </p>
   <p class="indent2">
-   <code>
-    PREALIGN:LG,NG,TN,CG&lt;tab&gt;
-   </code>
+   <code>PREALIGN:LG,NG,TN,CG&lt;tab&gt;</code>
   </p>
   <p class="indent2">
-   <code>
-    DOMAINS:Good|PREALIGN:LG,NG,CG&lt;tab&gt;
-   </code>
+   <code>DOMAINS:Good|PREALIGN:LG,NG,CG&lt;tab&gt;</code>
   </p>
   <p class="indent2">
-   <code>
-    DOMAINS:Knowledge,Poetry&lt;tab&gt;
-   </code>
+   <code>DOMAINS:Knowledge,Poetry&lt;tab&gt;</code>
   </p>
   <p class="indent2">
-   <code>
-    DEITYWEAP:Shepherd's
-Crook&lt;tab&gt;
-   </code>
+   <code>DEITYWEAP:Shepherd's
+Crook&lt;tab&gt;</code>
   </p>
   <p class="indent2">
-   <code>
-    APPEARANCE:She is sometimes seen with a
-crown of ivy
-   </code>
+   <code>APPEARANCE:She is sometimes seen with a
+crown of ivy</code>
   </p>
   <p class="indent3">
-   <code>
-    and a Shepherd's
-crook.&lt;tab&gt;
-   </code>
+   <code>and a Shepherd's
+crook.&lt;tab&gt;</code>
   </p>
   <p class="indent2">
-   <code>
-    WORSHIPPERS:Comedians and Pastoral
-Poets
-   </code>
+   <code>WORSHIPPERS:Comedians and Pastoral
+Poets</code>
   </p>
   <hr/>
   <p class="indent0">

--- a/docs/listfilepages/lstfileclass/lfc_lesson15_domains1.html
+++ b/docs/listfilepages/lstfileclass/lfc_lesson15_domains1.html
@@ -49,8 +49,7 @@
    </strong>
   </p>
   <p class="indent1">
-   <code>
-    <a href="../globalfilestagpages/globalfilesother.html#desc">
+   <code><a href="../globalfilestagpages/globalfilesother.html#desc">
      DESC
     </a>
     ,
@@ -60,8 +59,7 @@
     <a href="../globalfilestagpages/globalfilesother.html#sourcepage">
      SOURCEPAGE
     </a>
-    ,
-   </code>
+    ,</code>
   </p>
   <hr/>
   <p class="indent0">
@@ -284,12 +282,10 @@ Class Style Guide
   </p>
   <hr/>
   <p class="indent0">
-   <code>
-    <strong>
+   <code><strong>
      &lt;Domain
 Name&gt;
-    </strong>
-   </code>
+    </strong></code>
   </p>
   <p class="indent0">
    This is the name used for the domain. There is
@@ -303,26 +299,20 @@ simply enough with the following entries:
    </strong>
   </p>
   <p class="indent1">
-   <code>
-    War
-   </code>
+   <code>War</code>
    &lt;tab&gt;
   </p>
   <p class="indent1">
-   <code>
-    Poetry
-   </code>
+   <code>Poetry</code>
    &lt;tab&gt;
   </p>
   <p class="indent0">
   </p>
   <hr/>
   <p class="indent0">
-   <code>
-    <strong>
+   <code><strong>
      DESC
-    </strong>
-   </code>
+    </strong></code>
   </p>
   <p class="indent0">
    Now we are getting to the 'fun stuff'. This tag
@@ -335,9 +325,7 @@ your favorite source book, you can generally find this information
 identified as the 'Granted Powers' in the domain block. For the
 Poetry Domain listed above and the War Domain, found in the RSRD,
 the
-   <code>
-    DESC
-   </code>
+   <code>DESC</code>
    tags are reproduced below:
   </p>
   <p class="indent0">
@@ -347,47 +335,37 @@ the
   </p>
   <blockquote class="indent2">
    <p class="tagindent2">
-    <code>
-     War
-    </code>
+    <code>War</code>
    </p>
    <p class="tagindent2">
-    <code>
-     DESC:Free Martial Weapon Proficiency
+    <code>DESC:Free Martial Weapon Proficiency
 with deity’s favored weapon (if necessary) and Weapon Focus
-with the deity favored weapon.
-    </code>
+with the deity favored weapon.</code>
    </p>
   </blockquote>
   <p class="indent0">
   </p>
   <blockquote class="indent2">
    <p class="tagindent2">
-    <code>
-     Poetry
-    </code>
+    <code>Poetry</code>
    </p>
    <p class="tagindent2">
-    <code>
-     DESC:You add all Perform skills to your
+    <code>DESC:You add all Perform skills to your
 cleric class skills and automatically gain the ability to Scribe
 Scrolls at 3rd level. You cast mind-affecting spells at +1 caster
 level. and is graced by Great Intelligence every four levels to a
 maximum of 20th level. If you have a charisma score of 12 or
 greater you may use Ventriloquism once a day as a spell-like
-ability.
-    </code>
+ability.</code>
    </p>
   </blockquote>
   <p class="indent0">
   </p>
   <hr/>
   <p class="indent0">
-   <code>
-    <strong>
+   <code><strong>
      SPELLLEVEL:DOMAIN
-    </strong>
-   </code>
+    </strong></code>
   </p>
   <p class="indent0">
    In the domain file this tag provides a list of
@@ -398,18 +376,14 @@ to by the domain.
    There are two types of argument regularly used
 with this tag, used in pairs in a pipe (|) delimited list. These
 arguments are the domain spell level slot, appearing as
-   <code>
-    &lt;domain name&gt;=&lt;spell level&gt;
-   </code>
+   <code>&lt;domain name&gt;=&lt;spell level&gt;</code>
    , and the name
 of the spell that fills that level slot. Together, the string of
 arguments will look like this:
-   <code>
-    |&lt;domain name&gt;=&lt;spell
+   <code>|&lt;domain name&gt;=&lt;spell
 level 1&gt;|&lt;spell name 1&gt;|&lt;domain name&gt;=&lt;spell
 level 2&gt;|&lt;spell name 2&gt;|&lt;domain name&gt;=&lt;spell
-level 3&gt;|&lt;spell name 3&gt; . . .
-   </code>
+level 3&gt;|&lt;spell name 3&gt; . . .</code>
   </p>
   <p class="indent0">
    Using this format, and looking at the spell list
@@ -442,9 +416,7 @@ Lesser
     </strong>
    </em>
    . Other incarnations of the
-   <code>
-    SPELLLEVEL
-   </code>
+   <code>SPELLLEVEL</code>
    tag use comma-delimited data and including
 a comma in the domain's spell list will cause PCGen to ignore the
 spell reference, thereby not granting access to that spell as a
@@ -457,31 +429,23 @@ domain spell.
   </p>
   <blockquote>
    <p class="tagindent1">
-    <code>
-     War
-    </code>
+    <code>War</code>
     &lt;tab&gt; . . .
 &lt;tab&gt;
-    <code>
-     SPELLLEVEL:DOMAIN|War=1|Magic
+    <code>SPELLLEVEL:DOMAIN|War=1|Magic
 Weapon|War=2|Spiritual Weapon|War=3|Magic Vestment|War=4|Divine
 Power|War=5|Flame Strike|War=6|Blade Barrier|War=7|Power Word
-Blind|War=8|Power Word Stun|War=9|Power Word Kill
-    </code>
+Blind|War=8|Power Word Stun|War=9|Power Word Kill</code>
    </p>
    <p class="tagindent1">
-    <code>
-     Poetry
-    </code>
+    <code>Poetry</code>
     &lt;tab&gt; . . .
 &lt;tab&gt;
-    <code>
-     SPELLLEVEL:DOMAIN|Poetry=1|Hypnotism|Poetry=2|Suggestion|Poetry=3|Geas
+    <code>SPELLLEVEL:DOMAIN|Poetry=1|Hypnotism|Poetry=2|Suggestion|Poetry=3|Geas
 (Lesser)|Poetry=4|Modify Memory|Poetry=5|Song of
 Discord|Poetry=6|Irresistible Dance|Poetry=7|Hold Person
 (Mass)|Poetry=8|Charm Monster (Mass)|Poetry=9|Hold Monster
-(Mass)
-    </code>
+(Mass)</code>
    </p>
   </blockquote>
   <p class="indent0">
@@ -489,9 +453,7 @@ Discord|Poetry=6|Irresistible Dance|Poetry=7|Hold Person
   <hr/>
   <p class="indent0">
    <strong>
-    <code>
-     SOURCEPAGE
-    </code>
+    <code>SOURCEPAGE</code>
    </strong>
   </p>
   <p class="indent0">
@@ -500,50 +462,34 @@ the page within the source material where you can find the specific
 description, powers, and spells for the domain you are creating. It
 takes free-form text but most often you will find it in one of two
 forms. If your source material is an OGL book the format is usually
-   <code>
-    SOURCEPAGE:p.&lt;#&gt;
-   </code>
+   <code>SOURCEPAGE:p.&lt;#&gt;</code>
    . If you are working from an
 online source, such as the RSRD, you would use the filename, so
 your tag would look like
-   <code>
-    SOURCEPAGE:&lt;filename&gt;.
-   </code>
+   <code>SOURCEPAGE:&lt;filename&gt;.</code>
   </p>
   <p class="indent0">
    Since I have created the Poetry Domain from
 scratch there is no 'source', so there is no
-   <code>
-    SOURCEPAGE
-   </code>
+   <code>SOURCEPAGE</code>
    tag required, but many functions and
 filters in PCGen use it, so it is good to include it. Therefore, I
 will include the tag with an N/A for the source page. I will skip
 it. The War Domain on the other hand comes from the RSRD and
 therefore would use the
-   <code>
-    SOURCEPAGE
-   </code>
+   <code>SOURCEPAGE</code>
    tag per the example
 below.
   </p>
   <p class="indent0">
    Note: There are three other
-   <code>
-    SOURCExxx
-   </code>
+   <code>SOURCExxx</code>
    tags (
-   <code>
-    SOURCELONG
-   </code>
+   <code>SOURCELONG</code>
    ,
-   <code>
-    SOURCESHORT
-   </code>
+   <code>SOURCESHORT</code>
    and
-   <code>
-    SOURCEWEB
-   </code>
+   <code>SOURCEWEB</code>
    ) that will be
 covered in a separate class so we will not be covering them
 here.
@@ -554,23 +500,15 @@ here.
    </strong>
   </p>
   <p class="indent1">
-   <code>
-    War
-   </code>
+   <code>War</code>
    &lt;tab&gt; . . . &lt;tab&gt;
-   <code>
-    SOURCEPAGE:SpellListI.rtf
-   </code>
+   <code>SOURCEPAGE:SpellListI.rtf</code>
   </p>
   <p class="indent1">
-   <code>
-    Poetry
-   </code>
+   <code>Poetry</code>
    &lt;tab&gt; . . .
 &lt;tab&gt;
-   <code>
-    SOURCEPAGE:N/A
-   </code>
+   <code>SOURCEPAGE:N/A</code>
   </p>
   <p class="indent0">
   </p>
@@ -584,34 +522,26 @@ single line.):
   </p>
   <blockquote class="indent2">
    <p class="tagindent2">
-    <code>
-     Poetry
-    </code>
+    <code>Poetry</code>
    </p>
    <p class="tagindent2">
-    <code>
-     DESC:You add all Perform skills to your
+    <code>DESC:You add all Perform skills to your
 cleric class skills and automatically gain the ability to Scribe
 Scrolls at 3rd level. You cast mind-affectng spells at +1 caster
 level and is graced by Great Inteligence every four levels to a
 maximum of 20th level. If you have a charisma score of 12 or
 greater you may use Ventriloquism once a day as a spell-like
-ability.
-    </code>
+ability.</code>
    </p>
    <p class="tagindent2">
-    <code>
-     SPELLLEVEL:DOMAIN|Poetry=1|Hypnotism|Poetry=2|Suggestion|Poetry=3|Geas
+    <code>SPELLLEVEL:DOMAIN|Poetry=1|Hypnotism|Poetry=2|Suggestion|Poetry=3|Geas
 (Lesser)||Modify Memory|Poetry=5|Song of
 Discord|Poetry=6|Irresistible Dance|Poetry=7|Hold Person
 (Mass)|Poetry=8|Charm Monster (Mass)|Poetry=9|Hold Monster
-(Mass)
-    </code>
+(Mass)</code>
    </p>
    <p class="tagindent2">
-    <code>
-     SOURCEPAGE:SpellListI.rtf
-    </code>
+    <code>SOURCEPAGE:SpellListI.rtf</code>
    </p>
    <p class="indent0">
    </p>
@@ -624,9 +554,7 @@ Discord|Poetry=6|Irresistible Dance|Poetry=7|Hold Person
 domains to your campaign, albeit, only the most basic of
 functionality will exist. You may have noted a number of abilities
 are included in the
-   <code>
-    DESC
-   </code>
+   <code>DESC</code>
    tag that this domain entry
 doesn't implement. To see how to implement these abilities we will
 move to the

--- a/docs/listfilepages/lstfileclass/lfc_lesson16_domains2.html
+++ b/docs/listfilepages/lstfileclass/lfc_lesson16_domains2.html
@@ -49,8 +49,7 @@
    </strong>
   </p>
   <p class="indent1">
-   <code>
-    <a href="../globalfilestagpages/globalfilesother.html#cskil">
+   <code><a href="../globalfilestagpages/globalfilesother.html#cskil">
      CSKILL
     </a>
     ,
@@ -72,8 +71,7 @@
     ,
     <a href="../globalfilestagpages/globalfilesprexxx.html#prelevel">
      PREALIGN
-    </a>
-   </code>
+    </a></code>
   </p>
   <hr/>
   <p>
@@ -272,9 +270,7 @@ course you believe the pen is mightier than the sword . . .
    Before we begin we must first identify which 'Granted Powers'
 need to be implemented. Our source for these powers is the text
 following the
-   <code>
-    DESC
-   </code>
+   <code>DESC</code>
    tag. Looking at the Poetry domain
 listed above, we get the following powers:
   </p>
@@ -336,11 +332,9 @@ Class Style Guide
   </p>
   <hr/>
   <p>
-   <code>
-    <strong>
+   <code><strong>
      CSKILL
-    </strong>
-   </code>
+    </strong></code>
   </p>
   <p>
    This tag is used to add skills to the cleric's list of class
@@ -376,14 +370,10 @@ skills. The first example below gives the form of this tag.
   </p>
   <p>
    The skills being added may also be designated by
-   <code>
-    TYPE
-   </code>
+   <code>TYPE</code>
    , taking the form of
-   <code>
-    TYPE.&lt;skill
-type&gt;
-   </code>
+   <code>TYPE.&lt;skill
+type&gt;</code>
    . Our new domain is a good example of this as the
 domain adds all
    <em>
@@ -401,24 +391,18 @@ tag in action.
    </strong>
   </p>
   <p class="indent1">
-   <code>
-    Trickery &lt;tab&gt; . . . &lt;tab&gt;
-CSKILL:Bluff|Disguise|Hide
-   </code>
+   <code>Trickery &lt;tab&gt; . . . &lt;tab&gt;
+CSKILL:Bluff|Disguise|Hide</code>
   </p>
   <p class="indent1">
-   <code>
-    Poetry &lt;tab&gt; . . . &lt;tab&gt;
-CSKILL:TYPE.Perform
-   </code>
+   <code>Poetry &lt;tab&gt; . . . &lt;tab&gt;
+CSKILL:TYPE.Perform</code>
   </p>
   <hr/>
   <p>
-   <code>
-    <strong>
+   <code><strong>
      BONUS:CASTERLEVEL
-    </strong>
-   </code>
+    </strong></code>
   </p>
   <p>
    This tag grants a bonus to the character's caster level. This
@@ -426,72 +410,44 @@ bonus is dependent upon specific qualifying parameters, which are
 identified within the tag itself. The tag only requires two
 arguments, the qualifying tag and the number of levels the caster
 level is increased, with a third optional argument in the form of a
-   <code>
-    PRExxx
-   </code>
+   <code>PRExxx</code>
    tag. The general form this tag and its argument
 take as as follows:
   </p>
   <p class="indent1">
-   <code>
-    BONUS:CASTERLEVEL|&lt;qualifying
-tag&gt;|&lt;level bonus&gt;|PRExxx
-   </code>
+   <code>BONUS:CASTERLEVEL|&lt;qualifying
+tag&gt;|&lt;level bonus&gt;|PRExxx</code>
   </p>
   <p>
    There are several different types of qualifying tags, including
 the class name, a spell
-   <code>
-    DESCRIPTOR
-   </code>
+   <code>DESCRIPTOR</code>
    , a
-   <code>
-    DOMAIN
-   </code>
+   <code>DOMAIN</code>
    , a
-   <code>
-    RACE
-   </code>
+   <code>RACE</code>
    , a
-   <code>
-    SCHOOL
-   </code>
+   <code>SCHOOL</code>
    , a
-   <code>
-    SPELL
-   </code>
+   <code>SPELL</code>
    , a
-   <code>
-    SUBSCHOOL
-   </code>
+   <code>SUBSCHOOL</code>
    , and a
-   <code>
-    TYPE
-   </code>
+   <code>TYPE</code>
    . Each of these tags, except for the class name,
 take the form of
-   <code>
-    &lt;TAG&gt;.text
-   </code>
+   <code>&lt;TAG&gt;.text</code>
    , with the text being
 appropriate for the tag, i.e.
-   <code>
-    RACE.Elf%
-   </code>
+   <code>RACE.Elf%</code>
    ,
-   <code>
-    SCHOOL.Abjuration
-   </code>
+   <code>SCHOOL.Abjuration</code>
    ,
-   <code>
-    TYPE.Arcane
-   </code>
+   <code>TYPE.Arcane</code>
    , etc. The
 class name is a simple text entry giving the name of the
 appropriate class, i.e.
-   <code>
-    Cleric
-   </code>
+   <code>Cleric</code>
    . Looking at the Domain
 of Law in the RSRD, the
    <em>
@@ -501,21 +457,15 @@ of Law in the RSRD, the
 that a divine spell caster with this domain receives a bonus when
 casting lawful based spells. The specific spell descriptor of
 'Lawful' is used in this tag taking the form:
-   <code>
-    DESCRIPTOR.Lawful
-   </code>
+   <code>DESCRIPTOR.Lawful</code>
    . Examining the list of granted
 powers for the Domain of
-   <code>
-    Poetry
-   </code>
+   <code>Poetry</code>
    above, we see a divine
 spell caster with this domain receives a bonus when casting
 'Mind-Affecting' spells. The qualifying tag for the bonus takes the
 following form:
-   <code>
-    DESCRIPTOR.Mind-Affecting
-   </code>
+   <code>DESCRIPTOR.Mind-Affecting</code>
    .
   </p>
   <p>
@@ -538,14 +488,10 @@ determining the effects, DC, etc. In both the domain of
   </p>
   <p>
    Finally, this tag can take
-   <code>
-    PRExxx
-   </code>
+   <code>PRExxx</code>
    tags, with the
 most common tag being the
-   <code>
-    PRERULE
-   </code>
+   <code>PRERULE</code>
    tag which checks the
 state of rule as set in PCGen's 'House Rule' preferences. The rule
 must be defined in the
@@ -557,15 +503,11 @@ must be defined in the
    file in
 the 'system/gameModes' folder within PCGen. The particular rule we
 are interested in for the BONUS:
-   <code>
-    CASTERLEVEL
-   </code>
+   <code>CASTERLEVEL</code>
    tag
 applies Casterlevel Bonuses from Domains to all Spells and is
 referenced by the
-   <code>
-    VAR:SYS_DOMAIN
-   </code>
+   <code>VAR:SYS_DOMAIN</code>
    tag, as defined in
 the
    <em>
@@ -577,9 +519,7 @@ the
   </p>
   <p>
    Taking all of this together, the
-   <code>
-    BONUS:CASTERLEVEL
-   </code>
+   <code>BONUS:CASTERLEVEL</code>
    tag for our two sample domains take the form shown below.
   </p>
   <p>
@@ -588,24 +528,18 @@ the
    </strong>
   </p>
   <p class="indent1">
-   <code>
-    Law &lt;tab&gt; . . . &lt;tab&gt;
-BONUS:CASTERLEVEL|DESCRIPTOR.Lawful|1|PRERULE:SYS_DOMAIN
-   </code>
+   <code>Law &lt;tab&gt; . . . &lt;tab&gt;
+BONUS:CASTERLEVEL|DESCRIPTOR.Lawful|1|PRERULE:SYS_DOMAIN</code>
   </p>
   <p class="indent1">
-   <code>
-    Poetry &lt;tab&gt; . . . &lt;tab&gt;
-BONUS:CASTERLEVEL|DESCRIPTOR.Mind-Affecting|1|PRERULE:SYS_DOMAIN
-   </code>
+   <code>Poetry &lt;tab&gt; . . . &lt;tab&gt;
+BONUS:CASTERLEVEL|DESCRIPTOR.Mind-Affecting|1|PRERULE:SYS_DOMAIN</code>
   </p>
   <hr/>
   <p>
-   <code>
-    <strong>
+   <code><strong>
      PREALIGN
-    </strong>
-   </code>
+    </strong></code>
   </p>
   <p>
    The
@@ -617,84 +551,54 @@ specific prerequisites to the character before granting the
 selected domain and its granted powers and spells. You may include
 as many of these tags as you like and each of them will be applied
 to the domain as a whole. If the character does not meet ALL
-   <code>
-    PRExxx
-   </code>
+   <code>PRExxx</code>
    tags, the domain cannot be selected.
 Unfortunately, there are too many
-   <code>
-    PRExxx
-   </code>
+   <code>PRExxx</code>
    tags to go
 over in this class so I will restrict my coverage to the most
 likely tag. That is the
-   <code>
-    PREALIGN
-   </code>
+   <code>PREALIGN</code>
    tag.
   </p>
   <p>
    The
-   <code>
-    PREALIGN
-   </code>
+   <code>PREALIGN</code>
    tag applies an alignment requirement
 to the cleric. The form this tag takes is:
   </p>
   <p class="indent1">
-   <code>
-    PREALIGN:&lt;alignment
-list&gt;
-   </code>
+   <code>PREALIGN:&lt;alignment
+list&gt;</code>
    .
   </p>
   <p>
    The alignment list is a comma-delimited list of alignment
 abbreviations as follows: Lawful Good=
-   <code>
-    NG
-   </code>
+   <code>NG</code>
    , Lawful
 Neutral=
-   <code>
-    LN
-   </code>
+   <code>LN</code>
    , Lawful Evil=
-   <code>
-    LE
-   </code>
+   <code>LE</code>
    , Neutral
 Good=
-   <code>
-    NG
-   </code>
+   <code>NG</code>
    , True Neutral=
-   <code>
-    TN
-   </code>
+   <code>TN</code>
    , Neutral
 Evil=
-   <code>
-    NE
-   </code>
+   <code>NE</code>
    , Chaotic Good=
-   <code>
-    CG
-   </code>
+   <code>CG</code>
    , Chaotic
 Neutral=
-   <code>
-    CN
-   </code>
+   <code>CN</code>
    , and Chaotic Evil=
-   <code>
-    CE
-   </code>
+   <code>CE</code>
    . An
 additional identifier is
-   <code>
-    Deity
-   </code>
+   <code>Deity</code>
    , representing the
 alignment of the characters deity.
   </p>
@@ -714,9 +618,7 @@ alignment or by any other cr criteria, for the domain of
     </strong>
    </em>
    , we will not be including a
-   <code>
-    PRExxx
-   </code>
+   <code>PRExxx</code>
    tag in our
    <em>
     <strong>
@@ -729,9 +631,7 @@ alignment or by any other cr criteria, for the domain of
    As a final note, this tag provides prerequisites that are
 separate from the prerequisites used in conjunction with the
    <a href="../datafilestagpages/datafilesdeities.html#domains">
-    <code>
-     DOMAINS
-    </code>
+    <code>DOMAINS</code>
    </a>
    tag.
   </p>
@@ -741,18 +641,14 @@ separate from the prerequisites used in conjunction with the
    </strong>
   </p>
   <p class="indent1">
-   <code>
-    Law &lt;tab&gt; . . . &lt;tab&gt;
-PREALIGN:LG,LN,LE
-   </code>
+   <code>Law &lt;tab&gt; . . . &lt;tab&gt;
+PREALIGN:LG,LN,LE</code>
   </p>
   <hr/>
   <p>
-   <code>
-    <strong>
+   <code><strong>
      SPELLS
-    </strong>
-   </code>
+    </strong></code>
   </p>
   <p>
    This tag grants the cleric spell-like abilities. This tag has a
@@ -760,19 +656,15 @@ number of arguments that we will explain below but first, the
 general form of this tag and its many arguments are as follows:
   </p>
   <p class="indent1">
-   <code>
-    SPELLS:&lt;spellbook&gt;|TIMES=&lt;number
+   <code>SPELLS:&lt;spellbook&gt;|TIMES=&lt;number
 or formula&gt;|CASTERLEVEL=&lt;number
     <br/>
     of formula&gt;|&lt;spell name&gt;,&lt;spell DC&gt;|&lt;PRExxx
-tag&gt;
-   </code>
+tag&gt;</code>
   </p>
   <p>
    The first argument in the
-   <code>
-    SPELLS
-   </code>
+   <code>SPELLS</code>
    tag is the name of
 the spellbook that the spell-like ability will be displayed in
 within PCGen and on the character sheet. This may include any name
@@ -790,35 +682,25 @@ spellbook name NOT be the same as any Class names, i.e. 'Cleric',
 throw an exception and it will not function properly. For our
 purposes, the spell book entered is the domain name and takes the
 form of
-   <code>
-    &lt;domain name&gt; Domain
-   </code>
+   <code>&lt;domain name&gt; Domain</code>
    . For the poetry
 domain we would enter
-   <code>
-    Poetry Domain
-   </code>
+   <code>Poetry Domain</code>
    .
   </p>
   <p>
    The
-   <code>
-    TIMES
-   </code>
+   <code>TIMES</code>
    tag is an optional tag that identifies
 the number of times a day the spell-like ability may be used. If
 it's not included in the domain line, PCGen will default to 1 time
 per day. You may enter a specific value, a variable, or a formula
 in this tag. It is important to note that within the domain file
 the
-   <code>
-    SPELLS
-   </code>
+   <code>SPELLS</code>
    tag is not associated with any specific
 class, therefore, the variable
-   <code>
-    CL
-   </code>
+   <code>CL</code>
    will not work. (For
 more information about formulas within PCGen, see the
    <a href="../globalfilestagpages/globalfilesformulas.html">
@@ -830,30 +712,20 @@ Documentation.) A special value that may be entered is the value
 Will'. Both the Animal and Poetry domains grant spell-like
 abilities that are usable once per day so both domain entries will
 include the
-   <code>
-    TIMES=1
-   </code>
+   <code>TIMES=1</code>
    tag.
   </p>
   <p>
-   <code>
-    CASTERLEVEL
-   </code>
+   <code>CASTERLEVEL</code>
    is an optional tag that sets the level
 at which the spell-like ability is cast. As with the
-   <code>
-    TIMES
-   </code>
+   <code>TIMES</code>
    tag, you may enter any value, variable, or
 formula as desired. If it is not included, PCGen will default to 1.
 Only one
-   <code>
-    CASTERLEVEL
-   </code>
+   <code>CASTERLEVEL</code>
    tag is allowed in each
-   <code>
-    SPELLS
-   </code>
+   <code>SPELLS</code>
    tag entry. For the
    <em>
     <strong>
@@ -870,45 +742,33 @@ Only one
 on the total level of the character, including the PC, NPC, and
 Monster levels but not including any level adjustments, so we will
 be using the
-   <code>
-    TL
-   </code>
+   <code>TL</code>
    variable as the basis for the caster
 level. Unfortunately, there may be circumstances where the total
 level is reduced to zero or below, i.e. with the application of a
 template that applies negative levels. In this case, we still want
 the spell-like ability to function, even if at a minimum level.
 Therefore, we will use the
-   <code>
-    max()
-   </code>
+   <code>max()</code>
    formula tag. The
 entry for the casterlevel for both of our example domains becomes
-   <code>
-    CASTERLEVEL=max(TL,1)
-   </code>
+   <code>CASTERLEVEL=max(TL,1)</code>
    , setting the caster level of the
 spell-like ability to the character's total level with a minimum
 level of 1.
   </p>
   <p>
    Besides the spell book, the
-   <code>
-    &lt;spell name&gt;
-   </code>
+   <code>&lt;spell name&gt;</code>
    is
 the only other mandatory argument for the
-   <code>
-    SPELLS
-   </code>
+   <code>SPELLS</code>
    tag
 as it provides, as the tag implies, the name of the spell being
 granted as a spell-like ability. This spell must exist in the
 loaded datasets and must appear exactly as it does in the first
 position on the spell line in the spell file. The optional
-   <code>
-    &lt;spell DC&gt;
-   </code>
+   <code>&lt;spell DC&gt;</code>
    value may be a number, variable, or
 formula. I will establish the DC for the
    <em>
@@ -917,9 +777,7 @@ formula. I will establish the DC for the
     </strong>
    </em>
    domain as
-   <code>
-    12+WIS
-   </code>
+   <code>12+WIS</code>
    ,
 meaning a base score of twelve (12) plus the wisdom modifier. The
 RSRD gives the DC value for the
@@ -929,44 +787,28 @@ RSRD gives the DC value for the
     </strong>
    </em>
    domain as
-   <code>
-    11+WIS
-   </code>
+   <code>11+WIS</code>
    , being a base score of eleven (11)
 plus the wisdom modifier.
   </p>
   <p>
    The last argument to discuss is the global
-   <code>
-    PRExxx
-   </code>
+   <code>PRExxx</code>
    tag. These are used to set prerequisites for the spell-like ability
 such as alignment requirements or minimum stat requirements. If a
-   <code>
-    SPELLS
-   </code>
+   <code>SPELLS</code>
    tag requires multiple
-   <code>
-    PRExxx
-   </code>
+   <code>PRExxx</code>
    statements they are included as a pipe (|) delimited list at the
 end of the
-   <code>
-    SPELLS
-   </code>
+   <code>SPELLS</code>
    tag. Some of the
-   <code>
-    PRExxx
-   </code>
+   <code>PRExxx</code>
    statements have pipe (|) delimiting in them, in which case you
 simply put that
-   <code>
-    PRExxx
-   </code>
+   <code>PRExxx</code>
    statement in a separate
-   <code>
-    SPELLS
-   </code>
+   <code>SPELLS</code>
    tag by itself. The
    <em>
     <strong>
@@ -982,14 +824,10 @@ Animals
    </em>
    domain does not carry a
 prerequisite so you will not find a
-   <code>
-    PRExxx
-   </code>
+   <code>PRExxx</code>
    tag
 attached to the
-   <code>
-    SPELLS
-   </code>
+   <code>SPELLS</code>
    tag. The
    <em>
     <strong>
@@ -1005,9 +843,7 @@ require a minimum wisdom before the
    </em>
    ability is granted. This
 prerequisite is coded using the
-   <code>
-    PRESTAT
-   </code>
+   <code>PRESTAT</code>
    tag which
 takes two arguments; 1) the number of stats which must qualify, one
 in our case, and 2) the stat and its value, identified by the stat
@@ -1019,19 +855,13 @@ abbreviation defined in the
    </em>
    file and a numeric
 value representing the minimum stat value. Our
-   <code>
-    PRESTAT
-   </code>
+   <code>PRESTAT</code>
    tag takes this form:
-   <code>
-    PRESTAT:1,WIS=12
-   </code>
+   <code>PRESTAT:1,WIS=12</code>
   </p>
   <p>
    Ok, so we've gone over all the arguments allowed in the
-   <code>
-    SPELLS
-   </code>
+   <code>SPELLS</code>
    tag. The only thing left to do is put them al
 together so we can see the final tag, and this we have done
 below.
@@ -1042,48 +872,36 @@ below.
    </strong>
   </p>
   <p class="indent1">
-   <code>
-    Animal &lt;tab&gt; . . . &lt;tab&gt;
+   <code>Animal &lt;tab&gt; . . . &lt;tab&gt;
     <br/>
     SPELLS:Animal Domain|TIMES=1|CASTERLEVEL=max(TL,1)|Speak with
-Animals,11+WIS
-   </code>
+Animals,11+WIS</code>
   </p>
   <p class="indent1">
-   <code>
-    Poetry &lt;tab&gt; . . . &lt;tab&gt;
+   <code>Poetry &lt;tab&gt; . . . &lt;tab&gt;
     <br/>
     SPELLS:Poetry
-Domain|TIMES=1|CASTERLEVEL=max(TL,1)|Ventriloquism,12+WIS|PRESTAT:1,WIS=12
-   </code>
+Domain|TIMES=1|CASTERLEVEL=max(TL,1)|Ventriloquism,12+WIS|PRESTAT:1,WIS=12</code>
   </p>
   <hr/>
   <h3>
-   <code>
-    <strong>
+   <code><strong>
      VFEAT
-    </strong>
-   </code>
+    </strong></code>
   </h3>
   <p>
    The
-   <code>
-    VFEAT
-   </code>
+   <code>VFEAT</code>
    tag grants a feat, or a list of feats, to
 a character, even if the character would not normally meet the
 requirements for that feat. The tag takes a pipe-delimited list and
 can be as long as desired, but must contain at least one feat. The
 feats included in the feat list must exist and you should NOT use
 the feats
-   <code>
-    OUPUTNAME
-   </code>
+   <code>OUPUTNAME</code>
    , if one exists for the feat you
 are granting. Also keep in mind that some feats have a
-   <code>
-    CHOOSE
-   </code>
+   <code>CHOOSE</code>
    built into them, such as
    <strong>
     <em>
@@ -1122,9 +940,7 @@ element, i.e.
    </strong>
    ,
 which is a unique feat with no
-   <code>
-    CHOOSE
-   </code>
+   <code>CHOOSE</code>
    command, and the
 afore mentioned
    <em>
@@ -1136,83 +952,57 @@ afore mentioned
 PCGen differentiates between these two cases by the inclusion, or
 exclusion, of a space between the 'open' parentheses and the
 preceding alpha-character. For a feat with a built in
-   <code>
-    CHOOSE
-   </code>
+   <code>CHOOSE</code>
    command, there is NO intervening space while a
 unique feat with a parenthetical element has an intervening
 space.
   </p>
   <p>
    As stated before, the
-   <code>
-    VFEAT
-   </code>
+   <code>VFEAT</code>
    tag applies a feat
 irrespective of the prerequisites for that feat, but the
-   <code>
-    VFEAT
-   </code>
+   <code>VFEAT</code>
    tag also allows the application of new
 prerequisites through the use of the
-   <code>
-    PRExxx
-   </code>
+   <code>PRExxx</code>
    tag. The
 new prerequisite will be applied to all feats listed in the
-   <code>
-    VFEAT
-   </code>
+   <code>VFEAT</code>
    tag. This could cause a problem if you wanted to
 apply two feats, each with their own prerequisites, but
 fortunately, not only can we include as many feats in the
-   <code>
-    VFEAT
-   </code>
+   <code>VFEAT</code>
    tag as we need, we can also include as many
-   <code>
-    VFEAT
-   </code>
+   <code>VFEAT</code>
    tags in the domain line as we need, each with
 its own
-   <code>
-    PRExxx
-   </code>
+   <code>PRExxx</code>
    tag. If you browse through the
-   <code>
-    PRExxx
-   </code>
+   <code>PRExxx</code>
    section of the global tag documentation, you
 will find many tags that can be used when applying virtual feats,
 but I will be going over only one of them here. That is the
-   <code>
-    PRELEVEL
-   </code>
+   <code>PRELEVEL</code>
    tag.
   </p>
   <p>
    The
-   <code>
-    PRELEVEL
-   </code>
+   <code>PRELEVEL</code>
    tag establishes a prerequisite for a
 character to have a minimum number of levels. Its form is simple,
 having as a single argument the minimum level required. The tag
 takes the following form:
-   <code>
-    PRELEVEL:&lt;minimum
-level&gt;
-   </code>
+   <code>PRELEVEL:&lt;minimum
+level&gt;</code>
   </p>
   <p>
    With all of this in mind, the form the VFEAT tag takes in this
 file, with our selected PRExxx tag, is as follows:
   </p>
   <p class="indent1">
-   <code>
-    VFEAT:&lt;feat
-list&gt;|PRELEVEL:&lt;minimum level&gt;
-   </code>
+   <code>VFEAT:&lt;feat
+list&gt;|PRELEVEL:&lt;minimum level&gt;</code>
   </p>
   <p>
    For the
@@ -1255,18 +1045,12 @@ Intelligence
    feat is stackable so our application of
 the feat five times as the character advances from 1st to 20th
 level can be accommodated by simply including five
-   <code>
-    VFEAT
-   </code>
+   <code>VFEAT</code>
    tags, each with an appropriate
-   <code>
-    PRELEVEL
-   </code>
+   <code>PRELEVEL</code>
    tag, five time. See our example below for the
 final
-   <code>
-    VFEAT
-   </code>
+   <code>VFEAT</code>
    tag entries.
   </p>
   <p>
@@ -1275,8 +1059,7 @@ final
    </strong>
   </p>
   <p class="indent1">
-   <code>
-    Poetry &lt;tab&gt; . . . &lt;tab&gt;
+   <code>Poetry &lt;tab&gt; . . . &lt;tab&gt;
     <br/>
     VFEAT:Scribe Scrolls|PRELEVEL:3 &lt;tab&gt;
     <br/>
@@ -1288,8 +1071,7 @@ final
     <br/>
     VFEAT:Great Intelligence|PRELEVEL:16 &lt;tab&gt;
     <br/>
-    VFEAT:Greater Intelligence|PRELEVEL:20
-   </code>
+    VFEAT:Greater Intelligence|PRELEVEL:20</code>
   </p>
   <hr/>
   <h3>
@@ -1302,8 +1084,7 @@ this (all on a single line.):
   </p>
   <blockquote>
    <p>
-    <code>
-     Poetry &lt;tab&gt;
+    <code>Poetry &lt;tab&gt;
      <br/>
      CSKILL:TYPE.Perform &lt;tab&gt;
      <br/>
@@ -1384,8 +1165,7 @@ at +1 caster level. &lt;tab&gt;
       Poetry=9|Hold Monster
 (Mass)
      </span>
-     <br/>
-    </code>
+     <br/></code>
    </p>
   </blockquote>
   <hr/>

--- a/docs/listfilepages/lstfileclass/lfc_lesson17_converting_feats_to_abilities.html
+++ b/docs/listfilepages/lstfileclass/lfc_lesson17_converting_feats_to_abilities.html
@@ -75,8 +75,7 @@ Smith (Maredudd)
    </strong>
   </p>
   <p class="indent1">
-   <code>
-    <a href="../datafilestagpages/datafilesability.html#category2">
+   <code><a href="../datafilestagpages/datafilesability.html#category2">
      CATEGORY(ability)
     </a>
     ,
@@ -148,8 +147,7 @@ category)
     ,
     <a href="../globalfilestagpages/globalfilesbonus.html#var">
      BONUS:VAR
-    </a>
-   </code>
+    </a></code>
   </p>
   <hr/>
   <h2>
@@ -210,30 +208,20 @@ below.
 LST file class.
   </p>
   <p class="indent2">
-   <code>
-    Expert Defense
-   </code>
+   <code>Expert Defense</code>
   </p>
   <p class="indent2">
-   <code>
-    TYPE:Special
-   </code>
+   <code>TYPE:Special</code>
   </p>
   <p class="indent2">
-   <code>
-    VISIBLE:NO
-   </code>
+   <code>VISIBLE:NO</code>
   </p>
   <p class="indent2">
-   <code>
-    SAB:Expert Defense ~ Add % bonus to
-AC|INT
-   </code>
+   <code>SAB:Expert Defense ~ Add % bonus to
+AC|INT</code>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:COMBAT|AC|INT
-   </code>
+   <code>BONUS:COMBAT|AC|INT</code>
   </p>
   <p class="indent0">
    Note: This hidden feat has been created
@@ -295,9 +283,7 @@ conventions to convey these ideas:
   <p class="indent1">
    1) Coding examples and PCGen tags are identified
 by
-   <code>
-    code
-   </code>
+   <code>code</code>
    style.
   </p>
   <p class="indent1">
@@ -308,16 +294,12 @@ e.g. domain, feat, weapon, etc., I have included the name as a
    </span>
    text, except for when the
 object is part of a
-   <code>
-    code
-   </code>
+   <code>code</code>
    example.
   </p>
   <p class="indent1">
    3) Each new line should be considered a
-   <code>
-    &lt;TAB&gt;
-   </code>
+   <code>&lt;TAB&gt;</code>
    in the actual file.
   </p>
   <blockquote>
@@ -325,29 +307,21 @@ object is part of a
     Examples in this lesson will appear as:
    </p>
    <p class="indent2">
-    <code>
-     ABILITYCATEGORY:My Special Ability
-Category
-    </code>
+    <code>ABILITYCATEGORY:My Special Ability
+Category</code>
    </p>
    <p class="indent2">
-    <code>
-     CATEGORY:Special Ability
-    </code>
+    <code>CATEGORY:Special Ability</code>
    </p>
    <p class="indent1">
     Will in the LST file appear as:
    </p>
    <p class="indent2">
-    <code>
-     ABILITYCATEGORY:My Special Ability
-Category
-    </code>
+    <code>ABILITYCATEGORY:My Special Ability
+Category</code>
     &lt;tab&gt;
-    <code>
-     CATEGORY:Special
-Ability
-    </code>
+    <code>CATEGORY:Special
+Ability</code>
    </p>
   </blockquote>
   <h4>
@@ -378,9 +352,7 @@ that you wish to convert to the new file and removing them from the
    </span>
    file. You will then need
 to add the appropriate
-   <code>
-    CATEGORY
-   </code>
+   <code>CATEGORY</code>
    tag to the copied
 feats, making sure that any new ability categories are properly
 defined in the
@@ -393,13 +365,9 @@ modify your hombrew
     my_campaign.pcc
    </span>
    file by adding the
-   <code>
-    ABILITY
-   </code>
+   <code>ABILITY</code>
    and
-   <code>
-    ABILITYCATEGORY
-   </code>
+   <code>ABILITYCATEGORY</code>
    tags. The relevant files and tags to
 acomplish this are explained below.
   </p>
@@ -420,9 +388,7 @@ are very similar to those used in the
    </span>
    file. The major difference between these
 two files is that you will need to add the
-   <code>
-    CATEGORY
-   </code>
+   <code>CATEGORY</code>
    tag to your converted feat to make it an ability. To get an idea of
 how to build feats, you can look up
    <a href="lfc_lesson12_feat1.html">
@@ -447,18 +413,14 @@ the ability. You can use any name you prefer as long as it conforms
 to the standard requirements for feat names. For our purposes in
 this class, we will be using the same name we used for our sample
 feat. This means our new ability will be called
-   <code>
-    Expert
-Defense
-   </code>
+   <code>Expert
+Defense</code>
    .
   </p>
   <p class="sidebar1">
    Note: You can have two abilities with the same
 name as long as they are of different categories, i.e. the
-   <code>
-    CATEGORY
-   </code>
+   <code>CATEGORY</code>
    tag specifies a different category for each
 ability.
   </p>
@@ -468,9 +430,7 @@ ability.
    </strong>
   </p>
   <p class="indent1">
-   <code>
-    Expert Defense
-   </code>
+   <code>Expert Defense</code>
   </p>
   <p class="indent2">
    Amazingly enough, our new ability has the same
@@ -478,9 +438,7 @@ name as our old feat.
   </p>
   <hr/>
   <h4>
-   <code>
-    CATEGORY:My Super Ability
-   </code>
+   <code>CATEGORY:My Super Ability</code>
   </h4>
   <p class="indent0">
    This tag identifies the 'category' in which your
@@ -519,35 +477,23 @@ way it is hardcoded within PCGen.
 is in our new ability. The final Ability object is shown below:
   </p>
   <p class="indent2">
-   <code>
-    Expert Defense
-   </code>
+   <code>Expert Defense</code>
   </p>
   <p class="indent2">
-   <code>
-    CATEGORY:My Super Ability
-   </code>
+   <code>CATEGORY:My Super Ability</code>
   </p>
   <p class="indent2">
-   <code>
-    TYPE:Special
-   </code>
+   <code>TYPE:Special</code>
   </p>
   <p class="indent2">
-   <code>
-    VISIBLE:NO
-   </code>
+   <code>VISIBLE:NO</code>
   </p>
   <p class="indent2">
-   <code>
-    SAB:Expert Defense ~ Add % bonus to
-AC|INT
-   </code>
+   <code>SAB:Expert Defense ~ Add % bonus to
+AC|INT</code>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:COMBAT|AC|INT
-   </code>
+   <code>BONUS:COMBAT|AC|INT</code>
   </p>
   <hr style="height:3px"/>
   <h3>
@@ -588,9 +534,7 @@ use the
   </p>
   <hr/>
   <h4>
-   <code>
-    ABILITYCATEGORY:My Super Ability
-   </code>
+   <code>ABILITYCATEGORY:My Super Ability</code>
   </h4>
   <p class="indent0">
    The first entry in the ABILITYCATEGORY line is
@@ -613,9 +557,7 @@ same name as this ability category. In this case,
   </p>
   <hr/>
   <h4>
-   <code>
-    CATEGORY:Special Ability
-   </code>
+   <code>CATEGORY:Special Ability</code>
   </h4>
   <p class="indent0">
    This is a 'super-category', or parent, to which
@@ -637,9 +579,7 @@ defined in either the
   </p>
   <hr/>
   <h4>
-   <code>
-    TYPE:Special
-   </code>
+   <code>TYPE:Special</code>
   </h4>
   <p class="indent0">
    This is a
@@ -688,34 +628,24 @@ types can be found on the
   </p>
   <hr/>
   <h4>
-   <code>
-    PLURAL:My Super Abilities
-   </code>
+   <code>PLURAL:My Super Abilities</code>
   </h4>
   <p class="indent0">
    This has to do with the internationalization. An
 example is:
-   <code>
-    in_feats
-   </code>
+   <code>in_feats</code>
    which sets the category key to
 'in_feats'. It also shows up with the 'Plural' of the name. An
 example of this is
-   <code>
-    Feat
-   </code>
+   <code>Feat</code>
    would be
-   <code>
-    Feats
-   </code>
+   <code>Feats</code>
    .
 (Feats would display in the drop down bar).
   </p>
   <hr/>
   <h4>
-   <code>
-    EDITABLE:NO
-   </code>
+   <code>EDITABLE:NO</code>
   </h4>
   <p class="indent0">
    This defines whether a user can modify the
@@ -728,9 +658,7 @@ for class abilities which aren't chosen by the user.
   </p>
   <hr/>
   <h4>
-   <code>
-    EDITPOOL:NO
-   </code>
+   <code>EDITPOOL:NO</code>
   </h4>
   <p class="indent0">
    This defines whether a user can modify the pool
@@ -749,28 +677,20 @@ default is
   </p>
   <hr/>
   <h4>
-   <code>
-    FRACTIONALPOOL:NO
-   </code>
+   <code>FRACTIONALPOOL:NO</code>
   </h4>
   <p class="indent0">
    This defines whether the pool must be a whole
 number or can be fractions. Some abilities may have a cost less
 than '1' like .5 or .25. Available options are
-   <code>
-    YES
-   </code>
+   <code>YES</code>
    or
-   <code>
-    NO
-   </code>
+   <code>NO</code>
    .
   </p>
   <hr/>
   <h4>
-   <code>
-    POOL:0
-   </code>
+   <code>POOL:0</code>
   </h4>
   <p class="indent0">
    This tag establishes the base ability pool for
@@ -780,55 +700,39 @@ variable. If a variable is used, the variable
     MUST
    </strong>
    be defined by a
-   <code>
-    DEFINE
-   </code>
+   <code>DEFINE</code>
    tag. For our new ability
 category, we will start with an ability pool of zero (0).
   </p>
   <hr/>
   <h4>
-   <code>
-    VISIBLE:NO
-   </code>
+   <code>VISIBLE:NO</code>
   </h4>
   <p class="indent0">
    Defines whether this category is visible on the
 UI or it it is hidden. This tag is useful for hidden abilities and
 class abilities that require no interaction from the user.
 Available options are -
-   <code>
-    YES
-   </code>
+   <code>YES</code>
    ,
-   <code>
-    NO
-   </code>
+   <code>NO</code>
    , or
-   <code>
-    QUALIFY
-   </code>
+   <code>QUALIFY</code>
    .
   </p>
   <hr/>
   <h4>
-   <code>
-    DISPLAYLOCATION
-   </code>
+   <code>DISPLAYLOCATION</code>
   </h4>
   <p class="indent0">
    The
-   <code>
-    DISPLAYLOCATION
-   </code>
+   <code>DISPLAYLOCATION</code>
    is optional but
 will identify the sub-tab upon which the associated abilities will
 be displayed. Examples of some standard locations defined in the
 RSRD data set are "Class Abilities" and "Special Qualities and
 Attacks". If it is not included the
-   <code>
-    PLURAL
-   </code>
+   <code>PLURAL</code>
    text will
 be used instead.
   </p>
@@ -839,9 +743,7 @@ the "My Special Abilities" sub-tab.
   </p>
   <p class="indent0">
    Well, you could if we had not included the
-   <code>
-    VISIBLE:NO
-   </code>
+   <code>VISIBLE:NO</code>
    tag in our ability category entry.
   </p>
   <hr/>
@@ -856,45 +758,29 @@ the "My Special Abilities" sub-tab.
    is shown below:
   </p>
   <p class="indent2">
-   <code>
-    ABILITYCATEGORY:My Super
-Ability
-   </code>
+   <code>ABILITYCATEGORY:My Super
+Ability</code>
   </p>
   <p class="indent2">
-   <code>
-    CATEGORY:Special Ability
-   </code>
+   <code>CATEGORY:Special Ability</code>
   </p>
   <p class="indent2">
-   <code>
-    PLURAL:My Super Abilities
-   </code>
+   <code>PLURAL:My Super Abilities</code>
   </p>
   <p class="indent2">
-   <code>
-    EDITABLE:NO
-   </code>
+   <code>EDITABLE:NO</code>
   </p>
   <p class="indent2">
-   <code>
-    EDITPOOL:NO
-   </code>
+   <code>EDITPOOL:NO</code>
   </p>
   <p class="indent2">
-   <code>
-    FRACTIONALPOOL:NO
-   </code>
+   <code>FRACTIONALPOOL:NO</code>
   </p>
   <p class="indent2">
-   <code>
-    POOL:0
-   </code>
+   <code>POOL:0</code>
   </p>
   <p class="indent2">
-   <code>
-    VISIBLE:NO
-   </code>
+   <code>VISIBLE:NO</code>
   </p>
   <hr style="height:3px"/>
   <h3>
@@ -910,13 +796,9 @@ files to load as well as other information about the 'campaign'.
 Without these files and the related information, PCGen would not be
 able to load any datafiles. For the purposes of this lesson, there
 are only two tags we need to cover: The
-   <code>
-    ABILITY:my_abilities.lst
-   </code>
+   <code>ABILITY:my_abilities.lst</code>
    tag and the
-   <code>
-    ABILITYCATEGORY:my_abilitycategories.lst
-   </code>
+   <code>ABILITYCATEGORY:my_abilitycategories.lst</code>
    tag.
   </p>
   <p class="indent0">
@@ -943,26 +825,20 @@ absolute location within the PCGen installation. These are:
    <li>
     The "at" symbol (@) will load the file from a path relative to
 the data folder. (Example:
-    <code>
-     ABILITY:@/d20ogl/srd35/basics/rsrd_abilities_class.lst
-    </code>
+    <code>ABILITY:@/d20ogl/srd35/basics/rsrd_abilities_class.lst</code>
     )
    </li>
    <li>
     The ampersand (&amp;) will load the file from a path relative
 to the vendor data folder. (Example:
-    <code>
-     ABILITY:&amp;/complete_monkey/complete_monkey_abilities.lst
-    </code>
+    <code>ABILITY:&amp;/complete_monkey/complete_monkey_abilities.lst</code>
     )
    </li>
    <li>
     The asterisk (*) will load the file from a path relative to the
 vendor data folder and if that does not exist, uses a path relative
 to the data folder. (Example:
-    <code>
-     ABILITYCATEGORY:*/d20ogl/srd35/basics/rsrd_ability_categories_core.lst
-    </code>
+    <code>ABILITYCATEGORY:*/d20ogl/srd35/basics/rsrd_ability_categories_core.lst</code>
     )
    </li>
   </ol>
@@ -1005,9 +881,7 @@ RSRD/SRD for the
 ability categories or subcategories you MUST create it there. There
 are entries about them in the docs if you want to read up on them.
 To call the ability file it's (as you guessed),
-   <code>
-    ABILITY:ability.lst
-   </code>
+   <code>ABILITY:ability.lst</code>
    , in the .pcc file. Basically
 pretend that an
    <span class="lstfile">
@@ -1024,26 +898,20 @@ warning though, there may be exceptions to that rule of thumb).
    </a>
    when testing for the converted abilities as a prerequisite, as long
 as you use the
-   <code>
-    CATEGORY:FEAT
-   </code>
+   <code>CATEGORY:FEAT</code>
    tag, but it is
 recommended that you use
    <a href="../globalfilestagpages/globalfilesprexxx.html#preability">
     PREABILITY
    </a>
    instead. If you use any other category, e.g.
-   <code>
-    CATEGORY:MySpecialAbility
-   </code>
+   <code>CATEGORY:MySpecialAbility</code>
    , you
    <strong>
     MUST
    </strong>
    use the
-   <code>
-    PREABILITY
-   </code>
+   <code>PREABILITY</code>
    tag to check for your new abilities
 as prerequisites.
   </p>

--- a/docs/listfilepages/lstfileclass/lfc_lesson18_HD_LEVEL_conversion.html
+++ b/docs/listfilepages/lstfileclass/lfc_lesson18_HD_LEVEL_conversion.html
@@ -41,8 +41,7 @@
    </strong>
   </p>
   <p class="indent1">
-   <code>
-    <a href="../datafilestagpages/datafilestemplates.html#hd">
+   <code><a href="../datafilestagpages/datafilestemplates.html#hd">
      HD
     </a>
     ,
@@ -96,8 +95,7 @@
     ,
     <a href="../globalfilestagpages/globalfilesbonus.html#miscsr">
      BONUS:MISC|SR
-    </a>
-   </code>
+    </a></code>
   </p>
   <p class="indent1">
    The template tags HD and LEVEL are used in
@@ -137,22 +135,18 @@ of total levels the character has. Both of these tags can be
 expressed with this syntax:
   </p>
   <p class="indent1">
-   <code>
-    &lt;Prerequisite&gt;:&lt;levels
+   <code>&lt;Prerequisite&gt;:&lt;levels
 specified&gt;:&lt;Object granting tag&gt;:&lt;Object to be
-granted&gt;
-   </code>
+granted&gt;</code>
   </p>
   <p>
    The more modern syntax which replaces this can be expressed in
 this way:
   </p>
   <p class="indent1">
-   <code>
-    &lt;Object granting tag&gt;:&lt;Object to
+   <code>&lt;Object granting tag&gt;:&lt;Object to
 be granted&gt;|&lt;Prerequisite&gt;:&lt;levels
-specified&gt;
-   </code>
+specified&gt;</code>
   </p>
   <p>
    The function of the HD tag is replaced by the prerequisite tag
@@ -171,31 +165,19 @@ well as a good deal more because of the flexibility these tags
 have. For example:
   </p>
   <p class="indent1">
-   <code>
-    HD:2+
-   </code>
+   <code>HD:2+</code>
    is now
-   <code>
-    PREHD:MIN=2
-   </code>
+   <code>PREHD:MIN=2</code>
   </p>
   <p class="indent1">
-   <code>
-    HD:5-7
-   </code>
+   <code>HD:5-7</code>
    is now
-   <code>
-    PREHD:MIN=5,MAX=7
-   </code>
+   <code>PREHD:MIN=5,MAX=7</code>
   </p>
   <p class="indent1">
-   <code>
-    HD:1-10
-   </code>
+   <code>HD:1-10</code>
    is now
-   <code>
-    PREHD:MAX=10
-   </code>
+   <code>PREHD:MAX=10</code>
   </p>
   <p>
    The same syntax applies to LEVEL and PRELEVEL. In addition there
@@ -224,63 +206,45 @@ value at the levels specified. BONUS:MISC|CR|x can be used to
 replace this function in both HD and LEVEL
   </p>
   <p class="indent1">
-   <code>
-    HD:2+:CR:3
-   </code>
+   <code>HD:2+:CR:3</code>
    is now
-   <code>
-    BONUS:MISC|CR|3|PREHD:MIN=2
-   </code>
+   <code>BONUS:MISC|CR|3|PREHD:MIN=2</code>
   </p>
   <p class="indent1">
-   <code>
-    HD:1-10:CR:2
-   </code>
+   <code>HD:1-10:CR:2</code>
    is
 now
-   <code>
-    BONUS:MISC|CR|2|PREHD:MAX=10
-   </code>
+   <code>BONUS:MISC|CR|2|PREHD:MAX=10</code>
   </p>
   <p class="indent1">
-   <code>
-    LEVEL:5-7:CR:5
-   </code>
+   <code>LEVEL:5-7:CR:5</code>
    is
 now
-   <code>
-    BONUS:MISC|CR|5|PRELEVEL:MIN=5,MAX=7
-   </code>
+   <code>BONUS:MISC|CR|5|PRELEVEL:MIN=5,MAX=7</code>
   </p>
   <p>
    Keep in mind that CR is additive and there can be several way to
 express things, for example a template containing:
   </p>
   <p class="indent1">
-   <code>
-    HD:1-3:CR:2 &lt;tab&gt; HD:4-6:CR:3
-&lt;tab&gt; HD:7+:CR:4
-   </code>
+   <code>HD:1-3:CR:2 &lt;tab&gt; HD:4-6:CR:3
+&lt;tab&gt; HD:7+:CR:4</code>
   </p>
   <p>
    Can be converted most literally as:
   </p>
   <p class="indent1">
-   <code>
-    BONUS:MISC|CR|2|MAX=3 &lt;tab&gt;
+   <code>BONUS:MISC|CR|2|MAX=3 &lt;tab&gt;
 BONUS:MISC|CR|3|PREHD:MIN=4,MAX=6 &lt;tab&gt;
-BONUS:MISC|CR|4|PREHD:MIN=7
-   </code>
+BONUS:MISC|CR|4|PREHD:MIN=7</code>
   </p>
   <p>
    But can also be converted more economically as:
   </p>
   <p class="indent1">
-   <code>
-    CR:2 &lt;tab&gt;
+   <code>CR:2 &lt;tab&gt;
 BONUS:MISC|CR|1|PREHD:MIN=4 &lt;tab&gt;
-BONUS:MISC|CR|1|PREHD:MIN=7
-   </code>
+BONUS:MISC|CR|1|PREHD:MIN=7</code>
   </p>
   <hr/>
   <h3>
@@ -309,33 +273,21 @@ case 10/Magic). It also means that for the tag BONUS:DR|Magic|2 to
 have any effect you must first have a DR:x/Magic tag.
   </p>
   <p class="indent1">
-   <code>
-    HD:2+:DR:10/+1
-   </code>
+   <code>HD:2+:DR:10/+1</code>
    is
 now
-   <code>
-    DR:10/+1|PREHD:MIN=2
-   </code>
+   <code>DR:10/+1|PREHD:MIN=2</code>
   </p>
   <p class="indent1">
-   <code>
-    HD:1-10:DR:5/Cold
-Iron
-   </code>
+   <code>HD:1-10:DR:5/Cold
+Iron</code>
    is now
-   <code>
-    DR:5/Cold Iron|PREHD:MAX=10
-   </code>
+   <code>DR:5/Cold Iron|PREHD:MAX=10</code>
   </p>
   <p class="indent1">
-   <code>
-    LEVEL:5-7:DR:20/Silver
-   </code>
+   <code>LEVEL:5-7:DR:20/Silver</code>
    is now
-   <code>
-    DR:20/Silver|PRELEVEL:MIN=5,MAX=7
-   </code>
+   <code>DR:20/Silver|PRELEVEL:MIN=5,MAX=7</code>
   </p>
   <hr/>
   <h3>
@@ -347,23 +299,15 @@ adjust the feat pool. Feats granted by the HD and LEVEL tags can be
 converted to the ABILITY tag.
   </p>
   <p class="indent1">
-   <code>
-    HD:1-10:FEAT:Blind
-Fight
-   </code>
+   <code>HD:1-10:FEAT:Blind
+Fight</code>
    is now
-   <code>
-    ABILITY:FEAT|AUTOMATIC|Blind Fight|PREHD:MAX=10
-   </code>
+   <code>ABILITY:FEAT|AUTOMATIC|Blind Fight|PREHD:MAX=10</code>
   </p>
   <p class="indent1">
-   <code>
-    LEVEL:5-7:FEAT:Alertness
-   </code>
+   <code>LEVEL:5-7:FEAT:Alertness</code>
    is now
-   <code>
-    ABILITY:FEAT|AUTOMATIC|Alertness|PRELEVEL:MIN=5,MAX=7
-   </code>
+   <code>ABILITY:FEAT|AUTOMATIC|Alertness|PRELEVEL:MIN=5,MAX=7</code>
   </p>
   <p>
    The FEAT function of HD and LEVEL also supports TYPE.x which
@@ -397,25 +341,17 @@ tags granted with HD and LEVEL should be converted to SAB tags with
 the proper PRE tags.
   </p>
   <p class="indent1">
-   <code>
-    HD:1-10:SA:Banana
-toss
-   </code>
+   <code>HD:1-10:SA:Banana
+toss</code>
    is now
-   <code>
-    SAB:Banana toss|PREHD:MAX=10
-   </code>
+   <code>SAB:Banana toss|PREHD:MAX=10</code>
   </p>
   <p class="indent1">
-   <code>
-    LEVEL:5-7:SA:Fire in the
-Hole
-   </code>
+   <code>LEVEL:5-7:SA:Fire in the
+Hole</code>
    is now
-   <code>
-    SAB:Fire in the
-Hole|PRELEVEL:MIN=5,MAX=7
-   </code>
+   <code>SAB:Fire in the
+Hole|PRELEVEL:MIN=5,MAX=7</code>
   </p>
   <hr/>
   <h3>
@@ -431,63 +367,45 @@ at the levels specified. BONUS:MISC|SR|x can be used to replace
 this function in both HD and LEVEL
   </p>
   <p class="indent1">
-   <code>
-    HD:2+:SR:3
-   </code>
+   <code>HD:2+:SR:3</code>
    is now
-   <code>
-    BONUS:MISC|SR|3|PREHD:MIN=2
-   </code>
+   <code>BONUS:MISC|SR|3|PREHD:MIN=2</code>
   </p>
   <p class="indent1">
-   <code>
-    HD:1-10:SR:2
-   </code>
+   <code>HD:1-10:SR:2</code>
    is
 now
-   <code>
-    BONUS:MISC|SR|2|PREHD:MAX=10
-   </code>
+   <code>BONUS:MISC|SR|2|PREHD:MAX=10</code>
   </p>
   <p class="indent1">
-   <code>
-    LEVEL:5-7:SR:5
-   </code>
+   <code>LEVEL:5-7:SR:5</code>
    is
 now
-   <code>
-    BONUS:MISC|SR|5|PRELEVEL:MIN=5,MAX=7
-   </code>
+   <code>BONUS:MISC|SR|5|PRELEVEL:MIN=5,MAX=7</code>
   </p>
   <p>
    Keep in mind that SR is additive and there can be several way to
 express things, for example a template containing:
   </p>
   <p class="indent1">
-   <code>
-    HD:1-3:SR:2 &lt;tab&gt; HD:4-6:SR:3
-&lt;tab&gt; HD:7+:SR:4
-   </code>
+   <code>HD:1-3:SR:2 &lt;tab&gt; HD:4-6:SR:3
+&lt;tab&gt; HD:7+:SR:4</code>
   </p>
   <p>
    Can be converted most literally as:
   </p>
   <p class="indent1">
-   <code>
-    BONUS:MISC|SR|2|MAX=3 &lt;tab&gt;
+   <code>BONUS:MISC|SR|2|MAX=3 &lt;tab&gt;
 BONUS:MISC|SR|3|PREHD:MIN=4,MAX=6 &lt;tab&gt;
-BONUS:MISC|SR|4|PREHD:MIN=7
-   </code>
+BONUS:MISC|SR|4|PREHD:MIN=7</code>
   </p>
   <p>
    But can also be converted more economically as:
   </p>
   <p class="indent1">
-   <code>
-    SR:2 &lt;tab&gt;
+   <code>SR:2 &lt;tab&gt;
 BONUS:MISC|SR|1|PREHD:MIN=4 &lt;tab&gt;
-BONUS:MISC|SR|1|PREHD:MIN=7
-   </code>
+BONUS:MISC|SR|1|PREHD:MIN=7</code>
   </p>
   <hr/>
   <p>

--- a/docs/listfilepages/lstfileclass/lfc_lesson19_companion_mods.html
+++ b/docs/listfilepages/lstfileclass/lfc_lesson19_companion_mods.html
@@ -44,8 +44,7 @@
    </strong>
   </p>
   <p class="indent1">
-   <code>
-    <a href="">
+   <code><a href="">
      FOLLOWER
     </a>
     ,
@@ -91,8 +90,7 @@
     ,
     <a href="">
      COMPANIONLIST
-    </a>
-   </code>
+    </a></code>
   </p>
   <hr/>
   <p class="indent0">
@@ -160,16 +158,12 @@ with the Follower tag.
 telling the program what "level" things happen at. So like we have
 Class Level Lines to tell PCGen what is applied at that level and
 lower so to do we have a tag called
-   <code>
-    FOLLOWER
-   </code>
+   <code>FOLLOWER</code>
    which
 acts in much the same way.
   </p>
   <p class="indent1">
-   <code>
-    FOLLOWER:MonkeyFu=1
-   </code>
+   <code>FOLLOWER:MonkeyFu=1</code>
   </p>
   <p class="indent2">
    The Follower tag can take variables or Class
@@ -179,17 +173,13 @@ have this variable of at least 1 to obtain the rest of the benefits
 derived from the rest of the line.
   </p>
   <p class="indent1">
-   <code>
-    FOLLOWER:Paladin=1
-   </code>
+   <code>FOLLOWER:Paladin=1</code>
   </p>
   <p class="indent2">
    You need to have 1 level in paladin class.
   </p>
   <p class="indent1">
-   <code>
-    FOLLOWER:MagicItem=1
-   </code>
+   <code>FOLLOWER:MagicItem=1</code>
   </p>
   <p class="indent2">
    You need to have 1 in a variable name called
@@ -201,9 +191,7 @@ MagicItem
   </h4>
   <p class="indent0">
    The second and VERY important tag is
-   <code>
-    TYPE
-   </code>
+   <code>TYPE</code>
   </p>
   <p class="indent0">
    Type tells pcgen what applies to this line. The
@@ -215,9 +203,7 @@ Companion, Special Mount, Mount and Follower.
 benefits applied to them. Simply put without a TYPE PCGen won't be
 able to able the changes you code up. TYPE has to match exactly the
 name from
-   <code>
-    COMPANIONLIST
-   </code>
+   <code>COMPANIONLIST</code>
    . Think of TYPE as a Group as
 it groups things together, so with that frame of mind, Familiar is
 a group, as is Special Mount.
@@ -226,9 +212,7 @@ a group, as is Special Mount.
    Example of a Familiar:
   </p>
   <p class="indent1">
-   <code>
-    COMPANIONLIST:Familiar|Bat,Cat
-   </code>
+   <code>COMPANIONLIST:Familiar|Bat,Cat</code>
   </p>
   <p class="indent2">
    Bat and Cat are both of the Familiar TYPE or
@@ -254,9 +238,7 @@ Follower Line.
    This tag identifies the companion's Base Attack
 Bonus (BAB) progression and can be set to that of its master, by
 using the
-   <code>
-    MASTER
-   </code>
+   <code>MASTER</code>
    parameter, or you may use a number,
 variable or formula.
   </p>
@@ -266,9 +248,7 @@ the Master PC's BAB progression you would use the following
 tag:
   </p>
   <p class="indent1">
-   <code>
-    COPYMASTERBAB:MASTER
-   </code>
+   <code>COPYMASTERBAB:MASTER</code>
    (Common for
 familiars)
   </p>
@@ -278,9 +258,7 @@ familiars)
 following tag:
   </p>
   <p class="indent1">
-   <code>
-    COPYMASTERBAB:5
-   </code>
+   <code>COPYMASTERBAB:5</code>
   </p>
   <hr/>
   <h4>
@@ -292,9 +270,7 @@ Checks (Commonly Fortitude, Reflex and Will) The creature will use
 it's Stats to modify the base though (Common for Familiar)
   </p>
   <p class="indent1">
-   <code>
-    COPYMASTERCHECK:MASTER
-   </code>
+   <code>COPYMASTERCHECK:MASTER</code>
   </p>
   <hr/>
   <h4>
@@ -310,10 +286,8 @@ companionmod file.
    Example from the docs
   </p>
   <p class="indent1">
-   <code>
-    COMPANIONLIST:Animal
-Companion|Ape|FOLLOWERADJUSTMENT:-3
-   </code>
+   <code>COMPANIONLIST:Animal
+Companion|Ape|FOLLOWERADJUSTMENT:-3</code>
   </p>
   <p class="indent0">
    An Ape companion to a 4th level Druid gains the
@@ -328,9 +302,7 @@ benefits normally granted to a companion of a 1st level Druid.
 type.
   </p>
   <p class="indent1">
-   <code>
-    HD:5
-   </code>
+   <code>HD:5</code>
   </p>
   <p class="indent2">
    Will grant 5 bonus Hit Die (Or class levels) of
@@ -362,20 +334,16 @@ underestimated, with this tag you can grant a level dependent bonus
 to the master at a certain level.
   </p>
   <p class="indent1">
-   <code>
-    MASTERBONUSRACE:Bat &lt;TAB&gt;
-BONUS:SKILL|Spot|3
-   </code>
+   <code>MASTERBONUSRACE:Bat &lt;TAB&gt;
+BONUS:SKILL|Spot|3</code>
   </p>
   <p class="indent2">
    Would give the master +3 bonus to Spot checks if
 he has a Bat.
   </p>
   <p class="indent1">
-   <code>
-    MASTERBONUSRACE:Bat &lt;TAB&gt;
-BONUS:VAR|MyCoolVar|3|PREPCLEVEL:MIN=10
-   </code>
+   <code>MASTERBONUSRACE:Bat &lt;TAB&gt;
+BONUS:VAR|MyCoolVar|3|PREPCLEVEL:MIN=10</code>
   </p>
   <p class="indent2">
    At 10th level the Master of this Bat gets 3 to
@@ -383,11 +351,9 @@ his 'MyCoolVar' which can be attached to a feat, ability, or even
 an item with a Variable in the SPROP.
   </p>
   <p class="indent1">
-   <code>
-    MASTERBONUSRACE:Magic Item - Sword
+   <code>MASTERBONUSRACE:Magic Item - Sword
 &lt;TAB&gt;
-BONUS:VAR|MagicWeaponPlusIncrease|2|PREVARGTEQ:MagicItem,1
-   </code>
+BONUS:VAR|MagicWeaponPlusIncrease|2|PREVARGTEQ:MagicItem,1</code>
   </p>
   <p class="indent2">
    This will grant two (2) to the varaible
@@ -403,9 +369,7 @@ the one listed. RACETYPE affects the Bonus HD and progression of
 the creature.
   </p>
   <p class="indent1">
-   <code>
-    RACETYPE:Fey
-   </code>
+   <code>RACETYPE:Fey</code>
   </p>
   <p class="indent2">
    The creature now has the Fey Type which replaces
@@ -421,19 +385,13 @@ exact same skill ranks as the master.
   </p>
   <p class="indent0">
    Your choices are
-   <code>
-    YES
-   </code>
+   <code>YES</code>
    and
-   <code>
-    NO
-   </code>
+   <code>NO</code>
    (Default).
   </p>
   <p class="indent1">
-   <code>
-    USEMASTERSKILL:YES
-   </code>
+   <code>USEMASTERSKILL:YES</code>
   </p>
   <p class="indent2">
    Creature will have the exact same ranks in the
@@ -453,16 +411,12 @@ this class.
   </p>
   <p class="indent0">
    The
-   <code>
-    BONUS:FOLLOWER
-   </code>
+   <code>BONUS:FOLLOWER</code>
    tag is what
 allows us to actually gain a creature in a particular TYPE or
 group. Without it you won't be able to select or add any creatures
 from that TYPE or group. This needs to match the
-   <code>
-    COMPANIONLIST
-   </code>
+   <code>COMPANIONLIST</code>
    definition, which is seen as the
 companion type inside our actual file.
   </p>
@@ -487,13 +441,11 @@ non-companion mod lst file (e.g.
    , etc.)
   </p>
   <p class="indent1">
-   <code>
-    BONUS:FOLLOWERS|
+   <code>BONUS:FOLLOWERS|
     <b>
      Familiar
     </b>
-    |1
-   </code>
+    |1</code>
   </p>
   <p class="indent2">
    You can gain one (1) Familiar
@@ -507,26 +459,22 @@ the
    :
   </p>
   <p class="indent1">
-   <code>
-    FOLLOWER:Whatever=1 &lt;TAB&gt;
+   <code>FOLLOWER:Whatever=1 &lt;TAB&gt;
 TYPE:
     <b>
      Familiar
-    </b>
-   </code>
+    </b></code>
   </p>
   <p class="indent2">
   </p>
   <p class="indent0">
   </p>
   <p class="indent1">
-   <code>
-    COMPANIONLIST:
+   <code>COMPANIONLIST:
     <b>
      Familiar
     </b>
-    |Foo
-   </code>
+    |Foo</code>
   </p>
   <p class="indent2">
   </p>
@@ -552,26 +500,20 @@ something PCGen understands.
   </p>
   <blockquote class="indent1">
    <p class="tagindent1">
-    <code>
-     FOLLOWER:SlySlinkLvl=3 &lt;TAB&gt;
-TYPE:Sly Slink &lt;TAB&gt; HD:3
-    </code>
+    <code>FOLLOWER:SlySlinkLvl=3 &lt;TAB&gt;
+TYPE:Sly Slink &lt;TAB&gt; HD:3</code>
    </p>
    <p class="tagindent1">
-    <code>
-     FOLLOWER:SlySlinkLvl=5 &lt;TAB&gt;
-TYPE:Sly Slink &lt;TAB&gt; HD:3
-    </code>
+    <code>FOLLOWER:SlySlinkLvl=5 &lt;TAB&gt;
+TYPE:Sly Slink &lt;TAB&gt; HD:3</code>
    </p>
   </blockquote>
   <blockquote class="indent1">
    <p class="tagindent1">
-    <code>
-     MASTERBONUSRACE:Shadow Ferret
+    <code>MASTERBONUSRACE:Shadow Ferret
 &lt;TAB&gt; TYPE:Sly Slink &lt;TAB&gt;
 BONUS:SKILL|Hide|2|PREPCLEVEL:MIN=3 &lt;TAB&gt; SAB:use Shadow Walk
-once per day|PREPCLEVEL:MIN=5
-    </code>
+once per day|PREPCLEVEL:MIN=5</code>
    </p>
   </blockquote>
   <p class="indent0">
@@ -580,12 +522,10 @@ this:
   </p>
   <blockquote class="indent1">
    <p class="tagindent1">
-    <code>
-     FOLLOWERS:Sly Slink|1 &lt;TAB&gt;
+    <code>FOLLOWERS:Sly Slink|1 &lt;TAB&gt;
 COMPANIONLIST:Sly Slink|Shadow Ferret &lt;TAB&gt;
 DEFINE:SlySlinkLvl|0 &lt;TAB&gt;
-BONUS:VAR|SlySlinkLvl|TL
-    </code>
+BONUS:VAR|SlySlinkLvl|TL</code>
    </p>
   </blockquote>
   <p class="indent0">
@@ -594,47 +534,33 @@ critter
   </p>
   <blockquote class="indent1">
    <p class="tagindent1">
-    <code>
-     FOLLOWER:Monkey Warrior=1 &lt;TAB&gt;
+    <code>FOLLOWER:Monkey Warrior=1 &lt;TAB&gt;
 HD:5 &lt;TAB&gt; TYPE:Monkey Mount &lt;TAB&gt; ABILITY:Special
 Ability|AUTOMATIC|Dodging Foo|Nasty Breath &lt;TAB&gt;
-RACETYPE:Dragon &lt;TAB&gt; USEMASTERSKILL:YES
-    </code>
+RACETYPE:Dragon &lt;TAB&gt; USEMASTERSKILL:YES</code>
    </p>
   </blockquote>
   <p class="indent2">
    Okay Class, I threw a few curve balls in there.
 As a 1st level Monkey Warrior,
-   <code>
-    FOLLOWER:Monkey
-Warrior=1
-   </code>
+   <code>FOLLOWER:Monkey
+Warrior=1</code>
    , my critter of the Monkey Mount type,
-   <code>
-    TYPE:Monkey Mount
-   </code>
+   <code>TYPE:Monkey Mount</code>
    , will become a Dragon race type,
-   <code>
-    RACETYPE:Dragon
-   </code>
+   <code>RACETYPE:Dragon</code>
    . It will use my skill rank selection,
-   <code>
-    USEMASTERSKILL:YES
-   </code>
+   <code>USEMASTERSKILL:YES</code>
    , and get the special abilities of
 Dodging Foo and Nasty Breath,
-   <code>
-    ABILITY:Special
-Ability|AUTOMATIC|Dodging Foo|Nasty Breath
-   </code>
+   <code>ABILITY:Special
+Ability|AUTOMATIC|Dodging Foo|Nasty Breath</code>
    , as automatic
 abilities.
   </p>
   <p class="indent1">
-   <code>
-    FOLLOWER:Monkey Warrior=5 &lt;TAB&gt; HD:5
-&lt;TAB&gt; SR:12+HD
-   </code>
+   <code>FOLLOWER:Monkey Warrior=5 &lt;TAB&gt; HD:5
+&lt;TAB&gt; SR:12+HD</code>
   </p>
   <p class="indent2">
    When Monkey Warrior becomes 5th level, my
@@ -653,20 +579,16 @@ you choose what creatures belong in the Monkey Mount (TYPE) or
 group.
   </p>
   <p class="indent1">
-   <code>
-    COMPANIONLIST:Monkey Mount|Wolf,Fuzzy
-Bear
-   </code>
+   <code>COMPANIONLIST:Monkey Mount|Wolf,Fuzzy
+Bear</code>
   </p>
   <p class="indent2">
    That would make a Wolf and Fuzzy Bear part of
 the Monkey Mount (TYPE) or group.
   </p>
   <p class="indent1">
-   <code>
-    COMPANIONLIST:Monkey
-Mount|Bat|FOLLOWERADJUSTMENT:-5
-   </code>
+   <code>COMPANIONLIST:Monkey
+Mount|Bat|FOLLOWERADJUSTMENT:-5</code>
   </p>
   <p class="indent2">
    If my Monkey Warrior takes a bat companion he
@@ -681,25 +603,19 @@ makes a great example of this case.
 they understand this.
   </p>
   <p class="indent1">
-   <code>
-    COMPANIONLIST:Intelligent Item|Intelligent
-Weapon - Longsword
-   </code>
+   <code>COMPANIONLIST:Intelligent Item|Intelligent
+Weapon - Longsword</code>
   </p>
   <p class="indent1">
-   <code>
-    BONUS:FOLLOWERS|Intelligent
-Item|1
-   </code>
+   <code>BONUS:FOLLOWERS|Intelligent
+Item|1</code>
   </p>
   <blockquote class="indent1">
    <p class="tagindent1">
-    <code>
-     MASTERBONUSRACE:Intelligent Weapon -
+    <code>MASTERBONUSRACE:Intelligent Weapon -
 Longsword &lt;TAB&gt; BONUS:SKILL|Move Silently|5|TYPE=Competence
 &lt;TAB&gt; AUTO:FEAT|Weapon Focus(Longsword) &lt;TAB&gt;
-BONUS:VAR|WeaponPlusIncrease|1|PREPCLEVEL:MIN=8
-    </code>
+BONUS:VAR|WeaponPlusIncrease|1|PREPCLEVEL:MIN=8</code>
    </p>
   </blockquote>
   <p class="indent0">
@@ -727,17 +643,13 @@ time when you wish to add to the list of available critters to a
 certain class or group.
   </p>
   <p class="indent1">
-   <code>
-    COMPANIONLIST
-   </code>
+   <code>COMPANIONLIST</code>
    is additive. A good
 example of this case is Improved Familiar.
   </p>
   <p class="indent1">
-   <code>
-    COMPANIONLIST:Familiar|Shocker
-Lizard,Stirge|PRECLASS:1,SPELLCASTER.Arcane=5
-   </code>
+   <code>COMPANIONLIST:Familiar|Shocker
+Lizard,Stirge|PRECLASS:1,SPELLCASTER.Arcane=5</code>
   </p>
   <p class="indent0">
    This will grant the Shocker Lizard and Stirge to
@@ -745,10 +657,8 @@ the available list in the Familiar (TYPE) if the master is an
 Arcane Spell Caster of 5th level or higher.
   </p>
   <p class="indent1">
-   <code>
-    COMPANIONLIST:Monkey Mount|Sand
-Shark
-   </code>
+   <code>COMPANIONLIST:Monkey Mount|Sand
+Shark</code>
   </p>
   <p class="indent0">
    This will grant the Sand Shark to the available

--- a/docs/listfilepages/lstfileclass/lfc_style_guide.html
+++ b/docs/listfilepages/lstfileclass/lfc_style_guide.html
@@ -99,9 +99,7 @@ line-breaks with the subsequent lines indented.
    <dd>
     Text meant to display LST code, including LST objects and tags,
 will be displayed in
-    <code>
-     code font
-    </code>
+    <code>code font</code>
     .
    </dd>
    <dt>

--- a/docs/listfilepages/lstfileclass/lstfileclass_heading.html
+++ b/docs/listfilepages/lstfileclass/lstfileclass_heading.html
@@ -78,10 +78,8 @@ breaks with no additional indention.
    </dt>
    <dd>
     Text meant to display LST code will be in the
-    <code>
-     code
-font
-    </code>
+    <code>code
+font</code>
     .
    </dd>
    <dt>

--- a/docs/listfilepages/rulesguide/game_rules_reading_instructions.html
+++ b/docs/listfilepages/rulesguide/game_rules_reading_instructions.html
@@ -67,10 +67,8 @@ no additional indentation.
    </dt>
    <dd>
     Text meant to display LST code will be in the
-    <code>
-     code
-font
-    </code>
+    <code>code
+font</code>
     .
    </dd>
    <dt>

--- a/docs/listfilepages/rulesguide/grig_abilities_by_skill_ranks.html
+++ b/docs/listfilepages/rulesguide/grig_abilities_by_skill_ranks.html
@@ -357,9 +357,7 @@ stat:
     <strong>
      Tag Used:
     </strong>
-    <code>
-     DEFINE:AbilitybySkillMax|TL/2
-    </code>
+    <code>DEFINE:AbilitybySkillMax|TL/2</code>
    </p>
    <p class="indent1">
     <strong>
@@ -400,9 +398,7 @@ do this are explained below:
     <strong>
      Tag Used:
     </strong>
-    <code>
-     ABILITYCATEGORY:AbilitybySkill
-    </code>
+    <code>ABILITYCATEGORY:AbilitybySkill</code>
    </p>
    <p class="indent1">
     <strong>
@@ -418,9 +414,7 @@ show in the PCGen user interface, under the FEATs tab.
     <strong>
      Tag Used:
     </strong>
-    <code>
-     CATEGORY:AbilitybySkill
-    </code>
+    <code>CATEGORY:AbilitybySkill</code>
    </p>
    <p class="indent1">
     <strong>
@@ -435,9 +429,7 @@ category's parent category as the same as the new category.
     <strong>
      Tag Used:
     </strong>
-    <code>
-     PLURAL:AbilitybySkills
-    </code>
+    <code>PLURAL:AbilitybySkills</code>
    </p>
    <p class="indent1">
     <strong>
@@ -453,9 +445,7 @@ Internatinalization.)
     <strong>
      Tag Used:
     </strong>
-    <code>
-     EDITABLE:YES
-    </code>
+    <code>EDITABLE:YES</code>
    </p>
    <p class="indent1">
     <strong>
@@ -470,9 +460,7 @@ that that a user can select abilities in this category.
     <strong>
      Tag Used:
     </strong>
-    <code>
-     EDITPOOL:NO
-    </code>
+    <code>EDITPOOL:NO</code>
    </p>
    <p class="indent1">
     <strong>
@@ -487,9 +475,7 @@ category of ability cannot be modified by the user.
     <strong>
      Tag Used:
     </strong>
-    <code>
-     FRACTIONALPOOL:NO
-    </code>
+    <code>FRACTIONALPOOL:NO</code>
    </p>
    <p class="indent1">
     <strong>
@@ -505,9 +491,7 @@ only.
     <strong>
      Tag Used:
     </strong>
-    <code>
-     POOL:AbilitybySkillPool
-    </code>
+    <code>POOL:AbilitybySkillPool</code>
    </p>
    <p class="indent1">
     <strong>
@@ -528,9 +512,7 @@ DEFINE tag below.)
     <strong>
      Tag Used:
     </strong>
-    <code>
-     DEFINE:AbilitybySkillPool|0
-    </code>
+    <code>DEFINE:AbilitybySkillPool|0</code>
    </p>
    <p class="indent1">
     <strong>
@@ -550,9 +532,7 @@ zero.
     <strong>
      Tag Used:
     </strong>
-    <code>
-     VISIBLE:QUALIFY
-    </code>
+    <code>VISIBLE:QUALIFY</code>
    </p>
    <p class="indent1">
     <strong>
@@ -592,9 +572,7 @@ to do this are explained below:
     <strong>
      Tag Used:
     </strong>
-    <code>
-     TYPE:NoStat
-    </code>
+    <code>TYPE:NoStat</code>
    </p>
    <p class="indent1">
     <strong>
@@ -609,9 +587,7 @@ assigned a type of "NoStat".
     <strong>
      Tag Used:
     </strong>
-    <code>
-     VISIBLE:DISPLAY
-    </code>
+    <code>VISIBLE:DISPLAY</code>
    </p>
    <p class="indent1">
     <strong>
@@ -627,10 +603,8 @@ not appear on the Character sheet.
     <strong>
      Tag Used:
     </strong>
-    <code>
-     BONUS:ABILITYPOOL|AbilitybySkillPool|SKILL.Skills to
-Abilities.RANK
-    </code>
+    <code>BONUS:ABILITYPOOL|AbilitybySkillPool|SKILL.Skills to
+Abilities.RANK</code>
    </p>
    <p class="indent1">
     <strong>
@@ -677,9 +651,7 @@ do this are explained below:
     <strong>
      Tag Used:
     </strong>
-    <code>
-     CATEGORY:AbilitybySkill
-    </code>
+    <code>CATEGORY:AbilitybySkill</code>
    </p>
    <p class="indent1">
     <strong>
@@ -699,9 +671,7 @@ category. (See
     <strong>
      Tag Used:
     </strong>
-    <code>
-     TYPE:AbilitybySkill.Movement
-    </code>
+    <code>TYPE:AbilitybySkill.Movement</code>
    </p>
    <p class="indent1">
     <strong>
@@ -716,9 +686,7 @@ this ability to "AbilitybySkill" and "Movement".
     <strong>
      Tag Used:
     </strong>
-    <code>
-     VISIBLE:QUALIFY
-    </code>
+    <code>VISIBLE:QUALIFY</code>
    </p>
    <p class="indent1">
     <strong>
@@ -734,10 +702,8 @@ have been met.
     <strong>
      Tag Used:
     </strong>
-    <code>
-     !PREABILITY:1,CATEGORY=AbilitybySkill,Generic Skill Bought
-Ability
-    </code>
+    <code>!PREABILITY:1,CATEGORY=AbilitybySkill,Generic Skill Bought
+Ability</code>
    </p>
    <p class="indent1">
     <strong>
@@ -759,9 +725,7 @@ default of MULT:NO.)
     <strong>
      Tag Used:
     </strong>
-    <code>
-     PRESKILL:1,Tumble=12
-    </code>
+    <code>PRESKILL:1,Tumble=12</code>
    </p>
    <p class="indent1">
     <strong>
@@ -781,9 +745,7 @@ Specifically, the character must have at least 12 ranks in the
     <strong>
      Tag Used:
     </strong>
-    <code>
-     PREVARLT:AbilitybySkillCount,AbilitybySkillMax
-    </code>
+    <code>PREVARLT:AbilitybySkillCount,AbilitybySkillMax</code>
    </p>
    <p class="indent1">
     <strong>
@@ -808,9 +770,7 @@ ability to be selected.
     <strong>
      Tag Used:
     </strong>
-    <code>
-     DEFINE:AbilitybySkillCount|0
-    </code>
+    <code>DEFINE:AbilitybySkillCount|0</code>
    </p>
    <p class="indent1">
     <strong>
@@ -830,9 +790,7 @@ value zero.
     <strong>
      Tag Used:
     </strong>
-    <code>
-     DESC:&lt;appropriate description&gt;
-    </code>
+    <code>DESC:&lt;appropriate description&gt;</code>
    </p>
    <p class="indent1">
     <strong>
@@ -851,9 +809,7 @@ lesson.
     <strong>
      Tag Used:
     </strong>
-    <code>
-     BONUS:VAR|AbilitybySkillCount|1
-    </code>
+    <code>BONUS:VAR|AbilitybySkillCount|1</code>
    </p>
    <p class="indent1">
     <strong>
@@ -906,10 +862,8 @@ upon level-up. The tags used to do this are explained below:
     <strong>
      Tag Used:
     </strong>
-    <code>
-     ADD:ABILITY|FEAT|AUTOMATIC|Initialize Abilities by
-Skill
-    </code>
+    <code>ADD:ABILITY|FEAT|AUTOMATIC|Initialize Abilities by
+Skill</code>
    </p>
    <p class="indent1">
     <strong>
@@ -922,9 +876,7 @@ Skill
     <strong>
      Tag Used:
     </strong>
-    <code>
-     ADD:ABILITY|AbilitybySkill|AUTOMATIC|TYPE=AbilitybySkill
-    </code>
+    <code>ADD:ABILITY|AbilitybySkill|AUTOMATIC|TYPE=AbilitybySkill</code>
    </p>
    <p class="indent1">
     <strong>
@@ -961,53 +913,35 @@ examples only and are not part of any official PCGen dataset.
   </h4>
   <blockquote class="indent2">
    <p class="tagindent1">
-    <code>
-     STATNAME:Intelligence
-    </code>
+    <code>STATNAME:Intelligence</code>
    </p>
    <p class="tagindent1">
-    <code>
-     ABB:INT
-    </code>
+    <code>ABB:INT</code>
    </p>
    <p class="tagindent1">
-    <code>
-     STATMOD:floor(SCORE/2)-5
-    </code>
+    <code>STATMOD:floor(SCORE/2)-5</code>
    </p>
    <p class="tagindent1">
-    <code>
-     DEFINE:MAXLEVELSTAT=INT|INTSCORE-10
-    </code>
+    <code>DEFINE:MAXLEVELSTAT=INT|INTSCORE-10</code>
    </p>
    <p class="tagindent1">
-    <code>
-     DEFINE:AbilitybySkillMax|0
-    </code>
+    <code>DEFINE:AbilitybySkillMax|0</code>
     (This
 tag is added to the existing entry.)
    </p>
    <p class="tagindent1">
-    <code>
-     DEFINE:AbilitybySkillCount|0
-    </code>
+    <code>DEFINE:AbilitybySkillCount|0</code>
     (This tag is added to the existing entry.)
    </p>
    <p class="tagindent1">
-    <code>
-     BONUS:VAR|AbilitybySkillMax|TL
-    </code>
+    <code>BONUS:VAR|AbilitybySkillMax|TL</code>
     (This tag is added to the existing entry.)
    </p>
    <p class="tagindent1">
-    <code>
-     BONUS:LANG|BONUS|INT
-    </code>
+    <code>BONUS:LANG|BONUS|INT</code>
    </p>
    <p class="tagindent1">
-    <code>
-     BONUS:MODSKILLPOINTS|NUMBER|INT
-    </code>
+    <code>BONUS:MODSKILLPOINTS|NUMBER|INT</code>
    </p>
   </blockquote>
   <h4 class="indent1">
@@ -1017,39 +951,25 @@ tag is added to the existing entry.)
   </h4>
   <blockquote class="indent2">
    <p class="tagindent1">
-    <code>
-     ABILITYCATEGORY:AbilitybySkill
-    </code>
+    <code>ABILITYCATEGORY:AbilitybySkill</code>
    </p>
    <p class="tagindent1">
-    <code>
-     CATEGORY:AbilitybySkill
-    </code>
+    <code>CATEGORY:AbilitybySkill</code>
    </p>
    <p class="tagindent1">
-    <code>
-     PLURAL:AbilitybySkills
-    </code>
+    <code>PLURAL:AbilitybySkills</code>
    </p>
    <p class="tagindent1">
-    <code>
-     EDITABLE:YES
-    </code>
+    <code>EDITABLE:YES</code>
    </p>
    <p class="tagindent1">
-    <code>
-     EDITPOOL:NO
-    </code>
+    <code>EDITPOOL:NO</code>
    </p>
    <p class="tagindent1">
-    <code>
-     FRACTIONALPOOL:NO
-    </code>
+    <code>FRACTIONALPOOL:NO</code>
    </p>
    <p class="tagindent1">
-    <code>
-     VISIBLE:QUALIFY
-    </code>
+    <code>VISIBLE:QUALIFY</code>
    </p>
   </blockquote>
   <h4 class="indent1">
@@ -1060,25 +980,17 @@ Entry:
   </h4>
   <blockquote class="indent2">
    <p class="tagindent1">
-    <code>
-     Skills to Abilities
-    </code>
+    <code>Skills to Abilities</code>
    </p>
    <p class="tagindent1">
-    <code>
-     TYPE:None
-    </code>
+    <code>TYPE:None</code>
    </p>
    <p class="tagindent1">
-    <code>
-     VISIBLE:DISPLAY
-    </code>
+    <code>VISIBLE:DISPLAY</code>
    </p>
    <p class="tagindent1">
-    <code>
-     BONUS:ABILITYPOOL|AbilitybySkill|SKILL.Skills to
-Abilities.RANK
-    </code>
+    <code>BONUS:ABILITYPOOL|AbilitybySkill|SKILL.Skills to
+Abilities.RANK</code>
    </p>
   </blockquote>
   <h4 class="indent1">
@@ -1089,56 +1001,36 @@ Entry:
   </h4>
   <blockquote class="indent2">
    <p class="tagindent1">
-    <code>
-     Generic Skill Bought Ability
-    </code>
+    <code>Generic Skill Bought Ability</code>
    </p>
    <p class="tagindent1">
-    <code>
-     CATEGORY:AbilitybySkill
-    </code>
+    <code>CATEGORY:AbilitybySkill</code>
    </p>
    <p class="tagindent1">
-    <code>
-     TYPE:AbilitybySkill.Movement
-    </code>
+    <code>TYPE:AbilitybySkill.Movement</code>
    </p>
    <p class="tagindent1">
-    <code>
-     VISIBLE:QUALIFY
-    </code>
+    <code>VISIBLE:QUALIFY</code>
    </p>
    <p class="tagindent1">
-    <code>
-     !PREABILITY:1,CATEGORY=AbilitybySkill,Generic Skill Bought
-Ability
-    </code>
+    <code>!PREABILITY:1,CATEGORY=AbilitybySkill,Generic Skill Bought
+Ability</code>
    </p>
    <p class="tagindent1">
-    <code>
-     PRESKILL:1,Tumble=12
-    </code>
+    <code>PRESKILL:1,Tumble=12</code>
    </p>
    <p class="tagindent1">
-    <code>
-     PREVARLT:AbilitybySkillCount,AbilitybySkillMax
-    </code>
+    <code>PREVARLT:AbilitybySkillCount,AbilitybySkillMax</code>
    </p>
    <p class="tagindent1">
-    <code>
-     DEFINE:AbilitybySkillCount|0
-    </code>
+    <code>DEFINE:AbilitybySkillCount|0</code>
    </p>
    <p class="tagindent1">
-    <code>
-     DESC:&lt;appropriate
-description&gt;
-    </code>
+    <code>DESC:&lt;appropriate
+description&gt;</code>
    </p>
    <p class="tagindent1">
-    <code>
-     BONUS:VAR|AbilitybySkillCount|1
-    </code>
+    <code>BONUS:VAR|AbilitybySkillCount|1</code>
    </p>
   </blockquote>
   <h4 class="indent1">
@@ -1149,61 +1041,39 @@ Entry:
   </h4>
   <blockquote class="indent2">
    <p class="tagindent1">
-    <code>
-     CLASS:Generic Class
-    </code>
+    <code>CLASS:Generic Class</code>
    </p>
    <p class="tagindent1">
-    <code>
-     CLASS:Generic Class
-    </code>
+    <code>CLASS:Generic Class</code>
    </p>
    <p class="tagindent1">
-    <code>
-     CLASS:Generic Class
-    </code>
+    <code>CLASS:Generic Class</code>
    </p>
    <p class="tagindent1">
-    <code>
-     1
-    </code>
+    <code>1</code>
     [
-    <code>
-     ADD:ABILITY|FEAT|AUTOMATIC|Initialize Abilities by
-Skill
-    </code>
+    <code>ADD:ABILITY|FEAT|AUTOMATIC|Initialize Abilities by
+Skill</code>
     ] (Add this tag to an existing class)
    </p>
    <p class="tagindent1">
-    <code>
-     2
-    </code>
+    <code>2</code>
    </p>
    <p class="tagindent1">
-    <code>
-     3
-    </code>
+    <code>3</code>
    </p>
    <p class="tagindent1">
-    <code>
-     4
-    </code>
-    <code>
-     ADD:ABILITY|AbilitybySkill|AUTOMATIC|TYPE=AbilitybySkill
-&lt;tab&gt; BONUS:VAR|AbilitybySkillMax|1
-    </code>
+    <code>4</code>
+    <code>ADD:ABILITY|AbilitybySkill|AUTOMATIC|TYPE=AbilitybySkill
+&lt;tab&gt; BONUS:VAR|AbilitybySkillMax|1</code>
     (Add these two
 tags to an existing class level lines)
    </p>
    <p class="tagindent1">
-    <code>
-     5
-    </code>
+    <code>5</code>
    </p>
    <p class="tagindent1">
-    <code>
-     6
-    </code>
+    <code>6</code>
    </p>
   </blockquote>
   <hr/>

--- a/docs/listfilepages/rulesguide/grig_negative_levels.html
+++ b/docs/listfilepages/rulesguide/grig_negative_levels.html
@@ -146,9 +146,7 @@ load your datasets on the "Source Materials" tab.
     entry for the piece of equipment in question, include the
 appropriate tag to grant the "Negative Levels" feat. This is
 usually done with the
-    <code>
-     VFEAT:Negative Levels
-    </code>
+    <code>VFEAT:Negative Levels</code>
     tag. See
 the
     <a href="#vfeat">
@@ -159,9 +157,7 @@ how it works.
    </li>
    <li>
     Add a
-    <code>
-     BONUS:VAR|NegLevels|#|PRExxx
-    </code>
+    <code>BONUS:VAR|NegLevels|#|PRExxx</code>
     tag in the
     <span class="lstfile">
      equipment.lst
@@ -176,16 +172,12 @@ works.
    </li>
    <li>
     The PRExxx tag used in the
-    <code>
-     BONUS:VAR
-    </code>
+    <code>BONUS:VAR</code>
     tag above is
 used to define what prerequirements must be met before applying the
 negative levels. The most common prerequirement is the alignment of
 the character, in which case the
-    <code>
-     PREALIGN|x,x
-    </code>
+    <code>PREALIGN|x,x</code>
     tag
 would be used. See the
     <a href="#prealign">
@@ -252,12 +244,10 @@ the board. The tags used are explained below:
      <strong>
       Tag Used:
      </strong>
-     <code>
-      SA:%
+     <code>SA:%
 negative level(s) (-% effective level(s) and loses access to %
 spell(s) from the highest spell level
-castable)|NegLevels|NegLevels|NegLevels
-     </code>
+castable)|NegLevels|NegLevels|NegLevels</code>
     </p>
    </blockquote>
    <p class="indent1">
@@ -287,9 +277,7 @@ variable listed after subsequent pipes.
      </span>
      is defined
 by the
-     <code>
-      DEFINE
-     </code>
+     <code>DEFINE</code>
      tag within this feat.
     </li>
     <li>
@@ -307,9 +295,7 @@ last variable or formula equals "0".
     <strong>
      Tag Used:
     </strong>
-    <code>
-     DEFINE:NegLevels|0
-    </code>
+    <code>DEFINE:NegLevels|0</code>
    </p>
    <p class="indent1">
     <strong>
@@ -328,9 +314,7 @@ to a value of zero.
     <strong>
      Tag Used:
     </strong>
-    <code>
-     BONUS:CHECKS|Fortitude,Reflex,Will|-1*(NegLevels)
-    </code>
+    <code>BONUS:CHECKS|Fortitude,Reflex,Will|-1*(NegLevels)</code>
    </p>
    <p class="indent1">
     <strong>
@@ -346,9 +330,7 @@ and "Will" saving throws.
     <strong>
      Tag Used:
     </strong>
-    <code>
-     BONUS:COMBAT|TOHIT|-1*(NegLevels)
-    </code>
+    <code>BONUS:COMBAT|TOHIT|-1*(NegLevels)</code>
    </p>
    <p class="indent1">
     <strong>
@@ -364,10 +346,8 @@ number of negative leves granted from the primary attack bonus.
      <strong>
       Tag Used:
      </strong>
-     <code>
-      BONUS:SKILL|TYPE=Strength,TYPE=Dexterity,TYPE=Constitution,
-TYPE=Intelligence,TYPE=Wisdom,TYPE=Charisma|-1*(NegLevels)
-     </code>
+     <code>BONUS:SKILL|TYPE=Strength,TYPE=Dexterity,TYPE=Constitution,
+TYPE=Intelligence,TYPE=Wisdom,TYPE=Charisma|-1*(NegLevels)</code>
     </p>
    </blockquote>
    <p class="indent1">
@@ -393,15 +373,11 @@ number of negative levels granted from all skills.
 Levels
    </span>
    by using the
-   <code>
-    VFEAT
-   </code>
+   <code>VFEAT</code>
    tag in the specific
 equipment entry and then we must apply the specific number of
 negative levels through the
-   <code>
-    BONUS:VAR
-   </code>
+   <code>BONUS:VAR</code>
    tag.
   </p>
   <blockquote class="indent1">
@@ -411,9 +387,7 @@ negative levels through the
       Tag
 Used:
      </strong>
-     <code>
-      VFEAT:Negative Levels
-     </code>
+     <code>VFEAT:Negative Levels</code>
     </a>
    </p>
    <p class="indent1">
@@ -440,9 +414,7 @@ Entry above.)
       Tag
 Used:
      </strong>
-     <code>
-      BONUS:VAR|NegLevels|x|PREALIGN:LG,LN,NG,TN,CG,CN
-     </code>
+     <code>BONUS:VAR|NegLevels|x|PREALIGN:LG,LN,NG,TN,CG,CN</code>
     </a>
    </p>
    <p class="indent1">
@@ -504,9 +476,7 @@ restriction on the associated bonus.
     (RSRD)
    </p>
    <p class="indent2">
-    <code>
-     BONUS:VAR|NegLevels|1|PREALIGN:LG,LN,NG,TN,CG,CN
-    </code>
+    <code>BONUS:VAR|NegLevels|1|PREALIGN:LG,LN,NG,TN,CG,CN</code>
    </p>
    <p class="indent3">
     Demon Armor bestows one negative level to all
@@ -520,9 +490,7 @@ non-evil characters.
       Tag
 Used:
      </strong>
-     <code>
-      PREALIGN:LG,LN,NG,TN,CG,CN
-     </code>
+     <code>PREALIGN:LG,LN,NG,TN,CG,CN</code>
     </a>
    </p>
    <p class="indent1">
@@ -558,47 +526,31 @@ Levels
   </p>
   <blockquote class="indent2">
    <p class="tagindent1">
-    <code>
-     Negative Levels
-    </code>
+    <code>Negative Levels</code>
    </p>
    <p class="tagindent1">
-    <code>
-     TYPE:Special
-    </code>
+    <code>TYPE:Special</code>
    </p>
    <p class="tagindent1">
-    <code>
-     VISIBLE:NO
-    </code>
+    <code>VISIBLE:NO</code>
    </p>
    <p class="tagindent1">
-    <code>
-     SA:% negative level(s) (-% effective
+    <code>SA:% negative level(s) (-% effective
 level(s) and loses access to % spell(s) from the highest spell
-level castable)|NegLevels|NegLevels|NegLevels
-    </code>
+level castable)|NegLevels|NegLevels|NegLevels</code>
    </p>
    <p class="tagindent1">
-    <code>
-     DEFINE:NegLevels|0
-    </code>
+    <code>DEFINE:NegLevels|0</code>
    </p>
    <p class="tagindent1">
-    <code>
-     BONUS:CHECKS|Fortitude,Reflex,Will|-1*(NegLevels)
-    </code>
+    <code>BONUS:CHECKS|Fortitude,Reflex,Will|-1*(NegLevels)</code>
    </p>
    <p class="tagindent1">
-    <code>
-     BONUS:COMBAT|TOHIT|-1*(NegLevels)
-    </code>
+    <code>BONUS:COMBAT|TOHIT|-1*(NegLevels)</code>
    </p>
    <p class="tagindent1">
-    <code>
-     BONUS:SKILL|TYPE=Strength,TYPE=Dexterity,TYPE=Constitution,
-TYPE=Intelligence,TYPE=Wisdom,TYPE=Charisma|-1*(NegLevels)
-    </code>
+    <code>BONUS:SKILL|TYPE=Strength,TYPE=Dexterity,TYPE=Constitution,
+TYPE=Intelligence,TYPE=Wisdom,TYPE=Charisma|-1*(NegLevels)</code>
    </p>
   </blockquote>
   <p class="indent1">
@@ -610,9 +562,7 @@ Armor
   </p>
   <blockquote class="indent2">
    <p class="tagindent2">
-    <code>
-     Demon Armor
-    </code>
+    <code>Demon Armor</code>
    </p>
    <p class="tagindent2">
     .
@@ -625,14 +575,10 @@ item.)
     .
    </p>
    <p class="tagindent2">
-    <code>
-     VFEAT:Negative Levels
-    </code>
+    <code>VFEAT:Negative Levels</code>
    </p>
    <p class="tagindent2">
-    <code>
-     BONUS:VAR|NegLevels|1|PREALIGN:LG,LN,NG,TN,CG,CN
-    </code>
+    <code>BONUS:VAR|NegLevels|1|PREALIGN:LG,LN,NG,TN,CG,CN</code>
    </p>
   </blockquote>
   <hr/>

--- a/docs/listfilepages/rulesguide/grig_priesthoods1.html
+++ b/docs/listfilepages/rulesguide/grig_priesthoods1.html
@@ -66,8 +66,7 @@ Complete
    </strong>
   </p>
   <p class="indent1">
-   <code>
-    <a href="../datafilestagpages/datafilesfeats.html#visible">
+   <code><a href="../datafilestagpages/datafilesfeats.html#visible">
      VISIBLE
     </a>
     ,
@@ -89,8 +88,7 @@ Complete
     ,
     <a href="../datafilestagpages/datafilesdeities.html#domains">
      DOMAINS
-    </a>
-   </code>
+    </a></code>
   </p>
   <p class="sidebar1">
    NOTE: In this section we will discuss only
@@ -179,9 +177,7 @@ explained below:
     <strong>
      Tag Used:
     </strong>
-    <code>
-     VISIBLE:EXPORT
-    </code>
+    <code>VISIBLE:EXPORT</code>
    </p>
    <p class="indent1">
     <strong>
@@ -196,9 +192,7 @@ name from PCGen but displays it on the character sheet.
     <strong>
      Tag Used:
     </strong>
-    <code>
-     TYPE:Priesthood
-    </code>
+    <code>TYPE:Priesthood</code>
    </p>
    <p class="indent1">
     <strong>
@@ -213,9 +207,7 @@ TYPE of the associated priesthood feat as "Prisethood".
     <strong>
      Tag Used:
     </strong>
-    <code>
-     PREMULT:1,[!PREFEAT:TYPE=Priesthood],[PREFEAT:1,x]
-    </code>
+    <code>PREMULT:1,[!PREFEAT:TYPE=Priesthood],[PREFEAT:1,x]</code>
    </p>
    <p class="indent1">
     <strong>
@@ -238,9 +230,7 @@ priesthood feats at all.
     <strong>
      Sub-Tag Used:
     </strong>
-    <code>
-     !PREFEAT:1,TYPE=Priesthood
-    </code>
+    <code>!PREFEAT:1,TYPE=Priesthood</code>
    </p>
    <p class="indent1">
     <strong>
@@ -256,9 +246,7 @@ having a priesthood feat.
     <strong>
      Sub-Tag Used:
     </strong>
-    <code>
-     PREFEAT:1,x
-    </code>
+    <code>PREFEAT:1,x</code>
    </p>
    <p class="indent1">
     <strong>
@@ -323,11 +311,9 @@ Deities
     <strong>
      Tag Used:
     </strong>
-    <code>
-     ADD:FEAT|Priesthood of the Code Monkey, Priesthood of the
+    <code>ADD:FEAT|Priesthood of the Code Monkey, Priesthood of the
 Data Monkey,Priesthood of the Doc Monkey,Priesthood of the
-Monkey
-    </code>
+Monkey</code>
    </p>
    <p class="indent1">
     <strong>
@@ -342,9 +328,7 @@ character a choice of one of the four priesthood feats listed.
     <strong>
      Tag Used:
     </strong>
-    <code>
-     DOMAINS:x,x|PREFEAT:1,y,y
-    </code>
+    <code>DOMAINS:x,x|PREFEAT:1,y,y</code>
    </p>
    <p class="indent1">
     <strong>
@@ -390,9 +374,7 @@ add to the list of the deity's domains.
     <strong>
      Sub-Tag Used:
     </strong>
-    <code>
-     PREFEAT:1,x,x
-    </code>
+    <code>PREFEAT:1,x,x</code>
    </p>
    <p class="indent1">
     <strong>
@@ -423,9 +405,7 @@ clerics.
   </h3>
   <p class="indent1">
    The use of the
-   <code>
-    ADD:FEAT
-   </code>
+   <code>ADD:FEAT</code>
    tag
 introduces a problem with the removal and reselection of a
 deity.
@@ -446,96 +426,64 @@ and "Doc" Monkeys
   </p>
   <blockquote class="indent2">
    <p class="tagindent1">
-    <code>
-     Priesthood of the Code
-Monkey
-    </code>
+    <code>Priesthood of the Code
+Monkey</code>
    </p>
    <p class="tagindent1">
-    <code>
-     VISIBLE:EXPORT
-    </code>
+    <code>VISIBLE:EXPORT</code>
    </p>
    <p class="tagindent1">
-    <code>
-     TYPE:Priesthood
-    </code>
+    <code>TYPE:Priesthood</code>
    </p>
    <p class="tagindent1">
-    <code>
-     PREMULT:1,[!PREFEAT:1,TYPE=Priesthood],[PREFEAT:1,Priesthood
-of the Code Monkey]
-    </code>
+    <code>PREMULT:1,[!PREFEAT:1,TYPE=Priesthood],[PREFEAT:1,Priesthood
+of the Code Monkey]</code>
    </p>
   </blockquote>
   <blockquote class="indent2">
    <p class="tagindent1">
-    <code>
-     Priesthood of the Data
-Monkey
-    </code>
+    <code>Priesthood of the Data
+Monkey</code>
    </p>
    <p class="tagindent1">
-    <code>
-     VISIBLE:EXPORT
-    </code>
+    <code>VISIBLE:EXPORT</code>
    </p>
    <p class="tagindent1">
-    <code>
-     TYPE:Priesthood
-    </code>
+    <code>TYPE:Priesthood</code>
    </p>
    <p class="tagindent1">
-    <code>
-     PREMULT:1,[!PREFEAT:1,TYPE=Priesthood],[PREFEAT:1,Priesthood
-of the Data Monkey]
-    </code>
+    <code>PREMULT:1,[!PREFEAT:1,TYPE=Priesthood],[PREFEAT:1,Priesthood
+of the Data Monkey]</code>
    </p>
   </blockquote>
   <blockquote class="indent2">
    <p class="tagindent1">
-    <code>
-     Priesthood of the Doc Monkey
-    </code>
+    <code>Priesthood of the Doc Monkey</code>
    </p>
    <p class="tagindent1">
-    <code>
-     VISIBLE:EXPORT
-    </code>
+    <code>VISIBLE:EXPORT</code>
    </p>
    <p class="tagindent1">
-    <code>
-     TYPE:Priesthood
-    </code>
+    <code>TYPE:Priesthood</code>
    </p>
    <p class="tagindent1">
-    <code>
-     PREMULT:1,[!PREFEAT:1,TYPE=Priesthood],[PREFEAT:1,Priesthood
-of the Doc Monkey]
-    </code>
+    <code>PREMULT:1,[!PREFEAT:1,TYPE=Priesthood],[PREFEAT:1,Priesthood
+of the Doc Monkey]</code>
    </p>
   </blockquote>
   <blockquote class="indent2">
    <p class="tagindent1">
-    <code>
-     Priesthood of the Monkey
-    </code>
+    <code>Priesthood of the Monkey</code>
    </p>
    <p class="tagindent1">
-    <code>
-     VISIBLE:EXPORT
-    </code>
+    <code>VISIBLE:EXPORT</code>
    </p>
    <p class="tagindent1">
-    <code>
-     TYPE:Priesthood
-    </code>
+    <code>TYPE:Priesthood</code>
    </p>
    <p class="tagindent1">
-    <code>
-     PREMULT:1,[!PREFEAT:1,TYPE=Priesthood],[PREFEAT:1,Priesthood
-of the Monkey]
-    </code>
+    <code>PREMULT:1,[!PREFEAT:1,TYPE=Priesthood],[PREFEAT:1,Priesthood
+of the Monkey]</code>
    </p>
   </blockquote>
   <a id="deity" name="deity">
@@ -545,56 +493,38 @@ of the Monkey]
   </p>
   <blockquote class="indent2">
    <p class="tagindent1">
-    <code>
-     The Monkey God
-    </code>
+    <code>The Monkey God</code>
    </p>
    <p class="tagindent1">
-    <code>
-     ALIGN:TN
-    </code>
+    <code>ALIGN:TN</code>
    </p>
    <p class="tagindent1">
-    <code>
-     PREALIGN:NG,LN,TN,CN,NE
-    </code>
+    <code>PREALIGN:NG,LN,TN,CN,NE</code>
    </p>
    <p class="tagindent1">
-    <code>
-     DEITYWEAP:Pile of Poo
-    </code>
+    <code>DEITYWEAP:Pile of Poo</code>
    </p>
    <p class="tagindent1">
-    <code>
-     DOMAINS:Knowledge,Madness
-    </code>
+    <code>DOMAINS:Knowledge,Madness</code>
    </p>
    <p class="tagindent1">
-    <code>
-     DOMAINS:Creation|PREFEAT:1,Priesthood
-of the Code Monkey,Priesthood of the Data Monkey
-    </code>
+    <code>DOMAINS:Creation|PREFEAT:1,Priesthood
+of the Code Monkey,Priesthood of the Data Monkey</code>
    </p>
    <p class="tagindent1">
-    <code>
-     DOMAINS:Artifice|PREFEAT:1,Priesthood
-of the Data Monkey,Priesthood of the Doc Monkey
-    </code>
+    <code>DOMAINS:Artifice|PREFEAT:1,Priesthood
+of the Data Monkey,Priesthood of the Doc Monkey</code>
    </p>
    <p class="tagindent1">
-    <code>
-     DOMAINS:Magic|PREFEAT:1,Priesthood of
-the Code Monkey],Priesthood of the Doc Monkey
-    </code>
+    <code>DOMAINS:Magic|PREFEAT:1,Priesthood of
+the Code Monkey],Priesthood of the Doc Monkey</code>
    </p>
   </blockquote>
   <blockquote class="indent2">
    <p class="tagindent1">
-    <code>
-     ADD:FEAT|Priesthood of the Code
+    <code>ADD:FEAT|Priesthood of the Code
 Monkey,Priesthood of the Data Monkey, Priesthood of the Doc
-Monkey,Priesthood of the Monkey
-    </code>
+Monkey,Priesthood of the Monkey</code>
    </p>
   </blockquote>
   <p class="indent2">
@@ -641,9 +571,7 @@ BONUS tag.
     <strong>
      Tag Used:
     </strong>
-    <code>
-     BONUS:SKILL|Balance,Escape Artist|2
-    </code>
+    <code>BONUS:SKILL|Balance,Escape Artist|2</code>
    </p>
    <p class="indent1">
     <strong>
@@ -683,9 +611,7 @@ be accomplished with the BONUS tag.
     <strong>
      Tag Used:
     </strong>
-    <code>
-     BONUS:COMBAT|INITIATIVE|4
-    </code>
+    <code>BONUS:COMBAT|INITIATIVE|4</code>
    </p>
    <p class="indent1">
     <strong>
@@ -716,9 +642,7 @@ the VFEAT tag.
     <strong>
      Tag Used:
     </strong>
-    <code>
-     VFEAT:Leadership
-    </code>
+    <code>VFEAT:Leadership</code>
    </p>
    <p class="indent1">
     <strong>
@@ -768,9 +692,7 @@ with the HITDIE tag in a template.
     <strong>
      Tag Used:
     </strong>
-    <code>
-     HITDIE:%up2|CLASS=Cleric
-    </code>
+    <code>HITDIE:%up2|CLASS=Cleric</code>
    </p>
    <p class="indent1">
     <strong>
@@ -801,9 +723,7 @@ VISION tag in a template.
     <strong>
      Tag Used:
     </strong>
-    <code>
-     VISION:Darkvision (60')
-    </code>
+    <code>VISION:Darkvision (60')</code>
    </p>
    <p class="indent1">
     <strong>
@@ -841,10 +761,8 @@ with the SA tag in either a feat or a template.
     <strong>
      Tag Used:
     </strong>
-    <code>
-     SA:Scent (Ex) -
-track by sense of smell
-    </code>
+    <code>SA:Scent (Ex) -
+track by sense of smell</code>
    </p>
    <p class="indent1">
     <strong>

--- a/docs/listfilepages/systemfilestagpages/gamemodeequipicons.html
+++ b/docs/listfilepages/systemfilestagpages/gamemodeequipicons.html
@@ -90,9 +90,7 @@ higher priority.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ICON:Eyegear|system/icons/eyegear.png
-   </code>
+   <code>ICON:Eyegear|system/icons/eyegear.png</code>
   </p>
   <p class="indent3">
    The default icon for this type will be
@@ -103,9 +101,7 @@ higher priority.
 the program install directory. Priority will be 10.
   </p>
   <p class="indent2">
-   <code>
-    ICON:Container|system/icons/container.png|3
-   </code>
+   <code>ICON:Container|system/icons/container.png|3</code>
   </p>
   <p class="indent3">
    The default icon for this type will be

--- a/docs/listfilepages/systemfilestagpages/gamemodeequipmentslots.html
+++ b/docs/listfilepages/systemfilestagpages/gamemodeequipmentslots.html
@@ -47,9 +47,7 @@ default number of slots for each type
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    NUMSLOTS:DEFAULT HEAD:1 HANDS:2
-   </code>
+   <code>NUMSLOTS:DEFAULT HEAD:1 HANDS:2</code>
   </p>
   <p class="indent3">
    Sets the default number of slots for HEAD to 1
@@ -88,9 +86,7 @@ a NUMBER tag.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    EQSLOT:Eyes
-   </code>
+   <code>EQSLOT:Eyes</code>
   </p>
   <p class="indent3">
    Sets the name of this slot as Eyes.
@@ -127,9 +123,7 @@ Name:
   <ul class="indent2">
    <li>
     This tag follows the
-    <code>
-     EQSLOT
-    </code>
+    <code>EQSLOT</code>
     tag and sets what
 equipment type, and how many, the slot holds.
    </li>
@@ -144,17 +138,13 @@ equipment type, and how many, the slot holds.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CONTAINS:Eyegear=1
-   </code>
+   <code>CONTAINS:Eyegear=1</code>
   </p>
   <p class="indent3">
    This slot can hold 1 item of type Eyegear.
   </p>
   <p class="indent2">
-   <code>
-    CONTAINS:Armor,Robe=1
-   </code>
+   <code>CONTAINS:Armor,Robe=1</code>
   </p>
   <p class="indent3">
    This slot can hold 1 item of type Armor or
@@ -193,9 +183,7 @@ in the NUMSLOTS tag line.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    NUMBER:LEGS
-   </code>
+   <code>NUMBER:LEGS</code>
   </p>
   <p class="indent3">
    The default number of LEGS is 2 so this would
@@ -208,20 +196,16 @@ set this slot to 2.
    </strong>
   </p>
   <p class="indent1">
-   <code>
-    EQSLOT:Hand CONTAINS:Glove=1
-NUMBER:HANDS
-   </code>
+   <code>EQSLOT:Hand CONTAINS:Glove=1
+NUMBER:HANDS</code>
   </p>
   <p class="indent2">
    This defines a Hand slot, of which there are 2
 each of which can hold 1 Glove.
   </p>
   <p class="indent1">
-   <code>
-    EQSLOT:Fingers CONTAINS:Ring=2
-NUMBER:TORSO
-   </code>
+   <code>EQSLOT:Fingers CONTAINS:Ring=2
+NUMBER:TORSO</code>
   </p>
   <p class="indent2">
    This defines a Fingers slot which can hold 2
@@ -233,20 +217,16 @@ non standard numbers of arms, legs, heads etc. but all creatures
 have only one TORSO.
   </p>
   <p class="indent1">
-   <code>
-    EQSLOT:Skin CONTAINS:PsionicTattoo=20
-NUMBER:TORSO
-   </code>
+   <code>EQSLOT:Skin CONTAINS:PsionicTattoo=20
+NUMBER:TORSO</code>
   </p>
   <p class="indent2">
    This defines a Skin slot which can hold 20 items
 of TYPE:PsionicTattoo.
   </p>
   <p class="indent1">
-   <code>
-    EQSLOT:Body CONTAINS:Armor,Robe=1
-NUMBER:TORSO
-   </code>
+   <code>EQSLOT:Body CONTAINS:Armor,Robe=1
+NUMBER:TORSO</code>
   </p>
   <p class="indent2">
    This defines a Body slot which can hold 1 item

--- a/docs/listfilepages/systemfilestagpages/gamemodelevel.html
+++ b/docs/listfilepages/systemfilestagpages/gamemodelevel.html
@@ -51,13 +51,9 @@ LEVEL:x
    </li>
    <li>
     Using
-    <code>
-     LEVEL
-    </code>
+    <code>LEVEL</code>
     in conjunction with a formula on the
-    <code>
-     MINXP
-    </code>
+    <code>MINXP</code>
     tag that utilizes the
     <span class="lstvar">
      LEVEL
@@ -72,21 +68,17 @@ benefits.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    LEVEL:1 &lt;tab&gt; MINXP:0 &lt;tab&gt;
-CSKILLMAX:1 &lt;tab&gt; CCSKILLMAX:1
-   </code>
+   <code>LEVEL:1 &lt;tab&gt; MINXP:0 &lt;tab&gt;
+CSKILLMAX:1 &lt;tab&gt; CCSKILLMAX:1</code>
   </p>
   <p class="indent3">
    Identifies the minimum experience points amd
 maximum class and cross-class skill ranks for first level.
   </p>
   <p class="indent2">
-   <code>
-    LEVEL:LEVEL &lt;tab&gt;
+   <code>LEVEL:LEVEL &lt;tab&gt;
 MINXP:(LEVEL*LEVEL-LEVEL)*500 &lt;tab&gt; CSKILLMAX:LEVEL+3
-&lt;tab&gt; CCSKILLMAX:(LEVEL+3)/2
-   </code>
+&lt;tab&gt; CCSKILLMAX:(LEVEL+3)/2</code>
   </p>
   <p class="indent3">
    Establishes the standard level progression by
@@ -121,13 +113,9 @@ level.
    </li>
    <li>
     When used in conjunction with the
-    <code>
-     LEVEL:LEVEL
-    </code>
+    <code>LEVEL:LEVEL</code>
     tag,
-    <code>
-     MINXP
-    </code>
+    <code>MINXP</code>
    </li>
   </ul>
   <p class="indent1">
@@ -136,9 +124,7 @@ level.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    MINXP:(LEVEL*LEVEL-LEVEL)*500
-   </code>
+   <code>MINXP:(LEVEL*LEVEL-LEVEL)*500</code>
   </p>
   <p class="indent3">
    The standard formula for level progression for
@@ -175,9 +161,7 @@ Formula (Skill Rank)
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CSKILLMAX:LEVEL+3
-   </code>
+   <code>CSKILLMAX:LEVEL+3</code>
   </p>
   <p class="indent3">
    The standard formula for maximum class skill
@@ -215,9 +199,7 @@ skills.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CCSKILLMAX:(LEVEL+3)/2
-   </code>
+   <code>CCSKILLMAX:(LEVEL+3)/2</code>
   </p>
   <p class="indent3">
    The standard formula for maximum cross-class

--- a/docs/listfilepages/systemfilestagpages/gamemodeloadlist.html
+++ b/docs/listfilepages/systemfilestagpages/gamemodeloadlist.html
@@ -103,9 +103,7 @@ and is set by gameMode.
    </li>
    <li>
     The
-    <code>
-     ENCUMBRANCE
-    </code>
+    <code>ENCUMBRANCE</code>
     tag expects either two or four
 parameters with parameters (y) and (z) being optional.
    </li>
@@ -146,9 +144,7 @@ are required to be included in all
    </li>
    <li>
     The
-    <code>
-     ENCUMBRANCE
-    </code>
+    <code>ENCUMBRANCE</code>
     tag defines the output token used.
 See the entry for the output token
     <a href="../../outputsheetpages/tokens/outputsheettokensgeneral.html#weight">
@@ -168,49 +164,33 @@ provided below.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ENCUMBRANCE:Light|1/3||0
-   </code>
+   <code>ENCUMBRANCE:Light|1/3||0</code>
   </p>
   <p class="indent2">
-   <code>
-    ENCUMBRANCE:Medium|2/3||-3
-   </code>
+   <code>ENCUMBRANCE:Medium|2/3||-3</code>
   </p>
   <p class="indent2">
-   <code>
-    ENCUMBRANCE:Heavy|1||-6
-   </code>
+   <code>ENCUMBRANCE:Heavy|1||-6</code>
   </p>
   <p class="indent2">
-   <code>
-    ENCUMBRANCE:OverHead|1||-6
-   </code>
+   <code>ENCUMBRANCE:OverHead|1||-6</code>
   </p>
   <p class="indent2">
-   <code>
-    ENCUMBRANCE:OffGround|2||-6
-   </code>
+   <code>ENCUMBRANCE:OffGround|2||-6</code>
   </p>
   <p class="indent2">
-   <code>
-    ENCUMBRANCE:PushDrag|5||-6
-   </code>
+   <code>ENCUMBRANCE:PushDrag|5||-6</code>
   </p>
   <p class="indent3">
    These six categories must be included in all
 gameModes.
   </p>
   <p class="indent2">
-   <code>
-    ENCUMBRANCE:FooBar|8
-   </code>
+   <code>ENCUMBRANCE:FooBar|8</code>
   </p>
   <p class="indent3">
    The OS output token for this load category is
-   <code>
-    WEIGHT.FOOBAR
-   </code>
+   <code>WEIGHT.FOOBAR</code>
    .
   </p>
   <hr/>
@@ -252,18 +232,14 @@ of the Creature.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    LOAD:0|0
-   </code>
+   <code>LOAD:0|0</code>
    <br/>
   </p>
   <p class="indent3">
    This give a strength of 0 a heavy load of 0.
   </p>
   <p class="indent2">
-   <code>
-    LOAD:10|100
-   </code>
+   <code>LOAD:10|100</code>
    <br/>
   </p>
   <p class="indent3">
@@ -271,9 +247,7 @@ of the Creature.
 100.
   </p>
   <p class="indent2">
-   <code>
-    LOAD:27|1040
-   </code>
+   <code>LOAD:27|1040</code>
    <br/>
   </p>
   <p class="indent3">
@@ -314,9 +288,7 @@ Name:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    LOADMULT:4
-   </code>
+   <code>LOADMULT:4</code>
    <br/>
   </p>
   <p class="indent3">
@@ -350,9 +322,7 @@ Name:
   <p class="indent2">
    Used for determining encumbrance limits for
 values outside the range defined by the
-   <code>
-    LOAD
-   </code>
+   <code>LOAD</code>
    tags
   </p>
   <p class="indent1">
@@ -361,9 +331,7 @@ values outside the range defined by the
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    LOADSTEPMULT:4
-   </code>
+   <code>LOADSTEPMULT:4</code>
    <br/>
   </p>
   <p class="indent3">
@@ -407,9 +375,7 @@ internally generated $$SCORE$$.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    MODIFIER:$$SCORE$$*(1+EquipLoadBonusMult)
-   </code>
+   <code>MODIFIER:$$SCORE$$*(1+EquipLoadBonusMult)</code>
    <br/>
   </p>
   <p class="indent3">
@@ -455,44 +421,28 @@ Creature.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SIZEMULT:FINE|0.125
-   </code>
+   <code>SIZEMULT:FINE|0.125</code>
   </p>
   <p class="indent2">
-   <code>
-    SIZEMULT:Diminutive|0.25
-   </code>
+   <code>SIZEMULT:Diminutive|0.25</code>
   </p>
   <p class="indent2">
-   <code>
-    SIZEMULT:Tiny|0.5
-   </code>
+   <code>SIZEMULT:Tiny|0.5</code>
   </p>
   <p class="indent2">
-   <code>
-    SIZEMULT:Small|0.75
-   </code>
+   <code>SIZEMULT:Small|0.75</code>
   </p>
   <p class="indent2">
-   <code>
-    SIZEMULT:Large|2
-   </code>
+   <code>SIZEMULT:Large|2</code>
   </p>
   <p class="indent2">
-   <code>
-    SIZEMULT:Huge|4
-   </code>
+   <code>SIZEMULT:Huge|4</code>
   </p>
   <p class="indent2">
-   <code>
-    SIZEMULT:Gargantuan|8
-   </code>
+   <code>SIZEMULT:Gargantuan|8</code>
   </p>
   <p class="indent2">
-   <code>
-    SIZEMULT:Colossal|16
-   </code>
+   <code>SIZEMULT:Colossal|16</code>
   </p>
   <p class="indent3">
    These six categories must be included in all

--- a/docs/listfilepages/systemfilestagpages/gamemodemigrationlist.html
+++ b/docs/listfilepages/systemfilestagpages/gamemodemigrationlist.html
@@ -58,18 +58,12 @@ migration line is as follows:
    Migration Line Syntax
   </p>
   <p class="indent2">
-   <code>
-    &lt;Old Object Key&gt;
-   </code>
+   <code>&lt;Old Object Key&gt;</code>
    &lt;tab&gt;
-   <code>
-    &lt;New Object Key&gt;
-   </code>
+   <code>&lt;New Object Key&gt;</code>
    &lt;tab&gt;
-   <code>
-    &lt;Version
-Tags&gt;
-   </code>
+   <code>&lt;Version
+Tags&gt;</code>
   </p>
   <hr/>
   <h2>
@@ -145,9 +139,7 @@ format.
    </li>
    <li>
     This tag is optional and if included must be later than
-    <code>
-     MAXVER
-    </code>
+    <code>MAXVER</code>
     .
    </li>
   </ul>
@@ -157,9 +149,7 @@ format.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    MAXDEVVER:6.01.07
-   </code>
+   <code>MAXDEVVER:6.01.07</code>
   </p>
   <p class="indent3">
    The associated lst object was coded for PCGen
@@ -205,9 +195,7 @@ lst object was last coded in the old format.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    MAXVER:6.0.1
-   </code>
+   <code>MAXVER:6.0.1</code>
   </p>
   <p class="indent2">
    The associated lst object was coded for PCGen
@@ -246,9 +234,7 @@ format.
    </li>
    <li>
     This tag is optional and if included must be later than
-    <code>
-     MINVER
-    </code>
+    <code>MINVER</code>
     .
    </li>
   </ul>
@@ -258,9 +244,7 @@ format.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    MINDEVVER:6.01.01
-   </code>
+   <code>MINDEVVER:6.01.01</code>
   </p>
   <p class="indent3">
    The associated lst object was coded for PCGen
@@ -298,9 +282,7 @@ lst object was first coded in the old format.
    </li>
    <li>
     This tag is optional and if included must be earlier than
-    <code>
-     MAXVER
-    </code>
+    <code>MAXVER</code>
     .
    </li>
   </ul>
@@ -310,9 +292,7 @@ lst object was first coded in the old format.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    MINVER:6.0.0
-   </code>
+   <code>MINVER:6.0.0</code>
   </p>
   <p class="indent3">
    The associated lst object was coded for PCGen
@@ -367,9 +347,7 @@ ability key.
    </li>
    <li>
     The
-    <code>
-     ABILITY
-    </code>
+    <code>ABILITY</code>
     tag is used in conjunction with the
     <a href="#newkey">
      NEWKEY
@@ -387,10 +365,8 @@ ability key.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ABILITY:Special Ability|Animal
-Fury
-   </code>
+   <code>ABILITY:Special Ability|Animal
+Fury</code>
   </p>
   <p class="indent3">
   </p>
@@ -427,9 +403,7 @@ equipment key.
    </li>
    <li>
     The
-    <code>
-     EQUIPMENT
-    </code>
+    <code>EQUIPMENT</code>
     tag is used in conjunction with the
     <a href="#newkey">
      NEWKEY
@@ -443,9 +417,7 @@ equipment key.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    Kasari Gusoku
-   </code>
+   <code>Kasari Gusoku</code>
   </p>
   <p class="indent3">
   </p>
@@ -491,9 +463,7 @@ ability category will not change for the associated ability.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    NEWCATEGORY:Spell-like Ability
-   </code>
+   <code>NEWCATEGORY:Spell-like Ability</code>
   </p>
   <p class="indent3">
   </p>
@@ -533,24 +503,18 @@ associated LST object.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    NEWKEY:Guide To Pathfinder Society
-Organised Play
-   </code>
+   <code>NEWKEY:Guide To Pathfinder Society
+Organised Play</code>
   </p>
   <p class="indent3">
   </p>
   <p class="indent2">
-   <code>
-    NEWKEY:Animal Fury ~ Rage Power
-   </code>
+   <code>NEWKEY:Animal Fury ~ Rage Power</code>
   </p>
   <p class="indent3">
   </p>
   <p class="indent2">
-   <code>
-    NEWKEY:Kusari Gusoku
-   </code>
+   <code>NEWKEY:Kusari Gusoku</code>
   </p>
   <p class="indent3">
   </p>
@@ -585,9 +549,7 @@ the old race key as part of the migration to a new race key.
    </li>
    <li>
     The
-    <code>
-     RACE
-    </code>
+    <code>RACE</code>
     tag is used in conjunction with the
     <a href="#newkey">
      NEWKEY
@@ -601,9 +563,7 @@ the old race key as part of the migration to a new race key.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    RACE:Misspelt Key
-   </code>
+   <code>RACE:Misspelt Key</code>
   </p>
   <p class="indent3">
   </p>
@@ -640,9 +600,7 @@ key.
    </li>
    <li>
     The
-    <code>
-     SOURCE
-    </code>
+    <code>SOURCE</code>
     tag is used in conjunction with the
     <a href="#newkey">
      NEWKEY
@@ -656,10 +614,8 @@ key.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SOURCE:Paizo - Guide To Pathfinder Society
-Organised Play 4.0
-   </code>
+   <code>SOURCE:Paizo - Guide To Pathfinder Society
+Organised Play 4.0</code>
   </p>
   <p class="indent3">
   </p>
@@ -682,25 +638,17 @@ tabs.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ABILITY:Special Ability|Animal
-Fury
-   </code>
+   <code>ABILITY:Special Ability|Animal
+Fury</code>
   </p>
   <p class="indent3">
-   <code>
-    NEWKEY:Animal Fury ~ Rage Power
-   </code>
+   <code>NEWKEY:Animal Fury ~ Rage Power</code>
   </p>
   <p class="indent3">
-   <code>
-    MAXVER:6.00.01
-   </code>
+   <code>MAXVER:6.00.01</code>
   </p>
   <p class="indent3">
-   <code>
-    MAXDEVVER:6.01.02
-   </code>
+   <code>MAXDEVVER:6.01.02</code>
   </p>
   <p class="indent3">
    When any character last saved in v6.00.00 or
@@ -714,19 +662,13 @@ the new key "Animal Fury ~ Rage Power".
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    EQUIPMENT:Kasari Gusoku
-   </code>
+   <code>EQUIPMENT:Kasari Gusoku</code>
   </p>
   <p class="indent3">
-   <code>
-    NEWKEY:Kusari Gusoku
-   </code>
+   <code>NEWKEY:Kusari Gusoku</code>
   </p>
   <p class="indent3">
-   <code>
-    MAXVER:6.1.8
-   </code>
+   <code>MAXVER:6.1.8</code>
   </p>
   <p class="indent3">
    If a character has the equipment "Kasari Gusoku"
@@ -739,26 +681,18 @@ when last saved in PCGen 6.1.8 or earlier, it will instead load
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SOURCE:Paizo - Guide To Pathfinder Society
-Organised Play 4.0
-   </code>
+   <code>SOURCE:Paizo - Guide To Pathfinder Society
+Organised Play 4.0</code>
   </p>
   <p class="indent3">
-   <code>
-    NEWKEY:Guide To Pathfinder Society
-Organised Play
-   </code>
+   <code>NEWKEY:Guide To Pathfinder Society
+Organised Play</code>
   </p>
   <p class="indent3">
-   <code>
-    MAXVER:6.0.1
-   </code>
+   <code>MAXVER:6.0.1</code>
   </p>
   <p class="indent3">
-   <code>
-    MAXDEVVER:6.1.7
-   </code>
+   <code>MAXDEVVER:6.1.7</code>
   </p>
   <p class="indent3">
    If a character used the source "Paizo - Guide To

--- a/docs/listfilepages/systemfilestagpages/gamemodemiscinfolist.html
+++ b/docs/listfilepages/systemfilestagpages/gamemodemiscinfolist.html
@@ -177,18 +177,14 @@ of ability should be displayed in the UI.
    <br/>
   </p>
   <p class="indent2">
-   <code>
-    ABILITYCATEGORY:Special Attack
-   </code>
+   <code>ABILITYCATEGORY:Special Attack</code>
   </p>
   <p class="indent3">
    Defines a category named Special Attack.
   </p>
   <p class="indent2">
-   <code>
-    ABILITYCATEGORY:Special Attack &lt;tab&gt;
-PLURAL=Ambush
-   </code>
+   <code>ABILITYCATEGORY:Special Attack &lt;tab&gt;
+PLURAL=Ambush</code>
   </p>
   <p class="indent3">
    Defines a category named Special Attacka andsets
@@ -254,10 +250,8 @@ choices will be valid for that ability in the category.
    <br/>
   </p>
   <p class="indent2">
-   <code>
-    ABILITYLIST:Mounted Combat|Skill Focus
-(Ride)|Skill Focus (Handle Animal)|Ride-By Attack
-   </code>
+   <code>ABILITYLIST:Mounted Combat|Skill Focus
+(Ride)|Skill Focus (Handle Animal)|Ride-By Attack</code>
   </p>
   <p class="indent3">
    Defines that Mounted Combat, Ride-By Attack and
@@ -266,9 +260,7 @@ and Handle Animal will be offered if Skill Focus is chosen from
 this category.
   </p>
   <p class="indent2">
-   <code>
-    ABILITYLIST:Weapon Finesse
-   </code>
+   <code>ABILITYLIST:Weapon Finesse</code>
   </p>
   <p class="indent3">
    Defines that Weapon Finesse should be included
@@ -329,18 +321,14 @@ displayed using the ACABBREV tag to save space.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ACNAME:Armor Class
-   </code>
+   <code>ACNAME:Armor Class</code>
   </p>
   <p class="indent3">
    The Armor Rating is defined as "Armor
 Class".
   </p>
   <p class="indent2">
-   <code>
-    ACNAME:Defense
-   </code>
+   <code>ACNAME:Defense</code>
   </p>
   <p class="indent3">
    The Armor Rating is defined as "Defense".
@@ -380,18 +368,14 @@ defensive value.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ACABBREV:AC
-   </code>
+   <code>ACABBREV:AC</code>
   </p>
   <p class="indent3">
    The Armor Rating abbreviation is defined as
 "AC".
   </p>
   <p class="indent2">
-   <code>
-    ACABBREV:Def
-   </code>
+   <code>ACABBREV:Def</code>
   </p>
   <p class="indent3">
    The Armor Rating abbreviation is defined as
@@ -444,10 +428,8 @@ calculate this AC.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ACTYPE:Name ADD:List
-Remove:List
-   </code>
+   <code>ACTYPE:Name ADD:List
+Remove:List</code>
   </p>
   <p class="indent1">
    <strong>
@@ -455,19 +437,15 @@ Remove:List
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ACTYPE:Total ADD:TOTAL
-   </code>
+   <code>ACTYPE:Total ADD:TOTAL</code>
   </p>
   <p class="indent3">
    Defines the ACTYPE Total as the Total AC
 bonuses
   </p>
   <p class="indent2">
-   <code>
-    ACTYPE:Touch ADD:TOTAL
-REMOVE:Armor|NaturalArmor|Shield
-   </code>
+   <code>ACTYPE:Touch ADD:TOTAL
+REMOVE:Armor|NaturalArmor|Shield</code>
   </p>
   <p class="indent3">
    Defines the ACTYPE Touch as the Total AC minus
@@ -543,18 +521,14 @@ PRExxx tags.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ADD:TOTAL
-   </code>
+   <code>ADD:TOTAL</code>
   </p>
   <p class="indent3">
    Adds ACTYPE:TOTAL to the ACTYPE being defined in
 the ACTYPE line.
   </p>
   <p class="indent2">
-   <code>
-    ADD:Shield
-   </code>
+   <code>ADD:Shield</code>
   </p>
   <p class="indent3">
    Adds ACTYPE:SHIELD to the ACTYPE being defined
@@ -588,9 +562,7 @@ included with this source.
    </li>
    <li>
     The
-    <code>
-     ALLOWEDMODES
-    </code>
+    <code>ALLOWEDMODES</code>
     tag is case-sensitive.
    </li>
   </ul>
@@ -600,9 +572,7 @@ included with this source.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ALLOWEDMODES:DnD_v35e|DnD_Olerra
-   </code>
+   <code>ALLOWEDMODES:DnD_v35e|DnD_Olerra</code>
   </p>
   <p class="indent3">
    The 3.5 and Olerra sources can be safely
@@ -646,9 +616,7 @@ PCGen should allow the auto-resizing of equipment.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ALLOWAUTORESIZE:Y
-   </code>
+   <code>ALLOWAUTORESIZE:Y</code>
   </p>
   <p class="indent3">
    This gameMode will automatically resize
@@ -687,18 +655,14 @@ the Summary tab).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ALTHPABBREV:LP
-   </code>
+   <code>ALTHPABBREV:LP</code>
   </p>
   <p class="indent3">
    The secondary HP holder abbreviation is defined
 as "LP".
   </p>
   <p class="indent2">
-   <code>
-    ALTHPABBREV:Wnd
-   </code>
+   <code>ALTHPABBREV:Wnd</code>
   </p>
   <p class="indent3">
    The secondary HP holder abbreviation is defined
@@ -737,18 +701,14 @@ Summary tab).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ALTHPNAME:Life Points
-   </code>
+   <code>ALTHPNAME:Life Points</code>
   </p>
   <p class="indent3">
    The secondary HP holder is defined as "Life
 Points".
   </p>
   <p class="indent2">
-   <code>
-    ALTHPNAME:Wounds
-   </code>
+   <code>ALTHPNAME:Wounds</code>
   </p>
   <p class="indent3">
    The secondary HP holder is defined as
@@ -789,9 +749,7 @@ for Base Attack Bonus.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BABABBREV:OB
-   </code>
+   <code>BABABBREV:OB</code>
   </p>
   <p class="indent3">
    Displays OB: instead of BAB:.
@@ -833,9 +791,7 @@ first, subtract x to determine its bonus to hit.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BABATTCYC:5
-   </code>
+   <code>BABATTCYC:5</code>
   </p>
   <p class="indent3">
    Sets 5 as the difference between each attack in
@@ -882,9 +838,7 @@ and SECONDARYATTACKS tags.).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BABMAXATT:4
-   </code>
+   <code>BABMAXATT:4</code>
   </p>
   <p class="indent3">
    Sets 4 as the maximum number of attacks as the
@@ -925,9 +879,7 @@ progress to.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BABMAXLVL:20
-   </code>
+   <code>BABMAXLVL:20</code>
   </p>
   <p class="indent3">
    Limits a characters BAB progression to a maximum
@@ -969,9 +921,7 @@ least +x before being reported)
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BABMINVAL:1
-   </code>
+   <code>BABMINVAL:1</code>
   </p>
   <p class="indent3">
    Sets the starting minimum value for the BAB
@@ -1024,10 +974,8 @@ a progression set
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BASEDICE:1d6
-UP:1d8,2d6,3d6,4d6,6d6,8d6,12d6 DOWN:1d4,1d3,1d2,1
-   </code>
+   <code>BASEDICE:1d6
+UP:1d8,2d6,3d6,4d6,6d6,8d6,12d6 DOWN:1d4,1d3,1d2,1</code>
   </p>
   <p class="indent3">
    This states the base die is a d6 and determines
@@ -1091,27 +1039,21 @@ are given every three levels after that).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUSFEATLEVELSTARTINTERVAL:1|0
-   </code>
+   <code>BONUSFEATLEVELSTARTINTERVAL:1|0</code>
   </p>
   <p class="indent3">
    Character would get one bonus feat at creation
 and never again after that.
   </p>
   <p class="indent2">
-   <code>
-    BONUSFEATLEVELSTARTINTERVAL:3|3
-   </code>
+   <code>BONUSFEATLEVELSTARTINTERVAL:3|3</code>
   </p>
   <p class="indent3">
    Character would get a bonus feat every three
 levels, starting at level 3.
   </p>
   <p class="indent2">
-   <code>
-    BONUSFEATLEVELSTARTINTERVAL:2|3
-   </code>
+   <code>BONUSFEATLEVELSTARTINTERVAL:2|3</code>
   </p>
   <p class="indent3">
    Character would get a bonus feat every three
@@ -1157,37 +1099,25 @@ listed all in one tag or multiple tags can be used.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUSSTACKS:Defense.Dodge.Circumstance.NotRanged.NotFlatFooted
-   </code>
+   <code>BONUSSTACKS:Defense.Dodge.Circumstance.NotRanged.NotFlatFooted</code>
   </p>
   <p class="indent3">
    The listed Types will stack.
   </p>
   <p class="indent2">
-   <code>
-    BONUSSTACKS:Defense
-   </code>
+   <code>BONUSSTACKS:Defense</code>
   </p>
   <p class="indent2">
-   <code>
-    BONUSSTACKS:Dodge
-   </code>
+   <code>BONUSSTACKS:Dodge</code>
   </p>
   <p class="indent2">
-   <code>
-    BONUSSTACKS:Circumstance
-   </code>
+   <code>BONUSSTACKS:Circumstance</code>
   </p>
   <p class="indent2">
-   <code>
-    BONUSSTACKS:NotRanged
-   </code>
+   <code>BONUSSTACKS:NotRanged</code>
   </p>
   <p class="indent2">
-   <code>
-    BONUSSTACKS:NotFlatFooted
-   </code>
+   <code>BONUSSTACKS:NotFlatFooted</code>
   </p>
   <p class="indent3">
    The listed Types will stack.
@@ -1266,18 +1196,14 @@ points are given every four levels after that).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUSSTATLEVELSTARTINTERVAL:1|0
-   </code>
+   <code>BONUSSTATLEVELSTARTINTERVAL:1|0</code>
   </p>
   <p class="indent3">
    Character would get a bonus stat point at 1st
 with no bonuses after that.
   </p>
   <p class="indent2">
-   <code>
-    BONUSSTATLEVELSTARTINTERVAL:4|4
-   </code>
+   <code>BONUSSTATLEVELSTARTINTERVAL:4|4</code>
   </p>
   <p class="indent3">
    Character would get a bonus stat point at 4th
@@ -1285,27 +1211,21 @@ level with an additional stat boint every four levels after that.
 (e.g. 4,8,12,16, 20)
   </p>
   <p class="indent2">
-   <code>
-    BONUSSTATLEVELSTARTINTERVAL:2|3
-   </code>
+   <code>BONUSSTATLEVELSTARTINTERVAL:2|3</code>
   </p>
   <p class="indent3">
    Character would get a bonus stat point every
 three levels, starting at level 2.
   </p>
   <p class="indent2">
-   <code>
-    BONUSSTATLEVELSTARTINTERVAL:4|0|3
-   </code>
+   <code>BONUSSTATLEVELSTARTINTERVAL:4|0|3</code>
   </p>
   <p class="indent3">
    Character would get 3 bonus stat points at
 fourth level with no binuses after that.
   </p>
   <p class="indent2">
-   <code>
-    BONUSSTATLEVELSTARTINTERVAL:4|if(mod(TL,10)&gt;0&amp;&amp;mod(mod(TL,10),4)==0,1,0)|2
-   </code>
+   <code>BONUSSTATLEVELSTARTINTERVAL:4|if(mod(TL,10)&gt;0&amp;&amp;mod(mod(TL,10),4)==0,1,0)|2</code>
   </p>
   <p class="indent3">
    Character would get bonus 2 stat points at 4th
@@ -1347,15 +1267,11 @@ category is a sub-category of.
    </li>
    <li>
     For abilities that use
-    <code>
-     MULT:YES
-    </code>
+    <code>MULT:YES</code>
     , the parent
 category must be defined without a TYPE in order to funtion
 properly, with respect to the
-    <code>
-     MULT:YES
-    </code>
+    <code>MULT:YES</code>
     tag.
    </li>
    <li>
@@ -1368,9 +1284,7 @@ properly, with respect to the
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CATEGORY:Feat
-   </code>
+   <code>CATEGORY:Feat</code>
   </p>
   <p class="indent3">
    The parent ability category for this category is
@@ -1463,9 +1377,7 @@ base-saves may progress to.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHECKSMAXLVL:20
-   </code>
+   <code>CHECKSMAXLVL:20</code>
   </p>
   <p class="indent3">
    Sets the maximum level a characters base-saves
@@ -1523,9 +1435,7 @@ Classification and XP Penalties.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CLASSTYPE:PC
-   </code>
+   <code>CLASSTYPE:PC</code>
   </p>
   <p class="indent3">
    Indicates that classes of type PC will be
@@ -1564,9 +1474,7 @@ context help for the associated TAB.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CONTEXT:sectionheadingpages\walkthroughpages\Main\maintabability.html
-   </code>
+   <code>CONTEXT:sectionheadingpages\walkthroughpages\Main\maintabability.html</code>
   </p>
   <p class="indent3">
    Indicates which help file will be displayed for
@@ -1619,9 +1527,7 @@ that do not have a CR value, such als animal companions.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CRFORMULA:CL
-   </code>
+   <code>CRFORMULA:CL</code>
   </p>
   <p class="indent3">
    CR for a class of this type is equal to CL
@@ -1675,9 +1581,7 @@ adding up.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CRMOD:-1
-   </code>
+   <code>CRMOD:-1</code>
   </p>
   <p class="indent3">
    CR will be reduces by 1 after all CRFORMULA
@@ -1733,9 +1637,7 @@ choose the CRMOD with the lowest value of CRMODPROIRITY.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CRMODPRIORITY:1
-   </code>
+   <code>CRMODPRIORITY:1</code>
   </p>
   <p class="indent3">
    The CRMOD of this class type has the higher
@@ -1788,9 +1690,7 @@ string result as used in the rules.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CRSTEPS:1/2|1/3|1/4|1/6|1/8
-   </code>
+   <code>CRSTEPS:1/2|1/3|1/4|1/6|1/8</code>
   </p>
   <p class="indent3">
    Descending CR values below CR 1.
@@ -1832,9 +1732,7 @@ levels are counted as 1 CR per level for non-key classes.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CRSTEPS:BASECR
-   </code>
+   <code>CRSTEPS:BASECR</code>
   </p>
   <p class="indent3">
    Non-key class levels beyond a count of a
@@ -1870,9 +1768,7 @@ name of the standard unit of currency for this game mode).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CURRENTCYUNIT:Credit
-   </code>
+   <code>CURRENTCYUNIT:Credit</code>
   </p>
   <p class="indent3">
    Sets the currency unit to "Credit".
@@ -1909,9 +1805,7 @@ standard currency.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CURRENTCYUNITABBREV:Cr
-   </code>
+   <code>CURRENTCYUNITABBREV:Cr</code>
   </p>
   <p class="indent3">
    Sets the abbreviated currency unit to "Cr".
@@ -1958,9 +1852,7 @@ with two hands vs one hand, etc.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DAMAGEMULT:1=1,2=1.5
-   </code>
+   <code>DAMAGEMULT:1=1,2=1.5</code>
   </p>
   <p class="indent3">
    The damage multiplier becomes 1.5 if wielded two
@@ -2028,19 +1920,15 @@ page.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DEFAULTDATASET:3.5 RSRD
-   </code>
+   <code>DEFAULTDATASET:3.5 RSRD</code>
   </p>
   <p class="indent3">
    The "3.5 RSRD" data set will appear in the right
 panel on the sources tab when this gamemode is loaded.
   </p>
   <p class="indent2">
-   <code>
-    DEFAULTDATASET:MSRD - Basics,MSRD -
-Arcana,MSRD - Future,MSRD - Menaces|MSRD
-   </code>
+   <code>DEFAULTDATASET:MSRD - Basics,MSRD -
+Arcana,MSRD - Future,MSRD - Menaces|MSRD</code>
   </p>
   <p class="indent3">
    The default data sets for the game mode are the
@@ -2088,9 +1976,7 @@ Imperial.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DEFAULTUNITSET:Imperial
-   </code>
+   <code>DEFAULTUNITSET:Imperial</code>
   </p>
   <p class="indent3">
    Set Imperial as the Unit Set used by the game
@@ -2138,17 +2024,13 @@ size)
   <ul class="indent2">
    <li>
     Used to define the scale used by the
-    <code>
-     HITDIE
-    </code>
+    <code>HITDIE</code>
     tag to
 bump a character's hit die up or down.
    </li>
    <li>
     The
-    <code>
-     HITDIE
-    </code>
+    <code>HITDIE</code>
     tag is used in the
     <a href="../datafilestagpages/datafilesclasses.html#hitdie">
      Class
@@ -2164,46 +2046,30 @@ bump a character's hit die up or down.
     files.
    </li>
    <li>
-    <code>
-     MIN=x
-    </code>
+    <code>MIN=x</code>
     sets the lowest hit die size the
 "%downNumber"
-    <code>
-     HITDIE
-    </code>
+    <code>HITDIE</code>
     function allow.
    </li>
    <li>
-    <code>
-     MAX=x
-    </code>
+    <code>MAX=x</code>
     sets the highest hit die size the
 "%upNumber"
-    <code>
-     HITDIE
-    </code>
+    <code>HITDIE</code>
     function will allow.
    </li>
    <li>
     The "%Hup" and "%Hdown"
-    <code>
-     HITDIE
-    </code>
+    <code>HITDIE</code>
     functions will
 ignore
-    <code>
-     MIN
-    </code>
+    <code>MIN</code>
     and
-    <code>
-     MAX
-    </code>
+    <code>MAX</code>
     and move the hit die
 the full range of die sizes specified by the
-    <code>
-     DIESIZES
-    </code>
+    <code>DIESIZES</code>
     tag.
    </li>
   </ul>
@@ -2213,16 +2079,12 @@ the full range of die sizes specified by the
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DIESIZES:1,2,3,MIN=4,6,8,10,MAX=12,20,100,1000
-   </code>
+   <code>DIESIZES:1,2,3,MIN=4,6,8,10,MAX=12,20,100,1000</code>
   </p>
   <p class="indent3">
    Sets the range of hit die sizes used in the
 gameMode and limits the
-   <code>
-    HITDIE
-   </code>
+   <code>HITDIE</code>
    tags "%down" and "%up"
 functions to "4" and "12" respectively.
   </p>
@@ -2271,9 +2133,7 @@ sub-tab key in the form of "in_&lt;name&gt;", i.e. "in_feats".
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DISPLAYLOCATION:in_feat
-   </code>
+   <code>DISPLAYLOCATION:in_feat</code>
   </p>
   <p class="indent3">
    Abilities of the associated category will be
@@ -2333,9 +2193,7 @@ internationalization).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DISPLAYNAME:in_feat
-   </code>
+   <code>DISPLAYNAME:in_feat</code>
   </p>
   <p class="indent3">
    The displayed name for the category is the value
@@ -2384,9 +2242,7 @@ Mode/Campaign menu.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DISPLAYORDER:1
-   </code>
+   <code>DISPLAYORDER:1</code>
   </p>
   <p class="indent3">
    The Game Mode/Campaign menu will show this as
@@ -2428,9 +2284,7 @@ Tab.
    </li>
    <li>
     The variable name must match a valid
-    <code>
-     DEFINE
-    </code>
+    <code>DEFINE</code>
     tag
 for the variable to be displayed.
    </li>
@@ -2444,9 +2298,7 @@ for the variable to be displayed.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DISPLAYVARIABLE1NAME:1
-   </code>
+   <code>DISPLAYVARIABLE1NAME:1</code>
   </p>
   <p class="indent3">
    The ActionRemain variable will be displayed on
@@ -2485,9 +2337,7 @@ Name:
    <li>
     This tag provides the label to use for a matching variable
 being displayed as part of the
-    <code>
-     DISPLAYVARIABLExNAME
-    </code>
+    <code>DISPLAYVARIABLExNAME</code>
     tag.
    </li>
    <li>
@@ -2500,9 +2350,7 @@ being displayed as part of the
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DISPLAYVARIABLE1TEXT:1
-   </code>
+   <code>DISPLAYVARIABLE1TEXT:1</code>
   </p>
   <p class="indent3">
    The ActionRemain variable will be displayed on
@@ -2545,9 +2393,7 @@ factor of 1.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DISTANCEFACTOR:0.3
-   </code>
+   <code>DISTANCEFACTOR:0.3</code>
   </p>
   <p class="indent3">
    Defines the distance factor as "0.3".
@@ -2605,9 +2451,7 @@ of the Java class DecimaFormat and can be found
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DISTANCEPATTERN:#
-   </code>
+   <code>DISTANCEPATTERN:#</code>
   </p>
   <p class="indent3">
    Defines the distance unit abbreviation as
@@ -2663,9 +2507,7 @@ unit to follow directly after the value, prefix the string with
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DISTANCEUNIT:ft.
-   </code>
+   <code>DISTANCEUNIT:ft.</code>
   </p>
   <p class="indent3">
    Defines the distance unit abbreviation as
@@ -2715,9 +2557,7 @@ next die value in an incremental set
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DOWN:1d4,1d3,1d2,1
-   </code>
+   <code>DOWN:1d4,1d3,1d2,1</code>
   </p>
   <p class="indent3">
    The next die in the progression will be 1d4,
@@ -2774,9 +2614,7 @@ abilities may be added or removed by the user through the UI.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    EDITABLE:No
-   </code>
+   <code>EDITABLE:No</code>
   </p>
   <p class="indent3">
    Defines that abilities of this category can not
@@ -2833,9 +2671,7 @@ editing of the category's pool is allowed/disallowed.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    EDITPOOL:No
-   </code>
+   <code>EDITPOOL:No</code>
   </p>
   <p class="indent3">
    Defines that the category's pool can not be
@@ -2891,9 +2727,7 @@ used with this wield category.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    FINESSABLE:Yes
-   </code>
+   <code>FINESSABLE:Yes</code>
   </p>
   <p class="indent3">
    Allows weapon finesse to be used with this wield
@@ -2945,9 +2779,7 @@ can use fractional amounts.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    FRACTIONALPOOL:No
-   </code>
+   <code>FRACTIONALPOOL:No</code>
   </p>
   <p class="indent3">
    Define that the category's pool can only be a
@@ -3003,9 +2835,7 @@ its folder name.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    GAMEMODEKEY:35e
-   </code>
+   <code>GAMEMODEKEY:35e</code>
   </p>
   <p class="indent3">
    Defines the game mode as being 35e, no matter
@@ -3046,9 +2876,7 @@ wield the weapon for the wield category.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    HANDS:2
-   </code>
+   <code>HANDS:2</code>
   </p>
   <p class="indent3">
    Weapon must be wielded with two hands.
@@ -3099,9 +2927,7 @@ A Unit set which is native to the data will always have a factor of
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    HEIGHTUNIT:2.54
-   </code>
+   <code>HEIGHTUNIT:2.54</code>
   </p>
   <p class="indent3">
    Defines the height factored as "2.54".
@@ -3160,9 +2986,7 @@ of the Java class DecimaFormat and can be found
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    HEIGHTPATTERN:#
-   </code>
+   <code>HEIGHTPATTERN:#</code>
   </p>
   <p class="indent3">
    Defines the distance unit pattern as "#".
@@ -3217,9 +3041,7 @@ string 'ftin' is hard-coded to give results of the format x'y".
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    HEIGHTUNIT:cm
-   </code>
+   <code>HEIGHTUNIT:cm</code>
   </p>
   <p class="indent3">
    Defines the height unit abbreviation as
@@ -3272,9 +3094,7 @@ visible.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    HIDDENEQUIPTYPES:Standard|Resizable|Specific|Magic|Thief|Scribe|Wizard|Tools
-   </code>
+   <code>HIDDENEQUIPTYPES:Standard|Resizable|Specific|Magic|Thief|Scribe|Wizard|Tools</code>
   </p>
   <p class="indent3">
    Hides the listed equipment Types within the
@@ -3314,9 +3134,7 @@ a Type in the GUI. The feat itself will still be visible.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    HIDDENFEATTYPES:AttackOptions|ModifyAC|
-   </code>
+   <code>HIDDENFEATTYPES:AttackOptions|ModifyAC|</code>
   </p>
   <p class="indent3">
    Hides the listed feat Types within the GUI.
@@ -3355,9 +3173,7 @@ as a Type in the GUI. The skill itself will still be visible.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    HIDDENSKILLTYPES:St|Co|Ag|Qu|Pr|SD|In|Re
-   </code>
+   <code>HIDDENSKILLTYPES:St|Co|Ag|Qu|Pr|SD|In|Re</code>
   </p>
   <p class="indent3">
    Hides the listed skill Types within the GUI.
@@ -3396,18 +3212,14 @@ the Summary tab and HP button on the class tab).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    HPABBREV:HP
-   </code>
+   <code>HPABBREV:HP</code>
   </p>
   <p class="indent3">
    Sets the abbreviated primary hit point unit to
 "HP".
   </p>
   <p class="indent2">
-   <code>
-    HPABBREV:EP
-   </code>
+   <code>HPABBREV:EP</code>
   </p>
   <p class="indent3">
    Sets the abbreviated primary hit point unit to
@@ -3457,9 +3269,7 @@ character.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    HPFORMULA:SKILLTOTAL=Endurance
-   </code>
+   <code>HPFORMULA:SKILLTOTAL=Endurance</code>
   </p>
   <p class="indent3">
    Sets the HP total for a character equal to its
@@ -3498,18 +3308,14 @@ tab and HP pop-up from classes).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    HPNAME:Hit Points
-   </code>
+   <code>HPNAME:Hit Points</code>
   </p>
   <p class="indent3">
    Sets the primary hit point unit to "Hit
 Points".
   </p>
   <p class="indent2">
-   <code>
-    HPNAME:Energy Points
-   </code>
+   <code>HPNAME:Energy Points</code>
   </p>
   <p class="indent3">
    Sets the primary hit point unit to "Energy
@@ -3546,9 +3352,7 @@ or NO).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ISMONSTER:YES
-   </code>
+   <code>ISMONSTER:YES</code>
   </p>
   <p class="indent3">
    This is a Monster.
@@ -3594,10 +3398,8 @@ level.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    LEVELMSG:You may qualify for a new
-level
-   </code>
+   <code>LEVELMSG:You may qualify for a new
+level</code>
   </p>
   <p class="indent3">
    Sets the level up message.
@@ -3636,9 +3438,7 @@ for the gamemode.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    MAXNONEPICLEVEL:20
-   </code>
+   <code>MAXNONEPICLEVEL:20</code>
   </p>
   <p class="indent3">
    Levels above 20th are concidered epic
@@ -3677,9 +3477,7 @@ menu).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    &amp;S&amp;&amp;M
-   </code>
+   <code>&amp;S&amp;&amp;M</code>
   </p>
   <p class="indent3">
    Defines a menu entry that will display as
@@ -3716,9 +3514,7 @@ defined menuentry.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    MENUTOOLTIP:
-   </code>
+   <code>MENUTOOLTIP:</code>
   </p>
   <p class="indent3">
    Defines a menu entry tooltip that will display
@@ -3762,60 +3558,48 @@ as "Use 3e character creation settings".
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ROLLMETHOD:3d6 &lt;tab&gt;
-METHOD:3d6
-   </code>
+   <code>ROLLMETHOD:3d6 &lt;tab&gt;
+METHOD:3d6</code>
   </p>
   <p class="indent3">
    Menu displays "3d6" as the label for this method
 and simulates rolling 3 six sided dice.
   </p>
   <p class="indent2">
-   <code>
-    ROLLMETHOD:4d6 drop lowest &lt;tab&gt;
-METHOD:roll(4,6,[2,3,4])
-   </code>
+   <code>ROLLMETHOD:4d6 drop lowest &lt;tab&gt;
+METHOD:roll(4,6,[2,3,4])</code>
   </p>
   <p class="indent3">
    Simulates rolling 4 six sided dice and dropping
 the lowest.
   </p>
   <p class="indent2">
-   <code>
-    ROLLMETHOD:5d6 drop 2 lowest &lt;tab&gt;
-METHOD:roll(5,6,[3,4,5])
-   </code>
+   <code>ROLLMETHOD:5d6 drop 2 lowest &lt;tab&gt;
+METHOD:roll(5,6,[3,4,5])</code>
   </p>
   <p class="indent3">
    Simulates rolling 5 six sided dice and dropping
 the 2 lowest.
   </p>
   <p class="indent2">
-   <code>
-    ROLLMETHOD:4d6 drop lowest &lt;tab&gt;
-METHOD:roll(4,6,top(3))
-   </code>
+   <code>ROLLMETHOD:4d6 drop lowest &lt;tab&gt;
+METHOD:roll(4,6,top(3))</code>
   </p>
   <p class="indent3">
    Simulates rolling 4 six sided dice and dropping
 the lowest.
   </p>
   <p class="indent2">
-   <code>
-    ROLLMETHOD:4d6, reroll 1's, drop the
-lowest &lt;tab&gt; METHOD:roll(4,6,top(3),reroll(1))
-   </code>
+   <code>ROLLMETHOD:4d6, reroll 1's, drop the
+lowest &lt;tab&gt; METHOD:roll(4,6,top(3),reroll(1))</code>
   </p>
   <p class="indent3">
    Simulates rolling 4 six sided dice, rerolling
 1's and dropping the lowest.
   </p>
   <p class="indent2">
-   <code>
-    ROLLMETHOD:5d6, reroll 1&amp;2's, drop 2
-lowest &lt;tab&gt; METHOD:roll(5,6,top(3), reroll(2))
-   </code>
+   <code>ROLLMETHOD:5d6, reroll 1&amp;2's, drop 2
+lowest &lt;tab&gt; METHOD:roll(5,6,top(3), reroll(2))</code>
   </p>
   <p class="indent3">
    Simulates rolling 5 six sided dice, rerolling
@@ -3869,9 +3653,7 @@ none is listed.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    MONSTERROLEDEFAULT:Combat
-   </code>
+   <code>MONSTERROLEDEFAULT:Combat</code>
   </p>
   <p class="indent3">
    Creatures with no ROLE defined, should be
@@ -3913,9 +3695,7 @@ both racial hit dice and character classes.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    MONSTERROLES:Combat|Skill|Special|Cleric|Druid|Sorcerer|Wizard
-   </code>
+   <code>MONSTERROLES:Combat|Skill|Special|Cleric|Druid|Sorcerer|Wizard</code>
   </p>
   <p class="indent3">
    Defines a list of monster roles.
@@ -3953,17 +3733,13 @@ in_abilities) it will pull the tab name from the language files
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    NAME:Domains
-   </code>
+   <code>NAME:Domains</code>
   </p>
   <p class="indent3">
    Defines tab name as "Domains".
   </p>
   <p class="indent2">
-   <code>
-    NAME:Overview
-   </code>
+   <code>NAME:Overview</code>
   </p>
   <p class="indent3">
    Defines tab name as "Overview".
@@ -4036,27 +3812,21 @@ gamemode.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    OUTPUTSHHET:DIRECTORY|outputsheets/d20/fantasy
-   </code>
+   <code>OUTPUTSHHET:DIRECTORY|outputsheets/d20/fantasy</code>
   </p>
   <p class="indent3">
    Outputsheets for this gamemode will be stored in
 the "outputsheets/d20/fantasy" folder.
   </p>
   <p class="indent2">
-   <code>
-    OUTPUTSHHET:DEFAULT.PDF|outputsheets/d20/fantasy/pdf/csheet_fantasy_std_blue.xslt
-   </code>
+   <code>OUTPUTSHHET:DEFAULT.PDF|outputsheets/d20/fantasy/pdf/csheet_fantasy_std_blue.xslt</code>
   </p>
   <p class="indent3">
    The default pdf OS for this gamemode is
 "outputsheets/d20/fantasy/pdf/csheet_fantasy_std_blue.xslt" OS.
   </p>
   <p class="indent2">
-   <code>
-    OUTPUTSHHET:DEFAULT.HTM|outputsheets/d20/fantasy/htmlxml/csheet_fantasy_std.htm
-   </code>
+   <code>OUTPUTSHHET:DEFAULT.HTM|outputsheets/d20/fantasy/htmlxml/csheet_fantasy_std.htm</code>
   </p>
   <p class="indent3">
    The default html OS for this gamemode is
@@ -4103,9 +3873,7 @@ internationalization).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PLURAL:in_feats
-   </code>
+   <code>PLURAL:in_feats</code>
   </p>
   <p class="indent3">
    The plural name for the category is the value in
@@ -4154,9 +3922,7 @@ upon the formula entered.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PLUSCOST:AMMUNITION|BASEQTY*40*PLUS*PLUS
-   </code>
+   <code>PLUSCOST:AMMUNITION|BASEQTY*40*PLUS*PLUS</code>
   </p>
   <p class="indent3">
    Ammunition will be based upon quantity times 40
@@ -4164,9 +3930,7 @@ times the plus value desired and times the plus value desired again
 to result in the final cost.
   </p>
   <p class="indent2">
-   <code>
-    PLUSCOST:ARMOR|1000*PLUS*PLUS
-   </code>
+   <code>PLUSCOST:ARMOR|1000*PLUS*PLUS</code>
   </p>
   <p class="indent3">
    Takes the armor cost and then takes 1000 times
@@ -4174,9 +3938,7 @@ the plus value and then times the plus value to come up with the
 resulting cost.
   </p>
   <p class="indent2">
-   <code>
-    PLUSCOST:SHIELD|1000*PLUS*PLUS
-   </code>
+   <code>PLUSCOST:SHIELD|1000*PLUS*PLUS</code>
   </p>
   <p class="indent3">
    Takes the shield cost and then takes 1000 times
@@ -4184,9 +3946,7 @@ the plus value and then times the plus value to come up with the
 resulting cost.
   </p>
   <p class="indent2">
-   <code>
-    PLUSCOST:WEAPON|(2000*PLUS*PLUS)+(2000*ALTPLUS*ALTPLUS)
-   </code>
+   <code>PLUSCOST:WEAPON|(2000*PLUS*PLUS)+(2000*ALTPLUS*ALTPLUS)</code>
   </p>
   <p class="indent3">
    Takes the weapon cost and then takes 2000 times
@@ -4218,9 +3978,7 @@ it also calculates the cost using the same formula.
   <ul class="indent2">
    <li>
     The
-    <code>
-     POINTPOOLNAME
-    </code>
+    <code>POINTPOOLNAME</code>
     tag is used to make a default
 choice for a GameMode's preferred method of PointPooling for Stat
 creation.
@@ -4235,9 +3993,7 @@ the GameMode's
    </li>
    <li>
     When the
-    <code>
-     POINTPOOLNAME
-    </code>
+    <code>POINTPOOLNAME</code>
     tag is present in the
     <span class="lstfile">
      miscinfo.lst
@@ -4253,13 +4009,9 @@ total and stat mod total
       The Skills Tab displays the pool of availble skill points to
 spend instead of skill points by class/level requirement, and is
 populated by the classes
-      <code>
-       STARTSKILLPTS
-      </code>
+      <code>STARTSKILLPTS</code>
       and miscinfo
-      <code>
-       SKILLMULTIPLIER
-      </code>
+      <code>SKILLMULTIPLIER</code>
      </li>
      <li>
       The Feats Tab will show total point pool as described for the
@@ -4274,9 +4026,7 @@ skills tab.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    POINTPOOLNAME:Harp
-   </code>
+   <code>POINTPOOLNAME:Harp</code>
   </p>
   <p class="indent3">
    Means that PCGen will use the Harp Point Pool
@@ -4324,9 +4074,7 @@ pool size for this category of ability.
     </strong>
     be defined using
 the
-    <code>
-     DEFINE
-    </code>
+    <code>DEFINE</code>
     tag.
    </li>
   </ul>
@@ -4336,9 +4084,7 @@ the
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    POOL:TL/2
-   </code>
+   <code>POOL:TL/2</code>
   </p>
   <p class="indent3">
    The ability pool equals a value equal to that of
@@ -4404,9 +4150,7 @@ this path is the preview directory in the pcgen directory
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PREVIEWDIR:d20/fantasy
-   </code>
+   <code>PREVIEWDIR:d20/fantasy</code>
   </p>
   <p class="indent3">
    Sets "pcgen/preview/d20/fantasy" at the
@@ -4456,9 +4200,7 @@ directory set by the gameModes
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PREVIEWSHEET:preview.html
-   </code>
+   <code>PREVIEWSHEET:preview.html</code>
   </p>
   <p class="indent3">
    Sets the "preview.html" file as the default
@@ -4499,9 +4241,7 @@ range increment after the first.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    RANGEPENALTY:-2
-   </code>
+   <code>RANGEPENALTY:-2</code>
   </p>
   <p class="indent3">
    Sets the range penalty for those range
@@ -4554,9 +4294,7 @@ ranks.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    RANKMODFORMULA:IF($$RANK$$&gt;20,50+$$RANK$$,IF($$RANK$$&gt;10,50+($$RANK$$-10)*2,IF($$RANK$$&gt;0,$$RANK$$*5,-25)))-$$RANK$$
-   </code>
+   <code>RANKMODFORMULA:IF($$RANK$$&gt;20,50+$$RANK$$,IF($$RANK$$&gt;10,50+($$RANK$$-10)*2,IF($$RANK$$&gt;0,$$RANK$$*5,-25)))-$$RANK$$</code>
   </p>
   <p class="indent3">
    The first 10 ranks of a skill will each give +5
@@ -4632,18 +4370,14 @@ qualified with PRExxx tags.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    REMOVE:Base
-   </code>
+   <code>REMOVE:Base</code>
   </p>
   <p class="indent3">
    Subtracts ACTYPE:Base to the ACTYPE being
 defined in the ACTYPE line.
   </p>
   <p class="indent2">
-   <code>
-    REMOVE:Shield
-   </code>
+   <code>REMOVE:Shield</code>
   </p>
   <p class="indent3">
    Subtracts ACTYPE:Shield to the ACTYPE being
@@ -4684,9 +4418,7 @@ of PCGen.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    RESIZABLEEQUIPTYPE:Weapon|Resizable
-   </code>
+   <code>RESIZABLEEQUIPTYPE:Weapon|Resizable</code>
   </p>
   <p class="indent3">
    Equipment with a type of either Weapon or
@@ -4746,30 +4478,24 @@ scores using the method selected.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ROLLMETHOD:3d6 &lt;tab&gt;
-METHOD:3d6
-   </code>
+   <code>ROLLMETHOD:3d6 &lt;tab&gt;
+METHOD:3d6</code>
   </p>
   <p class="indent3">
    Menu displays "3d6" as the label for this method
 and simulates rolling 3 six sided dice.
   </p>
   <p class="indent2">
-   <code>
-    ROLLMETHOD:4d6 drop lowest &lt;tab&gt;
-METHOD:roll(4,6,[2,3,4])
-   </code>
+   <code>ROLLMETHOD:4d6 drop lowest &lt;tab&gt;
+METHOD:roll(4,6,[2,3,4])</code>
   </p>
   <p class="indent3">
    Menu displays "4d6 drop lowest" as the label for
 this method.
   </p>
   <p class="indent2">
-   <code>
-    ROLLMETHOD:5d6 drop 2 lowest &lt;tab&gt;
-METHOD:roll(5,6,[3,4,5])
-   </code>
+   <code>ROLLMETHOD:5d6 drop 2 lowest &lt;tab&gt;
+METHOD:roll(5,6,[3,4,5])</code>
   </p>
   <p class="indent3">
    Menu displays "5d6 drop 2 lowest" as the label
@@ -4821,9 +4547,7 @@ bonuses given with a BONUS:COMBAT|AC|x|TYPE=ClassDefense tag.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SHOWCLASSDEFENSE:YES
-   </code>
+   <code>SHOWCLASSDEFENSE:YES</code>
   </p>
   <p class="indent3">
    Allow bonuses of the
@@ -4868,9 +4592,7 @@ within the java code.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SIZEDIFF:-1
-   </code>
+   <code>SIZEDIFF:-1</code>
   </p>
   <p class="indent3">
    If this weapon was Medium sized, then this
@@ -4921,19 +4643,15 @@ skill.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SKILLCOST_CLASS:1
-   </code>
+   <code>SKILLCOST_CLASS:1</code>
   </p>
   <p class="indent3">
    Sets the cost of one rank of a class skill to
 one skill point.
   </p>
   <p class="indent2">
-   <code>
-    SKILLCOST_CROSSCLASS:1|PREFEAT:1,Fast
-Learner
-   </code>
+   <code>SKILLCOST_CROSSCLASS:1|PREFEAT:1,Fast
+Learner</code>
   </p>
   <p class="indent3">
    Does not work due to the chaining of the
@@ -4973,9 +4691,7 @@ skill.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SKILLCOST_CROSSCLASS:2
-   </code>
+   <code>SKILLCOST_CROSSCLASS:2</code>
   </p>
   <p class="indent3">
    Sets the cost of one rank of a cross class skill
@@ -5015,9 +4731,7 @@ skill.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SKILLCOST_EXCLUSIVE:1
-   </code>
+   <code>SKILLCOST_EXCLUSIVE:1</code>
   </p>
   <p class="indent3">
    Sets the cost of one rank of an exclusive skill
@@ -5060,27 +4774,21 @@ characters get 4x the normal amount of skills at first level.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SKILLMULTIPLIER:4
-   </code>
+   <code>SKILLMULTIPLIER:4</code>
   </p>
   <p class="indent3">
    Character gets 4x the normal amount of skills,
 at 1st level.
   </p>
   <p class="indent2">
-   <code>
-    SKILLMULTIPLIER:2|2|2
-   </code>
+   <code>SKILLMULTIPLIER:2|2|2</code>
   </p>
   <p class="indent3">
    Character gets 2x the normal amount of skills,
 at 1st, 2nd, and 3rd level.
   </p>
   <p class="indent2">
-   <code>
-    SKILLMULTIPLIER:10|4
-   </code>
+   <code>SKILLMULTIPLIER:10|4</code>
   </p>
   <p class="indent3">
    Character get 10x the normal amount of skills at
@@ -5125,46 +4833,32 @@ numbers.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SKILLRANKTEXT:1 &lt;tab&gt;
-Incompetant
-   </code>
+   <code>SKILLRANKTEXT:1 &lt;tab&gt;
+Incompetant</code>
   </p>
   <p class="indent2">
-   <code>
-    SKILLRANKTEXT:2 &lt;tab&gt;
-Novice
-   </code>
+   <code>SKILLRANKTEXT:2 &lt;tab&gt;
+Novice</code>
   </p>
   <p class="indent2">
-   <code>
-    SKILLRANKTEXT:3 &lt;tab&gt;
-Competant
-   </code>
+   <code>SKILLRANKTEXT:3 &lt;tab&gt;
+Competant</code>
   </p>
   <p class="indent2">
-   <code>
-    SKILLRANKTEXT:4 &lt;tab&gt;
-Expert
-   </code>
+   <code>SKILLRANKTEXT:4 &lt;tab&gt;
+Expert</code>
   </p>
   <p class="indent2">
-   <code>
-    SKILLRANKTEXT:5 &lt;tab&gt;
-Professional
-   </code>
+   <code>SKILLRANKTEXT:5 &lt;tab&gt;
+Professional</code>
   </p>
   <p class="indent2">
-   <code>
-    SKILLRANKTEXT:6 &lt;tab&gt;
-Master
-   </code>
+   <code>SKILLRANKTEXT:6 &lt;tab&gt;
+Master</code>
   </p>
   <p class="indent2">
-   <code>
-    SKILLRANKTEXT:7 &lt;tab&gt;
-Supreme
-   </code>
+   <code>SKILLRANKTEXT:7 &lt;tab&gt;
+Supreme</code>
   </p>
   <p class="indent3">
    Character skills with ranks of 1 through 7 will
@@ -5205,9 +4899,7 @@ to be hidden from view.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SKILLTABLEHIDDENCOLUMNS:1,2,3,5
-   </code>
+   <code>SKILLTABLEHIDDENCOLUMNS:1,2,3,5</code>
   </p>
   <p class="indent3">
    Columns 1, 2, 3 and 5 of the skill table are
@@ -5271,9 +4963,7 @@ should not display concentration check bonuses.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SPELLBASECONCENTRATION:CASTERLEVEL+BASESPELLSTAT
-   </code>
+   <code>SPELLBASECONCENTRATION:CASTERLEVEL+BASESPELLSTAT</code>
   </p>
   <p class="indent3">
    Adds the spell's caster level and the primary
@@ -5310,9 +5000,7 @@ BASE DC for a spell.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SPELLBASEDC:10+SPELLLEVEL+BASESPELLSTAT
-   </code>
+   <code>SPELLBASEDC:10+SPELLLEVEL+BASESPELLSTAT</code>
   </p>
   <p class="indent3">
    Takes the number 10 as the starting point, then
@@ -5360,9 +5048,7 @@ replace the name in the Spells.lst under the range.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SPELLRANGE:CLOSE|floor(CASTERLEVEL/2)*5+25
-   </code>
+   <code>SPELLRANGE:CLOSE|floor(CASTERLEVEL/2)*5+25</code>
   </p>
   <p class="indent3">
    Range value would be the caster's level divided
@@ -5374,18 +5060,14 @@ entered
 30
   </p>
   <p class="indent2">
-   <code>
-    SPELLRANGE:MEDIUM|(CASTERLEVEL*10)+100
-   </code>
+   <code>SPELLRANGE:MEDIUM|(CASTERLEVEL*10)+100</code>
   </p>
   <p class="indent3">
    Formula would determine medium to be the
 caster's level times 10 + 100
   </p>
   <p class="indent2">
-   <code>
-    SPELLRANGE:LONG|(CASTERLEVEL*40)+400
-   </code>
+   <code>SPELLRANGE:LONG|(CASTERLEVEL*40)+400</code>
   </p>
   <p class="indent3">
    Formula returns a long value based upon the
@@ -5427,9 +5109,7 @@ feet
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SQUARESIZE:5
-   </code>
+   <code>SQUARESIZE:5</code>
   </p>
   <p class="indent3">
    Sets the size of a battlemap square to 5
@@ -5474,9 +5154,7 @@ New 5.17.0
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    STARTSTATMIN:5
-   </code>
+   <code>STARTSTATMIN:5</code>
   </p>
   <p class="indent3">
    Sets the minimum STAT to "5".
@@ -5520,37 +5198,25 @@ numbers.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    STATROLLTEXT:1 &lt;tab&gt; Poor
-   </code>
+   <code>STATROLLTEXT:1 &lt;tab&gt; Poor</code>
   </p>
   <p class="indent2">
-   <code>
-    STATROLLTEXT:2 &lt;tab&gt; Low
-   </code>
+   <code>STATROLLTEXT:2 &lt;tab&gt; Low</code>
   </p>
   <p class="indent2">
-   <code>
-    STATROLLTEXT:3 &lt;tab&gt;
-Average
-   </code>
+   <code>STATROLLTEXT:3 &lt;tab&gt;
+Average</code>
   </p>
   <p class="indent2">
-   <code>
-    STATROLLTEXT:4 &lt;tab&gt; High
-   </code>
+   <code>STATROLLTEXT:4 &lt;tab&gt; High</code>
   </p>
   <p class="indent2">
-   <code>
-    STATROLLTEXT:5 &lt;tab&gt;
-Exceptional
-   </code>
+   <code>STATROLLTEXT:5 &lt;tab&gt;
+Exceptional</code>
   </p>
   <p class="indent2">
-   <code>
-    STATROLLTEXT:6 &lt;tab&gt;
-Awesome
-   </code>
+   <code>STATROLLTEXT:6 &lt;tab&gt;
+Awesome</code>
   </p>
   <p class="indent3">
    Character stat score of "1" will be labeled as
@@ -5588,9 +5254,7 @@ to be hidden from view.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    STATTABLEHIDDENCOLUMNS:1,2,3,5
-   </code>
+   <code>STATTABLEHIDDENCOLUMNS:1,2,3,5</code>
   </p>
   <p class="indent3">
    Columns 1, 2, 3 and 5 of the stat table are
@@ -5639,9 +5303,7 @@ based on weapon and PC size.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SWITCH:Light
-   </code>
+   <code>SWITCH:Light</code>
   </p>
   <p class="indent3">
    Wield category is switched to 'Light'.
@@ -5789,9 +5451,7 @@ VISIBLE:NO.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TAB:SUMMARY
-   </code>
+   <code>TAB:SUMMARY</code>
   </p>
   <p class="indent3">
    Indicates that the line will effect the
@@ -5865,18 +5525,14 @@ the category.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TYPE:Fighter.Wizard
-   </code>
+   <code>TYPE:Fighter.Wizard</code>
   </p>
   <p class="indent3">
    Defines that all fighter and wizard abilities
 should be included in the category.
   </p>
   <p class="indent2">
-   <code>
-    TYPE:*
-   </code>
+   <code>TYPE:*</code>
   </p>
   <p class="indent3">
    Defines that all abilities should be included in
@@ -5977,9 +5633,7 @@ and will default to Imperial if not present.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    UNITSET:Imperial
-   </code>
+   <code>UNITSET:Imperial</code>
   </p>
   <p class="indent3">
    Defines a Unit Set named Imperial.
@@ -6016,9 +5670,7 @@ next die value in an incremental set
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    UP:1d8,2d6,3d6,4d6,6d6,8d6,12d6
-   </code>
+   <code>UP:1d8,2d6,3d6,4d6,6d6,8d6,12d6</code>
   </p>
   <p class="indent3">
    Determines the next die in the progression will
@@ -6077,23 +5729,17 @@ be 1d8, then 2d6 if chosen again, etc.
     Turns the associated tab or sub-tab on or off in the GUI.
    </li>
    <li>
-    <code>
-     YES
-    </code>
+    <code>YES</code>
     - Used to make the tab display in the
 GUI.
    </li>
    <li>
-    <code>
-     NO
-    </code>
+    <code>NO</code>
     - Used to keep the tab from displaying in the
 GUI.
    </li>
    <li>
-    <code>
-     QUALIFY
-    </code>
+    <code>QUALIFY</code>
     - Ability category is only displayed if
 its total pool (spent + remaining) is not empty.
    </li>
@@ -6113,9 +5759,7 @@ categories be grouped where possible.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    VISIBLE:NO
-   </code>
+   <code>VISIBLE:NO</code>
   </p>
   <p class="indent3">
    Used to keep the tab from displaying in the
@@ -6166,33 +5810,25 @@ GUI.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    WEAPONCATEGORY:Simple
-   </code>
+   <code>WEAPONCATEGORY:Simple</code>
   </p>
   <p class="indent3">
    Defines Simple weapons
   </p>
   <p class="indent2">
-   <code>
-    WEAPONCATEGORY:Martial
-   </code>
+   <code>WEAPONCATEGORY:Martial</code>
   </p>
   <p class="indent3">
    Defines Martial weapons
   </p>
   <p class="indent2">
-   <code>
-    WEAPONCATEGORY:Exotic
-   </code>
+   <code>WEAPONCATEGORY:Exotic</code>
   </p>
   <p class="indent3">
    Defines Exotic weapons
   </p>
   <p class="indent2">
-   <code>
-    WEAPONCATEGORY:Natural
-   </code>
+   <code>WEAPONCATEGORY:Natural</code>
   </p>
   <p class="indent3">
    Defines Natural weapons
@@ -6231,9 +5867,7 @@ proficient.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    WEAPONNONPROFPENALTY:-4
-   </code>
+   <code>WEAPONNONPROFPENALTY:-4</code>
   </p>
   <p class="indent3">
    Defines a -4 penalty to attack for not being
@@ -6291,9 +5925,7 @@ set in the Weapon, if no REACH tag is present the value defaults to
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    WEAPONREACH:(RACEREACH+(max(0,REACH-5)))*REACHMULT
-   </code>
+   <code>WEAPONREACH:(RACEREACH+(max(0,REACH-5)))*REACHMULT</code>
   </p>
   <p class="indent3">
    This is the standard formula used in the 35e
@@ -6329,36 +5961,28 @@ letter(s) for output sheets.
    Example:
   </p>
   <p class="indent2">
-   <code>
-    WEAPONTYPE:Bludgeoning|B
-   </code>
+   <code>WEAPONTYPE:Bludgeoning|B</code>
   </p>
   <p class="indent3">
    Bludgeoning weapons will be represented by a
 letter “B” on the preview and output sheets.
   </p>
   <p class="indent2">
-   <code>
-    WEAPONTYPE:Slashing|S
-   </code>
+   <code>WEAPONTYPE:Slashing|S</code>
   </p>
   <p class="indent3">
    Slashing weapons will be represented by a letter
 “S” on the preview and output sheets.
   </p>
   <p class="indent2">
-   <code>
-    WEAPONTYPE:Electricity|E
-   </code>
+   <code>WEAPONTYPE:Electricity|E</code>
   </p>
   <p class="indent3">
    Electricity weapons/attacks will be represented
 by a letter “E” on the preview and output sheets.
   </p>
   <p class="indent2">
-   <code>
-    WEAPONTYPE:Sonic|So
-   </code>
+   <code>WEAPONTYPE:Sonic|So</code>
   </p>
   <p class="indent3">
    Sonic weapons/attacks will be represented by a
@@ -6402,9 +6026,7 @@ A Unit set which is native to the data will always have a factor of
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    WEIGHTFACTOR:0.5
-   </code>
+   <code>WEIGHTFACTOR:0.5</code>
   </p>
   <p class="indent3">
    Defines the weight factor as "0.5".
@@ -6463,9 +6085,7 @@ class DecimaFormat and can be found
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    WEIGHTPATTERN:#.##
-   </code>
+   <code>WEIGHTPATTERN:#.##</code>
   </p>
   <p class="indent3">
    Defines the weight unit pattern as "ft.".
@@ -6519,9 +6139,7 @@ to follow directly after the value, prefix the string with '~'.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    WEIGHTUNIT:lbs.
-   </code>
+   <code>WEIGHTUNIT:lbs.</code>
   </p>
   <p class="indent3">
    Defines the weight unit abbreviation as
@@ -6590,9 +6208,7 @@ PREVARxxx and SWITCH.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    WIELDCATEGORY:Light
-   </code>
+   <code>WIELDCATEGORY:Light</code>
   </p>
   <p class="indent3">
    Defines 'Light' weapon category.
@@ -6643,9 +6259,7 @@ listed.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    XPAWARD:1=400|2=600|3=800|4=1200|5=1600|6=2400|7=3200|8=4800
-   </code>
+   <code>XPAWARD:1=400|2=600|3=800|4=1200|5=1600|6=2400|7=3200|8=4800</code>
   </p>
   <p class="indent3">
    Define the fixed experience point awards for the
@@ -6683,9 +6297,7 @@ applied.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    XPPENALTY:YES
-   </code>
+   <code>XPPENALTY:YES</code>
   </p>
   <p class="indent3">
    A Penalty to XP will be applied.

--- a/docs/listfilepages/systemfilestagpages/gamemodepointbuymethodlist.html
+++ b/docs/listfilepages/systemfilestagpages/gamemodepointbuymethodlist.html
@@ -95,14 +95,10 @@ Name:
   <p class="indent2">
    When using the "Point Buy Method" of determining
 a characters stats, the Stat Line defines the
-   <code>
-    COST
-   </code>
+   <code>COST</code>
    to
 "buy" a particular
-   <code>
-    STAT
-   </code>
+   <code>STAT</code>
    .
   </p>
   <p class="indent1">
@@ -111,108 +107,84 @@ a characters stats, the Stat Line defines the
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    STAT:7 &lt;tab&gt; COST:-4
-   </code>
+   <code>STAT:7 &lt;tab&gt; COST:-4</code>
   </p>
   <p class="indent3">
    Starting with a stat of 10, buying a stat change
 to 7 will gain 4 points.
   </p>
   <p class="indent2">
-   <code>
-    STAT:8 &lt;tab&gt; COST:-2
-   </code>
+   <code>STAT:8 &lt;tab&gt; COST:-2</code>
   </p>
   <p class="indent3">
    Starting with a stat of 10, buying a stat change
 to 8 will gain 2 points.
   </p>
   <p class="indent2">
-   <code>
-    STAT:9 &lt;tab&gt; COST:-1
-   </code>
+   <code>STAT:9 &lt;tab&gt; COST:-1</code>
   </p>
   <p class="indent3">
    Starting with a stat of 10, buying a stat change
 to 9 will gain 3 points.
   </p>
   <p class="indent2">
-   <code>
-    STAT:10 &lt;tab&gt; COST:0
-   </code>
+   <code>STAT:10 &lt;tab&gt; COST:0</code>
   </p>
   <p class="indent3">
    Starting with a stat of 10, buying a stat change
 to 10 will cost 0 points.
   </p>
   <p class="indent2">
-   <code>
-    STAT:11 &lt;tab&gt; COST:1
-   </code>
+   <code>STAT:11 &lt;tab&gt; COST:1</code>
   </p>
   <p class="indent3">
    Starting with a stat of 10, buying a stat change
 to 11 will cost 1 points.
   </p>
   <p class="indent2">
-   <code>
-    STAT:12 &lt;tab&gt; COST:2
-   </code>
+   <code>STAT:12 &lt;tab&gt; COST:2</code>
   </p>
   <p class="indent3">
    Starting with a stat of 10, buying a stat change
 to 12 will cost 2 points.
   </p>
   <p class="indent2">
-   <code>
-    STAT:13 &lt;tab&gt; COST:3
-   </code>
+   <code>STAT:13 &lt;tab&gt; COST:3</code>
   </p>
   <p class="indent3">
    Starting with a stat of 10, buying a stat change
 to 13 will cost 3 points.
   </p>
   <p class="indent2">
-   <code>
-    STAT:14 &lt;tab&gt; COST:5
-   </code>
+   <code>STAT:14 &lt;tab&gt; COST:5</code>
   </p>
   <p class="indent3">
    Starting with a stat of 10, buying a stat change
 to 14 will cost 5 points.
   </p>
   <p class="indent2">
-   <code>
-    STAT:15 &lt;tab&gt; COST:7
-   </code>
+   <code>STAT:15 &lt;tab&gt; COST:7</code>
   </p>
   <p class="indent3">
    Starting with a stat of 10, buying a stat change
 to 15 will cost 7 points.
   </p>
   <p class="indent2">
-   <code>
-    STAT:16 &lt;tab&gt; COST:10
-   </code>
+   <code>STAT:16 &lt;tab&gt; COST:10</code>
   </p>
   <p class="indent3">
    Starting with a stat of 10, buying a stat change
 to 16 will cost 10 points.
   </p>
   <p class="indent2">
-   <code>
-    STAT:17 &lt;tab&gt; COST:13
-   </code>
+   <code>STAT:17 &lt;tab&gt; COST:13</code>
   </p>
   <p class="indent3">
    Starting with a stat of 10, buying a stat change
 to 17 will cost 13 points.
   </p>
   <p class="indent2">
-   <code>
-    STAT:18 &lt;tab&gt; COST:17
-   </code>
+   <code>STAT:18 &lt;tab&gt; COST:17</code>
   </p>
   <p class="indent3">
    Starting with a stat of 10, buying a stat change
@@ -276,9 +248,7 @@ name)
     When
 using the "Point Buy Method" of determining a characters stats, the
 Method Line defines the total
-    <code>
-     POINTS
-    </code>
+    <code>POINTS</code>
     available to buy
 stats.
    </a>
@@ -292,10 +262,8 @@ stats.
   </p>
   <p class="indent2">
    <a id="methodpoints" name="methodpoints">
-    <code>
-     METHOD:Low Fantasy &lt;tab&gt;
-POINTS:10
-    </code>
+    <code>METHOD:Low Fantasy &lt;tab&gt;
+POINTS:10</code>
    </a>
   </p>
   <p class="indent3">
@@ -307,10 +275,8 @@ purchasing stats.
   </p>
   <p class="indent2">
    <a id="methodpoints" name="methodpoints">
-    <code>
-     METHOD:Standard Fantasy &lt;tab&gt;
-POINTS:15
-    </code>
+    <code>METHOD:Standard Fantasy &lt;tab&gt;
+POINTS:15</code>
    </a>
   </p>
   <p class="indent3">
@@ -322,10 +288,8 @@ purchasing stats.
   </p>
   <p class="indent2">
    <a id="methodpoints" name="methodpoints">
-    <code>
-     METHOD:High Fantasy &lt;tab&gt;
-POINTS:20
-    </code>
+    <code>METHOD:High Fantasy &lt;tab&gt;
+POINTS:20</code>
    </a>
   </p>
   <p class="indent3">
@@ -337,10 +301,8 @@ purchasing stats.
   </p>
   <p class="indent2">
    <a id="methodpoints" name="methodpoints">
-    <code>
-     METHOD:Epic Fantasy &lt;tab&gt;
-POINTS:25
-    </code>
+    <code>METHOD:Epic Fantasy &lt;tab&gt;
+POINTS:25</code>
    </a>
   </p>
   <p class="indent3">

--- a/docs/listfilepages/systemfilestagpages/gamemoderules.html
+++ b/docs/listfilepages/systemfilestagpages/gamemoderules.html
@@ -36,11 +36,9 @@ the GUI.
    </strong>
   </p>
   <p class="indent0">
-   <code>
-    Name:aName &lt;tab&gt; VAR:/PARM:aKey
+   <code>Name:aName &lt;tab&gt; VAR:/PARM:aKey
 &lt;tab&gt; DEFAULT:YES/NO &lt;tab&gt; EXCLUDE:aKey &lt;tab&gt;
-DESC:optional description
-   </code>
+DESC:optional description</code>
   </p>
   <hr/>
   <p class="indent1">

--- a/docs/listfilepages/systemfilestagpages/gamemodestatsandcheckslist.html
+++ b/docs/listfilepages/systemfilestagpages/gamemodestatsandcheckslist.html
@@ -85,9 +85,7 @@ character to build upon.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    STATNAME:Awareness
-   </code>
+   <code>STATNAME:Awareness</code>
   </p>
   <p class="indent3">
    Creates a Stat named "Awareness".
@@ -133,9 +131,7 @@ statistic.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ABB:AWR
-   </code>
+   <code>ABB:AWR</code>
   </p>
   <p class="indent3">
    Example abbreviation of above example of
@@ -183,17 +179,13 @@ metamagic feat costs to apply.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ABILITY:ADDSPELLLEVEL|1
-   </code>
+   <code>ABILITY:ADDSPELLLEVEL|1</code>
   </p>
   <p class="indent3">
    Adds 1 to the spell level.
   </p>
   <p class="indent2">
-   <code>
-    ABILITY:ADDSPELLLEVEL|+2
-   </code>
+   <code>ABILITY:ADDSPELLLEVEL|+2</code>
   </p>
   <p class="indent3">
    Adds 2 to the spell level.
@@ -243,9 +235,7 @@ appropriate.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:COMBAT|AC|1|TYPE=NaturalArmor
-   </code>
+   <code>BONUS:COMBAT|AC|1|TYPE=NaturalArmor</code>
   </p>
   <p class="indent3">
    Bonus of +1 to Natural Armor.
@@ -296,36 +286,28 @@ defined HP type).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:HP|WOUNDPOINTS|CON
-   </code>
+   <code>BONUS:HP|WOUNDPOINTS|CON</code>
   </p>
   <p class="indent3">
    Adds a characters CON bonus to the WOUNDPOINTS
 total at each level.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:HP|ALTHP|CONSCORE
-   </code>
+   <code>BONUS:HP|ALTHP|CONSCORE</code>
   </p>
   <p class="indent3">
    Adds a characters CONSCORE to the ALTHP total as
 defined in miscinfo.lst.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:HP|BONUS|CON
-   </code>
+   <code>BONUS:HP|BONUS|CON</code>
   </p>
   <p class="indent3">
    Adds a characters CON bonus to the Primary HP
 total as defined in miscinfo.lst.
   </p>
   <p class="indent2">
-   <code>
-    BONUS:HP|CON
-   </code>
+   <code>BONUS:HP|CON</code>
   </p>
   <p class="indent3">
    Adds a characters CON bonus to the Primary HP
@@ -380,9 +362,7 @@ variable or formula
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:LANG|BONUS|INT
-   </code>
+   <code>BONUS:LANG|BONUS|INT</code>
   </p>
   <p class="indent3">
    Adds the value of INT modifier to total the
@@ -436,9 +416,7 @@ variable or formula
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:MODSKILLPOINTS|NUMBER|INT
-   </code>
+   <code>BONUS:MODSKILLPOINTS|NUMBER|INT</code>
   </p>
   <p class="indent3">
    Adds the value of INT modifier to total the
@@ -494,9 +472,7 @@ you can use based on the referenced stat.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DEFINE:MAXLEVELSTAT:WIS|WISSCORE-10
-   </code>
+   <code>DEFINE:MAXLEVELSTAT:WIS|WISSCORE-10</code>
   </p>
   <p class="indent3">
    Maximum spell level is Wisdom -10
@@ -560,9 +536,7 @@ modifiers.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    STATMOD:floor(SCORE/2)-5
-   </code>
+   <code>STATMOD:floor(SCORE/2)-5</code>
   </p>
   <p class="indent3">
    Would calculate a stat modification as STAT
@@ -571,27 +545,21 @@ the stat value). Note: the formula can only contain 1 SCORE
 variable.
   </p>
   <p class="indent2">
-   <code>
-    STATMOD:if(CL&lt;10,1,2)
-   </code>
+   <code>STATMOD:if(CL&lt;10,1,2)</code>
   </p>
   <p class="indent3">
    Would compare CL to 10 and return 1 or 2 as
 required.
   </p>
   <p class="indent2">
-   <code>
-    STATMOD:if((CL&gt;5)||(TL&gt;5),2,-4)
-   </code>
+   <code>STATMOD:if((CL&gt;5)||(TL&gt;5),2,-4)</code>
   </p>
   <p class="indent3">
    Asks if Class Level or Total Level is greater
 than 5 then returns 2 or else returns -4.
   </p>
   <p class="indent2">
-   <code>
-    STATMOD:if(STR&gt;DEX,STR,DEX)
-   </code>
+   <code>STATMOD:if(STR&gt;DEX,STR,DEX)</code>
   </p>
   <p class="indent3">
    Asks if STR is greater than DEX then returns STR
@@ -644,9 +612,7 @@ stat.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    STATRANGE:-100|100
-   </code>
+   <code>STATRANGE:-100|100</code>
   </p>
   <p class="indent3">
    Would allow a valid range for a stat of between
@@ -715,9 +681,7 @@ throws.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHECKNAME:Fortitude
-   </code>
+   <code>CHECKNAME:Fortitude</code>
   </p>
   <p class="indent3">
    Defines "Fortitude" as a valid check.
@@ -771,9 +735,7 @@ lines, besides the CHECKNAME tag itself).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:CHECKS|FORTITUDE|CON
-   </code>
+   <code>BONUS:CHECKS|FORTITUDE|CON</code>
   </p>
   <p class="indent3">
    Defines that "Constitution" gives a bonus to
@@ -793,10 +755,8 @@ lines, besides the CHECKNAME tag itself).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHECKNAME:Fortitude
-BONUS:CHECKS|FORTITUDE|CON
-   </code>
+   <code>CHECKNAME:Fortitude
+BONUS:CHECKS|FORTITUDE|CON</code>
   </p>
   <hr/>
   <h2>
@@ -838,9 +798,7 @@ level you are defining bonus spells for).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUSSPELLLEVEL:1
-   </code>
+   <code>BONUSSPELLLEVEL:1</code>
   </p>
   <p class="indent3">
    Defines that bonus spells are for level 1.
@@ -886,9 +844,7 @@ score is WIS for Sorcerers, INT for Wizards, etc.).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BASESTATSCORE:12
-   </code>
+   <code>BASESTATSCORE:12</code>
   </p>
   <p class="indent3">
    Defines that a base stat of 12 is required for
@@ -936,9 +892,7 @@ be given again.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    STATRANGE:8
-   </code>
+   <code>STATRANGE:8</code>
   </p>
   <p class="indent3">
    Base stat score +8 is required before another
@@ -958,10 +912,8 @@ spell is given.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUSSPELLLEVEL:1 BASESTATSCORE:12
-STATRANGE:8
-   </code>
+   <code>BONUSSPELLLEVEL:1 BASESTATSCORE:12
+STATRANGE:8</code>
   </p>
   <hr/>
   <h2>
@@ -1001,9 +953,7 @@ alignments are all possible.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ALIGNMENTNAME: Lawful Good
-   </code>
+   <code>ALIGNMENTNAME: Lawful Good</code>
   </p>
   <p class="indent3">
    Defines the alignment "Lawful Good".
@@ -1050,9 +1000,7 @@ necessarily have to be 2 letters, it can be longer.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ABB:LG
-   </code>
+   <code>ABB:LG</code>
   </p>
   <p class="indent3">
    Defines the abbreviated alignment as "LG".
@@ -1071,10 +1019,8 @@ necessarily have to be 2 letters, it can be longer.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ALIGNMENTNAME: Lawful Good
-ABB:LG
-   </code>
+   <code>ALIGNMENTNAME: Lawful Good
+ABB:LG</code>
   </p>
   <hr/>
   <p>

--- a/docs/listfilepages/systemfilestagpages/systemfilesbiosettingslist.html
+++ b/docs/listfilepages/systemfilestagpages/systemfilesbiosettingslist.html
@@ -88,18 +88,14 @@ difference between BASEAGE and MAXAGE at full value.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    AGEDIEROLL:5d4
-   </code>
+   <code>AGEDIEROLL:5d4</code>
   </p>
   <p class="indent3">
    This give a minimum age of 5 and maximum of
 20.
   </p>
   <p class="indent2">
-   <code>
-    AGEDIEROLL:4d20+1d4
-   </code>
+   <code>AGEDIEROLL:4d20+1d4</code>
   </p>
   <p class="indent3">
    This give a minimum age of 5 and maximum of
@@ -153,17 +149,13 @@ for the youngest age category.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    AGESET:0|Adulthood
-   </code>
+   <code>AGESET:0|Adulthood</code>
   </p>
   <p class="indent3">
    1st ageset is "Adulthood".
   </p>
   <p class="indent2">
-   <code>
-    AGESET:1|Middle Age
-   </code>
+   <code>AGESET:1|Middle Age</code>
   </p>
   <p class="indent3">
    2nd ageset is "Middle Age".
@@ -200,9 +192,7 @@ set.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BASEAGE:35
-   </code>
+   <code>BASEAGE:35</code>
   </p>
   <p class="indent3">
    Base Age is 35.
@@ -247,9 +237,7 @@ added to your base age for the class(es) it is paired with.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BASEAGEADD:2d4
-   </code>
+   <code>BASEAGEADD:2d4</code>
   </p>
   <p class="indent3">
    This class added 2d4 years to the Base Age of
@@ -288,9 +276,7 @@ needs to be in the base units set in the game mode.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BASEHT:53
-   </code>
+   <code>BASEHT:53</code>
   </p>
   <p class="indent3">
    Base height is 53 inches (in 3e mode).
@@ -328,9 +314,7 @@ needs to be in the base units set in the game mode.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BASEWT:85
-   </code>
+   <code>BASEWT:85</code>
   </p>
   <p class="indent3">
    Base weight is 85 lbs. in 3e mode.
@@ -374,9 +358,7 @@ to add to the base age, for each character class of this race.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CLASS:Barbarian,Rogue,Sorcerer[BASEAGEADD:1d4]
-   </code>
+   <code>CLASS:Barbarian,Rogue,Sorcerer[BASEAGEADD:1d4]</code>
   </p>
   <p class="indent3">
    If the class is "Barbarian", "Rogue" or
@@ -415,9 +397,7 @@ associated race.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    EYES:Blue|Black|Brown|Gray
-   </code>
+   <code>EYES:Blue|Black|Brown|Gray</code>
   </p>
   <p class="indent3">
    Eyes may be Blue, Black, Brown or Grey.
@@ -455,9 +435,7 @@ associated race.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    HAIR:Blue|Black|Brown|Gray
-   </code>
+   <code>HAIR:Blue|Black|Brown|Gray</code>
   </p>
   <p class="indent3">
    Hair may be Blue, Black, Brown or Grey.
@@ -504,9 +482,7 @@ randomization.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    HTDIEROLL:2d10
-   </code>
+   <code>HTDIEROLL:2d10</code>
   </p>
   <p class="indent3">
    This race added 2d10 to its base height.
@@ -543,9 +519,7 @@ set.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    MAXAGE:50
-   </code>
+   <code>MAXAGE:50</code>
   </p>
   <p class="indent3">
    Maximum age for this set is 50.
@@ -576,15 +550,11 @@ name of the race)
    Defines the name of the race. Will appear under
 every AGESET tag. If the name is followed by a "%" symbol then that
 BIOSET will apply to all subsets of that race name. For example
-   <code>
-    RACENAME:Elf%
-   </code>
+   <code>RACENAME:Elf%</code>
    will apply to Elf (Drow), Elf (Wood) and
 all other Elf races. Without the "%" symbol the age set will apply
 only to the race that matches the name exactly, so
-   <code>
-    RACENAME:Elf (House)
-   </code>
+   <code>RACENAME:Elf (House)</code>
    will only be used by the race
 "Elf (House)". Using parenthesis in combination with the "%" symbol
 will not work at all. BIOSET entries for specific subset races will
@@ -596,18 +566,14 @@ override a general BIOSET entry of the same race.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    RACENAME:Human%
-   </code>
+   <code>RACENAME:Human%</code>
   </p>
   <p class="indent3">
    The race name is "Human" and the BIOSET will
 apply to all subsets of the Human race.
   </p>
   <p class="indent2">
-   <code>
-    RACENAME:Elf (Drow)
-   </code>
+   <code>RACENAME:Elf (Drow)</code>
   </p>
   <p class="indent3">
    The race name is "Elf (Drow)" and the BIOSET
@@ -686,9 +652,7 @@ other with the same format as shown.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    Male[BASEHT:58|HTDIEROLL:2d10|BASEWT:130|WTDIEROLL:2d4|TOTALWT:BASEWT+(HTDIEROLL*WTDIEROLL)]
-   </code>
+   <code>Male[BASEHT:58|HTDIEROLL:2d10|BASEWT:130|WTDIEROLL:2d4|TOTALWT:BASEWT+(HTDIEROLL*WTDIEROLL)]</code>
   </p>
   <p class="indent3">
    Male height is 58+2d10 and Weight is
@@ -727,9 +691,7 @@ associated race.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SKINTONE:Tanned|Pasty|Gray
-   </code>
+   <code>SKINTONE:Tanned|Pasty|Gray</code>
   </p>
   <p class="indent3">
    Skin tone is Tanned Pasty or Gray.
@@ -768,9 +730,7 @@ variables.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TOTALWT:BASEWT+(HTDIEROLL*WTDIEROLL)
-   </code>
+   <code>TOTALWT:BASEWT+(HTDIEROLL*WTDIEROLL)</code>
   </p>
   <p class="indent3">
    Defines the total weight of the character.
@@ -817,9 +777,7 @@ randomization.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    WTDIEROLL:2d4
-   </code>
+   <code>WTDIEROLL:2d4</code>
   </p>
   <p class="indent3">
    This race added 2d10 to its base weight.

--- a/docs/listfilepages/systemfilestagpages/systemfilessizeadjustment.html
+++ b/docs/listfilepages/systemfilestagpages/systemfilessizeadjustment.html
@@ -22,9 +22,7 @@
       <li>
        <a href="#structure-of-the-sizeadjustment.lst-file">
         Structure of the
-        <code>
-         sizeAdjustment.lst
-        </code>
+        <code>sizeAdjustment.lst</code>
         file
        </a>
       </li>
@@ -36,17 +34,13 @@
       <li>
        <a href="#global-bonus-tags-which-are-useful-in-sizeadjustment.lst">
         Global BONUS tags which are useful in
-        <code>
-         sizeAdjustment.lst
-        </code>
+        <code>sizeAdjustment.lst</code>
        </a>
       </li>
       <li>
        <a href="#bonus-tags-specific-to-sizeadjustment.lst">
         BONUS tags specific to
-        <code>
-         sizeAdjustment.lst
-        </code>
+        <code>sizeAdjustment.lst</code>
        </a>
       </li>
      </ul>
@@ -58,15 +52,11 @@
   </h1>
   <p>
    The
-   <code>
-    sizeAdjustment.lst
-   </code>
+   <code>sizeAdjustment.lst</code>
    is a part of the "game mode".
   </p>
   <p>
-   <code>
-    sizeAdjustment.lst
-   </code>
+   <code>sizeAdjustment.lst</code>
    defines:
   </p>
   <ul class="incremental">
@@ -82,45 +72,31 @@
   </ul>
   <p>
    The
-   <code>
-    sizeAdjustment.lst
-   </code>
+   <code>sizeAdjustment.lst</code>
    files can be found in the
-   <code>
-    system/gameModes/&lt;game_mode_name&gt;/
-   </code>
+   <code>system/gameModes/&lt;game_mode_name&gt;/</code>
    directory for each game mode.
   </p>
   <h2 id="structure-of-the-sizeadjustment.lst-file">
    Structure of the
-   <code>
-    sizeAdjustment.lst
-   </code>
+   <code>sizeAdjustment.lst</code>
    file
   </h2>
   <p>
    Each creature size is identified by a
-   <code>
-    SIZENAME
-   </code>
+   <code>SIZENAME</code>
    .
   </p>
   <p>
    Tokens are added to the
-   <code>
-    SIZENAME
-   </code>
+   <code>SIZENAME</code>
    to indicate the in-game effects of the creature's size. The
-   <code>
-    SIZENUM
-   </code>
+   <code>SIZENUM</code>
    token is mandatory; all others are optional.
   </p>
   <p>
    A typical size definition, from
-   <code>
-    system/gameModes/35e/sizeAdjustment.lst
-   </code>
+   <code>system/gameModes/35e/sizeAdjustment.lst</code>
    , looks like:
   </p>
   <pre><code>SIZENAME:S
@@ -167,30 +143,20 @@ SIZENAME:S
    Syntax
   </h4>
   <p>
-   <code>
-    ABB:X
-   </code>
+   <code>ABB:X</code>
    , where
-   <code>
-    X
-   </code>
+   <code>X</code>
    is a single letter.
   </p>
   <h4 id="example">
    Example
   </h4>
   <p>
-   <code>
-    SIZENAME:Fine  →  ABB:F
-   </code>
+   <code>SIZENAME:Fine  →  ABB:F</code>
    sets the abbreviation for the
-   <code>
-    Fine
-   </code>
+   <code>Fine</code>
    size to the letter
-   <code>
-    F
-   </code>
+   <code>F</code>
    .
   </p>
   <h4 id="notes">
@@ -198,9 +164,7 @@ SIZENAME:S
   </h4>
   <p>
    The
-   <code>
-    ABB
-   </code>
+   <code>ABB</code>
    tag is implemented in
    <a href="https://github.com/PCGen/pcgen/blob/master/code/src/java/plugin/lsttokens/sizeadjustment/AbbToken.java">
     code/src/java/plugin/lsttokens/sizeadjustment/AbbToken.java
@@ -221,26 +185,18 @@ SIZENAME:S
    Syntax
   </h4>
   <p>
-   <code>
-    SIZENAME:size_1 → ISDEFAULTSIZE:Y
-   </code>
+   <code>SIZENAME:size_1 → ISDEFAULTSIZE:Y</code>
    indicates that
-   <code>
-    size_1
-   </code>
+   <code>size_1</code>
    <strong>
     is
    </strong>
    the default size for the game mode.
   </p>
   <p>
-   <code>
-    SIZENAME:size_2 → ISDEFAULTSIZE:N
-   </code>
+   <code>SIZENAME:size_2 → ISDEFAULTSIZE:N</code>
    indicates that
-   <code>
-    size_2
-   </code>
+   <code>size_2</code>
    <strong>
     is not
    </strong>
@@ -250,13 +206,9 @@ SIZENAME:S
    Example
   </h4>
   <p>
-   <code>
-    SIZENAME:Medium → ISDEFAULTSIZE:Y
-   </code>
+   <code>SIZENAME:Medium → ISDEFAULTSIZE:Y</code>
    makes
-   <code>
-    Medium
-   </code>
+   <code>Medium</code>
    the default size for this game mode.
   </p>
   <h4 id="notes-1">
@@ -275,17 +227,11 @@ SIZENAME:S
   </ul>
   <p>
    If the
-   <code>
-    ISDEFAULTSIZE
-   </code>
+   <code>ISDEFAULTSIZE</code>
    tag is missing for a particular
-   <code>
-    SIZENAME
-   </code>
+   <code>SIZENAME</code>
    , then
-   <code>
-    ISDEFAULTSIZE:N
-   </code>
+   <code>ISDEFAULTSIZE:N</code>
    is assumed.
   </p>
   <hr/>
@@ -297,40 +243,26 @@ SIZENAME:S
   </p>
   <p>
    Each line of the
-   <code>
-    sizeAdjustment.lst
-   </code>
+   <code>sizeAdjustment.lst</code>
    file
    <strong>
     MUST
    </strong>
    begin with a
-   <code>
-    SIZENAME
-   </code>
+   <code>SIZENAME</code>
    tag. Features are added to the category by adding sub-tags after the
-   <code>
-    SIZENAME
-   </code>
+   <code>SIZENAME</code>
    , such as
-   <code>
-    BONUS
-   </code>
+   <code>BONUS</code>
    tags.
   </p>
   <p>
    The same
-   <code>
-    SIZENAME
-   </code>
+   <code>SIZENAME</code>
    may appear on multiple lines. The tokens following the
-   <code>
-    SIZENAME
-   </code>
+   <code>SIZENAME</code>
    are appended to any tokens for the same
-   <code>
-    SIZENAME
-   </code>
+   <code>SIZENAME</code>
    on preceding lines.
   </p>
   <h4 id="status">
@@ -343,44 +275,26 @@ SIZENAME:S
    Syntax
   </h4>
   <p>
-   <code>
-    SIZENAME:size_name
-   </code>
+   <code>SIZENAME:size_name</code>
    , where
-   <code>
-    size_name
-   </code>
+   <code>size_name</code>
    is a single letter, i.e.
-   <code>
-    S
-   </code>
+   <code>S</code>
    ,
-   <code>
-    M
-   </code>
+   <code>M</code>
    ,
-   <code>
-    L
-   </code>
+   <code>L</code>
    . This is the current standard for all game modes included in PCGen.
   </p>
   <p>
    Alternately,
-   <code>
-    size_name
-   </code>
+   <code>size_name</code>
    may be a single word such as
-   <code>
-    Small
-   </code>
+   <code>Small</code>
    ,
-   <code>
-    Medium
-   </code>
+   <code>Medium</code>
    ,
-   <code>
-    Large
-   </code>
+   <code>Large</code>
    , etc.
   </p>
   <p>
@@ -389,23 +303,15 @@ SIZENAME:S
    </strong>
   </p>
   <p>
-   <code>
-    SIZENAME:F
-   </code>
+   <code>SIZENAME:F</code>
    defines a creature size named
-   <code>
-    F
-   </code>
+   <code>F</code>
    . (This form is preferred.)
   </p>
   <p>
-   <code>
-    SIZENAME:Fine
-   </code>
+   <code>SIZENAME:Fine</code>
    defines a creature size
-   <code>
-    Fine
-   </code>
+   <code>Fine</code>
    .
   </p>
   <hr/>
@@ -426,17 +332,11 @@ SIZENAME:S
   </p>
   <p>
    Before 6.05.04, the size order was inferred from the order of the
-   <code>
-    SIZENAME
-   </code>
+   <code>SIZENAME</code>
    tags in the
-   <code>
-    sizeAdjustment.lst
-   </code>
+   <code>sizeAdjustment.lst</code>
    file. As of 6.05.04, the order is explicitly indicated using the
-   <code>
-    SIZENUM
-   </code>
+   <code>SIZENUM</code>
    tag.
   </p>
   <ul class="incremental">
@@ -459,9 +359,7 @@ SIZENAME:S
      GitHub PR #410
     </a>
     - added
-    <code>
-     SIZENUM
-    </code>
+    <code>SIZENUM</code>
     tags to all the default game modes.
    </li>
   </ul>
@@ -469,14 +367,10 @@ SIZENAME:S
    Syntax:
   </h4>
   <p>
-   <code>
-    SIZENAME:size_name  →  SIZENUM:size_number
-   </code>
+   <code>SIZENAME:size_name  →  SIZENUM:size_number</code>
   </p>
   <p>
-   <code>
-    size_number
-   </code>
+   <code>size_number</code>
    is an integer. Bigger numbers correspond to larger size categories.
   </p>
   <h4 id="example-2">
@@ -484,17 +378,11 @@ SIZENAME:S
   </h4>
   <p>
    The following code, included in the
-   <code>
-    35e
-   </code>
+   <code>35e</code>
    version of
-   <code>
-    sizeAdjustment.lst
-   </code>
+   <code>sizeAdjustment.lst</code>
    , defines the ordering of the
-   <code>
-    35e
-   </code>
+   <code>35e</code>
    size categories:
   </p>
   <pre><code>SIZENAME:F  SIZENUM:010
@@ -510,19 +398,13 @@ SIZENAME:P  SIZENUM:100</code></pre>
   <hr/>
   <h2 id="global-bonus-tags-which-are-useful-in-sizeadjustment.lst">
    Global BONUS tags which are useful in
-   <code>
-    sizeAdjustment.lst
-   </code>
+   <code>sizeAdjustment.lst</code>
   </h2>
   <p>
    All global
-   <code>
-    BONUS
-   </code>
+   <code>BONUS</code>
    tags may be used in
-   <code>
-    sizeAdjustment.lst
-   </code>
+   <code>sizeAdjustment.lst</code>
    .
   </p>
   <p>
@@ -530,46 +412,32 @@ SIZENAME:P  SIZENUM:100</code></pre>
   </p>
   <ul class="incremental">
    <li>
-    <code>
-     BONUS:COMBAT|AC|1|TYPE=Size
-    </code>
+    <code>BONUS:COMBAT|AC|1|TYPE=Size</code>
     - grant a +1 size AC bonus due to size.
    </li>
    <li>
-    <code>
-     BONUS:COMBAT|TOHIT|1|Type=Size
-    </code>
+    <code>BONUS:COMBAT|TOHIT|1|Type=Size</code>
     - grant a +1 attack bonus due to size.
    </li>
    <li>
-    <code>
-     BONUS:COMBAT|TOHIT.GRAPPLE|5|Type=Size
-    </code>
+    <code>BONUS:COMBAT|TOHIT.GRAPPLE|5|Type=Size</code>
     - grant a bonus on Grapple checks due to large size.
    </li>
    <li>
-    <code>
-     BONUS:SKILL|Hide|4|TYPE=Size
-    </code>
+    <code>BONUS:SKILL|Hide|4|TYPE=Size</code>
     - grant a bonus on Hide checks due to small size.
    </li>
   </ul>
   <hr/>
   <h2 id="bonus-tags-specific-to-sizeadjustment.lst">
    BONUS tags specific to
-   <code>
-    sizeAdjustment.lst
-   </code>
+   <code>sizeAdjustment.lst</code>
   </h2>
   <p>
    The following
-   <code>
-    BONUS
-   </code>
+   <code>BONUS</code>
    tags function only in the
-   <code>
-    sizeAdjustment.lst
-   </code>
+   <code>sizeAdjustment.lst</code>
    file.
   </p>
   <h3 id="bonusacvalue">
@@ -577,13 +445,9 @@ SIZENAME:P  SIZENUM:100</code></pre>
   </h3>
   <p>
    Multiplies the AC bonus from a particular type of armour, such as
-   <code>
-    Armor
-   </code>
+   <code>Armor</code>
    or
-   <code>
-    Shield
-   </code>
+   <code>Shield</code>
    , based on the creature's size.
   </p>
   <h4 id="status-2">
@@ -596,64 +460,42 @@ SIZENAME:P  SIZENUM:100</code></pre>
    Syntax
   </h4>
   <p>
-   <code>
-    BONUS:ACVALUE|TYPE:type_1,TYPE:type_2, ...|ac_multiplier
-   </code>
+   <code>BONUS:ACVALUE|TYPE:type_1,TYPE:type_2, ...|ac_multiplier</code>
   </p>
   <ul class="incremental">
    <li>
-    <code>
-     type_1
-    </code>
+    <code>type_1</code>
     ,
-    <code>
-     type_2
-    </code>
+    <code>type_2</code>
     , ... may include armour types such as
-    <code>
-     TYPE:Armor
-    </code>
+    <code>TYPE:Armor</code>
     and
-    <code>
-     TYPE:Shield
-    </code>
+    <code>TYPE:Shield</code>
     .
     <ul class="incremental">
      <li>
       <em>
        [Ed: do things like
-       <code>
-        TYPE:Natural
-       </code>
+       <code>TYPE:Natural</code>
        ,
-       <code>
-        TYPE:Dodge
-       </code>
+       <code>TYPE:Dodge</code>
        ,
-       <code>
-        TYPE:Sacred
-       </code>
+       <code>TYPE:Sacred</code>
        ... also work?]
       </em>
      </li>
     </ul>
    </li>
    <li>
-    <code>
-     ac_multiplier
-    </code>
+    <code>ac_multiplier</code>
     is the multiplier to AC for the given armour types.
     <ul class="incremental">
      <li>
-      <code>
-       0.5
-      </code>
+      <code>0.5</code>
       would cause the creature to only receive half the normal AC bonus from the given armour types.
      </li>
      <li>
-      <code>
-       2
-      </code>
+      <code>2</code>
       would cause the creature to gain twice the AC bonus from the given armour types.
      </li>
     </ul>
@@ -664,9 +506,7 @@ SIZENAME:P  SIZENUM:100</code></pre>
   </h4>
   <ul class="incremental">
    <li>
-    <code>
-     BONUS:ACVALUE|TYPE.Armor,TYPE.Shield|0.5
-    </code>
+    <code>BONUS:ACVALUE|TYPE.Armor,TYPE.Shield|0.5</code>
    </li>
   </ul>
   <p>
@@ -674,9 +514,7 @@ SIZENAME:P  SIZENUM:100</code></pre>
   </p>
   <ul class="incremental">
    <li>
-    <code>
-     BONUS:ACVALUE|TYPE.Armor,TYPE.Shield|2
-    </code>
+    <code>BONUS:ACVALUE|TYPE.Armor,TYPE.Shield|2</code>
    </li>
   </ul>
   <p>
@@ -714,37 +552,23 @@ SIZENAME:P  SIZENUM:100</code></pre>
    Syntax
   </h4>
   <p>
-   <code>
-    BONUS:ITEMCAPACITY|TYPE=item_type|capacity_multiplier
-   </code>
+   <code>BONUS:ITEMCAPACITY|TYPE=item_type|capacity_multiplier</code>
   </p>
   <ul class="incremental">
    <li>
-    <code>
-     item_type
-    </code>
+    <code>item_type</code>
     is a type of equipment from the data set's equipment files, i.e. the
-    <code>
-     35e
-    </code>
+    <code>35e</code>
     files
-    <code>
-     rsrd_equip_arms_and_armor.lst
-    </code>
+    <code>rsrd_equip_arms_and_armor.lst</code>
     ,
-    <code>
-     rsrd_equip_general.lst
-    </code>
+    <code>rsrd_equip_general.lst</code>
     , and
-    <code>
-     rsrd_equip_magic_items.lst
-    </code>
+    <code>rsrd_equip_magic_items.lst</code>
     . Such types might include:
    </li>
    <li>
-    <code>
-     Resizable
-    </code>
+    <code>Resizable</code>
     - for items which are
     <a href="http://www.d20srd.org/srd/equipment/goodsAndServices.htm#adventuringGear">
      supposed to come in different sizes for different characters
@@ -753,13 +577,9 @@ SIZENAME:P  SIZENUM:100</code></pre>
    </li>
    <li>
     <p>
-     <code>
-      Goods
-     </code>
+     <code>Goods</code>
      - seems to include the majority of things in the
-     <code>
-      rsrd_equip_general.lst
-     </code>
+     <code>rsrd_equip_general.lst</code>
      , which covers general
      <a href="http://www.d20srd.org/srd/equipment/goodsAndServices.htm#adventuringGear">
       goods and services
@@ -769,9 +589,7 @@ SIZENAME:P  SIZENUM:100</code></pre>
    </li>
    <li>
     <p>
-     <code>
-      capacity_multiplier
-     </code>
+     <code>capacity_multiplier</code>
      is a number.
     </p>
    </li>
@@ -781,30 +599,22 @@ SIZENAME:P  SIZENUM:100</code></pre>
   </h4>
   <ul class="incremental">
    <li>
-    <code>
-     BONUS:ITEMCAPACITY|TYPE=Resizable|0.25
-    </code>
+    <code>BONUS:ITEMCAPACITY|TYPE=Resizable|0.25</code>
    </li>
   </ul>
   <p>
    Reduces the carrying capacity of items of
-   <code>
-    TYPE=Resizable
-   </code>
+   <code>TYPE=Resizable</code>
    to one quarter of the normal value.
   </p>
   <ul class="incremental">
    <li>
-    <code>
-     BONUS:ITEMCAPACITY|TYPE=Goods|2
-    </code>
+    <code>BONUS:ITEMCAPACITY|TYPE=Goods|2</code>
    </li>
   </ul>
   <p>
    Increases the carrying capacity of
-   <code>
-    TYPE=Goods
-   </code>
+   <code>TYPE=Goods</code>
    to double the normal value.
   </p>
   <hr/>
@@ -835,61 +645,39 @@ SIZENAME:P  SIZENUM:100</code></pre>
    Syntax
   </h4>
   <p>
-   <code>
-    BONUS:ITEMCOST|TYPE=item_type_1,TYPE=item_type_2,...|cost_multiplier
-   </code>
+   <code>BONUS:ITEMCOST|TYPE=item_type_1,TYPE=item_type_2,...|cost_multiplier</code>
   </p>
   <ul class="incremental">
    <li>
-    <code>
-     item_type
-    </code>
+    <code>item_type</code>
     is a type of equipment from the data set's equipment files, i.e. the
-    <code>
-     35e
-    </code>
+    <code>35e</code>
     files
-    <code>
-     rsrd_equip_arms_and_armor.lst
-    </code>
+    <code>rsrd_equip_arms_and_armor.lst</code>
     ,
-    <code>
-     rsrd_equip_general.lst
-    </code>
+    <code>rsrd_equip_general.lst</code>
     , and
-    <code>
-     rsrd_equip_magic_items.lst
-    </code>
+    <code>rsrd_equip_magic_items.lst</code>
     . Such types might include:
     <ul class="incremental">
      <li>
-      <code>
-       Armor
-      </code>
+      <code>Armor</code>
      </li>
      <li>
-      <code>
-       Weapon
-      </code>
+      <code>Weapon</code>
      </li>
      <li>
-      <code>
-       Potion
-      </code>
+      <code>Potion</code>
      </li>
      <li>
       Very specific types such as
-      <code>
-       Quarterstaff
-      </code>
+      <code>Quarterstaff</code>
       .
      </li>
     </ul>
    </li>
    <li>
-    <code>
-     cost_multiplier
-    </code>
+    <code>cost_multiplier</code>
     is a number.
    </li>
   </ul>
@@ -898,9 +686,7 @@ SIZENAME:P  SIZENUM:100</code></pre>
   </h4>
   <ul class="incremental">
    <li>
-    <code>
-     BONUS:ITEMCOST|TYPE=Weapon|0.5
-    </code>
+    <code>BONUS:ITEMCOST|TYPE=Weapon|0.5</code>
    </li>
   </ul>
   <p>
@@ -908,9 +694,7 @@ SIZENAME:P  SIZENUM:100</code></pre>
   </p>
   <ul class="incremental">
    <li>
-    <code>
-     BONUS:ITEMCOST|TYPE=Weapon,TYPE=Armor|2
-    </code>
+    <code>BONUS:ITEMCOST|TYPE=Weapon,TYPE=Armor|2</code>
    </li>
   </ul>
   <p>
@@ -918,9 +702,7 @@ SIZENAME:P  SIZENUM:100</code></pre>
   </p>
   <ul class="incremental">
    <li>
-    <code>
-     BONUS:ITEMCOST|TYPE=Scrolls,TYPE=Potions|1
-    </code>
+    <code>BONUS:ITEMCOST|TYPE=Scrolls,TYPE=Potions|1</code>
    </li>
   </ul>
   <p>
@@ -928,9 +710,7 @@ SIZENAME:P  SIZENUM:100</code></pre>
   </p>
   <ul class="incremental">
    <li>
-    <code>
-     BONUS:ITEMCOST|TYPE=Alchemical,TYPE=Liquid,TYPE=Clothing,TYPE=Food|2
-    </code>
+    <code>BONUS:ITEMCOST|TYPE=Alchemical,TYPE=Liquid,TYPE=Clothing,TYPE=Food|2</code>
    </li>
   </ul>
   <p>
@@ -960,25 +740,17 @@ SIZENAME:P  SIZENUM:100</code></pre>
    Syntax
   </h4>
   <p>
-   <code>
-    BONUS:ITEMWEIGHT|TYPE=item_type_1,TYPE=item_type_2,...|weight_multiplier
-   </code>
+   <code>BONUS:ITEMWEIGHT|TYPE=item_type_1,TYPE=item_type_2,...|weight_multiplier</code>
   </p>
   <ul class="incremental">
    <li>
-    <code>
-     item_type
-    </code>
+    <code>item_type</code>
     is a type of equipment from the data set's equipment files, as per
-    <code>
-     BONUS:ITEMCOST
-    </code>
+    <code>BONUS:ITEMCOST</code>
     above.
    </li>
    <li>
-    <code>
-     weight_multiplier
-    </code>
+    <code>weight_multiplier</code>
     is a number.
    </li>
   </ul>
@@ -987,9 +759,7 @@ SIZENAME:P  SIZENUM:100</code></pre>
   </h4>
   <ul class="incremental">
    <li>
-    <code>
-     ITEMWEIGHT|TYPE=Armor|2
-    </code>
+    <code>ITEMWEIGHT|TYPE=Armor|2</code>
    </li>
   </ul>
   <p>
@@ -997,16 +767,12 @@ SIZENAME:P  SIZENUM:100</code></pre>
   </p>
   <ul class="incremental">
    <li>
-    <code>
-     ITEMWEIGHT|TYPE=Resizable|0.25
-    </code>
+    <code>ITEMWEIGHT|TYPE=Resizable|0.25</code>
    </li>
   </ul>
   <p>
    Reduces the weight of
-   <code>
-    Resiable
-   </code>
+   <code>Resiable</code>
    items, such as backpacks and bedrolls, to one-quarter the normal value.
   </p>
   <hr/>
@@ -1015,13 +781,9 @@ SIZENAME:P  SIZENUM:100</code></pre>
   </h3>
   <p>
    Adds to the
-   <code>
-    SIZEMULT
-   </code>
+   <code>SIZEMULT</code>
    value as defined in the
-   <code>
-    load.lst
-   </code>
+   <code>load.lst</code>
    game mode file.
   </p>
   <p>
@@ -1030,13 +792,9 @@ SIZENAME:P  SIZENUM:100</code></pre>
     and so on
    </a>
    are implemented in
-   <code>
-    load.lst
-   </code>
+   <code>load.lst</code>
    . The
-   <code>
-    BONUS:LOADMULT
-   </code>
+   <code>BONUS:LOADMULT</code>
    tag is used to implement rules for creatures with four legs having greater load-carrying capacity.
   </p>
   <h4 id="status-6">
@@ -1049,23 +807,15 @@ SIZENAME:P  SIZENUM:100</code></pre>
    Syntax
   </h4>
   <p>
-   <code>
-    BONUS:LOADMULT|TYPE=SIZE|sizemult_modifier
-   </code>
+   <code>BONUS:LOADMULT|TYPE=SIZE|sizemult_modifier</code>
   </p>
   <ul class="incremental">
    <li>
-    <code>
-     sizemult_modifier
-    </code>
+    <code>sizemult_modifier</code>
     is a number. This number is added to the
-    <code>
-     SIZEMULT
-    </code>
+    <code>SIZEMULT</code>
     in the
-    <code>
-     load.lst
-    </code>
+    <code>load.lst</code>
     file to determine the "effective" carrying capacity multiplier, relative to a normal sized creature.
    </li>
   </ul>
@@ -1074,41 +824,29 @@ SIZENAME:P  SIZENUM:100</code></pre>
   </h5>
   <ul class="incremental">
    <li>
-    <code>
-     SIZENAME:H  →  BONUS:LOADMULT|TYPE=SIZE|2
-    </code>
+    <code>SIZENAME:H  →  BONUS:LOADMULT|TYPE=SIZE|2</code>
    </li>
   </ul>
   <p>
    Increases the creature's carrying capacity by one multiple of the normal carrying capacity. This adds with the multiplier already defined for the creature's size category, in
-   <code>
-    load.lst
-   </code>
+   <code>load.lst</code>
    .
   </p>
   <p>
    For example, in DnD 3.5e, a huge-size creature can already carry four times the load of a medium-size creature. This is defined by the code
-   <code>
-    SIZEMULT:H|4
-   </code>
+   <code>SIZEMULT:H|4</code>
    in
-   <code>
-    load.lst
-   </code>
+   <code>load.lst</code>
    .
   </p>
   <p>
    The above
-   <code>
-    BONUS:LOADMULT|...|2
-   </code>
+   <code>BONUS:LOADMULT|...|2</code>
    increases this by a further two multiples of the medium-size creature's carrying capacity, to a total of six times.
   </p>
   <ul class="incremental">
    <li>
-    <code>
-     SIZENAME:H  →  BONUS:LOADMULT|TYPE=SIZE|2|PRELEGSGTEQ:4
-    </code>
+    <code>SIZENAME:H  →  BONUS:LOADMULT|TYPE=SIZE|2|PRELEGSGTEQ:4</code>
    </li>
   </ul>
   <p>

--- a/docs/menupages/settings/pcgen/pcgenoutput.html
+++ b/docs/menupages/settings/pcgen/pcgenoutput.html
@@ -74,9 +74,7 @@ the file just created by the export.
    </strong>
   </p>
   <p>
-   <code>
-    cmd /c echo % &gt;&gt; exported_files_list.txt
-   </code>
+   <code>cmd /c echo % &gt;&gt; exported_files_list.txt</code>
   </p>
   <p>
    This will keep a list of every exported file in

--- a/docs/outputsheetpages/faqpages/faqstartupinstallissues.html
+++ b/docs/outputsheetpages/faqpages/faqstartupinstallissues.html
@@ -115,9 +115,7 @@ it, you should download:
 This will open the file in WinZip. On the menu-bar, click the
 "Extract to..." button, and enter the location where you want to
 have PCGen (Example:
-     <code>
-      c:\tools\pcgen
-     </code>
+     <code>c:\tools\pcgen</code>
      ). Make sure you
 have the "Include Subfolders" option checked!! Then you do the same
 thing for the other file. Make sure you extract to the same
@@ -199,10 +197,8 @@ on whatever came down.
        Unix/Linux
       </strong>
       , you need to execute
-      <code>
-       java
--jar pcgen.jar
-      </code>
+      <code>java
+-jar pcgen.jar</code>
       .
      </li>
     </ul>
@@ -358,33 +354,23 @@ never is). There are machine-specific releases of PCGen available,
 but unless you choose to use one of these, you'll have to manually
 change the addressing in the files you're to access. Normally this
 is a case of changing a
-     <code>
-      /
-     </code>
+     <code>/</code>
      to a
-     <code>
-      \
-     </code>
+     <code>\</code>
      or the
 other way round. Also make sure that you don't try to access
 something like
-     <code>
-      c:/program files/pcgen/
-     </code>
+     <code>c:/program files/pcgen/</code>
      when you should
 be accessing
-     <code>
-      c:/program~1/pcgen/
-     </code>
+     <code>c:/program~1/pcgen/</code>
      , or vice versa.
     </p>
     <p>
      Note that on Windows, enclosing the entire path in double
 quotation marks is an acceptable way to accessing the directory,
 i.e.
-     <code>
-      "c:\program files\pcgen\"
-     </code>
+     <code>"c:\program files\pcgen\"</code>
      . The same might also
 work on Mac OS X, but I'm not a Mac user, so I don't know.
     </p>
@@ -422,16 +408,12 @@ move the individual files to their right position.
        Another way is to use the terminal-window. Move the zip-files to
 where you want them, and use the terminal-window to manually unzip
 the files. The first two files, shouldn't be any problem just write
-       <code>
-        "unzip pcgenXXX_part1of3.zip"
-       </code>
+       <code>"unzip pcgenXXX_part1of3.zip"</code>
        , and watch the files
 being unstuffed. Do the same for pcgenXXX_part2of3.zip BUT, when
 you try this for pcgenXXX_part3of3.zip, you'll be asked a question.
 Answer this by typing "
-       <code>
-        A
-       </code>
+       <code>A</code>
        ". Wheee, look at it go!
 Anyway, you should now have a file called pcgen.jar, which you can
 double-click to start PCGen.

--- a/docs/outputsheetpages/outputsheetstutorial.html
+++ b/docs/outputsheetpages/outputsheetstutorial.html
@@ -75,10 +75,8 @@ the file.
    A sample line in an HTML template file might be:
   </p>
   <p class="indent1">
-   <code>
-    &lt;i&gt;Character Name:&lt;/i&gt;
-|NAME|
-   </code>
+   <code>&lt;i&gt;Character Name:&lt;/i&gt;
+|NAME|</code>
   </p>
   <p>
    If you open the template with an HTML browser you would see:
@@ -187,18 +185,12 @@ will discuss these shortly.
     Many tokens use variables so you can get at certain aspects.
 Variables come immediately after the token with a period "."
 between them. For example the token
-    <code>
-     EXPORT
-    </code>
+    <code>EXPORT</code>
     can provide
 date and time information on a sheet using
-    <code>
-     EXPORT.DATE
-    </code>
+    <code>EXPORT.DATE</code>
     and
-    <code>
-     EXPORT.TIME
-    </code>
+    <code>EXPORT.TIME</code>
     . The variables that may be used with
 each token are listed in the output sheet token documentation. Not
 all variables are capitalized. Some numeric variables start at zero
@@ -219,9 +211,7 @@ filter condition is not met. Filters all begin with a % (percent)
 sign and will run from the moment they are invoked until they
 encounter a different filter or until they encounter the end of
 filter token, which is a single % symbol (E.g.
-   <code>
-    |%|
-   </code>
+   <code>|%|</code>
    ) In
 case this wasn't clear, what it essentially means is that one, and
 only one, filter may be active at any time. Nested filters are not
@@ -229,9 +219,7 @@ supported.
   </p>
   <p>
    The simplest ones are in the form
-   <code>
-    |%TOKEN|
-   </code>
+   <code>|%TOKEN|</code>
    . Here
 PCGen simply checks to see if the character has the appropriate
 data. A good use of these simple filters is to suppress spell list
@@ -239,31 +227,21 @@ blocks for non-spellcasters so you can use the same character sheet
 for both types of characters and not have an empty spell list
 cluttering things up for a non-spellcaster. Examples of these types
 of tokens would be
-   <code>
-    |%SPELLISTBOOK|
-   </code>
+   <code>|%SPELLISTBOOK|</code>
    or
-   <code>
-    |%BIO|
-   </code>
+   <code>|%BIO|</code>
    .
   </p>
   <p>
    Some slightly more complex filters are in the form of
-   <code>
-    |%ARMORx|
-   </code>
+   <code>|%ARMORx|</code>
    and
-   <code>
-    |%WEAPONx|
-   </code>
+   <code>|%WEAPONx|</code>
    . In these
 filters x represents the number of appropriate items (armor type or
 weapon type for the above examples) that the character must have in
 order for the filter to allow output. For example:
-   <code>
-    |%WEAPON3|
-   </code>
+   <code>|%WEAPON3|</code>
    means that there would be no output after
 the filter until it reaches the next filter or filter end token
 unless the character has at least three weapons. If the character
@@ -272,21 +250,15 @@ has three weapons the output would proceed as normal.
   <p>
    The next form a filter may take is that of classname=level or
 SPELLLISTCLASSx=level. For example,
-   <code>
-    |%BARD=3|
-   </code>
+   <code>|%BARD=3|</code>
    would
 filter output if the character did not have at least three Bard
 levels.
-   <code>
-    |%SPELLLISTCLASS0=2|
-   </code>
+   <code>|%SPELLLISTCLASS0=2|</code>
    would filter output if
 the character did not have at least two levels in his first
 spellcasting class.
-   <code>
-    SPELLLISTCLASS
-   </code>
+   <code>SPELLLISTCLASS</code>
    is one of the
 tokens that starts at zero as mentioned earlier. These filters are
 usually used to put class specific information on a sheet and keep
@@ -296,57 +268,41 @@ level. (Barbarian Rage is a good example here).
   <p>
    The final form of filter is one that uses variables. They all
 start with %VAR and take the form of
-   <code>
-    |%VAR.name.label.value|
-   </code>
+   <code>|%VAR.name.label.value|</code>
    . The "name" is the name of any
 variable that has been set up in the LST files using the VAR tag.
 The label is a comparator and must be one of the following:
   </p>
   <ul class="indent 1">
    <li>
-    <code>
-     EQ
-    </code>
+    <code>EQ</code>
     (equals).
    </li>
    <li>
-    <code>
-     NEQ
-    </code>
+    <code>NEQ</code>
     (not equal).
    </li>
    <li>
-    <code>
-     LT
-    </code>
+    <code>LT</code>
     (less than).
    </li>
    <li>
-    <code>
-     LTEQ
-    </code>
+    <code>LTEQ</code>
     (less than or equal to).
    </li>
    <li>
-    <code>
-     GT
-    </code>
+    <code>GT</code>
     (greater than).
    </li>
    <li>
-    <code>
-     GTEQ
-    </code>
+    <code>GTEQ</code>
     (greater than or equal to).
    </li>
   </ul>
   <p>
    An example using the variable TOTALPOWERPOINTS defined in a LST
 from the Psionic Handbook would be:
-   <code>
-    |%VAR.TOTALPOWERPOINTS.GTEQ.1|
-   </code>
+   <code>|%VAR.TOTALPOWERPOINTS.GTEQ.1|</code>
    . This would filter
 output unless the variable TOTALPOWERPOINTS was greater than or
 equal to 1.
@@ -365,9 +321,7 @@ a filter.
 takes a variable, but in a slightly different form. The variable
 for the COUNT token goes inside a set of [] (square brackets). This
 token returns the number of items of the variable type given.
-   <code>
-    |COUNT[CLASSES]|
-   </code>
+   <code>|COUNT[CLASSES]|</code>
    would return the number of classes a
 character has. While this has some limited use as an actual output
 token, these tags are more often used to set the lower or upper
@@ -385,16 +339,12 @@ the output sheet token documentation.
 IIF/OIF tokens. The simpler of the two is the OIF token. It is used
 to evaluate an expression and return a value (text or number). This
 token is in the form
-   <code>
-    |OIF(expr,true,false)|
-   </code>
+   <code>|OIF(expr,true,false)|</code>
    . There are
 only certain expressions that may be used, and they are listed in
 the output sheet token documentation. The "true" and "false" parts
 may be anything you want them to be.
-   <code>
-    |OIF(SPELLCASTER0=PREPARE,Yes,No)|
-   </code>
+   <code>|OIF(SPELLCASTER0=PREPARE,Yes,No)|</code>
    would return "Yes"
 if the character's first spellcasting class had to prepare spells
 and "No" if it didn't.
@@ -404,29 +354,19 @@ and "No" if it didn't.
 output itself. The IIF statement takes the form of:
   </p>
   <p class="indent1">
-   <code>
-    |IIF(expr)|
-   </code>
+   <code>|IIF(expr)|</code>
   </p>
   <p class="indent1">
-   <code>
-    &lt;true actions&gt;
-   </code>
+   <code>&lt;true actions&gt;</code>
   </p>
   <p class="indent1">
-   <code>
-    |ELSE|
-   </code>
+   <code>|ELSE|</code>
   </p>
   <p class="indent1">
-   <code>
-    &lt;false actions&gt;
-   </code>
+   <code>&lt;false actions&gt;</code>
   </p>
   <p class="indent1">
-   <code>
-    |ENDIF|
-   </code>
+   <code>|ENDIF|</code>
   </p>
   <p>
    The IIF token, like the OIF token, can only take the expressions
@@ -436,29 +376,19 @@ of actions based upon the evaluation of the expression. An example
 of the IIF token could be:
   </p>
   <p class="indent1">
-   <code>
-    |IIF(SKILL0.UNTRAINED)|
-   </code>
+   <code>|IIF(SKILL0.UNTRAINED)|</code>
   </p>
   <p class="indent1">
-   <code>
-    *
-   </code>
+   <code>*</code>
   </p>
   <p class="indent1">
-   <code>
-    |ELSE|
-   </code>
+   <code>|ELSE|</code>
   </p>
   <p class="indent1">
-   <code>
-    x
-   </code>
+   <code>x</code>
   </p>
   <p class="indent1">
-   <code>
-    |ENDIF|
-   </code>
+   <code>|ENDIF|</code>
   </p>
   <p>
    This bit would check to see if your first skill (SKILL0) is
@@ -475,10 +405,8 @@ so that you may compare (exact match only) the result of
 functionality has also been added.
   </p>
   <p>
-   <code>
-    |IIF(SPELLLISTCLASS.%class:Psychic
-Warrior.OR.SPELLLISTCLASS.%class:Psion)|
-   </code>
+   <code>|IIF(SPELLLISTCLASS.%class:Psychic
+Warrior.OR.SPELLLISTCLASS.%class:Psion)|</code>
    would trigger if
 the class number represented by %class was either a Psychic Warrior
 OR a Psion.
@@ -497,19 +425,13 @@ skills, spells, etc.
 is:
   </p>
   <p class="indent1">
-   <code>
-    |FOR,%var,min,max,step,exists|
-   </code>
+   <code>|FOR,%var,min,max,step,exists|</code>
   </p>
   <p class="indent1">
-   <code>
-    &lt;character sheet stuff&gt;
-   </code>
+   <code>&lt;character sheet stuff&gt;</code>
   </p>
   <p class="indent1">
-   <code>
-    |ENDFOR|
-   </code>
+   <code>|ENDFOR|</code>
   </p>
   <p>
    In this token, %var is a variable name that you assign when you
@@ -526,9 +448,7 @@ zero indexed.
   <p>
    You may also use a COUNT statement here, or any token that
 returns a number. You may use the
-   <code>
-    COUNT[xxx]
-   </code>
+   <code>COUNT[xxx]</code>
    token in
 the max field to tell the loop when to stop, or any token that
 normally returns a number. The step field is how much you want it
@@ -545,16 +465,12 @@ and continue on through the sheet as if the loop had reached the
 max. If exists is 2 and the character sheet is currently within a
 filter, PCGen will not print anything else until the end of the
 filter
-   <code>
-    |%|
-   </code>
+   <code>|%|</code>
    is reached or another filter is begun.
   </p>
   <p>
    The
-   <code>
-    |ENDFOR|
-   </code>
+   <code>|ENDFOR|</code>
    token tells the program where the loop
 ends and is required when you use a |FOR, loop.
   </p>
@@ -562,19 +478,13 @@ ends and is required when you use a |FOR, loop.
    Here is an example demonstrating a FOR loop:
   </p>
   <p class="indent1">
-   <code>
-    |FOR,%eqp,0,COUNT[EQUIPMENT]-1,1,1|
-   </code>
+   <code>|FOR,%eqp,0,COUNT[EQUIPMENT]-1,1,1|</code>
   </p>
   <p class="indent1">
-   <code>
-    |EQ%eqp.NAME|&lt;br&gt;
-   </code>
+   <code>|EQ%eqp.NAME|&lt;br&gt;</code>
   </p>
   <p class="indent1">
-   <code>
-    |ENDFOR|
-   </code>
+   <code>|ENDFOR|</code>
   </p>
   <p>
    This loop will generate a list of the names of all of your
@@ -586,21 +496,17 @@ break.)
    Example output for a typical starting fighter would be:
   </p>
   <p class="indent1">
-   <code>
-    Half-Plate
+   <code>Half-Plate
     <br/>
     Outfit (Explorer's)
     <br/>
     Shield (Large/Steel)
     <br/>
-    Battleaxe
-   </code>
+    Battleaxe</code>
   </p>
   <p>
    The variable in the above loop is %eqp. The min is 0. The max is
-   <code>
-    COUNT[EQUIPMENT]-1
-   </code>
+   <code>COUNT[EQUIPMENT]-1</code>
    . I subtracted 1 because we are
 going to cycle through the equipment list and the equipment list
 array starts at 0 while the COUNT statement starts at 1. Because of
@@ -619,34 +525,22 @@ effort. This is the main reason to use loops.
 may be nested. For example:
   </p>
   <p class="indent1">
-   <code>
-    |FOR,%spbk,0,COUNT[SPELLBOOKS]-1,1,1|
-   </code>
+   <code>|FOR,%spbk,0,COUNT[SPELLBOOKS]-1,1,1|</code>
   </p>
   <p class="indent1">
-   <code>
-    |SPELLBOOKNAME%spbk|
-   </code>
+   <code>|SPELLBOOKNAME%spbk|</code>
   </p>
   <p class="indent1">
-   <code>
-    |FOR,%lvl,0,9,1,1|
-   </code>
+   <code>|FOR,%lvl,0,9,1,1|</code>
   </p>
   <p class="indent1">
-   <code>
-    |SPELLLISTBOOK%spbk.%lvl|
-   </code>
+   <code>|SPELLLISTBOOK%spbk.%lvl|</code>
   </p>
   <p class="indent1">
-   <code>
-    |ENDFOR|
-   </code>
+   <code>|ENDFOR|</code>
   </p>
   <p class="indent1">
-   <code>
-    |ENDFOR|
-   </code>
+   <code>|ENDFOR|</code>
   </p>
   <p>
    This would create a list of spells for each of your spellbooks
@@ -657,18 +551,14 @@ may be nested. For example:
 book loop. This allows us to use two variables. If you need more
 variables, you may nest more loops. Notice that each loop needs its
 own
-   <code>
-    |ENDFOR|
-   </code>
+   <code>|ENDFOR|</code>
    statement.
   </p>
   <p>
    The format for the next kind of FOR loop looks like this:
   </p>
   <p>
-   <code>
-    |FOR.min,max,perLine,phrase,startLine,endLine,exists|
-   </code>
+   <code>|FOR.min,max,perLine,phrase,startLine,endLine,exists|</code>
   </p>
   <p>
    This kind of FOR loop can be used to generate multi-column
@@ -715,19 +605,13 @@ it.
    A real example (for a single character sheet):
   </p>
   <p class="indent1">
-   <code>
-    &lt;table&gt;
-   </code>
+   <code>&lt;table&gt;</code>
   </p>
   <p class="indent1">
-   <code>
-    |FOR.0,COUNT[EQUIPMENT]-1,2,&lt;td&gt;\EQ%.NAME\&lt;/td&gt;,&lt;tr&gt;,&lt;/tr&gt;,1|
-   </code>
+   <code>|FOR.0,COUNT[EQUIPMENT]-1,2,&lt;td&gt;\EQ%.NAME\&lt;/td&gt;,&lt;tr&gt;,&lt;/tr&gt;,1|</code>
   </p>
   <p class="indent1">
-   <code>
-    &lt;/table&gt;
-   </code>
+   <code>&lt;/table&gt;</code>
   </p>
   <p>
    HTML note: The &lt;table&gt; and &lt;/table&gt; are the HTML
@@ -743,35 +627,25 @@ all your equipment.
    Example Output:
   </p>
   <p class="indent1">
-   <code>
-    Half-Plate
+   <code>Half-Plate
     <br/>
     Outfit (Explorer's)
     <br/>
     Shield (Large/Steel)
     <br/>
-    Battleaxe
-   </code>
+    Battleaxe</code>
   </p>
   <p>
    There is no named variable in this loop. The min is 0. The max
 is
-   <code>
-    COUNT[EQUIPMENT]-1
-   </code>
+   <code>COUNT[EQUIPMENT]-1</code>
    . The perLine is 2, so there will
 be two phrases output before the endLine. The phrase is
-   <code>
-    &lt;td&gt;\EQ%.NAME\&lt;/td&gt;
-   </code>
+   <code>&lt;td&gt;\EQ%.NAME\&lt;/td&gt;</code>
    . The startLine is
-   <code>
-    &lt;tr&gt;
-   </code>
+   <code>&lt;tr&gt;</code>
    (to start the row) and the endLine is
-   <code>
-    &lt;/tr&gt;
-   </code>
+   <code>&lt;/tr&gt;</code>
    (to end the row).
   </p>
   <p>
@@ -787,21 +661,15 @@ table of elements down and then across.
    <thead>
     <tr>
      <td class="center">
-      <code>
-       FOR,
-      </code>
+      <code>FOR,</code>
       Loop Output
      </td>
      <td class="center">
-      <code>
-       FOR.
-      </code>
+      <code>FOR.</code>
       Loop Output
      </td>
      <td class="center">
-      <code>
-       DFOR
-      </code>
+      <code>DFOR</code>
       Loop Output
      </td>
     </tr>
@@ -863,9 +731,7 @@ table of elements down and then across.
    The format for the DFOR loop:
   </p>
   <p>
-   <code>
-    |DFOR.min,maxDown,stepNextLine,totalMax,stepInLine,phrase,startLine,endLine,exists|
-   </code>
+   <code>|DFOR.min,maxDown,stepNextLine,totalMax,stepInLine,phrase,startLine,endLine,exists|</code>
   </p>
   <p>
    Explanation coming shortly (as soon as I figure out the best way
@@ -898,14 +764,10 @@ so will cause the math operation to fail.
   <p>
    Math can also be performed on attack routines without any extra
 effort. For example: Say you use the token
-   <code>
-    |WEAPON%.TOTALHIT|
-   </code>
+   <code>|WEAPON%.TOTALHIT|</code>
    and it returns "+6/+1". Were you to
 use
-   <code>
-    |WEAPON%.TOTALHIT+2
-   </code>
+   <code>|WEAPON%.TOTALHIT+2</code>
    |, the output would be
 "+8/+3".
   </p>
@@ -935,9 +797,7 @@ result.
    These variables may be used in combination with each other. For
 example:
    <br/>
-   <code>
-    |(VAR.Turn Level+STAT5.MOD).INTVAL.SIGN|
-   </code>
+   <code>|(VAR.Turn Level+STAT5.MOD).INTVAL.SIGN|</code>
    would add the
 variable "Turn Level" and the Wisdom Modifier together, return only
 the integer portion of that operation and prepend the appropriate
@@ -1059,85 +919,47 @@ are;
   </p>
   <p>
    For the identification we have:
-   <code>
-    NAME
-   </code>
+   <code>NAME</code>
    ,
-   <code>
-    PLAYERNAME
-   </code>
+   <code>PLAYERNAME</code>
    ,
-   <code>
-    CLASSLIST
-   </code>
+   <code>CLASSLIST</code>
    ,
-   <code>
-    TOTALLEVELS
-   </code>
+   <code>TOTALLEVELS</code>
   </p>
   <p>
    For the weapons we have:
-   <code>
-    WEAPONx.NAME
-   </code>
+   <code>WEAPONx.NAME</code>
    ,
-   <code>
-    WEAPONx.TOTALHIT
-   </code>
+   <code>WEAPONx.TOTALHIT</code>
    ,
-   <code>
-    WEAPONx.DAMAGE
-   </code>
+   <code>WEAPONx.DAMAGE</code>
    ,
-   <code>
-    WEAPONx.HAND
-   </code>
+   <code>WEAPONx.HAND</code>
    ,
-   <code>
-    WEAPONx.RANGE
-   </code>
+   <code>WEAPONx.RANGE</code>
    ,
-   <code>
-    WEAPONx.TYPE
-   </code>
+   <code>WEAPONx.TYPE</code>
    ,
-   <code>
-    WEAPONx.SIZE
-   </code>
+   <code>WEAPONx.SIZE</code>
    ,
-   <code>
-    WEAPONx.SPROP
-   </code>
+   <code>WEAPONx.SPROP</code>
    ,
-   <code>
-    WEAPONx.CRIT
-   </code>
+   <code>WEAPONx.CRIT</code>
    ,
-   <code>
-    WEAPONx.MULT
-   </code>
+   <code>WEAPONx.MULT</code>
   </p>
   <p>
    For the equipment we have:
-   <code>
-    EQx.NAME.MAGIC~&lt;b&gt;~&lt;/b&gt;
-   </code>
+   <code>EQx.NAME.MAGIC~&lt;b&gt;~&lt;/b&gt;</code>
    ,
-   <code>
-    EQx.EQUIPPED
-   </code>
+   <code>EQx.EQUIPPED</code>
    ,
-   <code>
-    EQx.WT
-   </code>
+   <code>EQx.WT</code>
    ,
-   <code>
-    EQx.QTY
-   </code>
+   <code>EQx.QTY</code>
    ,
-   <code>
-    EQx.SPROP
-   </code>
+   <code>EQx.SPROP</code>
   </p>
   <p>
    The "x" in all of the tokens above will actually be a variable
@@ -1166,8 +988,7 @@ like a white background, and a title to be displayed in the title
 bar of the browser when the final sheet is opened.
   </p>
   <p class="indent1">
-   <code>
-    &lt;html&gt;
+   <code>&lt;html&gt;
     <br/>
     &lt;head&gt;
     <br/>
@@ -1175,8 +996,7 @@ bar of the browser when the final sheet is opened.
     <br/>
     &lt;/head&gt;
     <br/>
-    &lt;body bgcolor="white"&gt;
-   </code>
+    &lt;body bgcolor="white"&gt;</code>
   </p>
   <p>
    Our first table will hold the identification and appear at the
@@ -1190,8 +1010,7 @@ the actual sheet this is referring to
    ):
   </p>
   <p class="indent1">
-   <code>
-    &lt;!-- Start Character Info Table
+   <code>&lt;!-- Start Character Info Table
 --&gt;
     <br/>
     &lt;table cellpadding="0" cellspacing="4" border="0"
@@ -1221,27 +1040,18 @@ width="100%"&gt;
     <br/>
     &lt;/tr&gt;
     <br/>
-    &lt;/table&gt;
-   </code>
+    &lt;/table&gt;</code>
   </p>
   <p>
    The
-   <code>
-    &lt;tr&gt;
-   </code>
+   <code>&lt;tr&gt;</code>
    and
-   <code>
-    &lt;/tr&gt;
-   </code>
+   <code>&lt;/tr&gt;</code>
    are the
 opening and closing tags for a table row. The
-   <code>
-    &lt;td&gt;
-   </code>
+   <code>&lt;td&gt;</code>
    and
-   <code>
-    &lt;/td&gt;
-   </code>
+   <code>&lt;/td&gt;</code>
    are the
 opening and closing tags for each piece of table data (basically an
 individual cell to think in spreadsheet terms).
@@ -1262,8 +1072,7 @@ the weapons and the other half for the rest of the equipment, we
 start another table.
   </p>
   <p class="indent1">
-   <code>
-    &lt;!-- Start Main Sheet Table
+   <code>&lt;!-- Start Main Sheet Table
 --&gt;
     <br/>
     &lt;table cellpadding="0" width="100%" cellspacing="5"
@@ -1271,8 +1080,7 @@ border="0"&gt;
     <br/>
     &lt;tr&gt;
     <br/>
-    &lt;td valign="top" width="50%"&gt;
-   </code>
+    &lt;td valign="top" width="50%"&gt;</code>
   </p>
   <p>
    This opens the table we will use as the main container for the
@@ -1287,8 +1095,7 @@ page with a label describing what information the tables following
 it contain.
   </p>
   <p class="indent1">
-   <code>
-    &lt;!-- Start Weapon Tables --&gt;
+   <code>&lt;!-- Start Weapon Tables --&gt;
     <br/>
     &lt;table cellpadding="0" width="100%" cellspacing="0"
 border="0"&gt;
@@ -1299,8 +1106,7 @@ border="0"&gt;
     <br/>
     &lt;/tr&gt;
     <br/>
-    &lt;/table&gt;
-   </code>
+    &lt;/table&gt;</code>
   </p>
   <p>
    The next step is to start the actual weapons tables. The first
@@ -1313,9 +1119,7 @@ of FOR loop that I described first.
 we're using it for. Then, because the equipment arrays are 0
 indexed, we want our start number to be 0. To get the max number we
 will use
-   <code>
-    COUNT[EQTYPE.WEAPON]-1
-   </code>
+   <code>COUNT[EQTYPE.WEAPON]-1</code>
    (remember the loop
 starts at 0 so we need to end it one step early, hence the -1 on
 the end). We want it to step through the loop one at a time so we
@@ -1325,9 +1129,7 @@ took and entire paragraph to write out boils down to the
 following:
   </p>
   <p class="indent1">
-   <code>
-    |FOR,%weap,0,COUNT[EQTYPE.WEAPON]-1,1,0|
-   </code>
+   <code>|FOR,%weap,0,COUNT[EQTYPE.WEAPON]-1,1,0|</code>
   </p>
   <p>
    Our weapons information will be contained in two tables, one
@@ -1341,8 +1143,7 @@ try and produce.
 and critical hit information. The HTML would look like this:
   </p>
   <p class="indent1">
-   <code>
-    &lt;table cellpadding="0" width="100%"
+   <code>&lt;table cellpadding="0" width="100%"
 cellspacing="0" border="0"&gt;
     <br/>
     &lt;tr&gt;
@@ -1374,8 +1175,7 @@ align="center"&gt;&lt;b&gt;|WEAPON.%weap.CRIT|/x|WEAPON.%weap.MULT|&lt;/td&gt;
     <br/>
     &lt;/tr&gt;
     <br/>
-    &lt;/table&gt;
-   </code>
+    &lt;/table&gt;</code>
   </p>
   <p>
    Immediately following this will be another table that contains
@@ -1384,8 +1184,7 @@ special properties). That portion of the weapon display would look
 like this:
   </p>
   <p class="indent1">
-   <code>
-    &lt;table cellpadding="0" cellspacing="0"
+   <code>&lt;table cellpadding="0" cellspacing="0"
 border="0" width="100%"&gt;
     <br/>
     &lt;tr&gt;
@@ -1421,8 +1220,7 @@ PROPERTIES&lt;/td&gt;
     <br/>
     &lt;/tr&gt;
     <br/>
-    &lt;/table&gt;
-   </code>
+    &lt;/table&gt;</code>
   </p>
   <p>
    We then need to end the weapons loop and jump to the other half
@@ -1430,15 +1228,13 @@ of the sheet to do our other equipment, so after the above tables
 would be the following:
   </p>
   <p class="indent1">
-   <code>
-    |ENDFOR|
+   <code>|ENDFOR|
     <br/>
     &lt;!-- End Weapon Tables --&gt;
     <br/>
     &lt;/td&gt;
     <br/>
-    &lt;td valign="top" width="50%"&gt;
-   </code>
+    &lt;td valign="top" width="50%"&gt;</code>
   </p>
   <p>
    Once again, we need to start a new table to contain our next
@@ -1446,8 +1242,7 @@ group of data. As before, we'll put a title identifying the
 information the section will contain, as well as headers.
   </p>
   <p class="indent1">
-   <code>
-    &lt;!-- Start Equipment Tables
+   <code>&lt;!-- Start Equipment Tables
 --&gt;
     <br/>
     &lt;table cellpadding="0" width="100%" cellspacing="0"
@@ -1475,8 +1270,7 @@ align="center"&gt;&lt;b&gt;WT.&lt;/b&gt;&lt;/td&gt;
     &lt;td width="10%" align="center"&gt;&lt;b&gt;GP
 COST&lt;/b&gt;&lt;/td&gt;
     <br/>
-    &lt;/tr&gt;
-   </code>
+    &lt;/tr&gt;</code>
   </p>
   <p>
    As we did for the weapons, we need to devise a loop to go
@@ -1487,9 +1281,7 @@ through all the equipment we have.
 we're using it for. Then, because the equipment arrays are 0
 indexed, we want our start number to be 0. To get the max number we
 will use
-   <code>
-    COUNT[EQ.NOT.Weapon]-1
-   </code>
+   <code>COUNT[EQ.NOT.Weapon]-1</code>
    (remember the loop
 starts at 0 so we need to end it one step early, hence the -1 on
 the end). We want it to step through the loop one at a time so we
@@ -1499,9 +1291,7 @@ again took an entire paragraph to write out boils down to the
 following:
   </p>
   <p class="indent1">
-   <code>
-    |FOR,%eqp,0,COUNT[EQUIPMENT.Not.Weapon]-1,1,0|
-   </code>
+   <code>|FOR,%eqp,0,COUNT[EQUIPMENT.Not.Weapon]-1,1,0|</code>
   </p>
   <p>
    Unlike the weapons, the equipment will all be in one table,
@@ -1510,8 +1300,7 @@ just need to get the proper information to line up under the proper
 header. The next section looks like this:
   </p>
   <p class="indent1">
-   <code>
-    &lt;tr&gt;
+   <code>&lt;tr&gt;
     <br/>
     &lt;td
 class="border"&gt;|EQ.NOT.Weapon.%eqp.NAME.MAGIC~&lt;b&gt;~&lt;/b&gt;|&lt;br/&gt;
@@ -1529,21 +1318,18 @@ class="border"&gt;|EQ.NOT.Weapon.%eqp.NAME.MAGIC~&lt;b&gt;~&lt;/b&gt;|&lt;br/&gt
     &lt;td class="border"&gt;|EQ.NOT.Weapon.%eqp.COST|&lt;br
 /&gt;&lt;/td&gt;
     <br/>
-    &lt;/tr&gt;
-   </code>
+    &lt;/tr&gt;</code>
   </p>
   <p>
    We now need to end the equipment loop and close out the
 equipment table.
   </p>
   <p class="indent1">
-   <code>
-    |ENDFOR|
+   <code>|ENDFOR|
     <br/>
     &lt;/table&gt;
     <br/>
-    &lt;!-- End Equipment Table --&gt;
-   </code>
+    &lt;!-- End Equipment Table --&gt;</code>
   </p>
   <p>
    Since our sheet is done at this point, we also need to close the
@@ -1551,8 +1337,7 @@ master table and the html page. The last bits of our character
 sheet should look like this:
   </p>
   <p class="indent1">
-   <code>
-    &lt;/td&gt;
+   <code>&lt;/td&gt;
     <br/>
     &lt;/tr&gt;
     <br/>
@@ -1562,8 +1347,7 @@ sheet should look like this:
     <br/>
     &lt;/body&gt;
     <br/>
-    &lt;/html&gt;
-   </code>
+    &lt;/html&gt;</code>
   </p>
   <p>
    That about covers it. More complex sheets are simply using more

--- a/docs/outputsheetpages/tokens/outputsheettokensability.html
+++ b/docs/outputsheetpages/tokens/outputsheettokensability.html
@@ -59,9 +59,7 @@ defined in miscinfo.lst and calculate the AC.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    AC.Flatfooted
-   </code>
+   <code>AC.Flatfooted</code>
   </p>
   <p class="indent3">
    Will get the Flatfooted ACTYPE formula from
@@ -92,9 +90,7 @@ all equiped armor.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ACCHECK
-   </code>
+   <code>ACCHECK</code>
   </p>
   <p class="indent3">
    Displays Armour Check Penalty for all equiped
@@ -206,9 +202,7 @@ will be stripped from the output.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ARMOR.0.MAXDEX
-   </code>
+   <code>ARMOR.0.MAXDEX</code>
   </p>
   <p class="indent3">
    Displays the max dex adjustment to AC allowed by
@@ -316,9 +310,7 @@ will be stripped from the output.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ARMOR.EQUIPPED.3.NAME
-   </code>
+   <code>ARMOR.EQUIPPED.3.NAME</code>
   </p>
   <p class="indent3">
    Would display the name of the 4th equipped item
@@ -447,9 +439,7 @@ skills.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ARMOR.ITEM.EQUIPPED.1.NAME
-   </code>
+   <code>ARMOR.ITEM.EQUIPPED.1.NAME</code>
   </p>
   <p class="indent3">
    Would display the name of the 2nd equipped armor
@@ -585,9 +575,7 @@ skills.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ARMOR.ITEM.MITHRAL.EQUIPPED.x.NAME
-   </code>
+   <code>ARMOR.ITEM.MITHRAL.EQUIPPED.x.NAME</code>
   </p>
   <p class="indent3">
    Would display the name of the xth equipped
@@ -653,77 +641,59 @@ an exclude.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS.COMBAT.AC.BASE
-   </code>
+   <code>BONUS.COMBAT.AC.BASE</code>
   </p>
   <p class="indent3">
    Would display base AC.
   </p>
   <p class="indent2">
-   <code>
-    BONUS.COMBAT.AC.TOTAL
-   </code>
+   <code>BONUS.COMBAT.AC.TOTAL</code>
   </p>
   <p class="indent3">
    Would display total AC.
   </p>
   <p class="indent2">
-   <code>
-    BONUS.COMBAT.AC.TOTAL.!Armor
-   </code>
+   <code>BONUS.COMBAT.AC.TOTAL.!Armor</code>
   </p>
   <p class="indent3">
    Would display the total AC less the Armor and
 Shield.
   </p>
   <p class="indent2">
-   <code>
-    BONUS.COMBAT.AC.TOTAL.!Ability
-   </code>
+   <code>BONUS.COMBAT.AC.TOTAL.!Ability</code>
   </p>
   <p class="indent3">
    Would display total AC - Ability Bonus.
   </p>
   <p class="indent2">
-   <code>
-    BONUS.COMBAT.AC.Armor.Deflection.Ability
-   </code>
+   <code>BONUS.COMBAT.AC.Armor.Deflection.Ability</code>
   </p>
   <p class="indent3">
    Would display the sum of Armor + Deflection
 Bonuses + Ability Bonus.
   </p>
   <p class="indent2">
-   <code>
-    BONUS.COMBAT.AC.Natural Armor
-   </code>
+   <code>BONUS.COMBAT.AC.Natural Armor</code>
   </p>
   <p class="indent3">
    Would display natural AC.
   </p>
   <p class="indent2">
-   <code>
-    BONUS.COMBAT.AC.LISTING
-   </code>
+   <code>BONUS.COMBAT.AC.LISTING</code>
   </p>
   <p class="indent3">
    Would display a list of all the components that
 make up the AC total.
   </p>
   <p class="indent2">
-   <code>
-    BONUS.COMBAT.AC.ARMOR.!TYPE=Shield
-   </code>
+   <code>BONUS.COMBAT.AC.ARMOR.!TYPE=Shield</code>
   </p>
   <p class="indent3">
    Would display the armor bonus w/o the shield
 included.
   </p>
   <p class="indent2">
-   <code>
-    BONUS.COMBAT.AC.TYPE=Shield
-   </code>
+   <code>BONUS.COMBAT.AC.TYPE=Shield</code>
   </p>
   <p class="indent3">
    Would display the armor bonus granted by an
@@ -754,9 +724,7 @@ armor.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    MAXDEX
-   </code>
+   <code>MAXDEX</code>
   </p>
   <p class="indent3">
    Displays max Dex bonus for all equiped
@@ -786,9 +754,7 @@ armor.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SPELLFAILURE
-   </code>
+   <code>SPELLFAILURE</code>
   </p>
   <p class="indent3">
    Displays spell failure for all equiped
@@ -901,33 +867,25 @@ property.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    STAT.1.MOD
-   </code>
+   <code>STAT.1.MOD</code>
   </p>
   <p class="indent3">
    The Dexterity modifier for the stat.
   </p>
   <p class="indent2">
-   <code>
-    STAT.1
-   </code>
+   <code>STAT.1</code>
   </p>
   <p class="indent3">
    The adjusted Dexterity total.
   </p>
   <p class="indent2">
-   <code>
-    STAT.2.LEVEL.4
-   </code>
+   <code>STAT.2.LEVEL.4</code>
   </p>
   <p class="indent3">
    The Constitution at level 4.
   </p>
   <p class="indent2">
-   <code>
-    STAT.2.LEVEL.4.NOPOST.NOEQUIP
-   </code>
+   <code>STAT.2.LEVEL.4.NOPOST.NOEQUIP</code>
   </p>
   <p class="indent3">
    The Constitution at Level 4 with no user

--- a/docs/outputsheetpages/tokens/outputsheettokensattack.html
+++ b/docs/outputsheetpages/tokens/outputsheettokensattack.html
@@ -137,44 +137,34 @@ iteratives (output: +16).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ATTACK.GRAPPLE
-   </code>
+   <code>ATTACK.GRAPPLE</code>
   </p>
   <p class="indent3">
    Displays the Grapple Attack Bonus with no
 modifiers.
   </p>
   <p class="indent2">
-   <code>
-    ATTACK.GRAPPLE.TOTAL.SHORT
-   </code>
+   <code>ATTACK.GRAPPLE.TOTAL.SHORT</code>
   </p>
   <p class="indent3">
    Displays a single Grapple Attack Bonus with all
 modifiers but no iteratives shown. e.g. +16
   </p>
   <p class="indent2">
-   <code>
-    ATTACK.MELEE.BASE
-   </code>
+   <code>ATTACK.MELEE.BASE</code>
   </p>
   <p class="indent3">
    Displays the Melee Base Attack Bonus
   </p>
   <p class="indent2">
-   <code>
-    ATTACK.RANGED.STAT
-   </code>
+   <code>ATTACK.RANGED.STAT</code>
   </p>
   <p class="indent3">
    Displays the Ranged bonus/penalty due to the
 corresponding ability score.
   </p>
   <p class="indent2">
-   <code>
-    ATTACK.UNARMED.TOTAL
-   </code>
+   <code>ATTACK.UNARMED.TOTAL</code>
   </p>
   <p class="indent3">
    Displays the total Unarmed Attack Bonus.
@@ -204,9 +194,7 @@ the Unarmed damage.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DAMAGE.UNARMED
-   </code>
+   <code>DAMAGE.UNARMED</code>
   </p>
   <p class="indent3">
    Displays unarmed damage value.
@@ -236,9 +224,7 @@ initiative feat).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    INITIATIVEMISC
-   </code>
+   <code>INITIATIVEMISC</code>
   </p>
   <p class="indent3">
    Displays your adjustment to initiative excluding
@@ -269,9 +255,7 @@ Initiative feat).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    INITIATIVEMOD
-   </code>
+   <code>INITIATIVEMOD</code>
   </p>
   <p class="indent3">
    Displays your adjustment to initiative.

--- a/docs/outputsheetpages/tokens/outputsheettokensequip.html
+++ b/docs/outputsheetpages/tokens/outputsheettokensequip.html
@@ -217,17 +217,13 @@ property (x).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    EQ.%.NAME
-   </code>
+   <code>EQ.%.NAME</code>
   </p>
   <p class="indent3">
    Displays a list of equipment names.
   </p>
   <p class="indent2">
-   <code>
-    EQ.%.NAME.MAGIC~&lt;b&gt;~&lt;/b&gt;
-   </code>
+   <code>EQ.%.NAME.MAGIC~&lt;b&gt;~&lt;/b&gt;</code>
   </p>
   <p class="indent3">
    Displays a list of equipment names in
@@ -238,9 +234,7 @@ property (x).
 &lt;/b&gt; after the name of magic items.
   </p>
   <p class="indent2">
-   <code>
-    EQ.%.SPROP
-   </code>
+   <code>EQ.%.SPROP</code>
   </p>
   <p class="indent3">
    Displays a list of equipment special
@@ -278,17 +272,13 @@ returned list of equipment.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    EQ.ADD.Armor
-   </code>
+   <code>EQ.ADD.Armor</code>
   </p>
   <p class="indent3">
    Displays all armor type items.
   </p>
   <p class="indent2">
-   <code>
-    EQ.ADD.CONTAINED
-   </code>
+   <code>EQ.ADD.CONTAINED</code>
   </p>
   <p class="indent3">
    Displays all items contained in another.
@@ -519,35 +509,27 @@ statements.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    EQ.IS.Metal.1.TYPE1
-   </code>
+   <code>EQ.IS.Metal.1.TYPE1</code>
   </p>
   <p class="indent3">
    If the item was type
 "MAGIC.WEAPON.MARTIAL.METAL", then "WEAPON" would be displayed.
   </p>
   <p class="indent2">
-   <code>
-    EQ.IS.ROD.5.NAME.MAGIC~&lt;b&gt;~&lt;/b&gt;
-   </code>
+   <code>EQ.IS.ROD.5.NAME.MAGIC~&lt;b&gt;~&lt;/b&gt;</code>
   </p>
   <p class="indent3">
    Would display the name of the 6th rod in the
 equipment list and bold it if it was magical.
   </p>
   <p class="indent2">
-   <code>
-    EQ.IS.0.CONTAINS.0.LONGNAME
-   </code>
+   <code>EQ.IS.0.CONTAINS.0.LONGNAME</code>
   </p>
   <p class="indent3">
    Returns Longbow +1 (Flaming).
   </p>
   <p class="indent2">
-   <code>
-    EQ.IS.2.CONTAINS.4.QTY
-   </code>
+   <code>EQ.IS.2.CONTAINS.4.QTY</code>
   </p>
   <p class="indent3">
    Returns the quantity of the 5
@@ -562,9 +544,7 @@ contained in 3
    Equipment.
   </p>
   <p class="indent2">
-   <code>
-    EQ.IS.ROD.0.NOTE
-   </code>
+   <code>EQ.IS.ROD.0.NOTE</code>
   </p>
   <p class="indent3">
    Would display a player added note on the
@@ -642,9 +622,7 @@ etc).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    EQ.MERGEALL.0.CHARGES
-   </code>
+   <code>EQ.MERGEALL.0.CHARGES</code>
   </p>
   <p class="indent3">
    Displays the number of charges of all items of
@@ -655,9 +633,7 @@ the same name as the 1
    item.
   </p>
   <p class="indent2">
-   <code>
-    EQ.MERGELOC.3.LOCATION
-   </code>
+   <code>EQ.MERGELOC.3.LOCATION</code>
   </p>
   <p class="indent3">
    Displays blank if not carried, "Equipped", the
@@ -670,9 +646,7 @@ items with the same name in the same container as the
    item.
   </p>
   <p class="indent2">
-   <code>
-    EQ.MERGE.NONE.1.SIZE
-   </code>
+   <code>EQ.MERGE.NONE.1.SIZE</code>
   </p>
   <p class="indent3">
    Displays a one letter description of the size of
@@ -714,9 +688,7 @@ subtype from the returned list of equipment.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    EQ.NOT.Metal
-   </code>
+   <code>EQ.NOT.Metal</code>
   </p>
   <p class="indent3">
    Displays all items that are not metal type
@@ -770,27 +742,21 @@ quality position number - 0-based index).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    EQ.0.QUALITY
-   </code>
+   <code>EQ.0.QUALITY</code>
   </p>
   <p class="indent3">
    Displays all the Name/Value pairs of
 qualities.
   </p>
   <p class="indent2">
-   <code>
-    EQ.0.QUALITY.Restriction
-   </code>
+   <code>EQ.0.QUALITY.Restriction</code>
   </p>
   <p class="indent3">
    Displays the Value of the Restriction quality
 (if the equipment has this quality).
   </p>
   <p class="indent2">
-   <code>
-    EQ.0.QUALITY.0
-   </code>
+   <code>EQ.0.QUALITY.0</code>
   </p>
   <p class="indent3">
    Displays the Name/Value of the first quality the
@@ -870,9 +836,7 @@ container type equipment.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    EQCONTAINER.0.ITEMWEIGHT
-   </code>
+   <code>EQCONTAINER.0.ITEMWEIGHT</code>
   </p>
   <p class="indent3">
    Displays the weight of the 1
@@ -882,9 +846,7 @@ container type equipment.
    container itself.
   </p>
   <p class="indent2">
-   <code>
-    EQCONTAINER.3.CONTENTWEIGHT
-   </code>
+   <code>EQCONTAINER.3.CONTENTWEIGHT</code>
   </p>
   <p class="indent3">
    Displays the weight of the contents of the
@@ -895,9 +857,7 @@ container type equipment.
    container.
   </p>
   <p class="indent2">
-   <code>
-    EQCONTAINER.1.TOTALWEIGHT
-   </code>
+   <code>EQCONTAINER.1.TOTALWEIGHT</code>
   </p>
   <p class="indent3">
    Displays the total weight of the 2
@@ -951,9 +911,7 @@ from the ARMOR and ATTACK tokens (ACMOD, MAXDEX, DAMAGE, etc).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    EQCONTAINERS.0.COST
-   </code>
+   <code>EQCONTAINERS.0.COST</code>
   </p>
   <p class="indent3">
    Display the cost in gold of the 1
@@ -1007,9 +965,7 @@ from the ARMOR and ATTACK tokens (ACMOD, MAXDEX, DAMAGE, etc).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    EQCONTAINERW.0.SPROP
-   </code>
+   <code>EQCONTAINERW.0.SPROP</code>
   </p>
   <p class="indent3">
    Displays the special properties of the
@@ -1063,8 +1019,7 @@ eqsheets.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    EQSET.START
+   <code>EQSET.START
     <br/>
     EQSET.NAME
     <br/>
@@ -1074,8 +1029,7 @@ eqsheets.
     <br/>
     ENDFOR
     <br/>
-    EQSET.END
-   </code>
+    EQSET.END</code>
   </p>
   <p class="indent3">
    The above code would loop once for each
@@ -1215,9 +1169,7 @@ statement.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    EQTYPE.GEM.5.COST
-   </code>
+   <code>EQTYPE.GEM.5.COST</code>
   </p>
   <p class="indent3">
    Would display the cost of the 4
@@ -1228,9 +1180,7 @@ statement.
 in the equipment list.
   </p>
   <p class="indent2">
-   <code>
-    EQTYPE.GEM.1.NOTE
-   </code>
+   <code>EQTYPE.GEM.1.NOTE</code>
   </p>
   <p class="indent3">
    Would display a player added note on the
@@ -1241,18 +1191,14 @@ in the equipment list.
    gem in the equipment list. (If available)
   </p>
   <p class="indent2">
-   <code>
-    EQTYPE.MAGIC.IS.STAFF.ADD.ROD.x.NAME
-   </code>
+   <code>EQTYPE.MAGIC.IS.STAFF.ADD.ROD.x.NAME</code>
   </p>
   <p class="indent3">
    Would display the name of the x-th magical staff
 or rod in the equipment list.
   </p>
   <p class="indent2">
-   <code>
-    EQTYPE.MERGE.NONE.MAGIC.IS.STAFF.ADD.ROD.NAME
-   </code>
+   <code>EQTYPE.MERGE.NONE.MAGIC.IS.STAFF.ADD.ROD.NAME</code>
   </p>
   <p class="indent3">
    Would display the name of all magical staves or

--- a/docs/outputsheetpages/tokens/outputsheettokensfeat-skill.html
+++ b/docs/outputsheetpages/tokens/outputsheettokensfeat-skill.html
@@ -114,23 +114,17 @@ after filtering (see below) for ability category (u), visibility
 (v) of each ability. The allowed visibility sub-tokens are:
     <ul>
      <li>
-      <code>
-       VISIBLE
-      </code>
+      <code>VISIBLE</code>
       - Filter the abilities that are visible in
 the outputsheets (default option).
      </li>
      <li>
-      <code>
-       HIDDEN
-      </code>
+      <code>HIDDEN</code>
       - Filter the abilities that are not visible
 in the outputsheets.
      </li>
      <li>
-      <code>
-       ALL
-      </code>
+      <code>ALL</code>
       - Shows all abilities.
      </li>
     </ul>
@@ -145,33 +139,25 @@ default will be to include abilities of all types.
      </li>
      <li>
       If you use the type syntax
-      <code>
-       &lt;Text&gt;
-      </code>
+      <code>&lt;Text&gt;</code>
       (w), you
 MUST place the type before the ability position (x).
      </li>
      <li>
       If you use the type syntax
-      <code>
-       TYPE=&lt;Text&gt;
-      </code>
+      <code>TYPE=&lt;Text&gt;</code>
       (y),
 you MUST place the type after the ability position (x) and before
 the property (z).
      </li>
      <li>
       You may include more than one
-      <code>
-       TYPE=&lt;Text&gt;
-      </code>
+      <code>TYPE=&lt;Text&gt;</code>
       sub-tokens in this token.
      </li>
      <li>
       You may use
-      <code>
-       !TYPE=&lt;Text&gt;
-      </code>
+      <code>!TYPE=&lt;Text&gt;</code>
       to exclude the
 particular type from the list.
      </li>
@@ -209,101 +195,73 @@ filtering.
 identified ability:
     <ul>
      <li>
-      <code>
-       ASPECT
-      </code>
+      <code>ASPECT</code>
       - Displays the comma-delimited list of
 aspects associated with the ability.
      </li>
      <li>
-      <code>
-       ASPECT.&lt;number&gt;
-      </code>
+      <code>ASPECT.&lt;number&gt;</code>
       - Displays the name/value of
 the numbered aspect, on a zero-based index of aspects, associated
 with the ability.
      </li>
      <li>
-      <code>
-       ASPECT.&lt;text&gt;
-      </code>
+      <code>ASPECT.&lt;text&gt;</code>
       - Displays the value of the
 named aspect associated with the ability.
      </li>
      <li>
-      <code>
-       ASPECTCOUNT
-      </code>
+      <code>ASPECTCOUNT</code>
       - Returns the total number of aspects
 associated with the ability.
      </li>
      <li>
-      <code>
-       HASASPECT
-      </code>
+      <code>HASASPECT</code>
       - Returns a boolean result on the named
 aspect in association with the ability.
      </li>
      <li>
-      <code>
-       ASSOCIATED
-      </code>
+      <code>ASSOCIATED</code>
       - Displays a comma separated list of
 the associated values (i.e. choices) of the ability.
      </li>
      <li>
-      <code>
-       ASSOCIATED.&lt;number&gt;
-      </code>
+      <code>ASSOCIATED.&lt;number&gt;</code>
       - Displays the numbered
 associated value (i.e. choice) of the ability. This can be combined
 with ASSOCIATEDCOUNT to loop through the choices.
      </li>
      <li>
-      <code>
-       ASSOCIATEDCOUNT
-      </code>
+      <code>ASSOCIATEDCOUNT</code>
       - Returns the total number of
 associated values (i.e. choices) of the ability.
      </li>
      <li>
-      <code>
-       BENEFIT
-      </code>
+      <code>BENEFIT</code>
       - Displays the benefit of the
 ability.
      </li>
      <li>
-      <code>
-       DESC
-      </code>
+      <code>DESC</code>
       - Displays the description of the
 ability.
      </li>
      <li>
-      <code>
-       KEY
-      </code>
+      <code>KEY</code>
       - Displays the internal key of the
 ability.
      </li>
      <li>
-      <code>
-       NAME
-      </code>
+      <code>NAME</code>
       - Displays the display name of the ability
 without any choices etc included.
      </li>
      <li>
-      <code>
-       SOURCE
-      </code>
+      <code>SOURCE</code>
       - Displays the source of the ability.
      </li>
      <li>
-      <code>
-       TYPE
-      </code>
+      <code>TYPE</code>
       - Displays the type of the ability.
      </li>
     </ul>
@@ -315,9 +273,7 @@ without any choices etc included.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ABILITY.FEAT.0
-   </code>
+   <code>ABILITY.FEAT.0</code>
   </p>
   <p class="indent3">
    Displays the name of the 1
@@ -328,9 +284,7 @@ without any choices etc included.
 feat.
   </p>
   <p class="indent2">
-   <code>
-    ABILITY.Fighter.0.DESC
-   </code>
+   <code>ABILITY.Fighter.0.DESC</code>
   </p>
   <p class="indent3">
    Displays the description of the 1
@@ -340,9 +294,7 @@ feat.
    chosen fighter ability.
   </p>
   <p class="indent2">
-   <code>
-    ABILITY.FEAT.3.TYPE=General
-   </code>
+   <code>ABILITY.FEAT.3.TYPE=General</code>
   </p>
   <p class="indent3">
    Displays the name of the 4
@@ -353,9 +305,7 @@ feat.
 general feat.
   </p>
   <p class="indent2">
-   <code>
-    ABILITY.Echidna.3.TYPE=General.TYPE
-   </code>
+   <code>ABILITY.Echidna.3.TYPE=General.TYPE</code>
   </p>
   <p class="indent3">
    Displays the type of the 4
@@ -366,9 +316,7 @@ general feat.
 "Echidna" category ability with a type of general.
   </p>
   <p class="indent2">
-   <code>
-    ABILITY.FEAT.HIDDEN.0
-   </code>
+   <code>ABILITY.FEAT.HIDDEN.0</code>
   </p>
   <p class="indent3">
    Displays the name of the 1
@@ -379,9 +327,7 @@ general feat.
 hidden feat.
   </p>
   <p class="indent2">
-   <code>
-    ABILITY.Power.0.ASPECT
-   </code>
+   <code>ABILITY.Power.0.ASPECT</code>
   </p>
   <p class="indent3">
    Displays the list of "aspects" for the
@@ -392,9 +338,7 @@ hidden feat.
    chosen "Power" category ability.
   </p>
   <p class="indent2">
-   <code>
-    ABILITY.Power.0.ASPECT.0
-   </code>
+   <code>ABILITY.Power.0.ASPECT.0</code>
   </p>
   <p class="indent3">
    Displays the name and value of the
@@ -410,10 +354,8 @@ hidden feat.
 category ability.
   </p>
   <p class="indent2">
-   <code>
-    ABILITY.Power.0.ASPECT.Attack
-Type
-   </code>
+   <code>ABILITY.Power.0.ASPECT.Attack
+Type</code>
   </p>
   <p class="indent3">
    Displays the value of the "Attack Type" aspect
@@ -424,9 +366,7 @@ for the 1
    chosen "Power" category ability.
   </p>
   <p class="indent2">
-   <code>
-    ABILITY.Power.0.ASPECTCOUNT
-   </code>
+   <code>ABILITY.Power.0.ASPECTCOUNT</code>
   </p>
   <p class="indent3">
    Returns the number of aspects associated with
@@ -437,9 +377,7 @@ the 1
    chosen "Power" category ability.
   </p>
   <p class="indent2">
-   <code>
-    ABILITY.Power.0.HASASPECT.Miss
-   </code>
+   <code>ABILITY.Power.0.HASASPECT.Miss</code>
   </p>
   <p class="indent3">
    Returns a boolean result of "Y" if the
@@ -529,23 +467,17 @@ after filtering (see below) for ability category (u), visibility
 (v) of each ability. The allowed visibility sub-tokens are:
     <ul>
      <li>
-      <code>
-       VISIBLE
-      </code>
+      <code>VISIBLE</code>
       - Filter the abilities that are visible in
 the outputsheets (default option).
      </li>
      <li>
-      <code>
-       HIDDEN
-      </code>
+      <code>HIDDEN</code>
       - Filter the abilities that are not visible
 in the outputsheets.
      </li>
      <li>
-      <code>
-       ALL
-      </code>
+      <code>ALL</code>
       - Shows all abilities.
      </li>
     </ul>
@@ -560,33 +492,25 @@ default will be to include abilities of all types.
      </li>
      <li>
       If you use the type syntax
-      <code>
-       &lt;Text&gt;
-      </code>
+      <code>&lt;Text&gt;</code>
       (w), you
 MUST place the type before the ability position (x).
      </li>
      <li>
       If you use the type syntax
-      <code>
-       TYPE=&lt;Text&gt;
-      </code>
+      <code>TYPE=&lt;Text&gt;</code>
       (y),
 you MUST place the type after the ability position (x) and before
 the property (z).
      </li>
      <li>
       You may include more than one
-      <code>
-       TYPE=&lt;Text&gt;
-      </code>
+      <code>TYPE=&lt;Text&gt;</code>
       sub-tokens in this token.
      </li>
      <li>
       You may use
-      <code>
-       !TYPE=&lt;Text&gt;
-      </code>
+      <code>!TYPE=&lt;Text&gt;</code>
       to exclude the
 particular type from the list.
      </li>
@@ -624,101 +548,73 @@ filtering.
 identified ability:
     <ul>
      <li>
-      <code>
-       ASPECT
-      </code>
+      <code>ASPECT</code>
       - Displays the comma-delimited list of
 aspects associated with the ability.
      </li>
      <li>
-      <code>
-       ASPECT.&lt;number&gt;
-      </code>
+      <code>ASPECT.&lt;number&gt;</code>
       - Displays the name/value of
 the numbered aspect, on a zero-based index of aspects, associated
 with the ability.
      </li>
      <li>
-      <code>
-       ASPECT.&lt;text&gt;
-      </code>
+      <code>ASPECT.&lt;text&gt;</code>
       - Displays the value of the
 named aspect associated with the ability.
      </li>
      <li>
-      <code>
-       ASPECTCOUNT
-      </code>
+      <code>ASPECTCOUNT</code>
       - Returns the total number of aspects
 associated with the ability.
      </li>
      <li>
-      <code>
-       HASASPECT
-      </code>
+      <code>HASASPECT</code>
       - Returns a boolean result on the named
 aspect in association with the ability.
      </li>
      <li>
-      <code>
-       ASSOCIATED
-      </code>
+      <code>ASSOCIATED</code>
       - Displays a comma separated list of
 the associated values (i.e. choices) of the ability.
      </li>
      <li>
-      <code>
-       ASSOCIATED.&lt;number&gt;
-      </code>
+      <code>ASSOCIATED.&lt;number&gt;</code>
       - Displays the numbered
 associated value (i.e. choice) of the ability. This can be combined
 with ASSOCIATEDCOUNT to loop through the choices.
      </li>
      <li>
-      <code>
-       ASSOCIATEDCOUNT
-      </code>
+      <code>ASSOCIATEDCOUNT</code>
       - Returns the total number of
 associated values (i.e. choices) of the ability.
      </li>
      <li>
-      <code>
-       BENEFIT
-      </code>
+      <code>BENEFIT</code>
       - Displays the benefit of the
 ability.
      </li>
      <li>
-      <code>
-       DESC
-      </code>
+      <code>DESC</code>
       - Displays the description of the
 ability.
      </li>
      <li>
-      <code>
-       KEY
-      </code>
+      <code>KEY</code>
       - Displays the internal key of the
 ability.
      </li>
      <li>
-      <code>
-       NAME
-      </code>
+      <code>NAME</code>
       - Displays the display name of the ability
 without any choices etc included.
      </li>
      <li>
-      <code>
-       SOURCE
-      </code>
+      <code>SOURCE</code>
       - Displays the source of the ability.
      </li>
      <li>
-      <code>
-       TYPE
-      </code>
+      <code>TYPE</code>
       - Displays the type of the ability.
      </li>
     </ul>
@@ -730,26 +626,20 @@ without any choices etc included.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ABILITYALL.FEAT.0
-   </code>
+   <code>ABILITYALL.FEAT.0</code>
   </p>
   <p class="indent3">
    Displays the first feat name.
   </p>
   <p class="indent2">
-   <code>
-    ABILITYALL.Fighter.0.DESC
-   </code>
+   <code>ABILITYALL.Fighter.0.DESC</code>
   </p>
   <p class="indent3">
    Displays the description of the first category
 "Fighter" ability.
   </p>
   <p class="indent2">
-   <code>
-    ABILITYALL.Wizard.1.TYPE=Metamagic
-   </code>
+   <code>ABILITYALL.Wizard.1.TYPE=Metamagic</code>
   </p>
   <p class="indent3">
    Displays the 2
@@ -760,9 +650,7 @@ without any choices etc included.
 ability description of type "Metamagic".
   </p>
   <p class="indent2">
-   <code>
-    ABILITYALL.Fighter.2.!TYPE=General.DESC
-   </code>
+   <code>ABILITYALL.Fighter.2.!TYPE=General.DESC</code>
   </p>
   <p class="indent3">
    Displays the 3
@@ -773,9 +661,7 @@ ability description of type "Metamagic".
 ability description of type "General".
   </p>
   <p class="indent2">
-   <code>
-    ABILITYALL.Starting.3.TYPE=Occupation.TYPE
-   </code>
+   <code>ABILITYALL.Starting.3.TYPE=Occupation.TYPE</code>
   </p>
   <p class="indent3">
    Displays the type of the 4
@@ -786,10 +672,8 @@ ability description of type "General".
 "Starting" ability of type "Occupation".
   </p>
   <p class="indent2">
-   <code>
-    ABILITYALL.Special
-Ability.HIDDEN.1.TYPE=Special
-   </code>
+   <code>ABILITYALL.Special
+Ability.HIDDEN.1.TYPE=Special</code>
   </p>
   <p class="indent3">
    Displays the 2
@@ -800,9 +684,7 @@ Ability.HIDDEN.1.TYPE=Special
 Ability" hidden ability name of type "Special".
   </p>
   <p class="indent2">
-   <code>
-    ABILITYALL.Power.0.ASPECT
-   </code>
+   <code>ABILITYALL.Power.0.ASPECT</code>
   </p>
   <p class="indent3">
    Displays the list of "aspects" for the
@@ -813,9 +695,7 @@ Ability" hidden ability name of type "Special".
    "Power" category ability.
   </p>
   <p class="indent2">
-   <code>
-    ABILITYALL.Power.0.ASPECT.0
-   </code>
+   <code>ABILITYALL.Power.0.ASPECT.0</code>
   </p>
   <p class="indent3">
    Displays the name and value of the
@@ -831,10 +711,8 @@ Ability" hidden ability name of type "Special".
 ability.
   </p>
   <p class="indent2">
-   <code>
-    ABILITYALL.Power.0.ASPECT.Attack
-Type
-   </code>
+   <code>ABILITYALL.Power.0.ASPECT.Attack
+Type</code>
   </p>
   <p class="indent3">
    Displays the value of the "Attack Type" aspect
@@ -845,9 +723,7 @@ for the 1
    "Power" category ability.
   </p>
   <p class="indent2">
-   <code>
-    ABILITYALL.Power.0.ASPECTCOUNT
-   </code>
+   <code>ABILITYALL.Power.0.ASPECTCOUNT</code>
   </p>
   <p class="indent3">
    Returns the number of aspects associated with
@@ -858,9 +734,7 @@ the 1
    "Power" category ability.
   </p>
   <p class="indent2">
-   <code>
-    ABILITYALL.Power.0.HASASPECT.Miss
-   </code>
+   <code>ABILITYALL.Power.0.HASASPECT.Miss</code>
   </p>
   <p class="indent3">
    Returns a boolean result of "Y" if the
@@ -935,27 +809,21 @@ variables.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ABILITYALLLIST.FEAT
-   </code>
+   <code>ABILITYALLLIST.FEAT</code>
   </p>
   <p class="indent3">
    Displays all of the character's feats (comma
 delimited).
   </p>
   <p class="indent2">
-   <code>
-    ABILITYALLLIST.FEAT.TYPE=Fighter
-   </code>
+   <code>ABILITYALLLIST.FEAT.TYPE=Fighter</code>
   </p>
   <p class="indent3">
    Displays all of the character's fighter feats
 (comma delimited).
   </p>
   <p class="indent2">
-   <code>
-    ABILITYALLLIST.WIZARD.!TYPE=Metamagic.!TYPE=ItemCreation
-   </code>
+   <code>ABILITYALLLIST.WIZARD.!TYPE=Metamagic.!TYPE=ItemCreation</code>
   </p>
   <p class="indent3">
    Displays all of the character's wizard abilities
@@ -1040,23 +908,17 @@ after filtering (see below) for ability category (u), visibility
 (v) of each ability. The allowed visibility sub-tokens are:
     <ul>
      <li>
-      <code>
-       VISIBLE
-      </code>
+      <code>VISIBLE</code>
       - Filter the abilities that are visible in
 the outputsheets (default option).
      </li>
      <li>
-      <code>
-       HIDDEN
-      </code>
+      <code>HIDDEN</code>
       - Filter the abilities that are not visible
 in the outputsheets.
      </li>
      <li>
-      <code>
-       ALL
-      </code>
+      <code>ALL</code>
       - Shows all abilities.
      </li>
     </ul>
@@ -1071,33 +933,25 @@ default will be to include abilities of all types.
      </li>
      <li>
       If you use the type syntax
-      <code>
-       &lt;Text&gt;
-      </code>
+      <code>&lt;Text&gt;</code>
       (w), you
 MUST place the type before the ability position (x).
      </li>
      <li>
       If you use the type syntax
-      <code>
-       TYPE=&lt;Text&gt;
-      </code>
+      <code>TYPE=&lt;Text&gt;</code>
       (y),
 you MUST place the type after the ability position (x) and before
 the property (z).
      </li>
      <li>
       You may include more than one
-      <code>
-       TYPE=&lt;Text&gt;
-      </code>
+      <code>TYPE=&lt;Text&gt;</code>
       sub-tokens in this token.
      </li>
      <li>
       You may use
-      <code>
-       !TYPE=&lt;Text&gt;
-      </code>
+      <code>!TYPE=&lt;Text&gt;</code>
       to exclude the
 particular type from the list.
      </li>
@@ -1135,101 +989,73 @@ filtering.
 identified ability:
     <ul>
      <li>
-      <code>
-       ASPECT
-      </code>
+      <code>ASPECT</code>
       - Displays the comma-delimited list of
 aspects associated with the ability.
      </li>
      <li>
-      <code>
-       ASPECT.&lt;number&gt;
-      </code>
+      <code>ASPECT.&lt;number&gt;</code>
       - Displays the name/value of
 the numbered aspect, on a zero-based index of aspects, associated
 with the ability.
      </li>
      <li>
-      <code>
-       ASPECT.&lt;text&gt;
-      </code>
+      <code>ASPECT.&lt;text&gt;</code>
       - Displays the value of the
 named aspect associated with the ability.
      </li>
      <li>
-      <code>
-       ASPECTCOUNT
-      </code>
+      <code>ASPECTCOUNT</code>
       - Returns the total number of aspects
 associated with the ability.
      </li>
      <li>
-      <code>
-       HASASPECT
-      </code>
+      <code>HASASPECT</code>
       - Returns a boolean result on the named
 aspect in association with the ability.
      </li>
      <li>
-      <code>
-       ASSOCIATED
-      </code>
+      <code>ASSOCIATED</code>
       - Displays a comma separated list of
 the associated values (i.e. choices) of the ability.
      </li>
      <li>
-      <code>
-       ASSOCIATED.&lt;number&gt;
-      </code>
+      <code>ASSOCIATED.&lt;number&gt;</code>
       - Displays the numbered
 associated value (i.e. choice) of the ability. This can be combined
 with ASSOCIATEDCOUNT to loop through the choices.
      </li>
      <li>
-      <code>
-       ASSOCIATEDCOUNT
-      </code>
+      <code>ASSOCIATEDCOUNT</code>
       - Returns the total number of
 associated values (i.e. choices) of the ability.
      </li>
      <li>
-      <code>
-       BENEFIT
-      </code>
+      <code>BENEFIT</code>
       - Displays the benefit of the
 ability.
      </li>
      <li>
-      <code>
-       DESC
-      </code>
+      <code>DESC</code>
       - Displays the description of the
 ability.
      </li>
      <li>
-      <code>
-       KEY
-      </code>
+      <code>KEY</code>
       - Displays the internal key of the
 ability.
      </li>
      <li>
-      <code>
-       NAME
-      </code>
+      <code>NAME</code>
       - Displays the display name of the ability
 without any choices etc included.
      </li>
      <li>
-      <code>
-       SOURCE
-      </code>
+      <code>SOURCE</code>
       - Displays the source of the ability.
      </li>
      <li>
-      <code>
-       TYPE
-      </code>
+      <code>TYPE</code>
       - Displays the type of the ability.
      </li>
     </ul>
@@ -1241,9 +1067,7 @@ without any choices etc included.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ABILITYAUTO.FEAT.0
-   </code>
+   <code>ABILITYAUTO.FEAT.0</code>
   </p>
   <p class="indent3">
    Displays the name of the 1
@@ -1253,9 +1077,7 @@ without any choices etc included.
    automatic feat.
   </p>
   <p class="indent2">
-   <code>
-    ABILITYAUTO.Rogue.0.DESC
-   </code>
+   <code>ABILITYAUTO.Rogue.0.DESC</code>
   </p>
   <p class="indent3">
    Displays the description of the 1
@@ -1265,9 +1087,7 @@ without any choices etc included.
    automatic rogue ability.
   </p>
   <p class="indent2">
-   <code>
-    ABILITYAUTO.Rogue.1.TYPE=General
-   </code>
+   <code>ABILITYAUTO.Rogue.1.TYPE=General</code>
   </p>
   <p class="indent3">
    Displays the name of the 2
@@ -1277,9 +1097,7 @@ without any choices etc included.
    automatic rogue ability if it is a general type ability.
   </p>
   <p class="indent2">
-   <code>
-    ABILITYAUTO.Racial.1.TYPE=General.TYPE
-   </code>
+   <code>ABILITYAUTO.Racial.1.TYPE=General.TYPE</code>
   </p>
   <p class="indent3">
    Displays the type of the 2
@@ -1289,9 +1107,7 @@ without any choices etc included.
    automatic racial ability if it is a general type ability.
   </p>
   <p class="indent2">
-   <code>
-    ABILITYAUTO.Power.0.ASPECT
-   </code>
+   <code>ABILITYAUTO.Power.0.ASPECT</code>
   </p>
   <p class="indent3">
    Displays the list of "aspects" for the
@@ -1302,9 +1118,7 @@ without any choices etc included.
    automatic "Power" category ability.
   </p>
   <p class="indent2">
-   <code>
-    ABILITYAUTO.Power.0.ASPECT.0
-   </code>
+   <code>ABILITYAUTO.Power.0.ASPECT.0</code>
   </p>
   <p class="indent3">
    Displays the name and value of the
@@ -1320,10 +1134,8 @@ without any choices etc included.
 category ability.
   </p>
   <p class="indent2">
-   <code>
-    ABILITYAUTO.Power.0.ASPECT.Attack
-Type
-   </code>
+   <code>ABILITYAUTO.Power.0.ASPECT.Attack
+Type</code>
   </p>
   <p class="indent3">
    Displays the value of the "Attack Type" aspect
@@ -1334,9 +1146,7 @@ for the 1
    automatic "Power" category ability.
   </p>
   <p class="indent2">
-   <code>
-    ABILITYAUTO.Power.0.ASPECTCOUNT
-   </code>
+   <code>ABILITYAUTO.Power.0.ASPECTCOUNT</code>
   </p>
   <p class="indent3">
    Returns the number of aspects associated with
@@ -1347,9 +1157,7 @@ the 1
    automatic "Power" category ability.
   </p>
   <p class="indent2">
-   <code>
-    ABILITYAUTO.Power.0.HASASPECT.Miss
-   </code>
+   <code>ABILITYAUTO.Power.0.HASASPECT.Miss</code>
   </p>
   <p class="indent3">
    Returns a boolean result of "Y" if the
@@ -1425,18 +1233,14 @@ variables.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ABILITYAUTOLIST.RACIAL
-   </code>
+   <code>ABILITYAUTOLIST.RACIAL</code>
   </p>
   <p class="indent3">
    Displays all of the character's automatic racial
 abilities (comma delimited).
   </p>
   <p class="indent2">
-   <code>
-    ABILITYAUTOLIST.RACIAL.!TYPE=General
-   </code>
+   <code>ABILITYAUTOLIST.RACIAL.!TYPE=General</code>
   </p>
   <p class="indent3">
    Displays all of the character's automatic racial
@@ -1507,18 +1311,14 @@ variables.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ABILITYLIST.ROGUE
-   </code>
+   <code>ABILITYLIST.ROGUE</code>
   </p>
   <p class="indent3">
    Displays all of the character's chosen rogue
 abilities (comma delimited).
   </p>
   <p class="indent2">
-   <code>
-    ABILITYLIST.WIZARD.TYPE=ItemCreation
-   </code>
+   <code>ABILITYLIST.WIZARD.TYPE=ItemCreation</code>
   </p>
   <p class="indent3">
    Displays all of the character's chosen item
@@ -1596,23 +1396,17 @@ filtering (see below) for visibility (v) and type (w and y).
 of each feat. The allowed visibility sub-tokens are:
     <ul>
      <li>
-      <code>
-       VISIBLE
-      </code>
+      <code>VISIBLE</code>
       - Filter the feats that are visible in the
 outputsheets (default option).
      </li>
      <li>
-      <code>
-       HIDDEN
-      </code>
+      <code>HIDDEN</code>
       - Filter the feats that are not visible in
 the outputsheets.
      </li>
      <li>
-      <code>
-       ALL
-      </code>
+      <code>ALL</code>
       - Shows all feats.
      </li>
     </ul>
@@ -1627,33 +1421,25 @@ default will be to include feats of all types.
      </li>
      <li>
       If you use the type syntax
-      <code>
-       &lt;Text&gt;
-      </code>
+      <code>&lt;Text&gt;</code>
       (w), you
 MUST place the type before the feat position (x).
      </li>
      <li>
       If you use the type syntax
-      <code>
-       TYPE=&lt;Text&gt;
-      </code>
+      <code>TYPE=&lt;Text&gt;</code>
       (y),
 you MUST place the type after the feat position (x) and before the
 property (z).
      </li>
      <li>
       You may include more than one
-      <code>
-       TYPE=&lt;Text&gt;
-      </code>
+      <code>TYPE=&lt;Text&gt;</code>
       sub-tokens in this token.
      </li>
      <li>
       You may use
-      <code>
-       !TYPE=&lt;Text&gt;
-      </code>
+      <code>!TYPE=&lt;Text&gt;</code>
       to exclude the
 particular type from the list.
      </li>
@@ -1691,101 +1477,73 @@ filtering.
 identified feat:
     <ul>
      <li>
-      <code>
-       ASPECT
-      </code>
+      <code>ASPECT</code>
       - Displays the comma-delimited list of
 aspects associated with the feat.
      </li>
      <li>
-      <code>
-       ASPECT.&lt;number&gt;
-      </code>
+      <code>ASPECT.&lt;number&gt;</code>
       - Displays the name/value of
 the numbered aspect, on a zero-based index of aspects, associated
 with the feat.
      </li>
      <li>
-      <code>
-       ASPECT.&lt;text&gt;
-      </code>
+      <code>ASPECT.&lt;text&gt;</code>
       - Displays the value of the
 named aspect associated with the feat.
      </li>
      <li>
-      <code>
-       ASPECTCOUNT
-      </code>
+      <code>ASPECTCOUNT</code>
       - Returns the total number of aspects
 associated with the feat.
      </li>
      <li>
-      <code>
-       HASASPECT
-      </code>
+      <code>HASASPECT</code>
       - Returns a boolean result on the named
 aspect in association with the feat.
      </li>
      <li>
-      <code>
-       ASSOCIATED
-      </code>
+      <code>ASSOCIATED</code>
       - Displays a comma separated list of
 the associated values (i.e. choices) of the ability.
      </li>
      <li>
-      <code>
-       ASSOCIATED.&lt;number&gt;
-      </code>
+      <code>ASSOCIATED.&lt;number&gt;</code>
       - Displays the numbered
 associated value (i.e. choice) of the ability. This can be combined
 with ASSOCIATEDCOUNT to loop through the choices.
      </li>
      <li>
-      <code>
-       ASSOCIATEDCOUNT
-      </code>
+      <code>ASSOCIATEDCOUNT</code>
       - Returns the total number of
 associated values (i.e. choices) of the ability.
      </li>
      <li>
-      <code>
-       BENEFIT
-      </code>
+      <code>BENEFIT</code>
       - Displays the benefit of the
 ability.
      </li>
      <li>
-      <code>
-       DESC
-      </code>
+      <code>DESC</code>
       - Displays the description of the
 ability.
      </li>
      <li>
-      <code>
-       KEY
-      </code>
+      <code>KEY</code>
       - Displays the internal key of the
 ability.
      </li>
      <li>
-      <code>
-       NAME
-      </code>
+      <code>NAME</code>
       - Displays the display name of the ability
 without any choices etc included.
      </li>
      <li>
-      <code>
-       SOURCE
-      </code>
+      <code>SOURCE</code>
       - Displays the source of the ability.
      </li>
      <li>
-      <code>
-       TYPE
-      </code>
+      <code>TYPE</code>
       - Displays the type of the ability.
      </li>
     </ul>
@@ -1797,9 +1555,7 @@ without any choices etc included.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    FEAT.0
-   </code>
+   <code>FEAT.0</code>
   </p>
   <p class="indent3">
    Displays the name of the 1
@@ -1810,9 +1566,7 @@ without any choices etc included.
 feat.
   </p>
   <p class="indent2">
-   <code>
-    FEAT.0.DESC
-   </code>
+   <code>FEAT.0.DESC</code>
   </p>
   <p class="indent3">
    Displays the description of the 1
@@ -1822,9 +1576,7 @@ feat.
    chosen feat.
   </p>
   <p class="indent2">
-   <code>
-    FEAT.3.TYPE=General
-   </code>
+   <code>FEAT.3.TYPE=General</code>
   </p>
   <p class="indent3">
    Displays the name of the 4
@@ -1835,9 +1587,7 @@ feat.
 feat if it is a general type feat.
   </p>
   <p class="indent2">
-   <code>
-    FEAT.3.TYPE=General.TYPE
-   </code>
+   <code>FEAT.3.TYPE=General.TYPE</code>
   </p>
   <p class="indent3">
    Displays the type of the 4
@@ -1848,9 +1598,7 @@ feat if it is a general type feat.
 feat if it is a general type feat.
   </p>
   <p class="indent2">
-   <code>
-    FEAT.0.ASPECT
-   </code>
+   <code>FEAT.0.ASPECT</code>
   </p>
   <p class="indent3">
    Displays the list of "aspects" for the
@@ -1861,9 +1609,7 @@ feat if it is a general type feat.
    chosen feat.
   </p>
   <p class="indent2">
-   <code>
-    FEAT.0.ASPECT.0
-   </code>
+   <code>FEAT.0.ASPECT.0</code>
   </p>
   <p class="indent3">
    Displays the name and value of the
@@ -1878,9 +1624,7 @@ feat if it is a general type feat.
    chosen feat.
   </p>
   <p class="indent2">
-   <code>
-    FEAT.0.ASPECT.Attack Type
-   </code>
+   <code>FEAT.0.ASPECT.Attack Type</code>
   </p>
   <p class="indent3">
    Displays the value of the "Attack Type" aspect
@@ -1891,9 +1635,7 @@ for the 1
    chosen feat.
   </p>
   <p class="indent2">
-   <code>
-    FEAT.0.ASPECTCOUNT
-   </code>
+   <code>FEAT.0.ASPECTCOUNT</code>
   </p>
   <p class="indent3">
    Returns the number of aspects associated with
@@ -1904,9 +1646,7 @@ the 1
    chosen feat.
   </p>
   <p class="indent2">
-   <code>
-    FEAT.0.HASASPECT.Miss
-   </code>
+   <code>FEAT.0.HASASPECT.Miss</code>
   </p>
   <p class="indent3">
    Returns a boolean result of "Y" if the
@@ -1989,23 +1729,17 @@ filtering (see below) for visibility (v) and type (w and y).
 of each feat. The allowed visibility sub-tokens are:
     <ul>
      <li>
-      <code>
-       VISIBLE
-      </code>
+      <code>VISIBLE</code>
       - Filter the feats that are visible in the
 outputsheets (default option).
      </li>
      <li>
-      <code>
-       HIDDEN
-      </code>
+      <code>HIDDEN</code>
       - Filter the feats that are not visible in
 the outputsheets.
      </li>
      <li>
-      <code>
-       ALL
-      </code>
+      <code>ALL</code>
       - Shows all feats.
      </li>
     </ul>
@@ -2020,33 +1754,25 @@ default will be to include feats of all types.
      </li>
      <li>
       If you use the type syntax
-      <code>
-       &lt;Text&gt;
-      </code>
+      <code>&lt;Text&gt;</code>
       (w), you
 MUST place the type before the feat position (x).
      </li>
      <li>
       If you use the type syntax
-      <code>
-       TYPE=&lt;Text&gt;
-      </code>
+      <code>TYPE=&lt;Text&gt;</code>
       (y),
 you MUST place the type after the feat position (x) and before the
 property (z).
      </li>
      <li>
       You may include more than one
-      <code>
-       TYPE=&lt;Text&gt;
-      </code>
+      <code>TYPE=&lt;Text&gt;</code>
       sub-tokens in this token.
      </li>
      <li>
       You may use
-      <code>
-       !TYPE=&lt;Text&gt;
-      </code>
+      <code>!TYPE=&lt;Text&gt;</code>
       to exclude the
 particular type from the list.
      </li>
@@ -2084,101 +1810,73 @@ filtering.
 identified feat:
     <ul>
      <li>
-      <code>
-       ASPECT
-      </code>
+      <code>ASPECT</code>
       - Displays the comma-delimited list of
 aspects associated with the feat.
      </li>
      <li>
-      <code>
-       ASPECT.&lt;number&gt;
-      </code>
+      <code>ASPECT.&lt;number&gt;</code>
       - Displays the name/value of
 the numbered aspect, on a zero-based index of aspects, associated
 with the feat.
      </li>
      <li>
-      <code>
-       ASPECT.&lt;text&gt;
-      </code>
+      <code>ASPECT.&lt;text&gt;</code>
       - Displays the value of the
 named aspect associated with the feat.
      </li>
      <li>
-      <code>
-       ASPECTCOUNT
-      </code>
+      <code>ASPECTCOUNT</code>
       - Returns the total number of aspects
 associated with the feat.
      </li>
      <li>
-      <code>
-       HASASPECT
-      </code>
+      <code>HASASPECT</code>
       - Returns a boolean result on the named
 aspect in association with the feat.
      </li>
      <li>
-      <code>
-       ASSOCIATED
-      </code>
+      <code>ASSOCIATED</code>
       - Displays a comma separated list of
 the associated values (i.e. choices) of the ability.
      </li>
      <li>
-      <code>
-       ASSOCIATED.&lt;number&gt;
-      </code>
+      <code>ASSOCIATED.&lt;number&gt;</code>
       - Displays the numbered
 associated value (i.e. choice) of the ability. This can be combined
 with ASSOCIATEDCOUNT to loop through the choices.
      </li>
      <li>
-      <code>
-       ASSOCIATEDCOUNT
-      </code>
+      <code>ASSOCIATEDCOUNT</code>
       - Returns the total number of
 associated values (i.e. choices) of the ability.
      </li>
      <li>
-      <code>
-       BENEFIT
-      </code>
+      <code>BENEFIT</code>
       - Displays the benefit of the
 ability.
      </li>
      <li>
-      <code>
-       DESC
-      </code>
+      <code>DESC</code>
       - Displays the description of the
 ability.
      </li>
      <li>
-      <code>
-       KEY
-      </code>
+      <code>KEY</code>
       - Displays the internal key of the
 ability.
      </li>
      <li>
-      <code>
-       NAME
-      </code>
+      <code>NAME</code>
       - Displays the display name of the ability
 without any choices etc included.
      </li>
      <li>
-      <code>
-       SOURCE
-      </code>
+      <code>SOURCE</code>
       - Displays the source of the ability.
      </li>
      <li>
-      <code>
-       TYPE
-      </code>
+      <code>TYPE</code>
       - Displays the type of the ability.
      </li>
     </ul>
@@ -2190,25 +1888,19 @@ without any choices etc included.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    FEATALL.0
-   </code>
+   <code>FEATALL.0</code>
   </p>
   <p class="indent3">
    Displays the first feat name.
   </p>
   <p class="indent2">
-   <code>
-    FEATALL.0.DESC
-   </code>
+   <code>FEATALL.0.DESC</code>
   </p>
   <p class="indent3">
    Displays the description of the first feat.
   </p>
   <p class="indent2">
-   <code>
-    FEATALL.1.TYPE=Metamagic
-   </code>
+   <code>FEATALL.1.TYPE=Metamagic</code>
   </p>
   <p class="indent3">
    Displays the 2
@@ -2219,9 +1911,7 @@ without any choices etc included.
 metamagic feat.
   </p>
   <p class="indent2">
-   <code>
-    FEATALL.2.!TYPE=General.DESC
-   </code>
+   <code>FEATALL.2.!TYPE=General.DESC</code>
   </p>
   <p class="indent3">
    Displays the feat description of the
@@ -2232,9 +1922,7 @@ metamagic feat.
    non-general feat.
   </p>
   <p class="indent2">
-   <code>
-    FEATALL.3.TYPE=Occupation.TYPE
-   </code>
+   <code>FEATALL.3.TYPE=Occupation.TYPE</code>
   </p>
   <p class="indent3">
    Displays the type of the 4
@@ -2245,9 +1933,7 @@ metamagic feat.
 it is an Occupation feat.
   </p>
   <p class="indent2">
-   <code>
-    FEATALL.0.ASPECT
-   </code>
+   <code>FEATALL.0.ASPECT</code>
   </p>
   <p class="indent3">
    Displays the list of "aspects" for the
@@ -2258,9 +1944,7 @@ it is an Occupation feat.
    feat.
   </p>
   <p class="indent2">
-   <code>
-    FEATALL.0.ASPECT.0
-   </code>
+   <code>FEATALL.0.ASPECT.0</code>
   </p>
   <p class="indent3">
    Displays the name and value of the
@@ -2275,9 +1959,7 @@ it is an Occupation feat.
    feat.
   </p>
   <p class="indent2">
-   <code>
-    FEATALL.0.ASPECT.Attack Type
-   </code>
+   <code>FEATALL.0.ASPECT.Attack Type</code>
   </p>
   <p class="indent3">
    Displays the value of the "Attack Type" aspect
@@ -2288,9 +1970,7 @@ for the 1
    feat.
   </p>
   <p class="indent2">
-   <code>
-    FEATALL.0.ASPECTCOUNT
-   </code>
+   <code>FEATALL.0.ASPECTCOUNT</code>
   </p>
   <p class="indent3">
    Returns the number of aspects associated with
@@ -2301,9 +1981,7 @@ the 1
    feat.
   </p>
   <p class="indent2">
-   <code>
-    FEATALL.0.HASASPECT.Miss
-   </code>
+   <code>FEATALL.0.HASASPECT.Miss</code>
   </p>
   <p class="indent3">
    Returns a boolean result of "Y" if the
@@ -2371,27 +2049,21 @@ variables.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    FEATALLLIST
-   </code>
+   <code>FEATALLLIST</code>
   </p>
   <p class="indent3">
    Displays all of the character's feats (comma
 delimited).
   </p>
   <p class="indent2">
-   <code>
-    FEATALLLIST.TYPE=Fighter
-   </code>
+   <code>FEATALLLIST.TYPE=Fighter</code>
   </p>
   <p class="indent3">
    Displays all of the character's fighter feats
 (comma delimited).
   </p>
   <p class="indent2">
-   <code>
-    FEATALLLIST.!TYPE=Metamagic.!TYPE=ItemCreation
-   </code>
+   <code>FEATALLLIST.!TYPE=Metamagic.!TYPE=ItemCreation</code>
   </p>
   <p class="indent3">
    Displays all of the character's feats except
@@ -2468,23 +2140,17 @@ filtering (see below) for visibility (v) and type (w and y).
 of each feat. The allowed visibility sub-tokens are:
     <ul>
      <li>
-      <code>
-       VISIBLE
-      </code>
+      <code>VISIBLE</code>
       - Filter the feats that are visible in the
 outputsheets (default option).
      </li>
      <li>
-      <code>
-       HIDDEN
-      </code>
+      <code>HIDDEN</code>
       - Filter the feats that are not visible in
 the outputsheets.
      </li>
      <li>
-      <code>
-       ALL
-      </code>
+      <code>ALL</code>
       - Shows all feats.
      </li>
     </ul>
@@ -2499,33 +2165,25 @@ default will be to include feats of all types.
      </li>
      <li>
       If you use the type syntax
-      <code>
-       &lt;Text&gt;
-      </code>
+      <code>&lt;Text&gt;</code>
       (w), you
 MUST place the type before the feat position (x).
      </li>
      <li>
       If you use the type syntax
-      <code>
-       TYPE=&lt;Text&gt;
-      </code>
+      <code>TYPE=&lt;Text&gt;</code>
       (y),
 you MUST place the type after the feat position (x) and before the
 property (z).
      </li>
      <li>
       You may include more than one
-      <code>
-       TYPE=&lt;Text&gt;
-      </code>
+      <code>TYPE=&lt;Text&gt;</code>
       sub-tokens in this token.
      </li>
      <li>
       You may use
-      <code>
-       !TYPE=&lt;Text&gt;
-      </code>
+      <code>!TYPE=&lt;Text&gt;</code>
       to exclude the
 particular type from the list.
      </li>
@@ -2563,101 +2221,73 @@ filtering.
 identified feat:
     <ul>
      <li>
-      <code>
-       ASPECT
-      </code>
+      <code>ASPECT</code>
       - Displays the comma-delimited list of
 aspects associated with the feat.
      </li>
      <li>
-      <code>
-       ASPECT.&lt;number&gt;
-      </code>
+      <code>ASPECT.&lt;number&gt;</code>
       - Displays the name/value of
 the numbered aspect, on a zero-based index of aspects, associated
 with the feat.
      </li>
      <li>
-      <code>
-       ASPECT.&lt;text&gt;
-      </code>
+      <code>ASPECT.&lt;text&gt;</code>
       - Displays the value of the
 named aspect associated with the feat.
      </li>
      <li>
-      <code>
-       ASPECTCOUNT
-      </code>
+      <code>ASPECTCOUNT</code>
       - Returns the total number of aspects
 associated with the feat.
      </li>
      <li>
-      <code>
-       HASASPECT
-      </code>
+      <code>HASASPECT</code>
       - Returns a boolean result on the named
 aspect in association with the feat.
      </li>
      <li>
-      <code>
-       ASSOCIATED
-      </code>
+      <code>ASSOCIATED</code>
       - Displays a comma separated list of
 the associated values (i.e. choices) of the ability.
      </li>
      <li>
-      <code>
-       ASSOCIATED.&lt;number&gt;
-      </code>
+      <code>ASSOCIATED.&lt;number&gt;</code>
       - Displays the numbered
 associated value (i.e. choice) of the ability. This can be combined
 with ASSOCIATEDCOUNT to loop through the choices.
      </li>
      <li>
-      <code>
-       ASSOCIATEDCOUNT
-      </code>
+      <code>ASSOCIATEDCOUNT</code>
       - Returns the total number of
 associated values (i.e. choices) of the ability.
      </li>
      <li>
-      <code>
-       BENEFIT
-      </code>
+      <code>BENEFIT</code>
       - Displays the benefit of the
 ability.
      </li>
      <li>
-      <code>
-       DESC
-      </code>
+      <code>DESC</code>
       - Displays the description of the
 ability.
      </li>
      <li>
-      <code>
-       KEY
-      </code>
+      <code>KEY</code>
       - Displays the internal key of the
 ability.
      </li>
      <li>
-      <code>
-       NAME
-      </code>
+      <code>NAME</code>
       - Displays the display name of the ability
 without any choices etc included.
      </li>
      <li>
-      <code>
-       SOURCE
-      </code>
+      <code>SOURCE</code>
       - Displays the source of the ability.
      </li>
      <li>
-      <code>
-       TYPE
-      </code>
+      <code>TYPE</code>
       - Displays the type of the ability.
      </li>
     </ul>
@@ -2669,9 +2299,7 @@ without any choices etc included.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    FEATAUTO.0
-   </code>
+   <code>FEATAUTO.0</code>
   </p>
   <p class="indent3">
    Displays the name of the 1
@@ -2681,9 +2309,7 @@ without any choices etc included.
    automatic feat.
   </p>
   <p class="indent2">
-   <code>
-    FEATAUTO.0.DESC
-   </code>
+   <code>FEATAUTO.0.DESC</code>
   </p>
   <p class="indent3">
    Displays the description of the 1
@@ -2693,9 +2319,7 @@ without any choices etc included.
    automatic feat.
   </p>
   <p class="indent2">
-   <code>
-    FEATAUTO.1.TYPE=General
-   </code>
+   <code>FEATAUTO.1.TYPE=General</code>
   </p>
   <p class="indent3">
    Displays the name of the 2
@@ -2706,9 +2330,7 @@ without any choices etc included.
 type automatic feat.
   </p>
   <p class="indent2">
-   <code>
-    FEATAUTO.1.!TYPE=General.TYPE
-   </code>
+   <code>FEATAUTO.1.!TYPE=General.TYPE</code>
   </p>
   <p class="indent3">
    Displays the type of the 2
@@ -2718,9 +2340,7 @@ type automatic feat.
    non-general type automatic feat.
   </p>
   <p class="indent2">
-   <code>
-    FEATAUTO.0.ASPECT
-   </code>
+   <code>FEATAUTO.0.ASPECT</code>
   </p>
   <p class="indent3">
    Displays the list of "aspects" for the
@@ -2731,9 +2351,7 @@ type automatic feat.
    automatic feat.
   </p>
   <p class="indent2">
-   <code>
-    FEATAUTO.0.ASPECT.0
-   </code>
+   <code>FEATAUTO.0.ASPECT.0</code>
   </p>
   <p class="indent3">
    Displays the name and value of the
@@ -2748,9 +2366,7 @@ type automatic feat.
    automatic feat.
   </p>
   <p class="indent2">
-   <code>
-    FEATAUTO.0.ASPECT.Attack Type
-   </code>
+   <code>FEATAUTO.0.ASPECT.Attack Type</code>
   </p>
   <p class="indent3">
    Displays the value of the "Attack Type" aspect
@@ -2761,9 +2377,7 @@ for the 1
    automatic feat.
   </p>
   <p class="indent2">
-   <code>
-    FEATAUTO.0.ASPECTCOUNT
-   </code>
+   <code>FEATAUTO.0.ASPECTCOUNT</code>
   </p>
   <p class="indent3">
    Returns the number of aspects associated with
@@ -2774,9 +2388,7 @@ the 1
    automatic feat.
   </p>
   <p class="indent2">
-   <code>
-    FEATAUTO.0.HASASPECT.Miss
-   </code>
+   <code>FEATAUTO.0.HASASPECT.Miss</code>
   </p>
   <p class="indent3">
    Returns a boolean result of "Y" if the
@@ -2845,18 +2457,14 @@ variables.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    FEATAUTOLIST
-   </code>
+   <code>FEATAUTOLIST</code>
   </p>
   <p class="indent3">
    Displays all of the character's automatic feats
 (comma delimited).
   </p>
   <p class="indent2">
-   <code>
-    FEATAUTOLIST.!TYPE=General
-   </code>
+   <code>FEATAUTOLIST.!TYPE=General</code>
   </p>
   <p class="indent3">
    Displays all of the character's automatic feats
@@ -2921,18 +2529,14 @@ variables.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    FEATLIST
-   </code>
+   <code>FEATLIST</code>
   </p>
   <p class="indent3">
    Displays all of the character's chosen feats
 (comma delimited).
   </p>
   <p class="indent2">
-   <code>
-    FEATLIST.TYPE=ItemCreation
-   </code>
+   <code>FEATLIST.TYPE=ItemCreation</code>
   </p>
   <p class="indent3">
    Displays all of the character's chosen item
@@ -2962,9 +2566,7 @@ feat points.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    FEATPOINTS
-   </code>
+   <code>FEATPOINTS</code>
   </p>
   <p class="indent3">
    Displays all the character's remaining un-spent
@@ -2998,9 +2600,7 @@ level.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    MAXCCSKILLLEVEL
-   </code>
+   <code>MAXCCSKILLLEVEL</code>
   </p>
   <p class="indent3">
    Displays the maximum Cross Class Skill
@@ -3029,9 +2629,7 @@ level.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    MAXSKILLLEVEL
-   </code>
+   <code>MAXSKILLLEVEL</code>
   </p>
   <p class="indent3">
    Displays the maximum Class Skill Level.
@@ -3093,24 +2691,18 @@ list.
     The properties allowed are:
     <ul>
      <li>
-      <code>
-       ABILITY
-      </code>
+      <code>ABILITY</code>
       - Displays the key ability (stat) for the
 skill in position x in the character's skill list.
      </li>
      <li>
-      <code>
-       ABMOD
-      </code>
+      <code>ABMOD</code>
       - Displays the modifier from the key
 ability, for the skill in position x in the character's skill
 list.
      </li>
      <li>
-      <code>
-       ACP
-      </code>
+      <code>ACP</code>
       s,t,u,v - Displays the Armor Check Penalty for
 the skill in position x.
       <ul>
@@ -3131,93 +2723,67 @@ Swim
       </ul>
      </li>
      <li>
-      <code>
-       CLASS
-      </code>
+      <code>CLASS</code>
       - Displays a list of the character's classes
 that have this skill as a class skill.
      </li>
      <li>
-      <code>
-       EXCLUSIVE
-      </code>
+      <code>EXCLUSIVE</code>
       - Displays "Y" if the skill is an
 exlusive class skill and "N" if it is not.
      </li>
      <li>
-      <code>
-       EXCLUSIVE_TOTAL
-      </code>
+      <code>EXCLUSIVE_TOTAL</code>
       - Displays "0" if the skill is
 exclusive, not usable untrained and has 0 ranks.
      </li>
      <li>
-      <code>
-       EXPLAIN
-      </code>
+      <code>EXPLAIN</code>
       - Displays the make-up of the misc
 modifier in an abbreviated format.
      </li>
      <li>
-      <code>
-       EXPLAIN_LONG
-      </code>
+      <code>EXPLAIN_LONG</code>
       - Displays the make-up of the misc
 modifier in a verbose format.
      </li>
      <li>
-      <code>
-       MISC
-      </code>
+      <code>MISC</code>
       - equals TOTAL - RANK - ABMOD.
      </li>
      <li>
-      <code>
-       MOD
-      </code>
+      <code>MOD</code>
       - Displays the total modifiers from abilities,
 equipment, etc.? of the skill in position x in the character's
 skill list.
      </li>
      <li>
-      <code>
-       RANK
-      </code>
+      <code>RANK</code>
       - Displays the number of skill ranks of the
 skill in position x in the character's skill list.
      </li>
      <li>
-      <code>
-       SIZE
-      </code>
+      <code>SIZE</code>
       - Displays the character's size modifier as
 applied to the skill.
      </li>
      <li>
-      <code>
-       TOTAL
-      </code>
+      <code>TOTAL</code>
       - Displays the total bonus for the skill in
 position x in the character's skill list.
      </li>
      <li>
-      <code>
-       TRAINED_TOTAL
-      </code>
+      <code>TRAINED_TOTAL</code>
       - Displays "0" if the skill is not
 usable untrained and has 0 ranks.
      </li>
      <li>
-      <code>
-       TYPE
-      </code>
+      <code>TYPE</code>
       - Displays the type of the skill in position
 x in the character's skill list.
      </li>
      <li>
-      <code>
-       UNTRAINED
-      </code>
+      <code>UNTRAINED</code>
       - Displays "Y" if the skill can be used
 untrained and "N" if it cannot.
      </li>
@@ -3230,18 +2796,14 @@ untrained and "N" if it cannot.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SKILL.Alchemy.TOTAL
-   </code>
+   <code>SKILL.Alchemy.TOTAL</code>
   </p>
   <p class="indent3">
    Would display the total bonus on your Alchemy
 skill check.
   </p>
   <p class="indent2">
-   <code>
-    SKILL.Jump.EXPLAIN_LONG
-   </code>
+   <code>SKILL.Jump.EXPLAIN_LONG</code>
   </p>
   <p class="indent3">
    Displays the make-up of the misc modifier in the
@@ -3251,9 +2813,7 @@ Jump skill.
 -6.0[|TYPE=SPEED.STACK] +4.0[OTHER]
   </p>
   <p class="indent2">
-   <code>
-    SKILL.2.RANK
-   </code>
+   <code>SKILL.2.RANK</code>
   </p>
   <p class="indent3">
    Displays the number of ranks in the
@@ -3264,9 +2824,7 @@ Jump skill.
    skill.
   </p>
   <p class="indent2">
-   <code>
-    SKILL.1.MISC
-   </code>
+   <code>SKILL.1.MISC</code>
   </p>
   <p class="indent3">
    Displays the bonus for the 2
@@ -3277,9 +2835,7 @@ Jump skill.
 not from the key ability score or ranks (e.g. A synergy bonus).
   </p>
   <p class="indent2">
-   <code>
-    SKILL.0.ABILITY
-   </code>
+   <code>SKILL.0.ABILITY</code>
   </p>
   <p class="indent3">
    Displays the key ability name for the
@@ -3290,9 +2846,7 @@ not from the key ability score or ranks (e.g. A synergy bonus).
    skill.
   </p>
   <p class="indent2">
-   <code>
-    SKILL.2.EXPLAIN
-   </code>
+   <code>SKILL.2.EXPLAIN</code>
   </p>
   <p class="indent3">
    Displays the make-up of the misc modifier in the
@@ -3327,9 +2881,7 @@ not from the key ability score or ranks (e.g. A synergy bonus).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SKILLLEVEL.1.TOTAL
-   </code>
+   <code>SKILLLEVEL.1.TOTAL</code>
   </p>
   <p class="indent3">
    Displays skill points gained at level 1.
@@ -3358,9 +2910,7 @@ adjustment.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SKILLLISTMODS
-   </code>
+   <code>SKILLLISTMODS</code>
   </p>
   <p class="indent3">
    Displays a list of all skills with a non-zero
@@ -3384,23 +2934,17 @@ adjustment.
   </p>
   <ul class="indent2">
    <li>
-    <code>
-     TOTAL
-    </code>
+    <code>TOTAL</code>
     - Displays the total skill points the
 character has.
    </li>
    <li>
-    <code>
-     USED
-    </code>
+    <code>USED</code>
     - Displays the number of skill points that
 have been assigned to skills.
    </li>
    <li>
-    <code>
-     UNUSED
-    </code>
+    <code>UNUSED</code>
     - Displays the number of skill points that
 remain unassigned.
    </li>
@@ -3428,18 +2972,14 @@ single class or the character.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SKILLPOINTS.TOTAL
-   </code>
+   <code>SKILLPOINTS.TOTAL</code>
   </p>
   <p class="indent3">
    Displays the total skill points the character
 has.
   </p>
   <p class="indent2">
-   <code>
-    SKILLPOINTS.TOTAL.0
-   </code>
+   <code>SKILLPOINTS.TOTAL.0</code>
   </p>
   <p class="indent3">
    Displays the total skill points the character
@@ -3509,24 +3049,18 @@ designated skill or for the "x"th skill in the character's skill
 list. The properties allowed are:
     <ul>
      <li>
-      <code>
-       ABILITY
-      </code>
+      <code>ABILITY</code>
       - Displays the key ability (stat) for the
 skill in position "x" in the character's skill list.
      </li>
      <li>
-      <code>
-       ABMOD
-      </code>
+      <code>ABMOD</code>
       - Displays the modifier from the key
 ability, for the skill in position "x" in the character's skill
 list.
      </li>
      <li>
-      <code>
-       ACP
-      </code>
+      <code>ACP</code>
       s,t,u,v - Displays the Armor Check Penalty for
 the skill in position "x".
       <ul>
@@ -3547,93 +3081,67 @@ Swim
       </ul>
      </li>
      <li>
-      <code>
-       CLASS
-      </code>
+      <code>CLASS</code>
       - Displays a list of the character's classes
 that have this skill as a class skill.
      </li>
      <li>
-      <code>
-       EXCLUSIVE
-      </code>
+      <code>EXCLUSIVE</code>
       - Displays "Y" if the skill is an
 exlusive class skill and "N" if it is not.
      </li>
      <li>
-      <code>
-       EXCLUSIVE_TOTAL
-      </code>
+      <code>EXCLUSIVE_TOTAL</code>
       - Displays "0" if the skill is
 exclusive, not usable untrained and has 0 ranks.
      </li>
      <li>
-      <code>
-       EXPLAIN
-      </code>
+      <code>EXPLAIN</code>
       - Displays the make-up of the misc
 modifier in an abbreviated format.
      </li>
      <li>
-      <code>
-       EXPLAIN_LONG
-      </code>
+      <code>EXPLAIN_LONG</code>
       - Displays the make-up of the misc
 modifier in a verbose format.
      </li>
      <li>
-      <code>
-       MISC
-      </code>
+      <code>MISC</code>
       - equals TOTAL - RANK - ABMOD.
      </li>
      <li>
-      <code>
-       MOD
-      </code>
+      <code>MOD</code>
       - Displays the total modifiers from abilities,
 equipment, etc.? of the skill in position x in the character's
 skill list.
      </li>
      <li>
-      <code>
-       RANK
-      </code>
+      <code>RANK</code>
       - Displays the number of skill ranks of the
 skill in position x in the character's skill list.
      </li>
      <li>
-      <code>
-       SIZE
-      </code>
+      <code>SIZE</code>
       - Displays the character's size modifier as
 applied to the skill.
      </li>
      <li>
-      <code>
-       TOTAL
-      </code>
+      <code>TOTAL</code>
       - Displays the total bonus for the skill in
 position x in the character's skill list.
      </li>
      <li>
-      <code>
-       TRAINED_TOTAL
-      </code>
+      <code>TRAINED_TOTAL</code>
       - Displays "0" if the skill is not
 usable untrained and has 0 ranks.
      </li>
      <li>
-      <code>
-       TYPE
-      </code>
+      <code>TYPE</code>
       - Displays the type of the skill in position
 x in the character's skill list.
      </li>
      <li>
-      <code>
-       UNTRAINED
-      </code>
+      <code>UNTRAINED</code>
       - Displays "Y" if the skill can be used
 untrained and "N" if it cannot.
      </li>
@@ -3646,9 +3154,7 @@ untrained and "N" if it cannot.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SKILLSIT.0.ABILITY
-   </code>
+   <code>SKILLSIT.0.ABILITY</code>
   </p>
   <p class="indent3">
    Displays the key ability name for the
@@ -3660,9 +3166,7 @@ untrained and "N" if it cannot.
 that skill.
   </p>
   <p class="indent2">
-   <code>
-    SKILLSIT.2.TOTAL
-   </code>
+   <code>SKILLSIT.2.TOTAL</code>
   </p>
   <p class="indent3">
    Displays the total bonus for the 3
@@ -3708,73 +3212,53 @@ index).
 character's skill list.
    </li>
    <li>
-    <code>
-     ABILITY
-    </code>
+    <code>ABILITY</code>
     - Displays the key ability for the skill
 in position x in the character's skill list.
    </li>
    <li>
-    <code>
-     ABMOD
-    </code>
+    <code>ABMOD</code>
     - Displays the modifier from the key
 ability, for the skill in position x in the character's skill
 list.
    </li>
    <li>
-    <code>
-     EXCLUSIVE
-    </code>
+    <code>EXCLUSIVE</code>
     - Displays "Y" if the skill is an
 exlusive class skill and "N" if it is not.
    </li>
    <li>
-    <code>
-     EXCLUSIVE_TOTAL
-    </code>
+    <code>EXCLUSIVE_TOTAL</code>
     - Displays "0" if the skill is
 exclusive, not usable untrained and has 0 ranks.
    </li>
    <li>
-    <code>
-     MISC
-    </code>
+    <code>MISC</code>
     - equals TOTAL - RANK - ABMOD.
    </li>
    <li>
-    <code>
-     MOD
-    </code>
+    <code>MOD</code>
     - Displays the total modifiers from abilities,
 equipment, etc.? of the skill in position x in the character's
 skill list.
    </li>
    <li>
-    <code>
-     RANK
-    </code>
+    <code>RANK</code>
     - Displays the number of skill ranks of the
 skill in position x in the character's skill list.
    </li>
    <li>
-    <code>
-     TOTAL
-    </code>
+    <code>TOTAL</code>
     - Displays the total bonus for the skill in
 position x in the character's skill list.
    </li>
    <li>
-    <code>
-     TRAINED_TOTAL
-    </code>
+    <code>TRAINED_TOTAL</code>
     - Displays "0" if the skill is not
 usable untrained and has 0 ranks.
    </li>
    <li>
-    <code>
-     UNTRAINED
-    </code>
+    <code>UNTRAINED</code>
     - Displays "Y" if the skill can be used
 untrained and "N" if it cannot.
    </li>
@@ -3796,9 +3280,7 @@ comparing subname to the beginning of the skill name, if they match
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SKILLSUBSET.2.KNOWLEDGE.RANK
-   </code>
+   <code>SKILLSUBSET.2.KNOWLEDGE.RANK</code>
   </p>
   <p class="indent3">
    Displays the number of skill ranks of the
@@ -3809,9 +3291,7 @@ comparing subname to the beginning of the skill name, if they match
    knowledge skill in the character's skill list.
   </p>
   <p class="indent2">
-   <code>
-    SKILLSUBSET.2.KNOWLEDGE.MISC
-   </code>
+   <code>SKILLSUBSET.2.KNOWLEDGE.MISC</code>
   </p>
   <p class="indent3">
    Displays the miscelaneous bonus for the
@@ -3857,80 +3337,58 @@ index).
   </p>
   <ul class="indent2">
    <li>
-    <code>
-     ABILITY
-    </code>
+    <code>ABILITY</code>
     - Displays the key ability for the skill
 in position x in the character's skill list.
    </li>
    <li>
-    <code>
-     ABMOD
-    </code>
+    <code>ABMOD</code>
     - Displays the modifier from the key
 ability, for the skill in position x in the character's skill
 list.
    </li>
    <li>
-    <code>
-     EXCLUSIVE
-    </code>
+    <code>EXCLUSIVE</code>
     - Displays "Y" if the skill is an
 exlusive class skill and "N" if it is not.
    </li>
    <li>
-    <code>
-     EXCLUSIVE_TOTAL
-    </code>
+    <code>EXCLUSIVE_TOTAL</code>
     - Displays "0" if the skill is
 exclusive, not usable untrained and has 0 ranks.
    </li>
    <li>
-    <code>
-     MISC
-    </code>
+    <code>MISC</code>
     - equals TOTAL - RANK - ABMOD.
    </li>
    <li>
-    <code>
-     MOD
-    </code>
+    <code>MOD</code>
     - Displays the total modifiers from abilities,
 equipment, etc.? of the skill in position x in the character's
 skill list.
    </li>
    <li>
-    <code>
-     NAME
-    </code>
+    <code>NAME</code>
     - Displays the name of the skill in position
 x in the character's skill list.
    </li>
    <li>
-    <code>
-     RANK
-    </code>
+    <code>RANK</code>
     - Displays the number of skill ranks of the
 skill in position x in the character's skill list.
    </li>
    <li>
-    <code>
-     TOTAL
-    </code>
+    <code>TOTAL</code>
     - Displays the total bonus for the skill in
 position x in the character's skill list.
    </li>
    <li>
-    <code>
-     TRAINED_TOTAL
-    </code>
+    <code>TRAINED_TOTAL</code>
     - Displays "0" if the skill is not
 usable untrained and has 0 ranks.
    </li>
    <li>
-    <code>
-     UNTRAINED
-    </code>
+    <code>UNTRAINED</code>
     - Displays "Y" if the skill can be used
 untrained and "N" if it cannot.
    </li>
@@ -3953,18 +3411,14 @@ the subtype the skill is in the subset.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SKILLTYPE.0.DEX.NAME
-   </code>
+   <code>SKILLTYPE.0.DEX.NAME</code>
   </p>
   <p class="indent3">
    Displays the name of skill of the 1st skill in
 the character's skill list.
   </p>
   <p class="indent2">
-   <code>
-    SKILLTYPE.1.DEX.TOTAL
-   </code>
+   <code>SKILLTYPE.1.DEX.TOTAL</code>
   </p>
   <p class="indent3">
    Displays the total numbrer of skills from the
@@ -3997,91 +3451,67 @@ templates position in the character's complete template list -
   </p>
   <ul class="indent2">
    <li>
-    <code>
-     NAME
-    </code>
+    <code>NAME</code>
     - Displays the name of the template at
 position x the characters list of templates.
    </li>
    <li>
-    <code>
-     CHAMOD
-    </code>
+    <code>CHAMOD</code>
     - Displays the Charisma Modifier granted by
 the template at position x in the characters list of
 templates.
    </li>
    <li>
-    <code>
-     CONMOD
-    </code>
+    <code>CONMOD</code>
     - Displays the Constitution Modifier
 granted by the template at position x in the characters list of
 templates.
    </li>
    <li>
-    <code>
-     CR
-    </code>
+    <code>CR</code>
     - Displays the Challenge Rating granted by the
 template at position x in the characters list of templates.
    </li>
    <li>
-    <code>
-     DEXMOD
-    </code>
+    <code>DEXMOD</code>
     - Displays the Dexterity Modifier granted
 by the template at position x in the characters list of
 templates.
    </li>
    <li>
-    <code>
-     DR
-    </code>
+    <code>DR</code>
     - Displays the Damage Reduction granted by the
 template at position x in the characters list of templates.
    </li>
    <li>
-    <code>
-     FEAT
-    </code>
+    <code>FEAT</code>
     - Displays the Feats granted by the template
 at position x in the characters list of templates.
    </li>
    <li>
-    <code>
-     INTMOD
-    </code>
+    <code>INTMOD</code>
     - Displays the Intelligence Modifier
 granted by the template at position x in the characters list of
 templates.
    </li>
    <li>
-    <code>
-     SA
-    </code>
+    <code>SA</code>
     - Displays the Special Abilities granted by the
 template at position x in the characters list of templates.
    </li>
    <li>
-    <code>
-     SR
-    </code>
+    <code>SR</code>
     - Displays the Spell Resistance granted by the
 template at position x in the characters list of templates.
    </li>
    <li>
-    <code>
-     STRMOD
-    </code>
+    <code>STRMOD</code>
     - Displays the Strength Modifier granted by
 the template at position x in the characters list of
 templates.
    </li>
    <li>
-    <code>
-     WISMOD
-    </code>
+    <code>WISMOD</code>
     - Displays the Wisdom Modifier granted by
 the template at position x in the characters list of
 templates.
@@ -4102,9 +3532,7 @@ to the character.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TEMPLATE0.NAME
-   </code>
+   <code>TEMPLATE0.NAME</code>
   </p>
   <p class="indent3">
    Displays the name of the 1
@@ -4115,9 +3543,7 @@ to the character.
 in the characters list of templates.
   </p>
   <p class="indent2">
-   <code>
-    TEMPLATE0.STRMOD
-   </code>
+   <code>TEMPLATE0.STRMOD</code>
   </p>
   <p class="indent3">
    Displays the Strength Modifiaction granted by
@@ -4152,9 +3578,7 @@ list.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TEMPLATELIST
-   </code>
+   <code>TEMPLATELIST</code>
   </p>
   <p class="indent3">
    Displays your templates in a comma delimited
@@ -4239,23 +3663,17 @@ after filtering (see below) for ability category (u), visibility
 (v) of each ability. The allowed visibility sub-tokens are:
     <ul>
      <li>
-      <code>
-       VISIBLE
-      </code>
+      <code>VISIBLE</code>
       - Filter the abilities that are visible in
 the outputsheets (default option).
      </li>
      <li>
-      <code>
-       HIDDEN
-      </code>
+      <code>HIDDEN</code>
       - Filter the abilities that are not visible
 in the outputsheets.
      </li>
      <li>
-      <code>
-       ALL
-      </code>
+      <code>ALL</code>
       - Shows all abilities.
      </li>
     </ul>
@@ -4270,33 +3688,25 @@ default will be to include abilities of all types.
      </li>
      <li>
       If you use the type syntax
-      <code>
-       &lt;Text&gt;
-      </code>
+      <code>&lt;Text&gt;</code>
       (w), you
 MUST place the type before the ability position (x).
      </li>
      <li>
       If you use the type syntax
-      <code>
-       TYPE=&lt;Text&gt;
-      </code>
+      <code>TYPE=&lt;Text&gt;</code>
       (y),
 you MUST place the type after the ability position (x) and before
 the property (z).
      </li>
      <li>
       You may include more than one
-      <code>
-       TYPE=&lt;Text&gt;
-      </code>
+      <code>TYPE=&lt;Text&gt;</code>
       sub-tokens in this token.
      </li>
      <li>
       You may use
-      <code>
-       !TYPE=&lt;Text&gt;
-      </code>
+      <code>!TYPE=&lt;Text&gt;</code>
       to exclude the
 particular type from the list.
      </li>
@@ -4334,101 +3744,73 @@ filtering.
 identified ability:
     <ul>
      <li>
-      <code>
-       ASPECT
-      </code>
+      <code>ASPECT</code>
       - Displays the comma-delimited list of
 aspects associated with the ability.
      </li>
      <li>
-      <code>
-       ASPECT.&lt;number&gt;
-      </code>
+      <code>ASPECT.&lt;number&gt;</code>
       - Displays the name/value of
 the numbered aspect, on a zero-based index of aspects, associated
 with the ability.
      </li>
      <li>
-      <code>
-       ASPECT.&lt;text&gt;
-      </code>
+      <code>ASPECT.&lt;text&gt;</code>
       - Displays the value of the
 named aspect associated with the ability.
      </li>
      <li>
-      <code>
-       ASPECTCOUNT
-      </code>
+      <code>ASPECTCOUNT</code>
       - Returns the total number of aspects
 associated with the ability.
      </li>
      <li>
-      <code>
-       HASASPECT
-      </code>
+      <code>HASASPECT</code>
       - Returns a boolean result on the named
 aspect in association with the ability.
      </li>
      <li>
-      <code>
-       ASSOCIATED
-      </code>
+      <code>ASSOCIATED</code>
       - Displays a comma separated list of
 the associated values (i.e. choices) of the ability.
      </li>
      <li>
-      <code>
-       ASSOCIATED.&lt;number&gt;
-      </code>
+      <code>ASSOCIATED.&lt;number&gt;</code>
       - Displays the numbered
 associated value (i.e. choice) of the ability. This can be combined
 with ASSOCIATEDCOUNT to loop through the choices.
      </li>
      <li>
-      <code>
-       ASSOCIATEDCOUNT
-      </code>
+      <code>ASSOCIATEDCOUNT</code>
       - Returns the total number of
 associated values (i.e. choices) of the ability.
      </li>
      <li>
-      <code>
-       BENEFIT
-      </code>
+      <code>BENEFIT</code>
       - Displays the benefit of the
 ability.
      </li>
      <li>
-      <code>
-       DESC
-      </code>
+      <code>DESC</code>
       - Displays the description of the
 ability.
      </li>
      <li>
-      <code>
-       KEY
-      </code>
+      <code>KEY</code>
       - Displays the internal key of the
 ability.
      </li>
      <li>
-      <code>
-       NAME
-      </code>
+      <code>NAME</code>
       - Displays the display name of the ability
 without any choices etc included.
      </li>
      <li>
-      <code>
-       SOURCE
-      </code>
+      <code>SOURCE</code>
       - Displays the source of the ability.
      </li>
      <li>
-      <code>
-       TYPE
-      </code>
+      <code>TYPE</code>
       - Displays the type of the ability.
      </li>
     </ul>
@@ -4440,9 +3822,7 @@ without any choices etc included.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    VABILITY.Fighter.0
-   </code>
+   <code>VABILITY.Fighter.0</code>
   </p>
   <p class="indent3">
    Displays the name of the 1
@@ -4453,9 +3833,7 @@ without any choices etc included.
 ability in the character's fighter ability list.
   </p>
   <p class="indent2">
-   <code>
-    VABILITY.Fighter.0.DESC
-   </code>
+   <code>VABILITY.Fighter.0.DESC</code>
   </p>
   <p class="indent3">
    Displays the description of the 1
@@ -4465,9 +3843,7 @@ ability in the character's fighter ability list.
    virtual ability in the character's fighter ability list.
   </p>
   <p class="indent2">
-   <code>
-    VABILITY.FEAT.2.TYPE=Fighter
-   </code>
+   <code>VABILITY.FEAT.2.TYPE=Fighter</code>
   </p>
   <p class="indent3">
    Displays the name of the 3
@@ -4478,9 +3854,7 @@ ability in the character's fighter ability list.
 ability in the character's fighter feat list.
   </p>
   <p class="indent2">
-   <code>
-    VABILITY.FEAT.2.!TYPE=Fighter.TYPE
-   </code>
+   <code>VABILITY.FEAT.2.!TYPE=Fighter.TYPE</code>
   </p>
   <p class="indent3">
    Displays the type of the 3
@@ -4491,9 +3865,7 @@ ability in the character's fighter feat list.
 ability in the character's list of non-fighter feats.
   </p>
   <p class="indent2">
-   <code>
-    VABILITY.Power.0.ASPECT
-   </code>
+   <code>VABILITY.Power.0.ASPECT</code>
   </p>
   <p class="indent3">
    Displays the list of "aspects" for the
@@ -4504,9 +3876,7 @@ ability in the character's list of non-fighter feats.
    virtual "Power" category ability.
   </p>
   <p class="indent2">
-   <code>
-    VABILITY.Power.0.ASPECT.0
-   </code>
+   <code>VABILITY.Power.0.ASPECT.0</code>
   </p>
   <p class="indent3">
    Displays the name and value of the
@@ -4522,10 +3892,8 @@ ability in the character's list of non-fighter feats.
 category ability.
   </p>
   <p class="indent2">
-   <code>
-    VABILITY.Power.0.ASPECT.Attack
-Type
-   </code>
+   <code>VABILITY.Power.0.ASPECT.Attack
+Type</code>
   </p>
   <p class="indent3">
    Displays the value of the "Attack Type" aspect
@@ -4536,9 +3904,7 @@ for the 1
    virtual "Power" category ability.
   </p>
   <p class="indent2">
-   <code>
-    ABILITY.Power.0.ASPECTCOUNT
-   </code>
+   <code>ABILITY.Power.0.ASPECTCOUNT</code>
   </p>
   <p class="indent3">
    Returns the number of aspects associated with
@@ -4549,9 +3915,7 @@ the 1
    virtual "Power" category ability.
   </p>
   <p class="indent2">
-   <code>
-    ABILITY.Power.0.HASASPECT.Miss
-   </code>
+   <code>ABILITY.Power.0.HASASPECT.Miss</code>
   </p>
   <p class="indent3">
    Returns a boolean result of "Y" if the
@@ -4626,18 +3990,14 @@ variables.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    VABILITYLIST.RACIAL
-   </code>
+   <code>VABILITYLIST.RACIAL</code>
   </p>
   <p class="indent3">
    Displays all of the character's virtual racial
 abilities (comma delimited).
   </p>
   <p class="indent2">
-   <code>
-    VABILITYLIST.FEAT.TYPE=Fighter
-   </code>
+   <code>VABILITYLIST.FEAT.TYPE=Fighter</code>
   </p>
   <p class="indent3">
    Displays all of the character's virtual feats
@@ -4714,23 +4074,17 @@ filtering (see below) for visibility (v) and type (w and y).
 of each feat. The allowed visibility sub-tokens are:
     <ul>
      <li>
-      <code>
-       VISIBLE
-      </code>
+      <code>VISIBLE</code>
       - Filter the feats that are visible in the
 outputsheets (default option).
      </li>
      <li>
-      <code>
-       HIDDEN
-      </code>
+      <code>HIDDEN</code>
       - Filter the feats that are not visible in
 the outputsheets.
      </li>
      <li>
-      <code>
-       ALL
-      </code>
+      <code>ALL</code>
       - Shows all feats.
      </li>
     </ul>
@@ -4745,33 +4099,25 @@ default will be to include feats of all types.
      </li>
      <li>
       If you use the type syntax
-      <code>
-       &lt;Text&gt;
-      </code>
+      <code>&lt;Text&gt;</code>
       (w), you
 MUST place the type before the feat position (x).
      </li>
      <li>
       If you use the type syntax
-      <code>
-       TYPE=&lt;Text&gt;
-      </code>
+      <code>TYPE=&lt;Text&gt;</code>
       (y),
 you MUST place the type after the feat position (x) and before the
 property (z).
      </li>
      <li>
       You may include more than one
-      <code>
-       TYPE=&lt;Text&gt;
-      </code>
+      <code>TYPE=&lt;Text&gt;</code>
       sub-tokens in this token.
      </li>
      <li>
       You may use
-      <code>
-       !TYPE=&lt;Text&gt;
-      </code>
+      <code>!TYPE=&lt;Text&gt;</code>
       to exclude the
 particular type from the list.
      </li>
@@ -4809,101 +4155,73 @@ filtering.
 identified feat:
     <ul>
      <li>
-      <code>
-       ASPECT
-      </code>
+      <code>ASPECT</code>
       - Displays the comma-delimited list of
 aspects associated with the feat.
      </li>
      <li>
-      <code>
-       ASPECT.&lt;number&gt;
-      </code>
+      <code>ASPECT.&lt;number&gt;</code>
       - Displays the name/value of
 the numbered aspect, on a zero-based index of aspects, associated
 with the feat.
      </li>
      <li>
-      <code>
-       ASPECT.&lt;text&gt;
-      </code>
+      <code>ASPECT.&lt;text&gt;</code>
       - Displays the value of the
 named aspect associated with the feat.
      </li>
      <li>
-      <code>
-       ASPECTCOUNT
-      </code>
+      <code>ASPECTCOUNT</code>
       - Returns the total number of aspects
 associated with the feat.
      </li>
      <li>
-      <code>
-       HASASPECT
-      </code>
+      <code>HASASPECT</code>
       - Returns a boolean result on the named
 aspect in association with the feat.
      </li>
      <li>
-      <code>
-       ASSOCIATED
-      </code>
+      <code>ASSOCIATED</code>
       - Displays a comma separated list of
 the associated values (i.e. choices) of the ability.
      </li>
      <li>
-      <code>
-       ASSOCIATED.&lt;number&gt;
-      </code>
+      <code>ASSOCIATED.&lt;number&gt;</code>
       - Displays the numbered
 associated value (i.e. choice) of the ability. This can be combined
 with ASSOCIATEDCOUNT to loop through the choices.
      </li>
      <li>
-      <code>
-       ASSOCIATEDCOUNT
-      </code>
+      <code>ASSOCIATEDCOUNT</code>
       - Returns the total number of
 associated values (i.e. choices) of the ability.
      </li>
      <li>
-      <code>
-       BENEFIT
-      </code>
+      <code>BENEFIT</code>
       - Displays the benefit of the
 ability.
      </li>
      <li>
-      <code>
-       DESC
-      </code>
+      <code>DESC</code>
       - Displays the description of the
 ability.
      </li>
      <li>
-      <code>
-       KEY
-      </code>
+      <code>KEY</code>
       - Displays the internal key of the
 ability.
      </li>
      <li>
-      <code>
-       NAME
-      </code>
+      <code>NAME</code>
       - Displays the display name of the ability
 without any choices etc included.
      </li>
      <li>
-      <code>
-       SOURCE
-      </code>
+      <code>SOURCE</code>
       - Displays the source of the ability.
      </li>
      <li>
-      <code>
-       TYPE
-      </code>
+      <code>TYPE</code>
       - Displays the type of the ability.
      </li>
     </ul>
@@ -4915,9 +4233,7 @@ without any choices etc included.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    VFEAT.0
-   </code>
+   <code>VFEAT.0</code>
   </p>
   <p class="indent3">
    Displays the name of the 1
@@ -4928,9 +4244,7 @@ without any choices etc included.
 the character's virtual feat list.
   </p>
   <p class="indent2">
-   <code>
-    VFEAT.0.DESC
-   </code>
+   <code>VFEAT.0.DESC</code>
   </p>
   <p class="indent3">
    Displays the description of the 1
@@ -4940,9 +4254,7 @@ the character's virtual feat list.
    feat in the character's virtual feat list.
   </p>
   <p class="indent2">
-   <code>
-    VFEAT.2.TYPE=Fighter
-   </code>
+   <code>VFEAT.2.TYPE=Fighter</code>
   </p>
   <p class="indent3">
    Displays the name of the 3
@@ -4953,9 +4265,7 @@ the character's virtual feat list.
 feat in the character's virtual feat list.
   </p>
   <p class="indent2">
-   <code>
-    VFEAT.2.!TYPE=Fighter.TYPE
-   </code>
+   <code>VFEAT.2.!TYPE=Fighter.TYPE</code>
   </p>
   <p class="indent3">
    Displays the type of the 3
@@ -4965,9 +4275,7 @@ feat in the character's virtual feat list.
    non-fighter feat in the character's virtual feat list.
   </p>
   <p class="indent2">
-   <code>
-    VFEAT.0.ASPECT
-   </code>
+   <code>VFEAT.0.ASPECT</code>
   </p>
   <p class="indent3">
    Displays the list of "aspects" for the
@@ -4978,9 +4286,7 @@ feat in the character's virtual feat list.
    virtual feat.
   </p>
   <p class="indent2">
-   <code>
-    VFEAT.0.ASPECT.0
-   </code>
+   <code>VFEAT.0.ASPECT.0</code>
   </p>
   <p class="indent3">
    Displays the name and value of the
@@ -4995,9 +4301,7 @@ feat in the character's virtual feat list.
    virtual feat.
   </p>
   <p class="indent2">
-   <code>
-    VFEAT.0.ASPECT.Attack Type
-   </code>
+   <code>VFEAT.0.ASPECT.Attack Type</code>
   </p>
   <p class="indent3">
    Displays the value of the "Attack Type" aspect
@@ -5008,9 +4312,7 @@ for the 1
    virtual feat.
   </p>
   <p class="indent2">
-   <code>
-    VFEAT.0.ASPECTCOUNT
-   </code>
+   <code>VFEAT.0.ASPECTCOUNT</code>
   </p>
   <p class="indent3">
    Returns the number of aspects associated with
@@ -5021,9 +4323,7 @@ the 1
    virtual feat.
   </p>
   <p class="indent2">
-   <code>
-    VFEAT.0.HASASPECT.Miss
-   </code>
+   <code>VFEAT.0.HASASPECT.Miss</code>
   </p>
   <p class="indent3">
    Returns a boolean result of "Y" if the
@@ -5092,18 +4392,14 @@ variables.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    VFEATLIST
-   </code>
+   <code>VFEATLIST</code>
   </p>
   <p class="indent3">
    Displays all of the character's virtual feats
 (comma delimited).
   </p>
   <p class="indent2">
-   <code>
-    VFEATLIST.TYPE=Fighter
-   </code>
+   <code>VFEATLIST.TYPE=Fighter</code>
   </p>
   <p class="indent3">
    Displays all of the character's virtual feats

--- a/docs/outputsheetpages/tokens/outputsheettokensgeneral.html
+++ b/docs/outputsheetpages/tokens/outputsheettokensgeneral.html
@@ -50,9 +50,7 @@ Name:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    AGE
-   </code>
+   <code>AGE</code>
   </p>
   <p class="indent3">
    Displays characters age.
@@ -86,9 +84,7 @@ Name:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    AGE.CATEGORY
-   </code>
+   <code>AGE.CATEGORY</code>
   </p>
   <p class="indent3">
    Displays characters age category.
@@ -118,9 +114,7 @@ Lawful Good, Chaotic Evil, None etc.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ALIGNMENT
-   </code>
+   <code>ALIGNMENT</code>
   </p>
   <p class="indent3">
    Displays characters alignment as full words.
@@ -149,9 +143,7 @@ Lawful Good, Chaotic Evil, None etc.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ALIGNMENT.SHORT
-   </code>
+   <code>ALIGNMENT.SHORT</code>
   </p>
   <p class="indent3">
    Displays characters alignment as 2 letters or
@@ -175,9 +167,7 @@ Name:
   <p class="indent2">
    Displays characters Alternate Hit Points as
 defined by the
-   <code>
-    BONUS:HP|ALTHP|x
-   </code>
+   <code>BONUS:HP|ALTHP|x</code>
    tag. This is used in
 gameModes which uses two separate categories of hit points such as
 Spycraft which uses Wound Points and Vitality Points.
@@ -188,9 +178,7 @@ Spycraft which uses Wound Points and Vitality Points.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ALTHP
-   </code>
+   <code>ALTHP</code>
   </p>
   <p class="indent3">
    Displays characters Alternate Hit Points.
@@ -223,9 +211,7 @@ appended to the end of each new line.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BIO
-   </code>
+   <code>BIO</code>
   </p>
   <p class="indent3">
    Display characters biography. Note that for each
@@ -245,27 +231,21 @@ newline in the BIO the OS creates a gap. e.g.
    <br/>
   </p>
   <p class="indent2">
-   <code>
-    BIO,Text
-   </code>
+   <code>BIO,Text</code>
   </p>
   <p class="indent3">
    Display characters biography and appends the
 word 'Text' at the end of each new line.
   </p>
   <p class="indent2">
-   <code>
-    BIO.beforevalue
-   </code>
+   <code>BIO.beforevalue</code>
   </p>
   <p class="indent3">
    Display characters biography but prefixes
 beforevalue for each new line.
   </p>
   <p class="indent2">
-   <code>
-    BIO.beforevalue.aftervalue
-   </code>
+   <code>BIO.beforevalue.aftervalue</code>
   </p>
   <p class="indent3">
    Display characters biography but prefixes
@@ -295,9 +275,7 @@ Name:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BIRTHDAY
-   </code>
+   <code>BIRTHDAY</code>
   </p>
   <p class="indent3">
    Display characters birthday.
@@ -325,9 +303,7 @@ Name:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CATCHPHRASE
-   </code>
+   <code>CATCHPHRASE</code>
   </p>
   <p class="indent3">
    Display characters catch phrase.
@@ -427,18 +403,14 @@ entries after filtering (see above) for visibility (v).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CAMPAIGNHISTORY.0
-   </code>
+   <code>CAMPAIGNHISTORY.0</code>
   </p>
   <p class="indent3">
    Output the text of the 1st (top-most) campaign
 history entry that is marked for export.
   </p>
   <p class="indent2">
-   <code>
-    CAMPAIGNHISTORY.ALL.0.CAMPAIGN
-   </code>
+   <code>CAMPAIGNHISTORY.ALL.0.CAMPAIGN</code>
   </p>
   <p class="indent3">
    Output the campaign name from the 1st (top-most)
@@ -476,9 +448,7 @@ export.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHARACTERTYPE
-   </code>
+   <code>CHARACTERTYPE</code>
   </p>
   <p class="indent3">
    Display the character's type.
@@ -541,17 +511,13 @@ index).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CLASS.0
-   </code>
+   <code>CLASS.0</code>
   </p>
   <p class="indent3">
    Displays the name of the 1st class.
   </p>
   <p class="indent2">
-   <code>
-    CLASS.0.LEVEL
-   </code>
+   <code>CLASS.0.LEVEL</code>
   </p>
   <p class="indent3">
    Displays the level of the 1st class.
@@ -589,9 +555,7 @@ class.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CLASSABB.0
-   </code>
+   <code>CLASSABB.0</code>
   </p>
   <p class="indent3">
    Displays the abbreviated name of the 1st
@@ -622,9 +586,7 @@ classes including their levels.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CLASSLIST
-   </code>
+   <code>CLASSLIST</code>
   </p>
   <p class="indent3">
    Displays a comma delimited list of all your
@@ -672,25 +634,19 @@ Name:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    COLOR.EYE
-   </code>
+   <code>COLOR.EYE</code>
   </p>
   <p class="indent3">
    Display characters eye color.
   </p>
   <p class="indent2">
-   <code>
-    COLOR.HAIR
-   </code>
+   <code>COLOR.HAIR</code>
   </p>
   <p class="indent3">
    Display characters hair color.
   </p>
   <p class="indent2">
-   <code>
-    COLOR.SKIN
-   </code>
+   <code>COLOR.SKIN</code>
   </p>
   <p class="indent3">
    Display characters skin color.
@@ -719,9 +675,7 @@ Name:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CR
-   </code>
+   <code>CR</code>
   </p>
   <p class="indent3">
    Displays characters Chalenge Rating.
@@ -801,9 +755,7 @@ alignments.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DEITY.DESCRIPTION
-   </code>
+   <code>DEITY.DESCRIPTION</code>
   </p>
   <p class="indent3">
    Prints the deity description.
@@ -836,17 +788,13 @@ appended to the end of each new line.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DESC
-   </code>
+   <code>DESC</code>
   </p>
   <p class="indent3">
    Display characters description.
   </p>
   <p class="indent2">
-   <code>
-    DESC,Text
-   </code>
+   <code>DESC,Text</code>
   </p>
   <p class="indent3">
    Display characters description and appends the
@@ -900,9 +848,7 @@ selected domains.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DOMAIN.1
-   </code>
+   <code>DOMAIN.1</code>
   </p>
   <p class="indent3">
    Displays the name of the 2
@@ -912,9 +858,7 @@ selected domains.
    domain.
   </p>
   <p class="indent2">
-   <code>
-    DOMAIN.1.POWER
-   </code>
+   <code>DOMAIN.1.POWER</code>
   </p>
   <p class="indent3">
    Displays the domain powers of the 2
@@ -947,9 +891,7 @@ Name:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DR
-   </code>
+   <code>DR</code>
   </p>
   <p class="indent3">
    Displays characters damage reduction.
@@ -979,9 +921,7 @@ Level.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    ECL
-   </code>
+   <code>ECL</code>
   </p>
   <p class="indent3">
    Displays characters Effective Character
@@ -1034,9 +974,7 @@ Points.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    EXP.CURRENT
-   </code>
+   <code>EXP.CURRENT</code>
   </p>
   <p class="indent3">
    Displays current Experience Points.
@@ -1096,9 +1034,7 @@ integers (x,y).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    FACE.SHORT
-   </code>
+   <code>FACE.SHORT</code>
   </p>
   <p class="indent3">
    Displays the characters Face or Space
@@ -1128,9 +1064,7 @@ favored classes.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    FAVOREDLIST
-   </code>
+   <code>FAVOREDLIST</code>
   </p>
   <p class="indent3">
    Displays a comma delimited list of all your
@@ -1176,9 +1110,7 @@ the specified follower.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    FOLLOWER0.RACE
-   </code>
+   <code>FOLLOWER0.RACE</code>
   </p>
   <p class="indent3">
    Displays the 1
@@ -1188,9 +1120,7 @@ the specified follower.
    followers race.
   </p>
   <p class="indent2">
-   <code>
-    FOLLOWER0.GENDER.LONG
-   </code>
+   <code>FOLLOWER0.GENDER.LONG</code>
   </p>
   <p class="indent3">
    Displays the 1
@@ -1224,9 +1154,7 @@ names.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    FOLLOWERLIST
-   </code>
+   <code>FOLLOWERLIST</code>
   </p>
   <p class="indent3">
    Displays a comma delimited list of follower
@@ -1256,9 +1184,7 @@ and the master's name (e.g. "Familiar of Jorge").
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    FOLLOWEROF
-   </code>
+   <code>FOLLOWEROF</code>
   </p>
   <p class="indent3">
    Displays the type of follower the character is
@@ -1330,9 +1256,7 @@ token to export the proper information.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    FOLLOWERTYPE.FAMILIAR.0.NAME
-   </code>
+   <code>FOLLOWERTYPE.FAMILIAR.0.NAME</code>
   </p>
   <p class="indent3">
    The name of the 1
@@ -1366,9 +1290,7 @@ Name:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    GAMEMODE
-   </code>
+   <code>GAMEMODE</code>
   </p>
   <p class="indent3">
    Displays the current Game Mode.
@@ -1419,9 +1341,7 @@ for Male, F for Female.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    GENDER
-   </code>
+   <code>GENDER</code>
   </p>
   <p class="indent3">
    Displays characters gender as a single letter, M
@@ -1452,9 +1372,7 @@ Items tab.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    GOLD
-   </code>
+   <code>GOLD</code>
   </p>
   <p class="indent3">
    Displays the amount of gold displayed in the
@@ -1485,9 +1403,7 @@ Right Handed.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    HANDED
-   </code>
+   <code>HANDED</code>
   </p>
   <p class="indent3">
    Displays characters handedness, Left Handed,
@@ -1538,9 +1454,7 @@ selected height unit (e.g. 6' 2").
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    HEIGHT
-   </code>
+   <code>HEIGHT</code>
   </p>
   <p class="indent3">
    Displays characters complete height.
@@ -1595,9 +1509,7 @@ format..
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    HITDICE
-   </code>
+   <code>HITDICE</code>
   </p>
   <p class="indent3">
    Displays characters total hit dice.
@@ -1626,9 +1538,7 @@ Name:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    HP
-   </code>
+   <code>HP</code>
   </p>
   <p class="indent3">
    Displays characters Hit Points.
@@ -1657,9 +1567,7 @@ Name:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    INTERESTS
-   </code>
+   <code>INTERESTS</code>
   </p>
   <p class="indent3">
    Display characters interests.
@@ -1710,9 +1618,7 @@ under /character/export in the
     base.xml
    </span>
    , similar to the
-   <code>
-    PAPERINFO
-   </code>
+   <code>PAPERINFO</code>
    token, which is then used in the XSLT code.
   </p>
   <p class="indent1">
@@ -1724,34 +1630,25 @@ under /character/export in the
    Node in base.xml file:
   </p>
   <p class="indent3">
-   <code>
-    &lt;invalidtext&gt;
-   </code>
+   <code>&lt;invalidtext&gt;</code>
    <br/>
   </p>
   <p class="indent3">
-   <code>
-    &lt;tohit&gt;|INVALIDTEXT.TOHIT|&lt;/tohit&gt;
-   </code>
+   <code>&lt;tohit&gt;|INVALIDTEXT.TOHIT|&lt;/tohit&gt;</code>
    <br/>
   </p>
   <p class="indent3">
-   <code>
-    &lt;damage&gt;|INVALIDTEXT.DAMAGE|&lt;/damage&gt;
-   </code>
+   <code>&lt;damage&gt;|INVALIDTEXT.DAMAGE|&lt;/damage&gt;</code>
    <br/>
   </p>
   <p class="indent3">
-   <code>
-    &lt;/invalidtext&gt;
-   </code>
+   <code>&lt;/invalidtext&gt;</code>
   </p>
   <p class="indent2">
    Code in xslt file:
   </p>
   <p class="indent3">
-   <code>
-    &lt;xsl:if test="not(w1_h1_p/to_hit =
+   <code>&lt;xsl:if test="not(w1_h1_p/to_hit =
 /character/export/invalidtext/tohit
     <br/>
     and w1_h1_p/damage = /character/export/invalidtext/damage
@@ -1759,8 +1656,7 @@ under /character/export in the
     and w2_p_oh/to_hit = /character/export/invalidtext/tohit
     <br/>
     and w2_p_oh/damage =
-/character/export/invalidtext/damage)"&gt;
-   </code>
+/character/export/invalidtext/damage)"&gt;</code>
   </p>
   <p class="indent4">
    Displays the invalid to-hit and damage text on
@@ -1807,18 +1703,14 @@ list - 0-based index.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    LANGUAGES
-   </code>
+   <code>LANGUAGES</code>
   </p>
   <p class="indent3">
    Displays a comma delimited list of known
 languages.
   </p>
   <p class="indent2">
-   <code>
-    LANGUAGES.3
-   </code>
+   <code>LANGUAGES.3</code>
   </p>
   <p class="indent3">
    the 3
@@ -1864,9 +1756,7 @@ Name:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    LENGTH.HAIR
-   </code>
+   <code>LENGTH.HAIR</code>
   </p>
   <p class="indent3">
    Display characters hair length.
@@ -1895,9 +1785,7 @@ Name:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    LOCATION
-   </code>
+   <code>LOCATION</code>
   </p>
   <p class="indent3">
    Display characters location.
@@ -1955,9 +1843,7 @@ formating).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    MISC.MAGIC,&lt;br/&gt;
-   </code>
+   <code>MISC.MAGIC,&lt;br/&gt;</code>
   </p>
   <p class="indent3">
    Displays the contents of the Magic the free-form
@@ -2020,9 +1906,7 @@ type.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    MOVE0.NAME
-   </code>
+   <code>MOVE0.NAME</code>
   </p>
   <p class="indent3">
    Displays the name only of the 1
@@ -2055,9 +1939,7 @@ Name:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    MOVEMENT
-   </code>
+   <code>MOVEMENT</code>
   </p>
   <p class="indent3">
    Displays characters movement rate.
@@ -2086,9 +1968,7 @@ Name:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    NAME
-   </code>
+   <code>NAME</code>
   </p>
   <p class="indent3">
    Displays characters name.
@@ -2153,9 +2033,7 @@ note's position in the character's note list - 0-based index).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    NOTE.0.NAME
-   </code>
+   <code>NOTE.0.NAME</code>
   </p>
   <p class="indent3">
    Displays the 1
@@ -2166,9 +2044,7 @@ note's position in the character's note list - 0-based index).
 character's note list.
   </p>
   <p class="indent2">
-   <code>
-    NOTE.0.NAME.&lt;b&gt;.&lt;/b&gt;
-   </code>
+   <code>NOTE.0.NAME.&lt;b&gt;.&lt;/b&gt;</code>
   </p>
   <p class="indent3">
    Displays the 1
@@ -2255,9 +2131,7 @@ want to skip a field you need to put a space between them (e.g.?
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    NOTE.ALL.&lt;b&gt;.&lt;/b&gt;.&lt;br&gt;
-   </code>
+   <code>NOTE.ALL.&lt;b&gt;.&lt;/b&gt;.&lt;br&gt;</code>
   </p>
   <p class="indent3">
    This would bold the header of the note (from the
@@ -2331,9 +2205,7 @@ preferences for the Output Sheet.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PAPERINFO.NAME
-   </code>
+   <code>PAPERINFO.NAME</code>
   </p>
   <p class="indent3">
    Displays the name of the Paper Type defined in
@@ -2385,9 +2257,7 @@ unit is).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PC.HEIGHT
-   </code>
+   <code>PC.HEIGHT</code>
   </p>
   <p class="indent3">
    Display characters height.
@@ -2415,9 +2285,7 @@ unit is).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PERSONALITY.1
-   </code>
+   <code>PERSONALITY.1</code>
   </p>
   <p class="indent3">
    Display characters first personality trait.
@@ -2442,9 +2310,7 @@ unit is).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PERSONALITY.2
-   </code>
+   <code>PERSONALITY.2</code>
   </p>
   <p class="indent3">
    Display characters second personality trait.
@@ -2473,9 +2339,7 @@ Name:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PHOBIAS
-   </code>
+   <code>PHOBIAS</code>
   </p>
   <p class="indent3">
    Display characters phobias.
@@ -2503,9 +2367,7 @@ Name:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PLAYERNAME
-   </code>
+   <code>PLAYERNAME</code>
   </p>
   <p class="indent3">
    Displays Player's Name.
@@ -2550,9 +2412,7 @@ it was done in Purchase Mode.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    POOL.CURRENT
-   </code>
+   <code>POOL.CURRENT</code>
   </p>
   <p class="indent3">
    Displays the remaining stat pool.
@@ -2586,9 +2446,7 @@ on the DESCRIPTION tab.
    </li>
    <li>
     If
-    <code>
-     THUMB
-    </code>
+    <code>THUMB</code>
     is used PCGen outputs the path and file
 name to the generated thumbnail of the portrait selected on the
 DESCRIPTION tab.
@@ -2600,18 +2458,14 @@ DESCRIPTION tab.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PORTRAIT
-   </code>
+   <code>PORTRAIT</code>
   </p>
   <p class="indent3">
    Outputs the path and file name to the portrait
 selected on the DESCRIPTION tab.
   </p>
   <p class="indent2">
-   <code>
-    PORTRAIT.THUMB
-   </code>
+   <code>PORTRAIT.THUMB</code>
   </p>
   <p class="indent3">
    Outputs the path and file name to the thumbnail
@@ -2641,9 +2495,7 @@ Name:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    RACE
-   </code>
+   <code>RACE</code>
   </p>
   <p class="indent3">
    Displays characters race.
@@ -2687,9 +2539,7 @@ index).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    RACESUBTYPE.0
-   </code>
+   <code>RACESUBTYPE.0</code>
   </p>
   <p class="indent3">
    Displays the characters first racial
@@ -2726,9 +2576,7 @@ subtype.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    RACETYPE
-   </code>
+   <code>RACETYPE</code>
   </p>
   <p class="indent3">
    Displays characters race type.
@@ -2757,9 +2605,7 @@ Name:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    REACH
-   </code>
+   <code>REACH</code>
   </p>
   <p class="indent3">
    Displays characters reach.
@@ -2789,9 +2635,7 @@ their region template.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    REGION
-   </code>
+   <code>REGION</code>
   </p>
   <p class="indent3">
    Displays the character's region as defined by
@@ -2821,9 +2665,7 @@ Name:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    RESIDENCE
-   </code>
+   <code>RESIDENCE</code>
   </p>
   <p class="indent3">
    Display characters residence.
@@ -2853,9 +2695,7 @@ single letter.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SIZE
-   </code>
+   <code>SIZE</code>
   </p>
   <p class="indent3">
    Displays your size as a single letter.
@@ -2885,9 +2725,7 @@ Name:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SIZELONG
-   </code>
+   <code>SIZELONG</code>
   </p>
   <p class="indent3">
    Displays your size as a single letter.
@@ -2915,9 +2753,7 @@ Name:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SPEECHTENDENCY
-   </code>
+   <code>SPEECHTENDENCY</code>
   </p>
   <p class="indent3">
    Display characters speechtendency.
@@ -2946,9 +2782,7 @@ Name:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SR
-   </code>
+   <code>SR</code>
   </p>
   <p class="indent3">
    Displays characters spell resistance.
@@ -2978,9 +2812,7 @@ their region template.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SUBREGION
-   </code>
+   <code>SUBREGION</code>
   </p>
   <p class="indent3">
    Displays the character's subregion as defined by
@@ -3036,9 +2868,7 @@ equipment.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TOTAL.CAPACITY
-   </code>
+   <code>TOTAL.CAPACITY</code>
   </p>
   <p class="indent3">
    Displays 'total' information about carried
@@ -3067,9 +2897,7 @@ equipment.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TOTALLEVELS
-   </code>
+   <code>TOTALLEVELS</code>
   </p>
   <p class="indent3">
    Displays an integer of your total levels.
@@ -3102,9 +2930,7 @@ Name:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TYPE
-   </code>
+   <code>TYPE</code>
   </p>
   <p class="indent3">
    Displays the race type.
@@ -3157,18 +2983,14 @@ Name:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    UNITSET
-   </code>
+   <code>UNITSET</code>
   </p>
   <p class="indent3">
    Displays the name of the currently selected unit
 set.
   </p>
   <p class="indent2">
-   <code>
-    UNITSET.WEIGHTUNIT
-   </code>
+   <code>UNITSET.WEIGHTUNIT</code>
   </p>
   <p class="indent3">
    Displays the weight unit of the currently
@@ -3218,18 +3040,14 @@ types.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    VISION
-   </code>
+   <code>VISION</code>
   </p>
   <p class="indent3">
    Displays a comma delimited list of the
 character's vision types.
   </p>
   <p class="indent2">
-   <code>
-    VISION.3
-   </code>
+   <code>VISION.3</code>
   </p>
   <p class="indent3">
    the 3
@@ -3308,18 +3126,14 @@ six properties are defined in the Load.lst gameMode file with the
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    WEIGHT
-   </code>
+   <code>WEIGHT</code>
   </p>
   <p class="indent3">
    Displays characters weight in the currently
 selected weight unit.
   </p>
   <p class="indent2">
-   <code>
-    WEIGHT.LIGHT
-   </code>
+   <code>WEIGHT.LIGHT</code>
   </p>
   <p class="indent3">
    Displays max weight for the light load
@@ -3353,9 +3167,7 @@ as the Pathfinder RPG.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    XPAWARD
-   </code>
+   <code>XPAWARD</code>
   </p>
   <p class="indent3">
    Display the XP award.

--- a/docs/outputsheetpages/tokens/outputsheettokensmisc.html
+++ b/docs/outputsheetpages/tokens/outputsheettokensmisc.html
@@ -111,44 +111,34 @@ operator.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TOTALLEVELS+15
-   </code>
+   <code>TOTALLEVELS+15</code>
   </p>
   <p class="indent3">
    Displays the total number of levels plus 15.
   </p>
   <p class="indent2">
-   <code>
-    (COMBAT.AC.TOTAL-3).INTVAL
-   </code>
+   <code>(COMBAT.AC.TOTAL-3).INTVAL</code>
   </p>
   <p class="indent3">
    Displays the integer portion of the Combat Armor
 Class minus 3.
   </p>
   <p class="indent2">
-   <code>
-    SKILL.Spot.RANKS*SKILL.Listen.RANKS
-   </code>
+   <code>SKILL.Spot.RANKS*SKILL.Listen.RANKS</code>
   </p>
   <p class="indent3">
    Displays the number of spot ranks multiplied by
 the number of listen ranks.
   </p>
   <p class="indent2">
-   <code>
-    (SKILLPOINTS.UNUSED/2).TRUNC
-   </code>
+   <code>(SKILLPOINTS.UNUSED/2).TRUNC</code>
   </p>
   <p class="indent3">
    Displays the integer and fist decimal place of
 the unused skill points divided by 2.
   </p>
   <p class="indent2">
-   <code>
-    (VAR.RangeMod-2).INTVAL.SIGN
-   </code>
+   <code>(VAR.RangeMod-2).INTVAL.SIGN</code>
   </p>
   <p class="indent3">
    Displays the integer portion preceded with a
@@ -345,9 +335,7 @@ be nested).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    |%WEAPON.3|
-   </code>
+   <code>|%WEAPON.3|</code>
   </p>
   <p class="indent3">
    The filter will stop all output (until this
@@ -407,9 +395,7 @@ associated with the tags involved.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUSLIST.COMBAT.AC
-   </code>
+   <code>BONUSLIST.COMBAT.AC</code>
   </p>
   <p class="indent3">
    Would list all COMBAT.AC bonuses as a
@@ -441,18 +427,14 @@ sections.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    2|BR|3
-   </code>
+   <code>2|BR|3</code>
   </p>
   <p class="indent3">
    Then the output would look like:
    <br/>
-   <code>
-    2
+   <code>2
     <br/>
-    3
-   </code>
+    3</code>
   </p>
   <hr/>
   <p class="indent0">
@@ -690,35 +672,29 @@ character has.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:HP|CURRENTMAX|3*COUNT[FEATNAME=Toughness]
-   </code>
+   <code>BONUS:HP|CURRENTMAX|3*COUNT[FEATNAME=Toughness]</code>
   </p>
   <p class="indent3">
    The count token is used in this example to
 calculate the total bonus.
   </p>
   <p class="indent2">
-   <code>
-    FOR,%num,0,COUNT[SKILLS],1,1
+   <code>FOR,%num,0,COUNT[SKILLS],1,1
     <br/>
     {Statements}
     <br/>
-    ENDFOR
-   </code>
+    ENDFOR</code>
   </p>
   <p class="indent3">
    The {statements} would be processed for each of
 the skills the character has.
   </p>
   <p class="indent2">
-   <code>
-    FOR,%spell,0,COUNT[SPELLSINBOOK0.0.0],1,1
+   <code>FOR,%spell,0,COUNT[SPELLSINBOOK0.0.0],1,1
     <br/>
     {Statements}
     <br/>
-    ENDFOR
-   </code>
+    ENDFOR</code>
   </p>
   <p class="indent3">
    The {statements} would be processed for each of
@@ -782,15 +758,13 @@ loops to the character specified.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CSHEETTAG2.~
+   <code>CSHEETTAG2.~
     <br/>
     DFOR.0,(COUNT[SKILLS]+1)/2,1,COUNT[SKILLS],(COUNT[SKILLS]+1)/2,&lt;td&gt;~SKILL%~&lt;/td&gt;
 &lt;td&gt;~SKILL%.TOTAL~&lt;/td&gt;&lt;td&gt;~SKILL%.RANK~&lt;/td&gt;
     <br/>
     &lt;td&gt;~SKILL%.ABILITY~&lt;/td&gt;&lt;td&gt;~SKILL%.MOD~,&lt;tr
-align="center"&gt;,&lt;/tr&gt;,0
-   </code>
+align="center"&gt;,&lt;/tr&gt;,0</code>
   </p>
   <p class="indent3">
    This would change the field delimiter from the
@@ -963,15 +937,13 @@ CRLF iteration terminators.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DFOR.0,(COUNT[SKILLS]+1)/2,1,COUNT[SKILLS],
+   <code>DFOR.0,(COUNT[SKILLS]+1)/2,1,COUNT[SKILLS],
 (COUNT[SKILLS]+1)/2,&lt;td&gt;\SKILL%\&lt;/td&gt;
     <br/>
     &lt;td&gt;\SKILL%.TOTAL\&lt;/td&gt;&lt;td&gt;\SKILL%.RANK\&lt;/td&gt;
     <br/>
     &lt;td&gt;\SKILL%.ABILITY\&lt;/td&gt;&lt;td&gt;\SKILL%.MOD\,&lt;tr
-align="center"&gt;,&lt;/tr&gt;,0
-   </code>
+align="center"&gt;,&lt;/tr&gt;,0</code>
   </p>
   <p class="indent3">
    Produces a 2 column row table of all skills.
@@ -1025,86 +997,58 @@ directory.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    DIR.PCGen
-   </code>
+   <code>DIR.PCGen</code>
   </p>
   <p class="indent3">
    Would display "
-   <code>
-    D:\RPG\PCGen\system
-   </code>
+   <code>D:\RPG\PCGen\system</code>
    "
 if PCGen was installed in "
-   <code>
-    D:\RPG\PCGen
-   </code>
+   <code>D:\RPG\PCGen</code>
    ".
   </p>
   <p class="indent2">
-   <code>
-    DIR.TEMPLATES
-   </code>
+   <code>DIR.TEMPLATES</code>
   </p>
   <p class="indent3">
    Would display
 "
-   <code>
-    D:\RPG\PCGen\outputsheets\d20\fantasy
-   </code>
+   <code>D:\RPG\PCGen\outputsheets\d20\fantasy</code>
    " if PCGen was
 installed in "
-   <code>
-    D:\RPG\PCGen
-   </code>
+   <code>D:\RPG\PCGen</code>
    ".
   </p>
   <p class="indent2">
-   <code>
-    DIR.PCG
-   </code>
+   <code>DIR.PCG</code>
   </p>
   <p class="indent3">
    Would display
 "
-   <code>
-    D:\RPG\PCGen\characters
-   </code>
+   <code>D:\RPG\PCGen\characters</code>
    " if PCGen was installed in
 "
-   <code>
-    D:\RPG\PCGen
-   </code>
+   <code>D:\RPG\PCGen</code>
    ".
   </p>
   <p class="indent2">
-   <code>
-    DIR.html
-   </code>
+   <code>DIR.html</code>
   </p>
   <p class="indent3">
    Would display
 "
-   <code>
-    D:\RPG\PCGen\outputsheets\d20\fantasy\htmlxml
-   </code>
+   <code>D:\RPG\PCGen\outputsheets\d20\fantasy\htmlxml</code>
    " if
 PCGen was installed in "
-   <code>
-    D:\RPG\PCGen
-   </code>
+   <code>D:\RPG\PCGen</code>
    ".
   </p>
   <p class="indent2">
-   <code>
-    DIR.TEMP
-   </code>
+   <code>DIR.TEMP</code>
   </p>
   <p class="indent3">
    Would display "
-   <code>
-    C:\Temp
-   </code>
+   <code>C:\Temp</code>
    " if that was
 the Operating System's temp directory.
   </p>
@@ -1151,9 +1095,7 @@ character.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    EXPORT.DATE
-   </code>
+   <code>EXPORT.DATE</code>
   </p>
   <p class="indent3">
    Displays the date of export.
@@ -1169,13 +1111,11 @@ Name:
    FOR,%v,w,x,y,z
   </p>
   <p class="indent1">
-   <code>
-    FOR,%v,w,x,y,z
+   <code>FOR,%v,w,x,y,z
     <br/>
     {Statements}
     <br/>
-    ENDFOR
-   </code>
+    ENDFOR</code>
   </p>
   <p class="indent1">
    <strong>
@@ -1244,13 +1184,11 @@ the number of characters in the string.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    FOR,%test,0,20-STRLEN[SKILL.%skill],1,0
+   <code>FOR,%test,0,20-STRLEN[SKILL.%skill],1,0
     <br/>
     {Statements}
     <br/>
-    ENDFOR
-   </code>
+    ENDFOR</code>
   </p>
   <p class="indent3">
    Counts from 0 to 20 minus the sting length of
@@ -1333,25 +1271,19 @@ replaced with the actual value of the index.
    </li>
    <li>
     If you have a
-    <code>
-     FOR.
-    </code>
+    <code>FOR.</code>
     loop involving the characters
 within the party for-loop, you must enclose the character for-loop
 in double-backslash (\\) token markers.
    </li>
    <li>
-    <code>
-     FOR.
-    </code>
+    <code>FOR.</code>
     loop on party sheets (
     <span class="lstfile">
      psheet*.*
     </span>
     ) can only loop on character numbers, so
-    <code>
-     \\%.NAME\\
-    </code>
+    <code>\\%.NAME\\</code>
     is valid.
    </li>
    <li>
@@ -1379,9 +1311,7 @@ nothing)
      STRLEN
     </strong>
     takes the form of
-    <code>
-     STRLEN[stringtobecounted]
-    </code>
+    <code>STRLEN[stringtobecounted]</code>
     and returns the number of
 characters in the string.
    </li>
@@ -1408,58 +1338,38 @@ loop is reached, or another filter is begun.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    &lt;table&gt;
-   </code>
+   <code>&lt;table&gt;</code>
   </p>
   <p class="indent2">
-   <code>
-    |FOR.0,10,1,[td]
-   </code>
+   <code>|FOR.0,10,1,[td]</code>
   </p>
   <p class="indent2">
-   <code>
-    \\%.FOR.0,100,1,\SKILL%\,(,),2\\
-   </code>
+   <code>\\%.FOR.0,100,1,\SKILL%\,(,),2\\</code>
   </p>
   <p class="indent2">
-   <code>
-    ,&lt;tr&gt;,&lt;/tr&gt;,1|
-   </code>
+   <code>,&lt;tr&gt;,&lt;/tr&gt;,1|</code>
   </p>
   <p class="indent2">
-   <code>
-    &lt;/table&gt;
-   </code>
+   <code>&lt;/table&gt;</code>
   </p>
   <p class="indent3">
    Produces a list of all the party member's
 skills.
   </p>
   <p class="indent2">
-   <code>
-    &lt;table&gt;
-   </code>
+   <code>&lt;table&gt;</code>
   </p>
   <p class="indent2">
-   <code>
-    |FOR.0,100,1,
-   </code>
+   <code>|FOR.0,100,1,</code>
   </p>
   <p class="indent2">
-   <code>
-    \\%.NAME\\
-   </code>
+   <code>\\%.NAME\\</code>
   </p>
   <p class="indent2">
-   <code>
-    ,[ , ],1|
-   </code>
+   <code>,[ , ],1|</code>
   </p>
   <p class="indent2">
-   <code>
-    &lt;table&gt;
-   </code>
+   <code>&lt;table&gt;</code>
   </p>
   <p class="indent3">
    Produces a list of all the party member's
@@ -1547,8 +1457,7 @@ statement is false.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    IIF(CL&gt;3)
+   <code>IIF(CL&gt;3)
     <br/>
     {True Statement}
     <br/>
@@ -1556,8 +1465,7 @@ statement is false.
     <br/>
     {False Statement}
     <br/>
-    ENDIF
-   </code>
+    ENDIF</code>
   </p>
   <p class="indent3">
    Returns the results of the evaluation of the
@@ -1607,9 +1515,7 @@ statements.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    IIF(CL&gt;3.AND.TL&lt;10)
-   </code>
+   <code>IIF(CL&gt;3.AND.TL&lt;10)</code>
   </p>
   <p class="indent3">
    Returns TRUE is Class Level was greater then 3
@@ -1640,9 +1546,7 @@ expression&gt;)
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    IIF((CL&gt;5)||(TL&gt;5))
-   </code>
+   <code>IIF((CL&gt;5)||(TL&gt;5))</code>
   </p>
   <p class="indent3">
    Returns TRUE if Class Level or Total Level are
@@ -1669,9 +1573,7 @@ greater-then 5.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    IIF(EVEN:%spell)
-   </code>
+   <code>IIF(EVEN:%spell)</code>
   </p>
   <p class="indent3">
    Would be true if the spell line was even.
@@ -1696,9 +1598,7 @@ greater-then 5.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    IIF(VAR.IF(VAR("COUNT[SKILLTYPE=Strength]")&gt;0;1;0):1)
-   </code>
+   <code>IIF(VAR.IF(VAR("COUNT[SKILLTYPE=Strength]")&gt;0;1;0):1)</code>
   </p>
   <p class="indent3">
    Evaluates to true if number of skills with type
@@ -1727,9 +1627,7 @@ equipment.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    IIF(HASEQUIP:Dagger)
-   </code>
+   <code>IIF(HASEQUIP:Dagger)</code>
   </p>
   <p class="indent3">
    Would be true if character had a dagger.
@@ -1754,9 +1652,7 @@ equipment.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    IIF(HASFEAT:Sneak Attack)
-   </code>
+   <code>IIF(HASFEAT:Sneak Attack)</code>
   </p>
   <p class="indent3">
    Would be true if character has the Sneak Attack
@@ -1783,9 +1679,7 @@ Ability.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    IIF(HASSA:Greater Rage)
-   </code>
+   <code>IIF(HASSA:Greater Rage)</code>
   </p>
   <p class="indent3">
    Would be true if character has the Greater Rage
@@ -1813,9 +1707,7 @@ special abilities).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    IIF(HASVAR:BasePowerPoints)
-   </code>
+   <code>IIF(HASVAR:BasePowerPoints)</code>
   </p>
   <p class="indent3">
    Would be true if character has a class with Base
@@ -1848,9 +1740,7 @@ array number of the skill).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    IIF(SKILL.%skill.UNTRAINED)
-   </code>
+   <code>IIF(SKILL.%skill.UNTRAINED)</code>
   </p>
   <p class="indent3">
    Would be true if the current skill is usable
@@ -1927,9 +1817,7 @@ cycles.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    IIF(SKILL%.UNTRAINED,YES,NO)
-   </code>
+   <code>IIF(SKILL%.UNTRAINED,YES,NO)</code>
   </p>
   <p class="indent3">
    Prints out "YES" if the skill is usable
@@ -1985,9 +1873,7 @@ with this skill.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    IIF(SKILL%.ACP,NOT,IS,UNTRAINED,SWIM)
-   </code>
+   <code>IIF(SKILL%.ACP,NOT,IS,UNTRAINED,SWIM)</code>
   </p>
   <p class="indent3">
    Prints out "YES" if the skill is not effected by
@@ -2024,9 +1910,7 @@ specified.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    IIF(SPELLCASTER:Wizard)
-   </code>
+   <code>IIF(SPELLCASTER:Wizard)</code>
   </p>
   <p class="indent3">
    Would be true if the character is a Wizard.
@@ -2062,18 +1946,14 @@ array number of the spellcaster class).
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    IIF(SPELLCASTER:0=PREPARE)
-   </code>
+   <code>IIF(SPELLCASTER:0=PREPARE)</code>
   </p>
   <p class="indent3">
    Would be true if the character's 1st class
 prepares spells.
   </p>
   <p class="indent2">
-   <code>
-    IIF(SPELLCASTER:0=!PREPARE)
-   </code>
+   <code>IIF(SPELLCASTER:0=!PREPARE)</code>
   </p>
   <p class="indent3">
    Would be true if the character's 1st class does
@@ -2123,9 +2003,7 @@ the category
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    IIF(WEAPON.%weap.CATEGORY:Ranged)
-   </code>
+   <code>IIF(WEAPON.%weap.CATEGORY:Ranged)</code>
   </p>
   <p class="indent3">
    True if the current weapon is part of the Ranged
@@ -2166,17 +2044,13 @@ same value.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    IIF(COMBAT.AC.TOTAL:20)
-   </code>
+   <code>IIF(COMBAT.AC.TOTAL:20)</code>
   </p>
   <p class="indent3">
    Would be true if the combat AC total was 20.
   </p>
   <p class="indent2">
-   <code>
-    IIF(ABILITY.Special Ability.%subability.ASPECT.ChildAbility:ABILITYAUTO.Special Ability.%ability.ASPECT.MasterAbility)
-   </code>
+   <code>IIF(ABILITY.Special Ability.%subability.ASPECT.ChildAbility:ABILITYAUTO.Special Ability.%ability.ASPECT.MasterAbility)</code>
   </p>
   <p class="indent3">
    This could occur inside a double loop, and would
@@ -2227,17 +2101,13 @@ the same value or a substring of the evaluation result of token
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    IIF(COMBAT.AC.TOTAL:20)
-   </code>
+   <code>IIF(COMBAT.AC.TOTAL:20)</code>
   </p>
   <p class="indent3">
    Would be true if the combat AC total was 20.
   </p>
   <p class="indent2">
-   <code>
-    IIF(ABILITY.Special Ability.%subability.ASPECT.ChildAbility:ABILITYAUTO.Special Ability.%ability.ASPECT.MasterAbility)
-   </code>
+   <code>IIF(ABILITY.Special Ability.%subability.ASPECT.ChildAbility:ABILITYAUTO.Special Ability.%ability.ASPECT.MasterAbility)</code>
   </p>
   <p class="indent3">
    This could occur inside a double loop, and would
@@ -2255,14 +2125,12 @@ MasterAbility ASPECT of the ability represented by %ability.
    MANUALWHITESPACE
   </p>
   <p class="indent1">
-   <code>
-    MANUALWHITESPACE
+   <code>MANUALWHITESPACE
     <br/>
     {Statements}
     <br/>
     ENDMANUALWHITESPACE
-    <br/>
-   </code>
+    <br/></code>
   </p>
   <p class="indent1">
    <strong>
@@ -2288,8 +2156,7 @@ trimmed, as is normally done.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    |MANUALWHITESPACE| 1&amp;nbsp;
+   <code>|MANUALWHITESPACE| 1&amp;nbsp;
     <br/>
     |PLAYERNAME|
     <br/>
@@ -2297,16 +2164,13 @@ trimmed, as is normally done.
     <br/>
     4
     <br/>
-    |ENDMANUALWHITESPACE|
-   </code>
+    |ENDMANUALWHITESPACE|</code>
   </p>
   <p class="indent3">
    Where |PLAYERNAME| in this case is "Chuck Pint".
 Then the output would look like:
    <br/>
-   <code>
-    1&amp;nbsp;Chuck Pint23&lt;br&gt;4
-   </code>
+   <code>1&amp;nbsp;Chuck Pint23&lt;br&gt;4</code>
   </p>
   <hr/>
   <p class="indent0">
@@ -2366,19 +2230,15 @@ supported.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    OIF(HASFEAT:Armor Proficiency
-(Light),YES,NO)
-   </code>
+   <code>OIF(HASFEAT:Armor Proficiency
+(Light),YES,NO)</code>
   </p>
   <p class="indent3">
    If the character has the Light Armor
 proficiency, then returns "YES". Otherwise it returns "NO".
   </p>
   <p class="indent2">
-   <code>
-    OIF((CL&gt;5)||(TL&gt;5),YES,NO)
-   </code>
+   <code>OIF((CL&gt;5)||(TL&gt;5),YES,NO)</code>
   </p>
   <p class="indent3">
    Returns "YES" if Class Level or Total Level ar
@@ -2408,9 +2268,7 @@ Name:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    Pipe|PIPE|Example
-   </code>
+   <code>Pipe|PIPE|Example</code>
   </p>
   <p class="indent3">
    Would display "Pipe|Example".
@@ -2444,9 +2302,7 @@ sections.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    Space|SPACE|Example
-   </code>
+   <code>Space|SPACE|Example</code>
   </p>
   <p class="indent3">
    Would display "Space Example".
@@ -2495,9 +2351,7 @@ no more than x characters.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SUB10.SPELLMEM.0.0.0.0.COMPONENTS
-   </code>
+   <code>SUB10.SPELLMEM.0.0.0.0.COMPONENTS</code>
   </p>
   <p class="indent3">
    Would limit the output from the above tag to no
@@ -2549,19 +2403,13 @@ information.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    |FOR,%temp,0,COUNT[TEMPBONUSNAMES]-1,1,0|
-   </code>
+   <code>|FOR,%temp,0,COUNT[TEMPBONUSNAMES]-1,1,0|</code>
   </p>
   <p class="indent2">
-   <code>
-    |TEMPBONUS.%temp|
-   </code>
+   <code>|TEMPBONUS.%temp|</code>
   </p>
   <p class="indent2">
-   <code>
-    |ENDFOR|
-   </code>
+   <code>|ENDFOR|</code>
   </p>
   <hr/>
   <p class="indent0">
@@ -2664,40 +2512,28 @@ subrags allowed and their effect.
   </p>
   <ul class="indent2">
    <li>
-    <code>
-     LENGTH
-    </code>
+    <code>LENGTH</code>
     - Returns the length of the string the
 specified token produces. (Mostly useful to test for 0 length
 strings)
    </li>
    <li>
-    <code>
-     LOWER
-    </code>
+    <code>LOWER</code>
     ,
-    <code>
-     LOWERCASE
-    </code>
+    <code>LOWERCASE</code>
     - Output the tag
 result in lower case. e.g. the vitamins are in my fresh brussels
 sprouts
    </li>
    <li>
-    <code>
-     NUMSUFFIX
-    </code>
+    <code>NUMSUFFIX</code>
     - Output a numeric suffix appropriate
 for the tag result. e.g "th" or "rd"
    </li>
    <li>
-    <code>
-     REPLACEALL
-    </code>
+    <code>REPLACEALL</code>
     and
-    <code>
-     REPLACEFIRST
-    </code>
+    <code>REPLACEFIRST</code>
     -
 Performs a regular expression based search and replace on the
 string produced by the associated token. Multiple replacements can
@@ -2705,14 +2541,10 @@ be specified and are processed right to left. The proper syntax for
 these tags are as follows:
     <ul>
      <li>
-      <code>
-       REPLACEALL{regexp,newtest}
-      </code>
+      <code>REPLACEALL{regexp,newtest}</code>
      </li>
      <li>
-      <code>
-       REPLACEFIRST{regexp,newtest}
-      </code>
+      <code>REPLACEFIRST{regexp,newtest}</code>
      </li>
      <li>
       When writing regular expressions you may need to use character
@@ -2739,37 +2571,25 @@ substitution to get the results you are looking for. Examples:
     </ul>
    </li>
    <li>
-    <code>
-     SENTENCE
-    </code>
+    <code>SENTENCE</code>
     ,
-    <code>
-     SENTENCECASE
-    </code>
+    <code>SENTENCECASE</code>
     - Output the
 tag result in sentence case. e.g. The vitamins are in my fresh
 brussels sprouts
    </li>
    <li>
-    <code>
-     TITLE
-    </code>
+    <code>TITLE</code>
     ,
-    <code>
-     TITLECASE
-    </code>
+    <code>TITLECASE</code>
     - Output the tag
 result in title case. e.g. The Vitamins Are In My Fresh Brussels
 Sprouts
    </li>
    <li>
-    <code>
-     UPPER
-    </code>
+    <code>UPPER</code>
     ,
-    <code>
-     UPPERCASE
-    </code>
+    <code>UPPERCASE</code>
     - Output the tag
 result in upper case. e.g. THE VITAMINS ARE IN MY FRESH BRUSSELS
 SPROUTS
@@ -2781,27 +2601,21 @@ SPROUTS
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TEXT.LOWER.SPELLMEM.%class.0.%level.%spell.NAME
-   </code>
+   <code>TEXT.LOWER.SPELLMEM.%class.0.%level.%spell.NAME</code>
   </p>
   <p class="indent3">
    Would output the name for the spell in lower
 case.
   </p>
   <p class="indent2">
-   <code>
-    TEXT.REPLACEFIRST{\.0,}.SKILL.%skill.RANK
-   </code>
+   <code>TEXT.REPLACEFIRST{\.0,}.SKILL.%skill.RANK</code>
   </p>
   <p class="indent3">
    Would output "5" instead of "5.0" but would
 leave "5.5" as is.
   </p>
   <p class="indent2">
-   <code>
-    TEXT.NUMSUFFIX.22
-   </code>
+   <code>TEXT.NUMSUFFIX.22</code>
   </p>
   <p class="indent3">
    Would output a suffix of "nd" rather than the
@@ -2848,9 +2662,7 @@ the other 4).
    </li>
    <li>
     Also
-    <code>
-     .MINVAL
-    </code>
+    <code>.MINVAL</code>
     should be included if instead of the
 default maximum of multiple defines, you want the minimum.
    </li>
@@ -2861,33 +2673,25 @@ default maximum of multiple defines, you want the minimum.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    VAR.Turn Undead.MINVAL.INTVAL
-   </code>
+   <code>VAR.Turn Undead.MINVAL.INTVAL</code>
   </p>
   <p class="indent3">
    Would return 2.
   </p>
   <p class="indent2">
-   <code>
-    VAR.Turn Undead.INTVAL
-   </code>
+   <code>VAR.Turn Undead.INTVAL</code>
   </p>
   <p class="indent3">
    Would return 4.
   </p>
   <p class="indent2">
-   <code>
-    VAR.Turn Undead.MINVAL
-   </code>
+   <code>VAR.Turn Undead.MINVAL</code>
   </p>
   <p class="indent3">
    Would return 2.0.
   </p>
   <p class="indent2">
-   <code>
-    VAR.Turn Undead
-   </code>
+   <code>VAR.Turn Undead</code>
   </p>
   <p class="indent3">
    Would return 4.0.

--- a/docs/outputsheetpages/tokens/outputsheettokenssaves-hp.html
+++ b/docs/outputsheetpages/tokens/outputsheettokenssaves-hp.html
@@ -203,9 +203,7 @@ this tag.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHECK.REFLEX.FEATS
-   </code>
+   <code>CHECK.REFLEX.FEATS</code>
   </p>
   <p class="indent3">
    Would display only the bonuses from feats to the
@@ -217,9 +215,7 @@ Reflex saving throw.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CHECK.REFLEX.BASE.NOSTAT.EPIC
-   </code>
+   <code>CHECK.REFLEX.BASE.NOSTAT.EPIC</code>
   </p>
   <p class="indent3">
    Would display the Base Reflex, minus any bonuses
@@ -249,9 +245,7 @@ Name:
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    HP
-   </code>
+   <code>HP</code>
   </p>
   <p class="indent3">
    Would display the characters maximum hit
@@ -309,9 +303,7 @@ information.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    HPROLL.0
-   </code>
+   <code>HPROLL.0</code>
   </p>
   <p class="indent3">
    Displays the number entered by the player for
@@ -322,9 +314,7 @@ the 1
    level HP roll.
   </p>
   <p class="indent2">
-   <code>
-    HPROLL.0.STAT
-   </code>
+   <code>HPROLL.0.STAT</code>
   </p>
   <p class="indent3">
    Displays the bonus due to stat modifier for the

--- a/docs/outputsheetpages/tokens/outputsheettokensspecialability.html
+++ b/docs/outputsheetpages/tokens/outputsheettokensspecialability.html
@@ -59,9 +59,7 @@ x-th class.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    CLASS.0.SALIST
-   </code>
+   <code>CLASS.0.SALIST</code>
   </p>
   <p class="indent3">
    Displays the Special Abilities granted by the
@@ -95,9 +93,7 @@ schools. The selected school will be displayed in this list.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    PROHIBITEDLIST
-   </code>
+   <code>PROHIBITEDLIST</code>
   </p>
   <p class="indent3">
    Displays a comma delimited list of
@@ -127,9 +123,7 @@ characters racial special abilities.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    RACE.ABILITYLIST
-   </code>
+   <code>RACE.ABILITYLIST</code>
   </p>
   <p class="indent3">
    Displays a comma delimited list of the
@@ -159,9 +153,7 @@ characters special abilities.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SPECIALLIST
-   </code>
+   <code>SPECIALLIST</code>
   </p>
   <p class="indent3">
    Displays a comma delimited list of the
@@ -216,9 +208,7 @@ character's special abilities.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SPECIALABILITY.0.DESCRIPTION
-   </code>
+   <code>SPECIALABILITY.0.DESCRIPTION</code>
   </p>
   <p class="indent3">
    Displays the description of the 1
@@ -260,9 +250,7 @@ Ability.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TEMP.0
-   </code>
+   <code>TEMP.0</code>
   </p>
   <p class="indent3">
    Displays the name of the characters

--- a/docs/outputsheetpages/tokens/outputsheettokensspell.html
+++ b/docs/outputsheetpages/tokens/outputsheettokensspell.html
@@ -142,9 +142,7 @@ book or spell list.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SPELLBOOK.0.NAME
-   </code>
+   <code>SPELLBOOK.0.NAME</code>
   </p>
   <p class="indent3">
    Displays the name of the 1st spell book for the
@@ -202,9 +200,7 @@ have innate spells.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SPELLBOOKNAME.0
-   </code>
+   <code>SPELLBOOKNAME.0</code>
   </p>
   <p class="indent3">
    Display Spell Book 0 (the default
@@ -265,91 +261,67 @@ themselves.
     Spellbook options include the following sub-tokens:
     <ul>
      <li>
-      <code>
-       BOOK
-      </code>
+      <code>BOOK</code>
       - Displays a comma delimited list of spells
 known to spellcaster class number y for level z of book w.
      </li>
      <li>
-      <code>
-       CAST
-      </code>
+      <code>CAST</code>
       - Displays the number of spells you can cast
 for spellcaster class number y for level z.
      </li>
      <li>
-      <code>
-       CLASS
-      </code>
+      <code>CLASS</code>
       - Displays the spellcaster class
 information.
       <ul>
        <li>
-        <code>
-         CLASS.y
-        </code>
+        <code>CLASS.y</code>
         - Displays the spellcaster classname for
 class number y.
        </li>
        <li>
-        <code>
-         CLASS.y.CASTERLEVEL
-        </code>
+        <code>CLASS.y.CASTERLEVEL</code>
         - Displays the effective
 casting level for spells cast by spellcaster class y, including
 bonus levels from other classes.
        </li>
        <li>
-        <code>
-         CLASS.y.CONCENTRATION
-        </code>
+        <code>CLASS.y.CONCENTRATION</code>
         - Displays the concentration
 check bonus for spells cast by spellcaster class y (empty if no
 formula is defined in the game mode).
        </li>
        <li>
-        <code>
-         CLASS.y.LEVEL
-        </code>
+        <code>CLASS.y.LEVEL</code>
         - Displays the spellcaster's class
 level for spellcasting class y.
        </li>
       </ul>
      </li>
      <li>
-      <code>
-       DC
-      </code>
+      <code>DC</code>
       - Displays the casting DC for a z level spell
 for spellcaster class y.
      </li>
      <li>
-      <code>
-       DCSTAT
-      </code>
+      <code>DCSTAT</code>
       - Displays the STAT used to figure out the
 DC of a z level spell cast by spallcaster class y.
      </li>
      <li>
-      <code>
-       MEMORIZE
-      </code>
+      <code>MEMORIZE</code>
       - Returns a boolean "true" if the
 spellcaster class y needs to memorize spells, "false" if
 otherwise.
      </li>
      <li>
-      <code>
-       TYPE
-      </code>
+      <code>TYPE</code>
       - Displays the spell type (e.g. Arcane or
 Divine) of spellcaster class y.
      </li>
      <li>
-      <code>
-       KNOWN
-      </code>
+      <code>KNOWN</code>
       - Displays how many spells spellcaster class
 y can know for level z. For Clerics with domains, this does not
 include domain spells.
@@ -363,9 +335,7 @@ include domain spells.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SPELLLISTCAST.0.1
-   </code>
+   <code>SPELLLISTCAST.0.1</code>
   </p>
   <p class="indent3">
    Displays how many spells the character can cast
@@ -381,9 +351,7 @@ for the 1
 class the character has.
   </p>
   <p class="indent2">
-   <code>
-    SPELLLISTTYPE.0.1
-   </code>
+   <code>SPELLLISTTYPE.0.1</code>
   </p>
   <p class="indent3">
    Displays the spell list type of the
@@ -479,254 +447,182 @@ have innate spells.
     Spell properties are identified as follows:
     <ul>
      <li>
-      <code>
-       APPLIEDNAME
-      </code>
+      <code>APPLIEDNAME</code>
       - Display a list of adjectives for
 metamagic feats or abilities modifying this spell.
      </li>
      <li>
-      <code>
-       BASENAME
-      </code>
+      <code>BASENAME</code>
       - Display the name of the spell,
 unmodified by abilities such as metamagic feats or abilities.
      </li>
      <li>
-      <code>
-       BASEPPCOST
-      </code>
+      <code>BASEPPCOST</code>
       - Display the PPCOST for the a
 spell.
      </li>
      <li>
-      <code>
-       BONUSSPELL
-      </code>
+      <code>BONUSSPELL</code>
       - Display an * is the spell is a
 domain/specialty spell, display ** if it is ONLY a domain/specialty
 spell.
      </li>
      <li>
-      <code>
-       COMPONENTS
-      </code>
+      <code>COMPONENTS</code>
       - Display the necessary components of
 the indicated spell.
      </li>
      <li>
-      <code>
-       CASTERLEVEL
-      </code>
+      <code>CASTERLEVEL</code>
       - Display the caster level (including
 bonuses) of the indicated spell.
      </li>
      <li>
-      <code>
-       CASTINGTIME
-      </code>
+      <code>CASTINGTIME</code>
       - Display the casting time of the
 indicated spell.
      </li>
      <li>
-      <code>
-       CLASS
-      </code>
+      <code>CLASS</code>
       - Indicates spellcaster classname.
      </li>
      <li>
-      <code>
-       CONCENTRATION
-      </code>
+      <code>CONCENTRATION</code>
       - Displays the concentration check
 bonus for the indicated spell (empty if no formula is defined in
 the game mode).
      </li>
      <li>
-      <code>
-       CT
-      </code>
+      <code>CT</code>
       - Display the Casting Threshold of the
 indicated spell.
      </li>
      <li>
-      <code>
-       DC
-      </code>
+      <code>DC</code>
       - Display the DC of the indicated spell.
      </li>
      <li>
-      <code>
-       DCSTAT
-      </code>
+      <code>DCSTAT</code>
       - Display the STAT used to figure out DC of
 spell
      </li>
      <li>
-      <code>
-       DESC
-      </code>
+      <code>DESC</code>
       - Display the description of the indicated
 spell.
      </li>
      <li>
-      <code>
-       DESCRIPTION
-      </code>
+      <code>DESCRIPTION</code>
       - Display the description of the
 indicated spell.
      </li>
      <li>
-      <code>
-       DESCRIPTOR
-      </code>
+      <code>DESCRIPTOR</code>
       - Display the discriptor of the
 indicated spell.
      </li>
      <li>
-      <code>
-       DURATION
-      </code>
+      <code>DURATION</code>
       - Display the duration of the indicated
 spell.
      </li>
      <li>
-      <code>
-       EFFECT
-      </code>
+      <code>EFFECT</code>
       - Display the effect of the indicated
 spell.
      </li>
      <li>
-      <code>
-       EFFECTTYPE
-      </code>
+      <code>EFFECTTYPE</code>
       - Display the type of effect of the
 indicated spell.
      </li>
      <li>
-      <code>
-       FULLSCHOOL
-      </code>
+      <code>FULLSCHOOL</code>
       - Display the school, if any, of the
 indicated spell in long form.
      </li>
      <li>
-      <code>
-       NAME
-      </code>
+      <code>NAME</code>
       - Display the name of the indicated
 spell.
      </li>
      <li>
-      <code>
-       RANGE
-      </code>
+      <code>RANGE</code>
       - Display the range of the indicated
 spell.
      </li>
      <li>
-      <code>
-       SAVEINFO
-      </code>
+      <code>SAVEINFO</code>
       - Display the save info of the indicated
 spell.
      </li>
      <li>
-      <code>
-       SCHOOL
-      </code>
+      <code>SCHOOL</code>
       - Display the school, if any, of the
 indicated spell in short form.
      </li>
      <li>
-      <code>
-       SOURCE
-      </code>
+      <code>SOURCE</code>
       - Display the source of the indicated spell
 in long form.
      </li>
      <li>
-      <code>
-       SOURCELEVEL
-      </code>
+      <code>SOURCELEVEL</code>
       - Display all the sources and levels
 of the indicated spell (Wiz3,Sor3).
      </li>
      <li>
-      <code>
-       SOURCELINK
-      </code>
+      <code>SOURCELINK</code>
       - Display the URL of the online system
 reference document for the indicated spell.
      </li>
      <li>
-      <code>
-       SOURCEPAGE
-      </code>
+      <code>SOURCEPAGE</code>
       - Display the source page of the
 indicated spell.
      </li>
      <li>
-      <code>
-       SOURCESHORT
-      </code>
+      <code>SOURCESHORT</code>
       - Display the source of the indicated
 spell in short form.
      </li>
      <li>
-      <code>
-       SOURCEWEB
-      </code>
+      <code>SOURCEWEB</code>
       - Display the URL of the source of the
 indicated spell.
      </li>
      <li>
-      <code>
-       SUBSCHOOL
-      </code>
+      <code>SUBSCHOOL</code>
       - Display the subschool, if any, of the
 indicated spell.
      </li>
      <li>
-      <code>
-       SR
-      </code>
+      <code>SR</code>
       - Display the spell resistance properties of
 the indicated spell.
      </li>
      <li>
-      <code>
-       SRSHORT
-      </code>
+      <code>SRSHORT</code>
       - Returns an "N" if spell the spell
 ignores resistance, "Y" if it does not.
      </li>
      <li>
-      <code>
-       TARGET
-      </code>
+      <code>TARGET</code>
       - Display the target of the indicated spell
 (contents of the TARGETAREA lst tag).
      </li>
      <li>
-      <code>
-       TIMES
-      </code>
+      <code>TIMES</code>
       - Display the number of times the indicated
 spell is in the spellbook.
      </li>
      <li>
-      <code>
-       TIMEUNIT
-      </code>
+      <code>TIMEUNIT</code>
       - Display the unit of time (i.e.
 Encounter, Week, Month, etc.).
      </li>
      <li>
-      <code>
-       TYPE
-      </code>
+      <code>TYPE</code>
       - Display the type (i.e. Arcane or Divine) of
 spell class.
      </li>
@@ -739,9 +635,7 @@ spell class.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SPELLMEM.0.1.2.3.NAME
-   </code>
+   <code>SPELLMEM.0.1.2.3.NAME</code>
   </p>
   <p class="indent3">
    Displays the Name of the fourth 2
@@ -775,9 +669,7 @@ Spellpoints the character has.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    SPELLPOINTS
-   </code>
+   <code>SPELLPOINTS</code>
   </p>
   <p class="indent3">
    Gives the number of Spellpoints the character

--- a/docs/outputsheetpages/tokens/outputsheettokensweapon.html
+++ b/docs/outputsheetpages/tokens/outputsheettokensweapon.html
@@ -275,9 +275,7 @@ below) if you want ammunition bonuses included.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    WEAPON.0.SIZE
-   </code>
+   <code>WEAPON.0.SIZE</code>
   </p>
   <p class="indent3">
    Displays the size of the first weapon.
@@ -533,9 +531,7 @@ already one of the weapon's standard increments.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    WEAPON.0.RANGELIST.0
-   </code>
+   <code>WEAPON.0.RANGELIST.0</code>
   </p>
   <p class="indent3">
    Would display the damage for the the 1st range
@@ -611,9 +607,7 @@ increment.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    WEAPON.0.RANGELIST.0.AMMUNITION.0.DAMAGE
-   </code>
+   <code>WEAPON.0.RANGELIST.0.AMMUNITION.0.DAMAGE</code>
   </p>
   <p class="indent3">
    Displays the damage from the 1st type of
@@ -674,9 +668,7 @@ selected weapon.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    WEAPON.0.CONTENTS.0
-   </code>
+   <code>WEAPON.0.CONTENTS.0</code>
   </p>
   <p class="indent3">
    Displays the name of the 1st type of contained
@@ -750,9 +742,7 @@ selected weapon at the selected range increment.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    WEAPON.0.RANGELIST.0.CONTENTS.0.DAMAGE
-   </code>
+   <code>WEAPON.0.RANGELIST.0.CONTENTS.0.DAMAGE</code>
   </p>
   <p class="indent3">
    Displays the damage from the 1st type of
@@ -873,9 +863,7 @@ proficiencies.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    WEAPONPROFS
-   </code>
+   <code>WEAPONPROFS</code>
   </p>
   <p class="indent3">
    Displays the characters weapon

--- a/docs/standards.html
+++ b/docs/standards.html
@@ -110,9 +110,7 @@ it.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TAG:EXAMPLE
-   </code>
+   <code>TAG:EXAMPLE</code>
   </p>
   <p class="indent3">
    Description of what this example tag does.
@@ -123,9 +121,7 @@ it.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    TAG:EXAMPLE
-   </code>
+   <code>TAG:EXAMPLE</code>
   </p>
   <p class="indent3">
    Identify deprecated syntax.
@@ -312,14 +308,10 @@ in which the syntax was deprecated should be included as per the
 included here. The form of the example generally takes the form
 of:
    <br/>
-   <code>
-    old lst code
-   </code>
+   <code>old lst code</code>
    becomes
-   <code>
-    new lst
-code
-   </code>
+   <code>new lst
+code</code>
    .
   </p>
   <h3>

--- a/docs/tabpages/tabtemporarybonuses.html
+++ b/docs/tabpages/tabtemporarybonuses.html
@@ -136,14 +136,10 @@ circumstances needed for it to be valid.
    would be modified to:
   </p>
   <p class="indent2">
-   <code>
-    BONUS:WEAPON|TOHIT|-2|PREAPPLY:Weapon,Ranged
-   </code>
+   <code>BONUS:WEAPON|TOHIT|-2|PREAPPLY:Weapon,Ranged</code>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:WEAPON|ATTACKS|1|PREAPPLY:Weapon,Ranged
-   </code>
+   <code>BONUS:WEAPON|ATTACKS|1|PREAPPLY:Weapon,Ranged</code>
   </p>
   <p>
    Rapid Shot would then appear in this tab as an available
@@ -172,26 +168,18 @@ obtained, but your character can still gain the bonuses.
 template:
   </p>
   <p class="indent2">
-   <code>
-    Alter Self (Troglodyte)
-   </code>
+   <code>Alter Self (Troglodyte)</code>
   </p>
   <p class="indent2">
-   <code>
-    REMOVABLE:YES  
-VISIBLE:NO
-   </code>
+   <code>REMOVABLE:YES  
+VISIBLE:NO</code>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:COMBAT|AC|6|TYPE=NaturalArmor|PREAPPLY:ANYPC
-   </code>
+   <code>BONUS:COMBAT|AC|6|TYPE=NaturalArmor|PREAPPLY:ANYPC</code>
   </p>
   <p class="indent2">
-   <code>
-    TEMPDESC:Alter Self spell applied to a
-Medium sized creature to transform into a Troglodyte
-   </code>
+   <code>TEMPDESC:Alter Self spell applied to a
+Medium sized creature to transform into a Troglodyte</code>
   </p>
   <p>
    You do not have to apply this template to a PC, I can just add
@@ -219,15 +207,11 @@ Strength as an example.
    would be modified to:
   </p>
   <p class="indent2">
-   <code>
-    BONUS:STAT|STR|%CHOICE|PREAPPLY:ANYPC|TYPE=Enhancement
-   </code>
+   <code>BONUS:STAT|STR|%CHOICE|PREAPPLY:ANYPC|TYPE=Enhancement</code>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:NUMBER|MIN=2|MAX=5|TITLE=Roll
-1d4+1
-   </code>
+   <code>CHOOSE:NUMBER|MIN=2|MAX=5|TITLE=Roll
+1d4+1</code>
   </p>
   <p>
    When Bull's Strength is applied to the character a chooser
@@ -248,15 +232,11 @@ casterlevels up to 5.
    would be modified to:
   </p>
   <p class="indent2">
-   <code>
-    BONUS:COMBAT|TOHIT,DAMAGE|(((%CHOICE/3).TRUNC)MAX1)MIN5|PREAPPLY:Weapon|TYPE=Enhancement
-   </code>
+   <code>BONUS:COMBAT|TOHIT,DAMAGE|(((%CHOICE/3).TRUNC)MAX1)MIN5|PREAPPLY:Weapon|TYPE=Enhancement</code>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:NUMBER|MIN=3|MAX=20|TITLE=Choose
-Spell Caster Level
-   </code>
+   <code>CHOOSE:NUMBER|MIN=3|MAX=20|TITLE=Choose
+Spell Caster Level</code>
   </p>
   <p>
    When Greater Magic Weapon is applied to a character's weapon a
@@ -270,36 +250,24 @@ weapon.
 an example feat:
   </p>
   <p class="indent2">
-   <code>
-    Variable Spell Resistance
-   </code>
+   <code>Variable Spell Resistance</code>
   </p>
   <p class="indent2">
-   <code>
-    VISIBLE:No
-   </code>
+   <code>VISIBLE:No</code>
   </p>
   <p class="indent2">
-   <code>
-    TYPE:TemporaryBonus
-   </code>
+   <code>TYPE:TemporaryBonus</code>
   </p>
   <p class="indent2">
-   <code>
-    BONUS:MISC|SR|%CHOICE|PREAPPLY:ANYPC
-   </code>
+   <code>BONUS:MISC|SR|%CHOICE|PREAPPLY:ANYPC</code>
   </p>
   <p class="indent2">
-   <code>
-    CHOOSE:NUMBER|MIN=1|MAX=40|TITLE=Choose
-Spell Resistance
-   </code>
+   <code>CHOOSE:NUMBER|MIN=1|MAX=40|TITLE=Choose
+Spell Resistance</code>
   </p>
   <p class="indent2">
-   <code>
-    TEMPDESC:Assign Spell Resistance to a
-character
-   </code>
+   <code>TEMPDESC:Assign Spell Resistance to a
+character</code>
   </p>
   <p>
    The PC does not need to select this feat, you simply apply the

--- a/docs/walkthroughpages/walkthroughheadingstartup.html
+++ b/docs/walkthroughpages/walkthroughheadingstartup.html
@@ -240,11 +240,9 @@ begin in the pcgen folder.
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    pcgen -E
+   <code>pcgen -E
 outputsheets/d20/fantasy/pdf/csheet_fantasy_std_blue.xslt -c
-"characters/Test Bard.pcg"
-   </code>
+"characters/Test Bard.pcg"</code>
   </p>
   <p class="indent3">
    Output the character
@@ -259,20 +257,16 @@ sheet
    .
   </p>
   <p class="indent2">
-   <code>
-    pcgen -E
+   <code>pcgen -E
 outputsheets/d20/fantasy/htmlxml/psheet_fantasy_std_PFRPG.htm -p
-"characters/The Testers.pcp"
-   </code>
+"characters/The Testers.pcp"</code>
   </p>
   <p class="indent3">
    Output the listed party to html.
   </p>
   <p class="indent2">
-   <code>
-    pcgen -v -m "Pathfinder RPG for Players -
-Advanced"
-   </code>
+   <code>pcgen -v -m "Pathfinder RPG for Players -
+Advanced"</code>
   </p>
   <p class="indent3">
    Startup with debug logging and load the
@@ -287,10 +281,8 @@ Advanced"
    </strong>
   </p>
   <p class="indent2">
-   <code>
-    pcgen.sh -- -v -m "Pathfinder RPG for
-Players - Advanced"
-   </code>
+   <code>pcgen.sh -- -v -m "Pathfinder RPG for
+Players - Advanced"</code>
   </p>
   <p class="indent3">
    Startup with debug logging and load the


### PR DESCRIPTION
One of the automated formatting tools I used earlier - probably BeautifulSoup - doesn't know that whitespace inside `<code>` tags is significant.

Undo the munted formatting introduced by that tool.