### PR TITLE
Allow whitespace after cast:

### DIFF
--- a/code/standards/checkstyle.xml
+++ b/code/standards/checkstyle.xml
@@ -128,7 +128,9 @@
         <!-- See http://checkstyle.sf.net/config_whitespace.html -->
         <module name="EmptyForIteratorPad"/>
         <module name="MethodParamPad"/>
-        <module name="NoWhitespaceAfter"/>
+	    <module name="NoWhitespaceAfter">
+    		  <property name="tokens" value="BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS"/>
+	    </module>
         <module name="NoWhitespaceBefore"/>
         <module name="OperatorWrap"/>
         <module name="ParenPad"/>


### PR DESCRIPTION
((String) foo).length() is legal
today Checkstyle wants:
((String)foo).length() is legal

Allow whitespace in array initialization:
new String[] { "Blah" };
today Checkstyle wants:
new String[] {"Blah"};