### PR TITLE
CODE-2868 Windows install has links to the no longer issued .bat file

### DIFF
--- a/installers/win-installer/pcgen-nsis.jelly
+++ b/installers/win-installer/pcgen-nsis.jelly
@@ -340,8 +340,9 @@ Section "-Local" Section4
 	CreateDirectory "$$SMPROGRAMS\PCGen\$${APPDIR}"
 	CreateShortCut "$$DESKTOP\$${APPDIR}.lnk" "$$INSTDIR\$${APPDIR}\pcgen.exe" "" \
 				"$$INSTDIR\$${APPDIR}\Local\PCGen2.ico" 0 SW_SHOWMINIMIZED
-	CreateShortCut "$$SMPROGRAMS\PCGEN\$${APPDIR}\$${APPDIR}-Low.lnk" "$$INSTDIR\$${APPDIR}\pcgen_low_mem.bat" "" \
-				"$$INSTDIR\$${APPDIR}\Local\PCGen.ico" 0 SW_SHOWMINIMIZED
+# We no longer provide the .bat file.
+#	CreateShortCut "$$SMPROGRAMS\PCGEN\$${APPDIR}\$${APPDIR}-Low.lnk" "$$INSTDIR\$${APPDIR}\pcgen_low_mem.bat" "" \
+#				"$$INSTDIR\$${APPDIR}\Local\PCGen.ico" 0 SW_SHOWMINIMIZED
 	CreateShortCut "$$SMPROGRAMS\PCGEN\$${APPDIR}\$${APPDIR}.lnk" "$$INSTDIR\$${APPDIR}\pcgen.exe" "" \
 				"$$INSTDIR\$${APPDIR}\Local\pcgen2.ico" 0 SW_SHOWMINIMIZED
 	CreateShortCut "$$SMPROGRAMS\PCGen\$${APPDIR}\Convert Data.lnk" "$$SYSDIR\javaw.exe" "-Xmx256M -jar batch-convert.jar" \
@@ -420,7 +421,7 @@ Section Uninstall
 	Delete /REBOOTOK "$$INSTDIR\$${APPDIR}\pcgen-release-notes-$${SIMPVER}.html"
 	Delete /REBOOTOK "$$INSTDIR\$${APPDIR}\pcgen.exe"
 	Delete /REBOOTOK "$$INSTDIR\$${APPDIR}\pcgen.sh"
-	Delete /REBOOTOK "$$INSTDIR\$${APPDIR}\pcgen_low_mem.bat"
+#	Delete /REBOOTOK "$$INSTDIR\$${APPDIR}\pcgen_low_mem.bat"
 	Delete /REBOOTOK "$$INSTDIR\$${APPDIR}\batch-convert.jar"
 	Delete /REBOOTOK "$$INSTDIR\$${APPDIR}\filepaths.ini"
 	Delete /REBOOTOK "$$INSTDIR\$${APPDIR}\config.ini"

--- a/installers/win-installer/pcgen.nsis
+++ b/installers/win-installer/pcgen.nsis
@@ -239,8 +239,9 @@ Section "-Local" Section4
 	CreateDirectory "$SMPROGRAMS\PCGen\${APPDIR}"
 	CreateShortCut "$DESKTOP\${APPDIR}.lnk" "$INSTDIR\${APPDIR}\pcgen.exe" "" \
 				"$INSTDIR\${APPDIR}\Local\PCGen2.ico" 0 SW_SHOWMINIMIZED
-	CreateShortCut "$SMPROGRAMS\PCGEN\${APPDIR}\${APPDIR}-Low.lnk" "$INSTDIR\${APPDIR}\pcgen_low_mem.bat" "" \
-				"$INSTDIR\${APPDIR}\Local\PCGen.ico" 0 SW_SHOWMINIMIZED
+# We no longer provide the .bat file.
+#	CreateShortCut "$SMPROGRAMS\PCGEN\${APPDIR}\${APPDIR}-Low.lnk" "$INSTDIR\${APPDIR}\pcgen_low_mem.bat" "" \
+#				"$INSTDIR\${APPDIR}\Local\PCGen.ico" 0 SW_SHOWMINIMIZED
 	CreateShortCut "$SMPROGRAMS\PCGEN\${APPDIR}\${APPDIR}.lnk" "$INSTDIR\${APPDIR}\pcgen.exe" "" \
 				"$INSTDIR\${APPDIR}\Local\pcgen2.ico" 0 SW_SHOWMINIMIZED
 	CreateShortCut "$SMPROGRAMS\PCGen\${APPDIR}\Convert Data.lnk" "$SYSDIR\javaw.exe" "-Xmx256M -jar batch-convert.jar" \
@@ -319,7 +320,7 @@ Section Uninstall
 	Delete /REBOOTOK "$INSTDIR\${APPDIR}\pcgen-release-notes-${SIMPVER}.html"
 	Delete /REBOOTOK "$INSTDIR\${APPDIR}\pcgen.exe"
 	Delete /REBOOTOK "$INSTDIR\${APPDIR}\pcgen.sh"
-	Delete /REBOOTOK "$INSTDIR\${APPDIR}\pcgen_low_mem.bat"
+#	Delete /REBOOTOK "$INSTDIR\${APPDIR}\pcgen_low_mem.bat"
 	Delete /REBOOTOK "$INSTDIR\${APPDIR}\pcgen-batch-convert.jar"
 	Delete /REBOOTOK "$INSTDIR\${APPDIR}\filepaths.ini"
 	Delete /REBOOTOK "$INSTDIR\${APPDIR}\config.ini"


### PR DESCRIPTION
@jdempsey-au & @thpr 
I left the include references in other files. This is only to remove the shortcut link from being created.