### PR TITLE
Fix the travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 language: java
 jdk:
   - oraclejdk7
-script: ./gradlew clean build test datatest pfinttest
+script: ./gradlew -i clean build test datatest pfinttest
 
 before_install:
  - chmod +x gradlew

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 language: java
 jdk:
   - oraclejdk7
-script: ./gradlew -i clean build test datatest pfinttest
+script: ./gradlew clean build test datatest pfinttest
 
 before_install:
  - chmod +x gradlew

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ applicationDistribution.from(artifacts) {
 }
 
 repositories {
-        
+    mavenCentral()
 	ivy {
 	    url "http://pcgen.sourceforge.net/mvnrepo"
 	    layout "pattern", {
@@ -72,7 +72,6 @@ repositories {
         name "fileRepo"
         url 'http://librepo.pcgen.org'
     }
-    mavenCentral()
 }
 
 sourceSets {


### PR DESCRIPTION
Reordered the repositories used by gradle to avoid timeouts waiting for libraries that are not held in the pcgen specific repos.