### PR TITLE
Fix bug: CODE-2928 - CONVERTER 6.06: Cannot Parse BONUS:STAT|CAST.x|y

### DIFF
--- a/code/src/java/pcgen/gui2/converter/LSTConverter.java
+++ b/code/src/java/pcgen/gui2/converter/LSTConverter.java
@@ -41,6 +41,9 @@ import pcgen.core.Deity;
 import pcgen.core.Domain;
 import pcgen.core.EquipmentModifier;
 import pcgen.core.Language;
+import pcgen.core.PCAlignment;
+import pcgen.core.PCCheck;
+import pcgen.core.PCStat;
 import pcgen.core.PCTemplate;
 import pcgen.core.Race;
 import pcgen.core.ShieldProf;
@@ -58,6 +61,7 @@ import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.SourceFileLoader;
 import pcgen.persistence.lst.AbilityCategoryLoader;
 import pcgen.persistence.lst.CampaignSourceEntry;
+import pcgen.persistence.lst.GenericLoader;
 import pcgen.persistence.lst.LstFileLoader;
 import pcgen.rules.context.EditorLoadContext;
 import pcgen.rules.persistence.CDOMControlLoader;
@@ -67,6 +71,9 @@ import pcgen.util.Logging;
 public class LSTConverter extends Observable
 {
 	private final AbilityCategoryLoader catLoader = new AbilityCategoryLoader();
+	private final GenericLoader<PCCheck> savesLoader = new GenericLoader<PCCheck>(PCCheck.class);
+	private final GenericLoader<PCAlignment> alignmentLoader = new GenericLoader<PCAlignment>(PCAlignment.class);
+	private final GenericLoader<PCStat> statLoader = new GenericLoader<PCStat>(PCStat.class);
 	private final CDOMControlLoader dataControlLoader = new CDOMControlLoader();
 	private final EditorLoadContext context;
 	private List<Loader> loaders;
@@ -122,6 +129,13 @@ public class LSTConverter extends Observable
 			{
 				catLoader.loadLstFiles(context, campaign
 						.getSafeListFor(ListKey.FILE_ABILITY_CATEGORY));
+				statLoader.loadLstFiles(context,
+					campaign.getSafeListFor(ListKey.FILE_STAT));
+				savesLoader.loadLstFiles(context,
+					campaign.getSafeListFor(ListKey.FILE_SAVE));
+				alignmentLoader.loadLstFiles(context,
+					campaign.getSafeListFor(ListKey.FILE_ALIGNMENT));
+				
 			}
 			catch (PersistenceLayerException e)
 			{


### PR DESCRIPTION
Now that the stats etc are in the data, they need to be loaded by the converter.