### PR TITLE
Fix bug: CODE-2927 - CONVERTER 6.06: UDAM not set to match number of …

### DIFF
--- a/code/src/java/plugin/lsttokens/UdamLst.java
+++ b/code/src/java/plugin/lsttokens/UdamLst.java
@@ -142,13 +142,12 @@ public class UdamLst extends AbstractToken implements CDOMPrimaryToken<CDOMObjec
 			returnList.add(Constants.LST_DOT_CLEAR);
 		}
 		Collection<String> list = changes.getAdded();
-		if (list != null && (list.size() == 9 || list.size() == 1))
+		if (list != null)
 		{
 			returnList.add(StringUtil.join(list, Constants.COMMA));
 		}
 		if (returnList.isEmpty())
 		{
-			context.addWriteMessage(getTokenName() + " requires either 1 value or 9 values");
 			return null;
 		}
 		return returnList.toArray(new String[returnList.size()]);


### PR DESCRIPTION
…sizes, uses old default of 1 or 9