### PR TITLE
Fix bug: CODE-2946 - CONVERTER 6.06: PREMULT added where not required…

### DIFF
--- a/code/src/java/pcgen/persistence/lst/output/prereq/PrerequisiteMultWriter.java
+++ b/code/src/java/pcgen/persistence/lst/output/prereq/PrerequisiteMultWriter.java
@@ -31,6 +31,7 @@ package pcgen.persistence.lst.output.prereq;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteOperator;
 import pcgen.persistence.PersistenceLayerException;
+import pcgen.util.Logging;
 
 import java.io.IOException;
 import java.io.Writer;
@@ -60,9 +61,10 @@ public class PrerequisiteMultWriter extends AbstractPrerequisiteWriter
 			PrerequisiteOperator.NEQ};
 	}
 
-	/* (non-Javadoc)
-	 * @see pcgen.persistence.lst.output.prereq.PrerequisiteWriterInterface#write(java.io.Writer, pcgen.core.prereq.Prerequisite)
-	 */
+    
+    /**
+     * @{inheritdoc}
+     */
     @Override
 	public void write(Writer writer, Prerequisite prereq)
 		throws PersistenceLayerException
@@ -79,7 +81,12 @@ public class PrerequisiteMultWriter extends AbstractPrerequisiteWriter
 				handleSpecialCase(writer, prereq);
 				return;
 			}
-
+			if (isNegatedPreability(prereq))
+			{
+				Logging.errorPrint("Got [ability]");
+				handleNegatedPreAbility(writer, prereq);
+				return;
+			}
 			if (prereq.getPrerequisiteCount() != 0)
 			{
 				subreq = prereq.getPrerequisites().get(0);
@@ -193,4 +200,77 @@ public class PrerequisiteMultWriter extends AbstractPrerequisiteWriter
 		return false;
 	}
 
+	/**
+	 * Identify if this is a PREABILITY which has been converted into a PREMULT 
+	 * to include a negated check, i.e. ensure a particular ability is not
+	 * present in the character.
+	 *   
+	 * @param prereq The PREMULT to be checked.
+	 * @return true if this is a negated PREABILITY, false if not.
+	 */
+	private boolean isNegatedPreability(Prerequisite prereq)
+	{
+		if (prereq.getPrerequisites().isEmpty())
+		{
+			return false;
+		}
+		boolean hasNegated = false;
+		for (Prerequisite element : prereq.getPrerequisites())
+		{
+			if (!"ability".equalsIgnoreCase(element.getKind()))
+			{
+				return false;
+			}
+			if (element.getOperator() == PrerequisiteOperator.LT
+					&& "1".equals(element.getOperand()))
+			{
+				hasNegated = true;
+			}
+		}
+		return hasNegated;
+	}
+
+	/**
+	 * Restore the format of a prereq such as 
+	 * PREABILITY:1,CATEGORY=FEAT,[Surprise Strike]
+	 * 
+	 * @param writer The output destination writer.
+	 * @param prereq The prereq to be written, must be a negated PREABILITY
+	 * @throws IOException If the output cannot be written.
+	 */
+	private void handleNegatedPreAbility(Writer writer, Prerequisite prereq)
+		throws IOException
+	{
+		writer.write("PREABILITY:");
+		writer.write(String.valueOf(Integer.parseInt(prereq.getOperand()) - 1));
+		writer.write(",");
+		String cat = prereq.getPrerequisites().get(0).getCategoryName();
+		if (cat == null)
+		{
+			writer.write("CATEGORY=ANY");
+		}
+		else
+		{
+			writer.write("CATEGORY=" + cat);
+		}
+		for (Prerequisite child : prereq.getPrerequisites())
+		{
+			writer.write(",");
+			if (child.getOperator() == PrerequisiteOperator.LT)
+			{
+				writer.write("[");
+			}
+			writer.write(child.getKey());
+			if (child.getSubKey() != null)
+			{
+				writer.write(" (");
+				writer.write(child.getSubKey());
+				writer.write(")");
+			}
+			if (child.getOperator() == PrerequisiteOperator.LT)
+			{
+				writer.write("]");
+			}
+		}
+	}
 }

--- a/code/src/test/pcgen/persistence/lst/output/prereq/PrerequisiteWriterTest.java
+++ b/code/src/test/pcgen/persistence/lst/output/prereq/PrerequisiteWriterTest.java
@@ -399,6 +399,8 @@ public class PrerequisiteWriterTest extends TestCase
 		"PRESTAT:should_be_numeric,STR=18",												"PRESTAT:1,STR=18",
 		"PRESTAT:1,Strength=18",														"PRESTAT:1,Str=18",
 		"PREABILITY:1,CATEGORY=Special Ability,Dire Animal (Dire Rat)_Companion",		"PREABILITY:1,CATEGORY=Special Ability,Dire Animal (Dire Rat)_Companion",
+		"PREABILITY:1,CATEGORY=FEAT,[Surprise Strike]",									"PREABILITY:1,CATEGORY=FEAT,[Surprise Strike]",
+		"PREABILITY:1,CATEGORY=FEAT,Sneak Attack,[Alertness]",							"PREABILITY:1,CATEGORY=FEAT,Sneak Attack,[Alertness]",
 
 	//
 	// To cause exceptions


### PR DESCRIPTION
… when using more obscure syntax "PREABILITY:1,CATEGORY=Feat,[Feat Name]