### PR TITLE
Fix bug: CODE-2914 - Item Customizer uses the Display name, which can…

### DIFF
--- a/code/src/java/pcgen/core/Equipment.java
+++ b/code/src/java/pcgen/core/Equipment.java
@@ -1186,6 +1186,17 @@ public final class Equipment extends PObject implements Serializable,
 	 */
 	public String getItemNameFromModifiers()
 	{
+		return getItemNameFromModifiers(getBaseItemName());
+	}
+
+	/**
+	 * Get the item name based off the modifiers
+	 * 
+	 * @param The base name of the object, may instead be the base key if generating a key
+	 * @return item name based off the modifiers
+	 */
+	public String getItemNameFromModifiers(String baseName)
+	{
 
 		CDOMSingleRef<Equipment> baseItem = get(ObjectKey.BASE_ITEM);
 		if (baseItem == null)
@@ -1268,7 +1279,7 @@ public final class Equipment extends PObject implements Serializable,
 		}
 
 		// Add in the base name, less any modifiers
-		final String baseName = getBaseItemName().trim();
+		baseName = baseName.trim();
 		int idx = baseName.indexOf('(');
 		if (idx >= 0)
 		{
@@ -3505,12 +3516,16 @@ public final class Equipment extends PObject implements Serializable,
 	public String nameItemFromModifiers(final PlayerCharacter pc)
 	{
 
-		final String itemName = getItemNameFromModifiers();
+		final String itemName = getItemNameFromModifiers(getBaseItemName());
 		setDefaultCrit(pc);
 		setName(itemName);
+		String itemKey =
+				getItemNameFromModifiers(getBaseItemKeyName()).replaceAll(
+					"[^A-Za-z0-9/_() +-]", "_");
+		setKeyName(itemKey);
 		remove(StringKey.OUTPUT_NAME);
 
-		return getName();
+		return getKeyName();
 	}
 
 	/**

--- a/code/src/java/pcgen/core/EquipmentList.java
+++ b/code/src/java/pcgen/core/EquipmentList.java
@@ -656,9 +656,9 @@ public class EquipmentList {
 			//
 			// Change the names, to protect the innocent
 			//
-			final String sName = eq.nameItemFromModifiers(aPC);
+			final String sKeyName = eq.nameItemFromModifiers(aPC);
 			final Equipment eqExists = Globals.getContext().getReferenceContext().silentlyGetConstructedCDOMObject(
-					Equipment.class, sName);
+					Equipment.class, sKeyName);
 
 			if (eqExists != null) { return; }
 

--- a/code/src/test/pcgen/core/EquipmentTest.java
+++ b/code/src/test/pcgen/core/EquipmentTest.java
@@ -120,7 +120,7 @@ public class EquipmentTest extends AbstractCharacterTestCase
 				Equipment.class, OriginalKey);
 
 		eqDouble = eqLoader.parseLine(Globals.getContext(), null,
-			"Dummy	SIZE:M 	KEY:DoubleKey	TYPE:Weapon.Double", source);
+			"Double	SIZE:M 	KEY:DoubleKey	TYPE:Weapon.Double", source);
 
 		eqDouble = Globals.getContext().getReferenceContext().silentlyGetConstructedCDOMObject(
 				Equipment.class, "DoubleKey");
@@ -599,6 +599,16 @@ assertNotNull("Eqmod should be present", eqMod);
 		assertEquals("Dummy", name);
 		name = eq.nameItemFromModifiers(getCharacter());
 		assertEquals("Dummy", name);
+		
+		name = eqDouble.nameItemFromModifiers(getCharacter());
+		assertEquals("Double", name);
+		Equipment item = eqDouble.clone();
+		EquipmentModifier eqModPlus = Globals.getContext().getReferenceContext().silentlyGetConstructedCDOMObject(
+			EquipmentModifier.class, "PLUS1W");
+		item.addEqModifier(eqModPlus, true, getCharacter());
+		item.put(ObjectKey.BASE_ITEM, CDOMDirectSingleRef.getRef(eqDouble));
+		name = item.nameItemFromModifiers(getCharacter());
+		assertEquals("Double +1_-", name);
 	}
 	
 	/**


### PR DESCRIPTION
… contain illegal KEY characters, instead of the KEY name of the object, when writing to the pcg file.