### PR TITLE
Fix bug: CODE-2893 - Using the "sort A-Z" option in equipment does …

### DIFF
--- a/code/src/java/pcgen/gui2/facade/EquipmentSetFacadeImpl.java
+++ b/code/src/java/pcgen/gui2/facade/EquipmentSetFacadeImpl.java
@@ -1958,7 +1958,7 @@ public class EquipmentSetFacadeImpl implements EquipmentSetFacade,
 					String objKey = equipment.get(StringKey.SORT_KEY);
 					if (objKey == null)
 					{
-						objKey = equipment.getKeyName();
+						objKey = equipment.getDisplayName();
 					}
 					sortKey.append(objKey);
 					break;


### PR DESCRIPTION
…not use Output name