### PR TITLE
CODE-2958 - Validate leys in PREFACT and PREFACTSET on data load

### DIFF
--- a/code/src/java/pcgen/persistence/lst/output/prereq/PrerequisiteMultWriter.java
+++ b/code/src/java/pcgen/persistence/lst/output/prereq/PrerequisiteMultWriter.java
@@ -28,13 +28,12 @@
  */
 package pcgen.persistence.lst.output.prereq;
 
+import java.io.IOException;
+import java.io.Writer;
+
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteOperator;
 import pcgen.persistence.PersistenceLayerException;
-import pcgen.util.Logging;
-
-import java.io.IOException;
-import java.io.Writer;
 
 public class PrerequisiteMultWriter extends AbstractPrerequisiteWriter
 		implements PrerequisiteWriterInterface

--- a/code/src/java/plugin/pretokens/parser/PreFactParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreFactParser.java
@@ -20,6 +20,7 @@ package plugin.pretokens.parser;
 import java.util.ArrayList;
 import java.util.List;
 
+import pcgen.cdom.enumeration.FactKey;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteOperator;
 import pcgen.output.publish.OutputDB;
@@ -137,6 +138,7 @@ public class PreFactParser extends AbstractPrerequisiteListParser
 			// We only have a number of prereqs to pass, and a single prereq so we do not want a
 			// wrapper prereq around a list of 1 element.
 			// i.e. 2,TYPE=ItemCreation
+			checkFactKey(elements[2]);
 			prereq.setKey(elements[2]);
 		}
 		else
@@ -156,12 +158,37 @@ public class PreFactParser extends AbstractPrerequisiteListParser
 				// if it is the later, we need to extract the '9'
 				subreq.setOperator(PrerequisiteOperator.GTEQ);
 				subreq.setCategoryName(filetype);
+				checkFactKey(elements[i]);
 				subreq.setKey(elements[i]);
 				subreq.setOperand("1");
 				prereq.addPrerequisite(subreq);
 			}
 		}
 		setLocation(prereq, filetype);
+	}
+
+	/**
+	 * Check that the referenced fact key exists somewhere in the loaded data. 
+	 * This does not guarantee that the object tested will have a value for this 
+	 * fact, or that the fact is appropriate for the type of object being 
+	 * tested. However it will catch simple typos.
+	 *    
+	 * @param factTest The key=value test to be checked.
+	 * @throws PersistenceLayerException If the fact key is not defined in the data.
+	 */
+	private void checkFactKey(String factTest) throws PersistenceLayerException
+	{
+		String[] parts = factTest.split("=");
+		try
+		{
+			FactKey.valueOf(parts[0]);
+		}
+		catch (IllegalArgumentException e)
+		{
+			throw new PersistenceLayerException(
+				"Unknown FACT in PREFACT. Test was: "
+					+ factTest);
+		}
 	}
 
 	private void setLocation(Prerequisite prereq, String location)

--- a/code/src/java/plugin/pretokens/parser/PreFactSetParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreFactSetParser.java
@@ -20,6 +20,7 @@ package plugin.pretokens.parser;
 import java.util.ArrayList;
 import java.util.List;
 
+import pcgen.cdom.enumeration.FactSetKey;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteOperator;
 import pcgen.output.publish.OutputDB;
@@ -137,6 +138,7 @@ public class PreFactSetParser extends AbstractPrerequisiteListParser
 			// We only have a number of prereqs to pass, and a single prereq so we do not want a
 			// wrapper prereq around a list of 1 element.
 			// i.e. 1,DEITY,PANTHEONS=Greek
+			checkFactSetKey(elements[2]);
 			prereq.setKey(elements[2]);
 		}
 		else
@@ -155,12 +157,38 @@ public class PreFactSetParser extends AbstractPrerequisiteListParser
 				// The element is either of the form "TYPE=foo" or "DEX=9"
 				// if it is the later, we need to extract the '9'
 				subreq.setOperator(PrerequisiteOperator.GTEQ);
+				subreq.setCategoryName(filetype);
+				checkFactSetKey(elements[i]);
 				subreq.setKey(elements[i]);
 				subreq.setOperand("1");
 				prereq.addPrerequisite(subreq);
 			}
 		}
 		setLocation(prereq, filetype);
+	}
+
+	/**
+	 * Check that the referenced fact set key exists somewhere in the loaded data. 
+	 * This does not guarantee that the object tested will have a value for this 
+	 * fact, or that the fact is appropriate for the type of object being 
+	 * tested. However it will catch simple typos.
+	 *    
+	 * @param factTest The key=value test to be checked.
+	 * @throws PersistenceLayerException If the fact key is not defined in the data.
+	 */
+	private void checkFactSetKey(String factTest) throws PersistenceLayerException
+	{
+		String[] parts = factTest.split("=");
+		try
+		{
+			FactSetKey.valueOf(parts[0]);
+		}
+		catch (IllegalArgumentException e)
+		{
+			throw new PersistenceLayerException(
+				"Unknown FACT in PREFACT. Test was: "
+					+ factTest);
+		}
 	}
 
 	private void setLocation(Prerequisite prereq, String location)

--- a/code/src/java/plugin/pretokens/writer/PreFactSetWriter.java
+++ b/code/src/java/plugin/pretokens/writer/PreFactSetWriter.java
@@ -125,7 +125,7 @@ public class PreFactSetWriter extends AbstractPrerequisiteWriter implements
 				+ (prereq.isOverrideQualify() ? "Q:" : ""));
 		writer.write(po.equals(PrerequisiteOperator.GTEQ) ? prereq.getOperand()
 				: "1");
-		writer.write(",ID=" + cat);
+		writer.write("," + cat);
 		for (Prerequisite p : prereq.getPrerequisites())
 		{
 			writer.write(',');

--- a/code/src/test/pcgen/persistence/lst/output/prereq/PrerequisiteWriterTest.java
+++ b/code/src/test/pcgen/persistence/lst/output/prereq/PrerequisiteWriterTest.java
@@ -36,6 +36,9 @@ import java.io.Writer;
 import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
+import pcgen.base.format.StringManager;
+import pcgen.cdom.enumeration.FactKey;
+import pcgen.cdom.enumeration.FactSetKey;
 import pcgen.core.GameMode;
 import pcgen.core.Globals;
 import pcgen.core.SettingsHandler;
@@ -51,6 +54,8 @@ import pcgen.util.TestHelper;
  */
 public class PrerequisiteWriterTest extends TestCase
 {
+	private static final StringManager STR_MGR = new StringManager();
+
 	/**
 	 * Constructs a test case with the given name.
 	 * @param name
@@ -463,6 +468,9 @@ public class PrerequisiteWriterTest extends TestCase
 		SettingsHandler.setGame("3.5");
 		TestHelper.createAllAlignments();
 		TestHelper.makeSizeAdjustments();
+		FactKey.getConstant("IsPC", STR_MGR);
+		FactKey.getConstant("LEGS", STR_MGR);
+		FactSetKey.getConstant("PANTHEONS", STR_MGR);
 	}
 
 	/**

--- a/code/src/utest/plugin/pretokens/PreFactSetRoundRobin.java
+++ b/code/src/utest/plugin/pretokens/PreFactSetRoundRobin.java
@@ -16,7 +16,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  *
- * Created on 27 Aug 2015 9:11:34 am
+ * Created on 24 Dec 2015
  */
 package plugin.pretokens;
 
@@ -24,11 +24,11 @@ import junit.framework.Test;
 import junit.framework.TestSuite;
 import junit.textui.TestRunner;
 import pcgen.base.format.StringManager;
-import pcgen.cdom.enumeration.FactKey;
+import pcgen.cdom.enumeration.FactSetKey;
 import pcgen.cdom.facet.FacetInitialization;
 import plugin.lsttokens.testsupport.TokenRegistration;
-import plugin.pretokens.parser.PreFactParser;
-import plugin.pretokens.writer.PreFactWriter;
+import plugin.pretokens.parser.PreFactSetParser;
+import plugin.pretokens.writer.PreFactSetWriter;
 
 /**
  * The Class <code>PreFactRoundRobin</code> tests the parsing and unparsing of 
@@ -36,7 +36,7 @@ import plugin.pretokens.writer.PreFactWriter;
 
  * @author James Dempsey <jdempsey@users.sourceforge.net>
  */
-public class PreFactRoundRobin extends AbstractPreRoundRobin
+public class PreFactSetRoundRobin extends AbstractPreRoundRobin
 {
 	private static boolean initialised = false;
 	private static final StringManager STR_MGR = new StringManager();
@@ -44,7 +44,7 @@ public class PreFactRoundRobin extends AbstractPreRoundRobin
 	
 	public static void main(String args[])
 	{
-		TestRunner.run(PreFactRoundRobin.class);
+		TestRunner.run(PreFactSetRoundRobin.class);
 	}
 
 	
@@ -53,19 +53,19 @@ public class PreFactRoundRobin extends AbstractPreRoundRobin
 	 */
 	public static Test suite()
 	{
-		return new TestSuite(PreFactRoundRobin.class);
+		return new TestSuite(PreFactSetRoundRobin.class);
 	}
 
 	@Override
 	protected void setUp() throws Exception
 	{
 		super.setUp();
-		TokenRegistration.register(new PreFactParser());
-		TokenRegistration.register(new PreFactWriter());
-		FactKey.getConstant("Foo", STR_MGR);
-		FactKey.getConstant("Bard_Archetype_BardicKnowledge", STR_MGR);
-		FactKey.getConstant("Bard_Archetype_Countersong", STR_MGR);
-		FactKey.getConstant("Bard_Archetype_BardicPerformance", STR_MGR);
+		TokenRegistration.register(new PreFactSetParser());
+		TokenRegistration.register(new PreFactSetWriter());
+		FactSetKey.getConstant("Foo", STR_MGR);
+		FactSetKey.getConstant("Bard_Archetype_BardicKnowledge", STR_MGR);
+		FactSetKey.getConstant("Bard_Archetype_Countersong", STR_MGR);
+		FactSetKey.getConstant("Bard_Archetype_BardicPerformance", STR_MGR);
 		
 		if (!initialised)
 		{
@@ -76,17 +76,17 @@ public class PreFactRoundRobin extends AbstractPreRoundRobin
 
 	public void testBoolean()
 	{
-		runPositiveRoundRobin("PREFACT:1,RACE,Foo=true");
+		runPositiveRoundRobin("PREFACTSET:1,RACE,Foo=true");
 	}
 
 	public void testString()
 	{
-		runPositiveRoundRobin("PREFACT:1,RACE,Foo=Bar");
+		runPositiveRoundRobin("PREFACTSET:1,RACE,Foo=Bar");
 	}
 	
 	public void testMultipleBoolean()
 	{
-		runPositiveRoundRobin("PREFACT:1,RACE,"
+		runPositiveRoundRobin("PREFACTSET:1,RACE,"
 			+ "Bard_Archetype_BardicKnowledge=True,"
 			+ "Bard_Archetype_Countersong=True,"
 			+ "Bard_Archetype_BardicPerformance=True");


### PR DESCRIPTION
@LegacyKing Are you happy for me to merge this? It will cause failures in the dataload tests for pathfinder as it picks up previously hidden typos.