### PR TITLE
CODE-2977 - Advanced Source selection filter collapser doesn't collapse.

### DIFF
--- a/code/src/java/pcgen/gui2/filter/FilterBar.java
+++ b/code/src/java/pcgen/gui2/filter/FilterBar.java
@@ -55,6 +55,11 @@ public class FilterBar<C, E> extends JPanel implements DisplayableFilter<C, E>
 
 	public FilterBar()
 	{
+		this(true);
+	}
+
+	public FilterBar(boolean collapsable)
+	{
 		setLayout(new BorderLayout());
 		add(filterPanel, BorderLayout.CENTER);
 
@@ -72,7 +77,10 @@ public class FilterBar<C, E> extends JPanel implements DisplayableFilter<C, E>
 					}
 
 				});
-		add(arrowbutton, BorderLayout.SOUTH);
+		if (collapsable)
+		{
+			add(arrowbutton, BorderLayout.SOUTH);
+		}
 	}
 
 	public void addDisplayableFilter(DisplayableFilter<? super C, ? super E> filter)

--- a/code/src/java/pcgen/gui2/sources/AdvancedSourceSelectionPanel.java
+++ b/code/src/java/pcgen/gui2/sources/AdvancedSourceSelectionPanel.java
@@ -142,7 +142,7 @@ class AdvancedSourceSelectionPanel extends JPanel
 		gameModeList.addActionListener(this); 
 		panel.add(gameModeList, BorderLayout.CENTER);
 		
-		FilterBar<Object, CampaignFacade> bar = new FilterBar<Object, CampaignFacade>();
+		FilterBar<Object, CampaignFacade> bar = new FilterBar<Object, CampaignFacade>(false);
 		bar.add(panel, BorderLayout.WEST);
 		bar.addDisplayableFilter(new SearchFilterPanel());
 		panel = new JPanel(new BorderLayout());


### PR DESCRIPTION
There were two ways to fix this, either collapse the game mode combo box
along with the filters, or remove the collapser.
I chose the latter since game mode selection isn't a filter it would be undesireable to hide it from the user.