### PR TITLE
CODE-2994 Channel updates for Stat

### DIFF
--- a/code/src/java/pcgen/cdom/util/CControl.java
+++ b/code/src/java/pcgen/cdom/util/CControl.java
@@ -39,4 +39,6 @@ public class CControl
 	public static final String EQREACH = "EQREACH";
 	public static final String PCREACH = "PCREACH";
 
+	public static final String STATSCORE = "STATSCORE";
+
 }

--- a/code/src/java/pcgen/output/channel/ChannelCompatibility.java
+++ b/code/src/java/pcgen/output/channel/ChannelCompatibility.java
@@ -18,6 +18,7 @@
 package pcgen.output.channel;
 
 import pcgen.cdom.enumeration.CharID;
+import pcgen.cdom.util.CControl;
 import pcgen.cdom.util.ControlUtilities;
 import pcgen.core.Globals;
 import pcgen.core.PCStat;

--- a/code/src/java/pcgen/output/channel/ChannelCompatibility.java
+++ b/code/src/java/pcgen/output/channel/ChannelCompatibility.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Thomas Parker, 2016.
+ * 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+package pcgen.output.channel;
+
+import pcgen.cdom.enumeration.CharID;
+import pcgen.cdom.util.ControlUtilities;
+import pcgen.core.Globals;
+import pcgen.core.PCStat;
+import pcgen.facade.util.WriteableReferenceFacade;
+import pcgen.output.channel.compat.StatAdapter;
+
+public class ChannelCompatibility
+{
+
+	public static WriteableReferenceFacade<?> getStatScore(CharID id,
+		PCStat stat)
+	{
+		if (ControlUtilities.hasControlToken(Globals.getContext(),
+			CControl.STATSCORE))
+		{
+			return ChannelUtilities.getChannel(id, stat, CControl.STATSCORE);
+		}
+		else
+		{
+			return StatAdapter.generate(id, stat);
+		}
+	}
+}

--- a/code/src/java/pcgen/output/channel/compat/AbstractAdapter.java
+++ b/code/src/java/pcgen/output/channel/compat/AbstractAdapter.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) Thomas Parker, 2016.
+ * 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+package pcgen.output.channel.compat;
+
+import javax.swing.event.EventListenerList;
+
+import pcgen.facade.util.event.ReferenceEvent;
+import pcgen.facade.util.event.ReferenceListener;
+
+public class AbstractAdapter<T>
+{
+	/**
+	 * The list of listeners that listen to this VariableChannel for
+	 * ReferenceEvents.
+	 */
+	private final EventListenerList listenerList = new EventListenerList();
+
+	public void addReferenceListener(ReferenceListener<? super T> listener)
+	{
+		listenerList.add(ReferenceListener.class, listener);
+	}
+
+	public void removeReferenceListener(ReferenceListener<? super T> listener)
+	{
+		listenerList.remove(ReferenceListener.class, listener);
+	}
+
+	protected void fireReferenceChangedEvent(Object source, T oldValue, T newValue)
+	{
+		ReferenceListener[] listeners =
+				listenerList.getListeners(ReferenceListener.class);
+		ReferenceEvent<T> e = null;
+		for (int i = listeners.length - 1; i >= 0; i--)
+		{
+			if (e == null)
+			{
+				e = new ReferenceEvent<T>(source, oldValue, newValue);
+			}
+			listeners[i + 1].referenceChanged(e);
+		}
+	}
+
+}

--- a/code/src/java/pcgen/output/channel/compat/StatAdapter.java
+++ b/code/src/java/pcgen/output/channel/compat/StatAdapter.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) Thomas Parker, 2016.
+ * 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+package pcgen.output.channel.compat;
+
+import pcgen.cdom.enumeration.CharID;
+import pcgen.cdom.facet.FacetLibrary;
+import pcgen.cdom.facet.StatValueFacet;
+import pcgen.cdom.facet.event.ScopeFacetChangeEvent;
+import pcgen.cdom.facet.event.ScopeFacetChangeListener;
+import pcgen.core.PCStat;
+import pcgen.facade.util.WriteableReferenceFacade;
+
+public class StatAdapter extends AbstractAdapter<Integer> implements
+		WriteableReferenceFacade<Integer>,
+		ScopeFacetChangeListener<CharID, PCStat, Integer>
+{
+	private StatValueFacet statValueFacet = FacetLibrary
+		.getFacet(StatValueFacet.class);
+
+	private final CharID id;
+	private final PCStat stat;
+	private int lastKnown;
+
+	private StatAdapter(CharID id, PCStat stat)
+	{
+		this.id = id;
+		this.stat = stat;
+		lastKnown = 0;
+	}
+
+	@Override
+	public Integer get()
+	{
+		return statValueFacet.get(id, stat);
+	}
+
+	@Override
+	public void set(Integer value)
+	{
+		statValueFacet.set(id, stat, value);
+	}
+
+	public static StatAdapter generate(CharID id, PCStat stat)
+	{
+		StatAdapter sa = new StatAdapter(id, stat);
+		sa.statValueFacet.addScopeFacetChangeListener(sa);
+		return sa;
+	}
+
+	@Override
+	public void dataAdded(ScopeFacetChangeEvent<CharID, PCStat, Integer> dfce)
+	{
+		if (dfce.getCharID().equals(id) && dfce.getScope().equals(stat))
+		{
+			fireReferenceChangedEvent(this, lastKnown, dfce.getCDOMObject());
+		}
+	}
+
+	@Override
+	public void dataRemoved(ScopeFacetChangeEvent<CharID, PCStat, Integer> dfce)
+	{
+		if (dfce.getCharID().equals(id) && dfce.getScope().equals(stat))
+		{
+			lastKnown = dfce.getCDOMObject();
+		}
+	}
+
+}


### PR DESCRIPTION
Creates the actual "compatibility" interface for the UI to be able to attach to for stats, regardless of whether the STATSCORE code control is enabled.  (Note it can't be enabled at all because it doesn't actually exist, but this will at least return the "old style" object so that the UI code can be converted to using this subsystem.
