### PR TITLE
Fix the javadoc failure during Jenkins build.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,13 +4,13 @@
  * for specific output.
  *
  * Developer build: gradle
- * Incremental dev build: gradle build 
- * Full build: gradle all 
- * Build and run all tests: gradle clean build slowtest 
- * Run the data tests: gradle datatest 
- * Run the character integration tests: gradle inttest 
- * 
- * Author: James Dempsey 
+ * Incremental dev build: gradle build
+ * Full build: gradle all
+ * Build and run all tests: gradle clean build slowtest
+ * Run the data tests: gradle datatest
+ * Run the character integration tests: gradle inttest
+ *
+ * Author: James Dempsey
  */
 
 plugins {
@@ -33,13 +33,13 @@ sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
 ext {
-	binDir = "code/bin"
-	
-	// Default ignoreTestFailures to false if it is not provided
-	if (!hasProperty('ignoreTestFailures')) {
-		ignoreTestFailures = false;
-	}
-	
+    binDir = "code/bin"
+
+    // Default ignoreTestFailures to false if it is not provided
+    if (!hasProperty('ignoreTestFailures')) {
+        ignoreTestFailures = false;
+    }
+
 }
 
 mainClassName = 'pcgen.system.Main'
@@ -67,12 +67,12 @@ applicationDistribution.from(artifacts) {
 
 repositories {
     mavenCentral()
-	ivy {
-	    url "http://pcgen.sourceforge.net/mvnrepo"
-	    layout "pattern", {
-	       artifact "[organisation]/jars/[artifact]-[revision].[ext]"
-	    }
-    }     
+    ivy {
+        url "http://pcgen.sourceforge.net/mvnrepo"
+        layout "pattern", {
+            artifact "[organisation]/jars/[artifact]-[revision].[ext]"
+        }
+    }
     ivy {
         name "fileRepo"
         url 'http://librepo.pcgen.org'
@@ -86,51 +86,51 @@ sourceSets {
             srcDirs 'code/src/java'
         }
         resources {
-        	srcDirs 'code/src/java'
-        	include '**/*.properties'
-        	include '**/*.xml'
-        	include '**/*.gif'
-        	include '**/*.png'
-        	include '**/*.jpg'
+            srcDirs 'code/src/java'
+            include '**/*.properties'
+            include '**/*.xml'
+            include '**/*.gif'
+            include '**/*.png'
+            include '**/*.jpg'
         }
     }
     test {
         java {
-            srcDirs = ['code/src/utest', 'code/src/testcommon'] 
+            srcDirs = ['code/src/utest', 'code/src/testcommon']
         }
     }
     itest {
         java {
-            srcDirs = ['code/src/itest', 'code/src/testcommon'] 
+            srcDirs = ['code/src/itest', 'code/src/testcommon']
         }
     }
     slowtest {
         java {
-            srcDirs = ['code/src/test', 'code/src/testcommon'] 
+            srcDirs = ['code/src/test', 'code/src/testcommon']
         }
     }
-    
+
 }
 
 /* Copy 'master' outputsheets into different genre folders */
 task copyMasterSheets(type: Copy) {
-	outputs.upToDateWhen { false }
-    
+    outputs.upToDateWhen { false }
+
     include 'eqsheet_fantasy_std.htm'
     include 'psheet_fantasy_std.htm'
     from 'outputsheets/d20/fantasy/htmlxml'
     into 'outputsheets/d20/historical/htmlxml'
 
     into ('../../horror/htmlxml') {
-	    from 'outputsheets/d20/fantasy/htmlxml'
+        from 'outputsheets/d20/fantasy/htmlxml'
     }
     into ('../../sciencefiction/htmlxml') {
-	    from 'outputsheets/d20/fantasy/htmlxml'
+        from 'outputsheets/d20/fantasy/htmlxml'
     }
     into ('../../western/htmlxml') {
-	    from 'outputsheets/d20/fantasy/htmlxml'
-        }
+        from 'outputsheets/d20/fantasy/htmlxml'
     }
+}
 
 compileJava {
     it.dependsOn 'copyMasterSheets'
@@ -159,7 +159,7 @@ dependencies {
     compile group: 'com.incors.plaf', name: 'kunststoff', version:'2.0.2'
     compile group: 'net.sourceforge.pcgen', name: 'PCGen-base', version:'1.0.52'
     compile group: 'net.sourceforge.pcgen', name: 'PCGen-Formula', version:'1.0.60'
-    
+
     //testCompile group: 'org.easymock', name: 'easymock', version:'2.5.2'
     //testCompile group: 'org.easymock', name: 'easymockclassextension', version:'2.5.2'
     testCompile group: 'junit', name: 'junit', version:'4.11'
@@ -170,12 +170,12 @@ dependencies {
     //testCompile group: 'com.cenqua.clover', name: 'clover', version:'1.3.12'
     //testCompile group: 'emma', name: 'emma', version:'2.1.5320'
     //testCompile group: 'emma', name: 'emma_ant', version:'2.1.5320'
-    
+
     itestCompile sourceSets.main.output
     itestCompile configurations.testCompile
     itestCompile sourceSets.test.output
     itestRuntime configurations.testRuntime
-    
+
     slowtestCompile sourceSets.main.output
     slowtestCompile configurations.testCompile
     slowtestCompile sourceSets.test.output
@@ -186,27 +186,27 @@ ant.importBuild 'build-gradle.xml'
 ant.properties['src.java.dir']="code/src/java"
 ant.properties['build.classes.dir']="build/classes/main"
 
-configure('jar-all-plugins') {    
+configure('jar-all-plugins') {
     group = BasePlugin.BUILD_GROUP // Or use 'build'
     description = 'Create the plugin jars'
 }
 
 ext {
-	classpath = ""
-	configurations.runtime.each { lib -> classpath += " libs/${lib.name} "}
+    classpath = ""
+    configurations.runtime.each { lib -> classpath += " libs/${lib.name} "}
 }
 
 jar {
     it.dependsOn 'jar-all-plugins'
     manifest {
-        attributes 'Implementation-Title': 'PCGen', 'Implementation-Version': version, 
+        attributes 'Implementation-Title': 'PCGen', 'Implementation-Version': version,
         	'Main-Class': 'pcgen.system.Main', 'Class-Path': classpath
     }
 }
 
 task converterJar(type: Jar, dependsOn: jar) {
     manifest {
-        attributes 'Implementation-Title': 'PCGen Data Converter', 'Implementation-Version': version, 
+        attributes 'Implementation-Title': 'PCGen Data Converter', 'Implementation-Version': version,
         	'Main-Class': 'pcgen.gui2.converter.PCGenDataConvert', 'Class-Path': 'pcgen.jar' + classpath
     }
 
@@ -220,53 +220,53 @@ artifacts {
 }
 
 task copyToLibs(type: Copy) {
-	into "$buildDir/libs"
-	from configurations.runtime
-    }
+    into "$buildDir/libs"
+    from configurations.runtime
+}
 
 task copyToRoot(type: Copy, dependsOn: [copyToLibs, jar, converterJar]) {
     outputs.files.setFrom(file("$buildDir/libs/pcgen-${version}.jar"))
 
-	from "$buildDir/libs/pcgen-${version}.jar"
-	from "$buildDir/libs/pcgen-${version}-batch-convert.jar"
-	from "$buildDir/release/pcgen.exe"
-	from "$projectDir/code/pcgen.sh"
-	into "$projectDir"
- 	rename "(.+)-$version(.+)", '$1$2'
-    }
+    from "$buildDir/libs/pcgen-${version}.jar"
+    from "$buildDir/libs/pcgen-${version}-batch-convert.jar"
+    from "$buildDir/release/pcgen.exe"
+    from "$projectDir/code/pcgen.sh"
+    into "$projectDir"
+    rename "(.+)-$version(.+)", '$1$2'
+}
 
 task syncLibsToRoot(type: Sync, dependsOn: [copyToLibs, jar, converterJar]) {
-	outputs.files.setFrom(file("$buildDir/libs/pcgen-${version}.jar"))
+    outputs.files.setFrom(file("$buildDir/libs/pcgen-${version}.jar"))
 
-	from "${buildDir}/libs"
-	into "$projectDir/libs"
-	exclude "pcgen-*.jar"
+    from "${buildDir}/libs"
+    into "$projectDir/libs"
+    exclude "pcgen-*.jar"
 }
 
 task cleanRoot(type: Delete) {
-	description="Clean up things copied to the root folder by the build"
-	delete "$projectDir/pcgen.jar"
-	delete "$projectDir/pcgen-batch-convert.jar"
-	delete "$projectDir/batch-convert.jar"
-	delete "$projectDir/pcgen.sh"
-        delete "$projectDir/pcgen.exe"
-	delete "$projectDir/libs"
-	delete "$projectDir/autobuild.properties"
-	delete "$projectDir/svn.properties"
-    }
+    description="Clean up things copied to the root folder by the build"
+    delete "$projectDir/pcgen.jar"
+    delete "$projectDir/pcgen-batch-convert.jar"
+    delete "$projectDir/batch-convert.jar"
+    delete "$projectDir/pcgen.sh"
+    delete "$projectDir/pcgen.exe"
+    delete "$projectDir/libs"
+    delete "$projectDir/autobuild.properties"
+    delete "$projectDir/svn.properties"
+}
 
 build {
     it.dependsOn 'copyToRoot', 'syncLibsToRoot'
 }
 
 clean {
-	it.dependsOn 'clean-plugins'
-	it.dependsOn 'cleanRoot'
+    it.dependsOn 'clean-plugins'
+    it.dependsOn 'cleanRoot'
 }
- 
+
 test {
-	exclude 'pcgen/testsupport/**'
-//	maxParallelForks 4
+    exclude 'pcgen/testsupport/**'
+    //	maxParallelForks 4
     testLogging {
         exceptionFormat = 'full'
     }
@@ -319,10 +319,10 @@ task inttest(type: Test, dependsOn: 'jar') {
         exceptionFormat = 'full'
     }
 
-	// Report each test as it is started.
-	beforeTest { descriptor ->
+    // Report each test as it is started.
+    beforeTest { descriptor ->
     	logger.lifecycle("Running test: " + descriptor)
-	}
+    }
 }
 
 task pfinttest(type: Test, dependsOn: 'jar') {
@@ -335,10 +335,10 @@ task pfinttest(type: Test, dependsOn: 'jar') {
         exceptionFormat = 'full'
     }
 
-	// Report each test as it is started.
-	beforeTest { descriptor ->
+    // Report each test as it is started.
+    beforeTest { descriptor ->
     	logger.lifecycle("Running test: " + descriptor)
-	}
+    }
 }
 
 task rsrdinttest(type: Test, dependsOn: 'jar') {
@@ -351,10 +351,10 @@ task rsrdinttest(type: Test, dependsOn: 'jar') {
         exceptionFormat = 'full'
     }
 
-	// Report each test as it is started.
-	beforeTest { descriptor ->
+    // Report each test as it is started.
+    beforeTest { descriptor ->
     	logger.lifecycle("Running test: " + descriptor)
-	}
+    }
 }
 
 task msrdinttest(type: Test, dependsOn: 'jar') {
@@ -367,10 +367,10 @@ task msrdinttest(type: Test, dependsOn: 'jar') {
         exceptionFormat = 'full'
     }
 
-	// Report each test as it is started.
-	beforeTest { descriptor ->
+    // Report each test as it is started.
+    beforeTest { descriptor ->
     	logger.lifecycle("Running test: " + descriptor)
-	}
+    }
 }
 
 // Do the lot!
@@ -383,8 +383,10 @@ task wrapper(type: Wrapper) {
 
 //Disable failing on javadoc warning
 allprojects {
-  tasks.withType(Javadoc) {
-          options.addBooleanOption('Xdoclint:none', true)
+    if(JavaVersion.current() == JavaVersion.VERSION_1_8){
+        tasks.withType(Javadoc) {
+            options.addBooleanOption('Xdoclint:none', true)
+        }
     }
 }
 


### PR DESCRIPTION
The specified option is only valid for Java 1.8. Adding an if statement to only execute if running on Java 1.8.