### PR TITLE
Clean up output sheet to avoid FOP warnings

### DIFF
--- a/outputsheets/d20/fantasy/pdf/common_sheet/block_attack.xslt
+++ b/outputsheets/d20/fantasy/pdf/common_sheet/block_attack.xslt
@@ -18,7 +18,7 @@
 ====================================-->
 	<!-- Begin Conditional Combat Modifiers -->
 	<xsl:template match="attack" mode="conditional">
-		<fo:table table-layout="fixed" space-before="2mm">
+		<fo:table table-layout="fixed" width="100%" space-before="2mm">
 			<fo:table-column>
 				<xsl:attribute name="column-width"><xsl:value-of select="0.55 * $pagePrintableWidth -1" />mm</xsl:attribute>
 			</fo:table-column>
@@ -30,20 +30,21 @@
 											<xsl:message>Test</xsl:message>
 
 							<fo:table-cell>
-							<xsl:if test="count(conditional_modifiers/savebonus) &gt; 0">
-								<fo:block text-align="center" font-size="8pt" font-weight="bold">Conditional Save Modifiers:</fo:block>	
-							</xsl:if>
+								<fo:block>
+								<xsl:if test="count(conditional_modifiers/savebonus) &gt; 0">
+									<fo:block text-align="center" font-size="8pt" font-weight="bold">Conditional Save Modifiers:</fo:block>	
+								</xsl:if>
 								<xsl:for-each select="conditional_modifiers/savebonus">
 									<fo:block font-size="8pt" space-before.optimum="1pt"><xsl:value-of select="description"/></fo:block>
 								</xsl:for-each>
 							
-							<xsl:if test="count(conditional_modifiers/combatbonus) &gt; 0">
-								<fo:block text-align="center" font-size="8pt" font-weight="bold">Conditional Combat Modifiers:</fo:block>	
-							</xsl:if>
+								<xsl:if test="count(conditional_modifiers/combatbonus) &gt; 0">
+									<fo:block text-align="center" font-size="8pt" font-weight="bold">Conditional Combat Modifiers:</fo:block>	
+								</xsl:if>
 								<xsl:for-each select="conditional_modifiers/combatbonus">
 									<fo:block font-size="8pt" space-before.optimum="1pt"><xsl:value-of select="description"/></fo:block>
 								</xsl:for-each>
-								
+								</fo:block>
 							</fo:table-cell>
 						</fo:table-row>
 			</fo:table-body>
@@ -53,7 +54,7 @@
 
 	<xsl:template match="attack" mode="ranged_melee">
 <!-- BEGIN Attack table -->
-		<fo:table table-layout="fixed" space-before="2mm">
+		<fo:table table-layout="fixed" width="100%" space-before="2mm">
 			<fo:table-column column-width="18mm"/>
 			<fo:table-column column-width="2mm"/>
 			<fo:table-column>
@@ -78,14 +79,16 @@
 				</xsl:apply-templates>
 				<fo:table-row height="2.5pt">
 											<xsl:message>Test</xsl:message>
-					<fo:table-cell />
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 				</fo:table-row>
 				<xsl:apply-templates select="ranged" mode="to_hit">
 					<xsl:with-param name="title" select="'RANGED'"/>
 				</xsl:apply-templates>
 				<fo:table-row height="2.5pt">
 											<xsl:message>Test</xsl:message>
-					<fo:table-cell />
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 				</fo:table-row>
 				<xsl:apply-templates select="grapple" mode="to_hit">
 					<xsl:with-param name="title" select="'GRAPPLE'"/>
@@ -103,7 +106,8 @@
 		<xsl:param name="dalign" select="'after'"/>
 		<fo:table-row>
 											<xsl:message>Test</xsl:message>
-			<fo:table-cell/>
+			<fo:table-cell><fo:block/></fo:table-cell>
+
 			<xsl:call-template name="attack.header.entry"><xsl:with-param name="title" select="'TOTAL'"/><xsl:with-param name="font.size" select="'6pt'"/></xsl:call-template>
 			<xsl:call-template name="attack.header.entry"><xsl:with-param name="title" select="'BASE ATTACK BONUS'"/></xsl:call-template>
 			<xsl:call-template name="attack.header.entry"><xsl:with-param name="title" select="'STAT'"/></xsl:call-template>
@@ -116,7 +120,8 @@
 	<xsl:template name="attack.header.entry">
 		<xsl:param name="title"/>
 		<xsl:param name="font.size" select="'4pt'"/>
-		<fo:table-cell/>
+		<fo:table-cell><fo:block/></fo:table-cell>
+
 		<fo:table-cell display-align="after">
 			<fo:block text-align="center" font-size="6pt">
 				<xsl:attribute name="font-size"><xsl:value-of select="$font.size"/></xsl:attribute>
@@ -138,7 +143,8 @@
 				</fo:block>
 				<fo:block line-height="4pt" font-size="4pt">attack bonus</fo:block>
 			</fo:table-cell>
-			<fo:table-cell/>
+			<fo:table-cell><fo:block/></fo:table-cell>
+
 			<xsl:choose>
 				<xsl:when test="contains(title, 'CMB' )">
 					<xsl:call-template name="iterative.attack.entry">
@@ -162,9 +168,10 @@
 			<xsl:call-template name="attack.entry"><xsl:with-param name="value" select="misc_mod"/></xsl:call-template>
 			<xsl:call-template name="attack.entry"><xsl:with-param name="value" select="epic_mod"/></xsl:call-template>
 			<fo:table-cell>
-				<xsl:call-template name="attrib">
-					<xsl:with-param name="attribute" select="'border.temp'"/>
-				</xsl:call-template>
+					<xsl:call-template name="attrib">
+						<xsl:with-param name="attribute" select="'border.temp'"/>
+					</xsl:call-template>
+				<fo:block/>
 			</fo:table-cell>
 		</fo:table-row>
 	</xsl:template>
@@ -172,7 +179,7 @@
 <!-- Begin CMB different moves -->
 	<xsl:template match="cmb" mode="moves">
 		<!-- BEGIN CMB table -->
-		<fo:table table-layout="fixed" >
+		<fo:table table-layout="fixed" width="100%" >
 			<fo:table-column column-width="8mm"/>
 			<fo:table-column column-width="1mm"/>
 			<fo:table-column column-width="19mm"/>
@@ -209,7 +216,8 @@
 							<xsl:value-of select="'CMB'"/>
 						</fo:block>
 					</fo:table-cell>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 					<xsl:call-template name="iterative.attack.entry"><xsl:with-param name="value" select="grapple_attack"/><xsl:with-param name="bab" select="bab"/><xsl:with-param name="separator" select="''"/></xsl:call-template>
 					<xsl:call-template name="iterative.attack.entry"><xsl:with-param name="value" select="trip_attack"/><xsl:with-param name="bab" select="bab"/><xsl:with-param name="separator" select="''"/></xsl:call-template>
 					<xsl:call-template name="iterative.attack.entry"><xsl:with-param name="value" select="disarm_attack"/><xsl:with-param name="bab" select="bab"/><xsl:with-param name="separator" select="''"/></xsl:call-template>
@@ -221,7 +229,8 @@
 			
 				<fo:table-row height="2.5pt">
 											<xsl:message>Test</xsl:message>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 				</fo:table-row>
 <!-- Defense entries -->
 				<fo:table-row>		
@@ -234,7 +243,8 @@
 							<xsl:value-of select="'CMD'"/>
 						</fo:block>
 					</fo:table-cell>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 					<xsl:call-template name="attack.entry"><xsl:with-param name="value" select="grapple_defense"/><xsl:with-param name="separator" select="''"/></xsl:call-template>
 					<xsl:call-template name="attack.entry"><xsl:with-param name="value" select="trip_defense"/><xsl:with-param name="separator" select="''"/></xsl:call-template>
 					<xsl:call-template name="attack.entry"><xsl:with-param name="value" select="disarm_defense"/><xsl:with-param name="separator" select="''"/></xsl:call-template>
@@ -250,7 +260,8 @@
 	<xsl:template name="cmb.moves_header">
 		<fo:table-row>
 											<xsl:message>Test END</xsl:message>
-			<fo:table-cell/>
+			<fo:table-cell><fo:block/></fo:table-cell>
+
 			<xsl:call-template name="attack.header.entry"><xsl:with-param name="title" select="'GRAPPLE'"/></xsl:call-template>
 			<xsl:call-template name="attack.header.entry"><xsl:with-param name="title" select="'TRIP'"/></xsl:call-template>
 			<xsl:call-template name="attack.header.entry"><xsl:with-param name="title" select="'DISARM'"/></xsl:call-template>
@@ -272,7 +283,7 @@
 				<xsl:value-of select="$value"/>
 			</fo:block>
 		</fo:table-cell>
-		<fo:table-cell border-bottom="0pt" border-top="0pt">
+		<fo:table-cell border-bottom-width="0pt" border-top-width="0pt">
 			<xsl:call-template name="attrib">
 				<xsl:with-param name="attribute" select="'tohit'"/>
 			</xsl:call-template>
@@ -286,7 +297,7 @@
 		<xsl:param name="value" />
 		<xsl:param name="bab" />
 		<xsl:param name="separator" select="'+'"/>
-<xsl:param name="fontsize" select="'6pt'"/>
+		<xsl:param name="fontsize" select="'6pt'"/>
 											<xsl:message>Test END</xsl:message>
 		<fo:table-cell>
 											<xsl:message>Test END</xsl:message>
@@ -294,15 +305,15 @@
 				<xsl:with-param name="attribute" select="'tohit'"/>
 			</xsl:call-template>
 			<fo:block space-before.optimum="3pt" font-size="6pt">
- <xsl:attribute name="font-size"><xsl:value-of select="$fontsize"/></xsl:attribute>
+				<xsl:attribute name="font-size"><xsl:value-of select="$fontsize"/></xsl:attribute>
 				<xsl:call-template name="process.attack.string">
 					<xsl:with-param name="attack" select="$value"/>
 					<xsl:with-param name="bab" select="$bab"/>
-<xsl:with-param name="maxrepeat" select="4"/> 
+					<xsl:with-param name="maxrepeat" select="4"/> 
 				</xsl:call-template>
 			</fo:block>
 		</fo:table-cell>
-		<fo:table-cell border-bottom="0pt" border-top="0pt">
+		<fo:table-cell border-bottom-width="0pt" border-top-width="0pt">
 			<xsl:call-template name="attrib">
 				<xsl:with-param name="attribute" select="'tohit'"/>
 			</xsl:call-template>

--- a/outputsheets/d20/fantasy/pdf/common_sheet/block_bio_condensed.xslt
+++ b/outputsheets/d20/fantasy/pdf/common_sheet/block_bio_condensed.xslt
@@ -61,7 +61,7 @@
 						</xsl:if>
 					</fo:block>
 					<fo:block>
-						<fo:table table-layout="fixed">
+						<fo:table table-layout="fixed" width="100%">
 							<xsl:choose>
 								<xsl:when test="string-length(portrait) &gt; 0">
 									<fo:table-column>
@@ -89,7 +89,7 @@
 											<xsl:value-of select="race"/>
 										</fo:block>
 									</fo:table-cell>
-									<fo:table-cell number-rows-spanned="36"/>
+									<fo:table-cell number-rows-spanned="36"><fo:block/></fo:table-cell>
 									<xsl:if test="string-length(portrait/portrait) &gt; 0">
 										<fo:table-cell display-align="center" number-rows-spanned="36">
 											<xsl:call-template name="attrib">
@@ -273,7 +273,7 @@
 						<xsl:with-param name="attribute" select="'ac'"/>
 				</xsl:call-template>
 				<fo:flow flow-name="body" font-size="8pt">
-				<fo:table table-layout="fixed" space-before="2mm">
+				<fo:table table-layout="fixed" width="100%" space-before="2mm">
 			<xsl:call-template name="attrib">
 				<xsl:with-param name="attribute" select="'protection.border'"/>
 			</xsl:call-template>

--- a/outputsheets/d20/fantasy/pdf/common_sheet/block_class_features.xslt
+++ b/outputsheets/d20/fantasy/pdf/common_sheet/block_class_features.xslt
@@ -105,7 +105,7 @@ first page
 		<xsl:param name="description" />
 		<xsl:param name="width" select="'wide'" />
 
-		<fo:table table-layout="fixed" space-before="2mm" keep-together="always" border-collapse="collapse">
+		<fo:table table-layout="fixed" width="100%" space-before="2mm" keep-together="always" border-collapse="collapse">
 			<xsl:call-template name="attrib"><xsl:with-param name="attribute" select="concat($attribute, '.border')"/></xsl:call-template>
 			<fo:table-column column-width="18mm"/>
 			<fo:table-column>
@@ -288,7 +288,7 @@ first page
 			<xsl:value-of select="/channel_intensity"/>
 		</xsl:variable>
 		<!-- BEGIN Channeling Table -->
-		<fo:table table-layout="fixed" space-before="1mm" keep-together.within-column="always" border-collapse="collapse" padding="0.5pt">
+		<fo:table table-layout="fixed" width="100%" space-before="1mm" keep-together.within-column="always" border-collapse="collapse">
 			<xsl:call-template name="attrib"><xsl:with-param name="attribute" select="'turning'"/></xsl:call-template>
 			<xsl:call-template name="attrib"><xsl:with-param name="attribute" select="'turning.border'"/></xsl:call-template>
 			<fo:table-column>
@@ -311,7 +311,7 @@ first page
 											<xsl:message>Test</xsl:message>
 					<xsl:call-template name="attrib"><xsl:with-param name="attribute" select="'turning.title'"/></xsl:call-template>
 					<fo:table-cell>
-						<fo:table table-layout="fixed">
+						<fo:table table-layout="fixed" width="100%">
 							<fo:table-column>
 								<xsl:attribute name="column-width"><xsl:value-of select="0.30 * $column_width" />mm</xsl:attribute>
 							</fo:table-column>
@@ -336,7 +336,7 @@ first page
 						</fo:table>
 					</fo:table-cell>
 					<fo:table-cell>
-						<fo:table table-layout="fixed" border-collapse="collapse" padding="0.5pt">
+						<fo:table table-layout="fixed" width="100%" border-collapse="collapse">
 							<fo:table-column>
 								<xsl:attribute name="column-width"><xsl:value-of select="0.20 * $column_width" />mm</xsl:attribute>
 							</fo:table-column>
@@ -356,7 +356,7 @@ first page
 											<xsl:message>Test</xsl:message>
 					<fo:table-cell>
 						<xsl:call-template name="attrib"><xsl:with-param name="attribute" select="'turning.title'"/></xsl:call-template>
-						<fo:table table-layout="fixed" border-collapse="collapse" padding="0.5pt">
+						<fo:table table-layout="fixed" width="100%" border-collapse="collapse">
 							<fo:table-column>
 								<xsl:attribute name="column-width"><xsl:value-of select="0.30 * $column_width" />mm</xsl:attribute>
 							</fo:table-column>
@@ -413,7 +413,7 @@ first page
 						</fo:table>
 					</fo:table-cell>
 					<fo:table-cell>
-						<fo:table table-layout="fixed" border-collapse="collapse" padding="0.5pt">
+						<fo:table table-layout="fixed" width="100%" border-collapse="collapse">
 							<fo:table-column>
 								<xsl:attribute name="column-width"><xsl:value-of select="0.20 * $column_width" />mm</xsl:attribute>
 							</fo:table-column>
@@ -451,7 +451,7 @@ first page
 				<fo:table-row>
 											<xsl:message>Test</xsl:message>
 					<fo:table-cell number-columns-spanned="2">
-						<fo:table border-collapse="collapse" padding="0.5pt" table-layout="fixed">
+						<fo:table border-collapse="collapse" table-layout="fixed" width="100%">
 							<fo:table-column column-width="22mm"/>
 							<fo:table-column>
 								<xsl:attribute name="column-width"><xsl:value-of select="$column_width - 22" />mm</xsl:attribute>
@@ -554,7 +554,7 @@ first page
 	<xsl:template match="turning">
 		<xsl:param name="column_width" select="0.45 * $pagePrintableWidth"/>
 		<!-- BEGIN Turning Table -->
-		<fo:table table-layout="fixed" space-before="1mm" keep-together.within-column="always" border-collapse="collapse" padding="0.5pt">
+		<fo:table table-layout="fixed" width="100%" space-before="1mm" keep-together.within-column="always" border-collapse="collapse">
 			<xsl:call-template name="attrib"><xsl:with-param name="attribute" select="'turning'"/></xsl:call-template>
 			<xsl:call-template name="attrib"><xsl:with-param name="attribute" select="'turning.border'"/></xsl:call-template>
 			<fo:table-column>
@@ -577,7 +577,7 @@ first page
 											<xsl:message>Test</xsl:message>
 					<xsl:call-template name="attrib"><xsl:with-param name="attribute" select="'turning.title'"/></xsl:call-template>
 					<fo:table-cell>
-						<fo:table table-layout="fixed">
+						<fo:table table-layout="fixed" width="100%">
 							<fo:table-column>
 								<xsl:attribute name="column-width"><xsl:value-of select="0.30 * $column_width" />mm</xsl:attribute>
 							</fo:table-column>
@@ -602,7 +602,7 @@ first page
 						</fo:table>
 					</fo:table-cell>
 					<fo:table-cell>
-						<fo:table table-layout="fixed" border-collapse="collapse" padding="0.5pt">
+						<fo:table table-layout="fixed" width="100%" border-collapse="collapse">
 							<fo:table-column>
 								<xsl:attribute name="column-width"><xsl:value-of select="0.20 * $column_width" />mm</xsl:attribute>
 							</fo:table-column>
@@ -622,7 +622,7 @@ first page
 											<xsl:message>Test</xsl:message>
 					<fo:table-cell>
 						<xsl:call-template name="attrib"><xsl:with-param name="attribute" select="'turning.title'"/></xsl:call-template>
-						<fo:table table-layout="fixed" border-collapse="collapse" padding="0.5pt">
+						<fo:table table-layout="fixed" width="100%" border-collapse="collapse">
 							<fo:table-column>
 								<xsl:attribute name="column-width"><xsl:value-of select="0.30 * $column_width" />mm</xsl:attribute>
 							</fo:table-column>
@@ -674,7 +674,7 @@ first page
 						</fo:table>
 					</fo:table-cell>
 					<fo:table-cell>
-						<fo:table table-layout="fixed" border-collapse="collapse" padding="0.5pt">
+						<fo:table table-layout="fixed" width="100%" border-collapse="collapse">
 							<fo:table-column>
 								<xsl:attribute name="column-width"><xsl:value-of select="0.20 * $column_width" />mm</xsl:attribute>
 							</fo:table-column>
@@ -706,7 +706,7 @@ first page
 				<fo:table-row>
 											<xsl:message>Test</xsl:message>
 					<fo:table-cell number-columns-spanned="2">
-						<fo:table border-collapse="collapse" padding="0.5pt" table-layout="fixed">
+						<fo:table border-collapse="collapse" table-layout="fixed" width="100%">
 							<fo:table-column column-width="22mm"/>
 							<fo:table-column>
 								<xsl:attribute name="column-width"><xsl:value-of select="$column_width - 22" />mm</xsl:attribute>
@@ -828,7 +828,7 @@ first page
 	<xsl:template match="checklists">
 	<xsl:for-each select="checklist">
 		<!-- BEGIN Use Per Day Ability table -->
-		<fo:table table-layout="fixed" space-before="2mm" keep-together.within-column="always" border-collapse="collapse" >
+		<fo:table table-layout="fixed" width="100%" space-before="2mm" keep-together.within-column="always" border-collapse="collapse" >
 			<xsl:call-template name="attrib"><xsl:with-param name="attribute" select="'checklist.border'"/></xsl:call-template>
 			<fo:table-column column-width="23mm"/>
 			<fo:table-column column-width="63mm"/>

--- a/outputsheets/d20/fantasy/pdf/common_sheet/block_equipment.xslt
+++ b/outputsheets/d20/fantasy/pdf/common_sheet/block_equipment.xslt
@@ -18,9 +18,9 @@
 ====================================-->
 	<xsl:template match="equipment">
 		<fo:block>
-			<fo:table table-layout="fixed" border-collapse="collapse" padding="0.5pt" space-before="2mm">
+			<fo:table table-layout="fixed" width="100%" border-collapse="collapse" space-before="2mm">
 
-		<!--	<fo:table table-layout="fixed" space-before.optimum="2mm"> -->
+		<!--	<fo:table table-layout="fixed" width="100%" space-before.optimum="2mm"> -->
 				<xsl:call-template name="attrib">
 					<xsl:with-param name="attribute" select="'equipment.border'"/>
 				</xsl:call-template>
@@ -34,7 +34,7 @@
 				<fo:table-header>
 					<fo:table-row>
 											<xsl:message>Test</xsl:message>
-						<fo:table-cell padding-top="1pt" number-columns-spanned="5">
+						<fo:table-cell number-columns-spanned="5">
 							<xsl:call-template name="attrib">
 								<xsl:with-param name="attribute" select="'equipment.title'"/>
 							</xsl:call-template>
@@ -46,16 +46,16 @@
 						<xsl:call-template name="attrib">
 							<xsl:with-param name="attribute" select="'equipment.title'"/>
 						</xsl:call-template>
-						<fo:table-cell padding-top="1pt">
+						<fo:table-cell>
 							<fo:block font-size="7pt">ITEM</fo:block>
 						</fo:table-cell>
-						<fo:table-cell padding-top="1pt">
+						<fo:table-cell>
 							<fo:block font-size="7pt">LOCATION</fo:block>
 						</fo:table-cell>
-						<fo:table-cell padding-top="1pt">
+						<fo:table-cell>
 							<fo:block font-size="7pt">QTY</fo:block>
 						</fo:table-cell>
-						<fo:table-cell padding-top="1pt" number-columns-spanned="2">
+						<fo:table-cell number-columns-spanned="2">
 							<fo:block font-size="7pt">WT / COST</fo:block>
 						</fo:table-cell>
 <!-->						<fo:table-cell padding-top="1pt">
@@ -69,10 +69,10 @@
 						<xsl:call-template name="attrib">
 							<xsl:with-param name="attribute" select="'equipment.title'"/>
 						</xsl:call-template>
-						<fo:table-cell padding-top="1pt">
+						<fo:table-cell>
 							<fo:block font-size="7pt">TOTAL WEIGHT CARRIED/VALUE</fo:block>
 						</fo:table-cell>
-						<fo:table-cell padding-top="1pt">
+						<fo:table-cell>
 							<fo:block font-size="7pt">
 								<xsl:value-of select="total/weight"/>
 							</fo:block>
@@ -231,7 +231,7 @@
 ====================================-->
 	<xsl:template match="weight_allowance">
 		<!-- BEGIN Weight table -->
-		<fo:table table-layout="fixed" space-before.optimum="2mm" padding="0.5pt">
+		<fo:table table-layout="fixed" width="100%" space-before.optimum="2mm">
 			<xsl:call-template name="attrib"><xsl:with-param name="attribute" select="'weight.border'"/></xsl:call-template>
 			<fo:table-column>
 				<xsl:attribute name="column-width"><xsl:value-of select="0.65 * 0.5 * ($pagePrintableWidth - 2) div 3" />mm</xsl:attribute>
@@ -290,6 +290,7 @@
 						<xsl:with-param name="title" select="'Push / Drag'"/>
 						<xsl:with-param name="value" select="push_drag"/>
 					</xsl:call-template>
+											<xsl:message>Test</xsl:message>
 				</fo:table-row>
 			</fo:table-body>
 		</fo:table>
@@ -304,7 +305,7 @@
 
 
 		<xsl:if test="count (misc/funds/fund|equipment/item[contains(type, 'COIN') or contains(type, 'GEM')]) or (misc/gold) &gt; 0">	
-			<fo:table table-layout="fixed" space-before.optimum="2mm">
+			<fo:table table-layout="fixed" width="100%" space-before.optimum="2mm">
 				<xsl:call-template name="attrib">
 					<xsl:with-param name="attribute" select="'money.border'"/>
 				</xsl:call-template>
@@ -435,7 +436,7 @@
 ====================================-->
 	<xsl:template match="magics">
 		<xsl:if test="count(magic) &gt; 0">
-			<fo:table table-layout="fixed" space-before.optimum="2mm">
+			<fo:table table-layout="fixed" width="100%" space-before.optimum="2mm">
 				<xsl:call-template name="attrib">
 					<xsl:with-param name="attribute" select="'magic.border'"/>
 				</xsl:call-template>

--- a/outputsheets/d20/fantasy/pdf/common_sheet/block_features.xslt
+++ b/outputsheets/d20/fantasy/pdf/common_sheet/block_features.xslt
@@ -688,7 +688,7 @@
 	<xsl:template match="racial_traits">
 	<xsl:for-each select="racial_traits">
 		<!-- BEGIN Use Per Day Ability table -->
-		<fo:table table-layout="fixed" space-before="2mm" keep-together="always" border-collapse="collapse" >
+		<fo:table table-layout="fixed" width="100%" space-before="2mm" keep-together="always" border-collapse="collapse" >
 			<xsl:call-template name="attrib"><xsl:with-param name="attribute" select="'checklist.border'"/></xsl:call-template>
 			<fo:table-column column-width="23mm"/>
 			<fo:table-column column-width="63mm"/>

--- a/outputsheets/d20/fantasy/pdf/common_sheet/block_hp_defense.xslt
+++ b/outputsheets/d20/fantasy/pdf/common_sheet/block_hp_defense.xslt
@@ -18,7 +18,7 @@
 ====================================
 ====================================-->
 	<xsl:template match="character" mode="hp_table">	
-		<fo:table table-layout="fixed">
+		<fo:table table-layout="fixed" width="100%">
 			<xsl:choose>
 				<xsl:when test="hit_points/usealternatedamage = 0">
 					<fo:table-column column-width="12mm" />
@@ -54,24 +54,30 @@
 					<fo:table-body>
 						<fo:table-row>
 											<xsl:message>Test</xsl:message>
-							<fo:table-cell/>
-							<fo:table-cell/>
+							<fo:table-cell><fo:block/></fo:table-cell>
+
+							<fo:table-cell><fo:block/></fo:table-cell>
+
 							<fo:table-cell>
 								<fo:block/>
 							</fo:table-cell>
-							<fo:table-cell/>
+							<fo:table-cell><fo:block/></fo:table-cell>
+
 							<fo:table-cell display-align="after">
 								<fo:block text-align="center" font-size="4pt">WOUNDS/CURRENT HP</fo:block>
 							</fo:table-cell>
-							<fo:table-cell/>
+							<fo:table-cell><fo:block/></fo:table-cell>
+
 							<fo:table-cell display-align="after">
 								<fo:block text-align="center" font-size="4pt">SUBDUAL DAMAGE</fo:block>
 							</fo:table-cell>
-							<fo:table-cell/>
+							<fo:table-cell><fo:block/></fo:table-cell>
+
 							<fo:table-cell display-align="after">
 								<fo:block text-align="center" font-size="4pt">DAMAGE REDUCTION</fo:block>
 							</fo:table-cell>
-							<fo:table-cell/>
+							<fo:table-cell><fo:block/></fo:table-cell>
+
 							<fo:table-cell display-align="after">
 								<fo:block text-align="center" font-size="6pt">SPEED</fo:block>
 							</fo:table-cell>
@@ -85,7 +91,8 @@
 								<fo:block line-height="10pt" font-weight="bold" font-size="10pt" space-before="1pt">HP</fo:block>
 								<fo:block line-height="4pt" font-size="4pt">hit points</fo:block>
 							</fo:table-cell>
-							<fo:table-cell/>
+							<fo:table-cell><fo:block/></fo:table-cell>
+
 							<fo:table-cell>
 								<xsl:call-template name="attrib">
 									<xsl:with-param name="attribute" select="'hp.total'"/>
@@ -94,21 +101,24 @@
 									<xsl:value-of select="hit_points/points"/>
 								</fo:block>
 							</fo:table-cell>
-							<fo:table-cell/>
+							<fo:table-cell><fo:block/></fo:table-cell>
+
 							<fo:table-cell display-align="center">
 								<xsl:call-template name="attrib">
 									<xsl:with-param name="attribute" select="'hp.current'"/>
 								</xsl:call-template>
 								<fo:block font-size="10pt"/>
 							</fo:table-cell>
-							<fo:table-cell/>
+							<fo:table-cell><fo:block/></fo:table-cell>
+
 							<fo:table-cell display-align="center">
 								<xsl:call-template name="attrib">
 									<xsl:with-param name="attribute" select="'hp.subdual'"/>
 								</xsl:call-template>
 								<fo:block font-size="10pt"/>
 							</fo:table-cell>
-							<fo:table-cell/>
+							<fo:table-cell><fo:block/></fo:table-cell>
+
 							<fo:table-cell display-align="center">
 								<xsl:call-template name="attrib">
 									<xsl:with-param name="attribute" select="'damage.reduction'"/>
@@ -117,7 +127,8 @@
 									<xsl:value-of select="hit_points/damage_reduction"/>
 								</fo:block>
 							</fo:table-cell>
-							<fo:table-cell/>
+							<fo:table-cell><fo:block/></fo:table-cell>
+
 							<fo:table-cell display-align="center">
 								<xsl:call-template name="attrib">
 									<xsl:with-param name="attribute" select="'speed'"/>
@@ -170,30 +181,39 @@
 					<fo:table-body>
 						<fo:table-row>
 											<xsl:message>Test</xsl:message>
-							<fo:table-cell/><!-- TITLE Vitality -->
-							<fo:table-cell/><!-- space -->
+							<fo:table-cell><fo:block/></fo:table-cell>
+<!-- TITLE Vitality -->
+							<fo:table-cell><fo:block/></fo:table-cell>
+<!-- space -->
 							<fo:table-cell>	<!-- TOTAL Vitality -->
 								<fo:block/>
 							</fo:table-cell>
-							<fo:table-cell/><!-- space -->
+							<fo:table-cell><fo:block/></fo:table-cell>
+<!-- space -->
 							<fo:table-cell display-align="after">
 								<fo:block text-align="center" font-size="4pt">WOUNDS/CURRENT HP</fo:block>
 							</fo:table-cell>
-							<fo:table-cell/><!-- space -->
+							<fo:table-cell><fo:block/></fo:table-cell>
+<!-- space -->
 							<fo:table-cell display-align="after">
 								<fo:block text-align="center" font-size="4pt">SUBDUAL DAMAGE</fo:block>
 							</fo:table-cell>
-							<fo:table-cell/><!-- space -->
-							<fo:table-cell/><!-- TITLE Wound points -->
-							<fo:table-cell/><!-- space -->
+							<fo:table-cell><fo:block/></fo:table-cell>
+<!-- space -->
+							<fo:table-cell><fo:block/></fo:table-cell>
+<!-- TITLE Wound points -->
+							<fo:table-cell><fo:block/></fo:table-cell>
+<!-- space -->
 							<fo:table-cell>	<!-- TOTAL Wound points -->
 								<fo:block/>
 							</fo:table-cell>
-							<fo:table-cell/><!-- space -->
+							<fo:table-cell><fo:block/></fo:table-cell>
+<!-- space -->
 							<fo:table-cell display-align="after">
 								<fo:block text-align="center" font-size="4pt">DAMAGE REDUCTION</fo:block>
 							</fo:table-cell>
-							<fo:table-cell/><!-- space -->
+							<fo:table-cell><fo:block/></fo:table-cell>
+<!-- space -->
 							<fo:table-cell display-align="after">
 								<fo:block text-align="center" font-size="6pt">SPEED</fo:block>
 							</fo:table-cell>
@@ -207,7 +227,8 @@
 								<fo:block line-height="10pt" font-weight="bold" font-size="10pt" space-before="1pt">VP</fo:block>
 								<fo:block line-height="4pt" font-size="4pt">Vitality</fo:block>
 							</fo:table-cell>
-							<fo:table-cell/><!-- space -->
+							<fo:table-cell><fo:block/></fo:table-cell>
+<!-- space -->
 							<fo:table-cell>
 								<xsl:call-template name="attrib">
 									<xsl:with-param name="attribute" select="'hp.total'"/>
@@ -216,21 +237,24 @@
 									<xsl:value-of select="hit_points/points"/>
 								</fo:block>
 							</fo:table-cell>
-							<fo:table-cell/><!-- space -->
+							<fo:table-cell><fo:block/></fo:table-cell>
+<!-- space -->
 							<fo:table-cell display-align="center">
 								<xsl:call-template name="attrib">
 									<xsl:with-param name="attribute" select="'hp.current'"/>
 								</xsl:call-template>
 								<fo:block font-size="10pt"/>
 							</fo:table-cell>
-							<fo:table-cell/><!-- space -->
+							<fo:table-cell><fo:block/></fo:table-cell>
+<!-- space -->
 							<fo:table-cell display-align="center">
 								<xsl:call-template name="attrib">
 									<xsl:with-param name="attribute" select="'hp.subdual'"/>
 								</xsl:call-template>
 								<fo:block font-size="10pt"/>
 							</fo:table-cell>
-							<fo:table-cell/><!-- space -->
+							<fo:table-cell><fo:block/></fo:table-cell>
+<!-- space -->
 							<fo:table-cell>
 								<xsl:call-template name="attrib">
 									<xsl:with-param name="attribute" select="'hp.title'"/>
@@ -238,7 +262,8 @@
 								<fo:block line-height="10pt" font-weight="bold" font-size="10pt" space-before="1pt">WP</fo:block>
 								<fo:block line-height="4pt" font-size="4pt">Wound Points</fo:block>
 							</fo:table-cell>
-							<fo:table-cell/><!-- space -->
+							<fo:table-cell><fo:block/></fo:table-cell>
+<!-- space -->
 							<fo:table-cell>
 								<xsl:call-template name="attrib">
 									<xsl:with-param name="attribute" select="'hp.total'"/>
@@ -247,7 +272,8 @@
 									<xsl:value-of select="hit_points/alternate"/>
 								</fo:block>
 							</fo:table-cell>
-							<fo:table-cell/><!-- space -->
+							<fo:table-cell><fo:block/></fo:table-cell>
+<!-- space -->
 							<fo:table-cell display-align="center">
 								<xsl:call-template name="attrib">
 									<xsl:with-param name="attribute" select="'damage.reduction'"/>
@@ -256,7 +282,8 @@
 									<xsl:value-of select="hit_points/damage_reduction"/>
 								</fo:block>
 							</fo:table-cell>
-							<fo:table-cell/><!-- space -->
+							<fo:table-cell><fo:block/></fo:table-cell>
+<!-- space -->
 							<fo:table-cell display-align="center">
 								<xsl:call-template name="attrib">
 									<xsl:with-param name="attribute" select="'speed'"/>
@@ -279,7 +306,7 @@
 ====================================
 ====================================-->
 	<xsl:template match="armor_class">	
-		<fo:table table-layout="fixed" space-before="2pt">
+		<fo:table table-layout="fixed" width="100%" space-before="2pt">
 			<fo:table-column column-width="12mm"/>	<!--	1	-->
 			<!-- TITLE -->
 			<fo:table-column column-width="1mm"/>	<!--	2	-->
@@ -382,7 +409,8 @@
 						<fo:block line-height="10pt" font-weight="bold" font-size="10pt" space-before="1pt">AC</fo:block>
 						<fo:block line-height="4pt" font-size="4pt">armor class</fo:block>
 					</fo:table-cell>	<!--	1	-->
-					<fo:table-cell/>	<!--	2	-->
+					<fo:table-cell><fo:block/></fo:table-cell>
+	<!--	2	-->
 					<fo:table-cell display-align="center">
 						<xsl:call-template name="attrib">
 							<xsl:with-param name="attribute" select="'ac.total'"/>
@@ -556,80 +584,100 @@
 							<xsl:value-of select="misc"/>
 						</fo:block>
 					</fo:table-cell>	<!--	33	-->
-				<!-->	<fo:table-cell/>	-->
+				<!-->	<fo:table-cell><fo:block/></fo:table-cell>
+	-->
 				</fo:table-row>
 				<fo:table-row height="0.5pt">
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 				</fo:table-row>
 				<fo:table-row>
 											<xsl:message>Test</xsl:message>
-					<fo:table-cell/>	<!--	1	-->
-					<fo:table-cell/>	<!--	2	-->
+					<fo:table-cell><fo:block/></fo:table-cell>
+	<!--	1	-->
+					<fo:table-cell><fo:block/></fo:table-cell>
+	<!--	2	-->
 					<fo:table-cell>
 						<fo:block text-align="center" font-size="6pt">TOTAL</fo:block>
 					</fo:table-cell>	<!--	3	-->
-					<fo:table-cell/>	<!--	4	-->
+					<fo:table-cell><fo:block/></fo:table-cell>
+	<!--	4	-->
 					<fo:table-cell>
 						<fo:block text-align="center" font-size="6pt">FLAT</fo:block>
 					</fo:table-cell>	<!--	5	-->
-					<fo:table-cell/>	<!--	6	-->
+					<fo:table-cell><fo:block/></fo:table-cell>
+	<!--	6	-->
 					<fo:table-cell>
 						<fo:block text-align="center" font-size="6pt">TOUCH</fo:block>
 					</fo:table-cell>	<!--	7	-->
-					<fo:table-cell/>	<!--	8	-->
+					<fo:table-cell><fo:block/></fo:table-cell>
+	<!--	8	-->
 					<fo:table-cell>
 						<fo:block text-align="center" font-size="4pt">BASE</fo:block>
 					</fo:table-cell>	<!--	9	-->
-					<fo:table-cell/>	<!--	10	-->
+					<fo:table-cell><fo:block/></fo:table-cell>
+	<!--	10	-->
 					<fo:table-cell>
 						<fo:block text-align="center" font-size="4pt">ARMOR BONUS</fo:block>
 					</fo:table-cell>	<!--	11	-->
-					<fo:table-cell/>	<!--	12	-->
+					<fo:table-cell><fo:block/></fo:table-cell>
+	<!--	12	-->
 					<fo:table-cell>
 						<fo:block text-align="center" font-size="4pt">SHIELD BONUS</fo:block>
 					</fo:table-cell>	<!--	13	-->
-					<fo:table-cell/>	<!--	14	-->
+					<fo:table-cell><fo:block/></fo:table-cell>
+	<!--	14	-->
 					<fo:table-cell>
 						<fo:block text-align="center" font-size="4pt">STAT</fo:block>
 					</fo:table-cell>	<!--	15	-->
-					<fo:table-cell/>	<!--	16	-->
+					<fo:table-cell><fo:block/></fo:table-cell>
+	<!--	16	-->
 					<fo:table-cell>
 						<fo:block text-align="center" font-size="4pt">SIZE</fo:block>
 					</fo:table-cell>	<!--	17	-->
-					<fo:table-cell/>	<!--	18	-->
+					<fo:table-cell><fo:block/></fo:table-cell>
+	<!--	18	-->
 					<fo:table-cell>
 						<fo:block text-align="center" font-size="3pt">NATURAL ARMOR</fo:block>
 					</fo:table-cell>	<!--	19	-->
-					<fo:table-cell/>	<!--	20	-->
+					<fo:table-cell><fo:block/></fo:table-cell>
+	<!--	20	-->
 					<fo:table-cell>
 						<fo:block text-align="center" font-size="3pt">DEFLEC- TION</fo:block>
 					</fo:table-cell>	<!--	21	-->
-					<fo:table-cell/>	<!--	22	-->
+					<fo:table-cell><fo:block/></fo:table-cell>
+	<!--	22	-->
 					<fo:table-cell>
 						<fo:block text-align="center" font-size="4pt">DODGE</fo:block>
 					</fo:table-cell>	<!--	23	-->
-					<fo:table-cell/>	<!--	24	-->
+					<fo:table-cell><fo:block/></fo:table-cell>
+	<!--	24	-->
 					<fo:table-cell>
 						<fo:block text-align="center" font-size="4pt">Morale</fo:block>
 					</fo:table-cell>	<!--	25	-->
-					<fo:table-cell/>	<!--	26	-->
+					<fo:table-cell><fo:block/></fo:table-cell>
+	<!--	26	-->
 					<fo:table-cell>
 						<fo:block text-align="center" font-size="4pt">Insight</fo:block>
 					</fo:table-cell>	<!--	27	-->
-					<fo:table-cell/>	<!--	28	-->
+					<fo:table-cell><fo:block/></fo:table-cell>
+	<!--	28	-->
 					<fo:table-cell>
 						<fo:block text-align="center" font-size="4pt">Sacred</fo:block>
 					</fo:table-cell>	<!--	29	-->
-					<fo:table-cell/>	<!--	30	-->
+					<fo:table-cell><fo:block/></fo:table-cell>
+	<!--	30	-->
 					<fo:table-cell>
 						<fo:block text-align="center" font-size="4pt">Profane</fo:block>
 					</fo:table-cell>	<!--	31	-->
-					<fo:table-cell/>	<!--	32	-->
+					<fo:table-cell><fo:block/></fo:table-cell>
+	<!--	32	-->
 					<fo:table-cell>
 						<fo:block text-align="center" font-size="4pt">MISC</fo:block>
 					</fo:table-cell>	<!--	33	-->
 
-		<!-->			<fo:table-cell/> -->	<!--	34	-->
+		<!-->			<fo:table-cell><fo:block/></fo:table-cell>
+ -->	<!--	34	-->
 
 				</fo:table-row>
 			</fo:table-body>
@@ -644,7 +692,7 @@
 ====================================-->
 	<xsl:template match="initiative">
 		<!-- BEGIN ini-base table -->
-		<fo:table table-layout="fixed">		<!--space-before="2pt"-->
+		<fo:table table-layout="fixed" width="100%">		<!--space-before="2pt"-->
 			<!-- 0.26 * $pagePrintableWidth - mm -->
 			<fo:table-column>
 				<xsl:attribute name="column-width"><xsl:value-of select="0.49 * (0.26 * $pagePrintableWidth - 8)" />mm</xsl:attribute>
@@ -718,7 +766,8 @@
 			<fo:table-body>
 				<fo:table-row height="2pt">
 											<xsl:message>Test</xsl:message>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 				</fo:table-row>
 				<fo:table-row>
 											<xsl:message>Test</xsl:message>
@@ -729,7 +778,8 @@
 						<fo:block line-height="10pt" font-weight="bold" font-size="10pt" space-before="1pt">INITIATIVE</fo:block>
 						<fo:block line-height="4pt" font-size="4pt">modifier</fo:block>
 					</fo:table-cell>		<!--	1	-->
-					<fo:table-cell/>		<!--	2	-->
+					<fo:table-cell><fo:block/></fo:table-cell>
+		<!--	2	-->
 					<fo:table-cell>
 						<xsl:call-template name="attrib">
 							<xsl:with-param name="attribute" select="'initiative.total'"/>
@@ -760,7 +810,8 @@
 							<xsl:value-of select="misc_mod"/>
 						</fo:block>
 					</fo:table-cell>		<!--	7	-->
-					<fo:table-cell/>		<!--	8	-->
+					<fo:table-cell><fo:block/></fo:table-cell>
+		<!--	8	-->
 					<fo:table-cell display-align="center">
 						<xsl:call-template name="attrib">
 							<xsl:with-param name="attribute" select="'miss_chance'"/>
@@ -769,7 +820,8 @@
 							<!-- Miss chance -->
 						</fo:block>
 					</fo:table-cell>		<!--	9	-->
-					<fo:table-cell/>		<!--	10	-->
+					<fo:table-cell><fo:block/></fo:table-cell>
+		<!--	10	-->
 					<fo:table-cell display-align="center">
 						<xsl:call-template name="attrib">
 							<xsl:with-param name="attribute" select="'spell_failure'"/>
@@ -778,7 +830,8 @@
 							<xsl:value-of select="spell_failure"/>
 						</fo:block>
 					</fo:table-cell>		<!--	11	-->
-					<fo:table-cell/>		<!--	12	-->
+					<fo:table-cell><fo:block/></fo:table-cell>
+		<!--	12	-->
 					<fo:table-cell display-align="center">
 						<xsl:call-template name="attrib">
 							<xsl:with-param name="attribute" select="'ac_check'"/>
@@ -787,7 +840,8 @@
 							<xsl:value-of select="check_penalty"/>
 						</fo:block>
 					</fo:table-cell>		<!--	13	-->
-					<fo:table-cell/>		<!--	14	-->
+					<fo:table-cell><fo:block/></fo:table-cell>
+		<!--	14	-->
 					<fo:table-cell display-align="center">
 						<xsl:call-template name="attrib">
 							<xsl:with-param name="attribute" select="'spell_resistance'"/>
@@ -797,7 +851,8 @@
 						</fo:block>
 					</fo:table-cell>		<!--	15	-->
 
-					<fo:table-cell/>		<!--	14	-->
+					<fo:table-cell><fo:block/></fo:table-cell>
+		<!--	14	-->
 
 					<fo:table-cell display-align="center">
 						<xsl:call-template name="attrib">
@@ -809,7 +864,8 @@
 							</xsl:if>
 						</fo:block>
 					</fo:table-cell>		<!--	15	-->
-					<fo:table-cell/>		<!--	14	-->
+					<fo:table-cell><fo:block/></fo:table-cell>
+		<!--	14	-->
 					<fo:table-cell display-align="center">
 						<xsl:call-template name="attrib">
 							<xsl:with-param name="attribute" select="'spell_resistance'"/>
@@ -820,7 +876,8 @@
 							</xsl:if>
 						</fo:block>
 					</fo:table-cell>		<!--	15	-->
-					<fo:table-cell/>		<!--	14	-->
+					<fo:table-cell><fo:block/></fo:table-cell>
+		<!--	14	-->
 					<fo:table-cell display-align="center">
 						<xsl:call-template name="attrib">
 							<xsl:with-param name="attribute" select="'spell_resistance'"/>
@@ -831,7 +888,8 @@
 							</xsl:if>
 						</fo:block>
 					</fo:table-cell>		<!--	15	-->
-					<fo:table-cell/>		<!--	14	-->
+					<fo:table-cell><fo:block/></fo:table-cell>
+		<!--	14	-->
 					<fo:table-cell display-align="center">
 						<xsl:call-template name="attrib">
 							<xsl:with-param name="attribute" select="'spell_resistance'"/>
@@ -850,50 +908,62 @@
 <!-- Label Row -->
 				<fo:table-row>
 											<xsl:message>Test</xsl:message>
-					<fo:table-cell/>		<!--	1	-->
-					<fo:table-cell/>		<!--	2	-->
+					<fo:table-cell><fo:block/></fo:table-cell>
+		<!--	1	-->
+					<fo:table-cell><fo:block/></fo:table-cell>
+		<!--	2	-->
 					<fo:table-cell>
 						<fo:block text-align="center" space-before.optimum="1pt" font-size="6pt">TOTAL</fo:block>
 					</fo:table-cell>		<!--	3	-->
-					<fo:table-cell/>		<!--	4	-->
+					<fo:table-cell><fo:block/></fo:table-cell>
+		<!--	4	-->
 					<fo:table-cell>
 						<fo:block text-align="center" font-size="4pt">DEX MODIFIER</fo:block>
 					</fo:table-cell>		<!--	5	-->
-					<fo:table-cell/>		<!--	6	-->
+					<fo:table-cell><fo:block/></fo:table-cell>
+		<!--	6	-->
 					<fo:table-cell>
 						<fo:block text-align="center" font-size="4pt">MISC MODIFIER</fo:block>
 					</fo:table-cell>		<!--	7	-->
 					<!-- New Stuff	-->
-					<fo:table-cell/>		<!--	8	-->
+					<fo:table-cell><fo:block/></fo:table-cell>
+		<!--	8	-->
 					<fo:table-cell>
 						<fo:block text-align="center" font-size="4pt">MISS CHANCE</fo:block>
 					</fo:table-cell>		<!--	9	-->
-					<fo:table-cell/>		<!--	10	-->
+					<fo:table-cell><fo:block/></fo:table-cell>
+		<!--	10	-->
 					<fo:table-cell>
 						<fo:block text-align="center" font-size="4pt">Arcane Spell Failure</fo:block>
 					</fo:table-cell>		<!--	11	-->
-					<fo:table-cell/>		<!--	12	-->
+					<fo:table-cell><fo:block/></fo:table-cell>
+		<!--	12	-->
 					<fo:table-cell>
 						<fo:block text-align="center" font-size="4pt">ARMOR CHECK PENALTY</fo:block>
 					</fo:table-cell>		<!--	13	-->
-					<fo:table-cell/>		<!--	14	-->
+					<fo:table-cell><fo:block/></fo:table-cell>
+		<!--	14	-->
 					<fo:table-cell>
 						<fo:block text-align="center" font-size="4pt">SPELL RESIST</fo:block>
 					</fo:table-cell>		<!--	15	-->
 					
-					<fo:table-cell/>		<!--	14	-->
+					<fo:table-cell><fo:block/></fo:table-cell>
+		<!--	14	-->
 					<fo:table-cell>
 						<fo:block text-align="center" font-size="4pt">ACID RESIST</fo:block>
 					</fo:table-cell>		<!--	15	-->
-					<fo:table-cell/>		<!--	14	-->
+					<fo:table-cell><fo:block/></fo:table-cell>
+		<!--	14	-->
 					<fo:table-cell>
 						<fo:block text-align="center" font-size="4pt">COLD RESIST</fo:block>
 					</fo:table-cell>		<!--	15	-->
-					<fo:table-cell/>		<!--	14	-->
+					<fo:table-cell><fo:block/></fo:table-cell>
+		<!--	14	-->
 					<fo:table-cell>
 						<fo:block text-align="center" font-size="4pt">ELECT. RESIST</fo:block>
 					</fo:table-cell>		<!--	15	-->
-					<fo:table-cell/>		<!--	14	-->
+					<fo:table-cell><fo:block/></fo:table-cell>
+		<!--	14	-->
 					<fo:table-cell>
 						<fo:block text-align="center" font-size="4pt">FIRE RESIST</fo:block>
 					</fo:table-cell>		<!--	15	-->
@@ -923,7 +993,7 @@
 ====================================-->
 	<xsl:template match="bab" mode="bab">
 		<!-- BEGIN ini-base table -->
-		<fo:table table-layout="fixed">
+		<fo:table table-layout="fixed" width="100%">
 			<!-- 0.26 * $pagePrintableWidth - 2 mm -->
 			<fo:table-column>
 				<xsl:attribute name="column-width"><xsl:value-of select="0.44 * (0.26 * $pagePrintableWidth - 4)" />mm</xsl:attribute>
@@ -935,7 +1005,8 @@
 			<fo:table-body>
 				<fo:table-row height="2pt">
 											<xsl:message>Test</xsl:message>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 				</fo:table-row>
 				<fo:table-row>
 											<xsl:message>Test</xsl:message>
@@ -946,7 +1017,8 @@
 						<fo:block line-height="10pt" font-weight="bold" font-size="7.5pt">BASE ATTACK</fo:block>
 						<fo:block line-height="4pt" font-size="4pt">bonus</fo:block>
 					</fo:table-cell>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 					<fo:table-cell>
 						<xsl:call-template name="attrib">
 							<xsl:with-param name="attribute" select="'bab.total'"/>
@@ -974,7 +1046,7 @@
 	<xsl:template name="encumbrance">
 		<!-- BEGIN encumbrance table -->
 <!--	<xsl:if test="/character/equipment/total/load != 'Light'">	-->
-		<fo:table table-layout="fixed">
+		<fo:table table-layout="fixed" width="100%">
 			<!-- 0.26 * $pagePrintableWidth - 2 mm -->
 			<fo:table-column>
 				<xsl:attribute name="column-width"><xsl:value-of select="0.50 * (0.26 * $pagePrintableWidth - 4)" />mm</xsl:attribute>
@@ -986,7 +1058,8 @@
 			<fo:table-body>
 				<fo:table-row height="0pt">
 											<xsl:message>Test</xsl:message>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 				</fo:table-row>
 				<fo:table-row>
 											<xsl:message>Test</xsl:message>
@@ -996,7 +1069,8 @@
 						</xsl:call-template>
 					<fo:block line-height="10pt" font-weight="bold" font-size="7pt" space-before="0pt">Encumbrance</fo:block>
 					</fo:table-cell>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 					<fo:table-cell>
 						<xsl:call-template name="attrib">
 							<xsl:with-param name="attribute" select="'initiative.total'"/>
@@ -1029,7 +1103,7 @@
 ====================================-->
 	<xsl:template name="resistances">
 		<!-- BEGIN Resistance table -->
-		<fo:table table-layout="fixed">
+		<fo:table table-layout="fixed" width="100%">
 			<!-- 0.26 * $pagePrintableWidth - 2 mm -->
 			<fo:table-column>
 				<xsl:attribute name="column-width"><xsl:value-of select="0.50 * (0.26 * $pagePrintableWidth - 4)" />mm</xsl:attribute>
@@ -1037,7 +1111,8 @@
 			<fo:table-body>
 				<fo:table-row height="2pt">
 											<xsl:message>Test</xsl:message>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 				</fo:table-row>
 				<fo:table-row>
 											<xsl:message>Test</xsl:message>
@@ -1047,7 +1122,8 @@
 						</xsl:call-template>
 					<fo:block line-height="10pt" font-weight="bold" font-size="7pt" space-before="1pt">Res</fo:block>
 					</fo:table-cell>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 					<fo:table-cell>
 						<xsl:call-template name="attrib">
 							<xsl:with-param name="attribute" select="'initiative.total'"/>
@@ -1071,7 +1147,7 @@
 ====================================-->
 	<xsl:template match="saving_throws">
 		<!-- BEGIN Saves table -->
-		<fo:table table-layout="fixed" space-before="2mm">
+		<fo:table table-layout="fixed" width="100%" space-before="2mm">
 			<fo:table-column column-width="82mm"/>	<!-- Saves Row -->
 			<fo:table-column column-width="2mm"/>	<!-- Spacer -->
 			<fo:table-column>
@@ -1083,7 +1159,8 @@
 					<fo:table-cell>
 						<xsl:apply-templates select="." mode="saves"/>
 					</fo:table-cell>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 <!--	Square Box Conditional Save area that we no longer need	
 					<fo:table-cell padding-start="1pt">
 						<xsl:call-template name="attrib">
@@ -1107,7 +1184,7 @@
 ====================================-->
 	<xsl:template match="saving_throws" mode="saves">
 		<!-- BEGIN Saves table -->
-		<fo:table table-layout="fixed">
+		<fo:table table-layout="fixed" width="100%">
 			<fo:table-column column-width="23mm"/>
 			<fo:table-column column-width="2mm"/>
 			<fo:table-column column-width="7mm"/>
@@ -1135,23 +1212,28 @@
 					<fo:table-cell>
 						<fo:block text-align="center" font-size="4pt">BASE SAVE</fo:block>
 					</fo:table-cell>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 					<fo:table-cell>
 						<fo:block text-align="center" font-size="4pt">ABILITY</fo:block>
 					</fo:table-cell>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 					<fo:table-cell>
 						<fo:block text-align="center" font-size="4pt">MAGIC</fo:block>
 					</fo:table-cell>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 					<fo:table-cell>
 						<fo:block text-align="center" font-size="4pt">MISC</fo:block>
 					</fo:table-cell>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 					<fo:table-cell>
 						<fo:block text-align="center" font-size="4pt">EPIC</fo:block>
 					</fo:table-cell>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 					<fo:table-cell>
 						<fo:block text-align="center" font-size="4pt">TEMP</fo:block>
 					</fo:table-cell>
@@ -1168,7 +1250,8 @@
 							</fo:block>
 							<fo:block line-height="4pt" font-size="4pt">(<xsl:value-of select="ability"/>)</fo:block>
 						</fo:table-cell>
-						<fo:table-cell/>
+						<fo:table-cell><fo:block/></fo:table-cell>
+
 						<fo:table-cell>
 							<xsl:call-template name="attrib">
 								<xsl:with-param name="attribute" select="'saves.total'"/>
@@ -1186,9 +1269,10 @@
 						<xsl:call-template name="saves.entry"><xsl:with-param name="value" select="misc_mod"/></xsl:call-template>
 						<xsl:call-template name="saves.entry"><xsl:with-param name="value" select="epic_mod"/></xsl:call-template>
 						<fo:table-cell>
-							<xsl:call-template name="attrib">
-								<xsl:with-param name="attribute" select="'border.temp'"/>
-							</xsl:call-template>
+								<xsl:call-template name="attrib">
+									<xsl:with-param name="attribute" select="'border.temp'"/>
+								</xsl:call-template>
+							<fo:block/>
 						</fo:table-cell>
 					</fo:table-row>
 					<fo:table-row height="2pt">

--- a/outputsheets/d20/fantasy/pdf/common_sheet/block_misc.xslt
+++ b/outputsheets/d20/fantasy/pdf/common_sheet/block_misc.xslt
@@ -137,7 +137,7 @@
 	</xsl:template>
 	<xsl:template name="followers.list">
 		<xsl:if test="count(follower) &gt; 0">
-			<fo:table table-layout="fixed" space-after.optimum="2mm">
+			<fo:table table-layout="fixed" width="100%" space-after.optimum="2mm">
 				<fo:table-column>
 					<xsl:attribute name="column-width"><xsl:value-of select="0.5 * ($pagePrintableWidth - 2)" />mm</xsl:attribute>
 				</fo:table-column>
@@ -170,7 +170,7 @@
 	</xsl:template>
 	<xsl:template name="show_companion">
 		<xsl:param name="followerType" select="Follower"/>
-		<fo:table table-layout="fixed" space-before.optimum="2mm" keep-together="always">
+		<fo:table table-layout="fixed" width="100%" space-before.optimum="2mm" keep-together="always">
 				<fo:table-column>
 					<xsl:attribute name="column-width"><xsl:value-of select="0.5 * ($pagePrintableWidth - 2) - 69" />mm</xsl:attribute>
 				</fo:table-column>
@@ -392,7 +392,7 @@
 ====================================-->
 	<xsl:template match="misc/companions">
 		<xsl:if test="count(companion) &gt; 0">	
-			<fo:table table-layout="fixed" space-before.optimum="2mm">
+			<fo:table table-layout="fixed" width="100%" space-before.optimum="2mm">
 				<xsl:call-template name="attrib">
 					<xsl:with-param name="attribute" select="'magic.border'"/>
 				</xsl:call-template>

--- a/outputsheets/d20/fantasy/pdf/common_sheet/block_pc_header_row.xslt
+++ b/outputsheets/d20/fantasy/pdf/common_sheet/block_pc_header_row.xslt
@@ -21,7 +21,7 @@
 		<xsl:choose>		<!-- Determine which header to use -->
 			<xsl:when test="rules/pfs/os > 0">		
 				<!-- PFS Header -->
-				<fo:table table-layout="fixed">
+				<fo:table table-layout="fixed" width="100%">
 				<xsl:attribute name="width"><xsl:value-of select="$pagePrintableWidth" />mm</xsl:attribute>
 				<xsl:choose>
 					<xsl:when test="string-length(portrait/portrait) &gt; 0">
@@ -114,7 +114,8 @@
 								</xsl:if>
 							</fo:block>
 						</fo:table-cell>
-						<fo:table-cell/>
+						<fo:table-cell><fo:block/></fo:table-cell>
+
 						<fo:table-cell number-columns-spanned="3" font-weight="bold">
 							<xsl:call-template name="attrib">
 								<xsl:with-param name="attribute" select="'bio'"/>
@@ -124,7 +125,8 @@
 								
 							</fo:block>
 						</fo:table-cell>
-						<fo:table-cell/>
+						<fo:table-cell><fo:block/></fo:table-cell>
+
 						<fo:table-cell padding-top="2.5pt" number-columns-spanned="1">
 							<xsl:call-template name="attrib">
 								<xsl:with-param name="attribute" select="'bio'"/>
@@ -133,7 +135,8 @@
 								<xsl:value-of select="deity/name"/>	
 							</fo:block>
 						</fo:table-cell>
-						<fo:table-cell/>
+						<fo:table-cell><fo:block/></fo:table-cell>
+
 						<fo:table-cell padding-top="2.5pt" number-columns-spanned="1">
 							<xsl:call-template name="attrib">
 								<xsl:with-param name="attribute" select="'bio'"/>
@@ -143,7 +146,8 @@
 							</fo:block>
 						</fo:table-cell>
 
-						<fo:table-cell/>
+						<fo:table-cell><fo:block/></fo:table-cell>
+
 						<fo:table-cell padding-top="2.5pt">
 							<xsl:call-template name="attrib">
 								<xsl:with-param name="attribute" select="'bio'"/>
@@ -153,7 +157,8 @@
 							</fo:block>
 						</fo:table-cell>
 						<xsl:if test="string-length(portrait/portrait_thumb) &gt; 0">
-							<fo:table-cell/>
+							<fo:table-cell><fo:block/></fo:table-cell>
+
 							<fo:table-cell number-rows-spanned="6">
 								<xsl:call-template name="attrib">
 									<xsl:with-param name="attribute" select="'picture'"/>
@@ -175,35 +180,40 @@
 							</xsl:call-template>
 							<fo:block font-size="6pt" padding-top="1pt">Character Name</fo:block>
 						</fo:table-cell>
-						<fo:table-cell/>
+						<fo:table-cell><fo:block/></fo:table-cell>
+
 						<fo:table-cell number-columns-spanned="3">
 							<xsl:call-template name="attrib">
 								<xsl:with-param name="attribute" select="'bio.title'"/>
 							</xsl:call-template>
 							<fo:block font-size="6pt" padding-top="1pt">Player Name</fo:block>
 						</fo:table-cell>
-						<fo:table-cell/>
+						<fo:table-cell><fo:block/></fo:table-cell>
+
 						<fo:table-cell number-columns-spanned="1">
 							<xsl:call-template name="attrib">
 								<xsl:with-param name="attribute" select="'bio.title'"/>
 							</xsl:call-template>
 							<fo:block font-size="6pt" padding-top="1pt">Deity</fo:block>		
 						</fo:table-cell>
-						<fo:table-cell/>
+						<fo:table-cell><fo:block/></fo:table-cell>
+
 						<fo:table-cell number-columns-spanned="1">
 							<xsl:call-template name="attrib">
 								<xsl:with-param name="attribute" select="'bio.title'"/>
 							</xsl:call-template>
 							<fo:block font-size="6pt" padding-top="1pt">Region</fo:block>	
 						</fo:table-cell>
-						<fo:table-cell/>	<!-- SPACE -->
+						<fo:table-cell><fo:block/></fo:table-cell>
+	<!-- SPACE -->
 						<fo:table-cell>
 							<xsl:call-template name="attrib">
 								<xsl:with-param name="attribute" select="'bio.title'"/>
 							</xsl:call-template>
 							<fo:block font-size="6pt" padding-top="1pt">Alignment</fo:block>	
 						</fo:table-cell>
-						<fo:table-cell/>	<!-- SPACE -->
+						<fo:table-cell><fo:block/></fo:table-cell>
+	<!-- SPACE -->
 					</fo:table-row>
 	<!-- Second Row -->
 					<fo:table-row>
@@ -240,7 +250,8 @@
 								</xsl:for-each>
 							</fo:block>
 						</fo:table-cell>
-						<fo:table-cell/>	<!-- SPACE -->
+						<fo:table-cell><fo:block/></fo:table-cell>
+	<!-- SPACE -->
 						<fo:table-cell number-columns-spanned="3">
 							<xsl:call-template name="attrib">
 								<xsl:with-param name="attribute" select="'bio'"/>
@@ -258,7 +269,8 @@
 								</xsl:if>
 							</fo:block>
 						</fo:table-cell>
-						<fo:table-cell/>	<!-- SPACE -->
+						<fo:table-cell><fo:block/></fo:table-cell>
+	<!-- SPACE -->
 						<fo:table-cell>
 							<xsl:call-template name="attrib">
 								<xsl:with-param name="attribute" select="'bio'"/>
@@ -268,7 +280,8 @@
 								<xsl:if test="face/short != ''"> / <xsl:value-of select="face/short"/></xsl:if>
 							</fo:block>
 						</fo:table-cell>
-						<fo:table-cell/>	<!-- SPACE -->
+						<fo:table-cell><fo:block/></fo:table-cell>
+	<!-- SPACE -->
 						<fo:table-cell>
 							<xsl:call-template name="attrib">
 								<xsl:with-param name="attribute" select="'bio'"/>
@@ -278,7 +291,8 @@
 								<xsl:value-of select="weight/weight_unit"/>
 							</fo:block>
 						</fo:table-cell>
-						<fo:table-cell/>	<!-- SPACE -->
+						<fo:table-cell><fo:block/></fo:table-cell>
+	<!-- SPACE -->
 						<fo:table-cell>
 							<xsl:call-template name="attrib">
 								<xsl:with-param name="attribute" select="'bio'"/>
@@ -287,7 +301,8 @@
 								<xsl:value-of select="rules/pfs/id_number"/>
 							</fo:block>
 						</fo:table-cell>
-						<fo:table-cell/>
+						<fo:table-cell><fo:block/></fo:table-cell>
+
 					</fo:table-row>
 					<fo:table-row>
 												<xsl:message>Test</xsl:message>
@@ -299,35 +314,40 @@
 						</fo:table-cell>
 						
 					
-						<fo:table-cell/>
+						<fo:table-cell><fo:block/></fo:table-cell>
+
 						<fo:table-cell number-columns-spanned="3">
 							<xsl:call-template name="attrib">
 								<xsl:with-param name="attribute" select="'bio.title'"/>
 							</xsl:call-template>
 							<fo:block font-size="6pt" padding-top="1pt">RACE</fo:block>
 						</fo:table-cell>
-						<fo:table-cell/>
+						<fo:table-cell><fo:block/></fo:table-cell>
+
 						<fo:table-cell>
 							<xsl:call-template name="attrib">
 								<xsl:with-param name="attribute" select="'bio.title'"/>
 							</xsl:call-template>
 							<fo:block font-size="6pt" padding-top="1pt">SIZE / FACE</fo:block>
 						</fo:table-cell>
-						<fo:table-cell/>
+						<fo:table-cell><fo:block/></fo:table-cell>
+
 						<fo:table-cell>
 							<xsl:call-template name="attrib">
 								<xsl:with-param name="attribute" select="'bio.title'"/>
 							</xsl:call-template>
 							<fo:block font-size="6pt" padding-top="1pt">HEIGHT / WEIGHT</fo:block>
 						</fo:table-cell>
-						<fo:table-cell/>
+						<fo:table-cell><fo:block/></fo:table-cell>
+
 						<fo:table-cell>
 							<xsl:call-template name="attrib">
 								<xsl:with-param name="attribute" select="'bio.title'"/>
 							</xsl:call-template>
 							<fo:block font-size="6pt" padding-top="1pt">CHARACTER ID</fo:block>
 						</fo:table-cell>
-						<fo:table-cell/>
+						<fo:table-cell><fo:block/></fo:table-cell>
+
 					</fo:table-row>
 	<!--	Third Row-->
 					<fo:table-row>
@@ -343,7 +363,8 @@
 								(<xsl:value-of select="cr"/>)
 							</fo:block>
 						</fo:table-cell>
-						<fo:table-cell/>
+						<fo:table-cell><fo:block/></fo:table-cell>
+
 						<fo:table-cell>
 							<xsl:call-template name="attrib">
 								<xsl:with-param name="attribute" select="'bio'"/>
@@ -352,7 +373,8 @@
 								<xsl:value-of select="experience/current"/> / <xsl:value-of select="experience/next_level"/>
 							</fo:block>
 						</fo:table-cell>
-						<fo:table-cell/>
+						<fo:table-cell><fo:block/></fo:table-cell>
+
 						<fo:table-cell>
 							<xsl:call-template name="attrib">
 								<xsl:with-param name="attribute" select="'bio'"/>
@@ -362,7 +384,8 @@
 								<xsl:if test="birthday != ''"> (<xsl:value-of select="birthday"/>)</xsl:if>
 							</fo:block>
 						</fo:table-cell>
-						<fo:table-cell/>
+						<fo:table-cell><fo:block/></fo:table-cell>
+
 						<fo:table-cell>
 							<xsl:call-template name="attrib">
 								<xsl:with-param name="attribute" select="'bio'"/>
@@ -371,7 +394,8 @@
 								<xsl:value-of select="gender/long"/>
 							</fo:block>
 						</fo:table-cell>
-						<fo:table-cell/>
+						<fo:table-cell><fo:block/></fo:table-cell>
+
 						<fo:table-cell>
 							<xsl:call-template name="attrib">
 								<xsl:with-param name="attribute" select="'bio'"/>
@@ -380,7 +404,8 @@
 								<xsl:value-of select="eyes/color"/>
 							</fo:block>
 						</fo:table-cell>
-						<fo:table-cell/>
+						<fo:table-cell><fo:block/></fo:table-cell>
+
 						<fo:table-cell>
 							<xsl:call-template name="attrib">
 								<xsl:with-param name="attribute" select="'bio'"/>
@@ -390,7 +415,8 @@
 									<xsl:if test="hair/color != '' and hair/length !=''">, <xsl:value-of select="hair/length"/></xsl:if>
 							</fo:block>
 						</fo:table-cell>
-						<fo:table-cell/>
+						<fo:table-cell><fo:block/></fo:table-cell>
+
 						<fo:table-cell>
 							<xsl:call-template name="attrib">
 								<xsl:with-param name="attribute" select="'bio'"/>
@@ -399,7 +425,8 @@
 								<xsl:value-of select="rules/pfs/faction"/>	
 							</fo:block>
 						</fo:table-cell>
-						<fo:table-cell/>
+						<fo:table-cell><fo:block/></fo:table-cell>
+
 					</fo:table-row>
 
 	<!-- Third ROW Text-->
@@ -417,55 +444,62 @@
 								<xsl:text> (CR)</xsl:text>
 							</fo:block>
 						</fo:table-cell>
-						<fo:table-cell/>
+						<fo:table-cell><fo:block/></fo:table-cell>
+
 						<fo:table-cell>
 							<xsl:call-template name="attrib">
 								<xsl:with-param name="attribute" select="'bio.title'"/>
 							</xsl:call-template>
 							<fo:block font-size="6pt" padding-top="1pt">EXP/NEXT LEVEL</fo:block>
 						</fo:table-cell>
-						<fo:table-cell/>
+						<fo:table-cell><fo:block/></fo:table-cell>
+
 						<fo:table-cell>
 							<xsl:call-template name="attrib">
 								<xsl:with-param name="attribute" select="'bio.title'"/>
 							</xsl:call-template>
 							<fo:block font-size="6pt" padding-top="1pt">AGE</fo:block>
 						</fo:table-cell>
-						<fo:table-cell/>
+						<fo:table-cell><fo:block/></fo:table-cell>
+
 						<fo:table-cell>
 							<xsl:call-template name="attrib">
 								<xsl:with-param name="attribute" select="'bio.title'"/>
 							</xsl:call-template>
 							<fo:block font-size="6pt" padding-top="1pt">GENDER</fo:block>
 						</fo:table-cell>
-						<fo:table-cell/>
+						<fo:table-cell><fo:block/></fo:table-cell>
+
 						<fo:table-cell>
 							<xsl:call-template name="attrib">
 								<xsl:with-param name="attribute" select="'bio.title'"/>
 							</xsl:call-template>
 							<fo:block font-size="6pt" padding-top="1pt">EYES</fo:block>
 						</fo:table-cell>
-						<fo:table-cell/>
+						<fo:table-cell><fo:block/></fo:table-cell>
+
 						<fo:table-cell>
 							<xsl:call-template name="attrib">
 								<xsl:with-param name="attribute" select="'bio.title'"/>
 							</xsl:call-template>
 							<fo:block font-size="6pt" padding-top="1pt">HAIR</fo:block>
 						</fo:table-cell>
-						<fo:table-cell/>
+						<fo:table-cell><fo:block/></fo:table-cell>
+
 						<fo:table-cell>
 							<xsl:call-template name="attrib">
 								<xsl:with-param name="attribute" select="'bio.title'"/>
 							</xsl:call-template>
 							<fo:block font-size="6pt" padding-top="1pt">FACTION</fo:block>	
 						</fo:table-cell>
-						<fo:table-cell/>
+						<fo:table-cell><fo:block/></fo:table-cell>
+
 					</fo:table-row>	
 				</fo:table-body>
 			</fo:table>
 				</xsl:when>
 				<xsl:otherwise>
-					<fo:table table-layout="fixed">
+					<fo:table table-layout="fixed" width="100%">
 			<xsl:attribute name="width"><xsl:value-of select="$pagePrintableWidth" />mm</xsl:attribute>
 			<xsl:choose>
 				<xsl:when test="string-length(portrait/portrait) &gt; 0">
@@ -558,7 +592,7 @@
 							</xsl:if>
 						</fo:block>
 					</fo:table-cell>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
 					<fo:table-cell number-columns-spanned="3" font-weight="bold">
 						<xsl:call-template name="attrib">
 							<xsl:with-param name="attribute" select="'bio'"/>
@@ -568,7 +602,7 @@
 							
 						</fo:block>
 					</fo:table-cell>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
 					<fo:table-cell padding-top="2.5pt" number-columns-spanned="1">
 						<xsl:call-template name="attrib">
 							<xsl:with-param name="attribute" select="'bio'"/>
@@ -577,7 +611,7 @@
 							<xsl:value-of select="deity/name"/>	
 						</fo:block>
 					</fo:table-cell>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
 					<fo:table-cell padding-top="2.5pt" number-columns-spanned="1">
 						<xsl:call-template name="attrib">
 							<xsl:with-param name="attribute" select="'bio'"/>
@@ -587,7 +621,7 @@
 						</fo:block>
 					</fo:table-cell>
 
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
 					<fo:table-cell padding-top="2.5pt">
 						<xsl:call-template name="attrib">
 							<xsl:with-param name="attribute" select="'bio'"/>
@@ -597,7 +631,8 @@
 						</fo:block>
 					</fo:table-cell>
 					<xsl:if test="string-length(portrait/portrait_thumb) &gt; 0">
-						<fo:table-cell/>
+						<fo:table-cell><fo:block/></fo:table-cell>
+
 						<fo:table-cell number-rows-spanned="6">
 							<xsl:call-template name="attrib">
 								<xsl:with-param name="attribute" select="'picture'"/>
@@ -619,35 +654,40 @@
 						</xsl:call-template>
 						<fo:block font-size="6pt" padding-top="1pt">Character Name</fo:block>
 					</fo:table-cell>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 					<fo:table-cell number-columns-spanned="3">
 						<xsl:call-template name="attrib">
 							<xsl:with-param name="attribute" select="'bio.title'"/>
 						</xsl:call-template>
 						<fo:block font-size="6pt" padding-top="1pt">Player Name</fo:block>
 					</fo:table-cell>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 					<fo:table-cell number-columns-spanned="1">
 						<xsl:call-template name="attrib">
 							<xsl:with-param name="attribute" select="'bio.title'"/>
 						</xsl:call-template>
 						<fo:block font-size="6pt" padding-top="1pt">Deity</fo:block>		
 					</fo:table-cell>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 					<fo:table-cell number-columns-spanned="1">
 						<xsl:call-template name="attrib">
 							<xsl:with-param name="attribute" select="'bio.title'"/>
 						</xsl:call-template>
 						<fo:block font-size="6pt" padding-top="1pt">Region</fo:block>	
 					</fo:table-cell>
-					<fo:table-cell/>	<!-- SPACE -->
+					<fo:table-cell><fo:block/></fo:table-cell>
+	<!-- SPACE -->
 					<fo:table-cell>
 						<xsl:call-template name="attrib">
 							<xsl:with-param name="attribute" select="'bio.title'"/>
 						</xsl:call-template>
 						<fo:block font-size="6pt" padding-top="1pt">Alignment</fo:block>	
 					</fo:table-cell>
-					<fo:table-cell/>	<!-- SPACE -->
+					<fo:table-cell><fo:block/></fo:table-cell>
+	<!-- SPACE -->
 				</fo:table-row>
 <!-- Second Row -->
 				<fo:table-row>
@@ -684,7 +724,8 @@
 							</xsl:for-each>
 						</fo:block>
 					</fo:table-cell>
-					<fo:table-cell/>	<!-- SPACE -->
+					<fo:table-cell><fo:block/></fo:table-cell>
+	<!-- SPACE -->
 					<fo:table-cell number-columns-spanned="3">
 						<xsl:call-template name="attrib">
 							<xsl:with-param name="attribute" select="'bio'"/>
@@ -702,7 +743,8 @@
 							</xsl:if>
 						</fo:block>
 					</fo:table-cell>
-					<fo:table-cell/>	<!-- SPACE -->
+					<fo:table-cell><fo:block/></fo:table-cell>
+	<!-- SPACE -->
 					<fo:table-cell>
 						<xsl:call-template name="attrib">
 							<xsl:with-param name="attribute" select="'bio'"/>
@@ -712,7 +754,8 @@
 							<xsl:if test="face/short != ''"> / <xsl:value-of select="face/short"/></xsl:if>
 						</fo:block>
 					</fo:table-cell>
-					<fo:table-cell/>	<!-- SPACE -->
+					<fo:table-cell><fo:block/></fo:table-cell>
+	<!-- SPACE -->
 					<fo:table-cell>
 						<xsl:call-template name="attrib">
 							<xsl:with-param name="attribute" select="'bio'"/>
@@ -722,7 +765,8 @@
 							<xsl:value-of select="weight/weight_unit"/>
 						</fo:block>
 					</fo:table-cell>
-					<fo:table-cell/>	<!-- SPACE -->
+					<fo:table-cell><fo:block/></fo:table-cell>
+	<!-- SPACE -->
 					<fo:table-cell>
 						<xsl:call-template name="attrib">
 							<xsl:with-param name="attribute" select="'bio'"/>
@@ -732,7 +776,8 @@
 							<xsl:if test="vision/all = ''">Normal</xsl:if>
 						</fo:block>
 					</fo:table-cell>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 				</fo:table-row>
 				<fo:table-row>
 											<xsl:message>Test</xsl:message>
@@ -744,35 +789,40 @@
 					</fo:table-cell>
 					
 				
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 					<fo:table-cell number-columns-spanned="3">
 						<xsl:call-template name="attrib">
 							<xsl:with-param name="attribute" select="'bio.title'"/>
 						</xsl:call-template>
 						<fo:block font-size="6pt" padding-top="1pt">RACE</fo:block>
 					</fo:table-cell>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 					<fo:table-cell>
 						<xsl:call-template name="attrib">
 							<xsl:with-param name="attribute" select="'bio.title'"/>
 						</xsl:call-template>
 						<fo:block font-size="6pt" padding-top="1pt">SIZE / FACE</fo:block>
 					</fo:table-cell>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 					<fo:table-cell>
 						<xsl:call-template name="attrib">
 							<xsl:with-param name="attribute" select="'bio.title'"/>
 						</xsl:call-template>
 						<fo:block font-size="6pt" padding-top="1pt">HEIGHT / WEIGHT</fo:block>
 					</fo:table-cell>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 					<fo:table-cell>
 						<xsl:call-template name="attrib">
 							<xsl:with-param name="attribute" select="'bio.title'"/>
 						</xsl:call-template>
 						<fo:block font-size="6pt" padding-top="1pt">VISION</fo:block>
 					</fo:table-cell>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 				</fo:table-row>
 <!--	Third Row-->
 				<fo:table-row>
@@ -788,7 +838,8 @@
 							(<xsl:value-of select="cr"/>)
 						</fo:block>
 					</fo:table-cell>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 					<fo:table-cell>
 						<xsl:call-template name="attrib">
 							<xsl:with-param name="attribute" select="'bio'"/>
@@ -797,7 +848,8 @@
 							<xsl:value-of select="experience/current"/> / <xsl:value-of select="experience/next_level"/>
 						</fo:block>
 					</fo:table-cell>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 					<fo:table-cell>
 						<xsl:call-template name="attrib">
 							<xsl:with-param name="attribute" select="'bio'"/>
@@ -807,7 +859,8 @@
 							<xsl:if test="birthday != ''"> (<xsl:value-of select="birthday"/>)</xsl:if>
 						</fo:block>
 					</fo:table-cell>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 					<fo:table-cell>
 						<xsl:call-template name="attrib">
 							<xsl:with-param name="attribute" select="'bio'"/>
@@ -816,7 +869,8 @@
 							<xsl:value-of select="gender/long"/>
 						</fo:block>
 					</fo:table-cell>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 					<fo:table-cell>
 						<xsl:call-template name="attrib">
 							<xsl:with-param name="attribute" select="'bio'"/>
@@ -825,7 +879,8 @@
 							<xsl:value-of select="eyes/color"/>
 						</fo:block>
 					</fo:table-cell>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 					<fo:table-cell>
 						<xsl:call-template name="attrib">
 							<xsl:with-param name="attribute" select="'bio'"/>
@@ -835,7 +890,8 @@
 								<xsl:if test="hair/color != '' and hair/length !=''">, <xsl:value-of select="hair/length"/></xsl:if>
 						</fo:block>
 					</fo:table-cell>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 					<fo:table-cell>
 						<xsl:call-template name="attrib">
 							<xsl:with-param name="attribute" select="'bio'"/>
@@ -844,7 +900,8 @@
 							<xsl:if test="poolpoints/cost &gt; 0"> <xsl:value-of select="poolpoints/cost"/> </xsl:if>	
 						</fo:block>
 					</fo:table-cell>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 				</fo:table-row>
 
 <!-- Third ROW Text-->
@@ -862,49 +919,56 @@
 							<xsl:text> (CR)</xsl:text>
 						</fo:block>
 					</fo:table-cell>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 					<fo:table-cell>
 						<xsl:call-template name="attrib">
 							<xsl:with-param name="attribute" select="'bio.title'"/>
 						</xsl:call-template>
 						<fo:block font-size="6pt" padding-top="1pt">EXP/NEXT LEVEL</fo:block>
 					</fo:table-cell>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 					<fo:table-cell>
 						<xsl:call-template name="attrib">
 							<xsl:with-param name="attribute" select="'bio.title'"/>
 						</xsl:call-template>
 						<fo:block font-size="6pt" padding-top="1pt">AGE</fo:block>
 					</fo:table-cell>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 					<fo:table-cell>
 						<xsl:call-template name="attrib">
 							<xsl:with-param name="attribute" select="'bio.title'"/>
 						</xsl:call-template>
 						<fo:block font-size="6pt" padding-top="1pt">GENDER</fo:block>
 					</fo:table-cell>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 					<fo:table-cell>
 						<xsl:call-template name="attrib">
 							<xsl:with-param name="attribute" select="'bio.title'"/>
 						</xsl:call-template>
 						<fo:block font-size="6pt" padding-top="1pt">EYES</fo:block>
 					</fo:table-cell>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 					<fo:table-cell>
 						<xsl:call-template name="attrib">
 							<xsl:with-param name="attribute" select="'bio.title'"/>
 						</xsl:call-template>
 						<fo:block font-size="6pt" padding-top="1pt">HAIR</fo:block>
 					</fo:table-cell>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 					<fo:table-cell>
 						<xsl:call-template name="attrib">
 							<xsl:with-param name="attribute" select="'bio.title'"/>
 						</xsl:call-template>
 						<fo:block font-size="6pt" padding-top="1pt">Points</fo:block>	
 					</fo:table-cell>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 				</fo:table-row>	
 			</fo:table-body>
 		</fo:table>	<!-- Default Standard Fantasy -->

--- a/outputsheets/d20/fantasy/pdf/common_sheet/block_protection.xslt
+++ b/outputsheets/d20/fantasy/pdf/common_sheet/block_protection.xslt
@@ -20,8 +20,8 @@
 	<xsl:template match="protection">
 		<xsl:if test="count(armor|shield|item) &gt; 0" >
 		<!-- BEGIN Armor table -->
-		<fo:table table-layout="fixed" border-collapse="collapse" padding="0.5pt" space-before="2mm">
-	<!--	<fo:table table-layout="fixed" space-before="2mm">	-->
+		<fo:table table-layout="fixed" width="100%" border-collapse="collapse" space-before="2mm">
+	<!--	<fo:table table-layout="fixed" width="100%" space-before="2mm">	-->
 			<xsl:call-template name="attrib"><xsl:with-param name="attribute" select="'protection.border'"/></xsl:call-template>
 			<fo:table-column>
 				<xsl:attribute name="column-width"><xsl:value-of select="0.55 * $pagePrintableWidth - 49" />mm</xsl:attribute>

--- a/outputsheets/d20/fantasy/pdf/common_sheet/block_psionics.xslt
+++ b/outputsheets/d20/fantasy/pdf/common_sheet/block_psionics.xslt
@@ -109,7 +109,7 @@
 	<xsl:template match="psionics">
 		<!-- BEGIN psionicsTable -->
 		<xsl:variable name="endpoints" select="7"/>
-		<fo:table table-layout="fixed" space-before="2mm">
+		<fo:table table-layout="fixed" width="100%" space-before="2mm">
 			<xsl:call-template name="attrib"><xsl:with-param name="attribute" select="'psionics.border'"/></xsl:call-template>
 			<fo:table-column>
 				<xsl:attribute name="column-width"><xsl:value-of select="0.55 * ($pagePrintableWidth - $endpoints) div 6" />mm</xsl:attribute>
@@ -174,7 +174,7 @@
 		</fo:table>
 	<xsl:if test = "type = '3.0'">
 		<!-- Attack / Defence table -->
-		<fo:table table-layout="fixed" padding="0.5pt">
+		<fo:table table-layout="fixed" width="100%" padding="0.5pt">
 			<xsl:call-template name="attrib"><xsl:with-param name="attribute" select="'psionics.border'"/></xsl:call-template>
 			<fo:table-column>
 				<xsl:attribute name="column-width"><xsl:value-of select="0.55 * $pagePrintableWidth - 70" />mm</xsl:attribute>

--- a/outputsheets/d20/fantasy/pdf/common_sheet/block_skills.xslt
+++ b/outputsheets/d20/fantasy/pdf/common_sheet/block_skills.xslt
@@ -43,26 +43,34 @@
 		<fo:table-row height="9pt">
 											<xsl:message>Test</xsl:message>
 			<xsl:call-template name="attrib"><xsl:with-param name="attribute" select="concat('skills.', $shade)"/></xsl:call-template>
-			<fo:table-cell/>
-			<fo:table-cell/>
-			<fo:table-cell number-columns-spanned="2"/>
-			<fo:table-cell/>
-			<fo:table-cell number-columns-spanned="2"/>
+			<fo:table-cell><fo:block/></fo:table-cell>
+
+			<fo:table-cell><fo:block/></fo:table-cell>
+
+			<fo:table-cell number-columns-spanned="2"><fo:block/></fo:table-cell>
+			<fo:table-cell><fo:block/></fo:table-cell>
+
+			<fo:table-cell number-columns-spanned="2"><fo:block/></fo:table-cell>
 			<fo:table-cell>
-				<xsl:call-template name="attrib"><xsl:with-param name="attribute" select="concat('skills.', $shade, '.total')"/></xsl:call-template>
+				<fo:block>
+					<xsl:call-template name="attrib"><xsl:with-param name="attribute" select="concat('skills.', $shade, '.total')"/></xsl:call-template>
+				</fo:block>
 			</fo:table-cell>
 			<fo:table-cell number-columns-spanned="2">
 				<fo:block text-align="center" space-before.optimum="3pt" line-height="6pt" font-size="6pt">=</fo:block>
 			</fo:table-cell>
-			<fo:table-cell/>
+			<fo:table-cell><fo:block/></fo:table-cell>
+
 			<fo:table-cell number-columns-spanned="2">
 				<fo:block text-align="center" space-before.optimum="3pt" line-height="6pt" font-size="6pt">+</fo:block>
 			</fo:table-cell>
-			<fo:table-cell/>
+			<fo:table-cell><fo:block/></fo:table-cell>
+
 			<fo:table-cell number-columns-spanned="2">
 				<fo:block text-align="center" space-before.optimum="3pt" line-height="6pt" font-size="6pt">+</fo:block>
 			</fo:table-cell>
-			<fo:table-cell/>
+			<fo:table-cell><fo:block/></fo:table-cell>
+
 		</fo:table-row>
 	</xsl:template>
 
@@ -101,18 +109,19 @@
 				<fo:table-column column-width="6mm"/>
 			</xsl:variable>
 
-			<fo:table table-layout="fixed" border-collapse="collapse" padding="0.5pt">
+			<fo:table table-layout="fixed" width="100%" border-collapse="collapse">
 				<xsl:call-template name="attrib"><xsl:with-param name="attribute" select="'skills.border'"/></xsl:call-template>
 				<xsl:copy-of select="$columns"/>
 				<fo:table-body>
 					<fo:table-row height="2pt">
 											<xsl:message>Test</xsl:message>
-						<fo:table-cell/>
+						<fo:table-cell><fo:block/></fo:table-cell>
+
 					</fo:table-row>
 					<fo:table-row>
 											<xsl:message>Test</xsl:message>
 						<xsl:call-template name="attrib"><xsl:with-param name="attribute" select="'skills.header'"/></xsl:call-template>
-						<fo:table-cell></fo:table-cell>
+						<fo:table-cell><fo:block/></fo:table-cell>
 						<fo:table-cell number-columns-spanned="2" border-top-width="1pt" border-left-width="0pt" border-right-width="0pt" border-bottom-width="0pt">
 							<fo:block text-align="left" space-before.optimum="4pt" line-height="4pt" font-size="5pt">
 								<xsl:text>TOTAL SKILLPOINTS: </xsl:text>
@@ -144,7 +153,7 @@
 					<fo:table-row>
 											<xsl:message>Test</xsl:message>
 						<xsl:call-template name="attrib"><xsl:with-param name="attribute" select="'skills.header'"/></xsl:call-template>
-						<fo:table-cell></fo:table-cell>
+						<fo:table-cell><fo:block/></fo:table-cell>
 						<fo:table-cell number-columns-spanned="2">
 							<fo:block font-weight="bold" font-size="8pt">
 								SKILL NAME
@@ -182,7 +191,7 @@
 
 
 
-			<fo:table table-layout="fixed" border-collapse="collapse" padding="0.5pt">
+			<fo:table table-layout="fixed" width="100%" border-collapse="collapse">
 				<xsl:call-template name="attrib"><xsl:with-param name="attribute" select="'skills.border'"/></xsl:call-template>
 				<xsl:copy-of select="$columns"/>
 				<fo:table-body>
@@ -242,13 +251,13 @@
 										</xsl:otherwise>
 									</xsl:choose>
 								</fo:table-cell>
-								<fo:table-cell number-columns-spanned="2"/>
+								<fo:table-cell number-columns-spanned="2"><fo:block/></fo:table-cell>
 								<fo:table-cell>
 									<fo:block space-before.optimum="1pt" font-size="8pt">
 										<xsl:value-of select="ability"/>
 									</fo:block>
 								</fo:table-cell>
-								<fo:table-cell number-columns-spanned="2"/>
+								<fo:table-cell number-columns-spanned="2"><fo:block/></fo:table-cell>
 								<fo:table-cell>
 									<xsl:call-template name="attrib"><xsl:with-param name="attribute" select="concat('skills.', $shade, '.total')"/></xsl:call-template>
 									<fo:block text-align="center" space-before.optimum="1pt" font-size="8pt">
@@ -361,7 +370,7 @@
 		</xsl:variable>
 							<xsl:call-template name="attrib"><xsl:with-param name="attribute" select="concat('skills.', $shade)"/></xsl:call-template>
 -->
-		<fo:table table-layout="fixed" space-before="2mm" padding="0.5pt">
+		<fo:table table-layout="fixed" width="100%" space-before="2mm" padding="0.5pt">
 			<fo:table-column column-width="86mm"/>
 			<fo:table-column column-width="10mm"/>
 			<fo:table-column column-width="30mm"/>

--- a/outputsheets/d20/fantasy/pdf/common_sheet/block_spells_condensed.xslt
+++ b/outputsheets/d20/fantasy/pdf/common_sheet/block_spells_condensed.xslt
@@ -41,7 +41,7 @@
 	<xsl:template match="racial_innate">
 		<xsl:if test="count(.//spell) &gt; 0">
 			<fo:block>
-				<fo:table table-layout="fixed">
+				<fo:table table-layout="fixed" width="100%">
 					<xsl:call-template name="spells.known.header.row">
 						<xsl:with-param name="columnOne" select="''"/>
 						<xsl:with-param name="title" select="'Innate Racial Spells'"/>
@@ -64,7 +64,7 @@
 	<xsl:template match="class_innate">
 		<xsl:if test="count(.//spell) &gt; 0">
 			<xsl:for-each select="spellbook">
-				<fo:table table-layout="fixed" space-before="5mm">
+				<fo:table table-layout="fixed" width="100%" space-before="5mm">
 					<xsl:call-template name="spells.known.header.row">
 						<xsl:with-param name="columnOne" select="''"/>
 						<xsl:with-param name="title" select="concat(@name, ' Spell-like Abilities')"/>
@@ -98,7 +98,7 @@
 	<xsl:template match="class" mode="spells.known">
 		<xsl:if test="count(.//spell) &gt; 0">
 	<!--> This is causing the new page creation		<fo:block break-before="page"/>	-->
-			<fo:table table-layout="fixed">
+			<fo:table table-layout="fixed" width="100%">
 				<xsl:variable name="titletext">
 					<xsl:choose>
 						<xsl:when test="@spellcastertype = 'Psionic'">
@@ -132,7 +132,7 @@
 				<fo:table-body>
 					<fo:table-row height="2mm">
 											<xsl:message>Test</xsl:message>
-						<fo:table-cell />
+						<fo:table-cell><fo:block/></fo:table-cell>
 					</fo:table-row>
 					<fo:table-row>
 											<xsl:message>Test</xsl:message>
@@ -142,7 +142,7 @@
 					</fo:table-row>
 					<fo:table-row height="2mm">
 											<xsl:message>Test</xsl:message>
-						<fo:table-cell />
+						<fo:table-cell><fo:block/></fo:table-cell>
 					</fo:table-row>
 					<xsl:apply-templates select="level" mode="known.spells">
 						<xsl:with-param name="columnOne" select="$columnOne"/>
@@ -159,7 +159,7 @@
 ====================================
 ====================================-->
 	<xsl:template match="class" mode="spell.level.table">
-		<fo:table table-layout="fixed" border-collapse="collapse">
+		<fo:table table-layout="fixed" width="100%" border-collapse="collapse">
 			<fo:table-column column-width="proportional-column-width(2)"/>
 			<fo:table-column column-width="proportional-column-width(2)"/>
 			<xsl:for-each select="level">
@@ -188,7 +188,7 @@
 	<xsl:template match="class" mode="spell.level.count">
 		<fo:table-row keep-with-next.within-column="always">
 											<xsl:message>Test</xsl:message>
-			<fo:table-cell/>
+			<fo:table-cell><fo:block/></fo:table-cell>
 			<fo:table-cell>
 				<xsl:call-template name="attrib">
 					<xsl:with-param name="attribute" select="'spelllist.known.header.centre'"/>
@@ -205,7 +205,7 @@
 					</fo:block>
 				</fo:table-cell>
 			</xsl:for-each>
-			<fo:table-cell/>
+			<fo:table-cell><fo:block/></fo:table-cell>
 		</fo:table-row>
 	</xsl:template>
 	<!--
@@ -217,7 +217,7 @@
 	<xsl:template match="class" mode="spell.level.known">
 		<fo:table-row keep-with-next.within-column="always">
 											<xsl:message>Test</xsl:message>
-			<fo:table-cell/>
+			<fo:table-cell><fo:block/></fo:table-cell>
 			<fo:table-cell>
 				<xsl:call-template name="attrib">
 					<xsl:with-param name="attribute" select="'spelllist.known.header.centre'"/>
@@ -241,7 +241,7 @@
 					</fo:block>
 				</fo:table-cell>
 			</xsl:for-each>
-			<fo:table-cell/>
+			<fo:table-cell><fo:block/></fo:table-cell>
 		</fo:table-row>
 	</xsl:template>
 	<!--
@@ -251,9 +251,9 @@
 ====================================
 ====================================-->
 	<xsl:template match="class" mode="spell.level.cast">
-		<fo:table-row padding-bottom="2mm">
+		<fo:table-row>
 											<xsl:message>Test</xsl:message>
-			<fo:table-cell/>
+			<fo:table-cell><fo:block/></fo:table-cell>
 			<fo:table-cell>
 				<xsl:call-template name="attrib">
 					<xsl:with-param name="attribute" select="'spelllist.known.header.centre'"/>
@@ -284,7 +284,7 @@
 					</fo:block>
 				</fo:table-cell>
 			</xsl:for-each>
-			<fo:table-cell/>
+			<fo:table-cell><fo:block/></fo:table-cell>
 		</fo:table-row>
 	</xsl:template>
 
@@ -298,7 +298,7 @@
 	<xsl:template match="class" mode="spell.concentration">
 		<fo:table-row keep-with-next.within-column="always">	
 											<xsl:message>Test</xsl:message>
-			<fo:table-cell/>
+			<fo:table-cell><fo:block/></fo:table-cell>
 			<fo:table-cell>	
 				<xsl:call-template name="attrib">
 					<xsl:with-param name="attribute" select="'spelllist.known.header.centre'"/>
@@ -355,7 +355,7 @@
 			</xsl:apply-templates>
 			<fo:table-row height="1mm">
 											<xsl:message>Test</xsl:message>
-				<fo:table-cell />
+				<fo:table-cell><fo:block/></fo:table-cell>
 			</fo:table-row>
 		</xsl:if>
 	</xsl:template>
@@ -820,7 +820,7 @@
 ====================================-->
 	<xsl:template name="spells.memorized.header">
 		<xsl:param name="title" select="'Unknown'"/>
-		<fo:table table-layout="fixed">
+		<fo:table table-layout="fixed" width="100%">
 			<fo:table-column>
 				<xsl:attribute name="column-width"><xsl:value-of select="$pagePrintableWidth" />mm</xsl:attribute>
 			</fo:table-column>
@@ -849,7 +849,7 @@
 			<xsl:call-template name="spells.memorized.header">
 				<xsl:with-param name="title" select="'Innate'"/>
 			</xsl:call-template>
-			<fo:table table-layout="fixed" space-after="5mm">
+			<fo:table table-layout="fixed" width="100%" space-after="5mm">
 				<fo:table-column>
 					<xsl:attribute name="column-width"><xsl:value-of select="0.20 * $pagePrintableWidth div 5" />mm</xsl:attribute>
 				</fo:table-column>
@@ -884,7 +884,7 @@
 			<xsl:call-template name="spells.memorized.header">
 				<xsl:with-param name="title" select="concat(@name, ' Spell-like Abilities')"/>
 			</xsl:call-template>
-			<fo:table table-layout="fixed">
+			<fo:table table-layout="fixed" width="100%">
 				<fo:table-column>
 					<xsl:attribute name="column-width"><xsl:value-of select="0.20 * $pagePrintableWidth div 5" />mm</xsl:attribute>
 				</fo:table-column>
@@ -905,7 +905,7 @@
 ====================================-->
 	<xsl:template match="spellbook" mode="spells.memorized">
 		<xsl:if test="count(.//spell) &gt; 0">
-			<fo:table table-layout="fixed" space-before="4mm">
+			<fo:table table-layout="fixed" width="100%" space-before="4mm">
 				<fo:table-column>
 					<xsl:attribute name="column-width"><xsl:value-of select="$pagePrintableWidth div 5" />mm</xsl:attribute>
 				</fo:table-column>
@@ -975,7 +975,7 @@
 		<fo:table-cell padding-top="1pt">
 			<fo:block font-size="5pt">
 				<xsl:if test="count(.//spell) &gt; 0">
-					<fo:table table-layout="fixed">
+					<fo:table table-layout="fixed" width="100%">
 						<fo:table-column>
 							<xsl:attribute name="column-width"><xsl:value-of select="0.20 * $pagePrintableWidth div 5" />mm</xsl:attribute>
 						</fo:table-column>

--- a/outputsheets/d20/fantasy/pdf/common_sheet/block_spells_list.xslt
+++ b/outputsheets/d20/fantasy/pdf/common_sheet/block_spells_list.xslt
@@ -35,7 +35,7 @@
 	<xsl:template match="racial_innate">
 		<xsl:if test="count(.//spell) &gt; 0">
 			<fo:block>
-				<fo:table table-layout="fixed">
+				<fo:table table-layout="fixed" width="100%">
 					<xsl:call-template name="spells.known.header.row">
 						<xsl:with-param name="columnOne" select="''"/>
 						<xsl:with-param name="title" select="'Innate Racial Spells'"/>
@@ -58,7 +58,7 @@
 	<xsl:template match="class_innate">
 		<xsl:if test="count(.//spell) &gt; 0">
 			<xsl:for-each select="spellbook">
-				<fo:table table-layout="fixed" space-before="5mm">
+				<fo:table table-layout="fixed" width="100%" space-before="5mm">
 					<xsl:call-template name="spells.known.header.row">
 						<xsl:with-param name="columnOne" select="''"/>
 						<xsl:with-param name="title" select="concat(@name, ' Spell-like Abilities')"/>
@@ -92,7 +92,7 @@
 	<xsl:template match="class" mode="spells.known">
 		<xsl:if test="count(.//spell) &gt; 0">
 	<!--> This is causing the new page creation		<fo:block break-before="page"/>	-->
-			<fo:table table-layout="fixed">
+			<fo:table table-layout="fixed" width="100%">
 				<xsl:variable name="titletext">
 					<xsl:choose>
 						<xsl:when test="@spellcastertype = 'Psionic'">
@@ -153,7 +153,7 @@
 ====================================
 ====================================-->
 	<xsl:template match="class" mode="spell.level.table">
-		<fo:table table-layout="fixed" border-collapse="collapse">
+		<fo:table table-layout="fixed" width="100%" border-collapse="collapse">
 			<fo:table-column column-width="proportional-column-width(2)"/>
 			<fo:table-column column-width="proportional-column-width(2)"/>
 			<xsl:for-each select="level">
@@ -245,7 +245,7 @@
 ====================================
 ====================================-->
 	<xsl:template match="class" mode="spell.level.cast">
-		<fo:table-row padding-bottom="2mm">
+		<fo:table-row>
 											<xsl:message>Test</xsl:message>
 			<fo:table-cell/>
 			<fo:table-cell>
@@ -810,7 +810,7 @@
 ====================================-->
 	<xsl:template name="spells.memorized.header">
 		<xsl:param name="title" select="'Unknown'"/>
-		<fo:table table-layout="fixed">
+		<fo:table table-layout="fixed" width="100%">
 			<fo:table-column>
 				<xsl:attribute name="column-width"><xsl:value-of select="$pagePrintableWidth" />mm</xsl:attribute>
 			</fo:table-column>
@@ -840,7 +840,7 @@
 			<xsl:call-template name="spells.memorized.header">
 				<xsl:with-param name="title" select="'Innate'"/>
 			</xsl:call-template>
-			<fo:table table-layout="fixed" space-after="5mm">
+			<fo:table table-layout="fixed" width="100%" space-after="5mm">
 				<fo:table-column>
 					<xsl:attribute name="column-width"><xsl:value-of select="0.20 * $pagePrintableWidth div 5" />mm</xsl:attribute>
 				</fo:table-column>
@@ -875,7 +875,7 @@
 			<xsl:call-template name="spells.memorized.header">
 				<xsl:with-param name="title" select="concat(@name, ' Spell-like Abilities')"/>
 			</xsl:call-template>
-			<fo:table table-layout="fixed">
+			<fo:table table-layout="fixed" width="100%">
 				<fo:table-column>
 					<xsl:attribute name="column-width"><xsl:value-of select="0.20 * $pagePrintableWidth div 5" />mm</xsl:attribute>
 				</fo:table-column>
@@ -896,7 +896,7 @@
 ====================================-->
 	<xsl:template match="spellbook" mode="spells.memorized">
 		<xsl:if test="count(.//spell) &gt; 0">
-			<fo:table table-layout="fixed" space-before="4mm">
+			<fo:table table-layout="fixed" width="100%" space-before="4mm">
 				<fo:table-column>
 					<xsl:attribute name="column-width"><xsl:value-of select="$pagePrintableWidth div 5" />mm</xsl:attribute>
 				</fo:table-column>
@@ -970,7 +970,7 @@
 		<fo:table-cell padding-top="1pt">
 			<fo:block font-size="5pt">
 				<xsl:if test="count(.//spell) &gt; 0">
-					<fo:table table-layout="fixed">
+					<fo:table table-layout="fixed" width="100%">
 						<fo:table-column>
 							<xsl:attribute name="column-width"><xsl:value-of select="0.20 * $pagePrintableWidth div 5" />mm</xsl:attribute>
 						</fo:table-column>

--- a/outputsheets/d20/fantasy/pdf/common_sheet/block_stat_block.xslt
+++ b/outputsheets/d20/fantasy/pdf/common_sheet/block_stat_block.xslt
@@ -19,7 +19,7 @@
 ====================================-->
 	<xsl:template match="abilities">
 		<!-- BEGIN Ability Block -->
-		<fo:table table-layout="fixed">
+		<fo:table table-layout="fixed" width="100%">
 			<fo:table-column>
 				<xsl:attribute name="column-width"><xsl:value-of select="0.22 * (0.29 * $pagePrintableWidth - 9)" />mm</xsl:attribute>
 			</fo:table-column>
@@ -56,27 +56,33 @@
 					<fo:table-cell>
 						<fo:block text-align="center" font-size="4pt">ABILITY NAME</fo:block>
 					</fo:table-cell>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 					<fo:table-cell>
 						<fo:block text-align="center" font-size="4pt">BASE SCORE</fo:block>
 					</fo:table-cell>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 					<fo:table-cell>
 						<fo:block text-align="center" font-size="4pt">BASE MOD</fo:block>
 					</fo:table-cell>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 					<fo:table-cell>
 						<fo:block text-align="center" font-size="4pt">ABILITY SCORE</fo:block>
 					</fo:table-cell>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 					<fo:table-cell>
 						<fo:block text-align="center" font-size="4pt">ABILITY MOD</fo:block>
 					</fo:table-cell>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 					<fo:table-cell>
 						<fo:block text-align="center" font-size="4pt">TEMP SCORE</fo:block>
 					</fo:table-cell>
-					<fo:table-cell/>
+					<fo:table-cell><fo:block/></fo:table-cell>
+
 					<fo:table-cell>
 						<fo:block text-align="center" font-size="4pt">TEMP MOD</fo:block>
 					</fo:table-cell>
@@ -95,7 +101,8 @@
 								<xsl:value-of select="name/long"/>
 							</fo:block>
 						</fo:table-cell>
-						<fo:table-cell/>
+						<fo:table-cell><fo:block/></fo:table-cell>
+
 						<fo:table-cell>
 							<xsl:call-template name="attrib">
 								<xsl:with-param name="attribute" select="'stat.base.score'"/>
@@ -104,7 +111,8 @@
 								<xsl:value-of select="base"/>
 							</fo:block>
 						</fo:table-cell>
-						<fo:table-cell/>
+						<fo:table-cell><fo:block/></fo:table-cell>
+
 						<fo:table-cell>
 							<xsl:call-template name="attrib">
 								<xsl:with-param name="attribute" select="'stat.base.modifier'"/>
@@ -113,7 +121,8 @@
 								<xsl:value-of select="basemod"/>
 							</fo:block>
 						</fo:table-cell>
-						<fo:table-cell/>
+						<fo:table-cell><fo:block/></fo:table-cell>
+
 						<fo:table-cell>
 							<xsl:call-template name="attrib">
 								<xsl:with-param name="attribute" select="'stat.score'"/>
@@ -122,7 +131,8 @@
 								<xsl:value-of select="no_temp_score"/>
 							</fo:block>
 						</fo:table-cell>
-						<fo:table-cell/>
+						<fo:table-cell><fo:block/></fo:table-cell>
+
 						<fo:table-cell>
 							<xsl:call-template name="attrib">
 								<xsl:with-param name="attribute" select="'stat.modifier'"/>
@@ -131,32 +141,35 @@
 								<xsl:value-of select="no_temp_modifier"/>
 							</fo:block>
 						</fo:table-cell>
-						<fo:table-cell/>
+						<fo:table-cell><fo:block/></fo:table-cell>
+
 						<fo:table-cell height="4pt">
 							<xsl:call-template name="attrib">
 								<xsl:with-param name="attribute" select="'stat.temp.score'"/>
 							</xsl:call-template>
-							<xsl:if test="score != no_temp_score">
 							<fo:block space-before.optimum="2pt" font-size="10pt">
-								<xsl:value-of select="score"/>
+								<xsl:if test="score != no_temp_score">
+									<xsl:value-of select="score"/>
+								</xsl:if>
 							</fo:block>
-							</xsl:if>
 						</fo:table-cell>
-						<fo:table-cell/>
+						<fo:table-cell><fo:block/></fo:table-cell>
+
 						<fo:table-cell height="4pt">	<!-- Temp Score and Mod-->
 							<xsl:call-template name="attrib">
 								<xsl:with-param name="attribute" select="'stat.temp.modifier'"/>
 							</xsl:call-template>
-							<xsl:if test="score != no_temp_score">
 							<fo:block space-before.optimum="2pt" font-size="10pt">
-								<xsl:value-of select="modifier"/>
+								<xsl:if test="score != no_temp_score">
+									<xsl:value-of select="modifier"/>
+								</xsl:if>
 							</fo:block>
-							</xsl:if>
 						</fo:table-cell>
 					</fo:table-row>
 					<fo:table-row height="2pt">
 											<xsl:message>Test</xsl:message>
-						<fo:table-cell/>
+						<fo:table-cell><fo:block/></fo:table-cell>
+
 					</fo:table-row>
 				</xsl:for-each>
 			</fo:table-body>

--- a/outputsheets/d20/fantasy/pdf/common_sheet/block_weapons.xslt
+++ b/outputsheets/d20/fantasy/pdf/common_sheet/block_weapons.xslt
@@ -53,7 +53,7 @@
 ====================================-->
 	<xsl:template match="weapons/martialarts">
 		<!-- START Martial Arts Attack Table -->
-		<fo:table table-layout="fixed" space-before="2mm">
+		<fo:table table-layout="fixed" width="100%" space-before="2mm">
 			<fo:table-column column-width="27mm"/>
 			<fo:table-column>
 				<xsl:attribute name="column-width"><xsl:value-of select="0.55 * $pagePrintableWidth - 77" />mm</xsl:attribute>
@@ -153,7 +153,7 @@
 ====================================-->
 	<xsl:template match="weapons/spiritweaponmelee">
 		<!-- START Spirit Weapon Melee Attack Table -->
-		<fo:table table-layout="fixed" space-before="2mm">
+		<fo:table table-layout="fixed" width="100%" space-before="2mm">
 			<fo:table-column column-width="27mm"/>
 			<fo:table-column>
 				<xsl:attribute name="column-width"><xsl:value-of select="0.55 * $pagePrintableWidth - 77" />mm</xsl:attribute>
@@ -253,7 +253,7 @@
 ====================================-->
 	<xsl:template match="weapons/spiritweaponranged">
 		<!-- START Martial Arts Attack Table -->
-		<fo:table table-layout="fixed" space-before="2mm">
+		<fo:table table-layout="fixed" width="100%" space-before="2mm">
 			<fo:table-column column-width="27mm"/>
 			<fo:table-column>
 				<xsl:attribute name="column-width"><xsl:value-of select="0.55 * $pagePrintableWidth - 77" />mm</xsl:attribute>
@@ -355,7 +355,7 @@
 		<!-- START Unarmed Attack Table -->
 		<!--<xsl:choose>
 			<xsl:when test="(weapons/naturalattack) &lt; 1">	-->
-		<fo:table table-layout="fixed" space-before="2mm">
+		<fo:table table-layout="fixed" width="100%" space-before="2mm">
 			<fo:table-column column-width="27mm"/>
 			<fo:table-column>
 				<xsl:attribute name="column-width"><xsl:value-of select="0.55 * $pagePrintableWidth - 77" />mm</xsl:attribute>
@@ -553,7 +553,7 @@
 	<xsl:template match="weapons/naturalattack">
 		<!-- START Natural Attack Table -->
 
-		<fo:table table-layout="fixed" space-before="2mm">
+		<fo:table table-layout="fixed" width="100%" space-before="2mm">
 			<fo:table-column column-width="27mm"/>
 			<fo:table-column>
 				<xsl:attribute name="column-width"><xsl:value-of select="0.55 * $pagePrintableWidth - 77" />mm</xsl:attribute>
@@ -694,7 +694,8 @@
 			</xsl:choose>
 			<fo:table-row>
 											<xsl:message>Test</xsl:message>
-				<fo:table-cell/>
+				<fo:table-cell><fo:block/></fo:table-cell>
+
 			</fo:table-row>
 		</fo:table-body>
 	</fo:table>
@@ -718,7 +719,7 @@
 		<xsl:param name="distance"/>
 		<xsl:param name="damage"/>
 		<xsl:param name="tohit" select="''"/>
-			<fo:table table-layout="fixed" space-before="2mm">
+			<fo:table table-layout="fixed" width="100%" space-before="2mm">
 			<fo:table-column column-width="5mm"/>
 			<fo:table-column>
 				<xsl:attribute name="column-width"><xsl:value-of select="0.2 * ($column_width - 5)" />mm</xsl:attribute>
@@ -937,7 +938,7 @@
 	<xsl:template match="common">
 		<xsl:param name="column_width" select="0.55 * $pagePrintableWidth - 2"/>
 		<fo:block keep-with-next.within-page="always" keep-together.within-column="always">
-		<fo:table table-layout="fixed" border-collapse="collapse" padding="0.5pt" space-before="2mm">
+		<fo:table table-layout="fixed" width="100%" border-collapse="collapse" space-before="2mm">
 			<fo:table-column>
 				<xsl:attribute name="column-width"><xsl:value-of select="$column_width - 48" />mm</xsl:attribute>
 			</fo:table-column>
@@ -1078,7 +1079,7 @@
 	<xsl:template match="common" mode="special_properties">
 		<xsl:param name="column_width" select="0.55 * $pagePrintableWidth - 2"/>
 		<fo:block keep-with-previous.within-page="always" keep-together.within-column="always">
-		<fo:table table-layout="fixed">
+		<fo:table table-layout="fixed" width="100%">
 			<fo:table-column column-width="20mm"/>
 			<fo:table-column>
 				<xsl:attribute name="column-width"><xsl:value-of select="$column_width - 20" />mm</xsl:attribute>
@@ -1095,7 +1096,7 @@
 					</fo:table-cell>
 				</xsl:if>
 				<xsl:if test="special_properties = ''">
-					<fo:table-cell number-columns-spanned="2" />
+					<fo:table-cell number-columns-spanned="2"><fo:block/></fo:table-cell>
 				</xsl:if>
 				</fo:table-row>
 			</fo:table-body>
@@ -1122,7 +1123,7 @@
 		<xsl:param name="damage" select="''"/>
 		<xsl:param name="column_width" select="0.55 * $pagePrintableWidth"/>
 		<fo:block keep-with-previous.within-page="always" keep-together.within-column="always">
-		<fo:table table-layout="fixed">
+		<fo:table table-layout="fixed" width="100%">
 			<fo:table-column>
 				<xsl:attribute name="column-width"><xsl:value-of select="0.5 * $column_width" />mm</xsl:attribute>
 			</fo:table-column>
@@ -1247,7 +1248,7 @@
 	<xsl:template match="melee">
 		<xsl:param name="column_width" select="0.55 * $pagePrintableWidth - 1"/>
 		<fo:block keep-with-previous.within-page="always" keep-together.within-column="always">
-		<fo:table table-layout="fixed">
+		<fo:table table-layout="fixed" width="100%">
 			<fo:table-column column-width="8mm"/>
 			<fo:table-column>
 				<xsl:attribute name="column-width"><xsl:value-of select="0.35 * ($column_width - 19)" />mm</xsl:attribute>
@@ -1268,6 +1269,7 @@
 					<!-- To hit and Damage titles -->
 					<fo:table-cell>
 						<xsl:call-template name="attrib"><xsl:with-param name="attribute" select="'weapon.title'"/></xsl:call-template>
+						<fo:block/>
 					</fo:table-cell>
 					<fo:table-cell>
 						<xsl:call-template name="attrib"><xsl:with-param name="attribute" select="'weapon.title'"/></xsl:call-template>
@@ -1279,6 +1281,7 @@
 					</fo:table-cell>
 					<fo:table-cell>
 						<xsl:call-template name="attrib"><xsl:with-param name="attribute" select="'weapon.title'"/></xsl:call-template>
+						<fo:block/>
 					</fo:table-cell>
 					<fo:table-cell>
 						<xsl:call-template name="attrib"><xsl:with-param name="attribute" select="'weapon.title'"/></xsl:call-template>
@@ -1348,7 +1351,7 @@
 	<xsl:template match="ranges">
 		<xsl:param name="column_width" select="0.55 * $pagePrintableWidth - 2"/>
 		<fo:block keep-with-previous.within-page="always" keep-together.within-column="always">
-		<fo:table table-layout="fixed">
+		<fo:table table-layout="fixed" width="100%">
 			<fo:table-column column-width="5mm"/>
 			<fo:table-column>
 				<xsl:attribute name="column-width"><xsl:value-of select="0.2 * ($column_width - 5)" />mm</xsl:attribute>
@@ -1421,7 +1424,9 @@
 
 					<!-- Distances -->
 					<fo:table-cell>
-						<xsl:call-template name="attrib"><xsl:with-param name="attribute" select="'weapon.title'"/></xsl:call-template>
+						<fo:block>
+							<xsl:call-template name="attrib"><xsl:with-param name="attribute" select="'weapon.title'"/></xsl:call-template>
+						</fo:block>
 					</fo:table-cell>
 					<xsl:for-each select="range[position() &gt; 1 and position() &lt; 7]">
 						<fo:table-cell>
@@ -1482,6 +1487,7 @@
 					<!-- Distances -->
 					<fo:table-cell>
 						<xsl:call-template name="attrib"><xsl:with-param name="attribute" select="'weapon.title'"/></xsl:call-template>
+						<fo:block/>
 					</fo:table-cell>
 					<xsl:for-each select="range[position() &gt; 0 and position() &lt; 6]">
 						<fo:table-cell>
@@ -1540,6 +1546,7 @@
 					<!-- Distances -->
 					<fo:table-cell>
 						<xsl:call-template name="attrib"><xsl:with-param name="attribute" select="'weapon.title'"/></xsl:call-template>
+						<fo:block/>
 					</fo:table-cell>
 					<xsl:for-each select="range[position() &gt; 6 and position() &lt; 12]">
 						<fo:table-cell>

--- a/outputsheets/d20/fantasy/pdf/csheet_fantasy_no_header.xslt
+++ b/outputsheets/d20/fantasy/pdf/csheet_fantasy_no_header.xslt
@@ -81,67 +81,67 @@
 		<weapon><subattrib border="" centre="" normal=""/></weapon>
 
 		<protection.title><subattrib border="" centre="" inverse=""/></protection.title>
-		<protection.border padding="0.5pt"><subattrib border="" inverse=""/></protection.border>
+		<protection.border><subattrib border="" inverse=""/></protection.border>
 		<protection.darkline><subattrib  centre="" medium="" /></protection.darkline>
 		<protection.lightline><subattrib  centre="" light="" /></protection.lightline>
 
 		<rage.title><subattrib  centre="" inverse=""/></rage.title>
-		<rage.border padding="0.5pt"><subattrib border="" inverse=""/></rage.border>
+		<rage.border><subattrib border="" inverse=""/></rage.border>
 		<rage><subattrib normal=""/></rage>
 
 		<checklist.title><subattrib  centre="" inverse=""/></checklist.title>
-		<checklist.border padding="0.5pt"><subattrib border="" inverse=""/></checklist.border>
+		<checklist.border><subattrib border="" inverse=""/></checklist.border>
 		<checklist><subattrib normal=""/></checklist>
 
 		<wildshape.title><subattrib centre="" inverse=""/></wildshape.title>
-		<wildshape.border padding="0.5pt"><subattrib border="" inverse=""/></wildshape.border>
+		<wildshape.border><subattrib border="" inverse=""/></wildshape.border>
 		<wildshape><subattrib normal=""/></wildshape>
 
 		<bard.title><subattrib centre="" inverse=""/></bard.title>
-		<bard.border padding="0.5pt"><subattrib border="" inverse=""/></bard.border>
+		<bard.border><subattrib border="" inverse=""/></bard.border>
 		<bard><subattrib  normal=""/></bard>
 
 		<psionics.title><subattrib  centre="" inverse=""/></psionics.title>
-		<psionics.border padding="0.5pt"><subattrib border="" inverse=""/></psionics.border>
+		<psionics.border><subattrib border="" inverse=""/></psionics.border>
 		<psionics><subattrib border="" centre="" normal=""/></psionics>
 
 		<turning.title><subattrib centre="" inverse=""/></turning.title>
-		<turning.border padding="0.5pt"><subattrib border="" inverse=""/></turning.border>
+		<turning.border><subattrib border="" inverse=""/></turning.border>
 		<turning><subattrib  centre="" normal=""/></turning>
 		<turning.lightline><subattrib centre="" light=""/></turning.lightline>
 		<turning.darkline><subattrib centre="" medium=""/></turning.darkline>
 
 		<stunningfist.title><subattrib centre="" inverse=""/></stunningfist.title>
-		<stunningfist.border padding="0.5pt"><subattrib border="" inverse=""/></stunningfist.border>
+		<stunningfist.border><subattrib border="" inverse=""/></stunningfist.border>
 		<stunningfist><subattrib normal=""/></stunningfist>
 
 		<wholeness.title><subattrib  centre="" inverse=""/></wholeness.title>
-		<wholeness.border padding="0.5pt"><subattrib border="" inverse=""/></wholeness.border>
+		<wholeness.border><subattrib border="" inverse=""/></wholeness.border>
 		<wholeness><subattrib  normal=""/></wholeness>
 
 		<layonhands.title><subattrib centre="" inverse=""/></layonhands.title>
-		<layonhands.border padding="0.5pt"><subattrib border="" inverse=""/></layonhands.border>
+		<layonhands.border><subattrib border="" inverse=""/></layonhands.border>
 		<layonhands><subattrib  normal=""/></layonhands>
 
 		<domains.title><subattrib  centre="" inverse=""/></domains.title>
-		<domains.border padding="0.5pt"><subattrib border="" inverse=""/></domains.border>
+		<domains.border><subattrib border="" inverse=""/></domains.border>
 		<domains.lightline><subattrib  light=""/></domains.lightline>
 		<domains.darkline><subattrib  medium=""/></domains.darkline>
 
 		<proficiencies.title><subattrib centre="" inverse=""/></proficiencies.title>
-		<proficiencies.border padding="0.5pt"><subattrib border="" inverse=""/></proficiencies.border>
+		<proficiencies.border><subattrib border="" inverse=""/></proficiencies.border>
 		<proficiencies><subattrib centre="" normal=""/></proficiencies>
 
 		<prohibited.title><subattrib centre="" inverse=""/></prohibited.title>
-		<prohibited.border padding="0.5pt"><subattrib border="" inverse=""/></prohibited.border>
+		<prohibited.border><subattrib border="" inverse=""/></prohibited.border>
 		<prohibited><subattrib centre="" normal=""/></prohibited>
 
 		<languages.title><subattrib centre="" inverse=""/></languages.title>
-		<languages.border padding="0.5pt"><subattrib border="" inverse=""/></languages.border>
+		<languages.border><subattrib border="" inverse=""/></languages.border>
 		<languages><subattrib  centre="" normal=""/></languages>
 
 		<templates.title><subattrib centre="" inverse=""/></templates.title>
-		<templates.border padding="0.5pt"><subattrib border="" inverse=""/></templates.border>
+		<templates.border><subattrib border="" inverse=""/></templates.border>
 		<templates.lightline><subattrib light=""/></templates.lightline>
 		<templates.darkline><subattrib medium=""/></templates.darkline>
 
@@ -149,81 +149,81 @@
 		<companions><subattrib border="" centre="" normal=""/></companions>
 
 		<equipment.title><subattrib centre="" inverse=""/></equipment.title>
-		<equipment.border padding="0.5pt"><subattrib border="" inverse=""/></equipment.border>
+		<equipment.border><subattrib border="" inverse=""/></equipment.border>
 		<equipment.lightline><subattrib light=""/></equipment.lightline>
 		<equipment.darkline><subattrib medium=""/></equipment.darkline>
 
 		<weight.title><subattrib centre="" inverse=""/></weight.title>
-		<weight.border padding="0.5pt"><subattrib border="" inverse=""/></weight.border>
+		<weight.border><subattrib border="" inverse=""/></weight.border>
 		<weight.lightline><subattrib light=""/></weight.lightline>
 		<weight.darkline><subattrib  medium=""/></weight.darkline>
 
 		<money.title><subattrib  centre="" inverse=""/></money.title>
-		<money.border padding="0.5pt"><subattrib border="" inverse=""/></money.border>
+		<money.border><subattrib border="" inverse=""/></money.border>
 		<money.lightline><subattrib light=""/></money.lightline>
 		<money.darkline><subattrib medium=""/></money.darkline>
 
 		<magic.title><subattrib centre="" inverse=""/></magic.title>
-		<magic.border padding="0.5pt"><subattrib border="" inverse=""/></magic.border>
+		<magic.border><subattrib border="" inverse=""/></magic.border>
 		<magic.lightline><subattrib light=""/></magic.lightline>
 		<magic.darkline><subattrib medium=""/></magic.darkline>
 
 		<special_abilities.title><subattrib centre="" inverse=""/></special_abilities.title>
-		<special_abilities.border padding="0.5pt"><subattrib border="" inverse=""/></special_abilities.border>
+		<special_abilities.border><subattrib border="" inverse=""/></special_abilities.border>
 		<special_abilities.lightline><subattrib light=""/></special_abilities.lightline>
 		<special_abilities.darkline><subattrib medium=""/></special_abilities.darkline>
 
 		<archetypes.title><subattrib centre="" inverse=""/></archetypes.title>
-		<archetypes.border padding="0.5pt"><subattrib border="" inverse=""/></archetypes.border>
+		<archetypes.border><subattrib border="" inverse=""/></archetypes.border>
 		<archetypes.lightline><subattrib light=""/></archetypes.lightline>
 		<archetypes.darkline><subattrib medium=""/></archetypes.darkline>
 
 		<special_attacks.title><subattrib centre="" inverse=""/></special_attacks.title>
-		<special_attacks.border padding="0.5pt"><subattrib border="" inverse=""/></special_attacks.border>
+		<special_attacks.border><subattrib border="" inverse=""/></special_attacks.border>
 		<special_attacks.lightline><subattrib light=""/></special_attacks.lightline>
 		<special_attacks.darkline><subattrib medium=""/></special_attacks.darkline>
 
 		<special_qualities.title><subattrib centre="" inverse=""/></special_qualities.title>
-		<special_qualities.border padding="0.5pt"><subattrib border="" inverse=""/></special_qualities.border>
+		<special_qualities.border><subattrib border="" inverse=""/></special_qualities.border>
 		<special_qualities.lightline><subattrib light=""/></special_qualities.lightline>
 		<special_qualities.darkline><subattrib medium=""/></special_qualities.darkline>
 
 		<afflictions.title><subattrib centre="" inverse=""/></afflictions.title>
-		<afflictions.border padding="0.5pt"><subattrib border="" inverse=""/></afflictions.border>
+		<afflictions.border><subattrib border="" inverse=""/></afflictions.border>
 		<afflictions.lightline><subattrib light=""/></afflictions.lightline>
 		<afflictions.darkline><subattrib medium=""/></afflictions.darkline>
 
 		<tempbonuses.title><subattrib centre="" inverse=""/></tempbonuses.title>
-		<tempbonuses.border padding="0.5pt"><subattrib border="" inverse=""/></tempbonuses.border>
+		<tempbonuses.border><subattrib border="" inverse=""/></tempbonuses.border>
 		<tempbonuses.lightline><subattrib light=""/></tempbonuses.lightline>
 		<tempbonuses.darkline><subattrib medium=""/></tempbonuses.darkline>
 
 
 
 		<animal_tricks.title><subattrib centre="" inverse=""/></animal_tricks.title>
-		<animal_tricks.border padding="0.5pt"><subattrib border="" inverse=""/></animal_tricks.border>
+		<animal_tricks.border><subattrib border="" inverse=""/></animal_tricks.border>
 		<animal_tricks.lightline><subattrib light=""/></animal_tricks.lightline>
 		<animal_tricks.darkline><subattrib medium=""/></animal_tricks.darkline>
 
 
 		<intelligent_items.title><subattrib centre="" inverse=""/></intelligent_items.title>
-		<intelligent_items.border padding="0.5pt"><subattrib border="" inverse=""/></intelligent_items.border>
+		<intelligent_items.border><subattrib border="" inverse=""/></intelligent_items.border>
 		<intelligent_items.lightline><subattrib light=""/></intelligent_items.lightline>
 		<intelligent_items.darkline><subattrib medium=""/></intelligent_items.darkline>
 
 		<traits.title><subattrib centre="" inverse=""/></traits.title>
-		<traits.border padding="0.5pt"><subattrib border="" inverse=""/></traits.border>
+		<traits.border><subattrib border="" inverse=""/></traits.border>
 		<traits.lightline><subattrib light=""/></traits.lightline>
 		<traits.darkline><subattrib medium=""/></traits.darkline>
 
 
 		<salient_divine_abilities.title><subattrib centre="" inverse=""/></salient_divine_abilities.title>
-		<salient_divine_abilities.border padding="0.5pt"><subattrib border="" inverse=""/></salient_divine_abilities.border>
+		<salient_divine_abilities.border><subattrib border="" inverse=""/></salient_divine_abilities.border>
 		<salient_divine_abilities.lightline><subattrib light=""/></salient_divine_abilities.lightline>
 		<salient_divine_abilities.darkline><subattrib medium=""/></salient_divine_abilities.darkline>
 
 		<feats.title><subattrib centre="" inverse=""/></feats.title>
-		<feats.border padding="0.5pt"><subattrib border="" inverse=""/></feats.border>
+		<feats.border><subattrib border="" inverse=""/></feats.border>
 		<feats.lightline><subattrib light=""/></feats.lightline>
 		<feats.darkline><subattrib medium=""/></feats.darkline>
 

--- a/outputsheets/d20/fantasy/pdf/csheet_fantasy_spell_list_only.xslt
+++ b/outputsheets/d20/fantasy/pdf/csheet_fantasy_spell_list_only.xslt
@@ -81,67 +81,67 @@
 		<weapon><subattrib border="" centre="" normal=""/></weapon>
 
 		<protection.title><subattrib border="" centre="" inverse=""/></protection.title>
-		<protection.border padding="0.5pt"><subattrib border="" inverse=""/></protection.border>
+		<protection.border><subattrib border="" inverse=""/></protection.border>
 		<protection.darkline><subattrib  centre="" medium="" /></protection.darkline>
 		<protection.lightline><subattrib  centre="" light="" /></protection.lightline>
 
 		<rage.title><subattrib  centre="" inverse=""/></rage.title>
-		<rage.border padding="0.5pt"><subattrib border="" inverse=""/></rage.border>
+		<rage.border><subattrib border="" inverse=""/></rage.border>
 		<rage><subattrib normal=""/></rage>
 
 		<checklist.title><subattrib  centre="" inverse=""/></checklist.title>
-		<checklist.border padding="0.5pt"><subattrib border="" inverse=""/></checklist.border>
+		<checklist.border><subattrib border="" inverse=""/></checklist.border>
 		<checklist><subattrib normal=""/></checklist>
 
 		<wildshape.title><subattrib centre="" inverse=""/></wildshape.title>
-		<wildshape.border padding="0.5pt"><subattrib border="" inverse=""/></wildshape.border>
+		<wildshape.border><subattrib border="" inverse=""/></wildshape.border>
 		<wildshape><subattrib normal=""/></wildshape>
 
 		<bard.title><subattrib centre="" inverse=""/></bard.title>
-		<bard.border padding="0.5pt"><subattrib border="" inverse=""/></bard.border>
+		<bard.border><subattrib border="" inverse=""/></bard.border>
 		<bard><subattrib  normal=""/></bard>
 
 		<psionics.title><subattrib  centre="" inverse=""/></psionics.title>
-		<psionics.border padding="0.5pt"><subattrib border="" inverse=""/></psionics.border>
+		<psionics.border><subattrib border="" inverse=""/></psionics.border>
 		<psionics><subattrib border="" centre="" normal=""/></psionics>
 
 		<turning.title><subattrib centre="" inverse=""/></turning.title>
-		<turning.border padding="0.5pt"><subattrib border="" inverse=""/></turning.border>
+		<turning.border><subattrib border="" inverse=""/></turning.border>
 		<turning><subattrib  centre="" normal=""/></turning>
 		<turning.lightline><subattrib centre="" light=""/></turning.lightline>
 		<turning.darkline><subattrib centre="" medium=""/></turning.darkline>
 
 		<stunningfist.title><subattrib centre="" inverse=""/></stunningfist.title>
-		<stunningfist.border padding="0.5pt"><subattrib border="" inverse=""/></stunningfist.border>
+		<stunningfist.border><subattrib border="" inverse=""/></stunningfist.border>
 		<stunningfist><subattrib normal=""/></stunningfist>
 
 		<wholeness.title><subattrib  centre="" inverse=""/></wholeness.title>
-		<wholeness.border padding="0.5pt"><subattrib border="" inverse=""/></wholeness.border>
+		<wholeness.border><subattrib border="" inverse=""/></wholeness.border>
 		<wholeness><subattrib  normal=""/></wholeness>
 
 		<layonhands.title><subattrib centre="" inverse=""/></layonhands.title>
-		<layonhands.border padding="0.5pt"><subattrib border="" inverse=""/></layonhands.border>
+		<layonhands.border><subattrib border="" inverse=""/></layonhands.border>
 		<layonhands><subattrib  normal=""/></layonhands>
 
 		<domains.title><subattrib  centre="" inverse=""/></domains.title>
-		<domains.border padding="0.5pt"><subattrib border="" inverse=""/></domains.border>
+		<domains.border><subattrib border="" inverse=""/></domains.border>
 		<domains.lightline><subattrib  light=""/></domains.lightline>
 		<domains.darkline><subattrib  medium=""/></domains.darkline>
 
 		<proficiencies.title><subattrib centre="" inverse=""/></proficiencies.title>
-		<proficiencies.border padding="0.5pt"><subattrib border="" inverse=""/></proficiencies.border>
+		<proficiencies.border><subattrib border="" inverse=""/></proficiencies.border>
 		<proficiencies><subattrib centre="" normal=""/></proficiencies>
 
 		<prohibited.title><subattrib centre="" inverse=""/></prohibited.title>
-		<prohibited.border padding="0.5pt"><subattrib border="" inverse=""/></prohibited.border>
+		<prohibited.border><subattrib border="" inverse=""/></prohibited.border>
 		<prohibited><subattrib centre="" normal=""/></prohibited>
 
 		<languages.title><subattrib centre="" inverse=""/></languages.title>
-		<languages.border padding="0.5pt"><subattrib border="" inverse=""/></languages.border>
+		<languages.border><subattrib border="" inverse=""/></languages.border>
 		<languages><subattrib  centre="" normal=""/></languages>
 
 		<templates.title><subattrib centre="" inverse=""/></templates.title>
-		<templates.border padding="0.5pt"><subattrib border="" inverse=""/></templates.border>
+		<templates.border><subattrib border="" inverse=""/></templates.border>
 		<templates.lightline><subattrib light=""/></templates.lightline>
 		<templates.darkline><subattrib medium=""/></templates.darkline>
 
@@ -149,81 +149,81 @@
 		<companions><subattrib border="" centre="" normal=""/></companions>
 
 		<equipment.title><subattrib centre="" inverse=""/></equipment.title>
-		<equipment.border padding="0.5pt"><subattrib border="" inverse=""/></equipment.border>
+		<equipment.border><subattrib border="" inverse=""/></equipment.border>
 		<equipment.lightline><subattrib light=""/></equipment.lightline>
 		<equipment.darkline><subattrib medium=""/></equipment.darkline>
 
 		<weight.title><subattrib centre="" inverse=""/></weight.title>
-		<weight.border padding="0.5pt"><subattrib border="" inverse=""/></weight.border>
+		<weight.border><subattrib border="" inverse=""/></weight.border>
 		<weight.lightline><subattrib light=""/></weight.lightline>
 		<weight.darkline><subattrib  medium=""/></weight.darkline>
 
 		<money.title><subattrib  centre="" inverse=""/></money.title>
-		<money.border padding="0.5pt"><subattrib border="" inverse=""/></money.border>
+		<money.border><subattrib border="" inverse=""/></money.border>
 		<money.lightline><subattrib light=""/></money.lightline>
 		<money.darkline><subattrib medium=""/></money.darkline>
 
 		<magic.title><subattrib centre="" inverse=""/></magic.title>
-		<magic.border padding="0.5pt"><subattrib border="" inverse=""/></magic.border>
+		<magic.border><subattrib border="" inverse=""/></magic.border>
 		<magic.lightline><subattrib light=""/></magic.lightline>
 		<magic.darkline><subattrib medium=""/></magic.darkline>
 
 		<special_abilities.title><subattrib centre="" inverse=""/></special_abilities.title>
-		<special_abilities.border padding="0.5pt"><subattrib border="" inverse=""/></special_abilities.border>
+		<special_abilities.border><subattrib border="" inverse=""/></special_abilities.border>
 		<special_abilities.lightline><subattrib light=""/></special_abilities.lightline>
 		<special_abilities.darkline><subattrib medium=""/></special_abilities.darkline>
 
 		<archetypes.title><subattrib centre="" inverse=""/></archetypes.title>
-		<archetypes.border padding="0.5pt"><subattrib border="" inverse=""/></archetypes.border>
+		<archetypes.border><subattrib border="" inverse=""/></archetypes.border>
 		<archetypes.lightline><subattrib light=""/></archetypes.lightline>
 		<archetypes.darkline><subattrib medium=""/></archetypes.darkline>
 
 		<special_attacks.title><subattrib centre="" inverse=""/></special_attacks.title>
-		<special_attacks.border padding="0.5pt"><subattrib border="" inverse=""/></special_attacks.border>
+		<special_attacks.border><subattrib border="" inverse=""/></special_attacks.border>
 		<special_attacks.lightline><subattrib light=""/></special_attacks.lightline>
 		<special_attacks.darkline><subattrib medium=""/></special_attacks.darkline>
 
 		<special_qualities.title><subattrib centre="" inverse=""/></special_qualities.title>
-		<special_qualities.border padding="0.5pt"><subattrib border="" inverse=""/></special_qualities.border>
+		<special_qualities.border><subattrib border="" inverse=""/></special_qualities.border>
 		<special_qualities.lightline><subattrib light=""/></special_qualities.lightline>
 		<special_qualities.darkline><subattrib medium=""/></special_qualities.darkline>
 
 		<afflictions.title><subattrib centre="" inverse=""/></afflictions.title>
-		<afflictions.border padding="0.5pt"><subattrib border="" inverse=""/></afflictions.border>
+		<afflictions.border><subattrib border="" inverse=""/></afflictions.border>
 		<afflictions.lightline><subattrib light=""/></afflictions.lightline>
 		<afflictions.darkline><subattrib medium=""/></afflictions.darkline>
 
 		<tempbonuses.title><subattrib centre="" inverse=""/></tempbonuses.title>
-		<tempbonuses.border padding="0.5pt"><subattrib border="" inverse=""/></tempbonuses.border>
+		<tempbonuses.border><subattrib border="" inverse=""/></tempbonuses.border>
 		<tempbonuses.lightline><subattrib light=""/></tempbonuses.lightline>
 		<tempbonuses.darkline><subattrib medium=""/></tempbonuses.darkline>
 
 
 
 		<animal_tricks.title><subattrib centre="" inverse=""/></animal_tricks.title>
-		<animal_tricks.border padding="0.5pt"><subattrib border="" inverse=""/></animal_tricks.border>
+		<animal_tricks.border><subattrib border="" inverse=""/></animal_tricks.border>
 		<animal_tricks.lightline><subattrib light=""/></animal_tricks.lightline>
 		<animal_tricks.darkline><subattrib medium=""/></animal_tricks.darkline>
 
 
 		<intelligent_items.title><subattrib centre="" inverse=""/></intelligent_items.title>
-		<intelligent_items.border padding="0.5pt"><subattrib border="" inverse=""/></intelligent_items.border>
+		<intelligent_items.border><subattrib border="" inverse=""/></intelligent_items.border>
 		<intelligent_items.lightline><subattrib light=""/></intelligent_items.lightline>
 		<intelligent_items.darkline><subattrib medium=""/></intelligent_items.darkline>
 
 		<traits.title><subattrib centre="" inverse=""/></traits.title>
-		<traits.border padding="0.5pt"><subattrib border="" inverse=""/></traits.border>
+		<traits.border><subattrib border="" inverse=""/></traits.border>
 		<traits.lightline><subattrib light=""/></traits.lightline>
 		<traits.darkline><subattrib medium=""/></traits.darkline>
 
 
 		<salient_divine_abilities.title><subattrib centre="" inverse=""/></salient_divine_abilities.title>
-		<salient_divine_abilities.border padding="0.5pt"><subattrib border="" inverse=""/></salient_divine_abilities.border>
+		<salient_divine_abilities.border><subattrib border="" inverse=""/></salient_divine_abilities.border>
 		<salient_divine_abilities.lightline><subattrib light=""/></salient_divine_abilities.lightline>
 		<salient_divine_abilities.darkline><subattrib medium=""/></salient_divine_abilities.darkline>
 
 		<feats.title><subattrib centre="" inverse=""/></feats.title>
-		<feats.border padding="0.5pt"><subattrib border="" inverse=""/></feats.border>
+		<feats.border><subattrib border="" inverse=""/></feats.border>
 		<feats.lightline><subattrib light=""/></feats.lightline>
 		<feats.darkline><subattrib medium=""/></feats.darkline>
 

--- a/outputsheets/d20/fantasy/pdf/csheet_fantasy_std_blackandwhite.xslt
+++ b/outputsheets/d20/fantasy/pdf/csheet_fantasy_std_blackandwhite.xslt
@@ -81,67 +81,67 @@
 		<weapon><subattrib border="" centre="" normal=""/></weapon>
 
 		<protection.title><subattrib border="" centre="" inverse=""/></protection.title>
-		<protection.border padding="0.5pt"><subattrib border="" inverse=""/></protection.border>
+		<protection.border><subattrib border="" inverse=""/></protection.border>
 		<protection.darkline><subattrib  centre="" medium="" /></protection.darkline>
 		<protection.lightline><subattrib  centre="" light="" /></protection.lightline>
 
 		<rage.title><subattrib  centre="" inverse=""/></rage.title>
-		<rage.border padding="0.5pt"><subattrib border="" inverse=""/></rage.border>
+		<rage.border><subattrib border="" inverse=""/></rage.border>
 		<rage><subattrib normal=""/></rage>
 
 		<checklist.title><subattrib  centre="" inverse=""/></checklist.title>
-		<checklist.border padding="0.5pt"><subattrib border="" inverse=""/></checklist.border>
+		<checklist.border><subattrib border="" inverse=""/></checklist.border>
 		<checklist><subattrib normal=""/></checklist>
 
 		<wildshape.title><subattrib centre="" inverse=""/></wildshape.title>
-		<wildshape.border padding="0.5pt"><subattrib border="" inverse=""/></wildshape.border>
+		<wildshape.border><subattrib border="" inverse=""/></wildshape.border>
 		<wildshape><subattrib normal=""/></wildshape>
 
 		<bard.title><subattrib centre="" inverse=""/></bard.title>
-		<bard.border padding="0.5pt"><subattrib border="" inverse=""/></bard.border>
+		<bard.border><subattrib border="" inverse=""/></bard.border>
 		<bard><subattrib  normal=""/></bard>
 
 		<psionics.title><subattrib  centre="" inverse=""/></psionics.title>
-		<psionics.border padding="0.5pt"><subattrib border="" inverse=""/></psionics.border>
+		<psionics.border><subattrib border="" inverse=""/></psionics.border>
 		<psionics><subattrib border="" centre="" normal=""/></psionics>
 
 		<turning.title><subattrib centre="" inverse=""/></turning.title>
-		<turning.border padding="0.5pt"><subattrib border="" inverse=""/></turning.border>
+		<turning.border><subattrib border="" inverse=""/></turning.border>
 		<turning><subattrib  centre="" normal=""/></turning>
 		<turning.lightline><subattrib centre="" light=""/></turning.lightline>
 		<turning.darkline><subattrib centre="" medium=""/></turning.darkline>
 
 		<stunningfist.title><subattrib centre="" inverse=""/></stunningfist.title>
-		<stunningfist.border padding="0.5pt"><subattrib border="" inverse=""/></stunningfist.border>
+		<stunningfist.border><subattrib border="" inverse=""/></stunningfist.border>
 		<stunningfist><subattrib normal=""/></stunningfist>
 
 		<wholeness.title><subattrib  centre="" inverse=""/></wholeness.title>
-		<wholeness.border padding="0.5pt"><subattrib border="" inverse=""/></wholeness.border>
+		<wholeness.border><subattrib border="" inverse=""/></wholeness.border>
 		<wholeness><subattrib  normal=""/></wholeness>
 
 		<layonhands.title><subattrib centre="" inverse=""/></layonhands.title>
-		<layonhands.border padding="0.5pt"><subattrib border="" inverse=""/></layonhands.border>
+		<layonhands.border><subattrib border="" inverse=""/></layonhands.border>
 		<layonhands><subattrib  normal=""/></layonhands>
 
 		<domains.title><subattrib  centre="" inverse=""/></domains.title>
-		<domains.border padding="0.5pt"><subattrib border="" inverse=""/></domains.border>
+		<domains.border><subattrib border="" inverse=""/></domains.border>
 		<domains.lightline><subattrib  light=""/></domains.lightline>
 		<domains.darkline><subattrib  medium=""/></domains.darkline>
 
 		<proficiencies.title><subattrib centre="" inverse=""/></proficiencies.title>
-		<proficiencies.border padding="0.5pt"><subattrib border="" inverse=""/></proficiencies.border>
+		<proficiencies.border><subattrib border="" inverse=""/></proficiencies.border>
 		<proficiencies><subattrib centre="" normal=""/></proficiencies>
 
 		<prohibited.title><subattrib centre="" inverse=""/></prohibited.title>
-		<prohibited.border padding="0.5pt"><subattrib border="" inverse=""/></prohibited.border>
+		<prohibited.border><subattrib border="" inverse=""/></prohibited.border>
 		<prohibited><subattrib centre="" normal=""/></prohibited>
 
 		<languages.title><subattrib centre="" inverse=""/></languages.title>
-		<languages.border padding="0.5pt"><subattrib border="" inverse=""/></languages.border>
+		<languages.border><subattrib border="" inverse=""/></languages.border>
 		<languages><subattrib  centre="" normal=""/></languages>
 
 		<templates.title><subattrib centre="" inverse=""/></templates.title>
-		<templates.border padding="0.5pt"><subattrib border="" inverse=""/></templates.border>
+		<templates.border><subattrib border="" inverse=""/></templates.border>
 		<templates.lightline><subattrib light=""/></templates.lightline>
 		<templates.darkline><subattrib medium=""/></templates.darkline>
 
@@ -149,79 +149,79 @@
 		<companions><subattrib border="" centre="" normal=""/></companions>
 
 		<equipment.title><subattrib centre="" inverse=""/></equipment.title>
-		<equipment.border padding="0.5pt"><subattrib border="" inverse=""/></equipment.border>
+		<equipment.border><subattrib border="" inverse=""/></equipment.border>
 		<equipment.lightline><subattrib light=""/></equipment.lightline>
 		<equipment.darkline><subattrib medium=""/></equipment.darkline>
 
 		<weight.title><subattrib centre="" inverse=""/></weight.title>
-		<weight.border padding="0.5pt"><subattrib border="" inverse=""/></weight.border>
+		<weight.border><subattrib border="" inverse=""/></weight.border>
 		<weight.lightline><subattrib light=""/></weight.lightline>
 		<weight.darkline><subattrib  medium=""/></weight.darkline>
 
 		<money.title><subattrib  centre="" inverse=""/></money.title>
-		<money.border padding="0.5pt"><subattrib border="" inverse=""/></money.border>
+		<money.border><subattrib border="" inverse=""/></money.border>
 		<money.lightline><subattrib light=""/></money.lightline>
 		<money.darkline><subattrib medium=""/></money.darkline>
 
 		<magic.title><subattrib centre="" inverse=""/></magic.title>
-		<magic.border padding="0.5pt"><subattrib border="" inverse=""/></magic.border>
+		<magic.border><subattrib border="" inverse=""/></magic.border>
 		<magic.lightline><subattrib light=""/></magic.lightline>
 		<magic.darkline><subattrib medium=""/></magic.darkline>
 
 		<special_abilities.title><subattrib centre="" inverse=""/></special_abilities.title>
-		<special_abilities.border padding="0.5pt"><subattrib border="" inverse=""/></special_abilities.border>
+		<special_abilities.border><subattrib border="" inverse=""/></special_abilities.border>
 		<special_abilities.lightline><subattrib light=""/></special_abilities.lightline>
 		<special_abilities.darkline><subattrib medium=""/></special_abilities.darkline>
 
 		<special_attacks.title><subattrib centre="" inverse=""/></special_attacks.title>
-		<special_attacks.border padding="0.5pt"><subattrib border="" inverse=""/></special_attacks.border>
+		<special_attacks.border><subattrib border="" inverse=""/></special_attacks.border>
 		<special_attacks.lightline><subattrib light=""/></special_attacks.lightline>
 		<special_attacks.darkline><subattrib medium=""/></special_attacks.darkline>
 
 		<archetypes.title><subattrib centre="" inverse=""/></archetypes.title>
-		<archetypes.border padding="0.5pt"><subattrib border="" inverse=""/></archetypes.border>
+		<archetypes.border><subattrib border="" inverse=""/></archetypes.border>
 		<archetypes.lightline><subattrib light=""/></archetypes.lightline>
 		<archetypes.darkline><subattrib medium=""/></archetypes.darkline>
 
 		<animal_tricks.title><subattrib centre="" inverse=""/></animal_tricks.title>
-		<animal_tricks.border padding="0.5pt"><subattrib border="" inverse=""/></animal_tricks.border>
+		<animal_tricks.border><subattrib border="" inverse=""/></animal_tricks.border>
 		<animal_tricks.lightline><subattrib light=""/></animal_tricks.lightline>
 		<animal_tricks.darkline><subattrib medium=""/></animal_tricks.darkline>
 
 		<special_qualities.title><subattrib centre="" inverse=""/></special_qualities.title>
-		<special_qualities.border padding="0.5pt"><subattrib border="" inverse=""/></special_qualities.border>
+		<special_qualities.border><subattrib border="" inverse=""/></special_qualities.border>
 		<special_qualities.lightline><subattrib light=""/></special_qualities.lightline>
 		<special_qualities.darkline><subattrib medium=""/></special_qualities.darkline>
 
 		<afflictions.title><subattrib centre="" inverse=""/></afflictions.title>
-		<afflictions.border padding="0.5pt"><subattrib border="" inverse=""/></afflictions.border>
+		<afflictions.border><subattrib border="" inverse=""/></afflictions.border>
 		<afflictions.lightline><subattrib light=""/></afflictions.lightline>
 		<afflictions.darkline><subattrib medium=""/></afflictions.darkline>
 
 		<tempbonuses.title><subattrib centre="" inverse=""/></tempbonuses.title>
-		<tempbonuses.border padding="0.5pt"><subattrib border="" inverse=""/></tempbonuses.border>
+		<tempbonuses.border><subattrib border="" inverse=""/></tempbonuses.border>
 		<tempbonuses.lightline><subattrib light=""/></tempbonuses.lightline>
 		<tempbonuses.darkline><subattrib medium=""/></tempbonuses.darkline>
 
 
 
 		<intelligent_items.title><subattrib centre="" inverse=""/></intelligent_items.title>
-		<intelligent_items.border padding="0.5pt"><subattrib border="" inverse=""/></intelligent_items.border>
+		<intelligent_items.border><subattrib border="" inverse=""/></intelligent_items.border>
 		<intelligent_items.lightline><subattrib light=""/></intelligent_items.lightline>
 		<intelligent_items.darkline><subattrib medium=""/></intelligent_items.darkline>
 
         <traits.title><subattrib centre="" inverse=""/></traits.title>
-        <traits.border padding="0.5pt"><subattrib border="" inverse=""/></traits.border>
+        <traits.border><subattrib border="" inverse=""/></traits.border>
         <traits.lightline><subattrib light=""/></traits.lightline>
         <traits.darkline><subattrib medium=""/></traits.darkline>
 
 		<salient_divine_abilities.title><subattrib centre="" inverse=""/></salient_divine_abilities.title>
-		<salient_divine_abilities.border padding="0.5pt"><subattrib border="" inverse=""/></salient_divine_abilities.border>
+		<salient_divine_abilities.border><subattrib border="" inverse=""/></salient_divine_abilities.border>
 		<salient_divine_abilities.lightline><subattrib light=""/></salient_divine_abilities.lightline>
 		<salient_divine_abilities.darkline><subattrib medium=""/></salient_divine_abilities.darkline>
 
 		<feats.title><subattrib centre="" inverse=""/></feats.title>
-		<feats.border padding="0.5pt"><subattrib border="" inverse=""/></feats.border>
+		<feats.border><subattrib border="" inverse=""/></feats.border>
 		<feats.lightline><subattrib light=""/></feats.lightline>
 		<feats.darkline><subattrib medium=""/></feats.darkline>
 

--- a/outputsheets/d20/fantasy/pdf/csheet_fantasy_std_blue.xslt
+++ b/outputsheets/d20/fantasy/pdf/csheet_fantasy_std_blue.xslt
@@ -81,67 +81,67 @@
 		<weapon><subattrib border="" centre="" normal=""/></weapon>
 
 		<protection.title><subattrib border="" centre="" inverse=""/></protection.title>
-		<protection.border padding="0.5pt"><subattrib border="" inverse=""/></protection.border>
+		<protection.border><subattrib border="" inverse=""/></protection.border>
 		<protection.darkline><subattrib  centre="" medium="" /></protection.darkline>
 		<protection.lightline><subattrib  centre="" light="" /></protection.lightline>
 
 		<rage.title><subattrib  centre="" inverse=""/></rage.title>
-		<rage.border padding="0.5pt"><subattrib border="" inverse=""/></rage.border>
+		<rage.border><subattrib border="" inverse=""/></rage.border>
 		<rage><subattrib normal=""/></rage>
 
 		<checklist.title><subattrib  centre="" inverse=""/></checklist.title>
-		<checklist.border padding="0.5pt"><subattrib border="" inverse=""/></checklist.border>
+		<checklist.border><subattrib border="" inverse=""/></checklist.border>
 		<checklist><subattrib normal=""/></checklist>
 
 		<wildshape.title><subattrib centre="" inverse=""/></wildshape.title>
-		<wildshape.border padding="0.5pt"><subattrib border="" inverse=""/></wildshape.border>
+		<wildshape.border><subattrib border="" inverse=""/></wildshape.border>
 		<wildshape><subattrib normal=""/></wildshape>
 
 		<bard.title><subattrib centre="" inverse=""/></bard.title>
-		<bard.border padding="0.5pt"><subattrib border="" inverse=""/></bard.border>
+		<bard.border><subattrib border="" inverse=""/></bard.border>
 		<bard><subattrib  normal=""/></bard>
 
 		<psionics.title><subattrib  centre="" inverse=""/></psionics.title>
-		<psionics.border padding="0.5pt"><subattrib border="" inverse=""/></psionics.border>
+		<psionics.border><subattrib border="" inverse=""/></psionics.border>
 		<psionics><subattrib border="" centre="" normal=""/></psionics>
 
 		<turning.title><subattrib centre="" inverse=""/></turning.title>
-		<turning.border padding="0.5pt"><subattrib border="" inverse=""/></turning.border>
+		<turning.border><subattrib border="" inverse=""/></turning.border>
 		<turning><subattrib  centre="" normal=""/></turning>
 		<turning.lightline><subattrib centre="" light=""/></turning.lightline>
 		<turning.darkline><subattrib centre="" medium=""/></turning.darkline>
 
 		<stunningfist.title><subattrib centre="" inverse=""/></stunningfist.title>
-		<stunningfist.border padding="0.5pt"><subattrib border="" inverse=""/></stunningfist.border>
+		<stunningfist.border><subattrib border="" inverse=""/></stunningfist.border>
 		<stunningfist><subattrib normal=""/></stunningfist>
 
 		<wholeness.title><subattrib  centre="" inverse=""/></wholeness.title>
-		<wholeness.border padding="0.5pt"><subattrib border="" inverse=""/></wholeness.border>
+		<wholeness.border><subattrib border="" inverse=""/></wholeness.border>
 		<wholeness><subattrib  normal=""/></wholeness>
 
 		<layonhands.title><subattrib centre="" inverse=""/></layonhands.title>
-		<layonhands.border padding="0.5pt"><subattrib border="" inverse=""/></layonhands.border>
+		<layonhands.border><subattrib border="" inverse=""/></layonhands.border>
 		<layonhands><subattrib  normal=""/></layonhands>
 
 		<domains.title><subattrib  centre="" inverse=""/></domains.title>
-		<domains.border padding="0.5pt"><subattrib border="" inverse=""/></domains.border>
+		<domains.border><subattrib border="" inverse=""/></domains.border>
 		<domains.lightline><subattrib  light=""/></domains.lightline>
 		<domains.darkline><subattrib  medium=""/></domains.darkline>
 
 		<proficiencies.title><subattrib centre="" inverse=""/></proficiencies.title>
-		<proficiencies.border padding="0.5pt"><subattrib border="" inverse=""/></proficiencies.border>
+		<proficiencies.border><subattrib border="" inverse=""/></proficiencies.border>
 		<proficiencies><subattrib centre="" normal=""/></proficiencies>
 
 		<prohibited.title><subattrib centre="" inverse=""/></prohibited.title>
-		<prohibited.border padding="0.5pt"><subattrib border="" inverse=""/></prohibited.border>
+		<prohibited.border><subattrib border="" inverse=""/></prohibited.border>
 		<prohibited><subattrib centre="" normal=""/></prohibited>
 
 		<languages.title><subattrib centre="" inverse=""/></languages.title>
-		<languages.border padding="0.5pt"><subattrib border="" inverse=""/></languages.border>
+		<languages.border><subattrib border="" inverse=""/></languages.border>
 		<languages><subattrib  centre="" normal=""/></languages>
 
 		<templates.title><subattrib centre="" inverse=""/></templates.title>
-		<templates.border padding="0.5pt"><subattrib border="" inverse=""/></templates.border>
+		<templates.border><subattrib border="" inverse=""/></templates.border>
 		<templates.lightline><subattrib light=""/></templates.lightline>
 		<templates.darkline><subattrib medium=""/></templates.darkline>
 
@@ -149,80 +149,80 @@
 		<companions><subattrib border="" centre="" normal=""/></companions>
 
 		<equipment.title><subattrib centre="" inverse=""/></equipment.title>
-		<equipment.border padding="0.5pt"><subattrib border="" inverse=""/></equipment.border>
+		<equipment.border><subattrib border="" inverse=""/></equipment.border>
 		<equipment.lightline><subattrib light=""/></equipment.lightline>
 		<equipment.darkline><subattrib medium=""/></equipment.darkline>
 
 		<weight.title><subattrib centre="" inverse=""/></weight.title>
-		<weight.border padding="0.5pt"><subattrib border="" inverse=""/></weight.border>
+		<weight.border><subattrib border="" inverse=""/></weight.border>
 		<weight.lightline><subattrib light=""/></weight.lightline>
 		<weight.darkline><subattrib  medium=""/></weight.darkline>
 
 		<money.title><subattrib  centre="" inverse=""/></money.title>
-		<money.border padding="0.5pt"><subattrib border="" inverse=""/></money.border>
+		<money.border><subattrib border="" inverse=""/></money.border>
 		<money.lightline><subattrib light=""/></money.lightline>
 		<money.darkline><subattrib medium=""/></money.darkline>
 
 		<magic.title><subattrib centre="" inverse=""/></magic.title>
-		<magic.border padding="0.5pt"><subattrib border="" inverse=""/></magic.border>
+		<magic.border><subattrib border="" inverse=""/></magic.border>
 		<magic.lightline><subattrib light=""/></magic.lightline>
 		<magic.darkline><subattrib medium=""/></magic.darkline>
 
 		<special_abilities.title><subattrib centre="" inverse=""/></special_abilities.title>
-		<special_abilities.border padding="0.5pt"><subattrib border="" inverse=""/></special_abilities.border>
+		<special_abilities.border><subattrib border="" inverse=""/></special_abilities.border>
 		<special_abilities.lightline><subattrib light=""/></special_abilities.lightline>
 		<special_abilities.darkline><subattrib medium=""/></special_abilities.darkline>
 
 		<special_attacks.title><subattrib centre="" inverse=""/></special_attacks.title>
-		<special_attacks.border padding="0.5pt"><subattrib border="" inverse=""/></special_attacks.border>
+		<special_attacks.border><subattrib border="" inverse=""/></special_attacks.border>
 		<special_attacks.lightline><subattrib light=""/></special_attacks.lightline>
 		<special_attacks.darkline><subattrib medium=""/></special_attacks.darkline>
 
 		<archetypes.title><subattrib centre="" inverse=""/></archetypes.title>
-		<archetypes.border padding="0.5pt"><subattrib border="" inverse=""/></archetypes.border>
+		<archetypes.border><subattrib border="" inverse=""/></archetypes.border>
 		<archetypes.lightline><subattrib light=""/></archetypes.lightline>
 		<archetypes.darkline><subattrib medium=""/></archetypes.darkline>
 
 		<animal_tricks.title><subattrib centre="" inverse=""/></animal_tricks.title>
-		<animal_tricks.border padding="0.5pt"><subattrib border="" inverse=""/></animal_tricks.border>
+		<animal_tricks.border><subattrib border="" inverse=""/></animal_tricks.border>
 		<animal_tricks.lightline><subattrib light=""/></animal_tricks.lightline>
 		<animal_tricks.darkline><subattrib medium=""/></animal_tricks.darkline>
 
 		<special_qualities.title><subattrib centre="" inverse=""/></special_qualities.title>
-		<special_qualities.border padding="0.5pt"><subattrib border="" inverse=""/></special_qualities.border>
+		<special_qualities.border><subattrib border="" inverse=""/></special_qualities.border>
 		<special_qualities.lightline><subattrib light=""/></special_qualities.lightline>
 		<special_qualities.darkline><subattrib medium=""/></special_qualities.darkline>
 
 		<afflictions.title><subattrib centre="" inverse=""/></afflictions.title>
-		<afflictions.border padding="0.5pt"><subattrib border="" inverse=""/></afflictions.border>
+		<afflictions.border><subattrib border="" inverse=""/></afflictions.border>
 		<afflictions.lightline><subattrib light=""/></afflictions.lightline>
 		<afflictions.darkline><subattrib medium=""/></afflictions.darkline>
 
 		<tempbonuses.title><subattrib centre="" inverse=""/></tempbonuses.title>
-		<tempbonuses.border padding="0.5pt"><subattrib border="" inverse=""/></tempbonuses.border>
+		<tempbonuses.border><subattrib border="" inverse=""/></tempbonuses.border>
 		<tempbonuses.lightline><subattrib light=""/></tempbonuses.lightline>
 		<tempbonuses.darkline><subattrib medium=""/></tempbonuses.darkline>
 
 
 
 		<intelligent_items.title><subattrib centre="" inverse=""/></intelligent_items.title>
-		<intelligent_items.border padding="0.5pt"><subattrib border="" inverse=""/></intelligent_items.border>
+		<intelligent_items.border><subattrib border="" inverse=""/></intelligent_items.border>
 		<intelligent_items.lightline><subattrib light=""/></intelligent_items.lightline>
 		<intelligent_items.darkline><subattrib medium=""/></intelligent_items.darkline>
 
 
         <traits.title><subattrib centre="" inverse=""/></traits.title>
-        <traits.border padding="0.5pt"><subattrib border="" inverse=""/></traits.border>
+        <traits.border><subattrib border="" inverse=""/></traits.border>
         <traits.lightline><subattrib light=""/></traits.lightline>
         <traits.darkline><subattrib medium=""/></traits.darkline>
 
 		<salient_divine_abilities.title><subattrib centre="" inverse=""/></salient_divine_abilities.title>
-		<salient_divine_abilities.border padding="0.5pt"><subattrib border="" inverse=""/></salient_divine_abilities.border>
+		<salient_divine_abilities.border><subattrib border="" inverse=""/></salient_divine_abilities.border>
 		<salient_divine_abilities.lightline><subattrib light=""/></salient_divine_abilities.lightline>
 		<salient_divine_abilities.darkline><subattrib medium=""/></salient_divine_abilities.darkline>
 
 		<feats.title><subattrib centre="" inverse=""/></feats.title>
-		<feats.border padding="0.5pt"><subattrib border="" inverse=""/></feats.border>
+		<feats.border><subattrib border="" inverse=""/></feats.border>
 		<feats.lightline><subattrib light=""/></feats.lightline>
 		<feats.darkline><subattrib medium=""/></feats.darkline>
 

--- a/outputsheets/d20/fantasy/pdf/csheet_fantasy_std_blue_light.xslt
+++ b/outputsheets/d20/fantasy/pdf/csheet_fantasy_std_blue_light.xslt
@@ -81,67 +81,67 @@
 		<weapon><subattrib border="" centre="" normal=""/></weapon>
 
 		<protection.title><subattrib border="" centre="" inverse=""/></protection.title>
-		<protection.border padding="0.5pt"><subattrib border="" inverse=""/></protection.border>
+		<protection.border><subattrib border="" inverse=""/></protection.border>
 		<protection.darkline><subattrib  centre="" medium="" /></protection.darkline>
 		<protection.lightline><subattrib  centre="" light="" /></protection.lightline>
 
 		<rage.title><subattrib  centre="" inverse=""/></rage.title>
-		<rage.border padding="0.5pt"><subattrib border="" inverse=""/></rage.border>
+		<rage.border><subattrib border="" inverse=""/></rage.border>
 		<rage><subattrib normal=""/></rage>
 
 		<checklist.title><subattrib  centre="" inverse=""/></checklist.title>
-		<checklist.border padding="0.5pt"><subattrib border="" inverse=""/></checklist.border>
+		<checklist.border><subattrib border="" inverse=""/></checklist.border>
 		<checklist><subattrib normal=""/></checklist>
 
 		<wildshape.title><subattrib centre="" inverse=""/></wildshape.title>
-		<wildshape.border padding="0.5pt"><subattrib border="" inverse=""/></wildshape.border>
+		<wildshape.border><subattrib border="" inverse=""/></wildshape.border>
 		<wildshape><subattrib normal=""/></wildshape>
 
 		<bard.title><subattrib centre="" inverse=""/></bard.title>
-		<bard.border padding="0.5pt"><subattrib border="" inverse=""/></bard.border>
+		<bard.border><subattrib border="" inverse=""/></bard.border>
 		<bard><subattrib  normal=""/></bard>
 
 		<psionics.title><subattrib  centre="" inverse=""/></psionics.title>
-		<psionics.border padding="0.5pt"><subattrib border="" inverse=""/></psionics.border>
+		<psionics.border><subattrib border="" inverse=""/></psionics.border>
 		<psionics><subattrib border="" centre="" normal=""/></psionics>
 
 		<turning.title><subattrib centre="" inverse=""/></turning.title>
-		<turning.border padding="0.5pt"><subattrib border="" inverse=""/></turning.border>
+		<turning.border><subattrib border="" inverse=""/></turning.border>
 		<turning><subattrib  centre="" normal=""/></turning>
 		<turning.lightline><subattrib centre="" light=""/></turning.lightline>
 		<turning.darkline><subattrib centre="" medium=""/></turning.darkline>
 
 		<stunningfist.title><subattrib centre="" inverse=""/></stunningfist.title>
-		<stunningfist.border padding="0.5pt"><subattrib border="" inverse=""/></stunningfist.border>
+		<stunningfist.border><subattrib border="" inverse=""/></stunningfist.border>
 		<stunningfist><subattrib normal=""/></stunningfist>
 
 		<wholeness.title><subattrib  centre="" inverse=""/></wholeness.title>
-		<wholeness.border padding="0.5pt"><subattrib border="" inverse=""/></wholeness.border>
+		<wholeness.border><subattrib border="" inverse=""/></wholeness.border>
 		<wholeness><subattrib  normal=""/></wholeness>
 
 		<layonhands.title><subattrib centre="" inverse=""/></layonhands.title>
-		<layonhands.border padding="0.5pt"><subattrib border="" inverse=""/></layonhands.border>
+		<layonhands.border><subattrib border="" inverse=""/></layonhands.border>
 		<layonhands><subattrib  normal=""/></layonhands>
 
 		<domains.title><subattrib  centre="" inverse=""/></domains.title>
-		<domains.border padding="0.5pt"><subattrib border="" inverse=""/></domains.border>
+		<domains.border><subattrib border="" inverse=""/></domains.border>
 		<domains.lightline><subattrib  light=""/></domains.lightline>
 		<domains.darkline><subattrib  medium=""/></domains.darkline>
 
 		<proficiencies.title><subattrib centre="" inverse=""/></proficiencies.title>
-		<proficiencies.border padding="0.5pt"><subattrib border="" inverse=""/></proficiencies.border>
+		<proficiencies.border><subattrib border="" inverse=""/></proficiencies.border>
 		<proficiencies><subattrib centre="" normal=""/></proficiencies>
 
 		<prohibited.title><subattrib centre="" inverse=""/></prohibited.title>
-		<prohibited.border padding="0.5pt"><subattrib border="" inverse=""/></prohibited.border>
+		<prohibited.border><subattrib border="" inverse=""/></prohibited.border>
 		<prohibited><subattrib centre="" normal=""/></prohibited>
 
 		<languages.title><subattrib centre="" inverse=""/></languages.title>
-		<languages.border padding="0.5pt"><subattrib border="" inverse=""/></languages.border>
+		<languages.border><subattrib border="" inverse=""/></languages.border>
 		<languages><subattrib  centre="" normal=""/></languages>
 
 		<templates.title><subattrib centre="" inverse=""/></templates.title>
-		<templates.border padding="0.5pt"><subattrib border="" inverse=""/></templates.border>
+		<templates.border><subattrib border="" inverse=""/></templates.border>
 		<templates.lightline><subattrib light=""/></templates.lightline>
 		<templates.darkline><subattrib medium=""/></templates.darkline>
 
@@ -149,79 +149,79 @@
 		<companions><subattrib border="" centre="" normal=""/></companions>
 
 		<equipment.title><subattrib centre="" inverse=""/></equipment.title>
-		<equipment.border padding="0.5pt"><subattrib border="" inverse=""/></equipment.border>
+		<equipment.border><subattrib border="" inverse=""/></equipment.border>
 		<equipment.lightline><subattrib light=""/></equipment.lightline>
 		<equipment.darkline><subattrib medium=""/></equipment.darkline>
 
 		<weight.title><subattrib centre="" inverse=""/></weight.title>
-		<weight.border padding="0.5pt"><subattrib border="" inverse=""/></weight.border>
+		<weight.border><subattrib border="" inverse=""/></weight.border>
 		<weight.lightline><subattrib light=""/></weight.lightline>
 		<weight.darkline><subattrib  medium=""/></weight.darkline>
 
 		<money.title><subattrib  centre="" inverse=""/></money.title>
-		<money.border padding="0.5pt"><subattrib border="" inverse=""/></money.border>
+		<money.border><subattrib border="" inverse=""/></money.border>
 		<money.lightline><subattrib light=""/></money.lightline>
 		<money.darkline><subattrib medium=""/></money.darkline>
 
 		<magic.title><subattrib centre="" inverse=""/></magic.title>
-		<magic.border padding="0.5pt"><subattrib border="" inverse=""/></magic.border>
+		<magic.border><subattrib border="" inverse=""/></magic.border>
 		<magic.lightline><subattrib light=""/></magic.lightline>
 		<magic.darkline><subattrib medium=""/></magic.darkline>
 
 		<special_abilities.title><subattrib centre="" inverse=""/></special_abilities.title>
-		<special_abilities.border padding="0.5pt"><subattrib border="" inverse=""/></special_abilities.border>
+		<special_abilities.border><subattrib border="" inverse=""/></special_abilities.border>
 		<special_abilities.lightline><subattrib light=""/></special_abilities.lightline>
 		<special_abilities.darkline><subattrib medium=""/></special_abilities.darkline>
 
 		<special_attacks.title><subattrib centre="" inverse=""/></special_attacks.title>
-		<special_attacks.border padding="0.5pt"><subattrib border="" inverse=""/></special_attacks.border>
+		<special_attacks.border><subattrib border="" inverse=""/></special_attacks.border>
 		<special_attacks.lightline><subattrib light=""/></special_attacks.lightline>
 		<special_attacks.darkline><subattrib medium=""/></special_attacks.darkline>
 
 		<archetypes.title><subattrib centre="" inverse=""/></archetypes.title>
-		<archetypes.border padding="0.5pt"><subattrib border="" inverse=""/></archetypes.border>
+		<archetypes.border><subattrib border="" inverse=""/></archetypes.border>
 		<archetypes.lightline><subattrib light=""/></archetypes.lightline>
 		<archetypes.darkline><subattrib medium=""/></archetypes.darkline>
 
 		<animal_tricks.title><subattrib centre="" inverse=""/></animal_tricks.title>
-		<animal_tricks.border padding="0.5pt"><subattrib border="" inverse=""/></animal_tricks.border>
+		<animal_tricks.border><subattrib border="" inverse=""/></animal_tricks.border>
 		<animal_tricks.lightline><subattrib light=""/></animal_tricks.lightline>
 		<animal_tricks.darkline><subattrib medium=""/></animal_tricks.darkline>	
 
 		<special_qualities.title><subattrib centre="" inverse=""/></special_qualities.title>
-		<special_qualities.border padding="0.5pt"><subattrib border="" inverse=""/></special_qualities.border>
+		<special_qualities.border><subattrib border="" inverse=""/></special_qualities.border>
 		<special_qualities.lightline><subattrib light=""/></special_qualities.lightline>
 		<special_qualities.darkline><subattrib medium=""/></special_qualities.darkline>
 
 		<afflictions.title><subattrib centre="" inverse=""/></afflictions.title>
-		<afflictions.border padding="0.5pt"><subattrib border="" inverse=""/></afflictions.border>
+		<afflictions.border><subattrib border="" inverse=""/></afflictions.border>
 		<afflictions.lightline><subattrib light=""/></afflictions.lightline>
 		<afflictions.darkline><subattrib medium=""/></afflictions.darkline>
 
 		<tempbonuses.title><subattrib centre="" inverse=""/></tempbonuses.title>
-		<tempbonuses.border padding="0.5pt"><subattrib border="" inverse=""/></tempbonuses.border>
+		<tempbonuses.border><subattrib border="" inverse=""/></tempbonuses.border>
 		<tempbonuses.lightline><subattrib light=""/></tempbonuses.lightline>
 		<tempbonuses.darkline><subattrib medium=""/></tempbonuses.darkline>
 
 
 
 		<intelligent_items.title><subattrib centre="" inverse=""/></intelligent_items.title>
-		<intelligent_items.border padding="0.5pt"><subattrib border="" inverse=""/></intelligent_items.border>
+		<intelligent_items.border><subattrib border="" inverse=""/></intelligent_items.border>
 		<intelligent_items.lightline><subattrib light=""/></intelligent_items.lightline>
 		<intelligent_items.darkline><subattrib medium=""/></intelligent_items.darkline>
 
 		<traits.title><subattrib centre="" inverse=""/></traits.title>
-		<traits.border padding="0.5pt"><subattrib border="" inverse=""/></traits.border>
+		<traits.border><subattrib border="" inverse=""/></traits.border>
 		<traits.lightline><subattrib light=""/></traits.lightline>
 		<traits.darkline><subattrib medium=""/></traits.darkline>
 
 		<salient_divine_abilities.title><subattrib centre="" inverse=""/></salient_divine_abilities.title>
-		<salient_divine_abilities.border padding="0.5pt"><subattrib border="" inverse=""/></salient_divine_abilities.border>
+		<salient_divine_abilities.border><subattrib border="" inverse=""/></salient_divine_abilities.border>
 		<salient_divine_abilities.lightline><subattrib light=""/></salient_divine_abilities.lightline>
 		<salient_divine_abilities.darkline><subattrib medium=""/></salient_divine_abilities.darkline>
 
 		<feats.title><subattrib centre="" inverse=""/></feats.title>
-		<feats.border padding="0.5pt"><subattrib border="" inverse=""/></feats.border>
+		<feats.border><subattrib border="" inverse=""/></feats.border>
 		<feats.lightline><subattrib light=""/></feats.lightline>
 		<feats.darkline><subattrib medium=""/></feats.darkline>
 

--- a/outputsheets/d20/fantasy/pdf/csheet_fantasy_std_companion_box_first_page.xslt
+++ b/outputsheets/d20/fantasy/pdf/csheet_fantasy_std_companion_box_first_page.xslt
@@ -81,67 +81,67 @@
 		<weapon><subattrib border="" centre="" normal=""/></weapon>
 
 		<protection.title><subattrib border="" centre="" inverse=""/></protection.title>
-		<protection.border padding="0.5pt"><subattrib border="" inverse=""/></protection.border>
+		<protection.border><subattrib border="" inverse=""/></protection.border>
 		<protection.darkline><subattrib  centre="" medium="" /></protection.darkline>
 		<protection.lightline><subattrib  centre="" light="" /></protection.lightline>
 
 		<rage.title><subattrib  centre="" inverse=""/></rage.title>
-		<rage.border padding="0.5pt"><subattrib border="" inverse=""/></rage.border>
+		<rage.border><subattrib border="" inverse=""/></rage.border>
 		<rage><subattrib normal=""/></rage>
 
 		<checklist.title><subattrib  centre="" inverse=""/></checklist.title>
-		<checklist.border padding="0.5pt"><subattrib border="" inverse=""/></checklist.border>
+		<checklist.border><subattrib border="" inverse=""/></checklist.border>
 		<checklist><subattrib normal=""/></checklist>
 
 		<wildshape.title><subattrib centre="" inverse=""/></wildshape.title>
-		<wildshape.border padding="0.5pt"><subattrib border="" inverse=""/></wildshape.border>
+		<wildshape.border><subattrib border="" inverse=""/></wildshape.border>
 		<wildshape><subattrib normal=""/></wildshape>
 
 		<bard.title><subattrib centre="" inverse=""/></bard.title>
-		<bard.border padding="0.5pt"><subattrib border="" inverse=""/></bard.border>
+		<bard.border><subattrib border="" inverse=""/></bard.border>
 		<bard><subattrib  normal=""/></bard>
 
 		<psionics.title><subattrib  centre="" inverse=""/></psionics.title>
-		<psionics.border padding="0.5pt"><subattrib border="" inverse=""/></psionics.border>
+		<psionics.border><subattrib border="" inverse=""/></psionics.border>
 		<psionics><subattrib border="" centre="" normal=""/></psionics>
 
 		<turning.title><subattrib centre="" inverse=""/></turning.title>
-		<turning.border padding="0.5pt"><subattrib border="" inverse=""/></turning.border>
+		<turning.border><subattrib border="" inverse=""/></turning.border>
 		<turning><subattrib  centre="" normal=""/></turning>
 		<turning.lightline><subattrib centre="" light=""/></turning.lightline>
 		<turning.darkline><subattrib centre="" medium=""/></turning.darkline>
 
 		<stunningfist.title><subattrib centre="" inverse=""/></stunningfist.title>
-		<stunningfist.border padding="0.5pt"><subattrib border="" inverse=""/></stunningfist.border>
+		<stunningfist.border><subattrib border="" inverse=""/></stunningfist.border>
 		<stunningfist><subattrib normal=""/></stunningfist>
 
 		<wholeness.title><subattrib  centre="" inverse=""/></wholeness.title>
-		<wholeness.border padding="0.5pt"><subattrib border="" inverse=""/></wholeness.border>
+		<wholeness.border><subattrib border="" inverse=""/></wholeness.border>
 		<wholeness><subattrib  normal=""/></wholeness>
 
 		<layonhands.title><subattrib centre="" inverse=""/></layonhands.title>
-		<layonhands.border padding="0.5pt"><subattrib border="" inverse=""/></layonhands.border>
+		<layonhands.border><subattrib border="" inverse=""/></layonhands.border>
 		<layonhands><subattrib  normal=""/></layonhands>
 
 		<domains.title><subattrib  centre="" inverse=""/></domains.title>
-		<domains.border padding="0.5pt"><subattrib border="" inverse=""/></domains.border>
+		<domains.border><subattrib border="" inverse=""/></domains.border>
 		<domains.lightline><subattrib  light=""/></domains.lightline>
 		<domains.darkline><subattrib  medium=""/></domains.darkline>
 
 		<proficiencies.title><subattrib centre="" inverse=""/></proficiencies.title>
-		<proficiencies.border padding="0.5pt"><subattrib border="" inverse=""/></proficiencies.border>
+		<proficiencies.border><subattrib border="" inverse=""/></proficiencies.border>
 		<proficiencies><subattrib centre="" normal=""/></proficiencies>
 
 		<prohibited.title><subattrib centre="" inverse=""/></prohibited.title>
-		<prohibited.border padding="0.5pt"><subattrib border="" inverse=""/></prohibited.border>
+		<prohibited.border><subattrib border="" inverse=""/></prohibited.border>
 		<prohibited><subattrib centre="" normal=""/></prohibited>
 
 		<languages.title><subattrib centre="" inverse=""/></languages.title>
-		<languages.border padding="0.5pt"><subattrib border="" inverse=""/></languages.border>
+		<languages.border><subattrib border="" inverse=""/></languages.border>
 		<languages><subattrib  centre="" normal=""/></languages>
 
 		<templates.title><subattrib centre="" inverse=""/></templates.title>
-		<templates.border padding="0.5pt"><subattrib border="" inverse=""/></templates.border>
+		<templates.border><subattrib border="" inverse=""/></templates.border>
 		<templates.lightline><subattrib light=""/></templates.lightline>
 		<templates.darkline><subattrib medium=""/></templates.darkline>
 
@@ -149,81 +149,81 @@
 		<companions><subattrib border="" centre="" normal=""/></companions>
 
 		<equipment.title><subattrib centre="" inverse=""/></equipment.title>
-		<equipment.border padding="0.5pt"><subattrib border="" inverse=""/></equipment.border>
+		<equipment.border><subattrib border="" inverse=""/></equipment.border>
 		<equipment.lightline><subattrib light=""/></equipment.lightline>
 		<equipment.darkline><subattrib medium=""/></equipment.darkline>
 
 		<weight.title><subattrib centre="" inverse=""/></weight.title>
-		<weight.border padding="0.5pt"><subattrib border="" inverse=""/></weight.border>
+		<weight.border><subattrib border="" inverse=""/></weight.border>
 		<weight.lightline><subattrib light=""/></weight.lightline>
 		<weight.darkline><subattrib  medium=""/></weight.darkline>
 
 		<money.title><subattrib  centre="" inverse=""/></money.title>
-		<money.border padding="0.5pt"><subattrib border="" inverse=""/></money.border>
+		<money.border><subattrib border="" inverse=""/></money.border>
 		<money.lightline><subattrib light=""/></money.lightline>
 		<money.darkline><subattrib medium=""/></money.darkline>
 
 		<magic.title><subattrib centre="" inverse=""/></magic.title>
-		<magic.border padding="0.5pt"><subattrib border="" inverse=""/></magic.border>
+		<magic.border><subattrib border="" inverse=""/></magic.border>
 		<magic.lightline><subattrib light=""/></magic.lightline>
 		<magic.darkline><subattrib medium=""/></magic.darkline>
 
 		<special_abilities.title><subattrib centre="" inverse=""/></special_abilities.title>
-		<special_abilities.border padding="0.5pt"><subattrib border="" inverse=""/></special_abilities.border>
+		<special_abilities.border><subattrib border="" inverse=""/></special_abilities.border>
 		<special_abilities.lightline><subattrib light=""/></special_abilities.lightline>
 		<special_abilities.darkline><subattrib medium=""/></special_abilities.darkline>
 
 		<archetypes.title><subattrib centre="" inverse=""/></archetypes.title>
-		<archetypes.border padding="0.5pt"><subattrib border="" inverse=""/></archetypes.border>
+		<archetypes.border><subattrib border="" inverse=""/></archetypes.border>
 		<archetypes.lightline><subattrib light=""/></archetypes.lightline>
 		<archetypes.darkline><subattrib medium=""/></archetypes.darkline>
 
 		<special_attacks.title><subattrib centre="" inverse=""/></special_attacks.title>
-		<special_attacks.border padding="0.5pt"><subattrib border="" inverse=""/></special_attacks.border>
+		<special_attacks.border><subattrib border="" inverse=""/></special_attacks.border>
 		<special_attacks.lightline><subattrib light=""/></special_attacks.lightline>
 		<special_attacks.darkline><subattrib medium=""/></special_attacks.darkline>
 
 		<special_qualities.title><subattrib centre="" inverse=""/></special_qualities.title>
-		<special_qualities.border padding="0.5pt"><subattrib border="" inverse=""/></special_qualities.border>
+		<special_qualities.border><subattrib border="" inverse=""/></special_qualities.border>
 		<special_qualities.lightline><subattrib light=""/></special_qualities.lightline>
 		<special_qualities.darkline><subattrib medium=""/></special_qualities.darkline>
 
 		<afflictions.title><subattrib centre="" inverse=""/></afflictions.title>
-		<afflictions.border padding="0.5pt"><subattrib border="" inverse=""/></afflictions.border>
+		<afflictions.border><subattrib border="" inverse=""/></afflictions.border>
 		<afflictions.lightline><subattrib light=""/></afflictions.lightline>
 		<afflictions.darkline><subattrib medium=""/></afflictions.darkline>
 
 		<tempbonuses.title><subattrib centre="" inverse=""/></tempbonuses.title>
-		<tempbonuses.border padding="0.5pt"><subattrib border="" inverse=""/></tempbonuses.border>
+		<tempbonuses.border><subattrib border="" inverse=""/></tempbonuses.border>
 		<tempbonuses.lightline><subattrib light=""/></tempbonuses.lightline>
 		<tempbonuses.darkline><subattrib medium=""/></tempbonuses.darkline>
 
 
 
 		<animal_tricks.title><subattrib centre="" inverse=""/></animal_tricks.title>
-		<animal_tricks.border padding="0.5pt"><subattrib border="" inverse=""/></animal_tricks.border>
+		<animal_tricks.border><subattrib border="" inverse=""/></animal_tricks.border>
 		<animal_tricks.lightline><subattrib light=""/></animal_tricks.lightline>
 		<animal_tricks.darkline><subattrib medium=""/></animal_tricks.darkline>
 
 
 		<intelligent_items.title><subattrib centre="" inverse=""/></intelligent_items.title>
-		<intelligent_items.border padding="0.5pt"><subattrib border="" inverse=""/></intelligent_items.border>
+		<intelligent_items.border><subattrib border="" inverse=""/></intelligent_items.border>
 		<intelligent_items.lightline><subattrib light=""/></intelligent_items.lightline>
 		<intelligent_items.darkline><subattrib medium=""/></intelligent_items.darkline>
 
 		<traits.title><subattrib centre="" inverse=""/></traits.title>
-		<traits.border padding="0.5pt"><subattrib border="" inverse=""/></traits.border>
+		<traits.border><subattrib border="" inverse=""/></traits.border>
 		<traits.lightline><subattrib light=""/></traits.lightline>
 		<traits.darkline><subattrib medium=""/></traits.darkline>
 
 
 		<salient_divine_abilities.title><subattrib centre="" inverse=""/></salient_divine_abilities.title>
-		<salient_divine_abilities.border padding="0.5pt"><subattrib border="" inverse=""/></salient_divine_abilities.border>
+		<salient_divine_abilities.border><subattrib border="" inverse=""/></salient_divine_abilities.border>
 		<salient_divine_abilities.lightline><subattrib light=""/></salient_divine_abilities.lightline>
 		<salient_divine_abilities.darkline><subattrib medium=""/></salient_divine_abilities.darkline>
 
 		<feats.title><subattrib centre="" inverse=""/></feats.title>
-		<feats.border padding="0.5pt"><subattrib border="" inverse=""/></feats.border>
+		<feats.border><subattrib border="" inverse=""/></feats.border>
 		<feats.lightline><subattrib light=""/></feats.lightline>
 		<feats.darkline><subattrib medium=""/></feats.darkline>
 

--- a/outputsheets/d20/fantasy/pdf/csheet_fantasy_std_green_light.xslt
+++ b/outputsheets/d20/fantasy/pdf/csheet_fantasy_std_green_light.xslt
@@ -81,67 +81,67 @@
 		<weapon><subattrib border="" centre="" normal=""/></weapon>
 
 		<protection.title><subattrib border="" centre="" inverse=""/></protection.title>
-		<protection.border padding="0.5pt"><subattrib border="" inverse=""/></protection.border>
+		<protection.border><subattrib border="" inverse=""/></protection.border>
 		<protection.darkline><subattrib  centre="" medium="" /></protection.darkline>
 		<protection.lightline><subattrib  centre="" light="" /></protection.lightline>
 
 		<rage.title><subattrib  centre="" inverse=""/></rage.title>
-		<rage.border padding="0.5pt"><subattrib border="" inverse=""/></rage.border>
+		<rage.border><subattrib border="" inverse=""/></rage.border>
 		<rage><subattrib normal=""/></rage>
 
 		<checklist.title><subattrib  centre="" inverse=""/></checklist.title>
-		<checklist.border padding="0.5pt"><subattrib border="" inverse=""/></checklist.border>
+		<checklist.border><subattrib border="" inverse=""/></checklist.border>
 		<checklist><subattrib normal=""/></checklist>
 
 		<wildshape.title><subattrib centre="" inverse=""/></wildshape.title>
-		<wildshape.border padding="0.5pt"><subattrib border="" inverse=""/></wildshape.border>
+		<wildshape.border><subattrib border="" inverse=""/></wildshape.border>
 		<wildshape><subattrib normal=""/></wildshape>
 
 		<bard.title><subattrib centre="" inverse=""/></bard.title>
-		<bard.border padding="0.5pt"><subattrib border="" inverse=""/></bard.border>
+		<bard.border><subattrib border="" inverse=""/></bard.border>
 		<bard><subattrib  normal=""/></bard>
 
 		<psionics.title><subattrib  centre="" inverse=""/></psionics.title>
-		<psionics.border padding="0.5pt"><subattrib border="" inverse=""/></psionics.border>
+		<psionics.border><subattrib border="" inverse=""/></psionics.border>
 		<psionics><subattrib border="" centre="" normal=""/></psionics>
 
 		<turning.title><subattrib centre="" inverse=""/></turning.title>
-		<turning.border padding="0.5pt"><subattrib border="" inverse=""/></turning.border>
+		<turning.border><subattrib border="" inverse=""/></turning.border>
 		<turning><subattrib  centre="" normal=""/></turning>
 		<turning.lightline><subattrib centre="" light=""/></turning.lightline>
 		<turning.darkline><subattrib centre="" medium=""/></turning.darkline>
 
 		<stunningfist.title><subattrib centre="" inverse=""/></stunningfist.title>
-		<stunningfist.border padding="0.5pt"><subattrib border="" inverse=""/></stunningfist.border>
+		<stunningfist.border><subattrib border="" inverse=""/></stunningfist.border>
 		<stunningfist><subattrib normal=""/></stunningfist>
 
 		<wholeness.title><subattrib  centre="" inverse=""/></wholeness.title>
-		<wholeness.border padding="0.5pt"><subattrib border="" inverse=""/></wholeness.border>
+		<wholeness.border><subattrib border="" inverse=""/></wholeness.border>
 		<wholeness><subattrib  normal=""/></wholeness>
 
 		<layonhands.title><subattrib centre="" inverse=""/></layonhands.title>
-		<layonhands.border padding="0.5pt"><subattrib border="" inverse=""/></layonhands.border>
+		<layonhands.border><subattrib border="" inverse=""/></layonhands.border>
 		<layonhands><subattrib  normal=""/></layonhands>
 
 		<domains.title><subattrib  centre="" inverse=""/></domains.title>
-		<domains.border padding="0.5pt"><subattrib border="" inverse=""/></domains.border>
+		<domains.border><subattrib border="" inverse=""/></domains.border>
 		<domains.lightline><subattrib  light=""/></domains.lightline>
 		<domains.darkline><subattrib  medium=""/></domains.darkline>
 
 		<proficiencies.title><subattrib centre="" inverse=""/></proficiencies.title>
-		<proficiencies.border padding="0.5pt"><subattrib border="" inverse=""/></proficiencies.border>
+		<proficiencies.border><subattrib border="" inverse=""/></proficiencies.border>
 		<proficiencies><subattrib centre="" normal=""/></proficiencies>
 
 		<prohibited.title><subattrib centre="" inverse=""/></prohibited.title>
-		<prohibited.border padding="0.5pt"><subattrib border="" inverse=""/></prohibited.border>
+		<prohibited.border><subattrib border="" inverse=""/></prohibited.border>
 		<prohibited><subattrib centre="" normal=""/></prohibited>
 
 		<languages.title><subattrib centre="" inverse=""/></languages.title>
-		<languages.border padding="0.5pt"><subattrib border="" inverse=""/></languages.border>
+		<languages.border><subattrib border="" inverse=""/></languages.border>
 		<languages><subattrib  centre="" normal=""/></languages>
 
 		<templates.title><subattrib centre="" inverse=""/></templates.title>
-		<templates.border padding="0.5pt"><subattrib border="" inverse=""/></templates.border>
+		<templates.border><subattrib border="" inverse=""/></templates.border>
 		<templates.lightline><subattrib light=""/></templates.lightline>
 		<templates.darkline><subattrib medium=""/></templates.darkline>
 
@@ -149,79 +149,79 @@
 		<companions><subattrib border="" centre="" normal=""/></companions>
 
 		<equipment.title><subattrib centre="" inverse=""/></equipment.title>
-		<equipment.border padding="0.5pt"><subattrib border="" inverse=""/></equipment.border>
+		<equipment.border><subattrib border="" inverse=""/></equipment.border>
 		<equipment.lightline><subattrib light=""/></equipment.lightline>
 		<equipment.darkline><subattrib medium=""/></equipment.darkline>
 
 		<weight.title><subattrib centre="" inverse=""/></weight.title>
-		<weight.border padding="0.5pt"><subattrib border="" inverse=""/></weight.border>
+		<weight.border><subattrib border="" inverse=""/></weight.border>
 		<weight.lightline><subattrib light=""/></weight.lightline>
 		<weight.darkline><subattrib  medium=""/></weight.darkline>
 
 		<money.title><subattrib  centre="" inverse=""/></money.title>
-		<money.border padding="0.5pt"><subattrib border="" inverse=""/></money.border>
+		<money.border><subattrib border="" inverse=""/></money.border>
 		<money.lightline><subattrib light=""/></money.lightline>
 		<money.darkline><subattrib medium=""/></money.darkline>
 
 		<magic.title><subattrib centre="" inverse=""/></magic.title>
-		<magic.border padding="0.5pt"><subattrib border="" inverse=""/></magic.border>
+		<magic.border><subattrib border="" inverse=""/></magic.border>
 		<magic.lightline><subattrib light=""/></magic.lightline>
 		<magic.darkline><subattrib medium=""/></magic.darkline>
 
 		<special_abilities.title><subattrib centre="" inverse=""/></special_abilities.title>
-		<special_abilities.border padding="0.5pt"><subattrib border="" inverse=""/></special_abilities.border>
+		<special_abilities.border><subattrib border="" inverse=""/></special_abilities.border>
 		<special_abilities.lightline><subattrib light=""/></special_abilities.lightline>
 		<special_abilities.darkline><subattrib medium=""/></special_abilities.darkline>
 
 		<special_attacks.title><subattrib centre="" inverse=""/></special_attacks.title>
-		<special_attacks.border padding="0.5pt"><subattrib border="" inverse=""/></special_attacks.border>
+		<special_attacks.border><subattrib border="" inverse=""/></special_attacks.border>
 		<special_attacks.lightline><subattrib light=""/></special_attacks.lightline>
 		<special_attacks.darkline><subattrib medium=""/></special_attacks.darkline>
 
 		<archetypes.title><subattrib centre="" inverse=""/></archetypes.title>
-		<archetypes.border padding="0.5pt"><subattrib border="" inverse=""/></archetypes.border>
+		<archetypes.border><subattrib border="" inverse=""/></archetypes.border>
 		<archetypes.lightline><subattrib light=""/></archetypes.lightline>
 		<archetypes.darkline><subattrib medium=""/></archetypes.darkline>
 
 		<animal_tricks.title><subattrib centre="" inverse=""/></animal_tricks.title>
-		<animal_tricks.border padding="0.5pt"><subattrib border="" inverse=""/></animal_tricks.border>
+		<animal_tricks.border><subattrib border="" inverse=""/></animal_tricks.border>
 		<animal_tricks.lightline><subattrib light=""/></animal_tricks.lightline>
 		<animal_tricks.darkline><subattrib medium=""/></animal_tricks.darkline>
 
 		<special_qualities.title><subattrib centre="" inverse=""/></special_qualities.title>
-		<special_qualities.border padding="0.5pt"><subattrib border="" inverse=""/></special_qualities.border>
+		<special_qualities.border><subattrib border="" inverse=""/></special_qualities.border>
 		<special_qualities.lightline><subattrib light=""/></special_qualities.lightline>
 		<special_qualities.darkline><subattrib medium=""/></special_qualities.darkline>
 
 		<afflictions.title><subattrib centre="" inverse=""/></afflictions.title>
-		<afflictions.border padding="0.5pt"><subattrib border="" inverse=""/></afflictions.border>
+		<afflictions.border><subattrib border="" inverse=""/></afflictions.border>
 		<afflictions.lightline><subattrib light=""/></afflictions.lightline>
 		<afflictions.darkline><subattrib medium=""/></afflictions.darkline>
 
 		<tempbonuses.title><subattrib centre="" inverse=""/></tempbonuses.title>
-		<tempbonuses.border padding="0.5pt"><subattrib border="" inverse=""/></tempbonuses.border>
+		<tempbonuses.border><subattrib border="" inverse=""/></tempbonuses.border>
 		<tempbonuses.lightline><subattrib light=""/></tempbonuses.lightline>
 		<tempbonuses.darkline><subattrib medium=""/></tempbonuses.darkline>
 
 
 
 		<intelligent_items.title><subattrib centre="" inverse=""/></intelligent_items.title>
-		<intelligent_items.border padding="0.5pt"><subattrib border="" inverse=""/></intelligent_items.border>
+		<intelligent_items.border><subattrib border="" inverse=""/></intelligent_items.border>
 		<intelligent_items.lightline><subattrib light=""/></intelligent_items.lightline>
 		<intelligent_items.darkline><subattrib medium=""/></intelligent_items.darkline>
 
 		<traits.title><subattrib centre="" inverse=""/></traits.title>
-		<traits.border padding="0.5pt"><subattrib border="" inverse=""/></traits.border>
+		<traits.border><subattrib border="" inverse=""/></traits.border>
 		<traits.lightline><subattrib light=""/></traits.lightline>
 		<traits.darkline><subattrib medium=""/></traits.darkline>
 
 		<salient_divine_abilities.title><subattrib centre="" inverse=""/></salient_divine_abilities.title>
-		<salient_divine_abilities.border padding="0.5pt"><subattrib border="" inverse=""/></salient_divine_abilities.border>
+		<salient_divine_abilities.border><subattrib border="" inverse=""/></salient_divine_abilities.border>
 		<salient_divine_abilities.lightline><subattrib light=""/></salient_divine_abilities.lightline>
 		<salient_divine_abilities.darkline><subattrib medium=""/></salient_divine_abilities.darkline>
 
 		<feats.title><subattrib centre="" inverse=""/></feats.title>
-		<feats.border padding="0.5pt"><subattrib border="" inverse=""/></feats.border>
+		<feats.border><subattrib border="" inverse=""/></feats.border>
 		<feats.lightline><subattrib light=""/></feats.lightline>
 		<feats.darkline><subattrib medium=""/></feats.darkline>
 

--- a/outputsheets/d20/fantasy/pdf/csheet_fantasy_std_grey.xslt
+++ b/outputsheets/d20/fantasy/pdf/csheet_fantasy_std_grey.xslt
@@ -81,67 +81,67 @@
 		<weapon><subattrib border="" centre="" normal=""/></weapon>
 
 		<protection.title><subattrib border="" centre="" inverse=""/></protection.title>
-		<protection.border padding="0.5pt"><subattrib border="" inverse=""/></protection.border>
+		<protection.border><subattrib border="" inverse=""/></protection.border>
 		<protection.darkline><subattrib  centre="" medium="" /></protection.darkline>
 		<protection.lightline><subattrib  centre="" light="" /></protection.lightline>
 
 		<rage.title><subattrib  centre="" inverse=""/></rage.title>
-		<rage.border padding="0.5pt"><subattrib border="" inverse=""/></rage.border>
+		<rage.border><subattrib border="" inverse=""/></rage.border>
 		<rage><subattrib normal=""/></rage>
 
 		<checklist.title><subattrib  centre="" inverse=""/></checklist.title>
-		<checklist.border padding="0.5pt"><subattrib border="" inverse=""/></checklist.border>
+		<checklist.border><subattrib border="" inverse=""/></checklist.border>
 		<checklist><subattrib normal=""/></checklist>
 
 		<wildshape.title><subattrib centre="" inverse=""/></wildshape.title>
-		<wildshape.border padding="0.5pt"><subattrib border="" inverse=""/></wildshape.border>
+		<wildshape.border><subattrib border="" inverse=""/></wildshape.border>
 		<wildshape><subattrib normal=""/></wildshape>
 
 		<bard.title><subattrib centre="" inverse=""/></bard.title>
-		<bard.border padding="0.5pt"><subattrib border="" inverse=""/></bard.border>
+		<bard.border><subattrib border="" inverse=""/></bard.border>
 		<bard><subattrib  normal=""/></bard>
 
 		<psionics.title><subattrib  centre="" inverse=""/></psionics.title>
-		<psionics.border padding="0.5pt"><subattrib border="" inverse=""/></psionics.border>
+		<psionics.border><subattrib border="" inverse=""/></psionics.border>
 		<psionics><subattrib border="" centre="" normal=""/></psionics>
 
 		<turning.title><subattrib centre="" inverse=""/></turning.title>
-		<turning.border padding="0.5pt"><subattrib border="" inverse=""/></turning.border>
+		<turning.border><subattrib border="" inverse=""/></turning.border>
 		<turning><subattrib  centre="" normal=""/></turning>
 		<turning.lightline><subattrib centre="" light=""/></turning.lightline>
 		<turning.darkline><subattrib centre="" medium=""/></turning.darkline>
 
 		<stunningfist.title><subattrib centre="" inverse=""/></stunningfist.title>
-		<stunningfist.border padding="0.5pt"><subattrib border="" inverse=""/></stunningfist.border>
+		<stunningfist.border><subattrib border="" inverse=""/></stunningfist.border>
 		<stunningfist><subattrib normal=""/></stunningfist>
 
 		<wholeness.title><subattrib  centre="" inverse=""/></wholeness.title>
-		<wholeness.border padding="0.5pt"><subattrib border="" inverse=""/></wholeness.border>
+		<wholeness.border><subattrib border="" inverse=""/></wholeness.border>
 		<wholeness><subattrib  normal=""/></wholeness>
 
 		<layonhands.title><subattrib centre="" inverse=""/></layonhands.title>
-		<layonhands.border padding="0.5pt"><subattrib border="" inverse=""/></layonhands.border>
+		<layonhands.border><subattrib border="" inverse=""/></layonhands.border>
 		<layonhands><subattrib  normal=""/></layonhands>
 
 		<domains.title><subattrib  centre="" inverse=""/></domains.title>
-		<domains.border padding="0.5pt"><subattrib border="" inverse=""/></domains.border>
+		<domains.border><subattrib border="" inverse=""/></domains.border>
 		<domains.lightline><subattrib  light=""/></domains.lightline>
 		<domains.darkline><subattrib  medium=""/></domains.darkline>
 
 		<proficiencies.title><subattrib centre="" inverse=""/></proficiencies.title>
-		<proficiencies.border padding="0.5pt"><subattrib border="" inverse=""/></proficiencies.border>
+		<proficiencies.border><subattrib border="" inverse=""/></proficiencies.border>
 		<proficiencies><subattrib centre="" normal=""/></proficiencies>
 
 		<prohibited.title><subattrib centre="" inverse=""/></prohibited.title>
-		<prohibited.border padding="0.5pt"><subattrib border="" inverse=""/></prohibited.border>
+		<prohibited.border><subattrib border="" inverse=""/></prohibited.border>
 		<prohibited><subattrib centre="" normal=""/></prohibited>
 
 		<languages.title><subattrib centre="" inverse=""/></languages.title>
-		<languages.border padding="0.5pt"><subattrib border="" inverse=""/></languages.border>
+		<languages.border><subattrib border="" inverse=""/></languages.border>
 		<languages><subattrib  centre="" normal=""/></languages>
 
 		<templates.title><subattrib centre="" inverse=""/></templates.title>
-		<templates.border padding="0.5pt"><subattrib border="" inverse=""/></templates.border>
+		<templates.border><subattrib border="" inverse=""/></templates.border>
 		<templates.lightline><subattrib light=""/></templates.lightline>
 		<templates.darkline><subattrib medium=""/></templates.darkline>
 
@@ -149,79 +149,79 @@
 		<companions><subattrib border="" centre="" normal=""/></companions>
 
 		<equipment.title><subattrib centre="" inverse=""/></equipment.title>
-		<equipment.border padding="0.5pt"><subattrib border="" inverse=""/></equipment.border>
+		<equipment.border><subattrib border="" inverse=""/></equipment.border>
 		<equipment.lightline><subattrib light=""/></equipment.lightline>
 		<equipment.darkline><subattrib medium=""/></equipment.darkline>
 
 		<weight.title><subattrib centre="" inverse=""/></weight.title>
-		<weight.border padding="0.5pt"><subattrib border="" inverse=""/></weight.border>
+		<weight.border><subattrib border="" inverse=""/></weight.border>
 		<weight.lightline><subattrib light=""/></weight.lightline>
 		<weight.darkline><subattrib  medium=""/></weight.darkline>
 
 		<money.title><subattrib  centre="" inverse=""/></money.title>
-		<money.border padding="0.5pt"><subattrib border="" inverse=""/></money.border>
+		<money.border><subattrib border="" inverse=""/></money.border>
 		<money.lightline><subattrib light=""/></money.lightline>
 		<money.darkline><subattrib medium=""/></money.darkline>
 
 		<magic.title><subattrib centre="" inverse=""/></magic.title>
-		<magic.border padding="0.5pt"><subattrib border="" inverse=""/></magic.border>
+		<magic.border><subattrib border="" inverse=""/></magic.border>
 		<magic.lightline><subattrib light=""/></magic.lightline>
 		<magic.darkline><subattrib medium=""/></magic.darkline>
 
 		<special_abilities.title><subattrib centre="" inverse=""/></special_abilities.title>
-		<special_abilities.border padding="0.5pt"><subattrib border="" inverse=""/></special_abilities.border>
+		<special_abilities.border><subattrib border="" inverse=""/></special_abilities.border>
 		<special_abilities.lightline><subattrib light=""/></special_abilities.lightline>
 		<special_abilities.darkline><subattrib medium=""/></special_abilities.darkline>
 
 		<special_attacks.title><subattrib centre="" inverse=""/></special_attacks.title>
-		<special_attacks.border padding="0.5pt"><subattrib border="" inverse=""/></special_attacks.border>
+		<special_attacks.border><subattrib border="" inverse=""/></special_attacks.border>
 		<special_attacks.lightline><subattrib light=""/></special_attacks.lightline>
 		<special_attacks.darkline><subattrib medium=""/></special_attacks.darkline>
 
 		<archetypes.title><subattrib centre="" inverse=""/></archetypes.title>
-		<archetypes.border padding="0.5pt"><subattrib border="" inverse=""/></archetypes.border>
+		<archetypes.border><subattrib border="" inverse=""/></archetypes.border>
 		<archetypes.lightline><subattrib light=""/></archetypes.lightline>
 		<archetypes.darkline><subattrib medium=""/></archetypes.darkline>
 
 		<animal_tricks.title><subattrib centre="" inverse=""/></animal_tricks.title>
-		<animal_tricks.border padding="0.5pt"><subattrib border="" inverse=""/></animal_tricks.border>
+		<animal_tricks.border><subattrib border="" inverse=""/></animal_tricks.border>
 		<animal_tricks.lightline><subattrib light=""/></animal_tricks.lightline>
 		<animal_tricks.darkline><subattrib medium=""/></animal_tricks.darkline>
 
 		<special_qualities.title><subattrib centre="" inverse=""/></special_qualities.title>
-		<special_qualities.border padding="0.5pt"><subattrib border="" inverse=""/></special_qualities.border>
+		<special_qualities.border><subattrib border="" inverse=""/></special_qualities.border>
 		<special_qualities.lightline><subattrib light=""/></special_qualities.lightline>
 		<special_qualities.darkline><subattrib medium=""/></special_qualities.darkline>
 
 		<afflictions.title><subattrib centre="" inverse=""/></afflictions.title>
-		<afflictions.border padding="0.5pt"><subattrib border="" inverse=""/></afflictions.border>
+		<afflictions.border><subattrib border="" inverse=""/></afflictions.border>
 		<afflictions.lightline><subattrib light=""/></afflictions.lightline>
 		<afflictions.darkline><subattrib medium=""/></afflictions.darkline>
 
 		<tempbonuses.title><subattrib centre="" inverse=""/></tempbonuses.title>
-		<tempbonuses.border padding="0.5pt"><subattrib border="" inverse=""/></tempbonuses.border>
+		<tempbonuses.border><subattrib border="" inverse=""/></tempbonuses.border>
 		<tempbonuses.lightline><subattrib light=""/></tempbonuses.lightline>
 		<tempbonuses.darkline><subattrib medium=""/></tempbonuses.darkline>
 
 
 
 		<intelligent_items.title><subattrib centre="" inverse=""/></intelligent_items.title>
-		<intelligent_items.border padding="0.5pt"><subattrib border="" inverse=""/></intelligent_items.border>
+		<intelligent_items.border><subattrib border="" inverse=""/></intelligent_items.border>
 		<intelligent_items.lightline><subattrib light=""/></intelligent_items.lightline>
 		<intelligent_items.darkline><subattrib medium=""/></intelligent_items.darkline>
 
 		<traits.title><subattrib centre="" inverse=""/></traits.title>
-		<traits.border padding="0.5pt"><subattrib border="" inverse=""/></traits.border>
+		<traits.border><subattrib border="" inverse=""/></traits.border>
 		<traits.lightline><subattrib light=""/></traits.lightline>
 		<traits.darkline><subattrib medium=""/></traits.darkline>
 
 		<salient_divine_abilities.title><subattrib centre="" inverse=""/></salient_divine_abilities.title>
-		<salient_divine_abilities.border padding="0.5pt"><subattrib border="" inverse=""/></salient_divine_abilities.border>
+		<salient_divine_abilities.border><subattrib border="" inverse=""/></salient_divine_abilities.border>
 		<salient_divine_abilities.lightline><subattrib light=""/></salient_divine_abilities.lightline>
 		<salient_divine_abilities.darkline><subattrib medium=""/></salient_divine_abilities.darkline>
 
 		<feats.title><subattrib centre="" inverse=""/></feats.title>
-		<feats.border padding="0.5pt"><subattrib border="" inverse=""/></feats.border>
+		<feats.border><subattrib border="" inverse=""/></feats.border>
 		<feats.lightline><subattrib light=""/></feats.lightline>
 		<feats.darkline><subattrib medium=""/></feats.darkline>
 

--- a/outputsheets/d20/fantasy/pdf/csheet_fantasy_std_grey_light.xslt
+++ b/outputsheets/d20/fantasy/pdf/csheet_fantasy_std_grey_light.xslt
@@ -81,67 +81,67 @@
 		<weapon><subattrib border="" centre="" normal=""/></weapon>
 
 		<protection.title><subattrib border="" centre="" inverse=""/></protection.title>
-		<protection.border padding="0.5pt"><subattrib border="" inverse=""/></protection.border>
+		<protection.border><subattrib border="" inverse=""/></protection.border>
 		<protection.darkline><subattrib  centre="" medium="" /></protection.darkline>
 		<protection.lightline><subattrib  centre="" light="" /></protection.lightline>
 
 		<rage.title><subattrib  centre="" inverse=""/></rage.title>
-		<rage.border padding="0.5pt"><subattrib border="" inverse=""/></rage.border>
+		<rage.border><subattrib border="" inverse=""/></rage.border>
 		<rage><subattrib normal=""/></rage>
 
 		<checklist.title><subattrib  centre="" inverse=""/></checklist.title>
-		<checklist.border padding="0.5pt"><subattrib border="" inverse=""/></checklist.border>
+		<checklist.border><subattrib border="" inverse=""/></checklist.border>
 		<checklist><subattrib normal=""/></checklist>
 
 		<wildshape.title><subattrib centre="" inverse=""/></wildshape.title>
-		<wildshape.border padding="0.5pt"><subattrib border="" inverse=""/></wildshape.border>
+		<wildshape.border><subattrib border="" inverse=""/></wildshape.border>
 		<wildshape><subattrib normal=""/></wildshape>
 
 		<bard.title><subattrib centre="" inverse=""/></bard.title>
-		<bard.border padding="0.5pt"><subattrib border="" inverse=""/></bard.border>
+		<bard.border><subattrib border="" inverse=""/></bard.border>
 		<bard><subattrib  normal=""/></bard>
 
 		<psionics.title><subattrib  centre="" inverse=""/></psionics.title>
-		<psionics.border padding="0.5pt"><subattrib border="" inverse=""/></psionics.border>
+		<psionics.border><subattrib border="" inverse=""/></psionics.border>
 		<psionics><subattrib border="" centre="" normal=""/></psionics>
 
 		<turning.title><subattrib centre="" inverse=""/></turning.title>
-		<turning.border padding="0.5pt"><subattrib border="" inverse=""/></turning.border>
+		<turning.border><subattrib border="" inverse=""/></turning.border>
 		<turning><subattrib  centre="" normal=""/></turning>
 		<turning.lightline><subattrib centre="" light=""/></turning.lightline>
 		<turning.darkline><subattrib centre="" medium=""/></turning.darkline>
 
 		<stunningfist.title><subattrib centre="" inverse=""/></stunningfist.title>
-		<stunningfist.border padding="0.5pt"><subattrib border="" inverse=""/></stunningfist.border>
+		<stunningfist.border><subattrib border="" inverse=""/></stunningfist.border>
 		<stunningfist><subattrib normal=""/></stunningfist>
 
 		<wholeness.title><subattrib  centre="" inverse=""/></wholeness.title>
-		<wholeness.border padding="0.5pt"><subattrib border="" inverse=""/></wholeness.border>
+		<wholeness.border><subattrib border="" inverse=""/></wholeness.border>
 		<wholeness><subattrib  normal=""/></wholeness>
 
 		<layonhands.title><subattrib centre="" inverse=""/></layonhands.title>
-		<layonhands.border padding="0.5pt"><subattrib border="" inverse=""/></layonhands.border>
+		<layonhands.border><subattrib border="" inverse=""/></layonhands.border>
 		<layonhands><subattrib  normal=""/></layonhands>
 
 		<domains.title><subattrib  centre="" inverse=""/></domains.title>
-		<domains.border padding="0.5pt"><subattrib border="" inverse=""/></domains.border>
+		<domains.border><subattrib border="" inverse=""/></domains.border>
 		<domains.lightline><subattrib  light=""/></domains.lightline>
 		<domains.darkline><subattrib  medium=""/></domains.darkline>
 
 		<proficiencies.title><subattrib centre="" inverse=""/></proficiencies.title>
-		<proficiencies.border padding="0.5pt"><subattrib border="" inverse=""/></proficiencies.border>
+		<proficiencies.border><subattrib border="" inverse=""/></proficiencies.border>
 		<proficiencies><subattrib centre="" normal=""/></proficiencies>
 
 		<prohibited.title><subattrib centre="" inverse=""/></prohibited.title>
-		<prohibited.border padding="0.5pt"><subattrib border="" inverse=""/></prohibited.border>
+		<prohibited.border><subattrib border="" inverse=""/></prohibited.border>
 		<prohibited><subattrib centre="" normal=""/></prohibited>
 
 		<languages.title><subattrib centre="" inverse=""/></languages.title>
-		<languages.border padding="0.5pt"><subattrib border="" inverse=""/></languages.border>
+		<languages.border><subattrib border="" inverse=""/></languages.border>
 		<languages><subattrib  centre="" normal=""/></languages>
 
 		<templates.title><subattrib centre="" inverse=""/></templates.title>
-		<templates.border padding="0.5pt"><subattrib border="" inverse=""/></templates.border>
+		<templates.border><subattrib border="" inverse=""/></templates.border>
 		<templates.lightline><subattrib light=""/></templates.lightline>
 		<templates.darkline><subattrib medium=""/></templates.darkline>
 
@@ -149,81 +149,81 @@
 		<companions><subattrib border="" centre="" normal=""/></companions>
 
 		<equipment.title><subattrib centre="" inverse=""/></equipment.title>
-		<equipment.border padding="0.5pt"><subattrib border="" inverse=""/></equipment.border>
+		<equipment.border><subattrib border="" inverse=""/></equipment.border>
 		<equipment.lightline><subattrib light=""/></equipment.lightline>
 		<equipment.darkline><subattrib medium=""/></equipment.darkline>
 
 		<weight.title><subattrib centre="" inverse=""/></weight.title>
-		<weight.border padding="0.5pt"><subattrib border="" inverse=""/></weight.border>
+		<weight.border><subattrib border="" inverse=""/></weight.border>
 		<weight.lightline><subattrib light=""/></weight.lightline>
 		<weight.darkline><subattrib  medium=""/></weight.darkline>
 
 		<money.title><subattrib  centre="" inverse=""/></money.title>
-		<money.border padding="0.5pt"><subattrib border="" inverse=""/></money.border>
+		<money.border><subattrib border="" inverse=""/></money.border>
 		<money.lightline><subattrib light=""/></money.lightline>
 		<money.darkline><subattrib medium=""/></money.darkline>
 
 		<magic.title><subattrib centre="" inverse=""/></magic.title>
-		<magic.border padding="0.5pt"><subattrib border="" inverse=""/></magic.border>
+		<magic.border><subattrib border="" inverse=""/></magic.border>
 		<magic.lightline><subattrib light=""/></magic.lightline>
 		<magic.darkline><subattrib medium=""/></magic.darkline>
 
 		<special_abilities.title><subattrib centre="" inverse=""/></special_abilities.title>
-		<special_abilities.border padding="0.5pt"><subattrib border="" inverse=""/></special_abilities.border>
+		<special_abilities.border><subattrib border="" inverse=""/></special_abilities.border>
 		<special_abilities.lightline><subattrib light=""/></special_abilities.lightline>
 		<special_abilities.darkline><subattrib medium=""/></special_abilities.darkline>
 
 		<archetypes.title><subattrib centre="" inverse=""/></archetypes.title>
-		<archetypes.border padding="0.5pt"><subattrib border="" inverse=""/></archetypes.border>
+		<archetypes.border><subattrib border="" inverse=""/></archetypes.border>
 		<archetypes.lightline><subattrib light=""/></archetypes.lightline>
 		<archetypes.darkline><subattrib medium=""/></archetypes.darkline>
 
 		<special_attacks.title><subattrib centre="" inverse=""/></special_attacks.title>
-		<special_attacks.border padding="0.5pt"><subattrib border="" inverse=""/></special_attacks.border>
+		<special_attacks.border><subattrib border="" inverse=""/></special_attacks.border>
 		<special_attacks.lightline><subattrib light=""/></special_attacks.lightline>
 		<special_attacks.darkline><subattrib medium=""/></special_attacks.darkline>
 
 		<special_qualities.title><subattrib centre="" inverse=""/></special_qualities.title>
-		<special_qualities.border padding="0.5pt"><subattrib border="" inverse=""/></special_qualities.border>
+		<special_qualities.border><subattrib border="" inverse=""/></special_qualities.border>
 		<special_qualities.lightline><subattrib light=""/></special_qualities.lightline>
 		<special_qualities.darkline><subattrib medium=""/></special_qualities.darkline>
 
 		<afflictions.title><subattrib centre="" inverse=""/></afflictions.title>
-		<afflictions.border padding="0.5pt"><subattrib border="" inverse=""/></afflictions.border>
+		<afflictions.border><subattrib border="" inverse=""/></afflictions.border>
 		<afflictions.lightline><subattrib light=""/></afflictions.lightline>
 		<afflictions.darkline><subattrib medium=""/></afflictions.darkline>
 
 		<tempbonuses.title><subattrib centre="" inverse=""/></tempbonuses.title>
-		<tempbonuses.border padding="0.5pt"><subattrib border="" inverse=""/></tempbonuses.border>
+		<tempbonuses.border><subattrib border="" inverse=""/></tempbonuses.border>
 		<tempbonuses.lightline><subattrib light=""/></tempbonuses.lightline>
 		<tempbonuses.darkline><subattrib medium=""/></tempbonuses.darkline>
 
 
 
 		<animal_tricks.title><subattrib centre="" inverse=""/></animal_tricks.title>
-		<animal_tricks.border padding="0.5pt"><subattrib border="" inverse=""/></animal_tricks.border>
+		<animal_tricks.border><subattrib border="" inverse=""/></animal_tricks.border>
 		<animal_tricks.lightline><subattrib light=""/></animal_tricks.lightline>
 		<animal_tricks.darkline><subattrib medium=""/></animal_tricks.darkline>
 
 
 		<intelligent_items.title><subattrib centre="" inverse=""/></intelligent_items.title>
-		<intelligent_items.border padding="0.5pt"><subattrib border="" inverse=""/></intelligent_items.border>
+		<intelligent_items.border><subattrib border="" inverse=""/></intelligent_items.border>
 		<intelligent_items.lightline><subattrib light=""/></intelligent_items.lightline>
 		<intelligent_items.darkline><subattrib medium=""/></intelligent_items.darkline>
 
 		<traits.title><subattrib centre="" inverse=""/></traits.title>
-		<traits.border padding="0.5pt"><subattrib border="" inverse=""/></traits.border>
+		<traits.border><subattrib border="" inverse=""/></traits.border>
 		<traits.lightline><subattrib light=""/></traits.lightline>
 		<traits.darkline><subattrib medium=""/></traits.darkline>
 
 
 		<salient_divine_abilities.title><subattrib centre="" inverse=""/></salient_divine_abilities.title>
-		<salient_divine_abilities.border padding="0.5pt"><subattrib border="" inverse=""/></salient_divine_abilities.border>
+		<salient_divine_abilities.border><subattrib border="" inverse=""/></salient_divine_abilities.border>
 		<salient_divine_abilities.lightline><subattrib light=""/></salient_divine_abilities.lightline>
 		<salient_divine_abilities.darkline><subattrib medium=""/></salient_divine_abilities.darkline>
 
 		<feats.title><subattrib centre="" inverse=""/></feats.title>
-		<feats.border padding="0.5pt"><subattrib border="" inverse=""/></feats.border>
+		<feats.border><subattrib border="" inverse=""/></feats.border>
 		<feats.lightline><subattrib light=""/></feats.lightline>
 		<feats.darkline><subattrib medium=""/></feats.darkline>
 

--- a/outputsheets/d20/fantasy/pdf/csheet_fantasy_std_red_light.xslt
+++ b/outputsheets/d20/fantasy/pdf/csheet_fantasy_std_red_light.xslt
@@ -81,68 +81,68 @@
 		<weapon><subattrib border="" centre="" normal=""/></weapon>
 
 		<protection.title><subattrib border="" centre="" inverse=""/></protection.title>
-		<protection.border padding="0.5pt"><subattrib border="" inverse=""/></protection.border>
+		<protection.border><subattrib border="" inverse=""/></protection.border>
 		<protection.darkline><subattrib  centre="" medium="" /></protection.darkline>
 		<protection.lightline><subattrib  centre="" light="" /></protection.lightline>
 
 		<rage.title><subattrib  centre="" inverse=""/></rage.title>
-		<rage.border padding="0.5pt"><subattrib border="" inverse=""/></rage.border>
+		<rage.border><subattrib border="" inverse=""/></rage.border>
 		<rage><subattrib normal=""/></rage>
 
 		<checklist.title><subattrib  centre="" inverse=""/></checklist.title>
-		<checklist.border padding="0.5pt"><subattrib border="" inverse=""/></checklist.border>
+		<checklist.border><subattrib border="" inverse=""/></checklist.border>
 		<checklist.lightline><subattrib light="" /></checklist.lightline>
 		<checklist><subattrib normal=""/></checklist>
 
 		<wildshape.title><subattrib centre="" inverse=""/></wildshape.title>
-		<wildshape.border padding="0.5pt"><subattrib border="" inverse=""/></wildshape.border>
+		<wildshape.border><subattrib border="" inverse=""/></wildshape.border>
 		<wildshape><subattrib normal=""/></wildshape>
 
 		<bard.title><subattrib centre="" inverse=""/></bard.title>
-		<bard.border padding="0.5pt"><subattrib border="" inverse=""/></bard.border>
+		<bard.border><subattrib border="" inverse=""/></bard.border>
 		<bard><subattrib  normal=""/></bard>
 
 		<psionics.title><subattrib  centre="" inverse=""/></psionics.title>
-		<psionics.border padding="0.5pt"><subattrib border="" inverse=""/></psionics.border>
+		<psionics.border><subattrib border="" inverse=""/></psionics.border>
 		<psionics><subattrib border="" centre="" normal=""/></psionics>
 
 		<turning.title><subattrib centre="" inverse=""/></turning.title>
-		<turning.border padding="0.5pt"><subattrib border="" inverse=""/></turning.border>
+		<turning.border><subattrib border="" inverse=""/></turning.border>
 		<turning><subattrib  centre="" normal=""/></turning>
 		<turning.lightline><subattrib centre="" light=""/></turning.lightline>
 		<turning.darkline><subattrib centre="" medium=""/></turning.darkline>
 
 		<stunningfist.title><subattrib centre="" inverse=""/></stunningfist.title>
-		<stunningfist.border padding="0.5pt"><subattrib border="" inverse=""/></stunningfist.border>
+		<stunningfist.border><subattrib border="" inverse=""/></stunningfist.border>
 		<stunningfist><subattrib normal=""/></stunningfist>
 
 		<wholeness.title><subattrib  centre="" inverse=""/></wholeness.title>
-		<wholeness.border padding="0.5pt"><subattrib border="" inverse=""/></wholeness.border>
+		<wholeness.border><subattrib border="" inverse=""/></wholeness.border>
 		<wholeness><subattrib  normal=""/></wholeness>
 
 		<layonhands.title><subattrib centre="" inverse=""/></layonhands.title>
-		<layonhands.border padding="0.5pt"><subattrib border="" inverse=""/></layonhands.border>
+		<layonhands.border><subattrib border="" inverse=""/></layonhands.border>
 		<layonhands><subattrib  normal=""/></layonhands>
 
 		<domains.title><subattrib  centre="" inverse=""/></domains.title>
-		<domains.border padding="0.5pt"><subattrib border="" inverse=""/></domains.border>
+		<domains.border><subattrib border="" inverse=""/></domains.border>
 		<domains.lightline><subattrib  light=""/></domains.lightline>
 		<domains.darkline><subattrib  medium=""/></domains.darkline>
 
 		<proficiencies.title><subattrib centre="" inverse=""/></proficiencies.title>
-		<proficiencies.border padding="0.5pt"><subattrib border="" inverse=""/></proficiencies.border>
+		<proficiencies.border><subattrib border="" inverse=""/></proficiencies.border>
 		<proficiencies><subattrib centre="" normal=""/></proficiencies>
 
 		<prohibited.title><subattrib centre="" inverse=""/></prohibited.title>
-		<prohibited.border padding="0.5pt"><subattrib border="" inverse=""/></prohibited.border>
+		<prohibited.border><subattrib border="" inverse=""/></prohibited.border>
 		<prohibited><subattrib centre="" normal=""/></prohibited>
 
 		<languages.title><subattrib centre="" inverse=""/></languages.title>
-		<languages.border padding="0.5pt"><subattrib border="" inverse=""/></languages.border>
+		<languages.border><subattrib border="" inverse=""/></languages.border>
 		<languages><subattrib  centre="" normal=""/></languages>
 
 		<templates.title><subattrib centre="" inverse=""/></templates.title>
-		<templates.border padding="0.5pt"><subattrib border="" inverse=""/></templates.border>
+		<templates.border><subattrib border="" inverse=""/></templates.border>
 		<templates.lightline><subattrib light=""/></templates.lightline>
 		<templates.darkline><subattrib medium=""/></templates.darkline>
 
@@ -150,79 +150,79 @@
 		<companions><subattrib border="" centre="" normal=""/></companions>
 
 		<equipment.title><subattrib centre="" inverse=""/></equipment.title>
-		<equipment.border padding="0.5pt"><subattrib border="" inverse=""/></equipment.border>
+		<equipment.border><subattrib border="" inverse=""/></equipment.border>
 		<equipment.lightline><subattrib light=""/></equipment.lightline>
 		<equipment.darkline><subattrib medium=""/></equipment.darkline>
 
 		<weight.title><subattrib centre="" inverse=""/></weight.title>
-		<weight.border padding="0.5pt"><subattrib border="" inverse=""/></weight.border>
+		<weight.border><subattrib border="" inverse=""/></weight.border>
 		<weight.lightline><subattrib light=""/></weight.lightline>
 		<weight.darkline><subattrib  medium=""/></weight.darkline>
 
 		<money.title><subattrib  centre="" inverse=""/></money.title>
-		<money.border padding="0.5pt"><subattrib border="" inverse=""/></money.border>
+		<money.border><subattrib border="" inverse=""/></money.border>
 		<money.lightline><subattrib light=""/></money.lightline>
 		<money.darkline><subattrib medium=""/></money.darkline>
 
 		<magic.title><subattrib centre="" inverse=""/></magic.title>
-		<magic.border padding="0.5pt"><subattrib border="" inverse=""/></magic.border>
+		<magic.border><subattrib border="" inverse=""/></magic.border>
 		<magic.lightline><subattrib light=""/></magic.lightline>
 		<magic.darkline><subattrib medium=""/></magic.darkline>
 
 		<special_abilities.title><subattrib centre="" inverse=""/></special_abilities.title>
-		<special_abilities.border padding="0.5pt"><subattrib border="" inverse=""/></special_abilities.border>
+		<special_abilities.border><subattrib border="" inverse=""/></special_abilities.border>
 		<special_abilities.lightline><subattrib light=""/></special_abilities.lightline>
 		<special_abilities.darkline><subattrib medium=""/></special_abilities.darkline>
 
 		<special_attacks.title><subattrib centre="" inverse=""/></special_attacks.title>
-		<special_attacks.border padding="0.5pt"><subattrib border="" inverse=""/></special_attacks.border>
+		<special_attacks.border><subattrib border="" inverse=""/></special_attacks.border>
 		<special_attacks.lightline><subattrib light=""/></special_attacks.lightline>
 		<special_attacks.darkline><subattrib medium=""/></special_attacks.darkline>
 
 		<archetypes.title><subattrib centre="" inverse=""/></archetypes.title>
-		<archetypes.border padding="0.5pt"><subattrib border="" inverse=""/></archetypes.border>
+		<archetypes.border><subattrib border="" inverse=""/></archetypes.border>
 		<archetypes.lightline><subattrib light=""/></archetypes.lightline>
 		<archetypes.darkline><subattrib medium=""/></archetypes.darkline>
 
 		<animal_tricks.title><subattrib centre="" inverse=""/></animal_tricks.title>
-		<animal_tricks.border padding="0.5pt"><subattrib border="" inverse=""/></animal_tricks.border>
+		<animal_tricks.border><subattrib border="" inverse=""/></animal_tricks.border>
 		<animal_tricks.lightline><subattrib light=""/></animal_tricks.lightline>
 		<animal_tricks.darkline><subattrib medium=""/></animal_tricks.darkline>
 
 		<special_qualities.title><subattrib centre="" inverse=""/></special_qualities.title>
-		<special_qualities.border padding="0.5pt"><subattrib border="" inverse=""/></special_qualities.border>
+		<special_qualities.border><subattrib border="" inverse=""/></special_qualities.border>
 		<special_qualities.lightline><subattrib light=""/></special_qualities.lightline>
 		<special_qualities.darkline><subattrib medium=""/></special_qualities.darkline>
 
 		<afflictions.title><subattrib centre="" inverse=""/></afflictions.title>
-		<afflictions.border padding="0.5pt"><subattrib border="" inverse=""/></afflictions.border>
+		<afflictions.border><subattrib border="" inverse=""/></afflictions.border>
 		<afflictions.lightline><subattrib light=""/></afflictions.lightline>
 		<afflictions.darkline><subattrib medium=""/></afflictions.darkline>
 
 		<tempbonuses.title><subattrib centre="" inverse=""/></tempbonuses.title>
-		<tempbonuses.border padding="0.5pt"><subattrib border="" inverse=""/></tempbonuses.border>
+		<tempbonuses.border><subattrib border="" inverse=""/></tempbonuses.border>
 		<tempbonuses.lightline><subattrib light=""/></tempbonuses.lightline>
 		<tempbonuses.darkline><subattrib medium=""/></tempbonuses.darkline>
 
 
 
 		<intelligent_items.title><subattrib centre="" inverse=""/></intelligent_items.title>
-		<intelligent_items.border padding="0.5pt"><subattrib border="" inverse=""/></intelligent_items.border>
+		<intelligent_items.border><subattrib border="" inverse=""/></intelligent_items.border>
 		<intelligent_items.lightline><subattrib light=""/></intelligent_items.lightline>
 		<intelligent_items.darkline><subattrib medium=""/></intelligent_items.darkline>
 
 		<traits.title><subattrib centre="" inverse=""/></traits.title>
-		<traits.border padding="0.5pt"><subattrib border="" inverse=""/></traits.border>
+		<traits.border><subattrib border="" inverse=""/></traits.border>
 		<traits.lightline><subattrib light=""/></traits.lightline>
 		<traits.darkline><subattrib medium=""/></traits.darkline>
 
 		<salient_divine_abilities.title><subattrib centre="" inverse=""/></salient_divine_abilities.title>
-		<salient_divine_abilities.border padding="0.5pt"><subattrib border="" inverse=""/></salient_divine_abilities.border>
+		<salient_divine_abilities.border><subattrib border="" inverse=""/></salient_divine_abilities.border>
 		<salient_divine_abilities.lightline><subattrib light=""/></salient_divine_abilities.lightline>
 		<salient_divine_abilities.darkline><subattrib medium=""/></salient_divine_abilities.darkline>
 
 		<feats.title><subattrib centre="" inverse=""/></feats.title>
-		<feats.border padding="0.5pt"><subattrib border="" inverse=""/></feats.border>
+		<feats.border><subattrib border="" inverse=""/></feats.border>
 		<feats.lightline><subattrib light=""/></feats.lightline>
 		<feats.darkline><subattrib medium=""/></feats.darkline>
 

--- a/outputsheets/d20/fantasy/pdf/csheet_fantasy_std_yellow_full.xslt
+++ b/outputsheets/d20/fantasy/pdf/csheet_fantasy_std_yellow_full.xslt
@@ -81,67 +81,67 @@
 		<weapon><subattrib border="" centre="" normal=""/></weapon>
 
 		<protection.title><subattrib border="" centre="" inverse=""/></protection.title>
-		<protection.border padding="0.5pt"><subattrib border="" inverse=""/></protection.border>
+		<protection.border><subattrib border="" inverse=""/></protection.border>
 		<protection.darkline><subattrib  centre="" medium="" /></protection.darkline>
 		<protection.lightline><subattrib  centre="" light="" /></protection.lightline>
 
 		<rage.title><subattrib  centre="" inverse=""/></rage.title>
-		<rage.border padding="0.5pt"><subattrib border="" inverse=""/></rage.border>
+		<rage.border><subattrib border="" inverse=""/></rage.border>
 		<rage><subattrib normal=""/></rage>
 
 		<checklist.title><subattrib  centre="" inverse=""/></checklist.title>
-		<checklist.border padding="0.5pt"><subattrib border="" inverse=""/></checklist.border>
+		<checklist.border><subattrib border="" inverse=""/></checklist.border>
 		<checklist><subattrib normal=""/></checklist>
 
 		<wildshape.title><subattrib centre="" inverse=""/></wildshape.title>
-		<wildshape.border padding="0.5pt"><subattrib border="" inverse=""/></wildshape.border>
+		<wildshape.border><subattrib border="" inverse=""/></wildshape.border>
 		<wildshape><subattrib normal=""/></wildshape>
 
 		<bard.title><subattrib centre="" inverse=""/></bard.title>
-		<bard.border padding="0.5pt"><subattrib border="" inverse=""/></bard.border>
+		<bard.border><subattrib border="" inverse=""/></bard.border>
 		<bard><subattrib  normal=""/></bard>
 
 		<psionics.title><subattrib  centre="" inverse=""/></psionics.title>
-		<psionics.border padding="0.5pt"><subattrib border="" inverse=""/></psionics.border>
+		<psionics.border><subattrib border="" inverse=""/></psionics.border>
 		<psionics><subattrib border="" centre="" normal=""/></psionics>
 
 		<turning.title><subattrib centre="" inverse=""/></turning.title>
-		<turning.border padding="0.5pt"><subattrib border="" inverse=""/></turning.border>
+		<turning.border><subattrib border="" inverse=""/></turning.border>
 		<turning><subattrib  centre="" normal=""/></turning>
 		<turning.lightline><subattrib centre="" light=""/></turning.lightline>
 		<turning.darkline><subattrib centre="" medium=""/></turning.darkline>
 
 		<stunningfist.title><subattrib centre="" inverse=""/></stunningfist.title>
-		<stunningfist.border padding="0.5pt"><subattrib border="" inverse=""/></stunningfist.border>
+		<stunningfist.border><subattrib border="" inverse=""/></stunningfist.border>
 		<stunningfist><subattrib normal=""/></stunningfist>
 
 		<wholeness.title><subattrib  centre="" inverse=""/></wholeness.title>
-		<wholeness.border padding="0.5pt"><subattrib border="" inverse=""/></wholeness.border>
+		<wholeness.border><subattrib border="" inverse=""/></wholeness.border>
 		<wholeness><subattrib  normal=""/></wholeness>
 
 		<layonhands.title><subattrib centre="" inverse=""/></layonhands.title>
-		<layonhands.border padding="0.5pt"><subattrib border="" inverse=""/></layonhands.border>
+		<layonhands.border><subattrib border="" inverse=""/></layonhands.border>
 		<layonhands><subattrib  normal=""/></layonhands>
 
 		<domains.title><subattrib  centre="" inverse=""/></domains.title>
-		<domains.border padding="0.5pt"><subattrib border="" inverse=""/></domains.border>
+		<domains.border><subattrib border="" inverse=""/></domains.border>
 		<domains.lightline><subattrib  light=""/></domains.lightline>
 		<domains.darkline><subattrib  medium=""/></domains.darkline>
 
 		<proficiencies.title><subattrib centre="" inverse=""/></proficiencies.title>
-		<proficiencies.border padding="0.5pt"><subattrib border="" inverse=""/></proficiencies.border>
+		<proficiencies.border><subattrib border="" inverse=""/></proficiencies.border>
 		<proficiencies><subattrib centre="" normal=""/></proficiencies>
 
 		<prohibited.title><subattrib centre="" inverse=""/></prohibited.title>
-		<prohibited.border padding="0.5pt"><subattrib border="" inverse=""/></prohibited.border>
+		<prohibited.border><subattrib border="" inverse=""/></prohibited.border>
 		<prohibited><subattrib centre="" normal=""/></prohibited>
 
 		<languages.title><subattrib centre="" inverse=""/></languages.title>
-		<languages.border padding="0.5pt"><subattrib border="" inverse=""/></languages.border>
+		<languages.border><subattrib border="" inverse=""/></languages.border>
 		<languages><subattrib  centre="" normal=""/></languages>
 
 		<templates.title><subattrib centre="" inverse=""/></templates.title>
-		<templates.border padding="0.5pt"><subattrib border="" inverse=""/></templates.border>
+		<templates.border><subattrib border="" inverse=""/></templates.border>
 		<templates.lightline><subattrib light=""/></templates.lightline>
 		<templates.darkline><subattrib medium=""/></templates.darkline>
 
@@ -149,79 +149,79 @@
 		<companions><subattrib border="" centre="" normal=""/></companions>
 
 		<equipment.title><subattrib centre="" inverse=""/></equipment.title>
-		<equipment.border padding="0.5pt"><subattrib border="" inverse=""/></equipment.border>
+		<equipment.border><subattrib border="" inverse=""/></equipment.border>
 		<equipment.lightline><subattrib light=""/></equipment.lightline>
 		<equipment.darkline><subattrib medium=""/></equipment.darkline>
 
 		<weight.title><subattrib centre="" inverse=""/></weight.title>
-		<weight.border padding="0.5pt"><subattrib border="" inverse=""/></weight.border>
+		<weight.border><subattrib border="" inverse=""/></weight.border>
 		<weight.lightline><subattrib light=""/></weight.lightline>
 		<weight.darkline><subattrib  medium=""/></weight.darkline>
 
 		<money.title><subattrib  centre="" inverse=""/></money.title>
-		<money.border padding="0.5pt"><subattrib border="" inverse=""/></money.border>
+		<money.border><subattrib border="" inverse=""/></money.border>
 		<money.lightline><subattrib light=""/></money.lightline>
 		<money.darkline><subattrib medium=""/></money.darkline>
 
 		<magic.title><subattrib centre="" inverse=""/></magic.title>
-		<magic.border padding="0.5pt"><subattrib border="" inverse=""/></magic.border>
+		<magic.border><subattrib border="" inverse=""/></magic.border>
 		<magic.lightline><subattrib light=""/></magic.lightline>
 		<magic.darkline><subattrib medium=""/></magic.darkline>
 
 		<special_abilities.title><subattrib centre="" inverse=""/></special_abilities.title>
-		<special_abilities.border padding="0.5pt"><subattrib border="" inverse=""/></special_abilities.border>
+		<special_abilities.border><subattrib border="" inverse=""/></special_abilities.border>
 		<special_abilities.lightline><subattrib light=""/></special_abilities.lightline>
 		<special_abilities.darkline><subattrib medium=""/></special_abilities.darkline>
 
 		<special_attacks.title><subattrib centre="" inverse=""/></special_attacks.title>
-		<special_attacks.border padding="0.5pt"><subattrib border="" inverse=""/></special_attacks.border>
+		<special_attacks.border><subattrib border="" inverse=""/></special_attacks.border>
 		<special_attacks.lightline><subattrib light=""/></special_attacks.lightline>
 		<special_attacks.darkline><subattrib medium=""/></special_attacks.darkline>
 
 		<archetypes.title><subattrib centre="" inverse=""/></archetypes.title>
-		<archetypes.border padding="0.5pt"><subattrib border="" inverse=""/></archetypes.border>
+		<archetypes.border><subattrib border="" inverse=""/></archetypes.border>
 		<archetypes.lightline><subattrib light=""/></archetypes.lightline>
 		<archetypes.darkline><subattrib medium=""/></archetypes.darkline>
 
 		<animal_tricks.title><subattrib centre="" inverse=""/></animal_tricks.title>
-		<animal_tricks.border padding="0.5pt"><subattrib border="" inverse=""/></animal_tricks.border>
+		<animal_tricks.border><subattrib border="" inverse=""/></animal_tricks.border>
 		<animal_tricks.lightline><subattrib light=""/></animal_tricks.lightline>
 		<animal_tricks.darkline><subattrib medium=""/></animal_tricks.darkline>
 
 		<special_qualities.title><subattrib centre="" inverse=""/></special_qualities.title>
-		<special_qualities.border padding="0.5pt"><subattrib border="" inverse=""/></special_qualities.border>
+		<special_qualities.border><subattrib border="" inverse=""/></special_qualities.border>
 		<special_qualities.lightline><subattrib light=""/></special_qualities.lightline>
 		<special_qualities.darkline><subattrib medium=""/></special_qualities.darkline>
 
 		<afflictions.title><subattrib centre="" inverse=""/></afflictions.title>
-		<afflictions.border padding="0.5pt"><subattrib border="" inverse=""/></afflictions.border>
+		<afflictions.border><subattrib border="" inverse=""/></afflictions.border>
 		<afflictions.lightline><subattrib light=""/></afflictions.lightline>
 		<afflictions.darkline><subattrib medium=""/></afflictions.darkline>
 
 		<tempbonuses.title><subattrib centre="" inverse=""/></tempbonuses.title>
-		<tempbonuses.border padding="0.5pt"><subattrib border="" inverse=""/></tempbonuses.border>
+		<tempbonuses.border><subattrib border="" inverse=""/></tempbonuses.border>
 		<tempbonuses.lightline><subattrib light=""/></tempbonuses.lightline>
 		<tempbonuses.darkline><subattrib medium=""/></tempbonuses.darkline>
 
 
 
 		<intelligent_items.title><subattrib centre="" inverse=""/></intelligent_items.title>
-		<intelligent_items.border padding="0.5pt"><subattrib border="" inverse=""/></intelligent_items.border>
+		<intelligent_items.border><subattrib border="" inverse=""/></intelligent_items.border>
 		<intelligent_items.lightline><subattrib light=""/></intelligent_items.lightline>
 		<intelligent_items.darkline><subattrib medium=""/></intelligent_items.darkline>
 
         <traits.title><subattrib centre="" inverse=""/></traits.title>
-        <traits.border padding="0.5pt"><subattrib border="" inverse=""/></traits.border>
+        <traits.border><subattrib border="" inverse=""/></traits.border>
         <traits.lightline><subattrib light=""/></traits.lightline>
         <traits.darkline><subattrib medium=""/></traits.darkline>
 
 		<salient_divine_abilities.title><subattrib centre="" inverse=""/></salient_divine_abilities.title>
-		<salient_divine_abilities.border padding="0.5pt"><subattrib border="" inverse=""/></salient_divine_abilities.border>
+		<salient_divine_abilities.border><subattrib border="" inverse=""/></salient_divine_abilities.border>
 		<salient_divine_abilities.lightline><subattrib light=""/></salient_divine_abilities.lightline>
 		<salient_divine_abilities.darkline><subattrib medium=""/></salient_divine_abilities.darkline>
 
 		<feats.title><subattrib centre="" inverse=""/></feats.title>
-		<feats.border padding="0.5pt"><subattrib border="" inverse=""/></feats.border>
+		<feats.border><subattrib border="" inverse=""/></feats.border>
 		<feats.lightline><subattrib light=""/></feats.lightline>
 		<feats.darkline><subattrib medium=""/></feats.darkline>
 

--- a/outputsheets/d20/fantasy/pdf/csheet_fantasy_std_yellow_light.xslt
+++ b/outputsheets/d20/fantasy/pdf/csheet_fantasy_std_yellow_light.xslt
@@ -81,67 +81,67 @@
 		<weapon><subattrib border="" centre="" normal=""/></weapon>
 
 		<protection.title><subattrib border="" centre="" inverse=""/></protection.title>
-		<protection.border padding="0.5pt"><subattrib border="" inverse=""/></protection.border>
+		<protection.border><subattrib border="" inverse=""/></protection.border>
 		<protection.darkline><subattrib  centre="" medium="" /></protection.darkline>
 		<protection.lightline><subattrib  centre="" light="" /></protection.lightline>
 
 		<rage.title><subattrib  centre="" inverse=""/></rage.title>
-		<rage.border padding="0.5pt"><subattrib border="" inverse=""/></rage.border>
+		<rage.border><subattrib border="" inverse=""/></rage.border>
 		<rage><subattrib normal=""/></rage>
 
 		<checklist.title><subattrib  centre="" inverse=""/></checklist.title>
-		<checklist.border padding="0.5pt"><subattrib border="" inverse=""/></checklist.border>
+		<checklist.border><subattrib border="" inverse=""/></checklist.border>
 		<checklist><subattrib normal=""/></checklist>
 
 		<wildshape.title><subattrib centre="" inverse=""/></wildshape.title>
-		<wildshape.border padding="0.5pt"><subattrib border="" inverse=""/></wildshape.border>
+		<wildshape.border><subattrib border="" inverse=""/></wildshape.border>
 		<wildshape><subattrib normal=""/></wildshape>
 
 		<bard.title><subattrib centre="" inverse=""/></bard.title>
-		<bard.border padding="0.5pt"><subattrib border="" inverse=""/></bard.border>
+		<bard.border><subattrib border="" inverse=""/></bard.border>
 		<bard><subattrib  normal=""/></bard>
 
 		<psionics.title><subattrib  centre="" inverse=""/></psionics.title>
-		<psionics.border padding="0.5pt"><subattrib border="" inverse=""/></psionics.border>
+		<psionics.border><subattrib border="" inverse=""/></psionics.border>
 		<psionics><subattrib border="" centre="" normal=""/></psionics>
 
 		<turning.title><subattrib centre="" inverse=""/></turning.title>
-		<turning.border padding="0.5pt"><subattrib border="" inverse=""/></turning.border>
+		<turning.border><subattrib border="" inverse=""/></turning.border>
 		<turning><subattrib  centre="" normal=""/></turning>
 		<turning.lightline><subattrib centre="" light=""/></turning.lightline>
 		<turning.darkline><subattrib centre="" medium=""/></turning.darkline>
 
 		<stunningfist.title><subattrib centre="" inverse=""/></stunningfist.title>
-		<stunningfist.border padding="0.5pt"><subattrib border="" inverse=""/></stunningfist.border>
+		<stunningfist.border><subattrib border="" inverse=""/></stunningfist.border>
 		<stunningfist><subattrib normal=""/></stunningfist>
 
 		<wholeness.title><subattrib  centre="" inverse=""/></wholeness.title>
-		<wholeness.border padding="0.5pt"><subattrib border="" inverse=""/></wholeness.border>
+		<wholeness.border><subattrib border="" inverse=""/></wholeness.border>
 		<wholeness><subattrib  normal=""/></wholeness>
 
 		<layonhands.title><subattrib centre="" inverse=""/></layonhands.title>
-		<layonhands.border padding="0.5pt"><subattrib border="" inverse=""/></layonhands.border>
+		<layonhands.border><subattrib border="" inverse=""/></layonhands.border>
 		<layonhands><subattrib  normal=""/></layonhands>
 
 		<domains.title><subattrib  centre="" inverse=""/></domains.title>
-		<domains.border padding="0.5pt"><subattrib border="" inverse=""/></domains.border>
+		<domains.border><subattrib border="" inverse=""/></domains.border>
 		<domains.lightline><subattrib  light=""/></domains.lightline>
 		<domains.darkline><subattrib  medium=""/></domains.darkline>
 
 		<proficiencies.title><subattrib centre="" inverse=""/></proficiencies.title>
-		<proficiencies.border padding="0.5pt"><subattrib border="" inverse=""/></proficiencies.border>
+		<proficiencies.border><subattrib border="" inverse=""/></proficiencies.border>
 		<proficiencies><subattrib centre="" normal=""/></proficiencies>
 
 		<prohibited.title><subattrib centre="" inverse=""/></prohibited.title>
-		<prohibited.border padding="0.5pt"><subattrib border="" inverse=""/></prohibited.border>
+		<prohibited.border><subattrib border="" inverse=""/></prohibited.border>
 		<prohibited><subattrib centre="" normal=""/></prohibited>
 
 		<languages.title><subattrib centre="" inverse=""/></languages.title>
-		<languages.border padding="0.5pt"><subattrib border="" inverse=""/></languages.border>
+		<languages.border><subattrib border="" inverse=""/></languages.border>
 		<languages><subattrib  centre="" normal=""/></languages>
 
 		<templates.title><subattrib centre="" inverse=""/></templates.title>
-		<templates.border padding="0.5pt"><subattrib border="" inverse=""/></templates.border>
+		<templates.border><subattrib border="" inverse=""/></templates.border>
 		<templates.lightline><subattrib light=""/></templates.lightline>
 		<templates.darkline><subattrib medium=""/></templates.darkline>
 
@@ -149,77 +149,77 @@
 		<companions><subattrib border="" centre="" normal=""/></companions>
 
 		<equipment.title><subattrib centre="" inverse=""/></equipment.title>
-		<equipment.border padding="0.5pt"><subattrib border="" inverse=""/></equipment.border>
+		<equipment.border><subattrib border="" inverse=""/></equipment.border>
 		<equipment.lightline><subattrib light=""/></equipment.lightline>
 		<equipment.darkline><subattrib medium=""/></equipment.darkline>
 
 		<weight.title><subattrib centre="" inverse=""/></weight.title>
-		<weight.border padding="0.5pt"><subattrib border="" inverse=""/></weight.border>
+		<weight.border><subattrib border="" inverse=""/></weight.border>
 		<weight.lightline><subattrib light=""/></weight.lightline>
 		<weight.darkline><subattrib  medium=""/></weight.darkline>
 
 		<money.title><subattrib  centre="" inverse=""/></money.title>
-		<money.border padding="0.5pt"><subattrib border="" inverse=""/></money.border>
+		<money.border><subattrib border="" inverse=""/></money.border>
 		<money.lightline><subattrib light=""/></money.lightline>
 		<money.darkline><subattrib medium=""/></money.darkline>
 
 		<magic.title><subattrib centre="" inverse=""/></magic.title>
-		<magic.border padding="0.5pt"><subattrib border="" inverse=""/></magic.border>
+		<magic.border><subattrib border="" inverse=""/></magic.border>
 		<magic.lightline><subattrib light=""/></magic.lightline>
 		<magic.darkline><subattrib medium=""/></magic.darkline>
 
 		<special_abilities.title><subattrib centre="" inverse=""/></special_abilities.title>
-		<special_abilities.border padding="0.5pt"><subattrib border="" inverse=""/></special_abilities.border>
+		<special_abilities.border><subattrib border="" inverse=""/></special_abilities.border>
 		<special_abilities.lightline><subattrib light=""/></special_abilities.lightline>
 		<special_abilities.darkline><subattrib medium=""/></special_abilities.darkline>
 
 		<special_attacks.title><subattrib centre="" inverse=""/></special_attacks.title>
-		<special_attacks.border padding="0.5pt"><subattrib border="" inverse=""/></special_attacks.border>
+		<special_attacks.border><subattrib border="" inverse=""/></special_attacks.border>
 		<special_attacks.lightline><subattrib light=""/></special_attacks.lightline>
 		<special_attacks.darkline><subattrib medium=""/></special_attacks.darkline>
 
 		<archetypes.title><subattrib centre="" inverse=""/></archetypes.title>
-		<archetypes.border padding="0.5pt"><subattrib border="" inverse=""/></archetypes.border>
+		<archetypes.border><subattrib border="" inverse=""/></archetypes.border>
 		<archetypes.lightline><subattrib light=""/></archetypes.lightline>
 		<archetypes.darkline><subattrib medium=""/></archetypes.darkline>
 
 		<animal_tricks.title><subattrib centre="" inverse=""/></animal_tricks.title>
-		<animal_tricks.border padding="0.5pt"><subattrib border="" inverse=""/></animal_tricks.border>
+		<animal_tricks.border><subattrib border="" inverse=""/></animal_tricks.border>
 		<animal_tricks.lightline><subattrib light=""/></animal_tricks.lightline>
 		<animal_tricks.darkline><subattrib medium=""/></animal_tricks.darkline>
 
 		<special_qualities.title><subattrib centre="" inverse=""/></special_qualities.title>
-		<special_qualities.border padding="0.5pt"><subattrib border="" inverse=""/></special_qualities.border>
+		<special_qualities.border><subattrib border="" inverse=""/></special_qualities.border>
 		<special_qualities.lightline><subattrib light=""/></special_qualities.lightline>
 		<special_qualities.darkline><subattrib medium=""/></special_qualities.darkline>
 
 		<afflictions.title><subattrib centre="" inverse=""/></afflictions.title>
-		<afflictions.border padding="0.5pt"><subattrib border="" inverse=""/></afflictions.border>
+		<afflictions.border><subattrib border="" inverse=""/></afflictions.border>
 		<afflictions.lightline><subattrib light=""/></afflictions.lightline>
 		<afflictions.darkline><subattrib medium=""/></afflictions.darkline>
 
 		<tempbonuses.title><subattrib centre="" inverse=""/></tempbonuses.title>
-		<tempbonuses.border padding="0.5pt"><subattrib border="" inverse=""/></tempbonuses.border>
+		<tempbonuses.border><subattrib border="" inverse=""/></tempbonuses.border>
 		<tempbonuses.lightline><subattrib light=""/></tempbonuses.lightline>
 		<tempbonuses.darkline><subattrib medium=""/></tempbonuses.darkline>
 
 		<intelligent_items.title><subattrib centre="" inverse=""/></intelligent_items.title>
-		<intelligent_items.border padding="0.5pt"><subattrib border="" inverse=""/></intelligent_items.border>
+		<intelligent_items.border><subattrib border="" inverse=""/></intelligent_items.border>
 		<intelligent_items.lightline><subattrib light=""/></intelligent_items.lightline>
 		<intelligent_items.darkline><subattrib medium=""/></intelligent_items.darkline>
 
         <traits.title><subattrib centre="" inverse=""/></traits.title>
-        <traits.border padding="0.5pt"><subattrib border="" inverse=""/></traits.border>
+        <traits.border><subattrib border="" inverse=""/></traits.border>
         <traits.lightline><subattrib light=""/></traits.lightline>
         <traits.darkline><subattrib medium=""/></traits.darkline>
 
 		<salient_divine_abilities.title><subattrib centre="" inverse=""/></salient_divine_abilities.title>
-		<salient_divine_abilities.border padding="0.5pt"><subattrib border="" inverse=""/></salient_divine_abilities.border>
+		<salient_divine_abilities.border><subattrib border="" inverse=""/></salient_divine_abilities.border>
 		<salient_divine_abilities.lightline><subattrib light=""/></salient_divine_abilities.lightline>
 		<salient_divine_abilities.darkline><subattrib medium=""/></salient_divine_abilities.darkline>
 
 		<feats.title><subattrib centre="" inverse=""/></feats.title>
-		<feats.border padding="0.5pt"><subattrib border="" inverse=""/></feats.border>
+		<feats.border><subattrib border="" inverse=""/></feats.border>
 		<feats.lightline><subattrib light=""/></feats.lightline>
 		<feats.darkline><subattrib medium=""/></feats.darkline>
 

--- a/outputsheets/d20/fantasy/pdf/fantasy_common.xsl
+++ b/outputsheets/d20/fantasy/pdf/fantasy_common.xsl
@@ -164,7 +164,7 @@
 		<xsl:param name="title" />
 		<xsl:param name="value" />
 
-		<fo:table table-layout="fixed" space-before.optimum="2mm">
+		<fo:table table-layout="fixed" width="100%" space-before.optimum="2mm">
 			<xsl:call-template name="attrib"><xsl:with-param name="attribute" select="concat($attribute, '.border')"/></xsl:call-template>
 			<fo:table-column>
 			    <xsl:attribute name="column-width"><xsl:value-of select="($pagePrintableWidth - 2) div 2" />mm</xsl:attribute>
@@ -205,7 +205,7 @@
 		<xsl:param name="col1width" select="0.36 * ($pagePrintableWidth - 2) div 2"/>
 		<xsl:param name="col2width" select="0.64 * ($pagePrintableWidth - 2) div 2"/>
 
-		<fo:table table-layout="fixed" space-before="2mm" border-collapse="collapse" padding="0.5pt">
+		<fo:table table-layout="fixed" width="100%" space-before="2mm" border-collapse="collapse">
 			<xsl:call-template name="attrib"><xsl:with-param name="attribute" select="concat($attribute, '.border')"/></xsl:call-template>
 			<fo:table-column>
 			    <xsl:attribute name="column-width"><xsl:value-of select="$col1width" />mm</xsl:attribute>
@@ -265,7 +265,7 @@
 		<xsl:param name="desc.tag" select="''" />
 		<xsl:param name="benefit.tag" select="''" />
 
-		<fo:table table-layout="fixed" space-before="2mm" border-collapse="collapse" padding="0.5pt">
+		<fo:table table-layout="fixed" width="100%" space-before="2mm" border-collapse="collapse">
 			<xsl:call-template name="attrib"><xsl:with-param name="attribute" select="concat($attribute, '.border')"/></xsl:call-template>
 			<fo:table-column>
 			    <xsl:attribute name="column-width"><xsl:value-of select="($pagePrintableWidth - 2) div 6" />mm</xsl:attribute>
@@ -367,7 +367,7 @@
 		<xsl:param name="effect.tag"  />
 		<xsl:param name="sustain.tag"  />
 
-		<fo:table table-layout="fixed" space-before="2mm" border-collapse="collapse" padding="0.5pt">
+		<fo:table table-layout="fixed" width="100%" space-before="2mm" border-collapse="collapse">
 			<xsl:call-template name="attrib"><xsl:with-param name="attribute" select="concat($attribute, '.border')"/></xsl:call-template>
 			<fo:table-column>
 			    <xsl:attribute name="column-width"><xsl:value-of select="($pagePrintableWidth - 2) div 2" />mm</xsl:attribute>
@@ -515,7 +515,7 @@
 		<xsl:param name="appearance.tag"  />
 		<xsl:param name="worshippers.tag"  />
 
-		<fo:table table-layout="fixed" space-before="2mm" border-collapse="collapse" padding="0.5pt">
+		<fo:table table-layout="fixed" width="100%" space-before="2mm" border-collapse="collapse">
 			<xsl:call-template name="attrib">
 				<xsl:with-param name="attribute" select="concat($attribute, '.border')"/>
 			</xsl:call-template>
@@ -702,7 +702,7 @@
 			</xsl:call-template>
 			</subitems>
 		</xsl:variable>
-		<fo:table table-layout="fixed" space-before="2mm" >
+		<fo:table table-layout="fixed" width="100%" space-before="2mm" >
 			<xsl:call-template name="attrib"><xsl:with-param name="attribute" select="'equipment.border'"/></xsl:call-template>
 			<xsl:attribute name="text-align">left</xsl:attribute>
 			<fo:table-column><xsl:attribute name="column-width"><xsl:value-of select="$total_width - (12+16+20)"/>mm</xsl:attribute></fo:table-column>
@@ -785,7 +785,7 @@
 		<xsl:param name="depth" select="0"/>
 
 		<xsl:variable name="subitem">
-			<fo:table table-layout="fixed">
+			<fo:table table-layout="fixed" width="100%">
 				<fo:table-column><xsl:attribute name="column-width"><xsl:value-of select="( $total_width - (12+16+20)) - $depth*5"/>mm</xsl:attribute></fo:table-column>
 				<fo:table-column column-width="12mm"/>
 				<fo:table-column column-width="16mm"/>
@@ -804,7 +804,7 @@
 				<xsl:copy-of select="$subitem"/>
 			</xsl:when>
 			<xsl:otherwise>
-				<fo:table table-layout="fixed">
+				<fo:table table-layout="fixed" width="100%">
 					<fo:table-column column-width="5mm"/>
 					<fo:table-column><xsl:attribute name="column-width"><xsl:value-of select="$total_width - $depth*5"/>mm</xsl:attribute></fo:table-column>
 					<fo:table-body>
@@ -1012,7 +1012,7 @@
 ====================================-->
 	<xsl:template name="paragraghlist.table">
 		<xsl:for-each select="./table">
-			<fo:table table-layout="fixed" inline-progression-dimension="auto">
+			<fo:table table-layout="fixed" width="100%" inline-progression-dimension="auto">
 				<xsl:for-each select="./table-column">
 					<fo:table-column>
 						<xsl:attribute name="column-width">

--- a/outputsheets/d20/fantasy/pdf/fantasy_master_common_blocks.xslt
+++ b/outputsheets/d20/fantasy/pdf/fantasy_master_common_blocks.xslt
@@ -222,7 +222,7 @@
 ====================================
 ====================================-->
 	<xsl:template name="page.footer.content">
-		<fo:table table-layout="fixed">
+		<fo:table table-layout="fixed" width="100%">
 			<fo:table-column>
 				<xsl:attribute name="column-width"><xsl:value-of select="0.25 * $pagePrintableWidth" />mm</xsl:attribute>
 			</fo:table-column>
@@ -279,7 +279,7 @@
 						<xsl:apply-templates select="basics"/>
 					</fo:block>
 					<fo:block span="all">
-						<fo:table table-layout="fixed">
+						<fo:table table-layout="fixed" width="100%">
 							<fo:table-column>
 								<xsl:attribute name="column-width"><xsl:value-of select="0.29 * $pagePrintableWidth" />mm</xsl:attribute>
 							</fo:table-column>


### PR DESCRIPTION
This updates our default output sheets to current FOP syntax, so that they do not generate excessive warnings and can even be loaded with strict validation active.

These four syntax issues were occurring widely throughout the files:
* Empty `<fo:table-cell>` nodes are no longer allowed in FOP 1.0+. We had a lot of `<fo:table-cell/>`, or cells that can be empty if a loop or template called inside returns an empty result. I have added `<fo:block/>` to the empty cells or wrapped the loops and templates in a `<fo:block>` node.
* The `padding` attributes cannot be used with tables that use the collapsed-border table model and are ignored, but generate a warning. I have removed these attributes.
* The fixed table-layout assumes `width="auto"` when the `width` attribute is not present. However, auto layout is not supported by FOP. FOP then assumes `width="100%"` and generates a warning. I have explicitly added the `width="100%"` attribute.
* The attributes `border-top` and `border-bottom` should actually be `border-top-width` and `border-bottom-width`. I have fixed these appropriately.