### PR TITLE
fix a slight bug in my last PR

### DIFF
--- a/code/src/java/gmgen/plugin/Dice.java
+++ b/code/src/java/gmgen/plugin/Dice.java
@@ -60,8 +60,6 @@ public class Dice extends Die
     @Override
 	public int roll()
 	{
-		total = 0;
-
 		int value = 0;
 		for (int i = 0; i < num; i++)
 		{
@@ -69,10 +67,7 @@ public class Dice extends Die
 			value = rolls[i] + value;
 		}
 
-		total = value + aModifier;
-
-
-		return total;
+		return value + aModifier;
 	}
 
 	/** Name of the die in the nds+m format

--- a/code/src/java/gmgen/plugin/Die.java
+++ b/code/src/java/gmgen/plugin/Die.java
@@ -37,17 +37,11 @@ public abstract class Die
 	/** Holds the rolls of each die */
 	public int[] rolls;
 
-	/** Die modifier */
-	public int modifier;
-
 	/** Number of dice */
 	public int num;
 
 	/** Number of sides */
 	public int sides;
-
-	/** Total from last die roll */
-	public int total;
 
 	/** Roll the die, and get back a value
 	 * @return Result of the die roll
@@ -66,13 +60,5 @@ public abstract class Die
 	public static void setRandom(Random rand)
 	{
 		Die.rand = rand;
-	}
-
-	/** Returns the last roll.
-	 * @return The last roll
-	 */
-	public int value()
-	{
-		return total;
 	}
 }

--- a/code/src/java/gmgen/plugin/DieEx.java
+++ b/code/src/java/gmgen/plugin/DieEx.java
@@ -84,12 +84,6 @@ public class DieEx extends Die
 		}
 	}
 
-	/** Creates an instance of this class using the default roll */
-	public DieEx()
-	{
-		this("1d6");
-	}
-
 	/** Method used for testing and running on it's own
 	 * @param args Command line arguments
 	 */
@@ -113,11 +107,11 @@ public class DieEx extends Die
     @Override
 	public int roll()
 	{
-		total = 0;
+		int total = 0;
 
 		for (int x = 0; x < num; x++)
 		{
-			rolls[x] = rand.nextInt(sides) + 1;
+			rolls[x] = Die.rand.nextInt(sides) + 1;
 			total += rolls[x];
 		}
 

--- a/code/src/java/gmgen/plugin/InfoCharacterDetails.java
+++ b/code/src/java/gmgen/plugin/InfoCharacterDetails.java
@@ -29,7 +29,6 @@ import pcgen.util.Logging;
  * This class is a helper for the Combat Tracker.  This class helps display
  * all the statistics of a character.
  * @author Expires 2003
- * @version $Revision$
  *
  * <p>Current Ver: $Revision$</p>
  * <p>Last Editor: $Author$</p>

--- a/code/src/java/gmgen/plugin/InitHolder.java
+++ b/code/src/java/gmgen/plugin/InitHolder.java
@@ -30,7 +30,6 @@ import org.jdom.Element;
 /**
  *@author     devon
  *@since    March 20, 2003
- *@version $Revision$
  */
 public interface InitHolder
 {

--- a/code/src/java/gmgen/plugin/PcgCombatant.java
+++ b/code/src/java/gmgen/plugin/PcgCombatant.java
@@ -61,7 +61,6 @@ import pcgen.util.enumeration.View;
 /**
  *@author     devon
  *@since    March 20, 2003
- *@version $Revision$
  */
 public class PcgCombatant extends Combatant
 {

--- a/code/src/java/gmgen/plugin/SystemDie.java
+++ b/code/src/java/gmgen/plugin/SystemDie.java
@@ -58,18 +58,16 @@ class SystemDie extends Die
     @Override
 	public int roll()
 	{
-		int i;
-		total = 0;
 
-		for (i = 0; i < num; i++)
+		for (int i = 0; i < num; i++)
 		{
-			int thisRoll = rand.nextInt(sides) + 1;
+			int thisRoll = Die.rand.nextInt(sides) + 1;
 			rolls[i] = thisRoll;
 		}
 		return new SimpleSumCounter().totalCount(
 				ResultModifier.modify(rolls,
 						new SystemModifier(),
-						new SimpleModifier(modifier)
+						new SimpleModifier(aModifier)
 				)
 		);
 


### PR DESCRIPTION
This fixes a slight bug in my last PR: use aModifier instead of modifier.
Also reduces the chance of this happening in the future by removing 'modifier' from the Die base class.

In the long term most of the Die class should be pulled out into System/DieEx or be replaced with composable pieces.