### PR TITLE
move attribute fields outside of PlayerCharacter

### DIFF
--- a/code/src/java/pcgen/cdom/enumeration/BiographyField.java
+++ b/code/src/java/pcgen/cdom/enumeration/BiographyField.java
@@ -23,34 +23,46 @@
 package pcgen.cdom.enumeration;
 
 /**
- * <code>BiographyField</code> lists the possible biographical fields which may 
+ * {@code BiographyField} lists the possible biographical fields which may
  * be edited or suppressed from export.
  *
- * <br>
- * Last Editor: $Author$
- * Last Edited: $Date$
- * 
  * @author James Dempsey &lt;jdempsey@users.sourceforge.net&gt;
- * @version $Revision$
  */
 @SuppressWarnings("nls")
 public enum BiographyField
 {
-	NAME("in_nameLabel"), PLAYERNAME("in_player"), GENDER("in_gender"), HANDED(
-			"in_handString"), ALIGNMENT("in_alignString"), DEITY("in_deity"), AGE(
-			"in_age"), SKIN_TONE("in_appSkintoneColor"), HAIR_COLOR(
-			"in_appHairColor"), HAIR_STYLE("in_style"), EYE_COLOR(
-			"in_appEyeColor"), HEIGHT("in_height"), WEIGHT("in_weight"), SPEECH_PATTERN(
-			"in_speech"), BIRTHDAY("in_birthday"), LOCATION("in_location"), CITY(
-			"in_home"), REGION("in_region"), BIRTHPLACE("in_birthplace"), PERSONALITY_TRAIT_1(
-			"in_personality1"), PERSONALITY_TRAIT_2("in_personality2"), PHOBIAS(
-			"in_phobias"), INTERESTS("in_interest"), CATCH_PHRASE("in_phrase");
-	
+	NAME("in_nameLabel", PCAttribute.NAME),
+	PLAYERNAME("in_player", PCAttribute.PLAYERSNAME),
+	GENDER("in_gender", null),
+	HANDED("in_handString", null),
+	ALIGNMENT("in_alignString", null),
+	DEITY("in_deity", null),
+	AGE("in_age", null),
+	SKIN_TONE("in_appSkintoneColor", PCAttribute.SKINCOLOR),
+	HAIR_COLOR("in_appHairColor", PCAttribute.HAIRCOLOR),
+	HAIR_STYLE("in_style", PCAttribute.HAIRSTYLE),
+	EYE_COLOR("in_appEyeColor", PCAttribute.EYECOLOR),
+	HEIGHT("in_height", null),
+	WEIGHT("in_weight", null),
+	SPEECH_PATTERN("in_speech", PCAttribute.SPEECHTENDENCY),
+	BIRTHDAY("in_birthday", PCAttribute.BIRTHDAY),
+	LOCATION("in_location", PCAttribute.LOCATION),
+	CITY("in_home", null),
+	REGION("in_region", null),
+	BIRTHPLACE("in_birthplace", PCAttribute.BIRTHPLACE),
+	PERSONALITY_TRAIT_1("in_personality1", PCAttribute.PERSONALITY1),
+	PERSONALITY_TRAIT_2("in_personality2", PCAttribute.PERSONALITY2),
+	PHOBIAS("in_phobias", PCAttribute.PHOBIAS),
+	INTERESTS("in_interest", PCAttribute.INTERESTS),
+	CATCH_PHRASE("in_phrase", PCAttribute.CATCHPHRASE);
+
 	private final String il8nKey;
-	
-	private BiographyField(String key)
+	private final PCAttribute pcattr;
+
+	BiographyField(final String key, final PCAttribute pcattr)
 	{
 		il8nKey = key;
+		this.pcattr = pcattr;
 	}
 
 	/**
@@ -59,5 +71,10 @@ public enum BiographyField
 	public String getIl8nKey()
 	{
 		return il8nKey;
+	}
+
+	public PCAttribute getPcattr()
+	{
+		return pcattr;
 	}
 }

--- a/code/src/java/pcgen/cdom/enumeration/GenericPCAttribute.java
+++ b/code/src/java/pcgen/cdom/enumeration/GenericPCAttribute.java
@@ -1,0 +1,21 @@
+/*
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.cdom.enumeration;
+
+public interface GenericPCAttribute
+{
+	PCStringKey getStringKey();
+}

--- a/code/src/java/pcgen/cdom/enumeration/NotePCAttribute.java
+++ b/code/src/java/pcgen/cdom/enumeration/NotePCAttribute.java
@@ -1,0 +1,61 @@
+/*
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.cdom.enumeration;
+
+import java.util.stream.Stream;
+import pcgen.system.LanguageBundle;
+
+public enum NotePCAttribute implements GenericPCAttribute
+{
+	ASSETS(PCStringKey.ASSETS, "in_otherAssets"),
+	BIO(PCStringKey.BIO, "in_bio"),
+	COMPANIONS(PCStringKey.COMPANIONS, "in_companions"),
+	DESCRIPTION(PCStringKey.DESCRIPTION, "in_descrip"),
+	MAGIC(PCStringKey.MAGIC, "in_magicItems"),
+	GMNOTES(PCStringKey.GMNOTES, "in_gmNotes");
+
+	private final PCStringKey stringKey;
+	private final String noteName;
+
+	@Override
+	public PCStringKey getStringKey()
+	{
+		return stringKey;
+	}
+
+	public static NotePCAttribute getByNoteName(String noteName)
+	{
+		return Stream.of(NotePCAttribute.values()).filter(
+				x -> x.noteName.equals(noteName)
+		).findFirst().get();
+	}
+
+
+	NotePCAttribute(final PCStringKey stringKey, final String noteNameLocation)
+	{
+		this.stringKey = stringKey;
+		this.noteName = LanguageBundle.getString(noteNameLocation);
+	}
+
+	@Override
+	public String toString()
+	{
+		return "NotePCAttribute{" +
+				"stringKey=" + stringKey +
+				", noteName='" + noteName + '\'' +
+				'}';
+	}
+}

--- a/code/src/java/pcgen/cdom/enumeration/PCAttribute.java
+++ b/code/src/java/pcgen/cdom/enumeration/PCAttribute.java
@@ -1,0 +1,59 @@
+/*
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.cdom.enumeration;
+
+public enum PCAttribute implements GenericPCAttribute
+{
+	BIRTHDAY(PCStringKey.BIRTHDAY),
+	BIRTHPLACE(PCStringKey.BIRTHPLACE),
+	CATCHPHRASE(PCStringKey.CATCHPHRASE),
+	EYECOLOR(PCStringKey.EYECOLOR),
+	HAIRCOLOR(PCStringKey.HAIRCOLOR),
+	HAIRSTYLE(PCStringKey.HAIRSTYLE),
+	LOCATION(PCStringKey.LOCATION),
+	SPEECHTENDENCY(PCStringKey.SPEECHTENDENCY),
+	PERSONALITY1(PCStringKey.PERSONALITY1),
+	PERSONALITY2(PCStringKey.PERSONALITY2),
+	PHOBIAS(PCStringKey.PHOBIAS),
+	SKINCOLOR(PCStringKey.SKINCOLOR),
+	TABNAME(PCStringKey.TABNAME),
+	HANDED(PCStringKey.HANDED),
+	INTERESTS(PCStringKey.INTERESTS),
+	NAME(PCStringKey.NAME),
+	PLAYERSNAME(PCStringKey.PLAYERSNAME),
+	RESIDENCE(PCStringKey.RESIDENCE);
+
+	private final PCStringKey stringKey;
+
+	PCAttribute(final PCStringKey stringKey)
+	{
+		this.stringKey = stringKey;
+	}
+
+	@Override
+	public PCStringKey getStringKey()
+	{
+		return stringKey;
+	}
+
+	@Override
+	public String toString()
+	{
+		return "PCAttribute{" +
+				"stringKey=" + stringKey +
+				'}';
+	}
+}

--- a/code/src/java/pcgen/core/BioSet.java
+++ b/code/src/java/pcgen/core/BioSet.java
@@ -41,6 +41,7 @@ import pcgen.base.util.DoubleKeyMap;
 import pcgen.base.util.TripleKeyMapToList;
 import pcgen.cdom.base.Constants;
 import pcgen.cdom.base.NonInteractive;
+import pcgen.cdom.enumeration.PCAttribute;
 import pcgen.cdom.enumeration.Region;
 import pcgen.util.Logging;
 
@@ -229,36 +230,13 @@ public final class BioSet extends PObject implements NonInteractive
 
 		if (ranList.contains("HAIR"))
 		{
-			pc.setHairColor(generateBioValue("HAIR", pc));
+			pc.setPCAttribute(PCAttribute.HAIRCOLOR, generateBioValue("HAIR", pc));
 		}
 
 		if (ranList.contains("SKIN"))
 		{
-			pc.setSkinColor(generateBioValue("SKINTONE", pc));
+			pc.setPCAttribute(PCAttribute.SKINCOLOR, generateBioValue("SKINTONE", pc));
 		}
-	}
-
-	/**
-	 * Remove the user from the map
-	 * @param region
-	 * @param race
-	 * @param tag
-	 */
-	public void removeFromUserMap(final String region, final String race, final String tag)
-	{
-		final String key;
-		final int x = tag.indexOf(':');
-
-		if (x < 0)
-		{
-			key = tag;
-		}
-		else
-		{
-			key = tag.substring(0, x);
-		}
-
-		userMap.removeListFor(Region.getConstant(region), race, key);
 	}
 
 	@Override

--- a/code/src/java/pcgen/core/BonusManager.java
+++ b/code/src/java/pcgen/core/BonusManager.java
@@ -773,7 +773,6 @@ public class BonusManager
 		//
 		if (fullyQualifiedBonusType.equalsIgnoreCase("SKILL.LIST"))
 		{
-			pc.setDisplayUpdate(true);
 			return;
 		}
 		bonusMap.put(fullyQualifiedBonusType, bonusValue);

--- a/code/src/java/pcgen/core/PObject.java
+++ b/code/src/java/pcgen/core/PObject.java
@@ -52,8 +52,6 @@ import pcgen.system.PCGenSettings;
  *
  * @author Bryan McRoberts &lt;merton_monk@users.sourceforge.net&gt;
  * @version $Revision$
- */
-/**
  * @author Joe.Frazier
  *
  */
@@ -192,7 +190,7 @@ public class PObject extends CDOMObject implements Cloneable, Serializable, Comp
 	{
 		final String myType;
 
-		if (aType.length() == 0)
+		if (aType.isEmpty())
 		{
 			return false;
 		}

--- a/code/src/java/pcgen/core/PlayerCharacter.java
+++ b/code/src/java/pcgen/core/PlayerCharacter.java
@@ -13,13 +13,6 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
- *
- * Created on April 21, 2001, 2:15 PM
- *
- * Current Ver: $Revision$
- * Last Editor: $Author$
- * Last Edited: $Date$
- *
  */
 package pcgen.core;
 
@@ -43,7 +36,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.TreeSet;
-
 import pcgen.base.formula.Formula;
 import pcgen.base.formula.base.VarScoped;
 import pcgen.base.solver.AggressiveSolverManager;
@@ -80,6 +72,7 @@ import pcgen.cdom.enumeration.EquipmentLocation;
 import pcgen.cdom.enumeration.FactKey;
 import pcgen.cdom.enumeration.FormulaKey;
 import pcgen.cdom.enumeration.Gender;
+import pcgen.cdom.enumeration.GenericPCAttribute;
 import pcgen.cdom.enumeration.Handed;
 import pcgen.cdom.enumeration.IntegerKey;
 import pcgen.cdom.enumeration.ListKey;
@@ -283,20 +276,19 @@ import pcgen.util.enumeration.Load;
 import pcgen.util.enumeration.View;
 
 /**
- * <code>PlayerCharacter</code>.
- * 
+ * {@code PlayerCharacter}.
+ *
  * @author Bryan McRoberts &lt;merton_monk@users.sourceforge.net&gt;
- * @version $Revision$
  */
-public class PlayerCharacter  implements Cloneable, VariableContainer 
+public class PlayerCharacter implements Cloneable, VariableContainer
 {
 
 	// Constants for use in getBonus
 	private static String lastVariable = null;
 	// This marker is static so that the spells allocated to it can also be found in the cloned character.
 	private static ObjectCache grantedSpellCache = new ObjectCache();
-	
-	private CharID id;
+
+	private final CharID id;
 	private final SAtoStringProcessor SA_TO_STRING_PROC;
 	private final SAProcessor SA_PROC;
 	private final CharacterDisplay display;
@@ -405,7 +397,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	private MasterFacet masterFacet = FacetLibrary.getFacet(MasterFacet.class);
 	private AutoEquipmentListFacet autoListEquipmentFacet = FacetLibrary.getFacet(AutoEquipmentListFacet.class);
 	private FollowerFacet followerFacet = FacetLibrary.getFacet(FollowerFacet.class);
-	
+
 	private LanguageFacet languageFacet = FacetLibrary.getFacet(LanguageFacet.class);
 	private UserSpecialAbilityFacet userSpecialAbilityFacet = FacetLibrary.getFacet(UserSpecialAbilityFacet.class);
 	private SpecialAbilityFacet specialAbilityFacet = FacetLibrary.getFacet(SpecialAbilityFacet.class);
@@ -413,7 +405,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	private SecondaryWeaponFacet secondaryWeaponFacet = FacetLibrary.getFacet(SecondaryWeaponFacet.class);
 
 	private AutoLanguageGrantedFacet condLangFacet = FacetLibrary.getFacet(AutoLanguageGrantedFacet.class);
-	
+
 	private SkillCostFacet skillCostFacet = FacetLibrary.getFacet(SkillCostFacet.class);
 	private ProhibitedSchoolFacet prohibitedSchoolFacet = FacetLibrary.getFacet(ProhibitedSchoolFacet.class);
 	private SpellProhibitorFacet spellProhibitorFacet = FacetLibrary.getFacet(SpellProhibitorFacet.class);
@@ -450,7 +442,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	private SpellListFacet spellListFacet = FacetLibrary.getFacet(SpellListFacet.class);
 	private ChangeProfFacet changeProfFacet = FacetLibrary.getFacet(ChangeProfFacet.class);
 	private TargetTrackingFacet astocnasFacet = FacetLibrary.getFacet(TargetTrackingFacet.class);
-	
+
 	private PlayerCharacterTrackingFacet trackingFacet = FacetLibrary.getFacet(PlayerCharacterTrackingFacet.class);
 	private PortraitThumbnailRectFacet portraitThumbnailRectFacet = FacetLibrary
 			.getFacet(PortraitThumbnailRectFacet.class);
@@ -460,12 +452,12 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	private SolverManagerFacet solverManagerFacet = FacetLibrary.getFacet(SolverManagerFacet.class);
 	private SolverFactoryFacet solverFactoryFacet = FacetLibrary.getFacet(SolverFactoryFacet.class);
 	private FormulaSetupFacet formulaSetupFacet = FacetLibrary.getFacet(FormulaSetupFacet.class);
-	
+
 	private ResultFacet resultFacet = FacetLibrary.getFacet(ResultFacet.class);
 
 	private ScopeFacet scopeFacet = FacetLibrary.getFacet(ScopeFacet.class);
 	private VariableStoreFacet variableStoreFacet = FacetLibrary.getFacet(VariableStoreFacet.class);
-	
+
 	private ClassSource defaultDomainSource;
 
 	private Map<String, Integer> autoEquipOutputOrderCache = new HashMap<>();
@@ -498,7 +490,6 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	private boolean[] ageSetKitSelections = new boolean[Constants.NUMBER_OF_AGESET_KIT_SELECTIONS];
 	private boolean dirtyFlag = false;
 	private int serial = 0;
-	private boolean displayUpdate = false;
 	private boolean importing = false;
 
 	// Should temp mods/bonuses be used/saved?
@@ -513,7 +504,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	// order in which the skills will be output.
 	private SkillsOutputOrder skillsOutputOrder = SkillsOutputOrder.NAME_ASC;
-	
+
 	private int spellLevelTemp = 0;
 	private VariableProcessor variableProcessor;
 
@@ -554,7 +545,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	{
 		id = CharID.getID(Globals.getContext().getDataSetID());
 		doFormulaSetup();
-		
+
 		display = new CharacterDisplay(id);
 		SA_TO_STRING_PROC = new SAtoStringProcessor(this);
 		SA_PROC = new SAProcessor(this);
@@ -595,7 +586,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 		addSpellBook(new SpellBook(Globals.getDefaultSpellBook(), SpellBook.TYPE_KNOWN_SPELLS));
 		addSpellBook(new SpellBook(Constants.INNATE_SPELL_BOOK_NAME, SpellBook.TYPE_INNATE_SPELLS));
 	}
-	
+
 	private void doFormulaSetup()
 	{
 		SplitFormulaSetup formulaSetup =
@@ -608,9 +599,6 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 			mySetup.getFormulaManager(), solverFactory, mySetup.getVariableStore()));
 	}
 
-	/**
-	 * {@inheritDoc}
-	 */
 	@Override
 	public String toString()
 	{
@@ -620,7 +608,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Set the age.
-	 * 
+	 *
 	 * @param i The character's age
 	 */
 	public void setAge(final int i)
@@ -633,38 +621,19 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	}
 
 	/**
-	 * Set the character's BIO.
-	 * 
-	 * @param bio the biography
+	 * Sets player character information
+	 *
+	 * @param attr which attribute to set
+	 * @param value the value to set it to
 	 */
-	public void setBio(final String bio)
+	public void setPCAttribute(final GenericPCAttribute attr, final String value)
 	{
-		setStringFor(PCStringKey.BIO, bio);
-	}
-
-	/**
-	 * Set the birthday.
-	 * 
-	 * @param birthday the birthday to be set
-	 */
-	public void setBirthday(final String birthday)
-	{
-		setStringFor(PCStringKey.BIRTHDAY, birthday);
-	}
-
-	/**
-	 * Set the birthplace.
-	 * 
-	 * @param birthPlace the place of birth
-	 */
-	public void setBirthplace(final String birthPlace)
-	{
-		setStringFor(PCStringKey.BIRTHPLACE, birthPlace);
+		setStringFor(attr.getStringKey(), value);
 	}
 
 	/**
 	 * Set the current EquipSet that is used to Bonus/Equip calculations.
-	 * 
+	 *
 	 * @param eqSetId The equipSet to be used for Bonus Calculations and output
 	 */
 	public void setCalcEquipSetId(final String eqSetId)
@@ -683,7 +652,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Get the id for the equipment set being used for calculation.
-	 * 
+	 *
 	 * @return id
 	 */
 	public String getCalcEquipSetId()
@@ -726,7 +695,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	 * through all the equipment and sets the correct status of each (equipped,
 	 * carried, etc). Boolean parameter useTempBonuses controls whether or
 	 * not the temporary bonuses associated with equipment are applied.
-	 * 
+	 *
 	 * @param useTempBonuses whether to apply Temporary bonuses from equipment.
 	 */
 	public void setCalcEquipmentList(final boolean useTempBonuses)
@@ -886,18 +855,8 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	}
 
 	/**
-	 * Set the catchphrase.
-	 * 
-	 * @param phrase the catchphrase
-	 */
-	public void setCatchPhrase(final String phrase)
-	{
-		setStringFor(PCStringKey.CATCHPHRASE, phrase);
-	}
-
-	/**
 	 * Get a class, represented by a given key, from among those possessed by this pc.
-	 * 
+	 *
 	 * @param key the class's key
 	 * @return PCClass
 	 */
@@ -916,7 +875,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Get the class list.
-	 * 
+	 *
 	 * @return classList
 	 */
 	public ArrayList<PCClass> getClassList()
@@ -937,8 +896,8 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	}
 
 	/**
-	 * Set the cost pool, which is the number of points the character has spent. 
-	 * 
+	 * Set the cost pool, which is the number of points the character has spent.
+	 *
 	 * @param i the number of points spent
 	 */
 	public void setCostPool(final int i)
@@ -948,7 +907,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Get the cost pool, which is the number of points the character has spent.
-	 * 
+	 *
 	 * @return costPool
 	 */
 	public int getCostPool()
@@ -958,7 +917,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Set the current equipment set name.
-	 * 
+	 *
 	 * @param aName the name of the new current equipment set
 	 */
 	public void setCurrentEquipSetName(final String aName)
@@ -968,7 +927,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Get the deity.
-	 * 
+	 *
 	 * @return deity
 	 */
 	public Deity getDeity()
@@ -977,18 +936,8 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	}
 
 	/**
-	 * Set the description.
-	 * 
-	 * @param aString the description to set
-	 */
-	public void setDescription(final String aString)
-	{
-		setStringFor(PCStringKey.DESCRIPTION, aString);
-	}
-
-	/**
 	 * Selector.
-	 * 
+	 *
 	 * @return description lst
 	 */
 	public String getDescriptionLst()
@@ -998,11 +947,11 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Sets the character changed since last save.
-	 * NB: This is not a 'safe' call - its use should be considered carefully and in 
-	 * particular it should not be called from a method used as part of PlayerCharacter 
-	 * cloning as this can mean conditional abilities get dropped when they are actually 
+	 * NB: This is not a 'safe' call - its use should be considered carefully and in
+	 * particular it should not be called from a method used as part of PlayerCharacter
+	 * cloning as this can mean conditional abilities get dropped when they are actually
 	 * qualified for, just not at that point in the clone.
-	 * 
+	 *
 	 * @param dirtyState the new "dirty" value (may be false to indicate no change)
 	 */
 	public void setDirty(final boolean dirtyState)
@@ -1011,7 +960,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 		{
 			serial++;
 			cache = new ObjectCache();
-			getVariableProcessor().setSerial(serial);
+			variableProcessor.setSerial(serial);
 			cabFacet.update(id);
 			cAvSpellFacet.update(id);
 			cKnSpellFacet.update(id);
@@ -1024,7 +973,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Gets whether the character has been changed since last saved.
-	 * 
+	 *
 	 * @return true if dirty
 	 */
 	public boolean isDirty()
@@ -1035,7 +984,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	/**
 	 * Returns the serial for the instance - every time something changes the
 	 * serial is incremented. Use to detect change in PlayerCharacter.
-	 * 
+	 *
 	 * @return serial
 	 */
 	public int getSerial()
@@ -1044,29 +993,8 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	}
 
 	/**
-	 * set display update TODO - This probably doesn't belong here. It seems to
-	 * only be used by InfoSkills.
-	 * 
-	 * @param update Whether the display should be updated
-	 */
-	public void setDisplayUpdate(final boolean update)
-	{
-		this.displayUpdate = update;
-	}
-
-	/**
-	 * is display update.
-	 * 
-	 * @return True if display update
-	 */
-	public boolean isDisplayUpdate()
-	{
-		return displayUpdate;
-	}
-
-	/**
 	 * Get the list of equipment sets.
-	 * 
+	 *
 	 * @return List
 	 */
 	private Collection<EquipSet> getEquipSet()
@@ -1076,7 +1004,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Get the equipment set indexed by path.
-	 * 
+	 *
 	 * @param path the "path" of the equipSet to return
 	 * @return EquipSet
 	 */
@@ -1087,7 +1015,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Set the number of the current equipSet.
-	 * 
+	 *
 	 * @param anInt the new value for current equipSet index
 	 */
 	public void setEquipSetNumber(final int anInt)
@@ -1101,7 +1029,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Get the current equipment set number.
-	 * 
+	 *
 	 * @return equipSet number
 	 */
 	public int getEquipSetNumber()
@@ -1111,7 +1039,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * gets the total weight in an EquipSet.
-	 * 
+	 *
 	 * @param idPath The root of the equipment set (or subset)
 	 * @return equipment set weight
 	 */
@@ -1156,7 +1084,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Get equipment set.
-	 * 
+	 *
 	 * @return equipment set
 	 */
 	private Set<Equipment> getEquipmentSet()
@@ -1178,7 +1106,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	 * ascending order of the equipment's outputIndex field. If multiple items
 	 * of equipment have the same outputIndex they will be ordered by name. Note
 	 * hidden items (outputIndex = -1) are not included in this list.
-	 * 
+	 *
 	 * @return An ArrayList of the equipment objects in output order.
 	 */
 	public List<Equipment> getEquipmentListInOutputOrder()
@@ -1191,12 +1119,12 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	 * ascending order of the equipment's outputIndex field. If multiple items
 	 * of equipment have the same outputIndex they will be ordered by name. Note
 	 * hidden items (outputIndex = -1) are not included in this list.
-	 * 
+	 *
 	 * Deals with merge as well.  See the Constants package for acceptable values
 	 * of merge .
-	 * 
+	 *
 	 * @param merge controls how much merging is done.
-	 * 
+	 *
 	 * @return An ArrayList of the equipment objects in output order.
 	 */
 	public List<Equipment> getEquipmentListInOutputOrder(final int merge)
@@ -1206,7 +1134,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Get the master list of equipment.
-	 * 
+	 *
 	 * @return equipment master list
 	 */
 	public List<Equipment> getEquipmentMasterList()
@@ -1220,7 +1148,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Get equipment master list in output order.
-	 * 
+	 *
 	 * @return equipment master list in output order
 	 */
 	public List<Equipment> getEquipmentMasterListInOutputOrder()
@@ -1232,17 +1160,17 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Search for a piece of equipment in the specified list by name.
-	 * 
+	 *
 	 * TODO - This does not belong in PlayerCharacter. Move to Equipment if
 	 * needed.
-	 * 
+	 *
 	 * TODO - This probably won't work with i18n. Should always search by key.
-	 * 
+	 *
 	 * @param aString
 	 *            The name of the equipment.
 	 * @param aList
 	 *            The Collection of equipment to search in.
-	 * 
+	 *
 	 * @return The <tt>Equipment</tt> object or <tt>null</tt>
 	 */
 	private Equipment getEquipmentNamed(final String aString, final Collection<Equipment> aList)
@@ -1272,7 +1200,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Set the characters eye colour.
-	 * 
+	 *
 	 * @param aString
 	 *            the colour of their eyes
 	 */
@@ -1284,7 +1212,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	/**
 	 * Get a number that represents the number of feats added to this character
 	 * by BONUS statements.
-	 * 
+	 *
 	 * @return the number of feats added by bonus statements
 	 */
 	private double getBonusFeatPool()
@@ -1335,10 +1263,10 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	}
 
 	/**
-	 * Calculates the number of feats that should be granted as a result of LEVELPERFEAT 
-	 * entries in classes that the character has levels in. Stacking rules based on 
-	 * LEVELTYPE are applied as part of this calculation. 
-	 * 
+	 * Calculates the number of feats that should be granted as a result of LEVELPERFEAT
+	 * entries in classes that the character has levels in. Stacking rules based on
+	 * LEVELTYPE are applied as part of this calculation.
+	 *
 	 * @return the number of feats granted
 	 */
 	double getNumFeatsFromLevels()
@@ -1375,7 +1303,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	 * skill points and/or feat slots remaining. This can be used to enforce
 	 * correct spending of these resources when creating high-level multiclass
 	 * characters.
-	 * 
+	 *
 	 * @return true if the PC can level up
 	 */
 	public boolean canLevelUp()
@@ -1386,7 +1314,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Sets the filename of the character.
-	 * 
+	 *
 	 * @param newFileName the name of the file this character will be saved in
 	 */
 	public void setFileName(final String newFileName)
@@ -1396,7 +1324,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Gets the filename of the character.
-	 * 
+	 *
 	 * @return file name of character
 	 */
 	public String getFileName()
@@ -1406,7 +1334,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Returns the followers associated with this character.
-	 * 
+	 *
 	 * @return A <tt>Set</tt> of <tt>Follower</tt> objects.
 	 */
 	public Collection<Follower> getFollowerList()
@@ -1416,11 +1344,11 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Sets the character's gender.
-	 * 
+	 *
 	 * <p>
 	 * The gender will only be changed if the character does not have a template
 	 * that locks the character's gender.
-	 * 
+	 *
 	 * @param g
 	 *            A gender to try and set.
 	 */
@@ -1435,11 +1363,11 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Sets the character's wealth.
-	 * 
+	 *
 	 * <p>
 	 * Gold here is used as a character's total purchase power not actual gold
 	 * pieces.
-	 * 
+	 *
 	 * @param aString
 	 *            A String gold amount. TODO - Do this parsing elsewhere.
 	 */
@@ -1451,18 +1379,18 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Sets the character's wealth.
-	 * 
+	 *
 	 * <p>
 	 * Gold here is used as a character's total purchase power not actual gold
 	 * pieces.
-	 * 
+	 *
 	 * @param amt
-	 *            A gold amount. 
+	 *            A gold amount.
 	 */
 	public void setGold(final BigDecimal amt)
 	{
 		if (amt == null) return;
-		
+
 		// The equality comparison in AbstractItemFacet doesn't work on BigDecimal, need to use compareTo
 		BigDecimal oldAmt = goldFacet.get(id);
 		if (oldAmt == null || amt.compareTo(oldAmt) != 0)
@@ -1474,9 +1402,9 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Returns the character's total wealth.
-	 * 
+	 *
 	 * @see pcgen.core.PlayerCharacter#setGold(String)
-	 * 
+	 *
 	 * @return A <tt>BigDecimal</tt> value for the character's wealth.
 	 */
 	public BigDecimal getGold()
@@ -1486,31 +1414,8 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	}
 
 	/**
-	 * Sets the character's hair color as a string.
-	 * 
-	 * @param aString
-	 *            The hair color to set.
-	 */
-	public void setHairColor(final String aString)
-	{
-		setStringFor(PCStringKey.HAIRCOLOR, aString);
-	}
-
-	/**
-	 * Sets the character's hair style.
-	 * 
-	 * @param aString
-	 *            A hair style.
-	 */
-	public void setHairStyle(final String aString)
-	{
-		setStringFor(PCStringKey.HAIRSTYLE, aString);
-	}
-
-	/**
 	 * Sets the character's handedness.
-	 * 
-	 * 
+	 *
 	 * @param h A handedness to try and set.
 	 */
 	public void setHanded(final Handed h)
@@ -1523,10 +1428,10 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Sets the character's height in inches.
-	 * 
+	 *
 	 * @param i
 	 *            A height in inches.
-	 * 
+	 *
 	 * TODO - This should be a double value stored in CM
 	 */
 	public void setHeight(final int i)
@@ -1539,15 +1444,15 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Marks the character as being in the process of being loaded.
-	 * 
+	 *
 	 * <p>
 	 * This information is used to prevent the system from trying to calculate
 	 * values on partial information or values that should be set from the saved
 	 * character.
-	 * 
+	 *
 	 * <p>
 	 * TODO - This is pretty dangerous.
-	 * 
+	 *
 	 * @param newIsImporting
 	 *            <tt>true</tt> to mark the character as being imported.
 	 */
@@ -1557,35 +1462,13 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	}
 
 	/**
-	 * Sets the character's interests.
-	 * 
-	 * @param aString
-	 *            A string of interests for the character.
-	 */
-	public void setInterests(final String aString)
-	{
-		setStringFor(PCStringKey.INTERESTS, aString);
-	}
-
-	/**
 	 * Gets the character's list of languages.
-	 * 
+	 *
 	 * @return An unmodifiable language set.
 	 */
 	public Set<Language> getLanguageSet()
 	{
 		return languageFacet.getSet(id);
-	}
-
-	/**
-	 * Sets the character's location.
-	 * 
-	 * @param aString
-	 *            A location.
-	 */
-	public void setLocation(final String aString)
-	{
-		setStringFor(PCStringKey.LOCATION, aString);
 	}
 
 	/**
@@ -1597,7 +1480,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	 * variable (either Class or Variable).  Note it seems that this used to
 	 * be driven off types but now it's driven from a list of companion mods
 	 * but the java doc has not been updated.
-	 * 
+	 *
 	 * @param compList
 	 *            A list of companionMods to get level for
 	 * @return The effective level for this companion type
@@ -1638,7 +1521,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	 * Set the master for this object also set the level dependent stats based
 	 * on the masters level and info contained in the companionModList Array
 	 * such as HitDie, SR, BONUS, SA, etc.
-	 * 
+	 *
 	 * @param aM
 	 *            The master to be set.
 	 */
@@ -1829,7 +1712,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 					}
 
 				}
-				
+
 			}
 		}
 
@@ -1873,7 +1756,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	 * Returns the maximum number of followers this character can have from
 	 * the given companion list. This method does not adjust for any followers
 	 * already selected by the character.
-	 * 
+	 *
 	 * @param cList
 	 *            A list of potential follower races
 	 * @return The max number of followers -1 for any number
@@ -1920,7 +1803,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Get the PlayerCharacter that is the "master" for this object.
-	 * 
+	 *
 	 * @return master PC
 	 */
 	public PlayerCharacter getMasterPC()
@@ -1954,7 +1837,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Sets the character's name.
-	 * 
+	 *
 	 * @param aString
 	 *            A name to set.
 	 */
@@ -1965,7 +1848,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Gets the character's name.
-	 * 
+	 *
 	 * @return The name
 	 */
 	public String getName()
@@ -1976,7 +1859,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	/**
 	 * Takes all the Temporary Bonuses and Merges them into just the unique
 	 * named bonuses.
-	 * 
+	 *
 	 * @return List of Strings
 	 */
 	public List<String> getNamedTempBonusList()
@@ -1985,7 +1868,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	}
 
 	/**
-	 * Takes all the Temporary Bonuses and Merges them into just the unique 
+	 * Takes all the Temporary Bonuses and Merges them into just the unique
 	 * named bonuses.
 	 *
 	 * @return    List of Strings
@@ -1997,7 +1880,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Sets a string of phobias for the character.
-	 * 
+	 *
 	 * @param aString
 	 *            A string to set.
 	 */
@@ -2008,7 +1891,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Sets the name of the player for this character.
-	 * 
+	 *
 	 * @param aString
 	 *            A name to set.
 	 */
@@ -2037,7 +1920,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Selector Sets the path to the portrait of the character.
-	 * 
+	 *
 	 * @param newPortraitPath
 	 *            the path to the portrait file
 	 */
@@ -2057,7 +1940,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Get the character's race.
-	 * 
+	 *
 	 * @return the character's race
 	 */
 	public Race getRace()
@@ -2067,7 +1950,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Set the character's region.
-	 * 
+	 *
 	 * @param r the character's region
 	 */
 	public void setRegion(Region r)
@@ -2076,18 +1959,8 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	}
 
 	/**
-	 * Set the character's residence.
-	 * 
-	 * @param aString the character's residence
-	 */
-	public void setResidence(final String aString)
-	{
-		setStringFor(PCStringKey.RESIDENCE, aString);
-	}
-
-	/**
 	 * Set the location of the HTML sheet for this character.
-	 * 
+	 *
 	 * @param aString the location of the HTML sheet
 	 */
 	public void setSelectedCharacterHTMLOutputSheet(final String aString)
@@ -2097,7 +1970,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Get the Location of HTML Output Sheet to be used for this character.
-	 * 
+	 *
 	 * @return HTML output sheet
 	 */
 	public String getSelectedCharacterHTMLOutputSheet()
@@ -2107,7 +1980,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Set the location of the PDF Output Sheet for this character.
-	 * 
+	 *
 	 * @param aString the location of the PDF Output Sheet
 	 */
 	public void setSelectedCharacterPDFOutputSheet(final String aString)
@@ -2117,7 +1990,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Get the location of the PDF Output Sheet to be used for this character.
-	 * 
+	 *
 	 * @return pdf output sheet
 	 */
 	public String getSelectedCharacterPDFOutputSheet()
@@ -2127,7 +2000,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Get list of shield proficiencies.
-	 * 
+	 *
 	 * @return shield prof list
 	 */
 	public Collection<ProfProvider<ShieldProf>> getShieldProfList()
@@ -2137,7 +2010,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Get skill list.
-	 * 
+	 *
 	 * @return list of skills
 	 */
 	public Collection<Skill> getSkillSet()
@@ -2147,7 +2020,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Get skill points.
-	 * 
+	 *
 	 * @return skill points
 	 */
 	public int getSkillPoints()
@@ -2195,18 +2068,8 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	}
 
 	/**
-	 * Set skin colour.
-	 * 
-	 * @param colour the new skin colour
-	 */
-	public void setSkinColor(final String colour)
-	{
-		setStringFor(PCStringKey.SKINCOLOR, colour);
-	}
-
-	/**
 	 * Get list of special abilities.
-	 * 
+	 *
 	 * @return List of special abilities
 	 */
 	public List<SpecialAbility> getSpecialAbilityList()
@@ -2223,7 +2086,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Get list of special abilities as Strings.
-	 * 
+	 *
 	 * @return List of special abilities as Strings
 	 */
 	private List<String> getSpecialAbilityListStrings()
@@ -2241,7 +2104,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	/**
 	 * same as getSpecialAbilityList except if if you have the same ability
 	 * twice, it only lists it once with (2) at the end.
-	 * 
+	 *
 	 * @return List
 	 */
 	public ArrayList<String> getSpecialAbilityTimesList()
@@ -2285,18 +2148,8 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	}
 
 	/**
-	 * Set speech tendency.
-	 * 
-	 * @param tendency the speech tendency
-	 */
-	public void setSpeechTendency(final String tendency)
-	{
-		setStringFor(PCStringKey.SPEECHTENDENCY, tendency);
-	}
-
-	/**
 	 * Set the name of the spellbook to auto add new known spells to.
-	 * 
+	 *
 	 * @param aString
 	 *            The new spellbook name.
 	 */
@@ -2307,7 +2160,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Get the name of the spellbook to auto add new known spells to.
-	 * 
+	 *
 	 * @return spellbook name
 	 */
 	public String getSpellBookNameToAutoAddKnown()
@@ -2317,7 +2170,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Retrieve a spell book object given the name of the spell book.
-	 * 
+	 *
 	 * @param name
 	 *            The name of the spell book to be retrieved.
 	 * @return The spellbook (or null if not present).
@@ -2329,7 +2182,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Get spell books.
-	 * 
+	 *
 	 * @return spellBooks
 	 */
 	private List<String> getSpellBookNames()
@@ -2339,7 +2192,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Get spell class given an index.
-	 * 
+	 *
 	 * @param ix the index
 	 * @return spell class
 	 */
@@ -2358,7 +2211,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	/**
 	 * a temporary placeholder used for computing the DC of a spell Set from
 	 * within Spell.java before the getVariableValue() call.
-	 * 
+	 *
 	 * @param i the temporary spell level.
 	 */
 	public void setSpellLevelTemp(final int i)
@@ -2369,7 +2222,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Get spell level temp.
-	 * 
+	 *
 	 * @return temp spell level
 	 */
 	public int getSpellLevelTemp()
@@ -2378,7 +2231,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	}
 
 	/**
-	 * Set whether the field should be hidden from output. 
+	 * Set whether the field should be hidden from output.
 	 * @param field The BiographyField to set export suppression rules for.
 	 * @param suppress Should the field be hidden from output.
 	 */
@@ -2391,18 +2244,8 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	}
 
 	/**
-	 * Set the name on the tab.
-	 * 
-	 * @param name the new name for the tab
-	 */
-	public void setTabName(final String name)
-	{
-		setStringFor(PCStringKey.TABNAME, name);
-	}
-
-	/**
 	 * List if Items which have Temp Bonuses applied to them.
-	 * 
+	 *
 	 * @return List
 	 */
 	private List<Equipment> getTempBonusItemList()
@@ -2412,7 +2255,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Temp Bonus list.
-	 * 
+	 *
 	 * @return List
 	 */
 	public Map<BonusObj, BonusManager.TempBonusInfo> getTempBonusMap()
@@ -2422,7 +2265,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Get temp bonus filters.
-	 * 
+	 *
 	 * @return temp bonus filters
 	 */
 	public Set<String> getTempBonusFilters()
@@ -2432,7 +2275,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Add the temp bonus to the filter, thus removing its effects from the character.
-	 * 
+	 *
 	 * @param aBonusStr the temporary bonus to add.
 	 */
 	public void setTempBonusFilter(final String aBonusStr)
@@ -2443,7 +2286,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Remove the temp bonus from the filter, thus restoring its effects to the character.
-	 * 
+	 *
 	 * @param aBonusStr the temporary bonus to remove.
 	 */
 	public void unsetTempBonusFilter(final String aBonusStr)
@@ -2459,26 +2302,6 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	public Collection<PCTemplate> getTemplateSet()
 	{
 		return templateFacet.getSet(id);
-	}
-
-	/**
-	 * Set trait 1.
-	 * 
-	 * @param aString the trait.
-	 */
-	public void setTrait1(final String aString)
-	{
-		setStringFor(PCStringKey.PERSONALITY1, aString);
-	}
-
-	/**
-	 * Set trait 2.
-	 * 
-	 * @param aString the trait.
-	 */
-	public void setTrait2(final String aString)
-	{
-		setStringFor(PCStringKey.PERSONALITY2, aString);
 	}
 
 	/**
@@ -2550,7 +2373,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Sets the character's weight in pounds.
-	 * 
+	 *
 	 * @param i
 	 *            A weight to set.
 	 */
@@ -2627,7 +2450,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Add an item of equipment to the character.
-	 * 
+	 *
 	 * @param eq
 	 *            The equipment to be added.
 	 */
@@ -2670,7 +2493,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	 * Update the number of a particular equipment item the character possesses.
 	 * Mostly concerned with ensuring that the spellbook objects remain in sync
 	 * with the number of equipment spellbooks.
-	 * 
+	 *
 	 * @param eq
 	 *            The Equipment being updated.
 	 * @param oldQty
@@ -2739,7 +2562,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Adds a "temporary" bonus.
-	 * 
+	 *
 	 * @param aBonus The bonus object to add.
 	 * @param source The source of the temporary bonus
 	 * @param target The object getting the bonus (typically the PC, can also be equipment).
@@ -2764,7 +2587,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Compute the total bonus from a List of BonusObjs.
-	 * 
+	 *
 	 * @param aList The list of objects
 	 * @param source The source of the bonus objects.
 	 * @return The aggregate bonus
@@ -2911,14 +2734,14 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	 * returned by this function. The first bonus increases only the size of the
 	 * attacks generated. The second increases both the size and number of
 	 * attacks
-	 * 
+	 *
 	 * @param at
 	 *            The type of attack. Takes an AttackType (an enumeration)
-	 * 
+	 *
 	 * @param TOHITBonus
 	 *            A bonus that will be added to the TOHIT numbers. This bonus
 	 *            affects only the numbers produced, not the number of attacks
-	 * 
+	 *
 	 * @param BABBonus
 	 *            This bonus will be added to BAB before the number of attacks
 	 *            has been determined.
@@ -3079,7 +2902,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Sets the autoSortGear.
-	 * 
+	 *
 	 * @param autoSortGear
 	 *            The autoSortGear to set
 	 */
@@ -3094,7 +2917,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Returns the autoSortGear.
-	 * 
+	 *
 	 * @return boolean
 	 */
 	public boolean isAutoSortGear()
@@ -3104,7 +2927,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * whether we should add auto known spells at level up
-	 * 
+	 *
 	 * @param aBool
 	 */
 	public void setAutoSpells(final boolean aBool)
@@ -3132,7 +2955,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	/**
 	 * Determine whether higher level known spell slots can be used for lower
 	 * level spells, or if known spells are restricted to their own level only.
-	 * 
+	 *
 	 * @return Returns the useHigherKnownSlots.
 	 */
 	public boolean getUseHigherKnownSlots()
@@ -3143,7 +2966,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	/**
 	 * Set whether higher level known spell slots can be used for lower level
 	 * spells, or if known spells are restricted to their own level only.
-	 * 
+	 *
 	 * @param useHigher
 	 *            Can higher level known spell slots be used?
 	 */
@@ -3156,7 +2979,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	 * Determine whether higher level prepared spell slots can be used for lower
 	 * level spells, or if prepared spells are restricted to their own level
 	 * only.
-	 * 
+	 *
 	 * @return Returns the useHigherPreppedSlots.
 	 */
 	public boolean getUseHigherPreppedSlots()
@@ -3167,7 +2990,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	/**
 	 * Set whether higher level prepared spell slots can be used for lower level
 	 * spells, or if prepared spells are restricted to their own level only.
-	 * 
+	 *
 	 * @param useHigher
 	 *            Can higher level prepared spell slots be used?
 	 */
@@ -3179,14 +3002,14 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	/**
 	 * Returns the &quot;Base&quot; check value for the check at the index
 	 * specified.
-	 * 
+	 *
 	 * <p>
 	 * This method caps the base check based on the game mode setting for
 	 * {@link pcgen.core.GameMode#getChecksMaxLvl() checks max level}.
-	 * 
+	 *
 	 * @param check
 	 *            The index of the check to get
-	 * 
+	 *
 	 * @return The base check value.
 	 */
 	public int getBaseCheck(final PCCheck check)
@@ -3213,27 +3036,27 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 		if ((nPC != null) && (masterFacet.getCopyMasterCheck(id).length() > 0))
 		{
 			int masterBonus = nPC.getBaseCheck(check);
-			
+
 			final String copyMasterCheck = replaceMasterString(masterFacet.getCopyMasterCheck(id), masterBonus);
 			masterBonus = getVariableValue(copyMasterCheck, Constants.EMPTY_STRING).intValue();
-			
+
 			// use masters save if better
 			bonus = Math.max(bonus, masterBonus);
 		}
-		
+
 		getVariableProcessor().addCachedVariable(cacheLookup, Float.valueOf((float) bonus));
 		return (int) bonus;
 	}
 
 	/**
 	 * Returns the total check value for the check specified for the character.
-	 * 
+	 *
 	 * <p>
 	 * This total includes all check bonuses the character has.
-	 * 
+	 *
 	 * @param check
 	 *            The check to get.
-	 * 
+	 *
 	 * @return A check value.
 	 */
 	public int getTotalCheck(PCCheck check)
@@ -3245,7 +3068,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	/**
 	 * return bonus total for a specific bonusType e.g:
 	 * getBonusDueToType("COMBAT","AC","Armor") to get armor bonuses
-	 * 
+	 *
 	 * @param mainType
 	 * @param subType
 	 * @param bonusType
@@ -3267,7 +3090,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	/**
 	 * Retrieves an unsorted list of the character's equipment matching the
 	 * supplied type and status criteria.
-	 * 
+	 *
 	 * @param typeName
 	 *            The type of equipment to be selected
 	 * @param status
@@ -3283,7 +3106,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	/**
 	 * Retrieves an unsorted list of the character's equipment matching the
 	 * supplied type, sub type and status criteria.
-	 * 
+	 *
 	 * @param typeName
 	 *            The type of equipment to be selected
 	 * @param subtypeName
@@ -3320,7 +3143,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	 * order of the equipment's outputIndex field. If multiple items of
 	 * equipment have the same outputIndex they will be ordered by name. Note
 	 * hidden items (outputIndex = -1) are not included in this list.
-	 * 
+	 *
 	 * @param typeName
 	 *            The type of equipment to be selected
 	 * @param status
@@ -3368,9 +3191,9 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	 * Retrieve the expanded list of weapons Expanded weapons include: double
 	 * weapons and melee+ranged weapons Output order is assumed Merge of like
 	 * equipment depends on the passed in int
-	 * 
+	 *
 	 * @param merge The type of merge to perform
-	 * 
+	 *
 	 * @return the sorted list of weapons.
 	 */
 	public List<Equipment> getExpandedWeapons(final int merge)
@@ -3500,7 +3323,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Calculates total bonus from Feats
-	 * 
+	 *
 	 * @param aType
 	 * @param aName
 	 * @return feat bonus to
@@ -3508,7 +3331,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	public double getFeatBonusTo(String aType, String aName)
 	{
 		final Map<String, Ability> aHashMap = new HashMap<>();
-		
+
 		for (Ability aFeat : getAbilityList(AbilityCategory.FEAT, Nature.NORMAL))
 		{
 			if (aFeat != null)
@@ -3516,7 +3339,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 				aHashMap.put(aFeat.getKeyName(), aFeat);
 			}
 		}
-		
+
 		addUniqueAbilitiesToMap(aHashMap, getAbilityList(AbilityCategory.FEAT, Nature.VIRTUAL));
 		List<Ability> aggregateFeatList = new ArrayList<>();
 		addUniqueAbilitiesToMap(aHashMap, getAbilityList(AbilityCategory.FEAT, Nature.AUTOMATIC));
@@ -3601,7 +3424,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * whether we should load companions on master load
-	 * 
+	 *
 	 * @param aBool
 	 */
 	public void setLoadCompanion(final boolean aBool)
@@ -3643,7 +3466,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	/**
 	 * Calculate the maximum number of ranks the character is allowed to have in
 	 * the specified skill.
-	 * 
+	 *
 	 * @param aSkill
 	 *            The skill being checked.
 	 * @param aClass
@@ -3704,7 +3527,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Checks if the stat is a non ability.
-	 * 
+	 *
 	 * @return true, if is non ability
 	 */
 	public boolean isNonAbility(PCStat stat)
@@ -3737,7 +3560,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	/**
 	 * Changes the race of the character. First it removes the current Race,
 	 * then add the new Race.
-	 * 
+	 *
 	 * @param newRace
 	 */
 	public boolean setRace(final Race newRace)
@@ -3761,7 +3584,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * return bonus from a Race
-	 * 
+	 *
 	 * @param aType
 	 * @param aName
 	 * @return race bonus to
@@ -3786,7 +3609,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Calculates total bonus from Size adjustments
-	 * 
+	 *
 	 * @param aType
 	 * @param aName
 	 * @return size adjustment bonus to
@@ -3798,7 +3621,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Set the skill display filter
-	 * 
+	 *
 	 * @param filter
 	 *            The new filter
 	 */
@@ -3826,12 +3649,12 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 			}
 			setSkillFilter(filter);
 		}
-		return filter; 
+		return filter;
 	}
 
 	/**
 	 * Set the order in which skills should be sorted for output.
-	 * 
+	 *
 	 * @param i
 	 *            The new output order
 	 */
@@ -3855,7 +3678,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	/**
 	 * Method will go through the list of classes that the player character has
 	 * and see if they are a spell caster and of the desired caster level.
-	 * 
+	 *
 	 * @param minLevel
 	 * @return boolean
 	 */
@@ -3868,7 +3691,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	 * Method will go through the list of classes that the player character has
 	 * and see if they are a spell caster and of the total of all of their
 	 * spellcasting levels is at least the desired caster level.
-	 * 
+	 *
 	 * @param minLevel
 	 *            The desired caster level
 	 * @param sumOfLevels
@@ -3885,7 +3708,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	 * Method will go through the list of classes that the player character has
 	 * and see if they are a spell caster of the desired type and of the desired
 	 * caster level.
-	 * 
+	 *
 	 * @param spellType
 	 *            The type of spellcaster (i.e. "Arcane" or "Divine")
 	 * @param minLevel
@@ -3950,7 +3773,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	/**
 	 * Parses a spells range (short, medium or long) into an Integer based on
 	 * the spell and spell casters level
-	 * 
+	 *
 	 * @param aSpell
 	 *            The spell being output.
 	 * @param si
@@ -4010,7 +3833,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Computes the Caster Level for a Class
-	 * 
+	 *
 	 * @param aClass
 	 * @return caster level for class
 	 */
@@ -4024,7 +3847,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Computes the Caster Level for a Class
-	 * 
+	 *
 	 * @param aSpell
 	 * @return caster level for spell
 	 */
@@ -4035,7 +3858,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Calculates total bonus from all stats
-	 * 
+	 *
 	 * @param aType
 	 * @param aName
 	 * @return stat bonus to
@@ -4047,7 +3870,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Parses through all templates to calculate total bonus
-	 * 
+	 *
 	 * @param aType
 	 * @param aName
 	 * @return template bonus to
@@ -4061,7 +3884,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	 * Get the total bonus from Stats, Size, Age, Alignment, Classes,
 	 * companions, Equipment, Feats, Templates, Domains, Races, etc This value
 	 * is taken from an already populated HashMap for speed
-	 * 
+	 *
 	 * @param bonusType
 	 *            Type of bonus ("COMBAT" or "SKILL")
 	 * @param bonusName
@@ -4081,7 +3904,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	/**
 	 * Get the value of the desired stat at the point just before the character
 	 * was raised to the next level.
-	 * 
+	 *
 	 * @param stat
 	 *            The Stat to check.
 	 * @param level
@@ -4125,7 +3948,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * whether we should use/save Temporary bonuses
-	 * 
+	 *
 	 * @param aBool
 	 */
 	public void setUseTempMods(final boolean aBool)
@@ -4144,7 +3967,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	/**
 	 * Evaluates a variable for this character e.g:
 	 * getVariableValue("3+CHA","CLASS:Cleric") for Turn Undead
-	 * 
+	 *
 	 * @param aString
 	 *            The variable to be evaluated
 	 * @param src
@@ -4165,7 +3988,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	/**
 	 * Evaluates a variable for this character e.g:
 	 * getVariableValue("3+CHA","CLASS:Cleric") for Turn Undead
-	 * 
+	 *
 	 * @param aSpell
 	 *            This is specifically to compute bonuses to CASTERLEVEL for a
 	 *            specific spell.
@@ -4523,7 +4346,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * returns all equipment (from the equipmentList) of type aString
-	 * 
+	 *
 	 * @param aList
 	 * @param aType
 	 * @return List
@@ -4546,7 +4369,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Adds a <tt>Kit</tt> to the applied list of kits for the character.
-	 * 
+	 *
 	 * @param aKit
 	 *            The <tt>Kit</tt> to add.
 	 */
@@ -4573,7 +4396,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	 * @param adjSpellLevel
 	 *            is the adjustedLevel (including feat adjustments) of this
 	 *            spell, it may be higher if the user chooses a higher level.
-	 * 
+	 *
 	 * @return an empty string on successful completion, otherwise the return
 	 *         value indicates the reason the add function failed.
 	 */
@@ -4749,7 +4572,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 			else
 			{
 				ret = "You can only prepare "  + cast + " spells for level "
-					+ adjSpellLevel 
+					+ adjSpellLevel
 					+ " \nand there are no higher-level slots available.";
 				maxAllowed = cast;
 				int memTot = SpellCountCalc.memorizedSpellForLevelBook(this, aClass, adjSpellLevel, bookName);
@@ -4830,7 +4653,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * return value indicates if book was actually added or not
-	 * 
+	 *
 	 * @param aName
 	 * @return TRUE or FALSE
 	 */
@@ -5124,7 +4947,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	/**
 	 * Method will go through the list of classes that the PC has and see if
 	 * they can cast spells of desired type at desired <b>spell level</b>.
-	 * 
+	 *
 	 * @param spellType
 	 *            Spell type to check for
 	 * @param spellLevel
@@ -5175,7 +4998,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	/**
 	 * Method will go through the list of classes that the PC has and see if
 	 * they can cast spells of desired type at desired <b>spell level</b>.
-	 * 
+	 *
 	 * @param spellType
 	 *            Spell type to check for
 	 * @param spellLevel
@@ -5194,7 +5017,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 					&& ("Any".equalsIgnoreCase(spellType) || classSpellType.equalsIgnoreCase(spellType)))
 			{
 				int numCastLevel = this.getSpellSupport(aClass).getCastForLevel(spellLevel, this);
-				
+
 				// Get the number of known spells for the level
 				known += this.getSpellSupport(aClass).getKnownForLevel(spellLevel, "null", this);
 				if (numCastLevel > 0)
@@ -5222,7 +5045,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Check whether a deity can be selected by this character
-	 * 
+	 *
 	 * @return <code>true</code> means the deity can be a selected by a
 	 *         character with the given properties; <code>false</code> means
 	 *         the character cannot.
@@ -5234,7 +5057,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Return value indicates whether or not a spell was deleted.
-	 * 
+	 *
 	 * @param si
 	 * @param aClass
 	 * @param bookName
@@ -5319,7 +5142,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	 * <tt>save.BLABLA</tt> equals 0 whereas <tt>save.MAGIC.BLABLA</tt>
 	 * equals <tt>save.MAGIC</tt> <p> <br>
 	 * author: Thomas Behr 09-03-02
-	 * 
+	 *
 	 * @param check
 	 * @param tokenString
 	 *            tokenString to parse
@@ -5410,7 +5233,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * return value indicates whether or not a book was actually removed
-	 * 
+	 *
 	 * @param aName
 	 * @return true or false
 	 */
@@ -5634,7 +5457,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	 * previously saved character. there is no way to bypass the prerequisites
 	 * with this method, also this method does not print warning messages see:
 	 * incrementClassLevel(int, PCClass, boolean, boolean);
-	 * 
+	 *
 	 * @param mod
 	 *            the number of levels to add/remove
 	 * @param aClass
@@ -5647,9 +5470,9 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	}
 
 	/**
-	 * Calculates the number of languages that the character is qualified 
+	 * Calculates the number of languages that the character is qualified
 	 * for.
-	 *  
+	 *
 	 * @return The number of languages allowed
 	 */
 	public int getBonusLanguageCount()
@@ -5664,7 +5487,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Lists all the tokens that match prefix with associated values
-	 * 
+	 *
 	 * @param bonusType
 	 * @param bonusName
 	 * @return String TODO - Not sure what this is trying to do.
@@ -5840,7 +5663,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	 * Figure out if Load should affect AC and Skills, if so, set the load
 	 * appropriately, otherwise set a light load to eliminate the effects of
 	 * heavier loads
-	 * 
+	 *
 	 * @return a loadType appropriate for this Pc
 	 */
 	private Load getHouseRuledLoadType()
@@ -5855,7 +5678,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	/**
 	 * Calculate the AC bonus from equipped items. Extracted from
 	 * modToFromEquipment.
-	 * 
+	 *
 	 * @return PC's AC bonus from equipment
 	 */
 	public int modToACFromEquipment()
@@ -5871,9 +5694,9 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	/**
 	 * Calculate the ACCHECK bonus from equipped items. Extracted from
 	 * modToFromEquipment.
-	 * 
+	 *
 	 * TODO Penalty for load could/should be GameMode specific?
-	 * 
+	 *
 	 * @return PC's ACCHECK bonus from equipment
 	 * @deprecated due to PCACCHECK code control
 	 */
@@ -5883,9 +5706,9 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 		int bonus = 0;
 
 		int penaltyForLoad = (Load.MEDIUM == load) ? -3 : (Load.HEAVY == load) ? -6 : 0;
-		
+
 		final IdentityList<Equipment> vEqList = new IdentityList<>(getTempBonusItemList());
-		
+
 		for (Equipment eq : getEquippedEquipmentSet())
 		{
 			// Do not count virtual items created by temporary bonuses
@@ -5904,7 +5727,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	/**
 	 * Calculate the MAXDEX bonus taking account of equipped items. Extracted
 	 * from modToFromEquipment.
-	 * 
+	 *
 	 * @return MAXDEX bonus
 	 * @deprecated due to PCMAXDEX code control
 	 */
@@ -5951,7 +5774,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	/**
 	 * Takes a String and a Class name and computes spell based variable such as
 	 * Class level.
-	 * 
+	 *
 	 * @param aSpell The spell object
 	 * @param aString the variable to evaluate
 	 * @return String
@@ -6029,7 +5852,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Removes a "temporary" bonus
-	 * 
+	 *
 	 * @param aBonus
 	 */
 	public void removeTempBonus(final BonusObj aBonus)
@@ -6108,7 +5931,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	{
 		return sizeFacet.sizeInt(id);
 	}
-	
+
 	public int totalHitDice()
 	{
 		return levelFacet.getMonsterLevelCount(id);
@@ -6133,7 +5956,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * replaces oldItem with newItem in all EquipSets
-	 * 
+	 *
 	 * @param oldItem
 	 * @param newItem
 	 */
@@ -6295,7 +6118,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Active BonusObjs
-	 * 
+	 *
 	 * @return List
 	 */
 	public Collection<BonusObj> getActiveBonusList()
@@ -6305,7 +6128,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Parses through all Equipment items and calculates total Bonus
-	 * 
+	 *
 	 * @param aType
 	 * @param aName
 	 * @return equipment bonus to
@@ -6341,7 +6164,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	 * Return a hashmap of the first maxCharacterLevel character levels that a
 	 * character has taken This will be a hash of "Class name"=>"number of
 	 * levels as a string". For example, {"Fighter"=>"2", "Cleric":"16"}
-	 * 
+	 *
 	 * @param maxCharacterLevel
 	 *            the maximum character level that we can include in this map
 	 * @return character level map
@@ -6384,7 +6207,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Returns a bonus.
-	 * 
+	 *
 	 * @param aList
 	 * @param aType
 	 * @param aName
@@ -6423,7 +6246,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Get the class level as a String
-	 * 
+	 *
 	 * @param aClassKey
 	 * @param doReplace
 	 * @return class level as String
@@ -6604,10 +6427,10 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * availableSpells sk4p 13 Dec 2002
-	 * 
+	 *
 	 * For learning or preparing a spell: Are there slots available at this
 	 * level or higher Fixes BUG [569517]
-	 * 
+	 *
 	 * @param level
 	 *            the level being checked for availability
 	 * @param aClass
@@ -6867,21 +6690,21 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	/**
 	 * Compute total bonus from a List of BonusObjs Use cost of bonus to adjust
 	 * total bonus up or down This method takes a list of bonus objects.
-	 * 
+	 *
 	 * For each object in the list, it gets the creating object and queries it
 	 * for its "COST". It then multiplies the value of the bonus by this cost
 	 * and adds it to the cumulative total so far. If subSearch is true, the
 	 * choices made in the object that the bonus originated in are searched, the
 	 * effective bonus is multiplied by the number of times this bonus appears
 	 * in the list.
-	 * 
+	 *
 	 * Note: This COST seems to be used for several different things in the code
 	 * base, in feats for instance, it is used to modify the feat pool by
 	 * amounts other than 1 when selecting a given feat. Here it is used as a
 	 * multiplier to say how effective a given bonus is i.e. a bonus with a COST
 	 * of 0.5 counts for half its normal value. The COST is limited to a max of
 	 * 1, so it can only make bonuses less effective.
-	 * 
+	 *
 	 * @param aList
 	 *            a list of bonus objects
 	 * @return the calculated cumulative bonus
@@ -6895,7 +6718,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	 * calculate the total racial modifier to save: racial bonuses like the
 	 * standard halfling's +1 on all saves template bonuses like the Lightfoot
 	 * halfling's +1 on all saves racial base modifiers for certain monsters
-	 * 
+	 *
 	 * @param check
 	 * @return int
 	 */
@@ -6912,7 +6735,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	/**
 	 * Counts the number of spells inside a spellbook Yes, divine casters can
 	 * have a "spellbook"
-	 * 
+	 *
 	 * @param aString
 	 * @return spells in a book
 	 */
@@ -6966,7 +6789,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Get the spell class list
-	 * 
+	 *
 	 * @return List
 	 */
 	public List<? extends PObject> getSpellClassList()
@@ -6992,9 +6815,9 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	public boolean includeSkill(final Skill skill, final SkillFilter filter)
 	{
-		if (skill.getSafe(ObjectKey.EXCLUSIVE) && 
+		if (skill.getSafe(ObjectKey.EXCLUSIVE) &&
 				!this.isClassSkill(skill) &&
-				!this.isCrossClassSkill(skill)) 
+				!this.isCrossClassSkill(skill))
 		{
 			return false;
 		}
@@ -7005,9 +6828,9 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 		}
 		else if (filter == SkillFilter.NonDefault)
 		{
-			return (SkillRankControl.getTotalRank(this, skill).floatValue() > 0 || 
-					SkillModifier.modifier(skill, this) != 
-					SkillModifier.getStatMod(skill, this) + 
+			return (SkillRankControl.getTotalRank(this, skill).floatValue() > 0 ||
+					SkillModifier.modifier(skill, this) !=
+					SkillModifier.getStatMod(skill, this) +
 					getSizeAdjustmentBonusTo("SKILL", skill.getKeyName()));
 		}
 		else if (filter == SkillFilter.Usable)
@@ -7033,8 +6856,8 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	 * previously saved character. there is no way to bypass the prerequisites
 	 * with this method, see: incrementClassLevel(int, PCClass, boolean,
 	 * boolean);
-	 * 
-	 * 
+	 *
+	 *
 	 * @param numberOfLevels
 	 *            number of levels to add
 	 * @param globalClass
@@ -7051,7 +6874,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	 * Change the number of levels a character has in a particular class. Note:
 	 * It is assumed that this method is not used as part of loading a
 	 * previously saved character.
-	 * 
+	 *
 	 * @param numberOfLevels
 	 *            The number of levels to add or remove. If a positive number is
 	 *            passed in then that many levels will be added. If the number
@@ -7170,9 +6993,9 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	}
 
 	/**
-	 * Remove from the character the PCLevelInfo representing the highest level 
+	 * Remove from the character the PCLevelInfo representing the highest level
 	 * of the supplied class.
-	 *  
+	 *
 	 * @param classKeyName The keyname of the class to have a level removed.
 	 * @return The level removed, or null if none was found
 	 */
@@ -7199,7 +7022,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	 * Method: 1: 4d6 Drop Lowest 2: 3d6 3: 5d6 Drop 2 Lowest 4: 4d6 reroll 1's
 	 * drop lowest 5: 4d6 reroll 1's and 2's drop lowest 6: 3d6 +5 7: 5d6 Drop
 	 * lowest and middle as per FREQ #458917
-	 * 
+	 *
 	 * @param method
 	 *            the method to be used for rolling.
 	 */
@@ -7285,7 +7108,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	 * ascending order of the equipment's outputIndex field. If multiple items
 	 * of equipment have the same outputIndex they will be ordered by name. Note
 	 * hidden items (outputIndex = -1) are not included in list.
-	 * 
+	 *
 	 * @param unsortedEquip
 	 *            An ArrayList of the equipment to be sorted.
 	 * @param merge
@@ -7362,7 +7185,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 		/**
 		 * Constructor
-		 * 
+		 *
 		 * @param b
 		 * @param t
 		 */
@@ -7373,7 +7196,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 		/**
 		 * Get bonus
-		 * 
+		 *
 		 * @return bonus
 		 */
 		public int getBonus()
@@ -7383,7 +7206,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 		/**
 		 * Get type
-		 * 
+		 *
 		 * @return type
 		 */
 		public String getType()
@@ -7393,7 +7216,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 		/**
 		 * Set bonus
-		 * 
+		 *
 		 * @param newBonus
 		 */
 		public void setBonus(final int newBonus)
@@ -7435,7 +7258,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	 * replaced with the current list of languages in globals. These should be
 	 * further restricted by the prerequisites of the languages to ensure that
 	 * 'secret' languages are not offered.
-	 * 
+	 *
 	 * @return List of bonus languages for the character.
 	 */
 	public Set<Language> getLanguageBonusSelectionList()
@@ -7448,7 +7271,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	 * equipment bonuses or both. This method ensure stacking rules are applied
 	 * to all included bonuses. If not excluding either, it is quicker to use
 	 * getTotalBonusTo.
-	 * 
+	 *
 	 * @param stat
 	 *            The stat to calculate the bonus for.
 	 * @param useTemp
@@ -7469,7 +7292,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	 * temporary bonuses, equipment bonuses or both. This method ensures
 	 * stacking rules are applied to all included bonuses. If not excluding
 	 * either, it is quicker to use getTotalStatAtLevel.
-	 * 
+	 *
 	 * @param stat
 	 *            The stat to calculate the value of.
 	 * @param level
@@ -7498,7 +7321,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	 * Returns a deep copy of the PlayerCharacter. Note: This method does a
 	 * shallow copy of many lists in here that seem to point to "system"
 	 * objects. These copies should be validated before using this method.
-	 * 
+	 *
 	 * @return a new deep copy of the <code>PlayerCharacter</code>
 	 */
 	@Override
@@ -7553,7 +7376,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 		{
 			aClone.addEquipment(equip.clone());
 		}
-		
+
 		aClone.levelInfoFacet.removeAll(aClone.id);
 		for (PCLevelInfo info : getLevelInfo())
 		{
@@ -7580,8 +7403,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 		System.arraycopy(ageSetKitSelections, 0, aClone.ageSetKitSelections, 0, ageSetKitSelections.length);
 
 		// Not sure what this is for
-		aClone.displayUpdate = displayUpdate;
-		aClone.setImporting(false);
+		aClone.importing = false;
 		aClone.useTempMods = useTempMods;
 		aClone.costPool = costPool;
 		aClone.currentEquipSetNumber = currentEquipSetNumber;
@@ -7598,7 +7420,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 		aClone.calcActiveBonuses();
 		//Just to be safe
 		aClone.equippedFacet.reset(aClone.id);
-		
+
 		aClone.serial = serial;
 
 		return aClone;
@@ -7606,19 +7428,25 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Set the string for the characteristic
-	 * 
+	 *
 	 * @param key
 	 * @param s
 	 */
 	public void setStringFor(PCStringKey key, String s)
 	{
+		assert(key != null);
 		String currValue = factFacet.get(id, key);
-		if ((currValue == null && s != null)
-			|| (currValue != null && !currValue.equals(s)))
+		if (PlayerCharacter.shouldDirtyForChange(s, currValue))
 		{
 			factFacet.set(id, key, s);
 			setDirty(true);
 		}
+	}
+
+	private static boolean shouldDirtyForChange(final String s, final String currValue)
+	{
+		return (currValue == null && s != null)
+			|| (currValue != null && !currValue.equals(s));
 	}
 
 	private Float getEquippedQty(EquipSet eSet, Equipment eqI)
@@ -7629,7 +7457,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	/**
 	 * If an item can only go in one location, return the name of that location
 	 * to add to an EquipSet
-	 * 
+	 *
 	 * @param eqI
 	 * @return single location
 	 */
@@ -7669,7 +7497,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	}
 
 	/**
-	 * Identify the equipping location for a natural weapon. 
+	 * Identify the equipping location for a natural weapon.
 	 * @param eqI The natural weapon
 	 * @return The location name, or null if not a natural weapon.
 	 */
@@ -7691,7 +7519,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * returns true if you can put Equipment into a location in EquipSet
-	 * 
+	 *
 	 * @param eSet
 	 * @param locName
 	 * @param eqI
@@ -7856,7 +7684,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	/**
 	 * Checks to see if Equipment exists in selected EquipSet and if so, then
 	 * return the EquipSet containing eqI
-	 * 
+	 *
 	 * @param eSet
 	 * @param eqI
 	 * @return EquipSet
@@ -7885,10 +7713,10 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	}
 
 	/**
-	 * returns a new id_Path with the last id one higher than the current highest 
+	 * returns a new id_Path with the last id one higher than the current highest
 	 * child of the supplied EquipSet.
-	 * 
-	 * @param eSet The equipset which would be the parent of a new node. 
+	 *
+	 * @param eSet The equipset which would be the parent of a new node.
 	 * @return new id path
 	 */
 	private String getNewIdPath(EquipSet eSet)
@@ -7906,12 +7734,12 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	}
 
 	/**
-	 * Identify a new id (only the final number in the path) for a child 
-	 * equipment set. The id is guarantyeed to be unique and have no siblings 
+	 * Identify a new id (only the final number in the path) for a child
+	 * equipment set. The id is guarantyeed to be unique and have no siblings
 	 * with higher ids.
-	 *  
+	 *
 	 * @param pid The parent path.
-	 * @return New id for a child node 
+	 * @return New id for a child node
 	 */
 	public int getNewChildId(String pid)
 	{
@@ -8002,9 +7830,9 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 		else if (locName.equalsIgnoreCase("Equipped"))
 		{
 			String singleLoc = getSingleLocation(eqI);
-			if (singleLoc.length() > 0)
+			if (!singleLoc.isEmpty())
 			{
-				locName = singleLoc; 
+				locName = singleLoc;
 			}
 		}
 
@@ -8073,10 +7901,10 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 		String newPath = getNewIdPath(parent);
 		es.setIdPath(newPath);
 	}
-	
+
 	/**
 	 * Gets a 'safe' String representation
-	 * 
+	 *
 	 * @param key
 	 * @return a 'safe' String
 	 */
@@ -8093,11 +7921,11 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	/**
 	 * Sets if ADD: level abilities should be processed when incrementing a
 	 * level.
-	 * 
+	 *
 	 * <p>
 	 * <b>Note</b>: This is kind of a hack used by the Kit code to allow a kit
 	 * to specify what the level abilities are.
-	 * 
+	 *
 	 * @param yesNo
 	 *            Yes if level increases should process ADD: level abilities.
 	 */
@@ -8108,7 +7936,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Returns if level increases will process ADD: level abilities.
-	 * 
+	 *
 	 * @return <tt>true</tt> if ADD: level abilities will be processed.
 	 */
 	public boolean doLevelAbilities()
@@ -8118,22 +7946,22 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/*
 	 * For debugging purposes Dumps contents of spell books to System.err
-	 * 
+	 *
 	 * static public void dumpSpells(final PlayerCharacter pc) { final List
 	 * bookList = pc.getSpellBooks(); for(int bookIdx = 0; bookIdx <
 	 * bookList.size(); ++bookIdx) { final String bookName = (String)
 	 * pc.getSpellBooks().get(bookIdx);
-	 * 
+	 *
 	 * System.err.println("=========="); System.err.println("Book:" + bookName);
 	 * final List casterList = pc.getSpellClassList(); for(int casterIdx = 0;
 	 * casterIdx < casterList.size(); ++casterIdx) { final PObject aCaster =
 	 * (PObject) casterList.get(casterIdx); final List spellList =
 	 * aCaster.getCharacterSpellList(); if (spellList == null) { continue; }
 	 * System.err.println("Class/Race:" + aCaster.getName());
-	 * 
+	 *
 	 * for (Iterator i = spellList.iterator(); i.hasNext();) { final
 	 * CharacterSpell cs = (CharacterSpell) i.next();
-	 * 
+	 *
 	 * for (Iterator csi = cs.getInfoListIterator(); csi.hasNext();) { final
 	 * SpellInfo sInfo = (SpellInfo) csi.next(); if
 	 * (bookName.equals(sInfo.getBook())) {
@@ -8224,8 +8052,8 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	}
 
 	/**
-	 * Get the remaining Feat Points (or Skill Points if the GameMode uses a Point Pool).  
-	 * 
+	 * Get the remaining Feat Points (or Skill Points if the GameMode uses a Point Pool).
+	 *
 	 * @return Number of remaining Feat Points
 	 */
 	public double getRemainingFeatPoolPoints()
@@ -8244,7 +8072,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Get the number of remaining feat points.
-	 * 
+	 *
 	 * @param bIncludeBonus - Flag whether to include any bonus feat points
 	 * @return number of remaining feat points
 	 */
@@ -8325,17 +8153,17 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	}
 
 	/**
-	 * Retrieve a list of all abilities held by the character in the specified 
+	 * Retrieve a list of all abilities held by the character in the specified
 	 * category. <br>
-	 * NB: Abilities are only returned in the category they are taken 
+	 * NB: Abilities are only returned in the category they are taken
 	 * in, so if parent category is supplied only those taken directly in the
-	 * parent category will be returned. e.g. If asking for feats, Power Attack 
-	 * taken as a fighter feat will not be returned. You would need to query 
+	 * parent category will be returned. e.g. If asking for feats, Power Attack
+	 * taken as a fighter feat will not be returned. You would need to query
 	 * fighter feats to get that. <br>
 	 * NB: Duplicate abilities will not be returned by this method. The order
 	 * of priority is normal, virtual then automatic.
-	 * 
-	 * @param aCategory The ability category to be queried.  
+	 *
+	 * @param aCategory The ability category to be queried.
 	 * @return The list of abilities of the category regardless of nature.
 	 */
 	public List<Ability> getAggregateAbilityListNoDuplicates(final AbilityCategory aCategory)
@@ -8584,10 +8412,10 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	}
 
 	/**
-	 * Return a list of the choice assications in an export compatible string 
-	 * format. Note that this is not sufficient for the choice to be 
+	 * Return a list of the choice assications in an export compatible string
+	 * format. Note that this is not sufficient for the choice to be
 	 * reconstructed, so this format should never be saved, only output.
-	 * 
+	 *
 	 * @param obj The choice to be output.
 	 * @return The list of choices.
 	 */
@@ -8745,7 +8573,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	{
 		return statLockFacet.getLockedStat(id, stat);
 	}
-	
+
 	public String getDescription(CNAbility cna)
 	{
 		return getDescription(Collections.singletonList(cna));
@@ -8827,7 +8655,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * Retrieve the character's existing version of this spell, if any.
-	 * @param po The source of the spell list for this spell (normally a PCClass) 
+	 * @param po The source of the spell list for this spell (normally a PCClass)
 	 * @param spell The spell to be retrieved
 	 * @param owner The source of the spell (either the PCClass or the Domian)
 	 * @return The character's existing instance of the spell, or null if none.
@@ -9179,7 +9007,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	{
 		return statFacet.getSet(id);
 	}
-	
+
 	public boolean hasDefaultDomainSource()
 	{
 		return defaultDomainSource != null;
@@ -9230,7 +9058,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	{
 		return domainFacet.getCount(id);
 	}
-	
+
 	public Set<Domain> getDomainSet()
 	{
 		return domainFacet.getSet(id);
@@ -9451,7 +9279,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	 * WARNING: Use this method SPARINGLY... and only for transition to the
 	 * facet model. It is NOT an excuse to throw around a PlayerCharacter object
 	 * when unnecessary
-	 * 
+	 *
 	 * @return The id of the character as used by the facets.
 	 */
 	public CharID getCharID()
@@ -9720,7 +9548,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 		List<PCClass> newClasses = getClassList();
 		Collection<PCLevelInfo> levelInfo = getLevelInfo();
 		int levelIndex = 1;
-		
+
 		for (PCLevelInfo lvlInfo : levelInfo)
 		{
 			Map<String, PCClass> classMap = new HashMap<>();
@@ -9833,7 +9661,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	{
 		return spellListFacet.getSet(id, cdo);
 	}
-	
+
 	public boolean hasSpellList(CDOMObject cdo, CDOMList<Spell> list)
 	{
 		return spellListFacet.containsFrom(id, list, cdo);
@@ -9873,10 +9701,10 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	}
 
 	/**
-	 * Adds to the provided list any spells that have been granted to the character's class by abilities 
+	 * Adds to the provided list any spells that have been granted to the character's class by abilities
 	 * through the use of SPELLKNOWN:CLASS tags.
-	 * 
-	 * @param aClass The character class owning the spell list. 
+	 *
+	 * @param aClass The character class owning the spell list.
 	 * @param cSpells The list of spells to be updated.
 	 */
 	public void addBonusKnownSpellsToList(CDOMObject aClass,
@@ -9904,7 +9732,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 						break;
 					}
 				}
-				
+
 				if (acs == null)
 				{
 					acs = new CharacterSpell(aClass, spell);
@@ -9970,9 +9798,9 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 		int lockedMonsterSkillPoints;
 		int spMod = pcClass.getSafe(FormulaKey.START_SKILL_POINTS).resolve(this,
 			pcClass.getQualifiedKey()).intValue();
-	
+
 		spMod += (int) getTotalBonusTo("SKILLPOINTS", "NUMBER");
-	
+
 		if (pcClass.isMonster())
 		{
 			lockedMonsterSkillPoints =
@@ -9990,7 +9818,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 					spMod = monSkillPts;
 				}
 			}
-	
+
 			if (characterLevel != 1)
 			{
 				// If this level is one that is not entitled to skill points
@@ -10004,16 +9832,16 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 				}
 			}
 		}
-	
+
 		spMod = updateBaseSkillMod(pcClass, spMod);
-	
+
 		if (characterLevel == 1)
 		{
 			if (!SettingsHandler.getGame().isPurchaseStatMode())
 			{
 				setPoolAmount(0);
 			}
-	
+
 			spMod *= getRace().getSafe(IntegerKey.INITIAL_SKILL_MULT);
 			if (ageFacet.getAge(id) <= 0)
 			{
@@ -10025,7 +9853,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 		{
 			spMod *= Globals.getSkillMultiplierForLevel(characterLevel);
 		}
-	
+
 		return spMod;
 	}
 
@@ -10034,28 +9862,28 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 		// skill min is 1, unless class gets 0 skillpoints per level (for second
 		// apprentice class)
 		final int skillMin = (spMod > 0) ? 1 : 0;
-	
+
 		if (pcClass.getSafe(ObjectKey.MOD_TO_SKILLS))
 		{
 			spMod += (int) getStatBonusTo("MODSKILLPOINTS", "NUMBER");
-	
+
 			if (spMod < 1)
 			{
 				spMod = 1;
 			}
 		}
-	
+
 		// Race modifiers apply after Intellegence. BUG 577462
 		Formula safe = getRace().getSafe(FormulaKey.SKILL_POINTS_PER_LEVEL);
 		spMod += safe.resolve(this, "").intValue();
 		spMod = Math.max(skillMin, spMod); // Minimum 1, not sure if bonus
-	
+
 		// level can be < 1, better safe than sorry
 		for (PCTemplate template : getTemplateSet())
 		{
 			spMod += template.getSafe(IntegerKey.BONUS_CLASS_SKILL_POINTS);
 		}
-	
+
 		return spMod;
 	}
 
@@ -10142,9 +9970,9 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 				(pcc == null) ? null : getClassKeyed(pcc.getKeyName());
 		skillRankFacet.set(id, sk, localClass, value);
 	}
-	
+
 	/**
-	 * Retrieve the classes that have ranks in this skill. NB: For granted ranks 
+	 * Retrieve the classes that have ranks in this skill. NB: For granted ranks
 	 * this may include null.
 	 * @param sk The skill to be checked.
 	 * @return The collection of classes with ranks - may include null as a PCClass.
@@ -10156,7 +9984,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 
 	/**
 	 * returns ranks taken specifically in skill
-	 * 
+	 *
 	 * @return ranks taken in skill
 	 */
 	public Float getRank(Skill sk)
@@ -10221,7 +10049,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 				}
 			}
 		}
-	
+
 		return spellList;
 	}
 
@@ -10236,11 +10064,11 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 		// And we are set up to automatically assign known spells...
 		List<? extends CDOMList<Spell>> spellLists = getSpellLists(pcc);
 		SpellSupportForPCClass spellSupport = getSpellSupport(pcc);
-		
+
 		// Recalculate the number of spells per day of each level
 		// that this chracter can cast in this class.
 		spellSupport.calcCastPerDayMapForLevel(this);
-		
+
 		// Get the maximum spell level that this character can cast.
 		final int maxCastableLevel = spellSupport.getMaxCastLevel();
 
@@ -10442,7 +10270,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 		}
 		allowInteraction = b;
 	}
-	
+
 	public boolean isAllowInteraction()
 	{
 		return allowInteraction;
@@ -10548,7 +10376,7 @@ public class PlayerCharacter  implements Cloneable, VariableContainer
 	{
 		return resultFacet.getGlobalVariable(id, varName);
 	}
-	
+
 	public Object getLocal(CDOMObject owner, String varName)
 	{
 		return resultFacet.getLocalVariable(id, owner, varName);

--- a/code/src/java/pcgen/core/display/SkillCostDisplay.java
+++ b/code/src/java/pcgen/core/display/SkillCostDisplay.java
@@ -39,9 +39,8 @@ import pcgen.core.bonus.BonusPair;
 import pcgen.core.utils.CoreUtility;
 import pcgen.util.Delta;
 
-public class SkillCostDisplay
+public final class SkillCostDisplay
 {
-
 	/**
 	 * Builds up a string describing what makes up the misc modifier for a skill
 	 * for a character. This can either be in long form '+2[skill TUMBLE gteq
@@ -178,7 +177,7 @@ public class SkillCostDisplay
 		SkillCostDisplay.appendBonusDesc(bonusDetails, aCheckMod, "ARMOR");
 	
 		String aString = SettingsHandler.getGame().getRankModFormula();
-		if (aString.length() != 0)
+		if (!aString.isEmpty())
 		{
 			aString = aString.replaceAll(Pattern.quote("$$RANK$$"), SkillRankControl.getTotalRank(aPC, sk).toString());
 			bonus = aPC.getVariableValue(aString, "").intValue();

--- a/code/src/java/pcgen/core/npcgen/NPCGenerator.java
+++ b/code/src/java/pcgen/core/npcgen/NPCGenerator.java
@@ -45,6 +45,7 @@ import pcgen.core.Domain;
 import pcgen.core.GameMode;
 import pcgen.core.Globals;
 import pcgen.core.PCAlignment;
+import pcgen.cdom.enumeration.PCAttribute;
 import pcgen.core.PCClass;
 import pcgen.core.PCStat;
 import pcgen.core.PlayerCharacter;
@@ -727,25 +728,26 @@ public class NPCGenerator
 			aPC.getBioSet().randomize(randBioString, aPC);
 			
 			final List<String> globalHairStyleList = SystemCollections.getUnmodifiableHairStyleList();
-			aPC.setHairStyle(globalHairStyleList.get(RandomUtil.getRandomInt(globalHairStyleList.size())));
+			aPC.setPCAttribute(PCAttribute.HAIRSTYLE, globalHairStyleList.get(RandomUtil.getRandomInt(globalHairStyleList.size())));
 			final List<String> speechList = SystemCollections.getUnmodifiableSpeechList();
-			aPC.setSpeechTendency(speechList.get(RandomUtil.getRandomInt(speechList.size())));
+			aPC.setPCAttribute(PCAttribute.SPEECHTENDENCY, speechList.get(RandomUtil.getRandomInt(speechList.size())));
 			final List<String> globalPhobiaList = SystemCollections.getUnmodifiablePhobiaList();
-			aPC.setPhobias(globalPhobiaList.get(RandomUtil.getRandomInt(globalPhobiaList.size())));
+			aPC.setPCAttribute(PCAttribute.PHOBIAS, globalPhobiaList.get(RandomUtil.getRandomInt(globalPhobiaList.size())));
 			final List<String> globalInterestsList = SystemCollections.getUnmodifiableInterestsList();
-			aPC.setInterests(globalInterestsList.get(RandomUtil.getRandomInt(globalInterestsList.size())));
+			aPC.setPCAttribute(PCAttribute.INTERESTS, globalInterestsList.get(RandomUtil.getRandomInt(globalInterestsList.size())));
 			final List<String> globalPhraseList = SystemCollections.getUnmodifiablePhraseList();
-			aPC.setCatchPhrase(globalPhraseList.get(RandomUtil.getRandomInt(globalPhraseList.size())));
+			aPC.setPCAttribute(PCAttribute.CATCHPHRASE, globalPhraseList.get(RandomUtil.getRandomInt(globalPhraseList.size())));
 			final List<String> globalTraitList = SystemCollections.getUnmodifiableTraitList();
-			aPC.setTrait1(globalTraitList.get(RandomUtil.getRandomInt(globalTraitList.size())));
-			aPC.setTrait2(globalTraitList.get(RandomUtil.getRandomInt(globalTraitList.size())));
+			// TODO: it is possible for trait1 == trait2
+			aPC.setPCAttribute(PCAttribute.PERSONALITY1, globalTraitList.get(RandomUtil.getRandomInt(globalTraitList.size())));
+			aPC.setPCAttribute(PCAttribute.PERSONALITY2, globalTraitList.get(RandomUtil.getRandomInt(globalTraitList.size())));
 
 			final List<String> globalCityList = SystemCollections.getUnmodifiableCityList();
-			aPC.setResidence(globalCityList.get(RandomUtil.getRandomInt(globalCityList.size())));
+			aPC.setPCAttribute(PCAttribute.RESIDENCE, globalCityList.get(RandomUtil.getRandomInt(globalCityList.size())));
 			final List<String> globalLocationList = SystemCollections.getUnmodifiableLocationList();
-			aPC.setLocation(globalLocationList.get(RandomUtil.getRandomInt(globalLocationList.size())));
+			aPC.setPCAttribute(PCAttribute.LOCATION, globalLocationList.get(RandomUtil.getRandomInt(globalLocationList.size())));
 			final List<String> globalBirthplaceList = SystemCollections.getUnmodifiableBirthplaceList();
-			aPC.setBirthplace(globalBirthplaceList.get(RandomUtil.getRandomInt(globalBirthplaceList.size())));
+			aPC.setPCAttribute(PCAttribute.BIRTHPLACE, globalBirthplaceList.get(RandomUtil.getRandomInt(globalBirthplaceList.size())));
 			
 			//TODO: Link in with the doomsday book name generator
 //			final Names nameGen = Names.getInstance();

--- a/code/src/java/pcgen/gui2/facade/CharacterFacadeImpl.java
+++ b/code/src/java/pcgen/gui2/facade/CharacterFacadeImpl.java
@@ -92,6 +92,7 @@ import pcgen.core.Globals;
 import pcgen.core.Kit;
 import pcgen.core.Language;
 import pcgen.core.PCAlignment;
+import pcgen.cdom.enumeration.PCAttribute;
 import pcgen.core.PCClass;
 import pcgen.core.PCStat;
 import pcgen.core.PCTemplate;
@@ -2015,7 +2016,7 @@ public class CharacterFacadeImpl implements CharacterFacade, EquipmentListListen
 	public void setTabName(String name)
 	{
 		tabName.set(name);
-		theCharacter.setTabName(name);
+		theCharacter.setPCAttribute(PCAttribute.TABNAME, name);
 	}
 
 	/* (non-Javadoc)
@@ -2083,7 +2084,7 @@ public class CharacterFacadeImpl implements CharacterFacade, EquipmentListListen
 	public void setSkinColor(String color)
 	{
 		skinColor.set(color);
-		theCharacter.setSkinColor(color);
+		theCharacter.setPCAttribute(PCAttribute.SKINCOLOR, color);
 	}
 
 	/**
@@ -2102,7 +2103,7 @@ public class CharacterFacadeImpl implements CharacterFacade, EquipmentListListen
 	public void setHairColor(String color)
 	{
 		hairColor.set(color);
-		theCharacter.setHairColor(color);
+		theCharacter.setPCAttribute(PCAttribute.HAIRCOLOR, color);
 	}
 
 	/**

--- a/code/src/java/pcgen/gui2/facade/DescriptionFacadeImpl.java
+++ b/code/src/java/pcgen/gui2/facade/DescriptionFacadeImpl.java
@@ -22,16 +22,17 @@
  */
 package pcgen.gui2.facade;
 
+import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
-
 import org.apache.commons.lang.StringUtils;
-
 import pcgen.cdom.enumeration.BiographyField;
 import pcgen.cdom.enumeration.PCStringKey;
 import pcgen.core.ChronicleEntry;
 import pcgen.core.NoteItem;
+import pcgen.cdom.enumeration.NotePCAttribute;
 import pcgen.core.PlayerCharacter;
 import pcgen.core.display.CharacterDisplay;
 import pcgen.facade.core.ChronicleEntryFacade;
@@ -41,22 +42,18 @@ import pcgen.facade.util.DefaultListFacade;
 import pcgen.facade.util.DefaultReferenceFacade;
 import pcgen.facade.util.ListFacade;
 import pcgen.facade.util.ReferenceFacade;
+import pcgen.facade.util.WriteableReferenceFacade;
 import pcgen.system.LanguageBundle;
 
 /**
- * The Class <code>DescriptionFacadeImpl</code> is an implementation of 
+ * The Class {@code DescriptionFacadeImpl} is an implementation of
  * the DescriptionFacade interface for the new user interface. It is 
  * intended to provide a full implementation of the new ui/core 
  * interaction layer.
  *
- * <br>
- * Last Editor: $Author$
- * Last Edited: $Date$
- * 
  * @author James Dempsey &lt;jdempsey@users.sourceforge.net&gt;
- * @version $Revision$
  */
-public class DescriptionFacadeImpl implements DescriptionFacade
+class DescriptionFacadeImpl implements DescriptionFacade
 {
 	/** Name of the Biography node. */
 	private static final String NOTE_NAME_BIO = LanguageBundle
@@ -79,57 +76,49 @@ public class DescriptionFacadeImpl implements DescriptionFacade
 
 	private final PlayerCharacter theCharacter;
 	private final CharacterDisplay charDisplay;
-	private DefaultListFacade<ChronicleEntryFacade> chronicleEntries;
+	private final DefaultListFacade<ChronicleEntryFacade> chronicleEntries;
 	private DefaultListFacade<NoteFacade> notes;
 
-	private DefaultReferenceFacade<String> birthday;
-	private DefaultReferenceFacade<String> location;
-	private DefaultReferenceFacade<String> city;
-	private DefaultReferenceFacade<String> region;
-	private DefaultReferenceFacade<String> birthplace;
-	private DefaultReferenceFacade<String> personalityTrait1;
-	private DefaultReferenceFacade<String> personalityTrait2;
-	private DefaultReferenceFacade<String> phobias;
-	private DefaultReferenceFacade<String> interests;
-	private DefaultReferenceFacade<String> catchPhrase;
-	private DefaultReferenceFacade<String> hairStyle;
-	private DefaultReferenceFacade<String> speechPattern;
-	private DefaultListFacade<BiographyField> customBiographyFields; 	
+	private Map<BiographyField, WriteableReferenceFacade<String>> bioData = new EnumMap<>(BiographyField.class);
+
+	private final DefaultListFacade<BiographyField> customBiographyFields;
+
+	private static DefaultReferenceFacade<String> newDefaultBioFieldFor(final PlayerCharacter pc, final PCStringKey key)
+	{
+		return new DefaultReferenceFacade<>(pc.getDisplay().getSafeStringFor(key));
+	}
 
 	/**
 	 * Create a new DescriptionFacadeImpl instance for the character.
 	 * @param pc The character.
 	 */
-	public DescriptionFacadeImpl(PlayerCharacter pc)
+	DescriptionFacadeImpl(PlayerCharacter pc)
 	{
 		theCharacter = pc;
 		charDisplay = pc.getDisplay();
 		chronicleEntries = new DefaultListFacade<>();
-		for (ChronicleEntryFacade entry : charDisplay.getChronicleEntries())
-		{
-			chronicleEntries.addElement(entry);
-		}
-		
+		charDisplay.getChronicleEntries().forEach(chronicleEntries::addElement);
+
 		notes = new DefaultListFacade<>();
 		addDefaultNotes();
-		
-		for (NoteItem item : charDisplay.getNotesList())
+
+		charDisplay.getNotesList().forEach(item ->
 		{
 			notes.addElement(item);
-		}
+		});
 
-		birthday = new DefaultReferenceFacade<>(charDisplay.getSafeStringFor(PCStringKey.BIRTHDAY));
-		location = new DefaultReferenceFacade<>(charDisplay.getSafeStringFor(PCStringKey.LOCATION));
-		city = new DefaultReferenceFacade<>(charDisplay.getSafeStringFor(PCStringKey.RESIDENCE));
-		region = new DefaultReferenceFacade<>(charDisplay.getRegionString());
-		birthplace = new DefaultReferenceFacade<>(charDisplay.getSafeStringFor(PCStringKey.BIRTHPLACE));
-		personalityTrait1 = new DefaultReferenceFacade<>(charDisplay.getSafeStringFor(PCStringKey.PERSONALITY1));
-		personalityTrait2 = new DefaultReferenceFacade<>(charDisplay.getSafeStringFor(PCStringKey.PERSONALITY2));
-		phobias = new DefaultReferenceFacade<>(charDisplay.getSafeStringFor(PCStringKey.PHOBIAS));
-		interests = new DefaultReferenceFacade<>(charDisplay.getSafeStringFor(PCStringKey.INTERESTS));
-		catchPhrase = new DefaultReferenceFacade<>(charDisplay.getSafeStringFor(PCStringKey.CATCHPHRASE));
-		hairStyle = new DefaultReferenceFacade<>(charDisplay.getSafeStringFor(PCStringKey.HAIRSTYLE));
-		speechPattern = new DefaultReferenceFacade<>(charDisplay.getSafeStringFor(PCStringKey.SPEECHTENDENCY));
+		bioData.put(BiographyField.BIRTHDAY, DescriptionFacadeImpl.newDefaultBioFieldFor(pc, PCStringKey.BIRTHDAY));
+		bioData.put(BiographyField.BIRTHPLACE, new DefaultReferenceFacade<>(charDisplay.getSafeStringFor(PCStringKey.BIRTHPLACE)));
+		bioData.put(BiographyField.LOCATION, new DefaultReferenceFacade<>(charDisplay.getSafeStringFor(PCStringKey.LOCATION)));
+		bioData.put(BiographyField.CITY, new DefaultReferenceFacade<>(charDisplay.getSafeStringFor(PCStringKey.RESIDENCE)));
+		bioData.put(BiographyField.REGION, new DefaultReferenceFacade<>(charDisplay.getRegionString()));
+		bioData.put(BiographyField.PERSONALITY_TRAIT_1, new DefaultReferenceFacade<>(charDisplay.getSafeStringFor(PCStringKey.PERSONALITY1)));
+		bioData.put(BiographyField.PERSONALITY_TRAIT_2, new DefaultReferenceFacade<>(charDisplay.getSafeStringFor(PCStringKey.PERSONALITY2)));
+		bioData.put(BiographyField.PHOBIAS, new DefaultReferenceFacade<>(charDisplay.getSafeStringFor(PCStringKey.PHOBIAS)));
+		bioData.put(BiographyField.INTERESTS, new DefaultReferenceFacade<>(charDisplay.getSafeStringFor(PCStringKey.INTERESTS)));
+		bioData.put(BiographyField.CATCH_PHRASE, new DefaultReferenceFacade<>(charDisplay.getSafeStringFor(PCStringKey.CATCHPHRASE)));
+		bioData.put(BiographyField.HAIR_STYLE, new DefaultReferenceFacade<>(charDisplay.getSafeStringFor(PCStringKey.HAIRSTYLE)));
+		bioData.put(BiographyField.SPEECH_PATTERN, new DefaultReferenceFacade<>(charDisplay.getSafeStringFor(PCStringKey.SPEECHTENDENCY)));
 		customBiographyFields = new DefaultListFacade<>();
 		addCharacterCustomFields();
 	}
@@ -149,8 +138,8 @@ public class DescriptionFacadeImpl implements DescriptionFacade
 	}
 
 	/**
-	 * @param noteNameBio
-	 * @param bio
+	 * @param noteName
+	 * @param value
 	 * @return
 	 */
 	private NoteFacade createDefaultNote(String noteName, String value)
@@ -208,92 +197,55 @@ public class DescriptionFacadeImpl implements DescriptionFacade
 		return chronicleEntries;
 	}
 
-	/**
-	 * {@inheritDoc}
-	 */
 	@Override
 	public ListFacade<NoteFacade> getNotes()
 	{
 		return notes;
 	}
 
-	/**
-	 * {@inheritDoc}
-	 */
 	@Override
 	public void setNote(NoteFacade note, String text)
 	{
-		if (note == null || !(note instanceof NoteItem))
+		if (!(note instanceof NoteItem))
 		{
 			return;
 		}
-		
+
 		NoteItem noteItem = (NoteItem) note;
 		noteItem.setValue(text);
 		if (noteItem.isRequired())
 		{
-			String noteName = noteItem.getName(); 
-			if (NOTE_NAME_BIO.equals(noteName))
-			{
-				theCharacter.setBio(text);
-			}
-			else if (NOTE_NAME_DESCRIP.equals(noteName))
-			{
-				theCharacter.setDescription(text);
-			}
-			else if (NOTE_NAME_COMPANION.equals(noteName))
-			{
-				theCharacter.setStringFor(PCStringKey.COMPANIONS, text);
-			}
-			else if (NOTE_NAME_OTHER_ASSETS.equals(noteName))
-			{
-				theCharacter.setStringFor(PCStringKey.ASSETS, text);
-			}
-			else if (NOTE_NAME_MAGIC_ITEMS.equals(noteName))
-			{
-				theCharacter.setStringFor(PCStringKey.MAGIC, text);
-			}
-			else if (NOTE_NAME_GM_NOTES.equals(noteName))
-			{
-				theCharacter.setStringFor(PCStringKey.GMNOTES, text);
-			}
+			String noteName = noteItem.getName();
+			NotePCAttribute whichAttr = NotePCAttribute.getByNoteName(noteName);
+			theCharacter.setPCAttribute(whichAttr, text);
 		}
 	}
 
-	/**
-	 * {@inheritDoc}
-	 */
 	@Override
 	public void renameNote(NoteFacade note, String newName)
 	{
-		if (note == null || !(note instanceof NoteItem) || note.isRequired())
+		if (!(note instanceof NoteItem) || note.isRequired())
 		{
 			return;
 		}
-		
+
 		NoteItem noteItem = (NoteItem) note;
 		noteItem.setName(newName);
 		notes.modifyElement(noteItem);
 	}
 
-	/**
-	 * {@inheritDoc}
-	 */
 	@Override
 	public void deleteNote(NoteFacade note)
 	{
-		if (note == null || !(note instanceof NoteItem) || note.isRequired())
+		if (!(note instanceof NoteItem) || note.isRequired())
 		{
 			return;
 		}
-		
+
 		theCharacter.removeNote((NoteItem) note);
 		notes.removeElement(note);
 	}
 
-	/**
-	 * {@inheritDoc}
-	 */
 	@Override
 	public void addNewNote()
 	{
@@ -309,7 +261,7 @@ public class DescriptionFacadeImpl implements DescriptionFacade
 		}
 
 		++newNodeId;
-		
+
 		Set<String> names = new HashSet<>();
 		for (NoteFacade note : notes)
 		{
@@ -331,150 +283,64 @@ public class DescriptionFacadeImpl implements DescriptionFacade
 		notes.addElement(note);
 	}
 
-	/**
-	 * {@inheritDoc}
-	 */
 	@Override
-	public ReferenceFacade<String> getBiographyField(BiographyField field)
+	public ReferenceFacade<String> getBiographyField(final BiographyField field)
 	{
-		switch (field)
+		if (bioData.containsKey(field))
 		{
-			case SPEECH_PATTERN:
-				return speechPattern;
-
-			case BIRTHDAY:
-				return birthday;
-
-			case LOCATION:
-				return location;
-
-			case CITY:
-				return city;
-
-			case REGION:
-				return region;
-
-			case BIRTHPLACE:
-				return birthplace;
-
-			case PERSONALITY_TRAIT_1:
-				return personalityTrait1;
-
-			case PERSONALITY_TRAIT_2:
-				return personalityTrait2;
-
-			case PHOBIAS:
-				return phobias;
-
-			case INTERESTS:
-				return interests;
-
-			case CATCH_PHRASE:
-				return catchPhrase;
-
-			case HAIR_STYLE:
-				return hairStyle;
-				
-			default:
-				throw new UnsupportedOperationException("The field " + field //$NON-NLS-1$
-					+ " must use a dedicated getter."); //$NON-NLS-1$
+			return bioData.get(field);
 		}
+		throw new UnsupportedOperationException("The field " + field //$NON-NLS-1$
+				+ " must use a dedicated getter."); //$NON-NLS-1$
 	}
 
-	/**
-	 * {@inheritDoc}
-	 */
 	@Override
-	public void setBiographyField(BiographyField field, String newValue)
+	public void setBiographyField(final BiographyField field, final String newValue)
 	{
-		switch (field)
+		// TODO: generify this
+		Set<BiographyField> canBeDirectlySet = EnumSet.of(
+				BiographyField.LOCATION,
+				BiographyField.SPEECH_PATTERN,
+				BiographyField.INTERESTS,
+				BiographyField.BIRTHPLACE,
+				BiographyField.PERSONALITY_TRAIT_1,
+				BiographyField.PERSONALITY_TRAIT_2,
+				BiographyField.CITY,
+				BiographyField.PHOBIAS,
+				BiographyField.CATCH_PHRASE,
+				BiographyField.HAIR_STYLE,
+				BiographyField.BIRTHDAY
+		);
+
+		if (canBeDirectlySet.contains(field))
 		{
-			case SPEECH_PATTERN:
-				speechPattern.set(newValue);
-				theCharacter.setSpeechTendency(newValue);
-				break;
-
-			case BIRTHDAY:
-				birthday.set(newValue);
-				theCharacter.setBirthday(newValue);
-				break;
-
-			case LOCATION:
-				location.set(newValue);
-				theCharacter.setLocation(newValue);
-				break;
-
-			case CITY:
-				city.set(newValue);
-				theCharacter.setResidence(newValue);
-				break;
-
-			case BIRTHPLACE:
-				birthplace.set(newValue);
-				theCharacter.setBirthplace(newValue);
-				break;
-
-			case PERSONALITY_TRAIT_1:
-				personalityTrait1.set(newValue);
-				theCharacter.setTrait1(newValue);
-				break;
-
-			case PERSONALITY_TRAIT_2:
-				personalityTrait2.set(newValue);
-				theCharacter.setTrait2(newValue);
-				break;
-
-			case PHOBIAS:
-				phobias.set(newValue);
-				theCharacter.setPhobias(newValue);
-				break;
-
-			case INTERESTS:
-				interests.set(newValue);
-				theCharacter.setInterests(newValue);
-				break;
-
-			case CATCH_PHRASE:
-				catchPhrase.set(newValue);
-				theCharacter.setCatchPhrase(newValue);
-				break;
-
-			case HAIR_STYLE:
-				hairStyle.set(newValue);
-				theCharacter.setHairStyle(newValue);
-				break;
-				
-			case REGION:
-				throw new UnsupportedOperationException("The field " + field //$NON-NLS-1$
+			bioData.get(field).set(newValue);
+			theCharacter.setPCAttribute(field.getPcattr(), newValue);
+		}
+		else if (field == BiographyField.REGION)
+		{
+			throw new UnsupportedOperationException("The field " + field //$NON-NLS-1$
 					+ " cannot be set from the UI."); //$NON-NLS-1$
-
-			default:
-				throw new UnsupportedOperationException("The field " + field //$NON-NLS-1$
+		}
+		else
+		{
+			throw new UnsupportedOperationException("The field " + field //$NON-NLS-1$
 					+ " must use a dedicated setter."); //$NON-NLS-1$
 		}
 	}
 
-	/**
-	 * {@inheritDoc}
-	 */
 	@Override
 	public ListFacade<BiographyField> getCustomBiographyFields()
 	{
 		return customBiographyFields;
 	}
 
-	/**
-	 * {@inheritDoc}
-	 */
 	@Override
 	public void addCustomBiographyField(BiographyField field)
 	{
 		customBiographyFields.addElement(field);
 	}
 
-	/**
-	 * {@inheritDoc}
-	 */
 	@Override
 	public void removeCustomBiographyField(BiographyField field)
 	{

--- a/code/src/java/pcgen/io/PCGVer2Parser.java
+++ b/code/src/java/pcgen/io/PCGVer2Parser.java
@@ -92,7 +92,9 @@ import pcgen.core.Globals;
 import pcgen.core.Kit;
 import pcgen.core.Language;
 import pcgen.core.NoteItem;
+import pcgen.cdom.enumeration.NotePCAttribute;
 import pcgen.core.PCAlignment;
+import pcgen.cdom.enumeration.PCAttribute;
 import pcgen.core.PCClass;
 import pcgen.core.PCStat;
 import pcgen.core.PCTemplate;
@@ -634,7 +636,7 @@ final class PCGVer2Parser implements PCGParser, IOConstants
 
 	/**
 	 * Process the Use Higher Known Spell Slot line.
-	 * @param buffer The buffer to append to.
+	 * @param line The buffer to append to.
 	 */
 	private void parseUseHigherKnownSpellSlotsLine(String line)
 	{
@@ -643,7 +645,7 @@ final class PCGVer2Parser implements PCGParser, IOConstants
 
 	/**
 	 * Process the Use Higher Prepped Spell Slot line.
-	 * @param buffer The buffer to append to.
+	 * @param line The buffer to append to.
 	 */
 	private void parseUseHigherPreppedSpellSlotsLine(String line)
 	{
@@ -652,13 +654,13 @@ final class PCGVer2Parser implements PCGParser, IOConstants
 
 	private void parseBirthdayLine(String line)
 	{
-		thePC.setBirthday(EntityEncoder.decode(line.substring(TAG_BIRTHDAY
-			.length() + 1)));
+		thePC.setPCAttribute(PCAttribute.BIRTHDAY, EntityEncoder.decode(line.substring(TAG_BIRTHDAY
+						.length() + 1)));
 	}
 
 	private void parseBirthplaceLine(String line)
 	{
-		thePC.setBirthplace(EntityEncoder.decode(line.substring(TAG_BIRTHPLACE
+		thePC.setPCAttribute(PCAttribute.BIRTHPLACE, EntityEncoder.decode(line.substring(TAG_BIRTHPLACE
 			.length() + 1)));
 	}
 
@@ -1495,7 +1497,7 @@ final class PCGVer2Parser implements PCGParser, IOConstants
 
 	private void parseCatchPhraseLine(final String line)
 	{
-		thePC.setCatchPhrase(EntityEncoder.decode(line
+		thePC.setPCAttribute(PCAttribute.CATCHPHRASE, EntityEncoder.decode(line
 			.substring(TAG_CATCHPHRASE.length() + 1)));
 	}
 
@@ -1513,7 +1515,7 @@ final class PCGVer2Parser implements PCGParser, IOConstants
 
 	private void parseCharacterDescLine(final String line)
 	{
-		thePC.setDescription(EntityEncoder.decode(line
+		thePC.setPCAttribute(NotePCAttribute.DESCRIPTION, EntityEncoder.decode(line
 			.substring(TAG_CHARACTERDESC.length() + 1)));
 	}
 
@@ -1536,13 +1538,13 @@ final class PCGVer2Parser implements PCGParser, IOConstants
 	 */
 	private void parseCharacterNameLine(final String line)
 	{
-		thePC.setName(EntityEncoder.decode(line.substring(TAG_CHARACTERNAME
+		thePC.setPCAttribute(PCAttribute.NAME, EntityEncoder.decode(line.substring(TAG_CHARACTERNAME
 			.length() + 1)));
 	}
 
 	private void parseCityLine(final String line)
 	{
-		thePC.setResidence(EntityEncoder.decode(line.substring(TAG_CITY
+		thePC.setPCAttribute(PCAttribute.RESIDENCE, EntityEncoder.decode(line.substring(TAG_CITY
 			.length() + 1)));
 	}
 
@@ -3113,13 +3115,13 @@ final class PCGVer2Parser implements PCGParser, IOConstants
 
 	private void parseHairColorLine(final String line)
 	{
-		thePC.setHairColor(EntityEncoder.decode(line.substring(TAG_HAIRCOLOR
+		thePC.setPCAttribute(PCAttribute.HAIRCOLOR, EntityEncoder.decode(line.substring(TAG_HAIRCOLOR
 			.length() + 1)));
 	}
 
 	private void parseHairStyleLine(final String line)
 	{
-		thePC.setHairStyle(EntityEncoder.decode(line.substring(TAG_HAIRSTYLE
+		thePC.setPCAttribute(PCAttribute.HAIRSTYLE, EntityEncoder.decode(line.substring(TAG_HAIRSTYLE
 			.length() + 1)));
 	}
 
@@ -3164,7 +3166,7 @@ final class PCGVer2Parser implements PCGParser, IOConstants
 
 	private void parseInterestsLine(final String line)
 	{
-		thePC.setInterests(EntityEncoder.decode(line.substring(TAG_INTERESTS
+		thePC.setPCAttribute(PCAttribute.INTERESTS, EntityEncoder.decode(line.substring(TAG_INTERESTS
 			.length() + 1)));
 	}
 
@@ -3254,7 +3256,7 @@ final class PCGVer2Parser implements PCGParser, IOConstants
 
 	private void parseLocationLine(final String line)
 	{
-		thePC.setLocation(EntityEncoder.decode(line.substring(TAG_LOCATION
+		thePC.setPCAttribute(PCAttribute.LOCATION, EntityEncoder.decode(line.substring(TAG_LOCATION
 			.length() + 1)));
 	}
 
@@ -3591,13 +3593,13 @@ final class PCGVer2Parser implements PCGParser, IOConstants
 
 	private void parsePersonalityTrait1Line(final String line)
 	{
-		thePC.setTrait1(EntityEncoder.decode(line
+		thePC.setPCAttribute(PCAttribute.PERSONALITY1, EntityEncoder.decode(line
 			.substring(TAG_PERSONALITYTRAIT1.length() + 1)));
 	}
 
 	private void parsePersonalityTrait2Line(final String line)
 	{
-		thePC.setTrait2(EntityEncoder.decode(line
+		thePC.setPCAttribute(PCAttribute.PERSONALITY2, EntityEncoder.decode(line
 			.substring(TAG_PERSONALITYTRAIT2.length() + 1)));
 	}
 
@@ -3760,7 +3762,7 @@ final class PCGVer2Parser implements PCGParser, IOConstants
 	//this method is obsolete, but left in for backward-compatibility, replaced by parseCityLine()
 	private void parseResidenceLine(final String line)
 	{
-		thePC.setResidence(EntityEncoder.decode(line.substring(TAG_RESIDENCE
+		thePC.setPCAttribute(PCAttribute.RESIDENCE, EntityEncoder.decode(line.substring(TAG_RESIDENCE
 			.length() + 1)));
 		thePC.setDirty(true); // trigger a save prompt so that the PCG will be updated
 	}
@@ -3992,13 +3994,13 @@ final class PCGVer2Parser implements PCGParser, IOConstants
 
 	private void parseSkinColorLine(final String line)
 	{
-		thePC.setSkinColor(EntityEncoder.decode(line.substring(TAG_SKINCOLOR
+		thePC.setPCAttribute(PCAttribute.SKINCOLOR, EntityEncoder.decode(line.substring(TAG_SKINCOLOR
 			.length() + 1)));
 	}
 
 	private void parseSpeechPatternLine(final String line)
 	{
-		thePC.setSpeechTendency(EntityEncoder.decode(line
+		thePC.setPCAttribute(PCAttribute.SPEECHTENDENCY, EntityEncoder.decode(line
 			.substring(TAG_SPEECHPATTERN.length() + 1)));
 	}
 
@@ -4589,7 +4591,7 @@ final class PCGVer2Parser implements PCGParser, IOConstants
 
 	private void parseTabNameLine(final String line)
 	{
-		thePC.setTabName(EntityEncoder.decode(line.substring(TAG_TABNAME
+		thePC.setPCAttribute(PCAttribute.TABNAME, EntityEncoder.decode(line.substring(TAG_TABNAME
 			.length() + 1)));
 	}
 
@@ -5071,7 +5073,7 @@ final class PCGVer2Parser implements PCGParser, IOConstants
 	 */
 	private void parseCharacterBioLine(final String line)
 	{
-		thePC.setBio(EntityEncoder.decode(line.substring(TAG_CHARACTERBIO
+		thePC.setPCAttribute(NotePCAttribute.BIO, EntityEncoder.decode(line.substring(TAG_CHARACTERBIO
 			.length() + 1)));
 	}
 

--- a/code/src/java/pcgen/persistence/lst/BioSetLoader.java
+++ b/code/src/java/pcgen/persistence/lst/BioSetLoader.java
@@ -15,10 +15,6 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
- *
- * Created on October 10, 2002, 10:29 PM
- *
- * $Id$
  */
 package pcgen.persistence.lst;
 
@@ -46,7 +42,6 @@ import pcgen.util.Logging;
 /**
  *
  * @author  Bryan McRoberts &lt;merton_monk@yahoo.com&gt;
- * @version $Revision$
  */
 public final class BioSetLoader extends LstLineFileLoader
 {
@@ -165,9 +160,9 @@ public final class BioSetLoader extends LstLineFileLoader
 						final StringBuilder sBuf = new StringBuilder(100+colString.length());
 						sBuf.append(colString);
 
-						for (int i = 0, x = preReqList.size(); i < x; ++i)
+						for (String aPreReqList : preReqList)
 						{
-							sBuf.append('[').append(preReqList.get(i)).append(
+							sBuf.append('[').append(aPreReqList).append(
 									']');
 						}
 

--- a/code/src/java/plugin/initiative/gui/Initiative.java
+++ b/code/src/java/plugin/initiative/gui/Initiative.java
@@ -1687,12 +1687,9 @@ public class Initiative extends javax.swing.JPanel
 			{
 				Combatant cbt = (Combatant) iH;
 
-				//if (pcgcbt.getPC().isDisplayUpdate())
-				//{
-				//pcgcbt.getPC().setDisplayUpdate(false);
 				removeTab(cbt);
 				addTab(cbt);
-				//}
+
 			}
 		}
 	}

--- a/code/src/test/pcgen/core/prereq/PreBirthplaceTest.java
+++ b/code/src/test/pcgen/core/prereq/PreBirthplaceTest.java
@@ -25,6 +25,7 @@ import junit.framework.Test;
 import junit.framework.TestSuite;
 import junit.textui.TestRunner;
 import pcgen.AbstractCharacterTestCase;
+import pcgen.cdom.enumeration.PCAttribute;
 import pcgen.core.PlayerCharacter;
 import pcgen.persistence.lst.prereq.PreParserFactory;
 
@@ -60,7 +61,7 @@ public class PreBirthplaceTest extends AbstractCharacterTestCase
 	public void testAtt() throws Exception
 	{
 		final PlayerCharacter character = getCharacter();
-		character.setBirthplace("Klamath");
+		character.setPCAttribute(PCAttribute.BIRTHPLACE, "Klamath");
 
 		Prerequisite prereq;
 

--- a/code/src/test/pcgen/core/prereq/PreCityTest.java
+++ b/code/src/test/pcgen/core/prereq/PreCityTest.java
@@ -25,6 +25,7 @@ import junit.framework.Test;
 import junit.framework.TestSuite;
 import junit.textui.TestRunner;
 import pcgen.AbstractCharacterTestCase;
+import pcgen.cdom.enumeration.PCAttribute;
 import pcgen.core.PlayerCharacter;
 import pcgen.persistence.lst.prereq.PreParserFactory;
 
@@ -60,7 +61,7 @@ public class PreCityTest extends AbstractCharacterTestCase
 	public void testCity() throws Exception
 	{
 		final PlayerCharacter character = getCharacter();
-		character.setResidence("Klamath");
+		character.setPCAttribute(PCAttribute.RESIDENCE, "Klamath");
 
 		Prerequisite prereq;
 

--- a/code/src/test/pcgen/io/exporttoken/TextTokenTest.java
+++ b/code/src/test/pcgen/io/exporttoken/TextTokenTest.java
@@ -26,6 +26,7 @@ package pcgen.io.exporttoken;
 import junit.framework.Test;
 import junit.framework.TestSuite;
 import pcgen.AbstractCharacterTestCase;
+import pcgen.cdom.enumeration.PCAttribute;
 import pcgen.core.PlayerCharacter;
 import pcgen.io.ExportHandler;
 import plugin.exporttokens.TextToken;
@@ -61,7 +62,7 @@ public class TextTokenTest extends AbstractCharacterTestCase
 		super.setUp();
 		PlayerCharacter character = getCharacter();
 		character.setName("The Vitamins are in my Fresh Brussels Sprouts");
-		character.setInterests("one potatoe. two potatoe. mORe");
+		character.setPCAttribute(PCAttribute.INTERESTS, "one potatoe. two potatoe. mORe");
 	}
 
 	/**

--- a/code/src/test/plugin/exporttokens/BioTokenTest.java
+++ b/code/src/test/plugin/exporttokens/BioTokenTest.java
@@ -30,6 +30,7 @@ import java.io.StringWriter;
 import junit.framework.Test;
 import junit.framework.TestSuite;
 import pcgen.AbstractCharacterTestCase;
+import pcgen.cdom.enumeration.NotePCAttribute;
 import pcgen.core.PlayerCharacter;
 import pcgen.io.ExportHandler;
 import pcgen.io.FileAccess;
@@ -64,7 +65,7 @@ public class BioTokenTest extends AbstractCharacterTestCase
 		super.setUp();
 		PlayerCharacter character = getCharacter();
 
-		character.setBio("Test bio entry\n2nd line\nThird line\nlast one");
+		character.setPCAttribute(NotePCAttribute.BIO, "Test bio entry\n2nd line\nThird line\nlast one");
 	}
 
 	/**
@@ -96,7 +97,7 @@ public class BioTokenTest extends AbstractCharacterTestCase
 			evaluateToken("BIO..,", character));
 
 		FileAccess.setCurrentOutputFilter("foo.htm");
-		character.setBio("Test bio <br/>entry\n2nd line\nThird line\nlast one");
+		character.setPCAttribute(NotePCAttribute.BIO, "Test bio <br/>entry\n2nd line\nThird line\nlast one");
 
 		String expected =
 				"<p>[b]Test bio &lt;br/&gt;entry[/b]</p>\n<p>[b]2nd line[/b]</p>\n<p>[b]Third line[/b]</p>\n<p>[b]last one[/b]</p>";


### PR DESCRIPTION
Rather than keep PlayerCharacter attributes hardcoded with specific getters and setters for each, move them into appropriate enum types.