### PR TITLE
make orange extensions only needed during compilation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -136,7 +136,7 @@ compileJava {
 
 dependencies {
     compile group: 'cobra', name: 'cobra', version:'0.98.4-pcgen'
-    compile group: 'com.yuvimasory', name: 'orange-extensions', version: '1.3.0'
+
     compile group: 'commons-lang', name: 'commons-lang', version:'2.6'
     compile group: 'commons-io', name: 'commons-io', version:'2.4'
     compile group: 'rhino', name: 'js', version:'1.7R2'
@@ -161,6 +161,7 @@ dependencies {
     compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.21'
     runtime "ch.qos.logback:logback-classic:1.1.3"
     compileOnly group: 'org.jetbrains', name: 'annotations', version:'15.0'
+    compileOnly group: 'com.yuvimasory', name: 'orange-extensions', version: '1.3.0'
 
     //testCompile group: 'org.easymock', name: 'easymock', version:'2.5.2'
     //testCompile group: 'org.easymock', name: 'easymockclassextension', version:'2.5.2'


### PR DESCRIPTION
This (minorly) reduces the distribution size and makes our gradle file more honest