### PR TITLE
Add visible for testing annotation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -161,6 +161,7 @@ dependencies {
     runtime "ch.qos.logback:logback-classic:1.1.3"
     compileOnly group: 'org.jetbrains', name: 'annotations', version:'15.0'
     compileOnly group: 'com.yuvimasory', name: 'orange-extensions', version: '1.3.0'
+    compileOnly group: 'com.google.guava', name: 'guava', version: '19.0'
 
     //testCompile group: 'org.easymock', name: 'easymock', version:'2.5.2'
     //testCompile group: 'org.easymock', name: 'easymockclassextension', version:'2.5.2'

--- a/code/src/java/pcgen/core/PlayerCharacter.java
+++ b/code/src/java/pcgen/core/PlayerCharacter.java
@@ -275,6 +275,8 @@ import pcgen.util.Logging;
 import pcgen.util.enumeration.AttackType;
 import pcgen.util.enumeration.Load;
 
+import com.google.common.annotations.VisibleForTesting;
+
 /**
  * {@code PlayerCharacter}.
  *
@@ -8058,6 +8060,7 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 	}
 
 	//WARNING: This is public only for testing, do NOT use without understanding what you are shortcutting!!
+	@VisibleForTesting
 	public void applyAbility(CNAbilitySelection cas, Object source)
 	{
 		if (cas.hasPrerequisites())


### PR DESCRIPTION
While the VisibleForAnnotation can be added for a few different places I chose to get it from Guava since there are other annotations that may be useful
N.B. this only adds guava as a compile time dependency and does not affect distribution