### PR TITLE
update our checkstyle config

### DIFF
--- a/code/gradle/reporting.gradle
+++ b/code/gradle/reporting.gradle
@@ -9,9 +9,9 @@
 
 checkstyle {
 	configFile = new File('code/standards/checkstyle.xml')
-	ignoreFailures = true
 	showViolations = false
 	sourceSets = []
+	toolVersion = '7.1.1'
 }
 
 pmd {

--- a/code/standards/checkstyle.xml
+++ b/code/standards/checkstyle.xml
@@ -9,6 +9,7 @@
     Description: none
 -->
 <module name="Checker">
+  <property name="charset" value="UTF-8"/>
   <property name="severity" value="warning"/>
   <module name="TreeWalker">
     <property name="cacheFile" value="checkstyle-cachefile"/>
@@ -17,13 +18,17 @@
       <property name="allowUndeclaredRTE" value="true"/>
       <property name="allowMissingParamTags" value="true"/>
       <property name="allowMissingReturnTag" value="true"/>
+      <property name="allowMissingThrowsTags" value="true" />
       <property name="allowMissingPropertyJavadoc" value="true"/>
     </module>
     <module name="JavadocType"/>
     <module name="JavadocVariable">
       <property name="scope" value="public"/>
     </module>
-    <module name="ConstantName"/>
+    <module name="ConstantName">
+      <!--off for now to direct focus, but apply later-->
+      <property name="applyToPrivate" value="false" />
+    </module>
     <module name="LocalFinalVariableName"/>
     <module name="LocalVariableName"/>
     <module name="MemberName"/>
@@ -32,7 +37,9 @@
     <module name="ParameterName"/>
     <module name="StaticVariableName"/>
     <module name="TypeName"/>
-    <module name="AvoidStarImport"/>
+    <module name="AvoidStarImport">
+      <property name="allowStaticMemberImports" value="true"/>
+    </module>
     <module name="IllegalImport"/>
     <module name="RedundantImport"/>
     <module name="UnusedImports"/>
@@ -45,7 +52,6 @@
     <module name="MethodParamPad"/>
     <module name="NoWhitespaceAfter"/>
     <module name="NoWhitespaceBefore"/>
-    <module name="OperatorWrap"/>
     <module name="ParenPad"/>
     <module name="TypecastParenPad"/>
     <module name="WhitespaceAfter"/>
@@ -53,7 +59,7 @@
       <property name="tokens" value="ASSIGN"/>
     </module>
     <module name="ModifierOrder"/>
-    <module name="AvoidNestedBlocks"/>
+    <module name="AvoidNestedBlocks" />
     <module name="EmptyBlock"/>
     <module name="LeftCurly">
       <property name="option" value="nl"/>
@@ -61,7 +67,8 @@
     </module>
     <module name="NeedBraces"/>
     <module name="RightCurly">
-      <property name="option" value="alone"/>
+      <!-- Permit single line to allow for empty ctors like Foo() {}-->
+      <property name="option" value="alone_or_singleline" />
     </module>
     <module name="EmptyStatement"/>
     <module name="EqualsHashCode"/>
@@ -80,13 +87,20 @@
     <module name="FinalClass"/>
     <module name="HideUtilityClassConstructor"/>
     <module name="InterfaceIsType"/>
-    <module name="VisibilityModifier"/>
+    <module name="VisibilityModifier">
+      <property name="protectedAllowed" value="true" />
+      <property name="allowPublicImmutableFields" value="true" />
+    </module>
     <module name="ArrayTypeStyle"/>
     <module name="TodoComment">
       <property name="severity" value="info"/>
     </module>
-    <module name="UpperEll"/>
+    <module name="UpperEll">
+      <property name="severity" value="error"/>
+    </module>
   </module>
-  <module name="NewlineAtEndOfFile"/>
+  <module name="NewlineAtEndOfFile">
+    <property name="lineSeparator" value="lf"/>
+  </module>
   <module name="Translation"/>
 </module>


### PR DESCRIPTION
This add checkstyle to the build path. 
- update checkstyle to the latest version so that documentation applies
- be stricter about a few things
- begin to error rather than warn on things for which we have no current problems
- add checkstyle to the build path to help reduce the chance of adding regressions
- relax a few conventions to more accurately match what seems to be project style.

FWIW I ask that you avoid holding this review on the choice of specific style rules. Those can easily be changed. I want to make sure that we're on a path to making use of the tools that we can.
