### PR TITLE
remove jdepend

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,6 @@ plugins {
     id 'findbugs'
     id 'java'
     id 'maven'
-    id 'jdepend'
     id 'pmd'
 
     id "de.undercouch.download" version "3.1.1"

--- a/code/gradle/reporting.gradle
+++ b/code/gradle/reporting.gradle
@@ -1,5 +1,4 @@
-/*
- * PCGen code quality tasks. This file specifies the code quality
+/* PCGen code quality tasks. This file specifies the code quality
  * reports to be run as part of the PCGen nightly build. It is
  * called from the main build.gradle file.
  *
@@ -25,11 +24,6 @@ pmd {
 	toolVersion = "5.5.1"
 }
 
-jdepend {
-	ignoreFailures = true
-	sourceSets = []
-}
-
 findbugs {
 	ignoreFailures = true
 //	effort = 'max'
@@ -48,5 +42,4 @@ tasks.withType(FindBugs) {
 						'DoInsideDoPrivileged', 'CyclomaticComplexity']
 	}
 }
-
-task allReports { dependsOn = ['checkstyleMain', 'pmdMain', 'jdependMain', 'findbugs'] }
+task allReports { dependsOn = ['checkstyleMain', 'pmdMain', 'findbugs'] }


### PR DESCRIPTION
jdepend provides nearly zero value to pcpgen. Its useful for doing certain kinds of academic analysis; however since we're still not at the point of erroring out for true bugs or serious style errors don't even bother producing jdepend reports