### PR TITLE
dropkick PCGenTestCase

### DIFF
--- a/code/src/test/pcgen/AbstractCharacterTestCase.java
+++ b/code/src/test/pcgen/AbstractCharacterTestCase.java
@@ -34,6 +34,7 @@ import pcgen.persistence.SourceFileLoader;
 import pcgen.rules.context.AbstractReferenceContext;
 import pcgen.rules.context.LoadContext;
 import pcgen.util.TestHelper;
+
 import plugin.lsttokens.testsupport.BuildUtilities;
 
 /**
@@ -198,7 +199,6 @@ public abstract class AbstractCharacterTestCase extends PCGenTestCase
 	 */
 	public AbstractCharacterTestCase()
 	{
-		super();
 	}
 
 	/**

--- a/code/src/test/pcgen/PCGenTestCase.java
+++ b/code/src/test/pcgen/PCGenTestCase.java
@@ -2,60 +2,44 @@ package pcgen;
 
 import java.math.BigDecimal;
 
-import junit.framework.TestCase;
 import pcgen.core.GameMode;
 import pcgen.core.LevelInfo;
 import pcgen.core.SettingsHandler;
 import pcgen.core.SystemCollections;
 import pcgen.core.system.LoadInfo;
 import pcgen.persistence.GameModeFileLoader;
-import pcgen.util.Logging;
 import pcgen.util.TestChecker;
-import pcgen.util.testchecker.BoolAnd;
 import pcgen.util.testchecker.BoolNot;
-import pcgen.util.testchecker.BoolOr;
-import pcgen.util.testchecker.BoolXor;
 import pcgen.util.testchecker.CompareDeadband;
 import pcgen.util.testchecker.CompareEqualBoolean;
-import pcgen.util.testchecker.CompareEqualByte;
-import pcgen.util.testchecker.CompareEqualChar;
-import pcgen.util.testchecker.CompareEqualDouble;
-import pcgen.util.testchecker.CompareEqualFloat;
-import pcgen.util.testchecker.CompareEqualIgnoreCaseString;
 import pcgen.util.testchecker.CompareEqualInt;
-import pcgen.util.testchecker.CompareEqualLong;
 import pcgen.util.testchecker.CompareEqualObject;
-import pcgen.util.testchecker.CompareEqualShort;
 import pcgen.util.testchecker.CompareEqualString;
-import pcgen.util.testchecker.CompareGreaterOrEqual;
 import pcgen.util.testchecker.CompareGreaterThan;
-import pcgen.util.testchecker.CompareLessOrEqual;
-import pcgen.util.testchecker.CompareLessThan;
 import pcgen.util.testchecker.CompareNull;
-import pcgen.util.testchecker.CompareSame;
-import pcgen.util.testchecker.CompareSubstring;
+
+import junit.framework.TestCase;
 
 /**
  * Test case base for PCGen.  This addresses a common bug with JUnit whereby
- * when a unit test throws an exception, and then <code>tearDown</code> will not
+ * when a unit test throws an exception, and then {@code tearDown} will not
  * unwind correctly, the original exception from the unit test is buried by the
- * exception from <code>tearDown</code>.
+ * exception from {@code tearDown}.
  *
  * The solution is to override {@link #runBare()} and save the exception from
- * the unit test, rethrowing it after <code>tearDown</code> finishes.
+ * the unit test, rethrowing it after {@code tearDown} finishes.
  *
  * @author <a href="binkley@alumni.rice.edu">B. K Oxley (binkley)</a>
+ * @deprecated the described bug no longer exists on modern versions of junit
  */
 @SuppressWarnings("nls")
+@Deprecated
 public abstract class PCGenTestCase extends TestCase
 {
-	protected boolean verbose = false;
 	protected int     count   = 0;
-	protected int     errors  = 0;
 
 	/**
 	 * Sets up some basic stuff that must be present for tests to work.
-	 * @see junit.framework.TestCase#setUp()
 	 */
 	@Override
 	protected void setUp() throws Exception
@@ -76,11 +60,10 @@ public abstract class PCGenTestCase extends TestCase
 		SystemCollections.addToGameModeList(gamemode);
 		SettingsHandler.setGame("3.5");
 		count  = 0;
-		errors = 0;
 	}
 
 	/**
-	 * Constructs a new <code>PCGenTestCase</code>.
+	 * Constructs a new {@code PCGenTestCase}.
 	 *
 	 * @see TestCase#TestCase()
 	 */
@@ -90,7 +73,7 @@ public abstract class PCGenTestCase extends TestCase
 	}
 
 	/**
-	 * Constructs a new <code>PCGenTestCase</code> with the given <var>name</var>.
+	 * Constructs a new {@code PCGenTestCase} with the given <var>name</var>.
 	 *
 	 * @param name The name of the test case
      * @see TestCase#TestCase(String)
@@ -116,12 +99,6 @@ public abstract class PCGenTestCase extends TestCase
 		try
 		{
 			runTest();
-
-			if (verbose && 0 != errors)
-			{
-				Logging.errorPrint("Failed " + errors + " of " + count + " interruptable tests");
-				fail("Failed " + errors + " of " + count + " interruptable tests");
-			}
 		}
 
 		catch (final Throwable t)
@@ -140,7 +117,7 @@ public abstract class PCGenTestCase extends TestCase
 
 			finally
 			{
-				if (null != thrown)
+				if (thrown != null)
 				{
 					// Replace any tear down exception with
 					// unit test exception
@@ -154,25 +131,7 @@ public abstract class PCGenTestCase extends TestCase
 	{
         count += 1;
 
-		if (verbose)
-		{
-			if (matches.check(something))
-			{
-				Logging.errorPrint("OK - unlabelled test case");
-			}
-			else
-			{
-				Logging.errorPrint("\n!!! Not OK !!! - unlabelled test case");
-
-				final StringBuilder message = new StringBuilder("  Expected: ");
-				matches.scribe(message);
-				message.append("\n  but got: ").append(something).append('\n');
-
-				Logging.errorPrint(message.toString());
-                errors += 1;
-			}
-		}
-		else if (!matches.check(something))
+		if (!matches.check(something))
 		{
 
 			final StringBuilder message = new StringBuilder("\nExpected: ");
@@ -186,25 +145,7 @@ public abstract class PCGenTestCase extends TestCase
 	{
         count += 1;
 
-		if (verbose)
-		{
-			if (matches.check(something))
-			{
-				Logging.errorPrint("OK - " + testCase);
-			}
-			else
-			{
-				Logging.errorPrint("\n!!! Not OK !!! - " + testCase);
-
-				final StringBuilder message = new StringBuilder("  Expected: ");
-				matches.scribe(message);
-				message.append("\n  but got: ").append(something).append("\n");
-				
-				Logging.errorPrint(message.toString());
-                errors += 1;
-			}
-		}
-		else if (!matches.check(something))
+		if (!matches.check(something))
 		{
 
 			final StringBuilder message = new StringBuilder("\nExpected: ");
@@ -216,118 +157,43 @@ public abstract class PCGenTestCase extends TestCase
 		}
 	}
 
-	public CompareEqualString strEq(final String s)
+	public static CompareEqualString strEq(final String s)
 	{
 		return new CompareEqualString(s);
 	}
 
-	public CompareEqualIgnoreCaseString strEqIC(final String s)
-	{
-		return new CompareEqualIgnoreCaseString(s);
-	}
-
-	public CompareEqualObject eq(final Object operand)
+	public static CompareEqualObject eq(final Object operand)
 	{
 		return new CompareEqualObject(operand);
 	}
 
-	public CompareEqualBoolean eq(final boolean bo)
+	public static CompareEqualBoolean eq(final boolean bo)
 	{
 		return new CompareEqualBoolean(bo);
 	}
 
-	public CompareEqualByte eq(final byte operand)
-	{
-		return new CompareEqualByte(operand);
-	}
-
-	public CompareEqualShort eq(final short operand)
-	{
-		return new CompareEqualShort(operand);
-	}
-
-	public CompareEqualChar eq(final char operand)
-	{
-		return new CompareEqualChar(operand);
-	}
-
-	public CompareEqualInt eq(final int operand)
+	public static CompareEqualInt eq(final int operand)
 	{
 		return new CompareEqualInt(operand);
 	}
 
-	public CompareEqualLong eq(final long operand)
-	{
-		return new CompareEqualLong(operand);
-	}
-
-	public CompareEqualFloat eq(final float operand)
-	{
-		return new CompareEqualFloat(operand);
-	}
-
-	public CompareEqualDouble eq(final double operand)
-	{
-		return new CompareEqualDouble(operand);
-	}
-
-	public CompareDeadband eq(final double operand, final double error)
+	public static CompareDeadband eq(final double operand, final double error)
 	{
 		return new CompareDeadband(operand, error);
 	}
 
-	public CompareNull eqnull()
+	protected static CompareNull eqnull()
 	{
 		return new CompareNull();
 	}
 
-	public CompareSame same(final Object operand)
-	{
-		return new CompareSame(operand);
-	}
-
-	public CompareSubstring stringContains(final String substring)
-	{
-		return new CompareSubstring(substring);
-	}
-
-	public BoolNot not(final TestChecker c)
+	public static BoolNot not(final TestChecker c)
 	{
 		return new BoolNot(c);
 	}
 
-	public BoolAnd and(final TestChecker left, final TestChecker right)
-	{
-		return new BoolAnd(left, right);
-	}
-
-	public BoolOr or(final TestChecker left, final TestChecker right)
-	{
-		return new BoolOr(left, right);
-	}
-
-	public BoolXor xor(final TestChecker left, final TestChecker right)
-	{
-		return new BoolXor(left, right);
-	}
-
-	public CompareGreaterThan gt(Comparable operand)
+	protected static CompareGreaterThan gt(Comparable operand)
 	{
 		return new CompareGreaterThan(operand);
-	}
-
-	public CompareGreaterOrEqual ge(Comparable operand)
-	{
-		return new CompareGreaterOrEqual(operand);
-	}
-
-	public CompareLessThan lt(Comparable operand)
-	{
-		return new CompareLessThan(operand);
-	}
-
-	public CompareLessOrEqual le(Comparable operand)
-	{
-		return new CompareLessOrEqual(operand);
 	}
 }

--- a/code/src/test/pcgen/core/CampaignTest.java
+++ b/code/src/test/pcgen/core/CampaignTest.java
@@ -23,7 +23,7 @@
 
 package pcgen.core;
 
-import pcgen.PCGenTestCase;
+import junit.framework.TestCase;
 import pcgen.cdom.content.CampaignURL;
 import pcgen.cdom.enumeration.ListKey;
 import pcgen.rules.context.LoadContext;
@@ -39,7 +39,7 @@ import plugin.lsttokens.testsupport.TokenRegistration;
  * 
  * @author James Dempsey <jdempsey@users.sourceforge.net>
  */
-public class CampaignTest extends PCGenTestCase
+public class CampaignTest extends TestCase
 {
 
 	Campaign testCamp = new Campaign();

--- a/code/src/test/pcgen/core/ClassTypeTest.java
+++ b/code/src/test/pcgen/core/ClassTypeTest.java
@@ -1,13 +1,13 @@
 package pcgen.core;
 
-import pcgen.PCGenTestCase;
+import junit.framework.TestCase;
 
 /**
  * <code>ClassTypeTest</code> <strong>needs documentation</strong>.
  *
  * @author <a href="binkley@alumni.rice.edu">B. K. Oxley (binkley)</a>
  */
-public class ClassTypeTest extends PCGenTestCase
+public class ClassTypeTest extends TestCase
 {
 	/**
 	 * Constructs a new <code>ClassTypeTest</code>.

--- a/code/src/test/pcgen/core/DataSetTest.java
+++ b/code/src/test/pcgen/core/DataSetTest.java
@@ -24,7 +24,7 @@ package pcgen.core;
 
 import java.util.List;
 
-import pcgen.PCGenTestCase;
+import junit.framework.TestCase;
 import pcgen.cdom.base.Constants;
 import pcgen.facade.core.AbilityFacade;
 import pcgen.facade.core.BodyStructureFacade;
@@ -43,7 +43,7 @@ import plugin.pretokens.parser.PreAbilityParser;
  * @author James Dempsey <jdempsey@users.sourceforge.net>
  */
 @SuppressWarnings("nls")
-public class DataSetTest extends PCGenTestCase
+public class DataSetTest extends TestCase
 {
 
 	public final void testGetEquipmentLocationsAll()

--- a/code/src/test/pcgen/core/EquipmentListTest.java
+++ b/code/src/test/pcgen/core/EquipmentListTest.java
@@ -27,7 +27,7 @@ import java.util.List;
 
 import junit.framework.Test;
 import junit.framework.TestSuite;
-import pcgen.PCGenTestCase;
+import junit.framework.TestCase;
 import pcgen.cdom.enumeration.ObjectKey;
 import pcgen.cdom.enumeration.StringKey;
 import pcgen.cdom.reference.CDOMDirectSingleRef;
@@ -40,7 +40,7 @@ import pcgen.util.TestHelper;
  * @author James Dempsey <jdempsey@users.sourceforge.net>
  */
 @SuppressWarnings("nls")
-public class EquipmentListTest extends PCGenTestCase
+public class EquipmentListTest extends TestCase
 {
 
 	private Equipment eq = null;
@@ -79,7 +79,7 @@ public class EquipmentListTest extends PCGenTestCase
 	}
 
 	/**
-	 * @see pcgen.PCGenTestCase#setUp()
+	 * @see junit.framework.TestCase#setUp()
 	 */
 	@Override
 	public void setUp() throws Exception

--- a/code/src/test/pcgen/core/EquipmentModifierTest.java
+++ b/code/src/test/pcgen/core/EquipmentModifierTest.java
@@ -28,7 +28,7 @@ package pcgen.core;
 
 import java.util.List;
 
-import pcgen.PCGenTestCase;
+import junit.framework.TestCase;
 import pcgen.cdom.enumeration.ListKey;
 import pcgen.core.bonus.Bonus;
 import pcgen.core.bonus.BonusObj;
@@ -44,7 +44,7 @@ import junit.textui.TestRunner;
  * Equipment Modifer Test 
  */
 @SuppressWarnings("nls")
-public class EquipmentModifierTest extends PCGenTestCase
+public class EquipmentModifierTest extends TestCase
 {
 
 	/**
@@ -77,7 +77,7 @@ public class EquipmentModifierTest extends PCGenTestCase
 	/**
 	 * Starts the system plugins.
 	 * 
-	 * @see pcgen.PCGenTestCase#setUp()
+	 * @see junit.framework.TestCase#setUp()
 	 */
 	@Override
 	public void setUp() throws Exception

--- a/code/src/test/pcgen/core/EquipmentTest.java
+++ b/code/src/test/pcgen/core/EquipmentTest.java
@@ -32,7 +32,6 @@ import junit.framework.Test;
 import junit.framework.TestSuite;
 import junit.textui.TestRunner;
 import pcgen.AbstractCharacterTestCase;
-import pcgen.PCGenTestCase;
 import pcgen.base.lang.UnreachableError;
 import pcgen.cdom.base.Constants;
 import pcgen.cdom.content.BaseDice;

--- a/code/src/test/pcgen/core/GlobalsTest.java
+++ b/code/src/test/pcgen/core/GlobalsTest.java
@@ -32,7 +32,7 @@ public class GlobalsTest extends PCGenTestCase
 	}
 
 	/**
-	 * @see pcgen.PCGenTestCase#setUp()
+	 * @see junit.framework.TestCase#setUp()
 	 */
 	@Override
 	protected void setUp() throws Exception

--- a/code/src/test/pcgen/core/PCClassTest.java
+++ b/code/src/test/pcgen/core/PCClassTest.java
@@ -35,7 +35,7 @@ import java.util.StringTokenizer;
 import junit.framework.Test;
 import junit.framework.TestSuite;
 import pcgen.AbstractCharacterTestCase;
-import pcgen.PCGenTestCase;
+import junit.framework.TestCase;
 import pcgen.base.format.StringManager;
 import pcgen.base.lang.UnreachableError;
 import pcgen.cdom.base.AssociatedPrereqObject;

--- a/code/src/test/pcgen/core/PCTemplateTest.java
+++ b/code/src/test/pcgen/core/PCTemplateTest.java
@@ -33,7 +33,7 @@ import java.util.List;
 import junit.framework.Test;
 import junit.framework.TestSuite;
 import pcgen.AbstractCharacterTestCase;
-import pcgen.PCGenTestCase;
+import junit.framework.TestCase;
 import pcgen.base.lang.UnreachableError;
 import pcgen.cdom.base.CDOMReference;
 import pcgen.cdom.enumeration.IntegerKey;

--- a/code/src/test/pcgen/core/PObjectTest.java
+++ b/code/src/test/pcgen/core/PObjectTest.java
@@ -31,7 +31,7 @@ import java.util.Iterator;
 import junit.framework.Test;
 import junit.framework.TestSuite;
 import pcgen.AbstractCharacterTestCase;
-import pcgen.PCGenTestCase;
+import junit.framework.TestCase;
 import pcgen.base.format.OrderedPairManager;
 import pcgen.base.format.StringManager;
 import pcgen.base.lang.UnreachableError;

--- a/code/src/test/pcgen/core/prereq/PreReqHandlerTest.java
+++ b/code/src/test/pcgen/core/prereq/PreReqHandlerTest.java
@@ -32,7 +32,7 @@ import java.util.Locale;
 
 import pcgen.EnUsLocaleDependentTestCase;
 import pcgen.LocaleDependentTestCase;
-import pcgen.PCGenTestCase;
+import junit.framework.TestCase;
 import pcgen.persistence.lst.prereq.PreParserFactory;
 import pcgen.util.TestHelper;
 
@@ -44,7 +44,7 @@ import junit.textui.TestRunner;
  * @author wardc
  */
 @SuppressWarnings("nls")
-public class PreReqHandlerTest extends PCGenTestCase
+public class PreReqHandlerTest extends TestCase
 {
 
 	/**
@@ -67,7 +67,7 @@ public class PreReqHandlerTest extends PCGenTestCase
 	/**
 	 * Sets up the test case by loading the system plugins.
 	 * 
-	 * @see pcgen.PCGenTestCase#setUp()
+	 * @see junit.framework.TestCase#setUp()
 	 */
 	@Override
 	public void setUp() throws Exception

--- a/code/src/test/pcgen/core/prereq/PreRuleTest.java
+++ b/code/src/test/pcgen/core/prereq/PreRuleTest.java
@@ -52,7 +52,7 @@ public class PreRuleTest extends AbstractCharacterTestCase
 	}
 
 	/* (non-Javadoc)
-	 * @see pcgen.PCGenTestCase#setUp()
+	 * @see junit.framework.TestCase#setUp()
 	 */
 	@Override
 	protected void setUp() throws Exception

--- a/code/src/test/pcgen/core/term/EvaluatorFactoryTest.java
+++ b/code/src/test/pcgen/core/term/EvaluatorFactoryTest.java
@@ -37,7 +37,8 @@ import pcgen.util.TestHelper;
  * Current Ver: $Revision:$
  */
 
-public class EvaluatorFactoryTest extends PCGenTestCase {
+public class EvaluatorFactoryTest extends PCGenTestCase
+{
 
 	public EvaluatorFactoryTest(String name) {
 		super(name);

--- a/code/src/test/pcgen/core/utils/CoreUtilityTest.java
+++ b/code/src/test/pcgen/core/utils/CoreUtilityTest.java
@@ -23,7 +23,7 @@
  */
 package pcgen.core.utils;
 
-import pcgen.PCGenTestCase;
+import junit.framework.TestCase;
 import pcgen.base.lang.StringUtil;
 import pcgen.system.PCGenPropBundle;
 
@@ -39,7 +39,7 @@ import java.util.List;
  * @see pcgen.core.utils.CoreUtility
  */
 @SuppressWarnings("nls")
-public class CoreUtilityTest extends PCGenTestCase
+public class CoreUtilityTest extends TestCase
 {
 	/**
 	 * Constructs a new <code>CoreUtilityTest</code>.

--- a/code/src/test/pcgen/io/PCGFileTest.java
+++ b/code/src/test/pcgen/io/PCGFileTest.java
@@ -1,13 +1,13 @@
 package pcgen.io;
 
 import java.io.File;
-import pcgen.PCGenTestCase;
+import junit.framework.TestCase;
 import pcgen.cdom.base.Constants;
 
 /**
  * Tests {@link PCGFile}.
  */
-public class PCGFileTest extends PCGenTestCase
+public class PCGFileTest extends TestCase
 {
 
 	/**

--- a/code/src/test/pcgen/io/migration/AbilityMigrationTest.java
+++ b/code/src/test/pcgen/io/migration/AbilityMigrationTest.java
@@ -22,7 +22,7 @@
  */
 package pcgen.io.migration;
 
-import pcgen.PCGenTestCase;
+import junit.framework.TestCase;
 import pcgen.core.SettingsHandler;
 import pcgen.core.SystemCollections;
 import pcgen.core.system.MigrationRule;
@@ -35,7 +35,7 @@ import pcgen.io.migration.AbilityMigration.CategorisedKey;
  * 
  * @author James Dempsey <jdempsey@users.sourceforge.net>
  */
-public class AbilityMigrationTest extends PCGenTestCase
+public class AbilityMigrationTest extends TestCase
 {
 	
 	private String gameMode;

--- a/code/src/test/pcgen/io/migration/EquipmentMigrationTest.java
+++ b/code/src/test/pcgen/io/migration/EquipmentMigrationTest.java
@@ -22,7 +22,7 @@
  */
 package pcgen.io.migration;
 
-import pcgen.PCGenTestCase;
+import junit.framework.TestCase;
 import pcgen.core.SettingsHandler;
 import pcgen.core.SystemCollections;
 import pcgen.core.system.MigrationRule;
@@ -34,7 +34,7 @@ import pcgen.core.system.MigrationRule.ObjectType;
  * 
  * @author James Dempsey <jdempsey@users.sourceforge.net>
  */
-public class EquipmentMigrationTest extends PCGenTestCase
+public class EquipmentMigrationTest extends TestCase
 {
 	
 	private String gameMode;

--- a/code/src/test/pcgen/io/migration/RaceMigrationTest.java
+++ b/code/src/test/pcgen/io/migration/RaceMigrationTest.java
@@ -22,7 +22,7 @@
  */
 package pcgen.io.migration;
 
-import pcgen.PCGenTestCase;
+import junit.framework.TestCase;
 import pcgen.core.SettingsHandler;
 import pcgen.core.SystemCollections;
 import pcgen.core.system.MigrationRule;
@@ -34,7 +34,7 @@ import pcgen.core.system.MigrationRule.ObjectType;
  * 
  * @author James Dempsey <jdempsey@users.sourceforge.net>
  */
-public class RaceMigrationTest extends PCGenTestCase
+public class RaceMigrationTest extends TestCase
 {
 	
 	private String gameMode;

--- a/code/src/test/pcgen/io/migration/SourceMigrationTest.java
+++ b/code/src/test/pcgen/io/migration/SourceMigrationTest.java
@@ -22,7 +22,7 @@
  */
 package pcgen.io.migration;
 
-import pcgen.PCGenTestCase;
+import junit.framework.TestCase;
 import pcgen.core.SettingsHandler;
 import pcgen.core.SystemCollections;
 import pcgen.core.system.MigrationRule;
@@ -34,7 +34,7 @@ import pcgen.core.system.MigrationRule.ObjectType;
  * 
  * @author James Dempsey <jdempsey@users.sourceforge.net>
  */
-public class SourceMigrationTest extends PCGenTestCase
+public class SourceMigrationTest extends TestCase
 {
 	
 	private String gameMode;

--- a/code/src/test/pcgen/persistence/lst/BioSetLoaderTest.java
+++ b/code/src/test/pcgen/persistence/lst/BioSetLoaderTest.java
@@ -30,7 +30,7 @@ import java.net.URI;
 import java.util.List;
 import junit.framework.Test;
 import junit.framework.TestSuite;
-import pcgen.PCGenTestCase;
+import junit.framework.TestCase;
 import pcgen.cdom.base.Constants;
 import pcgen.core.BioSet;
 import pcgen.core.Globals;
@@ -42,7 +42,7 @@ import pcgen.rules.context.LoadContext;
  * Static methods are also made available should other test classes require
  * BioSet loading functions.
  */
-public final class BioSetLoaderTest extends PCGenTestCase
+public final class BioSetLoaderTest extends TestCase
 {
 	/**
 	 * The sample Bio set data for testing.

--- a/code/src/test/pcgen/persistence/lst/FeatTest.java
+++ b/code/src/test/pcgen/persistence/lst/FeatTest.java
@@ -53,7 +53,7 @@ public class FeatTest extends TestCase
 	/**
 	 * Sets up the test case by loading the system plugins.
 	 * 
-	 * @see pcgen.PCGenTestCase#setUp()
+	 * @see junit.framework.TestCase#setUp()
 	 */
 	@Override
 	public void setUp() throws Exception

--- a/code/src/test/pcgen/persistence/lst/InstallLoaderTest.java
+++ b/code/src/test/pcgen/persistence/lst/InstallLoaderTest.java
@@ -31,7 +31,7 @@ import java.util.Date;
 
 import junit.framework.Test;
 import junit.framework.TestSuite;
-import pcgen.PCGenTestCase;
+import junit.framework.TestCase;
 import pcgen.cdom.enumeration.ListKey;
 import pcgen.cdom.enumeration.ObjectKey;
 import pcgen.cdom.enumeration.StringKey;
@@ -42,7 +42,7 @@ import pcgen.util.TestHelper;
 /**
  * A collection of tests to validate the functioning of the InstallLoader class.
  */
-public final class InstallLoaderTest extends PCGenTestCase
+public final class InstallLoaderTest extends TestCase
 {
 	private static final String PUBNAMESHORT = "PCGen";
 	private static final String PUBNAMELONG = "PCGen Open Source Team";

--- a/code/src/test/pcgen/persistence/lst/PObjectLoaderTest.java
+++ b/code/src/test/pcgen/persistence/lst/PObjectLoaderTest.java
@@ -28,8 +28,6 @@ package pcgen.persistence.lst;
 
 import java.util.List;
 
-import junit.framework.Test;
-import junit.framework.TestSuite;
 import pcgen.PCGenTestCase;
 import pcgen.cdom.base.Constants;
 import pcgen.cdom.enumeration.ListKey;
@@ -45,6 +43,9 @@ import pcgen.rules.context.AbstractReferenceContext;
 import pcgen.rules.context.LoadContext;
 import pcgen.util.Logging;
 import pcgen.util.TestHelper;
+
+import junit.framework.Test;
+import junit.framework.TestSuite;
 import plugin.lsttokens.testsupport.BuildUtilities;
 
 public class PObjectLoaderTest extends PCGenTestCase
@@ -68,7 +69,7 @@ public class PObjectLoaderTest extends PCGenTestCase
 	/**
 	 * Sets up the test case by loading the system plugins.
 	 * 
-	 * @see pcgen.PCGenTestCase#setUp()
+	 * @see junit.framework.TestCase#setUp()
 	 */
 	@Override
 	public void setUp() throws Exception

--- a/code/src/test/pcgen/util/FileHelperTest.java
+++ b/code/src/test/pcgen/util/FileHelperTest.java
@@ -24,12 +24,12 @@ import java.io.File;
 
 import org.apache.commons.lang.SystemUtils;
 
-import pcgen.PCGenTestCase;
+import junit.framework.TestCase;
 
 /**
  * FileHelperTest
  */
-public class FileHelperTest extends PCGenTestCase
+public class FileHelperTest extends TestCase
 {
 
 	final static String BACK_ONE = ".." + File.separator;

--- a/code/src/test/pcgen/util/PJepTest.java
+++ b/code/src/test/pcgen/util/PJepTest.java
@@ -34,7 +34,7 @@ import junit.framework.TestSuite;
 import org.nfunk.jep.SymbolTable;
 
 import pcgen.AbstractCharacterTestCase;
-import pcgen.PCGenTestCase;
+import junit.framework.TestCase;
 import pcgen.cdom.base.FormulaFactory;
 import pcgen.cdom.enumeration.VariableKey;
 import pcgen.core.PlayerCharacter;

--- a/code/src/test/pcgen/util/ParameterTreeTest.java
+++ b/code/src/test/pcgen/util/ParameterTreeTest.java
@@ -24,11 +24,12 @@
 
 package pcgen.util;
 
-import org.junit.Test;
-import org.nfunk.jep.ParseException;
+import java.util.regex.Matcher;
+
 import pcgen.PCGenTestCase;
 
-import java.util.regex.Matcher;
+import org.junit.Test;
+import org.nfunk.jep.ParseException;
 
 /**
  * <code>ParameterTreeTest</code> is ...

--- a/code/src/test/pcgen/util/TermUtilitiesTest.java
+++ b/code/src/test/pcgen/util/TermUtilitiesTest.java
@@ -26,7 +26,8 @@ import pcgen.core.term.TermEvaulatorException;
  * Current Ver: $Revision:$
  */
 
-public class TermUtilitiesTest extends PCGenTestCase {
+public class TermUtilitiesTest extends PCGenTestCase
+{
 
     public TermUtilitiesTest(String name) {
         super(name);

--- a/code/src/test/plugin/PluginBuildTest.java
+++ b/code/src/test/plugin/PluginBuildTest.java
@@ -32,7 +32,7 @@ import java.util.Set;
 
 import junit.framework.Test;
 import junit.framework.TestSuite;
-import pcgen.PCGenTestCase;
+import junit.framework.TestCase;
 
 /**
  * <code>PluginBuildTest</code> verifies that the pluginbuild.xml file has all 
@@ -42,7 +42,7 @@ import pcgen.PCGenTestCase;
  *
  * @author James Dempsey <jdempsey@users.sourceforge.net>
  */
-public class PluginBuildTest extends PCGenTestCase
+public class PluginBuildTest extends TestCase
 {
 	/**
 	 * Array of exceptions to normal names. Each entry is a pair of

--- a/code/src/test/plugin/jepcommands/IfCommandTest.java
+++ b/code/src/test/plugin/jepcommands/IfCommandTest.java
@@ -23,13 +23,14 @@
  */
 package plugin.jepcommands;
 
+import java.util.Stack;
+
+import pcgen.PCGenTestCase;
+
 import junit.framework.Test;
 import junit.framework.TestSuite;
 import org.nfunk.jep.ParseException;
 import org.nfunk.jep.function.PostfixMathCommandI;
-import pcgen.PCGenTestCase;
-
-import java.util.Stack;
 
 /**
  * <code>IfCommandTest</code> tests the functioning of the jep if plugin

--- a/code/src/test/plugin/jepcommands/IsgamemodeCommandTest.java
+++ b/code/src/test/plugin/jepcommands/IsgamemodeCommandTest.java
@@ -24,13 +24,12 @@ package plugin.jepcommands;
 
 import java.util.Stack;
 
+import pcgen.PCGenTestCase;
+
 import junit.framework.Test;
 import junit.framework.TestSuite;
-
 import org.nfunk.jep.ParseException;
 import org.nfunk.jep.function.PostfixMathCommandI;
-
-import pcgen.PCGenTestCase;
 
 /**
  * The Class <code>IsgamemodeCommandTest</code> is responsible for checking 
@@ -56,7 +55,7 @@ public class IsgamemodeCommandTest extends PCGenTestCase
 	 * @see TestCase#setUp()
 	 */
 	/* (non-Javadoc)
-	 * @see pcgen.PCGenTestCase#setUp()
+	 * @see junit.framework.TestCase#setUp()
 	 */
     @Override
 	protected void setUp() throws Exception

--- a/code/src/test/plugin/jepcommands/OrCommandTest.java
+++ b/code/src/test/plugin/jepcommands/OrCommandTest.java
@@ -23,13 +23,15 @@
  */
 package plugin.jepcommands;
 
+import java.util.Stack;
+
+import pcgen.PCGenTestCase;
+import pcgen.util.testchecker.CompareEqualDouble;
+
 import junit.framework.Test;
 import junit.framework.TestSuite;
 import org.nfunk.jep.ParseException;
 import org.nfunk.jep.function.PostfixMathCommandI;
-import pcgen.PCGenTestCase;
-
-import java.util.Stack;
 
 /**
  * <code>OrCommandTest</code> tests the functioning of the jep or plugin
@@ -165,6 +167,6 @@ public class OrCommandTest extends PCGenTestCase
 
         final Object result = s.pop();
 
-        is(result, eq(0.0), "if (false,false,false,false) returns 0.0");
+        is(result, new CompareEqualDouble(0.0), "if (false,false,false,false) returns 0.0");
     }
 }

--- a/code/src/test/plugin/lsttokens/gamemode/IconTokenTest.java
+++ b/code/src/test/plugin/lsttokens/gamemode/IconTokenTest.java
@@ -24,7 +24,7 @@ package plugin.lsttokens.gamemode;
 
 import java.net.URI;
 
-import pcgen.PCGenTestCase;
+import junit.framework.TestCase;
 import pcgen.core.GameMode;
 import pcgen.core.SettingsHandler;
 
@@ -36,12 +36,12 @@ import pcgen.core.SettingsHandler;
  * 
  * @author James Dempsey <jdempsey@users.sourceforge.net>
  */
-public class IconTokenTest extends PCGenTestCase
+public class IconTokenTest extends TestCase
 {
 	private URI uri;
 	
 	/* (non-Javadoc)
-	 * @see pcgen.PCGenTestCase#setUp()
+	 * @see junit.framework.TestCase#setUp()
 	 */
 	@Override
 	protected void setUp() throws Exception

--- a/code/src/test/plugin/lsttokens/gamemode/abilitycategory/AbilityListTokenTest.java
+++ b/code/src/test/plugin/lsttokens/gamemode/abilitycategory/AbilityListTokenTest.java
@@ -26,7 +26,7 @@ package plugin.lsttokens.gamemode.abilitycategory;
 import java.util.ArrayList;
 import java.util.Collection;
 
-import pcgen.PCGenTestCase;
+import junit.framework.TestCase;
 import pcgen.cdom.reference.CDOMDirectSingleRef;
 import pcgen.cdom.reference.CDOMSingleRef;
 import pcgen.core.Ability;
@@ -44,7 +44,7 @@ import pcgen.rules.context.RuntimeReferenceContext;
  * 
  * @author James Dempsey <jdempsey@users.sourceforge.net>
  */
-public class AbilityListTokenTest extends PCGenTestCase
+public class AbilityListTokenTest extends TestCase
 {
 
 	private RuntimeLoadContext context;

--- a/code/src/utest/pcgen/cdom/util/MapKeyMapTest.java
+++ b/code/src/utest/pcgen/cdom/util/MapKeyMapTest.java
@@ -61,7 +61,7 @@ public class MapKeyMapTest
 	private Aspect breedAspect;
 
 	/* (non-Javadoc)
-	 * @see pcgen.PCGenTestCase#setUp()
+	 * @see junit.framework.TestCase#setUp()
 	 */
 	@Before
 	public void setUp() throws Exception


### PR DESCRIPTION
As far as I could tell the bug referenced by the comment at the top of the file no longer exists
The class does a lot more than the commentary explains and overall makes navigating the pcgen test codebase harder. It also makes identifying non junit4 tests slightly more difficult.
Finally, the class does a fair bit of work thus slowing down testing.