### PR TITLE
css/xml style and bugs

### DIFF
--- a/docs/acknowledgments/publishersandsources.html
+++ b/docs/acknowledgments/publishersandsources.html
@@ -1,13 +1,8 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <!--
                 PCGen Documentation Project
-                        
-                $Author$
-                $Date$
-                $Revision$      
-                
+
                 Contributors: 
                 Eddy Anthony - eddybaATmindspringDOTcom
                 Shane Molnar - shaneATcliftonmotelDOTcomDOTau
@@ -19,12 +14,15 @@
                 The Open Game License, version 1.0a.
         -->
 <head>
-<meta name="generator" content=
-"HTML Tidy for Cygwin (vers 25 March 2009), see www.w3.org" />
 <title>Publishers and Sources</title>
 <link rel="stylesheet" type="text/css" href="../pcgen.css" />
 <meta http-equiv="Content-Type" content=
 "text/html; charset=us-ascii" />
+	<style type="text/css">
+		.indent1 {
+			line-height: 1.5;
+		}
+	</style>
 </head>
 <body>
 <h1>Publisher and Source Information</h1>
@@ -55,7 +53,7 @@ Policy and Procedure</a></h2>
 <h3>Data Inclusion Policy</h3>
 <p class="indent1">The following is PCGen&rsquo;s policy on
 including data for distribution.</p>
-<ol class="indent1" style="line-height: 1.5">
+<ol class="indent1">
 <li><strong>Source Ownership:</strong> All source material is owned
 by the publishers. As such, PCGen shall comply with all publisher
 wishes as it relates to the use and distribution of the their
@@ -72,7 +70,7 @@ permissions were granted/last confirmed.</li>
 distributed with PCGen must have as a minimum a granted permission
 level, from the appropriate publisher, of "OGL+Title". This will
 ensure that all data used within PCGen can be properly identified.
-<ol style="list-style-type: lower-alpha">
+<ol style="list-style-type: lower-alpha;">
 <li>The only exception to this policy is where a dataset containing
 only OGL material,from a source where the publisher has granted
 'OGL Only' permission, and the dataset is used as the foundation
@@ -88,7 +86,7 @@ PCGen, found in a publishers source material (i.e. Abilities &amp;
 Feats, Classes, Equipment, Domains, Skills, Spells, and Races) are
 required for a dataset to be considered for inclusion in the PCGen
 Distribution.
-<ol style="list-style-type: lower-alpha">
+<ol style="list-style-type: lower-alpha;">
 <li>Object name. As per the RSRD vs the PHB/DMG/MM, the name can be
 different than the one used in the book. EXAMPLE: The <em>Quiver of
 Elhonna</em> from the DMG, &copy;WotC 2003, and not released under
@@ -113,7 +111,7 @@ all derived values for the game features.</li>
 <li><strong>Data Not Included in Datasets:</strong> PCGen will not
 incorporate the following in any distributed dataset, making owning
 the source necessary to use the dataset.
-<ol style="list-style-type: lower-alpha">
+<ol style="list-style-type: lower-alpha;">
 <li>The description of any game mechanic, using the permissioned
 data soley for the calculations described above.</li>
 <li>'Fluff' content, i.e. detailed object description or
@@ -124,7 +122,7 @@ story-line.</li>
 <h3>Data Inclusion Procedure</h3>
 <p class="indent1">The following is the procedure to be followed
 for including a dataset in PCGen for distribution.</p>
-<ol class="indent1" style="line-height: 1.5">
+<ol class="indent1" style="line-height: 1.5;">
 <li>PCGen&rsquo;s publisher liaison (PL) team contacts the
 publisher and asks for permission to include one or more of their
 sources in PCGen&rsquo;s distribution.</li>
@@ -1732,7 +1730,7 @@ Required</p>
 						<li>Shattered Star Player's Guide</li>
 					</ul>
 				</li>
-				<li>Skull &amp; Shackles</li>
+				<li>Skull &amp; Shackles
 					<ul>
 						<li>Skull &amp; Shackles Player's Guide</li>
 						<li>Skull &amp; Shackles Chapter 1 (AP55): The Wormwood Mutiny</li>
@@ -2617,10 +2615,10 @@ Games</a>
 <li><a href="http://www.paizo.com/">Paizo Publishing</a>
 <ul>
 <li>Paizo - Pathfinder Adventure Paths</li>
-<li style="list-style: none; display: inline">
+<li style="list-style: none; display: inline;">
 <ul>
 <li>Rise if the Rune Lords</li>
-<li style="list-style: none; display: inline">
+<li style="list-style: none; display: inline;">
 <ul>
 <li>Rise of the Rune Lords Players Guide</li>
 <li>Rise of the Rune Lords - Chapter 1 - Burnt Offerings</li>
@@ -2634,7 +2632,7 @@ Giants</li>
 </ul>
 </li>
 <li>Curse of the Crimson Throne</li>
-<li style="list-style: none; display: inline">
+<li style="list-style: none; display: inline;">
 <ul>
 <li>Curse of the Crimson Throne Players Guide</li>
 <li>Curse of the Crimson Throne - Chapter 1 - Edge of Anarchy</li>
@@ -2649,7 +2647,7 @@ Scarwall</li>
 </ul>
 </li>
 <li>Second Darkness</li>
-<li style="list-style: none; display: inline">
+<li style="list-style: none; display: inline;">
 <ul>
 <li>Second Darkness Player's Guide</li>
 <li>Second Darkness Chapter 1 - Shadow in the Sky</li>
@@ -2661,7 +2659,7 @@ Scarwall</li>
 </ul>
 </li>
 <li>Legacy of Fire</li>
-<li style="list-style: none; display: inline">
+<li style="list-style: none; display: inline;">
 <ul>
 <li>Legacy of Fire Player's Guide (<span class=
 "alpha">Alpha</span>)</li>
@@ -2670,7 +2668,7 @@ Scarwall</li>
 </ul>
 </li>
 <li>Paizo - Pathfinder/GameMastery Modules</li>
-<li style="list-style: none; display: inline">
+<li style="list-style: none; display: inline;">
 <ul>
 <li>GameMastery Module D0 - Hollow's Last Hope</li>
 <li>GameMastery Module D1 - Crown of the Kobold King</li>
@@ -2678,13 +2676,13 @@ Scarwall</li>
 </ul>
 </li>
 <li>Paizo - Pathfinder Campaign Setting / Chronicles</li>
-<li style="list-style: none; display: inline">
+<li style="list-style: none; display: inline;">
 <ul>
 <li>Dark Markets - A Guide to Katapesh</li>
 </ul>
 </li>
 <li>Paizo - Pathfinder Companion</li>
-<li style="list-style: none; display: inline">
+<li style="list-style: none; display: inline;">
 <ul>
 <li>Second Darkness Player's Guide</li>
 <li>Legacy of Fire Player's Guide</li>
@@ -3117,7 +3115,7 @@ Press</a>
 <li><a href="http://www.paizo.com/">Paizo Publishing</a>
 <ul>
 <li>Paizo - Pathfinder RPG</li>
-<li style="list-style: none; display: inline">
+<li style="list-style: none; display: inline;">
 <ul>
 <li>Core Rulebook</li>
 <li>Advanced Player's Guide (<span class="alpha">Alpha</span>)</li>
@@ -3132,7 +3130,7 @@ Press</a>
 </ul>
 </li>
 <li>Paizo - Pathfinder Adventure Paths</li>
-<li style="list-style: none; display: inline">
+<li style="list-style: none; display: inline;">
 <ul>
 <li>Rise if the Rune Lords (Pathfinder Conversion)
 <ul>
@@ -3209,7 +3207,7 @@ Scarwall</li>
 </ul>
 </li>
 <li>Skull &amp; Shackles</li>
-<li style="list-style: none; display: inline">
+<li style="list-style: none; display: inline;">
 <ul>
 <li>Skull &amp; Shackles Player's Guide (<span class=
 "alpha">Alpha</span>)</li>
@@ -3246,7 +3244,7 @@ Scarwall</li>
 </li>
 <li>Paizo - Pathfinder Modules</li>
 <li>Paizo - Pathfinder Campaign Setting / Chronicles</li>
-<li style="list-style: none; display: inline">
+<li style="list-style: none; display: inline;">
 <ul>
 <li>Pathfinder Campaign Setting (<span class=
 "alpha">Alpha</span>)</li>

--- a/docs/doc_tools/all_link_anchors_to_lowercase.py
+++ b/docs/doc_tools/all_link_anchors_to_lowercase.py
@@ -12,9 +12,10 @@
 # i.e. `# WIDGETS` becomes `<h1 id="widgets">WIDGETS</h1>`. But the `id`
 # attribute is always generated in lowercase.
 
-import bs4 # Requires package `beautifulsoup4` for HTML parsing
 import os
 import codecs
+
+import bs4 # Requires package `beautifulsoup4` for HTML parsing
 
 def list_all_html_files():
     html_files = list()

--- a/docs/faqpages/faqiwannahelp.html
+++ b/docs/faqpages/faqiwannahelp.html
@@ -25,7 +25,7 @@
 <body>
 <h1>I Want to Help to Make Datasets</h1>
 <p><span class="underline">How do I get started?</span></p>
-<ol style="list-style-type: upper-roman">
+<ol style="list-style-type: upper-roman;">
 <li>
 <p class="indent1">First do you have the current version of PcGen
 running on your system. If you do then you have Java installed and

--- a/docs/faqpages/faqoutofmemoryandjavaissues.html
+++ b/docs/faqpages/faqoutofmemoryandjavaissues.html
@@ -119,7 +119,7 @@ will work out better.
    <li>
     Look for the following text:
     <code>-Xms128m -Xmx256m</code>
-    <ol style="list-style-type: lower-alpha">
+    <ol style="list-style-type: lower-alpha;">
      <li>
       If you have 512MB of ram, you can change the text to the
 following:
@@ -378,7 +378,7 @@ problem is that Windows is not pointing the command "java" to the
     <code>&lt;Path to Java&gt; -Dswing.aatext=true -Xms&lt;Minimum
 Memory&gt;m -Xmx&lt;Maximum Memory&gt;m -jar &lt;Path to
 PcGen&gt;</code>
-    <div style="margin-left: 2em">
+    <div style="margin-left: 2em;">
      <code>Example Vista: "C:\Program
 Files (x86)\Java\jre1.6.0_01\bin\java.exe" -Dswing.aatext=true
 -Xms256m -Xmx512m -jar "C:\Program Files
@@ -388,7 +388,7 @@ Files (x86)\Java\jre1.6.0_01\bin\java.exe" -Dswing.aatext=true
    <li>
     Put your paths and memory limits in as appropriate. If the path
 has a space in it, you need the quotes.
-    <ol style="list-style-type: lower-alpha">
+    <ol style="list-style-type: lower-alpha;">
      <li>
       Sample Path to Java: "C:\Program Files
 (x86)\Java\jre1.6.0_01\bin\java.exe"

--- a/docs/faqpages/faqsubmittingabugreport.html
+++ b/docs/faqpages/faqsubmittingabugreport.html
@@ -128,7 +128,7 @@
       The first half of the Create Issue form.
      </p>
     </div>
-    <ol style="list-style-type: decimal">
+    <ol style="list-style-type: decimal;">
      <li>
       In the
       <em>
@@ -288,7 +288,7 @@
       The second half of the Create Issue form.
      </p>
     </div>
-    <ol start="7" style="list-style-type: decimal">
+    <ol start="7" style="list-style-type: decimal;">
      <li>
       You can attach files, such as PCGen character files or screenshots, using the
       <em>

--- a/docs/faqpages/faqsubmittingafeaturerequest.html
+++ b/docs/faqpages/faqsubmittingafeaturerequest.html
@@ -58,7 +58,7 @@ can then submit it.
    <li>
     <p>
      Go to
-     <a href="http://jira.pcgen.org/" style="color: blue; text-decoration: underline; text-underline: single">
+     <a href="http://jira.pcgen.org/" style="color: blue; text-decoration: underline; text-underline: single;">
       http://jira.pcgen.org/
      </a>
      .

--- a/docs/index.html
+++ b/docs/index.html
@@ -18,19 +18,9 @@
    PCGen Documentation
   </title>
  </head>
- <frameset cols="250,*" frameborder="no">
-  <frame name="navigation" src="navtree.html" target="content">
-   <frame name="content" src="greetings.html">
-    <noframes>
-     <a href="navtree.html">
-      No Frames?
-     </a>
-     <a href="navtree.html">
-      No Frames?
-     </a>
-    </noframes>
-   </frame>
-  </frame>
+ <frameset cols="250,*">
+  <frame name="navigation" src="navtree.html">
+  <frame name="content" src="greetings.html">
  </frameset>
  <frameset>
  </frameset>

--- a/docs/listfilepages/datafilestagpages/datafilesdomains.html
+++ b/docs/listfilepages/datafilestagpages/datafilesdomains.html
@@ -169,7 +169,7 @@ example below.)
        When including a feat with an internal chooser, subchoices can
 be handled one of two ways.
       </li>
-      <li style="list-style: none; display: inline">
+      <li style="list-style: none; display: inline;">
        <ul>
         <li>
          Subchoices must be specified within the tag. (e.g. Weapon Focus

--- a/docs/listfilepages/datafilestagpages/datafilesfeats.html
+++ b/docs/listfilepages/datafilestagpages/datafilesfeats.html
@@ -40,7 +40,7 @@
      PR #380
     </a>
    </li>
-   <li style="list-style: none; display: inline">
+   <li style="list-style: none; display: inline;">
     <ul class="incremental">
      <li>
       The feat files described below is deprecated.

--- a/docs/listfilepages/datafilestagpages/datafilespcc.html
+++ b/docs/listfilepages/datafilestagpages/datafilespcc.html
@@ -1648,7 +1648,7 @@ file.
     <code>URL:Barcommerce|http://www.barcommercesite.com/product_info.php?products_id=12345&amp;affiliate_id=54321|Support
 PCGen by buying this source now!</code>
    </p>
-   <p class="tagindent2" style="text-indent: -25px">
+   <p class="tagindent2" style="text-indent: -25px;">
     Displays the text
 "Support PCGen by buying this source now!" as an active link to the
 URL
@@ -1658,7 +1658,7 @@ URL
     <code>URL:WEBSITE|http://www.foopublisher.com|Visit FooPublishers
 website.</code>
    </p>
-   <p class="tagindent2" style="text-indent: -25px">
+   <p class="tagindent2" style="text-indent: -25px;">
     Displays the text
 "Visit Foopublishers website" as an active link to the website
 "http://www.foopublisher.com"
@@ -1668,7 +1668,7 @@ website.</code>
 visiting our user feedback page and letting us know what you
 think.</code>
    </p>
-   <p class="tagindent2" style="text-indent: -25px">
+   <p class="tagindent2" style="text-indent: -25px;">
     Displays the text
 "Help PCGen out by visiting our user feedback page and letting us
 know what you think!" as an active link to the website

--- a/docs/listfilepages/datafilestagpages/datafilesraces.html
+++ b/docs/listfilepages/datafilestagpages/datafilesraces.html
@@ -651,7 +651,7 @@ example below.)
      When including a feat with an internal chooser, subchoices can
 be handled one of two ways.
     </li>
-    <li style="list-style: none; display: inline">
+    <li style="list-style: none; display: inline;">
      <ul>
       <li>
        Subchoices must be specified within the tag. (e.g. Weapon Focus

--- a/docs/listfilepages/datafilestagpages/datafilesstartingkits.html
+++ b/docs/listfilepages/datafilestagpages/datafilesstartingkits.html
@@ -443,7 +443,7 @@
 <li>6.05.04 (July 2015): JIRA 
 <a href="http://jira.pcgen.org/browse/NEWTAG-477">NEWTAG-477</a> / Github 
 <a href="https://github.com/PCGen/pcgen/pull/380">PR #380</a></li>
-<li style="list-style: none; display: inline">
+<li style="list-style: none; display: inline;">
 <ul class="incremental">
 <li>The 
 <code>FEAT</code> tag is deprecated. Use 

--- a/docs/listfilepages/globalfilestagpages/globalfilesbonus.html
+++ b/docs/listfilepages/globalfilestagpages/globalfilesbonus.html
@@ -2051,7 +2051,7 @@ Domains.
      PR #380
     </a>
    </li>
-   <li style="list-style: none; display: inline">
+   <li style="list-style: none; display: inline;">
     <ul class="incremental">
      <li>
       The

--- a/docs/listfilepages/globalfilestagpages/globalfilesother.html
+++ b/docs/listfilepages/globalfilestagpages/globalfilesother.html
@@ -133,7 +133,7 @@ be charged only if the "Nature" is NORMAL.
     When including a feat with an internal chooser, subchoices can
 be handled one of two ways.
    </li>
-   <li style="list-style: none; display: inline">
+   <li style="list-style: none; display: inline;">
     <ul>
      <li>
       Subchoices must be specified within the tag. (e.g. Weapon Focus
@@ -484,7 +484,7 @@ of 15 or better.
      PR #380
     </a>
    </li>
-   <li style="list-style: none; display: inline">
+   <li style="list-style: none; display: inline;">
     <ul class="incremental">
      <li>
       <code>AUTO:FEAT</code>
@@ -543,7 +543,7 @@ the character as automatic feats.
      When including a feat with an internal chooser, subchoices can
 be handled one of two ways.
     </li>
-    <li style="list-style: none; display: inline">
+    <li style="list-style: none; display: inline;">
      <ul>
       <li>
        Subchoices must be specified within the tag. (e.g. Weapon Focus
@@ -2428,7 +2428,7 @@ character.
     This is a comma (,) and pipe-delimited (|) list of the natural
 attacks a creature has.
    </li>
-   <li style="list-style: none; display: inline">
+   <li style="list-style: none; display: inline;">
     <ul>
      <li>
       Pipes (|) are used to separate the entries of individual
@@ -2839,7 +2839,7 @@ Region3 as the character's region.
      PR #380
     </a>
    </li>
-   <li style="list-style: none; display: inline">
+   <li style="list-style: none; display: inline;">
     <ul class="incremental">
      <li>
       All
@@ -4741,7 +4741,7 @@ and heavy loads.
      PR #380
     </a>
    </li>
-   <li style="list-style: none; display: inline">
+   <li style="list-style: none; display: inline;">
     <ul class="incremental">
      <li>
       <code>VFEAT</code>
@@ -4808,7 +4808,7 @@ feats.
      When including a feat with an internal chooser, subchoices can
 be handled one of two ways.
     </li>
-    <li style="list-style: none; display: inline">
+    <li style="list-style: none; display: inline;">
      <ul>
       <li>
        Subchoices must be specified within the tag. (e.g. Weapon Focus
@@ -5678,7 +5678,7 @@ cleared&gt;</code>
    tag, allowing the removal of the tag from the
 item. Two ways to do that are:
   </p>
-  <ul class="indent2" style="list-style: lower-alpha">
+  <ul class="indent2" style="list-style: lower-alpha;">
    <li>
     <code>MULT:NO</code>
     - makes it a single feat, choice not

--- a/docs/listfilepages/globalfilestagpages/globalfilesprexxx.html
+++ b/docs/listfilepages/globalfilestagpages/globalfilesprexxx.html
@@ -2632,7 +2632,7 @@ fighting.
      PR #380
     </a>
    </li>
-   <li style="list-style: none; display: inline">
+   <li style="list-style: none; display: inline;">
     <ul class="incremental">
      <li>
       <code>PREFEAT</code>

--- a/docs/listfilepages/lstfileclass/lfc_lesson17_converting_feats_to_abilities.html
+++ b/docs/listfilepages/lstfileclass/lfc_lesson17_converting_feats_to_abilities.html
@@ -335,7 +335,7 @@ classes are being written for the new LST-Monkey, so there will be
 some overlap, but a student of the classes does not need to take
 them in order.
   </p>
-  <hr style="height:3px"/>
+  <hr style="height:3px;"/>
   <h2>
    The Conversion
   </h2>
@@ -495,7 +495,7 @@ AC|INT</code>
   <p class="indent2">
    <code>BONUS:COMBAT|AC|INT</code>
   </p>
-  <hr style="height:3px"/>
+  <hr style="height:3px;"/>
   <h3>
    The Ability Category File
   </h3>
@@ -782,7 +782,7 @@ Ability</code>
   <p class="indent2">
    <code>VISIBLE:NO</code>
   </p>
-  <hr style="height:3px"/>
+  <hr style="height:3px;"/>
   <h3>
    The PCC File
   </h3>
@@ -850,7 +850,7 @@ the
    </a>
    .
   </p>
-  <hr style="height:3px"/>
+  <hr style="height:3px;"/>
   <h2>
    Final Thoughts
   </h2>

--- a/docs/listfilepages/systemfilestagpages/gamemodemiscinfolist.html
+++ b/docs/listfilepages/systemfilestagpages/gamemodemiscinfolist.html
@@ -5392,7 +5392,7 @@ displayed.
       INVENTORY - The tab where inventory and equipping are
 displayed.
      </li>
-     <li style="list-style: none; display: inline">
+     <li style="list-style: none; display: inline;">
       <ul>
        <li>
         PURCHASE - The tab where a character owned gear is
@@ -5413,7 +5413,7 @@ displayed.
      <li>
       SPELLS - The tab where spells are displayed.
      </li>
-     <li style="list-style: none; display: inline">
+     <li style="list-style: none; display: inline;">
       <ul>
        <li>
         KNOWN - The tab where the spells the character knows are

--- a/docs/menupages/tools/template/templateeditorbasetab.html
+++ b/docs/menupages/tools/template/templateeditorbasetab.html
@@ -169,7 +169,7 @@ affects some skills.
    </strong>
    option sets the name of the sub
 race the character is , the default is none. If Yes is
-   <span style="font-size:10.0pt;font-family:Verdana">
+   <span style="font-size:10.0pt;font-family:Verdana,sans-serif;">
     specified
    </span>
    then it
@@ -183,7 +183,7 @@ on character sheet output.
    </strong>
    option sets the name of the
 region the character is from, the default is none. If Yes is
-   <span style="font-size:10.0pt;font-family:Verdana">
+   <span style="font-size:10.0pt;font-family:Verdana,sans-serif;">
     specified
    </span>
    then it will place the name of the template in parenthesis after

--- a/docs/navtree/navtree.css
+++ b/docs/navtree/navtree.css
@@ -23,8 +23,7 @@ ul.navtree li
 
 ul.navtree li.gap
 {
-    list-style-image: none;
-    list-style: none
+    list-style: none;
 }
 
 ul.navtree li a
@@ -41,10 +40,10 @@ img.newindex
  span.deprecated
  {
      color: #FF0000; 
-     font-size: 80%
+     font-size: 80%;
  }
 
  span.note
  {
-     font-size: 80%
+     font-size: 80%;
  }

--- a/docs/outputsheetpages/csheetexampleoutput.html
+++ b/docs/outputsheetpages/csheetexampleoutput.html
@@ -49,23 +49,23 @@ output sheet.
    </tr>
    <tr>
     <td class="topline">
-     <font style="font-size:6pt">
+     <font style="font-size:6pt;">
       CHARACTER
 NAME
      </font>
     </td>
     <td class="topline">
-     <font style="font-size:6pt">
+     <font style="font-size:6pt;">
       CLASS
      </font>
     </td>
     <td class="topline">
-     <font style="font-size:6pt">
+     <font style="font-size:6pt;">
       LEVEL
      </font>
     </td>
     <td class="topline">
-     <font style="font-size:6pt">
+     <font style="font-size:6pt;">
       PLAYER
      </font>
     </td>
@@ -80,7 +80,7 @@ NAME
      <table border="0" cellpadding="0" cellspacing="0" width="100%">
       <tr>
        <td align="center" bgcolor="black">
-        <font color="white" style="font-size: 9pt">
+        <font color="white" style="font-size: 9pt;">
          <strong>
           WEAPONS
          </strong>
@@ -88,13 +88,13 @@ NAME
        </td>
       </tr>
      </table>
-     <font style="font-size:2pt">
+     <font style="font-size:2pt;">
       <br/>
      </font>
      <table border="0" cellpadding="0" cellspacing="0" width="100%">
       <tr>
        <td align="center" bgcolor="black" height="15" rowspan="2" width="40%">
-        <font color="white" style="font-size:10pt">
+        <font color="white" style="font-size:10pt;">
          <strong>
           Elven
 Longbow +1
@@ -103,7 +103,7 @@ Longbow +1
         </font>
        </td>
        <td align="center" bgcolor="black" height="15" width="20%">
-        <font color="white" style="font-size:6pt">
+        <font color="white" style="font-size:6pt;">
          <strong>
           TOTAL ATTACK
 BONUS
@@ -111,14 +111,14 @@ BONUS
         </font>
        </td>
        <td align="center" bgcolor="black" height="15" width="20%">
-        <font color="white" style="font-size:6pt">
+        <font color="white" style="font-size:6pt;">
          <strong>
           DAMAGE
          </strong>
         </font>
        </td>
        <td align="center" bgcolor="black" height="15" width="20%">
-        <font color="white" style="font-size:6pt">
+        <font color="white" style="font-size:6pt;">
          <strong>
           CRITICAL
          </strong>
@@ -127,7 +127,7 @@ BONUS
       </tr>
       <tr>
        <td align="center" bgcolor="white" class="border">
-        <font color="black" style="font-size:8pt">
+        <font color="black" style="font-size:8pt;">
          <strong>
           +10
           <br/>
@@ -135,7 +135,7 @@ BONUS
         </font>
        </td>
        <td align="center" bgcolor="white" class="border">
-        <font color="black" style="font-size:8pt">
+        <font color="black" style="font-size:8pt;">
          <strong>
           1d8+1
           <br/>
@@ -143,7 +143,7 @@ BONUS
         </font>
        </td>
        <td align="center" bgcolor="white" class="border">
-        <font color="black" style="font-size:8pt">
+        <font color="black" style="font-size:8pt;">
          <strong>
           20/x3
           <br/>
@@ -155,35 +155,35 @@ BONUS
      <table border="0" cellpadding="0" cellspacing="0" width="100%">
       <tr>
        <td align="center" bgcolor="black" height="15" width="15%">
-        <font color="white" style="font-size:6pt">
+        <font color="white" style="font-size:6pt;">
          <strong>
           HAND
          </strong>
         </font>
        </td>
        <td align="center" bgcolor="black" height="15" width="15%">
-        <font color="white" style="font-size:6pt">
+        <font color="white" style="font-size:6pt;">
          <strong>
           RANGE
          </strong>
         </font>
        </td>
        <td align="center" bgcolor="black" height="15" width="15%">
-        <font color="white" style="font-size:6pt">
+        <font color="white" style="font-size:6pt;">
          <strong>
           TYPE
          </strong>
         </font>
        </td>
        <td align="center" bgcolor="black" height="15" width="15%">
-        <font color="white" style="font-size:6pt">
+        <font color="white" style="font-size:6pt;">
          <strong>
           SIZE
          </strong>
         </font>
        </td>
        <td align="center" bgcolor="black" height="15" width="40%">
-        <font color="white" style="font-size:6pt">
+        <font color="white" style="font-size:6pt;">
          <strong>
           SPECIAL
 PROPERTIES
@@ -193,7 +193,7 @@ PROPERTIES
       </tr>
       <tr>
        <td align="center" bgcolor="white" class="border">
-        <font color="black" style="font-size:8pt">
+        <font color="black" style="font-size:8pt;">
          <strong>
           Carried
           <br/>
@@ -201,7 +201,7 @@ PROPERTIES
         </font>
        </td>
        <td align="center" bgcolor="white" class="border">
-        <font color="black" style="font-size:8pt">
+        <font color="black" style="font-size:8pt;">
          <strong>
           100'
           <br/>
@@ -209,7 +209,7 @@ PROPERTIES
         </font>
        </td>
        <td align="center" bgcolor="white" class="border">
-        <font color="black" style="font-size:8pt">
+        <font color="black" style="font-size:8pt;">
          <strong>
           P
           <br/>
@@ -217,7 +217,7 @@ PROPERTIES
         </font>
        </td>
        <td align="center" bgcolor="white" class="border">
-        <font color="black" style="font-size:8pt">
+        <font color="black" style="font-size:8pt;">
          <strong>
           L
           <br/>
@@ -225,7 +225,7 @@ PROPERTIES
         </font>
        </td>
        <td align="center" bgcolor="white" class="border">
-        <font color="black" style="font-size:8pt">
+        <font color="black" style="font-size:8pt;">
          <strong>
           <br/>
          </strong>
@@ -233,13 +233,13 @@ PROPERTIES
        </td>
       </tr>
      </table>
-     <font style="font-size:2pt">
+     <font style="font-size:2pt;">
       <br/>
      </font>
      <table border="0" cellpadding="0" cellspacing="0" width="100%">
       <tr>
        <td align="center" bgcolor="black" height="15" rowspan="2" width="40%">
-        <font color="white" style="font-size:10pt">
+        <font color="white" style="font-size:10pt;">
          <strong>
           *Longsword
           <br/>
@@ -247,7 +247,7 @@ PROPERTIES
         </font>
        </td>
        <td align="center" bgcolor="black" height="15" width="20%">
-        <font color="white" style="font-size:6pt">
+        <font color="white" style="font-size:6pt;">
          <strong>
           TOTAL ATTACK
 BONUS
@@ -255,14 +255,14 @@ BONUS
         </font>
        </td>
        <td align="center" bgcolor="black" height="15" width="20%">
-        <font color="white" style="font-size:6pt">
+        <font color="white" style="font-size:6pt;">
          <strong>
           DAMAGE
          </strong>
         </font>
        </td>
        <td align="center" bgcolor="black" height="15" width="20%">
-        <font color="white" style="font-size:6pt">
+        <font color="white" style="font-size:6pt;">
          <strong>
           CRITICAL
          </strong>
@@ -271,7 +271,7 @@ BONUS
       </tr>
       <tr>
        <td align="center" bgcolor="white" class="border">
-        <font color="black" style="font-size:8pt">
+        <font color="black" style="font-size:8pt;">
          <strong>
           +4
           <br/>
@@ -279,7 +279,7 @@ BONUS
         </font>
        </td>
        <td align="center" bgcolor="white" class="border">
-        <font color="black" style="font-size:8pt">
+        <font color="black" style="font-size:8pt;">
          <strong>
           1d8+1
           <br/>
@@ -287,7 +287,7 @@ BONUS
         </font>
        </td>
        <td align="center" bgcolor="white" class="border">
-        <font color="black" style="font-size:8pt">
+        <font color="black" style="font-size:8pt;">
          <strong>
           19-20/x2
           <br/>
@@ -299,35 +299,35 @@ BONUS
      <table border="0" cellpadding="0" cellspacing="0" width="100%">
       <tr>
        <td align="center" bgcolor="black" height="15" width="15%">
-        <font color="white" style="font-size:6pt">
+        <font color="white" style="font-size:6pt;">
          <strong>
           HAND
          </strong>
         </font>
        </td>
        <td align="center" bgcolor="black" height="15" width="15%">
-        <font color="white" style="font-size:6pt">
+        <font color="white" style="font-size:6pt;">
          <strong>
           RANGE
          </strong>
         </font>
        </td>
        <td align="center" bgcolor="black" height="15" width="15%">
-        <font color="white" style="font-size:6pt">
+        <font color="white" style="font-size:6pt;">
          <strong>
           TYPE
          </strong>
         </font>
        </td>
        <td align="center" bgcolor="black" height="15" width="15%">
-        <font color="white" style="font-size:6pt">
+        <font color="white" style="font-size:6pt;">
          <strong>
           SIZE
          </strong>
         </font>
        </td>
        <td align="center" bgcolor="black" height="15" width="40%">
-        <font color="white" style="font-size:6pt">
+        <font color="white" style="font-size:6pt;">
          <strong>
           SPECIAL
 PROPERTIES
@@ -337,7 +337,7 @@ PROPERTIES
       </tr>
       <tr>
        <td align="center" bgcolor="white" class="border">
-        <font color="black" style="font-size:8pt">
+        <font color="black" style="font-size:8pt;">
          <strong>
           Primary
           <br/>
@@ -345,7 +345,7 @@ PROPERTIES
         </font>
        </td>
        <td align="center" bgcolor="white" class="border">
-        <font color="black" style="font-size:8pt">
+        <font color="black" style="font-size:8pt;">
          <strong>
           0'
           <br/>
@@ -353,7 +353,7 @@ PROPERTIES
         </font>
        </td>
        <td align="center" bgcolor="white" class="border">
-        <font color="black" style="font-size:8pt">
+        <font color="black" style="font-size:8pt;">
          <strong>
           S
           <br/>
@@ -361,7 +361,7 @@ PROPERTIES
         </font>
        </td>
        <td align="center" bgcolor="white" class="border">
-        <font color="black" style="font-size:8pt">
+        <font color="black" style="font-size:8pt;">
          <strong>
           M
           <br/>
@@ -369,7 +369,7 @@ PROPERTIES
         </font>
        </td>
        <td align="center" bgcolor="white" class="border">
-        <font color="black" style="font-size:8pt">
+        <font color="black" style="font-size:8pt;">
          <strong>
           <br/>
          </strong>
@@ -377,13 +377,13 @@ PROPERTIES
        </td>
       </tr>
      </table>
-     <font style="font-size:2pt">
+     <font style="font-size:2pt;">
       <br/>
      </font>
      <table border="0" cellpadding="0" cellspacing="0" width="100%">
       <tr>
        <td align="center" bgcolor="black" height="15" rowspan="2" width="40%">
-        <font color="white" style="font-size:10pt">
+        <font color="white" style="font-size:10pt;">
          <strong>
           *Sword,
 Short
@@ -392,7 +392,7 @@ Short
         </font>
        </td>
        <td align="center" bgcolor="black" height="15" width="20%">
-        <font color="white" style="font-size:6pt">
+        <font color="white" style="font-size:6pt;">
          <strong>
           TOTAL ATTACK
 BONUS
@@ -400,14 +400,14 @@ BONUS
         </font>
        </td>
        <td align="center" bgcolor="black" height="15" width="20%">
-        <font color="white" style="font-size:6pt">
+        <font color="white" style="font-size:6pt;">
          <strong>
           DAMAGE
          </strong>
         </font>
        </td>
        <td align="center" bgcolor="black" height="15" width="20%">
-        <font color="white" style="font-size:6pt">
+        <font color="white" style="font-size:6pt;">
          <strong>
           CRITICAL
          </strong>
@@ -416,7 +416,7 @@ BONUS
       </tr>
       <tr>
        <td align="center" bgcolor="white" class="border">
-        <font color="black" style="font-size:8pt">
+        <font color="black" style="font-size:8pt;">
          <strong>
           +4
           <br/>
@@ -424,7 +424,7 @@ BONUS
         </font>
        </td>
        <td align="center" bgcolor="white" class="border">
-        <font color="black" style="font-size:8pt">
+        <font color="black" style="font-size:8pt;">
          <strong>
           1d6
           <br/>
@@ -432,7 +432,7 @@ BONUS
         </font>
        </td>
        <td align="center" bgcolor="white" class="border">
-        <font color="black" style="font-size:8pt">
+        <font color="black" style="font-size:8pt;">
          <strong>
           19-20/x2
           <br/>
@@ -444,35 +444,35 @@ BONUS
      <table border="0" cellpadding="0" cellspacing="0" width="100%">
       <tr>
        <td align="center" bgcolor="black" height="15" width="15%">
-        <font color="white" style="font-size:6pt">
+        <font color="white" style="font-size:6pt;">
          <strong>
           HAND
          </strong>
         </font>
        </td>
        <td align="center" bgcolor="black" height="15" width="15%">
-        <font color="white" style="font-size:6pt">
+        <font color="white" style="font-size:6pt;">
          <strong>
           RANGE
          </strong>
         </font>
        </td>
        <td align="center" bgcolor="black" height="15" width="15%">
-        <font color="white" style="font-size:6pt">
+        <font color="white" style="font-size:6pt;">
          <strong>
           TYPE
          </strong>
         </font>
        </td>
        <td align="center" bgcolor="black" height="15" width="15%">
-        <font color="white" style="font-size:6pt">
+        <font color="white" style="font-size:6pt;">
          <strong>
           SIZE
          </strong>
         </font>
        </td>
        <td align="center" bgcolor="black" height="15" width="40%">
-        <font color="white" style="font-size:6pt">
+        <font color="white" style="font-size:6pt;">
          <strong>
           SPECIAL
 PROPERTIES
@@ -482,7 +482,7 @@ PROPERTIES
       </tr>
       <tr>
        <td align="center" bgcolor="white" class="border">
-        <font color="black" style="font-size:8pt">
+        <font color="black" style="font-size:8pt;">
          <strong>
           Off-hand
           <br/>
@@ -490,7 +490,7 @@ PROPERTIES
         </font>
        </td>
        <td align="center" bgcolor="white" class="border">
-        <font color="black" style="font-size:8pt">
+        <font color="black" style="font-size:8pt;">
          <strong>
           0'
           <br/>
@@ -498,7 +498,7 @@ PROPERTIES
         </font>
        </td>
        <td align="center" bgcolor="white" class="border">
-        <font color="black" style="font-size:8pt">
+        <font color="black" style="font-size:8pt;">
          <strong>
           P
           <br/>
@@ -506,7 +506,7 @@ PROPERTIES
         </font>
        </td>
        <td align="center" bgcolor="white" class="border">
-        <font color="black" style="font-size:8pt">
+        <font color="black" style="font-size:8pt;">
          <strong>
           S
           <br/>
@@ -514,7 +514,7 @@ PROPERTIES
         </font>
        </td>
        <td align="center" bgcolor="white" class="border">
-        <font color="black" style="font-size:8pt">
+        <font color="black" style="font-size:8pt;">
          <strong>
           <br/>
          </strong>
@@ -522,13 +522,13 @@ PROPERTIES
        </td>
       </tr>
      </table>
-     <font style="font-size:2pt">
+     <font style="font-size:2pt;">
       <br/>
      </font>
      <table border="0" cellpadding="0" cellspacing="0" width="100%">
       <tr>
        <td align="center" bgcolor="black" height="15" rowspan="2" width="40%">
-        <font color="white" style="font-size:10pt">
+        <font color="white" style="font-size:10pt;">
          <strong>
           Dagger
           <br/>
@@ -536,7 +536,7 @@ PROPERTIES
         </font>
        </td>
        <td align="center" bgcolor="black" height="15" width="20%">
-        <font color="white" style="font-size:6pt">
+        <font color="white" style="font-size:6pt;">
          <strong>
           TOTAL ATTACK
 BONUS
@@ -544,14 +544,14 @@ BONUS
         </font>
        </td>
        <td align="center" bgcolor="black" height="15" width="20%">
-        <font color="white" style="font-size:6pt">
+        <font color="white" style="font-size:6pt;">
          <strong>
           DAMAGE
          </strong>
         </font>
        </td>
        <td align="center" bgcolor="black" height="15" width="20%">
-        <font color="white" style="font-size:6pt">
+        <font color="white" style="font-size:6pt;">
          <strong>
           CRITICAL
          </strong>
@@ -560,7 +560,7 @@ BONUS
       </tr>
       <tr>
        <td align="center" bgcolor="white" class="border">
-        <font color="black" style="font-size:8pt">
+        <font color="black" style="font-size:8pt;">
          <strong>
           +6
           <br/>
@@ -568,7 +568,7 @@ BONUS
         </font>
        </td>
        <td align="center" bgcolor="white" class="border">
-        <font color="black" style="font-size:8pt">
+        <font color="black" style="font-size:8pt;">
          <strong>
           1d4+1
           <br/>
@@ -576,7 +576,7 @@ BONUS
         </font>
        </td>
        <td align="center" bgcolor="white" class="border">
-        <font color="black" style="font-size:8pt">
+        <font color="black" style="font-size:8pt;">
          <strong>
           19-20/x2
           <br/>
@@ -588,35 +588,35 @@ BONUS
      <table border="0" cellpadding="0" cellspacing="0" width="100%">
       <tr>
        <td align="center" bgcolor="black" height="15" width="15%">
-        <font color="white" style="font-size:6pt">
+        <font color="white" style="font-size:6pt;">
          <strong>
           HAND
          </strong>
         </font>
        </td>
        <td align="center" bgcolor="black" height="15" width="15%">
-        <font color="white" style="font-size:6pt">
+        <font color="white" style="font-size:6pt;">
          <strong>
           RANGE
          </strong>
         </font>
        </td>
        <td align="center" bgcolor="black" height="15" width="15%">
-        <font color="white" style="font-size:6pt">
+        <font color="white" style="font-size:6pt;">
          <strong>
           TYPE
          </strong>
         </font>
        </td>
        <td align="center" bgcolor="black" height="15" width="15%">
-        <font color="white" style="font-size:6pt">
+        <font color="white" style="font-size:6pt;">
          <strong>
           SIZE
          </strong>
         </font>
        </td>
        <td align="center" bgcolor="black" height="15" width="40%">
-        <font color="white" style="font-size:6pt">
+        <font color="white" style="font-size:6pt;">
          <strong>
           SPECIAL
 PROPERTIES
@@ -626,7 +626,7 @@ PROPERTIES
       </tr>
       <tr>
        <td align="center" bgcolor="white" class="border">
-        <font color="black" style="font-size:8pt">
+        <font color="black" style="font-size:8pt;">
          <strong>
           Carried
           <br/>
@@ -634,7 +634,7 @@ PROPERTIES
         </font>
        </td>
        <td align="center" bgcolor="white" class="border">
-        <font color="black" style="font-size:8pt">
+        <font color="black" style="font-size:8pt;">
          <strong>
           0'
           <br/>
@@ -642,7 +642,7 @@ PROPERTIES
         </font>
        </td>
        <td align="center" bgcolor="white" class="border">
-        <font color="black" style="font-size:8pt">
+        <font color="black" style="font-size:8pt;">
          <strong>
           P
           <br/>
@@ -650,7 +650,7 @@ PROPERTIES
         </font>
        </td>
        <td align="center" bgcolor="white" class="border">
-        <font color="black" style="font-size:8pt">
+        <font color="black" style="font-size:8pt;">
          <strong>
           T
           <br/>
@@ -658,7 +658,7 @@ PROPERTIES
         </font>
        </td>
        <td align="center" bgcolor="white" class="border">
-        <font color="black" style="font-size:8pt">
+        <font color="black" style="font-size:8pt;">
          <strong>
           <br/>
          </strong>
@@ -666,13 +666,13 @@ PROPERTIES
        </td>
       </tr>
      </table>
-     <font style="font-size:2pt">
+     <font style="font-size:2pt;">
       <br/>
      </font>
      <table border="0" cellpadding="0" cellspacing="0" width="100%">
       <tr>
        <td align="center" bgcolor="black" height="15" rowspan="2" width="40%">
-        <font color="white" style="font-size:10pt">
+        <font color="white" style="font-size:10pt;">
          <strong>
           Dagger
 (Thrown)
@@ -681,7 +681,7 @@ PROPERTIES
         </font>
        </td>
        <td align="center" bgcolor="black" height="15" width="20%">
-        <font color="white" style="font-size:6pt">
+        <font color="white" style="font-size:6pt;">
          <strong>
           TOTAL ATTACK
 BONUS
@@ -689,14 +689,14 @@ BONUS
         </font>
        </td>
        <td align="center" bgcolor="black" height="15" width="20%">
-        <font color="white" style="font-size:6pt">
+        <font color="white" style="font-size:6pt;">
          <strong>
           DAMAGE
          </strong>
         </font>
        </td>
        <td align="center" bgcolor="black" height="15" width="20%">
-        <font color="white" style="font-size:6pt">
+        <font color="white" style="font-size:6pt;">
          <strong>
           CRITICAL
          </strong>
@@ -705,7 +705,7 @@ BONUS
       </tr>
       <tr>
        <td align="center" bgcolor="white" class="border">
-        <font color="black" style="font-size:8pt">
+        <font color="black" style="font-size:8pt;">
          <strong>
           +9
           <br/>
@@ -713,7 +713,7 @@ BONUS
         </font>
        </td>
        <td align="center" bgcolor="white" class="border">
-        <font color="black" style="font-size:8pt">
+        <font color="black" style="font-size:8pt;">
          <strong>
           1d4+1
           <br/>
@@ -721,7 +721,7 @@ BONUS
         </font>
        </td>
        <td align="center" bgcolor="white" class="border">
-        <font color="black" style="font-size:8pt">
+        <font color="black" style="font-size:8pt;">
          <strong>
           19-20/x2
           <br/>
@@ -733,35 +733,35 @@ BONUS
      <table border="0" cellpadding="0" cellspacing="0" width="100%">
       <tr>
        <td align="center" bgcolor="black" height="15" width="15%">
-        <font color="white" style="font-size:6pt">
+        <font color="white" style="font-size:6pt;">
          <strong>
           HAND
          </strong>
         </font>
        </td>
        <td align="center" bgcolor="black" height="15" width="15%">
-        <font color="white" style="font-size:6pt">
+        <font color="white" style="font-size:6pt;">
          <strong>
           RANGE
          </strong>
         </font>
        </td>
        <td align="center" bgcolor="black" height="15" width="15%">
-        <font color="white" style="font-size:6pt">
+        <font color="white" style="font-size:6pt;">
          <strong>
           TYPE
          </strong>
         </font>
        </td>
        <td align="center" bgcolor="black" height="15" width="15%">
-        <font color="white" style="font-size:6pt">
+        <font color="white" style="font-size:6pt;">
          <strong>
           SIZE
          </strong>
         </font>
        </td>
        <td align="center" bgcolor="black" height="15" width="40%">
-        <font color="white" style="font-size:6pt">
+        <font color="white" style="font-size:6pt;">
          <strong>
           SPECIAL
 PROPERTIES
@@ -771,7 +771,7 @@ PROPERTIES
       </tr>
       <tr>
        <td align="center" bgcolor="white" class="border">
-        <font color="black" style="font-size:8pt">
+        <font color="black" style="font-size:8pt;">
          <strong>
           Carried
           <br/>
@@ -779,7 +779,7 @@ PROPERTIES
         </font>
        </td>
        <td align="center" bgcolor="white" class="border">
-        <font color="black" style="font-size:8pt">
+        <font color="black" style="font-size:8pt;">
          <strong>
           10'
           <br/>
@@ -787,7 +787,7 @@ PROPERTIES
         </font>
        </td>
        <td align="center" bgcolor="white" class="border">
-        <font color="black" style="font-size:8pt">
+        <font color="black" style="font-size:8pt;">
          <strong>
           P
           <br/>
@@ -795,7 +795,7 @@ PROPERTIES
         </font>
        </td>
        <td align="center" bgcolor="white" class="border">
-        <font color="black" style="font-size:8pt">
+        <font color="black" style="font-size:8pt;">
          <strong>
           T
           <br/>
@@ -803,7 +803,7 @@ PROPERTIES
         </font>
        </td>
        <td align="center" bgcolor="white" class="border">
-        <font color="black" style="font-size:8pt">
+        <font color="black" style="font-size:8pt;">
          <strong>
           <br/>
          </strong>
@@ -818,7 +818,7 @@ PROPERTIES
      <table border="0" cellpadding="2" cellspacing="0" width="100%">
       <tr>
        <td align="center" bgcolor="black" colspan="5">
-        <font color="white" style="font-size: 9pt">
+        <font color="white" style="font-size: 9pt;">
          <strong>
           EQUIPMENT
          </strong>
@@ -827,35 +827,35 @@ PROPERTIES
       </tr>
       <tr>
        <td class="border" valign="top" width="60%">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          <strong>
           ITEM
          </strong>
         </font>
        </td>
        <td align="center" class="border" valign="top" width="10%">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          <strong>
           EQUIPPED
          </strong>
         </font>
        </td>
        <td align="center" class="border" valign="top" width="10%">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          <strong>
           QTY
          </strong>
         </font>
        </td>
        <td align="center" class="border" valign="top" width="10%">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          <strong>
           WT.
          </strong>
         </font>
        </td>
        <td align="center" class="border" valign="top" width="10%">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          <strong>
           GP COST
          </strong>
@@ -864,33 +864,33 @@ PROPERTIES
       </tr>
       <tr>
        <td class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          Antitoxin (Vial)
         </font>
-        <font style="font-size: 5pt">
+        <font style="font-size: 5pt;">
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          N
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          2
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          0.0625
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          50
          <br/>
         </font>
@@ -898,33 +898,33 @@ PROPERTIES
       </tr>
       <tr>
        <td class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          Arrow
         </font>
-        <font style="font-size: 5pt">
+        <font style="font-size: 5pt;">
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          N
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          20
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          0.15
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          0.05
          <br/>
         </font>
@@ -932,33 +932,33 @@ PROPERTIES
       </tr>
       <tr>
        <td class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          Backpack
         </font>
-        <font style="font-size: 5pt">
+        <font style="font-size: 5pt;">
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          N
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          2
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          2
          <br/>
         </font>
@@ -966,33 +966,33 @@ PROPERTIES
       </tr>
       <tr>
        <td class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          Bedroll
         </font>
-        <font style="font-size: 5pt">
+        <font style="font-size: 5pt;">
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          N
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          5
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          0.1
          <br/>
         </font>
@@ -1000,34 +1000,34 @@ PROPERTIES
       </tr>
       <tr>
        <td class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          Bit
 and Bridle
         </font>
-        <font style="font-size: 5pt">
+        <font style="font-size: 5pt;">
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          N
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          2
          <br/>
         </font>
@@ -1035,33 +1035,33 @@ and Bridle
       </tr>
       <tr>
        <td class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          Blanket (Winter)
         </font>
-        <font style="font-size: 5pt">
+        <font style="font-size: 5pt;">
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          N
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          3
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          0.5
          <br/>
         </font>
@@ -1069,33 +1069,33 @@ and Bridle
       </tr>
       <tr>
        <td class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          Caltrops
         </font>
-        <font style="font-size: 5pt">
+        <font style="font-size: 5pt;">
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          N
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          2
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          2
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1
          <br/>
         </font>
@@ -1103,33 +1103,33 @@ and Bridle
       </tr>
       <tr>
        <td class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          Candle
         </font>
-        <font style="font-size: 5pt">
+        <font style="font-size: 5pt;">
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          N
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          4
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          0
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          0.01
          <br/>
         </font>
@@ -1137,34 +1137,34 @@ and Bridle
       </tr>
       <tr>
        <td class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          Case
 (Map or Scroll)
         </font>
-        <font style="font-size: 5pt">
+        <font style="font-size: 5pt;">
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          N
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          0.5
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1
          <br/>
         </font>
@@ -1172,34 +1172,34 @@ and Bridle
       </tr>
       <tr>
        <td class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          Coin
 (Gold)
         </font>
-        <font style="font-size: 5pt">
+        <font style="font-size: 5pt;">
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          N
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          25
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          0.02
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1
          <br/>
         </font>
@@ -1207,34 +1207,34 @@ and Bridle
       </tr>
       <tr>
        <td class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          Coin
 (Silver)
         </font>
-        <font style="font-size: 5pt">
+        <font style="font-size: 5pt;">
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          N
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          5
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          0.02
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          0.1
          <br/>
         </font>
@@ -1242,33 +1242,33 @@ and Bridle
       </tr>
       <tr>
        <td class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          Fishhook
         </font>
-        <font style="font-size: 5pt">
+        <font style="font-size: 5pt;">
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          N
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          2
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          0
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          0.1
          <br/>
         </font>
@@ -1276,34 +1276,34 @@ and Bridle
       </tr>
       <tr>
        <td class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          Flint
 and Steel
         </font>
-        <font style="font-size: 5pt">
+        <font style="font-size: 5pt;">
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          N
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          2
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          0
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1
          <br/>
         </font>
@@ -1311,35 +1311,35 @@ and Steel
       </tr>
       <tr>
        <td class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          <strong>
           Holy Arrow +1
          </strong>
         </font>
-        <font style="font-size: 5pt">
+        <font style="font-size: 5pt;">
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          N
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          14
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          0.15
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          47
          <br/>
         </font>
@@ -1347,34 +1347,34 @@ and Steel
       </tr>
       <tr>
        <td class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          Horse
 (Light)
         </font>
-        <font style="font-size: 5pt">
+        <font style="font-size: 5pt;">
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          N
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          0
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          75
          <br/>
         </font>
@@ -1382,33 +1382,33 @@ and Steel
       </tr>
       <tr>
        <td class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          Lantern (Hooded)
         </font>
-        <font style="font-size: 5pt">
+        <font style="font-size: 5pt;">
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          N
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          2
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          7
          <br/>
         </font>
@@ -1416,33 +1416,33 @@ and Steel
       </tr>
       <tr>
        <td class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          Leather
         </font>
-        <font style="font-size: 5pt">
+        <font style="font-size: 5pt;">
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          Y
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          15
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          10
          <br/>
         </font>
@@ -1450,34 +1450,34 @@ and Steel
       </tr>
       <tr>
        <td class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          Mirror
 (Small/Steel)
         </font>
-        <font style="font-size: 5pt">
+        <font style="font-size: 5pt;">
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          N
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          0.5
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          10
          <br/>
         </font>
@@ -1485,34 +1485,34 @@ and Steel
       </tr>
       <tr>
        <td class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          Oil (1
 Pt. Flask)
         </font>
-        <font style="font-size: 5pt">
+        <font style="font-size: 5pt;">
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          N
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          0.1
          <br/>
         </font>
@@ -1520,34 +1520,34 @@ Pt. Flask)
       </tr>
       <tr>
        <td class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          Outfit
 (Explorer's)
         </font>
-        <font style="font-size: 5pt">
+        <font style="font-size: 5pt;">
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          Y
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          8
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          10
          <br/>
         </font>
@@ -1555,33 +1555,33 @@ Pt. Flask)
       </tr>
       <tr>
        <td class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          Parchment (Sheet)
         </font>
-        <font style="font-size: 5pt">
+        <font style="font-size: 5pt;">
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          N
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          0
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          0.2
          <br/>
         </font>
@@ -1589,34 +1589,34 @@ Pt. Flask)
       </tr>
       <tr>
        <td class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          Pen
 (Ink)
         </font>
-        <font style="font-size: 5pt">
+        <font style="font-size: 5pt;">
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          N
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          0
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          0.1
          <br/>
         </font>
@@ -1624,34 +1624,34 @@ Pt. Flask)
       </tr>
       <tr>
        <td class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          Pouch
 (Belt)
         </font>
-        <font style="font-size: 5pt">
+        <font style="font-size: 5pt;">
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          N
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          3
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1
          <br/>
         </font>
@@ -1659,34 +1659,34 @@ Pt. Flask)
       </tr>
       <tr>
        <td class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          Pouch
 (Belt)
         </font>
-        <font style="font-size: 5pt">
+        <font style="font-size: 5pt;">
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          N
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          3
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1
          <br/>
         </font>
@@ -1694,33 +1694,33 @@ Pt. Flask)
       </tr>
       <tr>
        <td class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          Rations (Trail/Per Day)
         </font>
-        <font style="font-size: 5pt">
+        <font style="font-size: 5pt;">
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          N
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          5
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          0.5
          <br/>
         </font>
@@ -1728,36 +1728,36 @@ Pt. Flask)
       </tr>
       <tr>
        <td class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          <strong>
           Ring of Protection
 +3
          </strong>
         </font>
-        <font style="font-size: 5pt">
+        <font style="font-size: 5pt;">
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          Y
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          0
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          18000
          <br/>
         </font>
@@ -1765,36 +1765,36 @@ Pt. Flask)
       </tr>
       <tr>
        <td class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          <strong>
           Ring of Zylor
          </strong>
         </font>
-        <font style="font-size: 5pt">
+        <font style="font-size: 5pt;">
          <br/>
          Shield, Teleport
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          Y
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          0
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          153000
          <br/>
         </font>
@@ -1802,34 +1802,34 @@ Pt. Flask)
       </tr>
       <tr>
        <td class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          Saddle
 (Riding)
         </font>
-        <font style="font-size: 5pt">
+        <font style="font-size: 5pt;">
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          N
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          30
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          10
          <br/>
         </font>
@@ -1837,33 +1837,33 @@ Pt. Flask)
       </tr>
       <tr>
        <td class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          Sealing Wax
         </font>
-        <font style="font-size: 5pt">
+        <font style="font-size: 5pt;">
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          N
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1
          <br/>
         </font>
@@ -1871,34 +1871,34 @@ Pt. Flask)
       </tr>
       <tr>
        <td class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          Sewing
 Needle
         </font>
-        <font style="font-size: 5pt">
+        <font style="font-size: 5pt;">
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          N
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          2
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          0
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          0.5
          <br/>
         </font>
@@ -1906,34 +1906,34 @@ Needle
       </tr>
       <tr>
        <td class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          Soap
 (Per Lb.)
         </font>
-        <font style="font-size: 5pt">
+        <font style="font-size: 5pt;">
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          N
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          0.5
          <br/>
         </font>
@@ -1941,34 +1941,34 @@ Needle
       </tr>
       <tr>
        <td class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          Spade
 or Shovel
         </font>
-        <font style="font-size: 5pt">
+        <font style="font-size: 5pt;">
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          N
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          8
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          2
          <br/>
         </font>
@@ -1976,33 +1976,33 @@ or Shovel
       </tr>
       <tr>
        <td class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          Spyglass
         </font>
-        <font style="font-size: 5pt">
+        <font style="font-size: 5pt;">
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          N
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1000
          <br/>
         </font>
@@ -2010,33 +2010,33 @@ or Shovel
       </tr>
       <tr>
        <td class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          Torch
         </font>
-        <font style="font-size: 5pt">
+        <font style="font-size: 5pt;">
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          N
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          0.01
          <br/>
         </font>
@@ -2044,35 +2044,35 @@ or Shovel
       </tr>
       <tr>
        <td class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          <strong>
           War Arrow +5
          </strong>
         </font>
-        <font style="font-size: 5pt">
+        <font style="font-size: 5pt;">
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          N
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          4
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          0.15
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1007
          <br/>
         </font>
@@ -2080,33 +2080,33 @@ or Shovel
       </tr>
       <tr>
        <td class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          Waterskin
         </font>
-        <font style="font-size: 5pt">
+        <font style="font-size: 5pt;">
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          N
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          0
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1
          <br/>
         </font>
@@ -2114,33 +2114,33 @@ or Shovel
       </tr>
       <tr>
        <td class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          Waterskin
         </font>
-        <font style="font-size: 5pt">
+        <font style="font-size: 5pt;">
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          N
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          0
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1
          <br/>
         </font>
@@ -2148,33 +2148,33 @@ or Shovel
       </tr>
       <tr>
        <td class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          Whetstone
         </font>
-        <font style="font-size: 5pt">
+        <font style="font-size: 5pt;">
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          N
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          1
          <br/>
         </font>
        </td>
        <td align="center" class="border" valign="top">
-        <font style="font-size: 8pt">
+        <font style="font-size: 8pt;">
          0.02
          <br/>
         </font>

--- a/docs/pcgen.css
+++ b/docs/pcgen.css
@@ -3,7 +3,7 @@ body {
 	font-size: 10pt;
 }
 code {
-	font-family: "Courier New", Courier, mono;
+	font-family: "Courier New", Courier, mono, sans-serif;
 	font-size: 10pt;
 }
 dd	{
@@ -31,10 +31,6 @@ p {
 	font-size: 10pt;
 	text-align: justify;
 }
-p18 {
-	font-size: 18pt;
-	text-align: justify;
-}
 table {
 	font-family: Arial, Helvetica, sans-serif;
 	font-size: 10pt;
@@ -43,7 +39,7 @@ table {
 	padding: 10px;
 }
 td {
-	cell-spacing: 5px;
+	border-spacing: 5px;
 	padding: 1px 10px;
 }
 a img {
@@ -151,7 +147,7 @@ a img {
 	margin-right: 0px;
 	margin-bottom: 0px;
 	margin-left: 50px;
-	font-family: "Courier New", Courier, mono;
+	font-family: "Courier New", Courier, mono, sans-serif;
 	font-size: 10pt;
 }
 .tagexampdesc {
@@ -178,7 +174,7 @@ a img {
 .lstupnew {
 	color: #FF0000;
 	font-weight: bold;
-	margin-bottom: -10px
+	margin-bottom: -10px;
 }
 .lststatus {
 	color: #000000;
@@ -268,31 +264,31 @@ a img {
 	font-size: 6pt;
 }
 .cb9 {
-	blackground-color: #000000;
+	background-color: #000000;
 	color: #ffffff;
 	text-align: center;
 }
 .cw8 {
 	font-size: 8pt;
-	blackground-color: #ffffff;
+	background-color: #ffffff;
 	color: #000000;
 	text-align: center;
 }
 .cb8 {
 	font-size: 8pt;
-	blackground-color: #000000;
+	background-color: #000000;
 	color: #ffffff;
 	text-align: center;
 }
 .cw6 {
 	font-size: 6pt;
-	blackground-color: #ffffff;
+	background-color: #ffffff;
 	color: #000000;
 	text-align: center;
 }
 .cb6 {
 	font-size: 6pt;
-	blackground-color: #000000;
+	background-color: #000000;
 	color: #ffffff;
 	text-align: center;
 }

--- a/docs/sourcehelp/pcgen_ogc_help.html
+++ b/docs/sourcehelp/pcgen_ogc_help.html
@@ -326,7 +326,7 @@ Method. The 80 point system assumes initial stats are set to
 zero.
   </p>
   <blockquote>
-   <table border="1" style="text-align:center" width="20%">
+   <table border="1" style="text-align:center;" width="20%">
     <tr>
      <th>
       Stat Value

--- a/docs/tabpages/tabcharactersheet.html
+++ b/docs/tabpages/tabcharactersheet.html
@@ -122,9 +122,9 @@
   </p>
   <p>
    Character Sheets can utilize Javascript. Check out the
-   <scan class="lstfile">
+   <span class="lstfile">
     preview.html
-   </scan>
+   </span>
    sheet for examples 
 			of what can be accomplished by javascript savvy coders.
   </p>


### PR DESCRIPTION
This fixes a few things
- "blackground" -> "background"
- "cell-padding" -> "border-padding"
- add missing semi-colons
- remove "p18" selector which isn't used
- convert to html5 in some cases
- removes useless svn references
- adds generic font as fallback
- removes extra "li" closing tag causing ul to not be in li
- updates frames for html5 world