### PR TITLE
Remove java version check from xdoclint warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -389,10 +389,8 @@ task wrapper(type: Wrapper) {
 
 //Disable failing on javadoc warning
 allprojects {
-    if(JavaVersion.current() == JavaVersion.VERSION_1_8){
-        tasks.withType(Javadoc) {
-            options.addBooleanOption('Xdoclint:none', true)
-        }
+    tasks.withType(Javadoc) {
+        options.addBooleanOption('Xdoclint:none', true)
     }
 }
 


### PR DESCRIPTION
The minimum version of the JDK we support building with is 1.8, and this
check is "wrong" for the future 1.9