### PR TITLE
Fix issue CODE-3095

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -245,6 +245,8 @@ task copyToRoot(type: Copy, dependsOn: [copyToLibs, jar, converterJar]) {
 
 task syncLibsToRoot(type: Sync, dependsOn: [copyToLibs, jar, converterJar]) {
     outputs.files.setFrom(file("$buildDir/libs/pcgen-${version}.jar"))
+    outputs.dir("$projectDir/libs")
+    inputs.files(fileTree("$buildDir/libs"))
 
     from "${buildDir}/libs"
     into "$projectDir/libs"


### PR DESCRIPTION
Defined inputs and outputs for task. Now it verifies that:

1) The output folder is created (libs in root folder)
2) All sources are present.

Meaning that it will check if one or more of the source files are 
missing and/or the folder doesn't exist altogether before skipping.