### PR TITLE
[Paizo][Pathfinder][Adventurer’s Armory] fix leaf and rosewood armors

### DIFF
--- a/data/pathfinder/paizo/player_companion/adventurers_armory/aa_equip_arms_armor.lst
+++ b/data/pathfinder/paizo/player_companion/adventurers_armory/aa_equip_arms_armor.lst
@@ -7,9 +7,9 @@ SOURCELONG:Adventurer's Armory	SOURCESHORT:AA	SOURCEWEB:http://paizo.com/product
 #------light---------
 #Armored Kilt
 # Equipment Name	Required Armor Proficiency		Required Shield Proficiency		Type										Cost		Weight	AC Penalty Check	Modifier		Maximum DEX Bonus	Source Page		% of Spell Failure	Combat bonus											Bonus to skill
-Leaf			PROFICIENCY:ARMOR|Studded Leather							TYPE:Armor.Light.ArmorProfLight.Suit.Standard.Nonmetal	COST:500	WT:10		ACCHECK:0		EQMOD:LEATHER	MAXDEX:5		SOURCEPAGE:p.18	SPELLFAILURE:5		BONUS:COMBAT|AC|3|TYPE=Armor
+Leaf			PROFICIENCY:ARMOR|Studded Leather							TYPE:Armor.Light.ArmorProfLight.Suit.Standard.Nonmetal	COST:350	WT:10		ACCHECK:0		EQMOD:MWORKA	MAXDEX:5		SOURCEPAGE:p.18	SPELLFAILURE:15		BONUS:COMBAT|AC|3|TYPE=Armor
 Parade		PROFICIENCY:ARMOR|Leather								TYPE:Armor.Light.ArmorProfLight.Suit.Standard.Nonmetal	COST:25	WT:20		ACCHECK:-1		EQMOD:LEATHER	MAXDEX:5		SOURCEPAGE:p.5	SPELLFAILURE:15		BONUS:COMBAT|AC|3|TYPE=Armor									BONUS:SKILL|DIPLOMACY|1|TYPE=Circumstance	BONUS:SKILL|INTIMIDATE|1|TYPE=Circumstance
-Rosewood		PROFICIENCY:ARMOR|Leather								TYPE:Armor.Light.ArmorProfLight.Suit.Nonmetal			COST:50	WT:15		ACCHECK:0		EQMOD:LEATHER	MAXDEX:6		SOURCEPAGE:p.18	SPELLFAILURE:10		BONUS:COMBAT|AC|2|TYPE=Armor SPROP: Must be watered each day. Has spikes.
+Rosewood		PROFICIENCY:ARMOR|Leather								TYPE:Armor.Light.ArmorProfLight.Suit.Nonmetal			COST:0	WT:15		ACCHECK:0		EQMOD:LEATHER.SPIKE_A	MAXDEX:6		SOURCEPAGE:p.18	SPELLFAILURE:10		BONUS:COMBAT|AC|2|TYPE=Armor SPROP: Must be watered each day.
 #------heavy---------
 Field Plate		PROFICIENCY:ARMOR|Full Plate								TYPE:Armor.Heavy.ArmorProfHeavy.Suit.Standard			COST:1200	WT:50		ACCHECK:-5		EQMOD:STEEL		MAXDEX:1		SOURCEPAGE:p.18	SPELLFAILURE:35		BONUS:COMBAT|AC|7|TYPE=Armor
 Stoneplate		PROFICIENCY:ARMOR|Stoneplate								TYPE:Armor.Heavy.ArmorProfHeavy.Suit.Standard			COST:1800	WT:75		ACCHECK:-6		EQMOD:STONE		MAXDEX:1		SOURCEPAGE:p.14	SPELLFAILURE:35		BONUS:COMBAT|AC|9|TYPE=Armor


### PR DESCRIPTION
Leaf Armor is not leather (but leaf), and masterwork, spell failure is
15%.
Rosewood has spikes, using the eqmod for it.