### PR TITLE
Improve handling of arguments with spaces or other special characters.

### DIFF
--- a/code/pcgen.sh
+++ b/code/pcgen.sh
@@ -52,8 +52,6 @@ fi
 
 # To load all sources takes more than the default 64MB.
 javaargs="-Xms${default_min_memory}m -Xmx${default_max_memory}m"
-pcgenargs=""
-whosearg=java
 
 while [ "x$1" != x ]
 do
@@ -69,17 +67,13 @@ usage: $0 [java-options] [-- pcgen-options]
 EOM
         exit 0
         ;;
-    -- ) whosearg=pcgen
+    -- ) shift
+	 break
         ;;
-    * ) if [ "$whosearg" = java ]
-        then
-            javaargs="$javaargs $1"
-        else
-            pcgenargs="$pcgenargs $1"
-        fi
+    * ) javaargs="$javaargs $1"
+	shift
         ;;
     esac
-    shift
 done
 
 # PCGen related properties:
@@ -95,4 +89,4 @@ done
 #     -Dpcgen.filter=/path/to/filter.ini
 #     -Dpcgen.options=/path/to/options.ini
 
-exec java -DBROWSER="$BROWSER" $javaargs -jar ./pcgen.jar $pcgenargs
+exec java -DBROWSER="$BROWSER" $javaargs -jar ./pcgen.jar "$@"


### PR DESCRIPTION
The current command line script `pcgen.sh` fails to handle arguments that include spaces or other special characters properly.  For example, trying the command

```
pcgen.sh -- -v -m "Pathfinder RPG for Players - Advanced"
```

as the help suggests will result in an error message about the argument _RPG_ being unknown.

The issue here is the shuffling of the command line arguments into a new variable, _pcgenargs_, which is later expanded without any protection.  Even if the arguments are properly protected when calling the script, this protection is lost in this shuffling.

My suggested fix is to simply stop argument processing when the “--” divider is reached, and then use the `"$@"` syntax at the end, which will do proper quoting.

A minor change in behaviour by this change is that the `-h` argument will not be recognized after the divider.  If one really thinks that matters, one could do a separate loop through the arguments first to check for any `-h`.  But I felt it unlikely anyone would do

```
pcgen.sh -- -h
```

and I didn't include  that in my patch.
