### PR TITLE
[CODE-3102] Multiple equipmentset export (Freemarker) fix.

### DIFF
--- a/code/src/java/pcgen/io/freemarker/EquipSetLoopDirective.java
+++ b/code/src/java/pcgen/io/freemarker/EquipSetLoopDirective.java
@@ -88,6 +88,7 @@ public class EquipSetLoopDirective implements TemplateDirectiveModel
 		for (EquipSet equipSet : eqSetList)
 		{
 			pc.setCalcEquipSetId(equipSet.getIdPath());
+			pc.setCalcEquipmentList(equipSet.getUseTempMods());
 
 			// Executes the nested body (same as <#nested> in FTL). In this
 			// case we don't provide a special writer as the parameter:
@@ -97,6 +98,7 @@ public class EquipSetLoopDirective implements TemplateDirectiveModel
 		if (currSet != null)
 		{
 			pc.setCalcEquipSetId(currSet.getIdPath());
+			pc.setCalcEquipmentList(currSet.getUseTempMods());
 		}
 	}
 


### PR DESCRIPTION
Changing the CalcEquipSetId does not change data to be output.
Need to set the CalcEquipmentList after the id change to get the
equipment data to change.