### PR TITLE
Fix regression in SpinningTabbedPane.getMovableTabIndices() introduced

### DIFF
--- a/code/src/java/pcgen/gui2/tools/SpinningTabbedPane.java
+++ b/code/src/java/pcgen/gui2/tools/SpinningTabbedPane.java
@@ -315,7 +315,7 @@ public class SpinningTabbedPane extends JTabbedPane
             }
         }
 
-        return Arrays.copyOf(list1, n);
+        return Arrays.copyOf(list1, n - 1);
     }
 
     private String getPlainTitleAt(int index)


### PR DESCRIPTION
in PR #1818