### PR TITLE
[BUG-3112] Unnecessary javadoc and sources jars in libs and classpath.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -158,9 +158,11 @@ dependencies {
     compile group: 'xml-apis', name: 'xml-apis', version:'1.4.01'
     compile group: 'com.incors.plaf', name: 'kunststoff', version:'2.0.2'
     compile group: 'net.sourceforge.argparse4j', name: 'argparse4j', version: '0.7.0'
-    compile group: 'net.sourceforge.pcgen', name: 'PCGen-base', version:'1.0.83'
-    compile group: 'net.sourceforge.pcgen', name: 'PCGen-Formula', version:'1.0.95'
     compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.21'
+
+    // Use ext: 'jar' to stop javadoc and sources jars being included
+    compile group: 'net.sourceforge.pcgen', name: 'PCGen-base', ext: 'jar', version:'1.0.83'
+    compile group: 'net.sourceforge.pcgen', name: 'PCGen-Formula', ext: 'jar', version:'1.0.95'
 
     runtime group: 'ch.qos.logback', name: 'logback-classic', version:'1.1.6'
 


### PR DESCRIPTION
Use ext: 'jar' for the PCGen-Base and PCGen-Formula dependencies so the
corresponding javadoc and sources jars are not included as dependencies.
Not sure why this works but it works.