### PR TITLE
do more work to eliminate PCGenTestCase

### DIFF
--- a/code/src/test/pcgen/AbstractCharacterTestCase.java
+++ b/code/src/test/pcgen/AbstractCharacterTestCase.java
@@ -35,6 +35,7 @@ import pcgen.rules.context.AbstractReferenceContext;
 import pcgen.rules.context.LoadContext;
 import pcgen.util.TestHelper;
 
+import junit.framework.TestCase;
 import plugin.lsttokens.testsupport.BuildUtilities;
 
 /**
@@ -44,7 +45,7 @@ import plugin.lsttokens.testsupport.BuildUtilities;
  * @author frugal@purplewombat.co.uk
  */
 @SuppressWarnings("nls")
-public abstract class AbstractCharacterTestCase extends PCGenTestCase
+public abstract class AbstractCharacterTestCase extends TestCase
 {
 	private PlayerCharacter character = null;
 	protected PCStat str;

--- a/code/src/test/pcgen/PCGenTestCase.java
+++ b/code/src/test/pcgen/PCGenTestCase.java
@@ -82,50 +82,6 @@ public abstract class PCGenTestCase extends TestCase
 	{
 		super(name);
 	}
-	
-	/**
-	 * Fixes {@link TestCase#runBare()} to not swallow a throwable from {@link
-	 * #runTest()} if {@link #tearDown()} also throws.
-	 *
-	 * @throws Throwable
-	 */
-	@Override
-	public void runBare() throws Throwable
-	{
-		setUp();
-
-		Throwable thrown = null;
-
-		try
-		{
-			runTest();
-		}
-
-		catch (final Throwable t)
-		{
-			thrown = t;
-
-		}
-
-		finally
-		{
-			try
-			{
-				tearDown();
-
-			}
-
-			finally
-			{
-				if (thrown != null)
-				{
-					// Replace any tear down exception with
-					// unit test exception
-					throw thrown;
-				}
-			}
-		}
-	}
 
 	protected void is(final Object something, final TestChecker matches)
 	{


### PR DESCRIPTION
- this reduces the complexity of PCGenTestCase (the reason it exists)
- it also removes a dep where it isn't needed.

Ideally PCGenTestCase can be turned into a trait eventually