### PR TITLE
A variety of pcgen.sh improvements

### DIFF
--- a/code/pcgen.sh
+++ b/code/pcgen.sh
@@ -1,14 +1,10 @@
 #!/bin/sh
-cd `dirname $0`
-
-# java.awt.Desktop.browse should be available and setting BROWSER is not needed anymore
-if [ "x$BROWSER" = x ]
+set -e
+if command git rev-parse >/dev/null 2>&1
 then
-    case "$WINDOWMANAGER" in
-        *kde ) BROWSER=kde-open ;;
-        *gdm ) BROWSER=gnome-open ;;
-        * ) BROWSER=netscape ;;
-    esac
+  cd "$(git rev-parse --show-toplevel)"
+else
+  cd "$(dirname $0)"
 fi
 
 available_memory="unknown"
@@ -31,7 +27,7 @@ elif [ -x /usr/bin/vm_stat ]; then
 
 	echo "Available memory: $available_memory kB"
 else
-	echo "Could not detect available memory. Will stick to default of $available_memory kB"
+	echo "Could not detect available memory. Will stick to defaults"
 fi
 
 # Test if the value is numeric before performing arithmetic on it
@@ -60,10 +56,8 @@ do
 usage: $0 [java-options] [-- pcgen-options]
     For java options, try 'java -h' and 'java -X -h'.
     Useful java property defines:
-        -DBROWSER=/path/to/browser
         -Dpcgen.filter=/path/to/filter.ini
         -Dpcgen.options=/path/to/options.ini
-    This script recognizes the BROWSER environment variable.
 EOM
         exit 0
         ;;
@@ -85,8 +79,7 @@ done
 # files from the "user.dir" directory.
 #
 # Additional properties:
-#     -DBROWSER="$BROWSER"
 #     -Dpcgen.filter=/path/to/filter.ini
 #     -Dpcgen.options=/path/to/options.ini
 
-exec java -DBROWSER="$BROWSER" $javaargs -jar ./pcgen.jar "$@"
+exec java $javaargs -jar ./pcgen.jar -- "$@"


### PR DESCRIPTION
- use quotes where its supposed to exist
- stop passing BROWSER; the application should handle this anyways.
- include a "--" after java to handle passing arguments
- move to top of git repo during development