### PR TITLE
Make PMD fatal

### DIFF
--- a/code/gradle/reporting.gradle
+++ b/code/gradle/reporting.gradle
@@ -19,9 +19,8 @@ pmd {
     ruleSets = []
 	ruleSetFiles = files('code/standards/pmdruleset.xml')
 	
-	ignoreFailures = true
 	sourceSets = []
-	toolVersion = "5.5.1"
+	toolVersion = "5.5.3"
 }
 
 findbugs {

--- a/code/standards/pmdruleset.xml
+++ b/code/standards/pmdruleset.xml
@@ -19,15 +19,41 @@
   <!--<rule ref="rulesets/java/android.xml">-->
   <rule ref="rulesets/java/basic.xml">
     <exclude name="AvoidUsingHardCodedIP" />
+    <exclude name="AvoidDecimalLiteralsInBigDecimalConstructor" />
+    <exclude name="ForLoopShouldBeWhileLoop" />
+    <exclude name="BigIntegerInstantiation" />
+    <exclude name="CollapsibleIfStatements" />
+    <exclude name="AvoidBranchingStatementAsLastInLoop" />
+    <exclude name="SimplifiedTernary" />
+    <exclude name="OverrideBothEqualsAndHashcode" />
+    <exclude name="UnconditionalIfStatement" />
   </rule>
-  <rule ref="rulesets/java/braces.xml" />
+  <rule ref="rulesets/java/braces.xml">
+    <exclude name="IfStmtsMustUseBraces" />
+    <exclude name="ForLoopsMustUseBraces" />
+    <exclude name="IfElseStmtsMustUseBraces" />
+  </rule>
   <rule ref="rulesets/java/clone.xml">
     <exclude name="ProperCloneImplementation" />
     <exclude name="CloneThrowsCloneNotSupportedException" />
+    <exclude name="CloneMethodMustImplementCloneable" />
+    <exclude name="CloneMethodReturnTypeMustMatchClassName" />
+    <exclude name="CloneMethodMustBePublic" />
   </rule>
   <rule ref="rulesets/java/codesize.xml" >
-    <!--<exclude name="TooManyFields" />-->
-    <!--<exclude name="TooManyMethods" />-->
+    <exclude name="TooManyFields" />
+    <exclude name="TooManyMethods" />
+    <exclude name="CyclomaticComplexity" />
+    <exclude name="StdCyclomaticComplexity" />
+    <exclude name="ModifiedCyclomaticComplexity" />
+    <exclude name="ExcessivePublicCount" />
+    <exclude name="NPathComplexity" />
+    <exclude name="ExcessiveMethodLength" />
+    <exclude name="ExcessiveClassLength" />
+    <exclude name="NcssConstructorCount" />
+    <exclude name="NcssMethodCount" />
+    <exclude name="NcssTypeCount" />
+    <exclude name="ExcessiveParameterList" />
   </rule>
   <!--<rule ref="rulesets/java/comments.xml" />-->
   <!--<rule ref="rulesets/controversial.xml />-->
@@ -36,40 +62,101 @@
     <exclude name="CouplingBetweenObjects" />
     <exclude name="ExcessiveImports" />
     <exclude name="LawOfDemeter" />
+    <exclude name="LooseCoupling" />
   </rule>
   <!--<rule ref="rulesets/java/design.xml" />-->
-  <rule ref="rulesets/java/empty.xml" />
-  <rule ref="rulesets/java/finalizers.xml" />
-  <rule ref="rulesets/java/imports.xml" />
+  <rule ref="rulesets/java/empty.xml">
+    <exclude name="EmptyCatchBlock" />
+    <exclude name="EmptyIfStmt" />
+    <exclude name="EmptyWhileStmt" />
+    <exclude name="EmptyStaticInitializer" />
+    <exclude name="EmptyInitializer" />
+    <exclude name="EmptyStatementNotInLoop" />
+  </rule>
+  <rule ref="rulesets/java/finalizers.xml">
+    <exclude name="FinalizeOverloaded" />
+    <exclude name="AvoidCallingFinalize" />
+  </rule>
+  <rule ref="rulesets/java/imports.xml">
+    <exclude name="UnnecessaryFullyQualifiedName" />
+    <exclude name="UnusedImports" />
+    <exclude name="TooManyStaticImports" />
+    <exclude name="ImportFromSamePackage" />
+  </rule>
   <!--<rule ref="rulesets/java/j2ee.xml" />-->
   <!--<rule ref="rulesets/java/javabeans.xml" />-->
   <rule ref="rulesets/java/junit.xml" >
     <exclude name="UseAssertTrueInsteadOfAssertEquals" />
+    <exclude name="JUnitTestContainsTooManyAsserts" />
+    <exclude name="UseAssertSameInsteadOfAssertTrue" />
+    <exclude name="UseAssertEqualsInsteadOfAssertTrue" />
+    <exclude name="JUnitSpelling" />
   </rule>
   <!--<rule ref="rulesets/java/jakarta.xml" />-->
   <rule ref="rulesets/java/logging-jakarta-commons.xml" />
-  <rule ref="rulesets/java/logging-java.xml" />
+  <rule ref="rulesets/java/logging-java.xml">
+    <exclude name="AvoidPrintStackTrace" />
+    <exclude name="SystemPrintln" />
+    <exclude name="GuardLogStatementJavaUtil" />
+    <exclude name="LoggerIsNotStaticFinal" />
+    <exclude name="MoreThanOneLogger" />
+  </rule>
   <!--<rule ref="rulesets/java/migrating.xml" />-->
   <!--<rule ref="rulesets/java/naming.xml" />-->
   <rule ref="rulesets/java/optimizations.xml">
     <exclude name="RedundantFieldInitializer" />
     <exclude name="MethodArgumentCouldBeFinal" />
     <exclude name="LocalVariableCouldBeFinal" />
+    <exclude name="AvoidInstantiatingObjectsInLoops" />
+    <exclude name="PrematureDeclaration" />
+    <exclude name="UseStringBufferForStringAppends" />
+    <exclude name="UseArrayListInsteadOfVector" />
+    <exclude name="AddEmptyString" />
+    <exclude name="UnnecessaryWrapperObjectCreation" />
+    <exclude name="SimplifyStartsWith" />
   </rule>
-  <rule ref="rulesets/java/strictexception.xml"/>
+  <rule ref="rulesets/java/strictexception.xml">
+    <exclude name="AvoidCatchingGenericException" />
+    <exclude name="AvoidCatchingNPE" />
+    <exclude name="AvoidThrowingRawExceptionTypes" />
+    <exclude name="SignatureDeclareThrowsException" />
+    <exclude name="AvoidCatchingThrowable" />
+    <exclude name="DoNotThrowExceptionInFinally" />
+    <exclude name="AvoidThrowingNullPointerException" />
+  </rule>
   <rule ref="rulesets/java/strings.xml">
     <exclude name="AvoidDuplicateLiterals" />
     <exclude name="InefficientStringBuffering" />
     <exclude name="AppendCharacterWithChar" />
     <exclude name="ConsecutiveLiteralAppends" />
     <exclude name="AvoidStringBufferField" />
+    <exclude name="ConsecutiveAppendsShouldReuse" />
+    <exclude name="UseIndexOfChar" />
+    <exclude name="UseEqualsToCompareStrings" />
+    <exclude name="UselessStringValueOf" />
+    <exclude name="InsufficientStringBufferDeclaration" />
+    <exclude name="StringToString" />
+    <exclude name="InefficientEmptyStringCheck" />
+    <exclude name="StringInstantiation" />
   </rule>
   <!--<rule ref="rulesets/java/sunsecure.xml">-->
-  <rule ref="rulesets/java/typeresolution.xml" />
+  <rule ref="rulesets/java/typeresolution.xml">
+    <exclude name="LooseCoupling" />
+    <exclude name="UnusedImports" />
+    <exclude name="SignatureDeclareThrowsException" />
+  </rule>
   <rule ref="rulesets/java/unnecessary.xml">
     <exclude name="UselessParentheses" />
+    <exclude name="UselessOverridingMethod" />
+    <exclude name="UnnecessaryReturn" />
+    <exclude name="UselessQualifiedThis" />
+    <exclude name="UnnecessaryFinalModifier" />
   </rule>
   <rule ref="rulesets/java/unusedcode.xml">
     <exclude name="UnusedModifier" />
+    <exclude name="UnusedFormalParameter" />
+    <exclude name="UnusedLocalVariable" />
+    <exclude name="UnusedPrivateMethod" />
+    <exclude name="UnusedPrivateField" />
   </rule>
 </ruleset>


### PR DESCRIPTION
This adds excludes for all existing violations, but make it possible to
fatal on PMD errors. Over time we can remove more and more exclusions.

0 PMD rule violations were found.