### PR TITLE
Remove non-javadoc comments and turn them into Javadocs

### DIFF
--- a/code/src/test/pcgen/core/prereq/PreRuleTest.java
+++ b/code/src/test/pcgen/core/prereq/PreRuleTest.java
@@ -48,7 +48,7 @@ public class PreRuleTest extends AbstractCharacterTestCase
 		TestRunner.run(PreRuleTest.class);
 	}
 
-	/* (non-Javadoc)
+	/**
 	 * @see junit.framework.TestCase#setUp()
 	 */
 	@Override
@@ -63,7 +63,7 @@ public class PreRuleTest extends AbstractCharacterTestCase
 		gameMode.getModeContext().getReferenceContext().importObject(preRule);
 	}
 
-	/* (non-Javadoc)
+	/**
 	 * @see junit.framework.TestCase#tearDown()
 	 */
 	@Override

--- a/code/src/test/pcgen/core/prereq/PreShieldProfTest.java
+++ b/code/src/test/pcgen/core/prereq/PreShieldProfTest.java
@@ -316,7 +316,7 @@ public class PreShieldProfTest extends AbstractCharacterTestCase
 	
 	}
 	
-	/* (non-Javadoc)
+	/**
 	 * @see pcgen.AbstractCharacterTestCase#setUp()
 	 */
 	@Override

--- a/code/src/test/pcgen/core/prereq/PreSkillTest.java
+++ b/code/src/test/pcgen/core/prereq/PreSkillTest.java
@@ -65,7 +65,7 @@ public class PreSkillTest extends AbstractCharacterTestCase
 	Skill target = null;
 	Skill target2 = null;
 
-	/* (non-Javadoc)
+	/**
 	 * @see junit.framework.TestCase#setUp()
 	 */
 	@Override
@@ -139,7 +139,7 @@ public class PreSkillTest extends AbstractCharacterTestCase
 		context.getReferenceContext().resolveReferences(null);
 	}
 
-	/* (non-Javadoc)
+	/**
 	 * @see junit.framework.TestCase#tearDown()
 	 */
 	@Override

--- a/code/src/test/pcgen/core/prereq/PreWeaponProfTest.java
+++ b/code/src/test/pcgen/core/prereq/PreWeaponProfTest.java
@@ -315,7 +315,7 @@ public class PreWeaponProfTest extends AbstractCharacterTestCase
 	
 	}
 	
-	/* (non-Javadoc)
+	/**
 	 * @see pcgen.AbstractCharacterTestCase#setUp()
 	 */
 	@Override

--- a/code/src/test/pcgen/gui2/facade/CharacterAbilitiesTest.java
+++ b/code/src/test/pcgen/gui2/facade/CharacterAbilitiesTest.java
@@ -115,7 +115,7 @@ public class CharacterAbilitiesTest extends AbstractCharacterTestCase
 		
 	}
 	
-	/* (non-Javadoc)
+	/**
 	 * @see pcgen.AbstractCharacterTestCase#setUp()
 	 */
 	@Override

--- a/code/src/test/pcgen/gui2/facade/CharacterFacadeImplTest.java
+++ b/code/src/test/pcgen/gui2/facade/CharacterFacadeImplTest.java
@@ -60,7 +60,7 @@ public class CharacterFacadeImplTest extends AbstractCharacterTestCase
 			EquipSet.DEFAULT_SET_PATH, defaultEquipSet.getIdPath());
 	}
 	
-	/* (non-Javadoc)
+	/**
 	 * @see pcgen.AbstractCharacterTestCase#setUp()
 	 */
 	@Override

--- a/code/src/test/pcgen/gui2/facade/EquipmentSetFacadeImplTest.java
+++ b/code/src/test/pcgen/gui2/facade/EquipmentSetFacadeImplTest.java
@@ -470,7 +470,7 @@ public class EquipmentSetFacadeImplTest extends AbstractCharacterTestCase
 		return newSet;
 	}
 
-	/* (non-Javadoc)
+	/**
 	 * @see pcgen.AbstractCharacterTestCase#setUp()
 	 */
 	@Override

--- a/code/src/test/pcgen/gui2/facade/Gui2InfoFactoryTest.java
+++ b/code/src/test/pcgen/gui2/facade/Gui2InfoFactoryTest.java
@@ -97,7 +97,7 @@ public class Gui2InfoFactoryTest extends AbstractCharacterTestCase
 			infoFactory.getHTMLInfo(tbf));
 	}	
 	
-	/* (non-Javadoc)
+	/**
 	 * @see pcgen.AbstractCharacterTestCase#setUp()
 	 */
 	@Override

--- a/code/src/test/pcgen/gui2/facade/MockDataSetFacade.java
+++ b/code/src/test/pcgen/gui2/facade/MockDataSetFacade.java
@@ -80,7 +80,7 @@ public class MockDataSetFacade implements DataSetFacade
 		classes  = new DefaultListFacade<>();
 	}
 	
-	/* (non-Javadoc)
+	/**
 	 * @see pcgen.core.facade.DataSetFacade#getAbilities(pcgen.core.facade.AbilityCategoryFacade)
 	 */
     @Override
@@ -99,7 +99,7 @@ public class MockDataSetFacade implements DataSetFacade
 		abilityMap.putValue(cat, null);
 	}
 
-	/* (non-Javadoc)
+	/**
 	 * @see pcgen.core.facade.DataSetFacade#getAlignments()
 	 */
     @Override
@@ -109,7 +109,7 @@ public class MockDataSetFacade implements DataSetFacade
 		return null;
 	}
 
-	/* (non-Javadoc)
+	/**
 	 * @see pcgen.core.facade.DataSetFacade#getCampaigns()
 	 */
     @Override
@@ -119,7 +119,7 @@ public class MockDataSetFacade implements DataSetFacade
 		return null;
 	}
 
-	/* (non-Javadoc)
+	/**
 	 * @see pcgen.core.facade.DataSetFacade#getClasses()
 	 */
     @Override
@@ -137,7 +137,7 @@ public class MockDataSetFacade implements DataSetFacade
 		classes.addElement(cls);
 	}
 
-	/* (non-Javadoc)
+	/**
 	 * @see pcgen.core.facade.DataSetFacade#getDeities()
 	 */
     @Override
@@ -147,7 +147,7 @@ public class MockDataSetFacade implements DataSetFacade
 		return null;
 	}
 
-	/* (non-Javadoc)
+	/**
 	 * @see pcgen.core.facade.DataSetFacade#getDomains()
 	 */
 	public ListFacade<DomainFacade> getDomains()
@@ -156,7 +156,7 @@ public class MockDataSetFacade implements DataSetFacade
 		return null;
 	}
 
-	/* (non-Javadoc)
+	/**
 	 * @see pcgen.core.facade.DataSetFacade#getEquipment()
 	 */
     @Override
@@ -171,7 +171,7 @@ public class MockDataSetFacade implements DataSetFacade
 	{
 	}
 
-	/* (non-Javadoc)
+	/**
 	 * @see pcgen.core.facade.DataSetFacade#getEquipmentLocations()
 	 */
     @Override
@@ -180,7 +180,7 @@ public class MockDataSetFacade implements DataSetFacade
 		return equipmentLoc;
 	}
 
-	/* (non-Javadoc)
+	/**
 	 * @see pcgen.core.facade.DataSetFacade#getXPTableNames()
 	 */
     @Override
@@ -190,7 +190,7 @@ public class MockDataSetFacade implements DataSetFacade
 		return null;
 	}
 
-	/* (non-Javadoc)
+	/**
 	 * @see pcgen.core.facade.DataSetFacade#getCharacterTypes()
 	 */
     @Override
@@ -205,7 +205,7 @@ public class MockDataSetFacade implements DataSetFacade
 		equipmentLoc.addElement(elf);
 	}
 	
-	/* (non-Javadoc)
+	/**
 	 * @see pcgen.core.facade.DataSetFacade#getGameMode()
 	 */
     @Override
@@ -214,7 +214,7 @@ public class MockDataSetFacade implements DataSetFacade
 		return game;
 	}
 
-	/* (non-Javadoc)
+	/**
 	 * @see pcgen.core.facade.DataSetFacade#getRaces()
 	 */
     @Override
@@ -223,7 +223,7 @@ public class MockDataSetFacade implements DataSetFacade
 		return races;
 	}
 
-	/* (non-Javadoc)
+	/**
 	 * @see pcgen.core.facade.DataSetFacade#getSkills()
 	 */
     @Override
@@ -232,7 +232,7 @@ public class MockDataSetFacade implements DataSetFacade
 		return skills;
 	}
 
-	/* (non-Javadoc)
+	/**
 	 * @see pcgen.core.facade.DataSetFacade#getSpeakLanguageSkill()
 	 */
     @Override
@@ -242,7 +242,7 @@ public class MockDataSetFacade implements DataSetFacade
 		return null;
 	}
 
-	/* (non-Javadoc)
+	/**
 	 * @see pcgen.core.facade.DataSetFacade#getStatGenerators()
 	 */
     @Override
@@ -252,7 +252,7 @@ public class MockDataSetFacade implements DataSetFacade
 		return null;
 	}
 
-	/* (non-Javadoc)
+	/**
 	 * @see pcgen.core.facade.DataSetFacade#getStats()
 	 */
     @Override
@@ -261,7 +261,7 @@ public class MockDataSetFacade implements DataSetFacade
 		return stats;
 	}
 
-	/* (non-Javadoc)
+	/**
 	 * @see pcgen.core.facade.DataSetFacade#getTemplates()
 	 */
     @Override

--- a/code/src/test/pcgen/persistence/lst/BioSetLoaderTest.java
+++ b/code/src/test/pcgen/persistence/lst/BioSetLoaderTest.java
@@ -82,7 +82,7 @@ public final class BioSetLoaderTest extends TestCase
 
 	private BioSetLoader loader;
 
-	/* (non-Javadoc)
+	/**
 	 * @see junit.framework.TestCase#setUp()
 	 */
     @Override
@@ -94,7 +94,7 @@ public final class BioSetLoaderTest extends TestCase
 		BioSetLoaderTest.loadBioSet(Globals.getContext(), BIO_SET_DATA, loader);
 	}
 
-	/* (non-Javadoc)
+	/**
 	 * @see junit.framework.TestCase#tearDown()
 	 */
     @Override

--- a/code/src/test/pcgen/persistence/lst/InstallLoaderTest.java
+++ b/code/src/test/pcgen/persistence/lst/InstallLoaderTest.java
@@ -80,7 +80,7 @@ public final class InstallLoaderTest extends TestCase
 				"PUBNAMELONG:" + PUBNAMELONG, "PUBNAMESHORT:" + PUBNAMESHORT,
 				"PUBNAMEWEB:" + SOURCEWEB};
 
-	/* (non-Javadoc)
+	/**
 	 * @see junit.framework.TestCase#setUp()
 	 */
     @Override
@@ -90,7 +90,7 @@ public final class InstallLoaderTest extends TestCase
 		TestHelper.loadPlugins();
 	}
 
-	/* (non-Javadoc)
+	/**
 	 * @see junit.framework.TestCase#tearDown()
 	 */
     @Override

--- a/code/src/test/pcgen/persistence/lst/prereq/PreParserFactoryTest.java
+++ b/code/src/test/pcgen/persistence/lst/prereq/PreParserFactoryTest.java
@@ -52,7 +52,7 @@ public class PreParserFactoryTest extends AbstractCharacterTestCase
 		return new TestSuite(PreParserFactoryTest.class);
 	}
 
-	/* (non-Javadoc)
+	/**
 	 * @see pcgen.AbstractCharacterTestCase#setUp()
 	 */
 	@Override

--- a/code/src/test/plugin/jepcommands/IsgamemodeCommandTest.java
+++ b/code/src/test/plugin/jepcommands/IsgamemodeCommandTest.java
@@ -51,7 +51,7 @@ public class IsgamemodeCommandTest extends PCGenTestCase
 	/*
 	 * @see TestCase#setUp()
 	 */
-	/* (non-Javadoc)
+	/**
 	 * @see junit.framework.TestCase#setUp()
 	 */
     @Override

--- a/code/src/test/plugin/lsttokens/gamemode/IconTokenTest.java
+++ b/code/src/test/plugin/lsttokens/gamemode/IconTokenTest.java
@@ -37,7 +37,7 @@ public class IconTokenTest extends TestCase
 {
 	private URI uri;
 	
-	/* (non-Javadoc)
+	/**
 	 * @see junit.framework.TestCase#setUp()
 	 */
 	@Override

--- a/code/src/testcommon/pcgen/gui2/facade/MockUIDelegate.java
+++ b/code/src/testcommon/pcgen/gui2/facade/MockUIDelegate.java
@@ -37,7 +37,7 @@ import pcgen.util.Logging;
 public class MockUIDelegate implements UIDelegate
 {
 
-	/* (non-Javadoc)
+	/**
 	 * @see pcgen.core.facade.UIDelegate#maybeShowWarningConfirm(java.lang.String, java.lang.String, java.lang.String, pcgen.system.PropertyContext, java.lang.String)
 	 */
     @Override
@@ -48,7 +48,7 @@ public class MockUIDelegate implements UIDelegate
 		return false;
 	}
 
-	/* (non-Javadoc)
+	/**
 	 * @see pcgen.core.facade.UIDelegate#showErrorMessage(java.lang.String, java.lang.String)
 	 */
     @Override
@@ -57,7 +57,7 @@ public class MockUIDelegate implements UIDelegate
 		Logging.log(Logging.ERROR, title + " - " + message);
 	}
 
-	/* (non-Javadoc)
+	/**
 	 * @see pcgen.core.facade.UIDelegate#showInfoMessage(java.lang.String, java.lang.String)
 	 */
     @Override
@@ -66,7 +66,7 @@ public class MockUIDelegate implements UIDelegate
 		Logging.log(Logging.INFO, title + " - " + message);
 	}
 
-	/* (non-Javadoc)
+	/**
 	 * @see pcgen.core.facade.UIDelegate#showLevelUpInfo(pcgen.core.facade.CharacterFacade, int)
 	 */
     @Override
@@ -75,7 +75,7 @@ public class MockUIDelegate implements UIDelegate
 		// No action
 	}
 
-	/* (non-Javadoc)
+	/**
 	 * @see pcgen.core.facade.UIDelegate#showWarningConfirm(java.lang.String, java.lang.String)
 	 */
     @Override


### PR DESCRIPTION
This is a prep PR for reducing style errors relating to lack of Javadocs