### PR TITLE
[CODE-3070] Don't start macOS GUI if we're on Java 9 since it doesn't work

### DIFF
--- a/code/src/java/pcgen/gui2/PCGenUIManager.java
+++ b/code/src/java/pcgen/gui2/PCGenUIManager.java
@@ -46,7 +46,8 @@ public final class PCGenUIManager
 
 	public static void initializeGUI()
 	{
-		if (SystemUtils.IS_OS_MAC_OSX)
+		// Don't start macOS GUI if we're on Java 9 since it doesn't work.
+		if (SystemUtils.IS_OS_MAC_OSX && (System.getProperty("java.runtime.version").charAt(0) != '9'))
 		{
 			MacGUIHandler.initialize();
 		}


### PR DESCRIPTION
I'm going to try and get this to work, but work around the issue for now