### PR TITLE
[gradle] Remove clean from default build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ group = 'net.sourceforge.pcgen'
 
 description = """PCGen"""
 
-defaultTasks 'clean', 'build'
+defaultTasks 'build'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
@@ -313,7 +313,7 @@ task msrdinttest(type: Test, dependsOn: 'jar') {
 }
 
 // Do the lot!
-task all(dependsOn: ['clean', 'build', 'slowtest', 'javadoc', 'allReports']) {
+task all(dependsOn: ['build', 'slowtest', 'javadoc', 'allReports']) {
 }
 
 task wrapper(type: Wrapper) {


### PR DESCRIPTION
All the places that require it, already explicitly use clean. Clean
slows down builds, and it isn't usually required except in CI builds.