### PR TITLE
Fixing hardcoded row height(to FontMetrics.getHeight()) and hardcoded black text color(to SystemColor.text)

### DIFF
--- a/code/src/java/gmgen/gui/ImagePreview.java
+++ b/code/src/java/gmgen/gui/ImagePreview.java
@@ -1,6 +1,7 @@
 package gmgen.gui;
 
 import java.awt.Color;
+import java.awt.SystemColor;
 import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Image;
@@ -38,7 +39,6 @@ public final class ImagePreview
 			= LanguageBundle.getString("in_ImagePreview_notAnImage");
 	private static final String in_noCharacterPortrait
 			= LanguageBundle.getString("in_ImagePreview_noCharacterPortrait");
-
 	private final JFileChooser jfc;
 
 	private PlayerCharacter aPC;
@@ -143,9 +143,9 @@ public final class ImagePreview
 			// the values are visible against most possible image backgrounds.
 			final String dim = width + " x " + height;
 
-			g.setColor(Color.black);
+			g.setColor(SystemColor.text);
 			g.drawString(dim, textX, textY);
-			g.setColor(Color.white);
+			g.setColor(SystemColor.textText);
 			g.drawString(dim, textX - 1, textX - 1);
 		}
 		else

--- a/code/src/java/pcgen/cdom/base/Constants.java
+++ b/code/src/java/pcgen/cdom/base/Constants.java
@@ -18,6 +18,7 @@
  */
 package pcgen.cdom.base;
 
+import java.awt.SystemColor;
 import java.math.BigDecimal;
 import java.text.DecimalFormat;
 
@@ -503,7 +504,7 @@ public interface Constants
 	 * The default colour of items in the GUI which the character does qualify
 	 * for. 0x000000 is black. This  is used to initialise the value in the settings
 	 * handler if the user has not overridden it. */
-	int DEFAULT_PREREQ_QUALIFY_COLOUR = 0x000000;
+	int DEFAULT_PREREQ_QUALIFY_COLOUR = SystemColor.text.getRGB() & 0x00FFFFFF;
 
 
 	/** A constant used to define an array of age sets. */

--- a/code/src/java/pcgen/core/SettingsHandler.java
+++ b/code/src/java/pcgen/core/SettingsHandler.java
@@ -24,6 +24,7 @@
 package pcgen.core;
 
 import java.awt.Color;
+import java.awt.SystemColor;
 import java.awt.Dimension;
 import java.awt.Frame;
 import java.awt.Point;
@@ -963,7 +964,7 @@ public final class SettingsHandler
 		setPostExportCommandStandard(getPCGenOption("postExportCommandStandard", "")); //$NON-NLS-1$ //$NON-NLS-2$
 		setPostExportCommandPDF(getPCGenOption("postExportCommandPDF", "")); //$NON-NLS-1$ //$NON-NLS-2$
 		setPrereqFailColor(getPCGenOption("prereqFailColor", Color.red.getRGB())); //$NON-NLS-1$
-		setPrereqQualifyColor(getPCGenOption("prereqQualifyColor", Color.black.getRGB())); //$NON-NLS-1$
+		setPrereqQualifyColor(getPCGenOption("prereqQualifyColor", SystemColor.text.getRGB())); //$NON-NLS-1$
 		setPreviewTabShown(getPCGenOption("previewTabShown", true)); //$NON-NLS-1$
 		setROG(getPCGenOption("isROG", false)); //$NON-NLS-1$
 		setSaveCustomInLst(getPCGenOption("saveCustomInLst", false)); //$NON-NLS-1$

--- a/code/src/java/pcgen/gui2/InfoGuidePane.java
+++ b/code/src/java/pcgen/gui2/InfoGuidePane.java
@@ -24,6 +24,8 @@ import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
+import java.awt.GraphicsDevice;
+import java.awt.GraphicsEnvironment;
 
 import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
@@ -91,7 +93,11 @@ public class InfoGuidePane extends JComponent implements UIResource
 			 null));
 		
 		mainPanel.setLayout(new BoxLayout(mainPanel, BoxLayout.Y_AXIS));
-		mainPanel.setPreferredSize(new Dimension(650, 450));
+		
+		GraphicsDevice gd = GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice();
+		int width = gd.getDisplayMode().getWidth();
+		int height = gd.getDisplayMode().getHeight();
+		mainPanel.setPreferredSize(new Dimension(width / 2, height / 2));
 		setOpaque(false);
 
 		JPanel sourcesPanel = new JPanel(new GridBagLayout());

--- a/code/src/java/pcgen/gui2/SplashScreen.java
+++ b/code/src/java/pcgen/gui2/SplashScreen.java
@@ -24,6 +24,9 @@ import java.awt.Color;
 import java.awt.Component;
 import java.awt.Container;
 import java.awt.GridLayout;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Dimension;
 import javax.swing.BorderFactory;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
@@ -61,6 +64,11 @@ public class SplashScreen extends JWindow implements PCGenTaskListener
 		Component splashLabel = new JLabel(Icons.SplashPcgen_Ennie.getImageIcon());
 		pane.add(splashLabel, BorderLayout.NORTH);
 		loadingLabel.setBorder(BorderFactory.createEmptyBorder(10, 7, 10, 10));
+		
+		Font curFont = pane.getFont();
+		FontMetrics ftMetrics = pane.getFontMetrics(curFont);
+		int ftHeight = ftMetrics.getHeight();
+		loadingLabel.setPreferredSize(new Dimension(splashLabel.getWidth(), ftHeight));
 		pane.add(loadingLabel, BorderLayout.CENTER);
 
 		loadProgress.setStringPainted(true);

--- a/code/src/java/pcgen/gui2/UIPropertyContext.java
+++ b/code/src/java/pcgen/gui2/UIPropertyContext.java
@@ -20,6 +20,7 @@
 package pcgen.gui2;
 
 import java.awt.Color;
+import java.awt.SystemColor;
 import java.io.File;
 
 import pcgen.cdom.base.Constants;
@@ -73,7 +74,7 @@ public final class UIPropertyContext extends PropertyContext
 		setColor(NOT_QUALIFIED_COLOR, Color.RED);
 		setColor(AUTOMATIC_COLOR, Color.decode("0xB2B200"));
 		setColor(VIRTUAL_COLOR, Color.MAGENTA);
-		setColor(QUALIFIED_COLOR, Color.BLACK);
+		setColor(QUALIFIED_COLOR, SystemColor.text);
 
 	}
 
@@ -186,7 +187,7 @@ public final class UIPropertyContext extends PropertyContext
 
 	public static Color getSourceStatusReleaseColor()
 	{
-		return getInstance().initColor(SOURCE_STATUS_RELEASE_COLOR, Color.black);
+		return getInstance().initColor(SOURCE_STATUS_RELEASE_COLOR, SystemColor.text);
 	}
 
 	public static void setSourceStatusAlphaColor(Color color)

--- a/code/src/java/pcgen/gui2/dialog/CharacterHPDialog.java
+++ b/code/src/java/pcgen/gui2/dialog/CharacterHPDialog.java
@@ -28,6 +28,8 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.awt.Font;
+import java.awt.FontMetrics;
 
 import javax.swing.AbstractCellEditor;
 import javax.swing.Box;
@@ -115,7 +117,13 @@ public final class CharacterHPDialog extends JDialog implements ActionListener
 		table.setDefaultRenderer(JButton.class, new Renderer());
 		table.setDefaultEditor(JButton.class, new Editor());
 		table.setCellSelectionEnabled(false);
-		table.setRowHeight(new IntegerEditor(1, 10).getPreferredSize().height);
+		
+		Font curFont = table.getFont();
+		FontMetrics ftMetrics = table.getFontMetrics(curFont);
+		int ftHeight = ftMetrics.getHeight();
+		table.setRowHeight(ftHeight);
+		//table.setRowHeight(new IntegerEditor(1, 10).getPreferredSize().height);
+		
 		JTableHeader header = table.getTableHeader();
 		header.setReorderingAllowed(false);
 

--- a/code/src/java/pcgen/gui2/dialog/PostLevelUpDialog.java
+++ b/code/src/java/pcgen/gui2/dialog/PostLevelUpDialog.java
@@ -31,6 +31,8 @@ import java.awt.event.WindowEvent;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.awt.Font;
+import java.awt.FontMetrics;
 
 import javax.swing.Box;
 import javax.swing.JButton;
@@ -143,7 +145,13 @@ public final class PostLevelUpDialog extends JDialog implements ActionListener
 
 		};
 		table.setCellSelectionEnabled(false);
-		table.setRowHeight(new JSpinner().getPreferredSize().height);
+		
+		Font curFont = table.getFont();
+		FontMetrics ftMetrics = table.getFontMetrics(curFont);
+		int ftHeight = ftMetrics.getHeight();
+		table.setRowHeight(ftHeight);
+		//table.setRowHeight(new JSpinner().getPreferredSize().height);
+		
 		JTableHeader header = table.getTableHeader();
 		header.setReorderingAllowed(false);
 

--- a/code/src/java/pcgen/gui2/tabs/CompanionInfoTab.java
+++ b/code/src/java/pcgen/gui2/tabs/CompanionInfoTab.java
@@ -34,6 +34,8 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Vector;
+import java.awt.Font;
+import java.awt.FontMetrics;
 
 import javax.swing.AbstractAction;
 import javax.swing.AbstractCellEditor;
@@ -159,7 +161,12 @@ public class CompanionInfoTab extends FlippingSplitPane implements CharacterInfo
 		}
 		companionsTable.setIntercellSpacing(new Dimension(0, 0));
 		companionsTable.setFocusable(false);
-		companionsTable.setRowHeight(23);
+		
+		Font curFont = companionsTable.getFont();
+		FontMetrics ftMetrics = companionsTable.getFontMetrics(curFont);
+		int ftHeight = ftMetrics.getHeight();
+		companionsTable.setRowHeight(ftHeight);
+		
 		companionsTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
 		setLeftComponent(new JScrollPane(companionsTable));
 		JPanel rightPane = new JPanel(new BorderLayout());

--- a/code/src/java/pcgen/gui2/tabs/DomainInfoTab.java
+++ b/code/src/java/pcgen/gui2/tabs/DomainInfoTab.java
@@ -21,6 +21,8 @@ package pcgen.gui2.tabs;
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.event.ActionEvent;
+import java.awt.Font;
+import java.awt.FontMetrics;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -159,6 +161,11 @@ public class DomainInfoTab extends FlippingSplitPane implements CharacterInfoTab
 		selectionModel.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
 		domainTable.setAutoCreateColumnsFromModel(false);
 		domainTable.setColumnModel(createDomainColumnModel());
+
+		Font curFont = domainTable.getFont();
+		FontMetrics ftMetrics = domainTable.getFontMetrics(curFont);
+		int ftHeight = ftMetrics.getHeight();
+		domainTable.setRowHeight(ftHeight);
 
 		JScrollPane scrollPane = TableUtils.createCheckBoxSelectionPane(domainTable, domainRowHeaderTable);
 		panel.add(scrollPane, BorderLayout.CENTER);

--- a/code/src/java/pcgen/gui2/tabs/SkillInfoTab.java
+++ b/code/src/java/pcgen/gui2/tabs/SkillInfoTab.java
@@ -25,6 +25,8 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
+import java.awt.Font;
+import java.awt.FontMetrics;
 import java.text.DecimalFormat;
 import java.util.EventObject;
 
@@ -125,7 +127,12 @@ public class SkillInfoTab extends FlippingSplitPane implements CharacterInfoTab,
 				new TableCellUtilities.AlignRenderer(SwingConstants.CENTER));
 		skillTable.setDefaultRenderer(String.class,
 				new TableCellUtilities.AlignRenderer(SwingConstants.CENTER));
-		skillTable.setRowHeight(26);
+		
+		Font curFont = skillTable.getFont();
+		FontMetrics ftMetrics = skillTable.getFontMetrics(curFont);
+		int ftHeight = ftMetrics.getHeight();
+		skillTable.setRowHeight(ftHeight);
+		
 		FilterBar<CharacterFacade, SkillFacade> filterBar = new FilterBar<>();
 		filterBar.addDisplayableFilter(new SearchFilterPanel());
 

--- a/code/src/java/pcgen/gui2/tabs/ability/CategoryTableModel.java
+++ b/code/src/java/pcgen/gui2/tabs/ability/CategoryTableModel.java
@@ -18,6 +18,9 @@
  */
 package pcgen.gui2.tabs.ability;
 
+import java.awt.Font;
+import java.awt.FontMetrics;
+
 import javax.swing.JTable;
 
 import pcgen.facade.core.AbilityCategoryFacade;
@@ -49,6 +52,11 @@ public class CategoryTableModel extends
 		this.categoryTable = theCategoryTable;
 		setDelegate(categories);
 		setFilter(filter);
+
+		Font curFont = categoryTable.getFont();
+		FontMetrics ftMetrics = categoryTable.getFontMetrics(curFont);
+		int ftHeight = ftMetrics.getHeight();
+		categoryTable.setRowHeight(ftHeight);
 	}
 
 	public AbilityCategoryFacade getCategory(int index)

--- a/code/src/java/pcgen/gui2/tabs/bio/ImagePreviewer.java
+++ b/code/src/java/pcgen/gui2/tabs/bio/ImagePreviewer.java
@@ -19,6 +19,7 @@
 package pcgen.gui2.tabs.bio;
 
 import java.awt.Color;
+import java.awt.SystemColor;
 import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.image.BufferedImage;
@@ -91,9 +92,9 @@ class ImagePreviewer extends JComponent
 			// the values are visible against most possible image backgrounds.
 			final String dim = width + " x " + height;
 
-			g.setColor(Color.black);
+			g.setColor(SystemColor.text);
 			g.drawString(dim, textX, textY);
-			g.setColor(Color.white);
+			g.setColor(SystemColor.textText);
 			g.drawString(dim, textX - 1, textX - 1);
 		}
 		else

--- a/code/src/java/pcgen/gui2/tabs/bio/PortraitPane.java
+++ b/code/src/java/pcgen/gui2/tabs/bio/PortraitPane.java
@@ -19,6 +19,7 @@
 package pcgen.gui2.tabs.bio;
 
 import java.awt.Color;
+import java.awt.SystemColor;
 import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Insets;
@@ -73,8 +74,8 @@ class PortraitPane extends JComponent
 		{
 			g.drawImage(portrait, insets.left, insets.top, this);
 		}
-		g.setColor(Color.BLACK);
-		g.setXORMode(Color.WHITE);
+		g.setColor(SystemColor.text);
+		g.setXORMode(SystemColor.textHighlight);
 		if (cropRect != null)
 		{
 			if (scale < 1)

--- a/code/src/java/pcgen/gui2/tabs/equip/EquipmentModel.java
+++ b/code/src/java/pcgen/gui2/tabs/equip/EquipmentModel.java
@@ -24,6 +24,7 @@ import java.awt.Font;
 import java.awt.Rectangle;
 import java.util.HashMap;
 import java.util.Map;
+import java.awt.FontMetrics;
 
 import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
@@ -90,7 +91,11 @@ public class EquipmentModel implements ListListener<EquipmentSetFacade>, Referen
 
 	public static void initializeTreeTable(JTreeTable treeTable)
 	{
-		treeTable.getTree().setRowHeight(0);
+		Font curFont = treeTable.getFont();
+		FontMetrics ftMetrics = treeTable.getFontMetrics(curFont);
+		int ftHeight = ftMetrics.getHeight();
+		treeTable.getTree().setRowHeight(ftHeight);
+		
 		treeTable.setFocusable(false);
 		treeTable.getTree().putClientProperty("JTree.lineStyle", "Horizontal");
 		normFont = treeTable.getFont();
@@ -205,7 +210,7 @@ public class EquipmentModel implements ListListener<EquipmentSetFacade>, Referen
 					{
 						if (treeTable.getRowHeight(row) != bounds.height)
 						{
-							treeTable.setRowHeight(row, bounds.height);
+							//treeTable.setRowHeight(row, bounds.height);
 						}
 					}
 				}

--- a/code/src/java/pcgen/gui2/tabs/equip/EquipmentModels.java
+++ b/code/src/java/pcgen/gui2/tabs/equip/EquipmentModels.java
@@ -158,6 +158,11 @@ public class EquipmentModels
 		this.unequipButton = unequipButton;
 		this.moveUpButton = moveUpButton;
 		this.moveDownButton = moveDownButton;
+
+		Font curFont = equipmentTable.getFont();
+		FontMetrics ftMetrics = equipmentTable.getFontMetrics(curFont);
+		int ftHeight = ftMetrics.getHeight();
+		equipmentTable.setRowHeight(ftHeight);
 	}
 
 	public void install()
@@ -368,9 +373,9 @@ public class EquipmentModels
 				table.setDefaultEditor(Integer.class, new SpinnerEditor(equipSet.getEquippedItems()));
 				
 
-				JPanel panel = new JPanel(new BorderLayout());
-				Font curFont = panel.getFont();
-				FontMetrics ftMetrics = panel.getFontMetrics(curFont);
+				//JPanel panel = new JPanel(new BorderLayout());
+				Font curFont = table.getFont();
+				FontMetrics ftMetrics = table.getFontMetrics(curFont);
 				int ftHeight = ftMetrics.getHeight();
 				table.setRowHeight(ftHeight);
 				
@@ -380,7 +385,7 @@ public class EquipmentModels
 				JTableHeader header = table.getTableHeader();
 				header.setReorderingAllowed(false);
 				JScrollPane pane = EquipmentModels.prepareScrollPane(table);
-				//JPanel panel = new JPanel(new BorderLayout());
+				JPanel panel = new JPanel(new BorderLayout());
 				JLabel help = new JLabel(LanguageBundle.getString("in_equipSelectUnequipQty")); //$NON-NLS-1$
 				panel.add(help, BorderLayout.NORTH);
 				panel.add(pane, BorderLayout.CENTER);

--- a/code/src/java/pcgen/gui2/tabs/equip/EquipmentModels.java
+++ b/code/src/java/pcgen/gui2/tabs/equip/EquipmentModels.java
@@ -47,6 +47,9 @@ import javax.swing.table.JTableHeader;
 import javax.swing.table.TableCellEditor;
 import javax.swing.table.TableModel;
 
+import java.awt.Font;
+import java.awt.FontMetrics;
+
 import pcgen.base.util.HashMapToList;
 import pcgen.base.util.MapToList;
 import pcgen.facade.core.CharacterFacade;
@@ -363,14 +366,21 @@ public class EquipmentModels
 				table.setCellSelectionEnabled(false);
 				table.setDefaultRenderer(Integer.class, new TableCellUtilities.SpinnerRenderer());
 				table.setDefaultEditor(Integer.class, new SpinnerEditor(equipSet.getEquippedItems()));
-				table.setRowHeight(22);
+				
+
+				JPanel panel = new JPanel(new BorderLayout());
+				Font curFont = panel.getFont();
+				FontMetrics ftMetrics = panel.getFontMetrics(curFont);
+				int ftHeight = ftMetrics.getHeight();
+				table.setRowHeight(ftHeight);
+				
 				table.getColumnModel().getColumn(0).setPreferredWidth(140);
 				table.getColumnModel().getColumn(1).setPreferredWidth(50);
 				table.setPreferredScrollableViewportSize(table.getPreferredSize());
 				JTableHeader header = table.getTableHeader();
 				header.setReorderingAllowed(false);
 				JScrollPane pane = EquipmentModels.prepareScrollPane(table);
-				JPanel panel = new JPanel(new BorderLayout());
+				//JPanel panel = new JPanel(new BorderLayout());
 				JLabel help = new JLabel(LanguageBundle.getString("in_equipSelectUnequipQty")); //$NON-NLS-1$
 				panel.add(help, BorderLayout.NORTH);
 				panel.add(pane, BorderLayout.CENTER);
@@ -477,7 +487,12 @@ public class EquipmentModels
 				table.setDefaultEditor(Object.class, new ComboEditor(equipMap));
 				table.setDefaultRenderer(Integer.class, new TableCellUtilities.SpinnerRenderer());
 				table.setDefaultEditor(Integer.class, new SpinnerEditor(unequippedList));
-				table.setRowHeight(22);
+				
+				Font curFont = table.getFont();
+				FontMetrics ftMetrics = table.getFontMetrics(curFont);
+				int ftHeight = ftMetrics.getHeight();
+				table.setRowHeight(ftHeight);
+				
 				table.getColumnModel().getColumn(0).setPreferredWidth(140);
 				table.getColumnModel().getColumn(1).setPreferredWidth(50);
 				table.getColumnModel().getColumn(2).setPreferredWidth(120);

--- a/code/src/java/pcgen/gui2/tabs/skill/SkillPointTableModel.java
+++ b/code/src/java/pcgen/gui2/tabs/skill/SkillPointTableModel.java
@@ -19,6 +19,8 @@
 package pcgen.gui2.tabs.skill;
 
 import java.awt.Component;
+import java.awt.Font;
+import java.awt.FontMetrics;
 
 import javax.swing.JTable;
 import javax.swing.SwingConstants;
@@ -77,6 +79,12 @@ public class SkillPointTableModel extends AbstractTableModel
 			new TableCellUtilities.AlignRenderer(SwingConstants.CENTER));
 		table.setColumnModel(columns);
 		table.setFocusable(false);
+		
+		Font curFont = table.getFont();
+		FontMetrics ftMetrics = table.getFontMetrics(curFont);
+		int ftHeight = ftMetrics.getHeight();
+		table.setRowHeight(ftHeight);
+
 		header.setReorderingAllowed(false);
 		header.setResizingAllowed(false);
 	}

--- a/code/src/java/pcgen/gui2/tabs/summary/ClassLevelTableModel.java
+++ b/code/src/java/pcgen/gui2/tabs/summary/ClassLevelTableModel.java
@@ -23,6 +23,8 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
+import java.awt.Font;
+import java.awt.FontMetrics;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.HashMap;
@@ -98,7 +100,11 @@ public class ClassLevelTableModel extends AbstractTableModel
 		classLevelTable.setAutoResizeMode(JTable.AUTO_RESIZE_LAST_COLUMN);
 		classLevelTable.setFocusable(false);
 		classLevelTable.setCellSelectionEnabled(false);
-		classLevelTable.setRowHeight(20);
+		
+		Font curFont = classLevelTable.getFont();
+		FontMetrics ftMetrics = classLevelTable.getFontMetrics(curFont);
+		int ftHeight = ftMetrics.getHeight();
+		classLevelTable.setRowHeight(ftHeight);
 	}
 
 	public void install()

--- a/code/src/java/pcgen/gui2/tabs/summary/LanguageTableModel.java
+++ b/code/src/java/pcgen/gui2/tabs/summary/LanguageTableModel.java
@@ -25,6 +25,8 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.awt.Font;
+import java.awt.FontMetrics;
 
 import javax.swing.AbstractCellEditor;
 import javax.swing.Box;
@@ -80,7 +82,12 @@ public class LanguageTableModel extends AbstractTableModel
 		table.setRowSelectionAllowed(false);
 		table.setColumnSelectionAllowed(false);
 		table.setFocusable(false);
-		table.setRowHeight(21);
+		
+		Font curFont = table.getFont();
+		FontMetrics ftMetrics = table.getFontMetrics(curFont);
+		int ftHeight = ftMetrics.getHeight();
+		table.setRowHeight(ftHeight);
+		
 		table.getTableHeader().setReorderingAllowed(false);
 	}
 

--- a/code/src/java/pcgen/gui2/tabs/summary/StatTableModel.java
+++ b/code/src/java/pcgen/gui2/tabs/summary/StatTableModel.java
@@ -25,6 +25,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 import java.text.DecimalFormat;
 import java.text.ParseException;
+import java.awt.FontMetrics;
 
 import javax.swing.AbstractAction;
 import javax.swing.AbstractCellEditor;
@@ -180,7 +181,12 @@ public class StatTableModel extends AbstractTableModel implements ReferenceListe
 		statsTable.setCellSelectionEnabled(false);
 		statsTable.setFocusable(false);
 		// XXX this should be calculated relative to font size and the size of a jspinner
-		statsTable.setRowHeight(27);
+		
+		Font curFont = statsTable.getFont();
+		FontMetrics ftMetrics = statsTable.getFontMetrics(curFont);
+		int ftHeight = ftMetrics.getHeight();
+		statsTable.setRowHeight(ftHeight);
+		
 		statsTable.setOpaque(false);
 		tableHeader.setFont(FontManipulation.title(statsTable.getFont()));
 		FontManipulation.large(statsTable);

--- a/code/src/java/pcgen/gui2/util/JTreeTable.java
+++ b/code/src/java/pcgen/gui2/util/JTreeTable.java
@@ -25,6 +25,8 @@ import java.awt.event.MouseEvent;
 import java.util.Comparator;
 import java.util.Enumeration;
 import java.util.EventObject;
+import java.awt.Font;
+import java.awt.FontMetrics;
 
 import javax.swing.CellRendererPane;
 import javax.swing.JComponent;
@@ -131,7 +133,10 @@ public class JTreeTable extends JTableEx
 		if (tree.getRowHeight() < 1)
 		{
 			// Metal looks better like this.
-			setRowHeight(18);
+			Font curFont = super.getFont();
+			FontMetrics ftMetrics = super.getFontMetrics(curFont);
+			int ftHeight = ftMetrics.getHeight();
+			setRowHeight(ftHeight);
 		}
 		else
 		{

--- a/code/src/java/pcgen/gui2/util/JTreeTable.java
+++ b/code/src/java/pcgen/gui2/util/JTreeTable.java
@@ -27,6 +27,7 @@ import java.util.Enumeration;
 import java.util.EventObject;
 import java.awt.Font;
 import java.awt.FontMetrics;
+import java.awt.SystemColor;
 
 import javax.swing.CellRendererPane;
 import javax.swing.JComponent;
@@ -144,6 +145,8 @@ public class JTreeTable extends JTableEx
 			// we'd better all be using the same one!
 			setRowHeight(tree.getRowHeight());
 		}
+
+		setForeground(SystemColor.text);
 	}
 
 	public TreeTableModel getTreeTableModel()

--- a/code/src/java/pcgen/gui2/util/SimpleTextIcon.java
+++ b/code/src/java/pcgen/gui2/util/SimpleTextIcon.java
@@ -21,6 +21,7 @@
 package pcgen.gui2.util;
 
 import java.awt.Color;
+import java.awt.SystemColor;
 import java.awt.Component;
 import java.awt.FontMetrics;
 import java.awt.Graphics;
@@ -50,7 +51,7 @@ public class SimpleTextIcon implements Icon
 	 */
 	public SimpleTextIcon(Component c, String text)
 	{
-		this(c, text, Color.BLACK);
+		this(c, text, SystemColor.text);
 	}
 
 	/**

--- a/code/src/java/pcgen/gui2/util/table/TableUtils.java
+++ b/code/src/java/pcgen/gui2/util/table/TableUtils.java
@@ -21,6 +21,8 @@
 package pcgen.gui2.util.table;
 
 import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.FontMetrics;
 
 import javax.swing.JCheckBox;
 import javax.swing.JRadioButton;

--- a/code/src/java/pcgen/gui2/util/table/TableUtils.java
+++ b/code/src/java/pcgen/gui2/util/table/TableUtils.java
@@ -42,6 +42,12 @@ public class TableUtils
 	{
 		JTable table = new JTable();
 		table.setFillsViewportHeight(true);
+		
+		Font curFont = table.getFont();
+		FontMetrics ftMetrics = table.getFontMetrics(curFont);
+		int ftHeight = ftMetrics.getHeight();
+		table.setRowHeight(ftHeight);
+
 		return table;
 	}
 

--- a/code/src/java/plugin/notes/gui/NotesView.java
+++ b/code/src/java/plugin/notes/gui/NotesView.java
@@ -1336,7 +1336,7 @@ public class NotesView extends JPanel
 
 		formatBar.add(underlineButton);
 
-		colorButton.setForeground(new java.awt.Color(0, 0, 0));
+		colorButton.setForeground(java.awt.SystemColor.text);
 		colorButton.setIcon(Icons.createImageIcon("menu-mode-RGB-alt.png"));
 		colorButton.setToolTipText("Color");
 		colorButton.setBorder(new EtchedBorder());


### PR DESCRIPTION
This PR attempts to fix all hardcoded row heights for JTables and JTreeTables and replaces hardcoded black text color with SystemColor.text color.

See issue https://github.com/PCGen/pcgen/issues/1760