### PR TITLE
Add caching for Gradle deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,10 @@ before_install:
  - sudo apt-get install lib32z1 lib32ncurses5
  - chmod +x gradlew
  
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/


### PR DESCRIPTION
This reduces the chance for random failure due to network flakiness.