### PR TITLE
Add appveyor.yml for building on windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,24 @@
+version: 1.0.{build}
+
+pull_requests:
+  do_not_increment_build_number: true
+
+nuget:
+  disable_publish_on_pr: true
+
+build_script:
+  gradlew.bat build --info --no-daemon
+
+test_script:
+  gradlew.bat test compileSlowtest datatest pfinttest --info --no-daemon
+
+environment:
+  matrix:
+  - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+  - JAVA_HOME: C:\Program Files (x86)\Java\jdk1.8.0
+
+matrix:
+  fast_finish: true
+
+cache:
+  - C:\Users\appveyor\.gradle


### PR DESCRIPTION
This will help contributors without native access to windows ensure
their changes don't fail due to Windows specific things.

This incidentally also finds real data issues in other campaigns.