### PR TITLE
Fix minor language mistakes in the documentation.

### DIFF
--- a/docs/faqpages/faqotherissues.html
+++ b/docs/faqpages/faqotherissues.html
@@ -111,7 +111,7 @@ re-enter your character to be able to use that new feature.
    <li>
     <p>
      <span class="underline">
-      How do I downloading the Latest Alpha
+      How do I download the Latest Alpha
 Builds?
      </span>
     </p>

--- a/docs/faqpages/faqoutofmemoryandjavaissues.html
+++ b/docs/faqpages/faqoutofmemoryandjavaissues.html
@@ -320,7 +320,7 @@ Edition (build 1.5.0_06-b05)</code>
   </p>
   <hr/>
   <h2>
-   Miscelaneous Error Messages
+   Miscellaneous Error Messages
   </h2>
   <dl class="indent1">
    <dt>
@@ -471,23 +471,6 @@ from the program, If you can, you don't need the
     file.
    </li>
   </ol>
-  <h4>
-   For Fedora Users:
-  </h4>
-  <p class="indent1">
-   Question: Pcgen crashes on Fedora 7 just after
-the options directory selection.
-  </p>
-  <p class="indent1">
-   Answer: PCGen does not run under licgcj (GNU's
-Java library) because it is incomplete (it is not a complete
-implementation of Java, especially with respect to Swing (the UI)).
-You will need to download a complete Java implementation, such as
-that from
-   <a href="http://java.sun.com/">
-    Sun Microsystems
-   </a>
-  </p>
   <h4>
    For Ubuntu Users:
   </h4>

--- a/docs/faqpages/faqprintingissues.html
+++ b/docs/faqpages/faqprintingissues.html
@@ -341,7 +341,7 @@ feat with the following included in it:
     </p>
     <ol class="indent1">
      <li>
-      The quot;SkillBonusquot; type included in the type list.
+      The "SkillBonus" type included in the type list.
       <strong>
        Example:
       </strong>

--- a/docs/freemarkeroutputpages/pcgenfunctions.html
+++ b/docs/freemarkeroutputpages/pcgenfunctions.html
@@ -235,7 +235,7 @@ FreeMarker. These are referred to in the same way as any user
 defined variables.
   </p>
   <h3>
-   gameodename
+   gamemodename
   </h3>
   <p>
    This is the name of the current game mode.

--- a/docs/listfilepages/globalfilestagpages/globalfilesformulas.html
+++ b/docs/listfilepages/globalfilestagpages/globalfilesformulas.html
@@ -110,7 +110,7 @@ BardicKnowledgeLevel, TirelessRage.</code>
   </p>
   <p class="indent2">
    Examples of variables that must be called with
-the getvar() function:
+the var() function:
   </p>
   <p class="indent3">
    <code>var("CL=Fighter"), var("COUNT[FEATS]"),
@@ -1780,7 +1780,7 @@ running and a "0" if it is not.
      Variables Used (x):
     </strong>
     Text
-(Varuable Name)
+(Variable Name)
    </p>
    <p class="indent1">
     <strong>

--- a/docs/listfilepages/globalfilestagpages/globalfilestype.html
+++ b/docs/listfilepages/globalfilestagpages/globalfilestype.html
@@ -1535,7 +1535,7 @@ to race, such as the Rangers Favored Enemy
     In the past, the
     <code>TYPE</code>
     tag
-in tTemplate files have been used to alter the races Creature Type
+in template files have been used to alter the races Creature Type
 as defined in the game rules. This function is now being performed
 by the
     <a href="../datafilestagpages/datafilesraces.html#racetype">

--- a/docs/listfilepages/listfileLSTstandards.html
+++ b/docs/listfilepages/listfileLSTstandards.html
@@ -233,7 +233,7 @@ Contains ranged weapons</p>
 Contains wondrous items</p>
 <h3>SOURCELONG, SOURCESHORT, SOURCEWEB, SOURCEPAGE</h3>
 <p>SOURCELONG, SOURCESHORT, and SOURCEWEB are defined in both the
-PCC and the top of the LST files. These can be easily be changed by
+PCC and the top of the LST files. These can easily be changed by
 the submission team, so do not feel bad if they are. <b>Note:</b>
 Prior to version 5.10 SOURCE header tags were grouped in a single
 block separated with pipe (|) symbols. This has been changed to
@@ -355,7 +355,7 @@ to).</p>
 <li>
 <p>Please use formulas where possible. Such as CL=Name in for class
 abilities. 1 Bonus statement with a formula is processed faster
-than a BONUS statement on ever class line.</p>
+than a BONUS statement on every class line.</p>
 </li>
 <li>
 <p>Where it is possible to do so there should be only one DEFINE

--- a/docs/listfilepages/listfileLSTwalkthrough.html
+++ b/docs/listfilepages/listfileLSTwalkthrough.html
@@ -163,7 +163,7 @@ Material"
    Main Tab.
   </p>
   <p class="indent0">
-   FYou will see included below a sample PCC file.
+   You will see included below a sample PCC file.
 You can see the tags used and the order in which they are typically
 found. The order is not important, except for the first three tags,
 but following these conventions will help others help you if you
@@ -445,7 +445,7 @@ from any LST file by using the
   <p class="indent2">
    Loads the classes in
    <span class="lstfile">
-    myclass.lst
+    myfirstclass.lst
    </span>
    and the "Fighter" class from the SRD
 classes.

--- a/docs/listfilepages/listfileimportanttoknow.html
+++ b/docs/listfilepages/listfileimportanttoknow.html
@@ -172,7 +172,7 @@ there for you to look at.
 not care what you call your created files, whether it is .txt,
 .lst, .doc, or anything else for an extension. As long as you have
 the correct file name in the .pcc file, it will load. Second, the
-syntax of the tags used in the list files. the sections with the
+syntax of the tags used in the list files. The sections with the
 list file tags contain correct syntax to use for each tag. PCGen
 DOES care about this, if your syntax is wrong, then the tag you are
 working on will not work and PCGen will return errors.

--- a/docs/listfilepages/lstfileclass/lfc_lesson13_feat2.html
+++ b/docs/listfilepages/lstfileclass/lfc_lesson13_feat2.html
@@ -235,7 +235,7 @@ I cover them below.
   <p class="indent1">
    This tag is one of the exceptions mentioned
 above to the standard PRExxx format rule. This one takes the format
-of PREALIGN:&lt;align1&gt;,align&lt;2&gt;,etc. To pass this PRExxx
+of PREALIGN:&lt;align1&gt;,&lt;align2&gt;,etc. To pass this PRExxx
 you need only meet one of the listed criteria.
   </p>
   <p class="indent1">
@@ -347,7 +347,7 @@ the ones defined in your gamemode files or the tag will fail.
   </p>
   <p class="indent3">
    Would evaluate as true if the character's base
-Fortitude meets or exceeds 5 or their base Reflex meets or exceeds
+Fortitude meets or exceeds 1 or their base Reflex meets or exceeds
 3
   </p>
   <p class="indent2">
@@ -434,7 +434,7 @@ game mode files.
    <code>PREEQUIP:1,Longsword</code>
   </p>
   <p class="indent3">
-   Must have an item with the exact name "Longsword
+   Must have an item with the exact name "Longsword"
 equipped.
   </p>
   <p class="indent2">
@@ -523,7 +523,7 @@ school
   </p>
   <p class="indent2">
    <code>PREFEAT:2,CHECKMULT,Spell Focus,[Spell
-Focus(Evocation)</code>
+Focus(Evocation)]</code>
   </p>
   <p class="indent3">
    Must have two Spell Focus feats, and *not* have
@@ -688,7 +688,7 @@ being created).
   </p>
   <p class="indent1">
    The tag takes the following format:
-PREMULT:#,[&lt;PRExxx&gt;],[&lt;PRExxx&gt;]. The number is the of
+PREMULT:#,[&lt;PRExxx&gt;],[&lt;PRExxx&gt;]. The number is the number of
 the other bracketed PRExxx conditions you need to meet.
   </p>
   <p class="indent1">
@@ -814,7 +814,7 @@ It is PRESIZE&lt;suffix&gt;:&lt;sizeidentifier&gt;
    <code>PRESIZEEQ:L</code>
   </p>
   <p class="indent3">
-   MUst be Large size
+   Must be Large size
   </p>
   <p class="indent2">
    <code>PRESIZEGTEQ:H</code>

--- a/docs/listfilepages/lstfileclass/lfc_lesson14_deities.html
+++ b/docs/listfilepages/lstfileclass/lfc_lesson14_deities.html
@@ -146,7 +146,7 @@ which to build this class material.
     Symbol
    </strong>
    : A Kitten on a
-Keyboar
+Keyboard
   </p>
   <p class="indent2">
    <strong>
@@ -1047,7 +1047,7 @@ taken. The source page text generally takes the form of
 the page number on which the deity information can be found within
 the source material. For our sample deity
    <span class="lstobj">
-    MoSat
+    MoSaT
    </span>
    , the source material is PCGen's
    <span class="lstobj">

--- a/docs/listfilepages/lstfileclass/lfc_lesson15_domains1.html
+++ b/docs/listfilepages/lstfileclass/lfc_lesson15_domains1.html
@@ -145,7 +145,7 @@ Scrolls
     </em>
    </strong>
    You
-cast mind-affecting spells at +1 caster level. and is graced by
+cast mind-affecting spells at +1 caster level, and is graced by
    <em>
     <strong>
      Great Intelligence
@@ -474,8 +474,8 @@ scratch there is no 'source', so there is no
    <code>SOURCEPAGE</code>
    tag required, but many functions and
 filters in PCGen use it, so it is good to include it. Therefore, I
-will include the tag with an N/A for the source page. I will skip
-it. The War Domain on the other hand comes from the RSRD and
+will include the tag with an N/A for the source page.
+The War Domain on the other hand comes from the RSRD and
 therefore would use the
    <code>SOURCEPAGE</code>
    tag per the example
@@ -541,7 +541,7 @@ Discord|Poetry=6|Irresistible Dance|Poetry=7|Hold Person
 (Mass)</code>
    </p>
    <p class="tagindent2">
-    <code>SOURCEPAGE:SpellListI.rtf</code>
+    <code>SOURCEPAGE:N/A</code>
    </p>
    <p class="indent0">
    </p>

--- a/docs/listfilepages/rulesguide/game_rules_implement_heading.html
+++ b/docs/listfilepages/rulesguide/game_rules_implement_heading.html
@@ -39,7 +39,7 @@ the
    <a href="#homebrew">
     Rules for Homebrews
    </a>
-   . The exaples
+   . The examples
 provided are not the only way to implement the subject rules. They
 are given here simply as examples of how different rules can be
 implemented. For more general information on writing standard LST

--- a/docs/listfilepages/systemfilestagpages/gamemodeloadlist.html
+++ b/docs/listfilepages/systemfilestagpages/gamemodeloadlist.html
@@ -280,7 +280,7 @@ Name:
    <span class="lstfile">
     SizeAdjustment.lst
    </span>
-   file.&lt;.p&gt;
+   file.
   </p>
   <p class="indent1">
    <strong>
@@ -292,7 +292,7 @@ Name:
    <br/>
   </p>
   <p class="indent3">
-   Sets the original value to 1.
+   Sets the original value to 4.
   </p>
   <hr/>
   <p class="status">

--- a/docs/listfilepages/systemfilestagpages/gamemodemigrationlist.html
+++ b/docs/listfilepages/systemfilestagpages/gamemodemigrationlist.html
@@ -645,10 +645,10 @@ Fury</code>
    <code>NEWKEY:Animal Fury ~ Rage Power</code>
   </p>
   <p class="indent3">
-   <code>MAXVER:6.00.01</code>
+   <code>MAXVER:6.00.00</code>
   </p>
   <p class="indent3">
-   <code>MAXDEVVER:6.01.02</code>
+   <code>MAXDEVVER:6.01.01</code>
   </p>
   <p class="indent3">
    When any character last saved in v6.00.00 or

--- a/docs/listfilepages/systemfilestagpages/gamemodemiscinfolist.html
+++ b/docs/listfilepages/systemfilestagpages/gamemodemiscinfolist.html
@@ -1222,13 +1222,13 @@ three levels, starting at level 2.
   </p>
   <p class="indent3">
    Character would get 3 bonus stat points at
-fourth level with no binuses after that.
+fourth level with no bonuses after that.
   </p>
   <p class="indent2">
    <code>BONUSSTATLEVELSTARTINTERVAL:4|if(mod(TL,10)&gt;0&amp;&amp;mod(mod(TL,10),4)==0,1,0)|2</code>
   </p>
   <p class="indent3">
-   Character would get bonus 2 stat points at 4th
+   Character would get 2 bonus stat points at 4th
 level and at every interval determined by the formula provided.
 (e.g. 4, 8, 14, 18, 24, 28)
   </p>

--- a/docs/menupages/edit/editaddkitoptions.html
+++ b/docs/menupages/edit/editaddkitoptions.html
@@ -47,7 +47,7 @@ applied at any time to a character.
   <p>
    The left hand pane contains a list of available kits. Kits
 appearing in red contain prerequisites that the active character
-does not meet and therefoe may not be applied to the character.
+does not meet and therefore may not be applied to the character.
   </p>
   <p>
    You can click on a kit in the left hand pane to bring up

--- a/docs/menupages/file/filesectionheading.html
+++ b/docs/menupages/file/filesectionheading.html
@@ -224,7 +224,7 @@ user to preview the character sheet.
     <strong>
      Zoom
     </strong>
-    field an drop-down allows the user to
+    field and drop-down allows the user to
 change the zoom level of the character sheet. Alternatively, the
     <strong>
      Magnifying Glass

--- a/docs/menupages/tools/preferences/preferencespcgenoptions.html
+++ b/docs/menupages/tools/preferences/preferencespcgenoptions.html
@@ -43,7 +43,7 @@ information is output to the user.
     Equipment
    </strong>
    settings allow the user to
-configure following:
+configure the following:
   </p>
   <ul>
    <li>

--- a/docs/menupages/tools/preferences/preferencessectionheading.html
+++ b/docs/menupages/tools/preferences/preferencessectionheading.html
@@ -83,7 +83,7 @@ will be used when creating a new gamemode.
    <a href="preferencespluginoptions.html">
     <strong>
      Plugin
-Preferences.
+Preferences
     </strong>
    </a>
    allow the user to determine which plugins

--- a/docs/tabpages/tabdescription.html
+++ b/docs/tabpages/tabdescription.html
@@ -41,7 +41,7 @@ the PC's features.
   <p>
    The left pane of this tab lists a number of notes where
 additional information on the current character can be stored.
-There are a umber of standard notes provided by PCGen.
+There are a number of standard notes provided by PCGen.
   </p>
   <p>
    The
@@ -174,7 +174,7 @@ will not be printed out on character sheets, keeping those
 particular notes safe from prying eyes!
   </p>
   <p>
-   You can add your en note pages to the
+   You can add your own note pages to the
    <strong>
     Description
    </strong>

--- a/docs/tabpages/tabfeatsandabilities.html
+++ b/docs/tabpages/tabfeatsandabilities.html
@@ -77,7 +77,7 @@ the PC.
   </p>
   <p>
    By default the feats and abilities for the PC selected as
-optional feats and abilities are will show in black text in the
+optional feats and abilities are shown in black text in the
 table. Feats and abilities gained
    <strong>
     automatically

--- a/docs/tabpages/tabinventory.html
+++ b/docs/tabpages/tabinventory.html
@@ -357,9 +357,7 @@ right frame. Some items are automatically "Equipped" to the
 appropriate locations, e.g. Armor, Shields, and magical items, if
 the locations are not already filled. Equipping all items to the
 appropriate location ensures that PCGen will give the appropriate
-benefit for using the items. Additionally, every item your
-character is carrying should be marked as "Carried" so your
-character's encumbrance will be figured correctly.
+benefit for using the items.
   </p>
   <p>
    Every item your character is carrying should be marked "Carried"

--- a/docs/tabpages/tabsectionheading.html
+++ b/docs/tabpages/tabsectionheading.html
@@ -88,7 +88,7 @@ by any text you enter, PCGen will display only those items which
 have names or types that match the text entered, this is the reason
 the Kukri is displayed when filtering for the word "dagger", it has
 the "Dagger" type. If you have applied any other filters by using
-the Filter tool the text filter will limit it's search to those not
+the Filter tool the text filter will limit its search to those not
 filtered out by the filter tool. In other words the items displayed
 will match both the Filter tool and the text Filter.
   </p>

--- a/docs/tabpages/tabspells.html
+++ b/docs/tabpages/tabspells.html
@@ -59,7 +59,7 @@ Spells lists.
 displayed in the spells tables below.
   </p>
   <p>
-   Each spell casting class will display a list on the left os all
+   Each spell casting class will display a list on the left of all
 available spells the PC could potentially learn. All spell casters
 have a
    <strong>

--- a/docs/tabpages/tabtemporarybonuses.html
+++ b/docs/tabpages/tabtemporarybonuses.html
@@ -66,7 +66,7 @@ then press the
    </strong>
    button. If the
 target of the bonus is the PC, the bonus title will appear in the
-right pane. If the bonus the target applies to a piece of gear
+right pane. If the bonus applies to a piece of gear
 carried by the character, e.g. a weapon or piece of armor, the
 target selection dialog will appear.
   </p>

--- a/docs/walkthroughpages/walkthroughcreatecharacter.html
+++ b/docs/walkthroughpages/walkthroughcreatecharacter.html
@@ -162,7 +162,7 @@ ability scores, there are two ways to enter a name.
     </p>
     <p>
      The first, and, again as with ability scores, the method we will
-use here is to simply enter the new characr's name directly into
+use here is to simply enter the new character's name directly into
 the
      <strong>
       Name
@@ -469,7 +469,7 @@ warning:
     <p>
      It is important to note that many gameModes lock in the
 intelligence score bonus at 1st level so before you select your
-first class level you ant to make sure that your ability scores are
+first class level you want to make sure that your ability scores are
 acceptable. In the case of the sample character, as he is human and
 we are using the Pathfinder gameMode, he gets to select an ability
 score bonus. So we'll click the
@@ -664,8 +664,8 @@ relevant selections are to be made. If the selection to be made is
 located on the
       <strong>
        Summary Tab
-      </strong>
-      , PCgen will highlight
+      </strong>,
+      PCgen will highlight
 the relevant pane on the
       <strong>
        Summary Tab
@@ -680,7 +680,7 @@ the relevant pane on the
       listed in the order of
 priority. They can be taken care of in any order desired. Of course
 there are some options that will be taken that might benefit from
-other options, but with the shear number of options available
+other options, but with the sheer number of options available
 variety of effects, there really is no way to definitively
 determine which item should be handled before any other.
      </li>
@@ -875,20 +875,20 @@ Tab
      so you should be familiar with what you'll see here.
 The lower-left pane shows that the character has a total of 2 feats
 selections available with only one left to make. Review of the
-right pane shows there are htree feats appearing in yellow text.
-These are feats that have been added automatically. these are
+right pane shows there are three feats appearing in yellow text.
+These are feats that have been added automatically. These are
 generally added as class or racial features.
      <strong>
-      Arane
-Stike
+      Arcane
+Strike
      </strong>
-     is included in black text and represens the first of
+     is included in black text and represents the first of
 two feat selections. Pick your desired feats and double-click on
 them to add them to the character.
     </p>
     <p>
      Now that the feats have been selected and added to your
-character lets go back to the
+character let's go back to the
      <strong>
       Summary Tab
      </strong>
@@ -944,16 +944,16 @@ optional. If you choose not to use traits you simply find the
       No Traits
      </strong>
      item and add it to your character. If
-you wish to use traits, feel free to scroll though the list and
+you wish to use traits, feel free to scroll through the list and
 pick those of interest and add them to your character. Remember
-that you can use activate the
+that you can activate the
      <strong>
       Qualified
      </strong>
      button to
 shorten the list. Also be aware that as you make selections some
 traits will become unavailable. Clicking once on a trait will
-present the description and benefits in the lower-right pane so yu
+present the description and benefits in the lower-right pane so you
 can browse through them prior to making your final selections.
     </p>
     <p>
@@ -1157,7 +1157,7 @@ items left to take care of! . . . Ok, its not quite that easy.
      pane is now empty
 there are a number of tabs left that we have yet visit. For some of
 these there is nothing on them for the character I've been working
-on, but mostly bacause they are player driven and not so much
+on, but mostly because they are player driven and not so much
 because the character choices take you there as is the case with
 the tabs we have visted so far. These tabs will be covered in the
 next section.
@@ -1195,16 +1195,16 @@ Tab
      is
 separated into four panes.The upper-left pane lists all deities
 available in the loaded data sets. The upper-right pane will remain
-empty until a deity is selected, and ten it will list the
+empty until a deity is selected, and then it will list the
      <strong>
       Domains
      </strong>
      which the selected Deity can grant to
 their clerics. The lower panes will display the descriptions of the
-deity and domain seected in the panes above them.
+deity and domain selected in the panes above them.
     </p>
     <p>
-     To select a domain you must first selcet a
+     To select a domain you must first select a
      <strong>
       Deity
      </strong>
@@ -1260,7 +1260,7 @@ you will need to visit the
       Companions Tab
      </strong>
      is separated into two panes.
-The left pane lists the different categories of "Companions" tha
+The left pane lists the different categories of "Companions" that
 are available to your character. Next to each category is a pair of
 numbers within a set of parenthesis. The first number is the number
 of that type f comapnion that the current character has and the
@@ -1442,7 +1442,7 @@ Tab
      Character Sheet Tab
     </strong>
     <p>
-     Finally, once all character options have been decides, special
+     Finally, once all character options have been decided, special
 companions found, descriptions written, bonuses applied, and
 histories written, the only thing left is to print your character.
 PCGen has an extensive collection of output templates, but before
@@ -1450,10 +1450,10 @@ you print it out, you just might want to preview it. To do that you
 need to look to the
      <strong>
       Character Sheet Tab
-     </strong>
-     . For
+     </strong>.
+     For
 detailed information on how to select any of the provided templates
-as well as to pring your character you can visit the
+as well as to printing your character you can visit the
      <strong>
       <a href="../tabpages/tabcharactersheet.html">
        Character


### PR DESCRIPTION
While reading through the documentation, I stumbled on a number of minor editorial mistakes for which I submit fixes here.

In addition, I removed the section on running on Fedora.  Fedora 7 is very out of date, and on current Fedoras (24 and 25) PCGen works just fine with the standard Java (OpenJDK 1.8.0).