### PR TITLE
Move gradle output into a dedicated directory.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -224,7 +224,7 @@ task copyToRoot(type: Copy, dependsOn: [copyToLibs, jar, converterJar]) {
     from "$buildDir/libs/pcgen-${version}-batch-convert.jar"
     from "$buildDir/release/pcgen.exe"
     from "$projectDir/code/pcgen.sh"
-    into "$projectDir"
+    into "$projectDir/output"
     rename "(.+)-$version(.+)", '$1$2'
 }
 

--- a/code/pcgen.sh
+++ b/code/pcgen.sh
@@ -2,7 +2,7 @@
 set -e
 if command git rev-parse >/dev/null 2>&1
 then
-  cd "$(git rev-parse --show-toplevel)"
+  cd "$(git rev-parse --show-toplevel)/output"
 else
   cd "$(dirname $0)"
 fi


### PR DESCRIPTION
Gradle and windows do not seem to play nice with each other in ways I
don't fully understand.

This moves pcgen into a dedicated output directory instead as this is
better practice in the first place. We may need some slight changes to
other release scripts but that will happen in due course