### PR TITLE
Remove (false) Nsis dependency from itest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -277,7 +277,7 @@ test {
     exclude 'pcgen/testsupport/**'
 }
 
-task itest(type: Test, dependsOn: [jar, 'buildNsis']) {
+task itest(type: Test, dependsOn: [jar]) {
     testClassesDirs = sourceSets.itest.output.classesDirs
     classpath = sourceSets.itest.runtimeClasspath
     systemProperties['jar.path'] = jar.archivePath


### PR DESCRIPTION
One should not need a full deployment machine in order to run tests
before a code commit