### PR TITLE
Improve Output

### DIFF
--- a/code/src/java/pcgen/cdom/facet/CDOMWrapperInfoFacet.java
+++ b/code/src/java/pcgen/cdom/facet/CDOMWrapperInfoFacet.java
@@ -47,6 +47,7 @@ import pcgen.output.actor.DescriptionActor;
 import pcgen.output.actor.DisplayNameActor;
 import pcgen.output.actor.EqTypeActor;
 import pcgen.output.actor.InfoActor;
+import pcgen.output.actor.IsVisibleToActor;
 import pcgen.output.actor.KeyActor;
 import pcgen.output.actor.OutputNameActor;
 import pcgen.output.actor.SourceActor;
@@ -105,6 +106,7 @@ public class CDOMWrapperInfoFacet
 		set(dsID, SizeAdjustment.class, "outputname", outputNameActor);
 		set(dsID, WeaponProf.class, "outputname", outputNameActor);
 		set(dsID, Equipment.class, "type", new EqTypeActor());
+		set(dsID, CDOMObject.class, "visibleto", new IsVisibleToActor());
 	}
 
 	/**

--- a/code/src/java/pcgen/core/PlayerCharacter.java
+++ b/code/src/java/pcgen/core/PlayerCharacter.java
@@ -536,6 +536,34 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 	 *
 	 * @param loadedCampaigns The currently loaded campaign objects.
 	 */
+	private PlayerCharacter(PlayerCharacter from)
+	{
+		LoadContext context = Globals.getContext();
+		id = CharID.getID(context.getDataSetID());
+		doFormulaSetup(context);
+
+		display = new CharacterDisplay(id);
+		SA_TO_STRING_PROC = new SAtoStringProcessor(this);
+		SA_PROC = new SAProcessor(this);
+		PlayerCharacterTrackingFacet trackingFacet =
+				FacetLibrary.getFacet(PlayerCharacterTrackingFacet.class);
+		trackingFacet.associatePlayerCharacter(id, this);
+
+		variableProcessor = new VariableProcessorPC(this);
+		controller = from.controller;
+
+		for (int i = 0; i < Constants.NUMBER_OF_AGESET_KIT_SELECTIONS; i++)
+		{
+			ageSetKitSelections[i] = from.ageSetKitSelections[i];
+		}
+		theUserPoolBonuses = new HashMap<>(from.theUserPoolBonuses);
+	}
+
+	/**
+	 * Constructor.
+	 *
+	 * @param loadedCampaigns The currently loaded campaign objects.
+	 */
 	public PlayerCharacter(Collection<Campaign> loadedCampaigns)
 	{
 		LoadContext context = Globals.getContext();
@@ -7220,7 +7248,7 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 		// new data instances for all the final variables and I won't
 		// be able to reset them. Need to call new PlayerCharacter()
 		// aClone = (PlayerCharacter)super.clone();
-		aClone = new PlayerCharacter(campaignFacet.getSet(id));
+		aClone = new PlayerCharacter(this);
 		//aClone.variableProcessor = new VariableProcessorPC(aClone);
 		try
 		{

--- a/code/src/java/pcgen/output/actor/IsVisibleToActor.java
+++ b/code/src/java/pcgen/output/actor/IsVisibleToActor.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 (C) Tom Parker <thpr@users.sourceforge.net>
+ * 
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 59 Temple Place,
+ * Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.output.actor;
+
+import freemarker.template.TemplateModel;
+import freemarker.template.TemplateModelException;
+import pcgen.cdom.base.CDOMObject;
+import pcgen.cdom.enumeration.CharID;
+import pcgen.cdom.enumeration.ObjectKey;
+import pcgen.output.base.OutputActor;
+import pcgen.output.model.VisibleToModel;
+
+/**
+ * An IsVisibleToActor is designed to process an interpolation and convert the Visibility
+ * of a CDOMObject into a TemplateModel that can be queried based on the desired View.
+ * 
+ * Note that the actual name of the interpolation is stored externally to this Actor (in
+ * CDOMObjectWrapperInfo to be precise)
+ */
+public class IsVisibleToActor implements OutputActor<CDOMObject>
+{
+	@Override
+	public TemplateModel process(CharID id, CDOMObject d) throws TemplateModelException
+	{
+		return new VisibleToModel(d.getSafe(ObjectKey.VISIBILITY));
+	}
+}

--- a/code/src/java/pcgen/output/model/CNAbilitySelectionModel.java
+++ b/code/src/java/pcgen/output/model/CNAbilitySelectionModel.java
@@ -17,10 +17,12 @@
  */
 package pcgen.output.model;
 
+import pcgen.cdom.base.Category;
 import pcgen.cdom.enumeration.CharID;
 import pcgen.cdom.facet.FacetLibrary;
 import pcgen.cdom.facet.ObjectWrapperFacet;
 import pcgen.cdom.helper.CNAbilitySelection;
+import pcgen.core.Ability;
 import freemarker.template.TemplateHashModel;
 import freemarker.template.TemplateModel;
 import freemarker.template.TemplateModelException;
@@ -75,9 +77,15 @@ public class CNAbilitySelectionModel implements TemplateHashModel
 	public TemplateModel get(String key) throws TemplateModelException
 	{
 		Object towrap;
-		if ("category".equals(key))
+		if ("pool".equals(key))
 		{
 			towrap = cnas.getCNAbility().getAbilityCategory();
+		}
+		else if ("category".equals(key))
+		{
+			Category<Ability> cat = cnas.getCNAbility().getAbilityCategory();
+			Category<Ability> parent = cat.getParentCategory();
+			towrap = (parent == null) ? cat : parent;
 		}
 		else if ("nature".equals(key))
 		{

--- a/code/src/java/pcgen/output/model/VisibleToModel.java
+++ b/code/src/java/pcgen/output/model/VisibleToModel.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 (C) Tom Parker <thpr@users.sourceforge.net>
+ * 
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 59 Temple Place,
+ * Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.output.model;
+
+import java.util.List;
+import java.util.Objects;
+
+import freemarker.template.SimpleScalar;
+import freemarker.template.TemplateMethodModelEx;
+import freemarker.template.TemplateModelException;
+import pcgen.util.enumeration.View;
+import pcgen.util.enumeration.Visibility;
+
+/**
+ * VisibleToModel is a TemplateMethod for FreeMarker that takes in a view in order to
+ * determine whether an item is visible to that View. The View is received from FreeMarker
+ * in String format.
+ */
+public class VisibleToModel implements TemplateMethodModelEx
+{
+
+	/**
+	 * The underlying Visibility, which will be checked against a view.
+	 */
+	private final Visibility visibility;
+
+	/**
+	 * Constructs a new VisibleToModel with the given underlying Visibility
+	 * 
+	 * @param v
+	 *            The Visibility for this VisibleToModel
+	 */
+	public VisibleToModel(Visibility v)
+	{
+		visibility = Objects.requireNonNull(v);
+	}
+
+	@Override
+	public Object exec(@SuppressWarnings("rawtypes") List arguments)
+		throws TemplateModelException
+	{
+		if (arguments.size() != 1)
+		{
+			throw new TemplateModelException(
+				"Expected 1 argument but found: " + arguments.size());
+		}
+		View v = View.getViewFromName(((SimpleScalar) arguments.get(0)).getAsString());
+		return visibility.isVisibleTo(v);
+	}
+
+}

--- a/code/src/java/pcgen/output/wrapper/StringWrapper.java
+++ b/code/src/java/pcgen/output/wrapper/StringWrapper.java
@@ -17,6 +17,7 @@
  */
 package pcgen.output.wrapper;
 
+import pcgen.io.FileAccess;
 import pcgen.output.base.SimpleObjectWrapper;
 import pcgen.output.model.StringModel;
 import freemarker.template.TemplateModel;
@@ -33,7 +34,7 @@ public class StringWrapper implements SimpleObjectWrapper
 	{
 		if (o instanceof String)
 		{
-			return new StringModel(o.toString());
+			return new StringModel(FileAccess.filterString(o.toString()));
 		}
 		throw new TemplateModelException("Object was not a String");
 	}


### PR DESCRIPTION
Fixes a bug in PC's clone method (duped items added to facets in
constructor)

Enhances output to check view of CDOMObjects

Escapes Strings on output (does it universally - may need a better
method since old export system didn't do it on equipment)