### PR TITLE
Improve Output

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -162,8 +162,8 @@ dependencies {
 	// Eclipse requires this to be in the standard path for some unknown reason.
 	compile group: 'org.xmlunit', name: 'xmlunit-core', version:'2.4.0'
 	compile group: 'org.xmlunit', name: 'xmlunit-legacy', version:'2.4.0'
-        compile group: 'net.sourceforge.pcgen', name: 'PCGen-base', version:'1.0.114'
-        compile group: 'net.sourceforge.pcgen', name: 'PCGen-Formula', version:'1.0.134'
+        compile group: 'net.sourceforge.pcgen', name: 'PCGen-base', version:'1.0.119'
+        compile group: 'net.sourceforge.pcgen', name: 'PCGen-Formula', version:'1.0.136'
         compile group: 'xml-apis', name: 'xml-apis', version:'1.3.04'
     }
 

--- a/code/src/java/pcgen/cdom/facet/CDOMWrapperInfoFacet.java
+++ b/code/src/java/pcgen/cdom/facet/CDOMWrapperInfoFacet.java
@@ -47,6 +47,7 @@ import pcgen.output.actor.DescriptionActor;
 import pcgen.output.actor.DisplayNameActor;
 import pcgen.output.actor.EqTypeActor;
 import pcgen.output.actor.InfoActor;
+import pcgen.output.actor.IsVisibleToActor;
 import pcgen.output.actor.KeyActor;
 import pcgen.output.actor.OutputNameActor;
 import pcgen.output.actor.SourceActor;
@@ -105,6 +106,7 @@ public class CDOMWrapperInfoFacet
 		set(dsID, SizeAdjustment.class, "outputname", outputNameActor);
 		set(dsID, WeaponProf.class, "outputname", outputNameActor);
 		set(dsID, Equipment.class, "type", new EqTypeActor());
+		set(dsID, CDOMObject.class, "visibleto", new IsVisibleToActor());
 	}
 
 	/**

--- a/code/src/java/pcgen/cdom/facet/CategorizedAbilityFacet.java
+++ b/code/src/java/pcgen/cdom/facet/CategorizedAbilityFacet.java
@@ -22,10 +22,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.Map;
-import java.util.Set;
 import java.util.Map.Entry;
+import java.util.Set;
 
-import pcgen.base.util.WrappedMapSet;
 import pcgen.cdom.base.Category;
 import pcgen.cdom.enumeration.CharID;
 import pcgen.cdom.enumeration.Nature;
@@ -239,7 +238,7 @@ public class CategorizedAbilityFacet extends AbstractDataFacet<CharID, Ability>
 		{
 			isNew = true;
 			// abilitySet = new HashSet<Ability>();
-			abilitySet = new WrappedMapSet<>(IdentityHashMap.class);
+			abilitySet = Collections.newSetFromMap(new IdentityHashMap<>());
 			natureMap.put(nat, abilitySet);
 		}
 		return isNew;

--- a/code/src/java/pcgen/cdom/facet/EquippedEquipmentFacet.java
+++ b/code/src/java/pcgen/cdom/facet/EquippedEquipmentFacet.java
@@ -21,7 +21,6 @@ import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Set;
 
-import pcgen.base.util.WrappedMapSet;
 import pcgen.cdom.base.SetFacet;
 import pcgen.cdom.enumeration.CharID;
 import pcgen.cdom.facet.base.AbstractDataFacet;
@@ -54,8 +53,7 @@ public class EquippedEquipmentFacet extends
 		Set<Equipment> oldEquipped =
 				(Set<Equipment>) removeCache(id);
 		Set<Equipment> currentEquipment = equipmentFacet.getSet(id);
-		Set<Equipment> newEquipped = new WrappedMapSet<>(
-                IdentityHashMap.class);
+		Set<Equipment> newEquipped = Collections.newSetFromMap(new IdentityHashMap<>());
 		setCache(id, newEquipped);
 		if (oldEquipped != null)
 		{
@@ -125,8 +123,8 @@ public class EquippedEquipmentFacet extends
 		{
 			return Collections.emptySet();
 		}
-		Set<Equipment> returnEquipped = new WrappedMapSet<>(
-                IdentityHashMap.class);
+		Set<Equipment> returnEquipped =
+				Collections.newSetFromMap(new IdentityHashMap<>());
 		returnEquipped.addAll(set);
 		return returnEquipped;
 	}
@@ -184,8 +182,8 @@ public class EquippedEquipmentFacet extends
 		Set<Equipment> set = (Set<Equipment>) getCache(source);
 		if (set != null)
 		{
-			Set<Equipment> newEquipped = new WrappedMapSet<>(
-                    IdentityHashMap.class);
+			Set<Equipment> newEquipped =
+					Collections.newSetFromMap(new IdentityHashMap<>());
 			newEquipped.addAll(set);
 			setCache(copy, newEquipped);
 		}

--- a/code/src/java/pcgen/cdom/facet/SolverManagerFacet.java
+++ b/code/src/java/pcgen/cdom/facet/SolverManagerFacet.java
@@ -73,5 +73,4 @@ public class SolverManagerFacet extends
 	{
 		this.scopeFacet = scopeFacet;
 	}
-
 }

--- a/code/src/java/pcgen/cdom/facet/VariableStoreFacet.java
+++ b/code/src/java/pcgen/cdom/facet/VariableStoreFacet.java
@@ -49,4 +49,15 @@ public class VariableStoreFacet extends
 		this.solverFactoryFacet = solverFactoryFacet;
 	}
 
+	@Override
+	public void copyContents(CharID source, CharID copy)
+	{
+		MonitorableVariableStore obj = get(source);
+		if (obj != null)
+		{
+			MonitorableVariableStore replacement = new MonitorableVariableStore();
+			replacement.importFrom(get(source));
+			setCache(copy, replacement);
+		}
+	}
 }

--- a/code/src/java/pcgen/cdom/facet/analysis/FollowerLimitFacet.java
+++ b/code/src/java/pcgen/cdom/facet/analysis/FollowerLimitFacet.java
@@ -17,6 +17,7 @@
  */
 package pcgen.cdom.facet.analysis;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
@@ -24,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import pcgen.base.util.WrappedMapSet;
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.enumeration.CharID;
 import pcgen.cdom.enumeration.ListKey;
@@ -116,7 +116,7 @@ public class FollowerLimitFacet extends AbstractStorageFacet<CharID> implements
 		Set<CDOMObject> set = foMap.get(fo);
 		if (set == null)
 		{
-			set = new WrappedMapSet<>(IdentityHashMap.class);
+			set = Collections.newSetFromMap(new IdentityHashMap<>());
 			foMap.put(fo, set);
 		}
 		set.add(cdo);

--- a/code/src/java/pcgen/cdom/facet/analysis/FollowerOptionFacet.java
+++ b/code/src/java/pcgen/cdom/facet/analysis/FollowerOptionFacet.java
@@ -28,7 +28,6 @@ import java.util.Set;
 import java.util.TreeMap;
 
 import pcgen.base.util.CaseInsensitiveMap;
-import pcgen.base.util.WrappedMapSet;
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.enumeration.CharID;
 import pcgen.cdom.enumeration.ListKey;
@@ -113,7 +112,7 @@ public class FollowerOptionFacet extends AbstractStorageFacet<CharID> implements
 		Set<CDOMObject> set = foMap.get(fo);
 		if (set == null)
 		{
-			set = new WrappedMapSet<>(IdentityHashMap.class);
+			set = Collections.newSetFromMap(new IdentityHashMap<>());
 			foMap.put(fo, set);
 		}
 		set.add(cdo);

--- a/code/src/java/pcgen/cdom/facet/analysis/VariableFacet.java
+++ b/code/src/java/pcgen/cdom/facet/analysis/VariableFacet.java
@@ -17,6 +17,7 @@
  */
 package pcgen.cdom.facet.analysis;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
@@ -24,7 +25,6 @@ import java.util.Map;
 import java.util.Set;
 
 import pcgen.base.formula.Formula;
-import pcgen.base.util.WrappedMapSet;
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.enumeration.CharID;
 import pcgen.cdom.enumeration.VariableKey;
@@ -104,7 +104,7 @@ public class VariableFacet extends AbstractStorageFacet<CharID> implements
 		Set<CDOMObject> sources = subMap.get(formula);
 		if (sources == null)
 		{
-			sources = new WrappedMapSet<>(IdentityHashMap.class);
+			sources = Collections.newSetFromMap(new IdentityHashMap<>());
 			subMap.put(formula, sources);
 		}
 		sources.add(cdo);

--- a/code/src/java/pcgen/cdom/facet/base/AbstractItemConvertingFacet.java
+++ b/code/src/java/pcgen/cdom/facet/base/AbstractItemConvertingFacet.java
@@ -22,10 +22,9 @@ import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Set;
 import java.util.Map.Entry;
+import java.util.Set;
 
-import pcgen.base.util.WrappedMapSet;
 import pcgen.cdom.enumeration.CharID;
 import pcgen.cdom.facet.event.DataFacetChangeEvent;
 
@@ -564,7 +563,7 @@ public abstract class AbstractItemConvertingFacet<S, D> extends
 		 * The set of objects from which the converted object has been received
 		 */
 		public Set<Object> set =
-                new WrappedMapSet<>(IdentityHashMap.class);
+                Collections.newSetFromMap(new IdentityHashMap<>());
 
 		/**
 		 * The converted ("destination") object
@@ -607,7 +606,7 @@ public abstract class AbstractItemConvertingFacet<S, D> extends
 
 	public Collection<S> getSourceObjects(CharID id)
 	{
-		Set<S> set = new WrappedMapSet<>(IdentityHashMap.class);
+		Set<S> set = Collections.newSetFromMap(new IdentityHashMap<>());
 		Map<S, Target> componentMap = getCachedMap(id);
 		if (componentMap != null)
 		{
@@ -625,7 +624,7 @@ public abstract class AbstractItemConvertingFacet<S, D> extends
 	public Collection<Object> getSourcesFor(CharID id, S obj)
 	{
 		Map<S, Target> componentMap = getCachedMap(id);
-		Set<Object> set = new WrappedMapSet<>(IdentityHashMap.class);
+		Set<Object> set = Collections.newSetFromMap(new IdentityHashMap<>());
 		if (componentMap == null)
 		{
 			return set;

--- a/code/src/java/pcgen/cdom/facet/base/AbstractQualifiedListFacet.java
+++ b/code/src/java/pcgen/cdom/facet/base/AbstractQualifiedListFacet.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import pcgen.base.util.WrappedMapSet;
 import pcgen.cdom.base.QualifiedActor;
 import pcgen.cdom.base.QualifyingObject;
 import pcgen.cdom.enumeration.CharID;
@@ -105,7 +104,7 @@ public abstract class AbstractQualifiedListFacet<T extends QualifyingObject>
 		boolean fireNew = (set == null);
 		if (fireNew)
 		{
-			set = new WrappedMapSet<>(IdentityHashMap.class);
+			set = Collections.newSetFromMap(new IdentityHashMap<>());
 			map.put(obj, set);
 		}
 		set.add(source);
@@ -361,7 +360,7 @@ public abstract class AbstractQualifiedListFacet<T extends QualifyingObject>
 		Set<Object> set = map.get(obj);
 		if (set == null)
 		{
-			set = new WrappedMapSet<>(IdentityHashMap.class);
+			set = Collections.newSetFromMap(new IdentityHashMap<>());
 			map.put(obj, set);
 		}
 		return set;
@@ -693,7 +692,7 @@ public abstract class AbstractQualifiedListFacet<T extends QualifyingObject>
 	 */
 	public Collection<T> getQualifiedSet(CharID id, Object source)
 	{
-		Set<T> set = new WrappedMapSet<>(IdentityHashMap.class);
+		Set<T> set = Collections.newSetFromMap(new IdentityHashMap<>());
 		Map<T, Set<Object>> componentMap = getCachedMap(id);
 		if (componentMap != null)
 		{

--- a/code/src/java/pcgen/cdom/facet/base/AbstractScopeFacet.java
+++ b/code/src/java/pcgen/cdom/facet/base/AbstractScopeFacet.java
@@ -29,7 +29,6 @@ import java.util.TreeMap;
 
 import pcgen.base.util.GenericMapToList;
 import pcgen.base.util.MapToList;
-import pcgen.base.util.WrappedMapSet;
 import pcgen.cdom.base.PCGenIdentifier;
 import pcgen.cdom.facet.event.ScopeFacetChangeEvent;
 import pcgen.cdom.facet.event.ScopeFacetChangeListener;
@@ -70,7 +69,7 @@ public class AbstractScopeFacet<IDT extends PCGenIdentifier, S, T> extends
 		boolean isNew = (sources == null);
 		if (isNew)
 		{
-			sources = new WrappedMapSet<>(IdentityHashMap.class);
+			sources = Collections.newSetFromMap(new IdentityHashMap<>());
 			scopeMap.put(obj, sources);
 		}
 		sources.add(source);
@@ -100,7 +99,7 @@ public class AbstractScopeFacet<IDT extends PCGenIdentifier, S, T> extends
 			boolean isNew = (sources == null);
 			if (isNew)
 			{
-				sources = new WrappedMapSet<>(IdentityHashMap.class);
+				sources = Collections.newSetFromMap(new IdentityHashMap<>());
 				scopeMap.put(obj, sources);
 			}
 			sources.add(source);

--- a/code/src/java/pcgen/cdom/facet/base/AbstractSourcedListFacet.java
+++ b/code/src/java/pcgen/cdom/facet/base/AbstractSourcedListFacet.java
@@ -28,7 +28,6 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 import pcgen.base.util.ListSet;
-import pcgen.base.util.WrappedMapSet;
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.base.PCGenIdentifier;
 import pcgen.cdom.facet.event.DataFacetChangeEvent;
@@ -89,7 +88,7 @@ public abstract class AbstractSourcedListFacet<IDT extends PCGenIdentifier, T>
 		boolean fireNew = (set == null);
 		if (fireNew)
 		{
-			set = new WrappedMapSet<>(IdentityHashMap.class);
+			set = Collections.newSetFromMap(new IdentityHashMap<>());
 			map.put(obj, set);
 		}
 		set.add(source);
@@ -341,7 +340,7 @@ public abstract class AbstractSourcedListFacet<IDT extends PCGenIdentifier, T>
 	{
 		Map<T, Set<Object>> map = getConstructingCachedMap(id);
 		Set<Object> set =
-				map.computeIfAbsent(obj, k -> new WrappedMapSet<>(IdentityHashMap.class));
+				map.computeIfAbsent(obj, k -> Collections.newSetFromMap(new IdentityHashMap<>()));
 
 		return set;
 	}

--- a/code/src/java/pcgen/cdom/facet/base/AbstractSubAssociationFacet.java
+++ b/code/src/java/pcgen/cdom/facet/base/AbstractSubAssociationFacet.java
@@ -21,8 +21,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Map;
+import java.util.Set;
 
-import pcgen.base.util.WrappedMapSet;
 import pcgen.cdom.base.PCGenIdentifier;
 
 public abstract class AbstractSubAssociationFacet<IDT extends PCGenIdentifier, S1, S2, A>
@@ -124,12 +124,12 @@ public abstract class AbstractSubAssociationFacet<IDT extends PCGenIdentifier, S
 		return subMap;
 	}
 
-	protected Map<S1, Map<S2, A>> getComponentMap()
+	protected <MV> Map<S1, MV> getComponentMap()
 	{
 		return new IdentityHashMap<>();
 	}
 
-	protected Map<S2, A> getSubComponentMap()
+	protected <MV> Map<S2, MV> getSubComponentMap()
 	{
 		return new IdentityHashMap<>();
 	}
@@ -155,8 +155,7 @@ public abstract class AbstractSubAssociationFacet<IDT extends PCGenIdentifier, S
 		{
 			return Collections.emptyList();
 		}
-		WrappedMapSet<S1> set =
-                new WrappedMapSet<>(getComponentMap().getClass());
+		Set<S1> set = Collections.newSetFromMap(getComponentMap());
 		set.addAll(map.keySet());
 		return set;
 	}
@@ -173,8 +172,7 @@ public abstract class AbstractSubAssociationFacet<IDT extends PCGenIdentifier, S
 		{
 			return Collections.emptyList();
 		}
-		WrappedMapSet<S2> set =
-                new WrappedMapSet<>(getSubComponentMap().getClass());
+		Set<S2> set = Collections.newSetFromMap(getSubComponentMap());
 		set.addAll(subMap.keySet());
 		return set;
 	}

--- a/code/src/java/pcgen/cdom/facet/base/AbstractSubScopeFacet.java
+++ b/code/src/java/pcgen/cdom/facet/base/AbstractSubScopeFacet.java
@@ -27,7 +27,6 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
 
-import pcgen.base.util.WrappedMapSet;
 import pcgen.cdom.enumeration.CharID;
 import pcgen.cdom.facet.event.SubScopeFacetChangeEvent;
 import pcgen.cdom.facet.event.SubScopeFacetChangeListener;
@@ -74,7 +73,7 @@ public class AbstractSubScopeFacet<S1, S2, T> extends
 		boolean isNew = (sources == null);
 		if (isNew)
 		{
-			sources = new WrappedMapSet<>(IdentityHashMap.class);
+			sources = Collections.newSetFromMap(new IdentityHashMap<>());
 			scope2Map.put(obj, sources);
 		}
 		sources.add(source);

--- a/code/src/java/pcgen/cdom/facet/model/TemplateFacet.java
+++ b/code/src/java/pcgen/cdom/facet/model/TemplateFacet.java
@@ -37,6 +37,7 @@ public class TemplateFacet extends AbstractSourcedListFacet<CharID, PCTemplate>
 		implements DataFacetChangeListener<CharID, PCTemplate>,
 		SetFacet<CharID, PCTemplate>
 {
+
 	/**
 	 * Adds the active PCTemplate to this facet.
 	 * 

--- a/code/src/java/pcgen/cdom/facet/model/WeaponProfModelFacet.java
+++ b/code/src/java/pcgen/cdom/facet/model/WeaponProfModelFacet.java
@@ -17,10 +17,10 @@
  */
 package pcgen.cdom.facet.model;
 
+import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Set;
 
-import pcgen.base.util.WrappedMapSet;
 import pcgen.cdom.base.SetFacet;
 import pcgen.cdom.enumeration.CharID;
 import pcgen.cdom.enumeration.ObjectKey;
@@ -73,8 +73,7 @@ public class WeaponProfModelFacet implements SetFacet<CharID, WeaponProf>
 	@Override
 	public Set<WeaponProf> getSet(CharID id)
 	{
-		final Set<WeaponProf> ret =
-                new WrappedMapSet<>(IdentityHashMap.class);
+		Set<WeaponProf> ret = Collections.newSetFromMap(new IdentityHashMap<>());
 		ret.addAll(weaponProfFacet.getSet(id));
 		ret.addAll(autoWeaponProfFacet.getWeaponProfs(id));
 		if (hasDeityWeaponProfFacet.hasDeityWeaponProf(id))

--- a/code/src/java/pcgen/cdom/format/table/ColumnFormatManager.java
+++ b/code/src/java/pcgen/cdom/format/table/ColumnFormatManager.java
@@ -98,4 +98,10 @@ public class ColumnFormatManager<T> implements FormatManager<TableColumn>
 	{
 		return underlying;
 	}
+
+	@Override
+	public boolean isDirect()
+	{
+		return false;
+	}
 }

--- a/code/src/java/pcgen/cdom/format/table/TableFormatManager.java
+++ b/code/src/java/pcgen/cdom/format/table/TableFormatManager.java
@@ -164,4 +164,10 @@ public final class TableFormatManager implements FormatManager<DataTable>
 	{
 		return resultFormat;
 	}
+
+	@Override
+	public boolean isDirect()
+	{
+		return false;
+	}
 }

--- a/code/src/java/pcgen/cdom/reference/AbstractReferenceManufacturer.java
+++ b/code/src/java/pcgen/cdom/reference/AbstractReferenceManufacturer.java
@@ -1352,4 +1352,10 @@ public abstract class AbstractReferenceManufacturer<T extends Loadable>
 	{
 		return null;
 	}
+
+	@Override
+	public boolean isDirect()
+	{
+		return false;
+	}
 }

--- a/code/src/java/pcgen/core/AbilityCategory.java
+++ b/code/src/java/pcgen/core/AbilityCategory.java
@@ -30,7 +30,6 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import pcgen.base.formula.Formula;
-import pcgen.base.util.WrappedMapSet;
 import pcgen.cdom.base.Category;
 import pcgen.cdom.base.ChooseInformation;
 import pcgen.cdom.base.FormulaFactory;
@@ -48,10 +47,10 @@ import pcgen.cdom.reference.CategorizedCreator;
 import pcgen.cdom.reference.ManufacturableFactory;
 import pcgen.cdom.reference.ReferenceManufacturer;
 import pcgen.cdom.reference.UnconstructedValidator;
-import pcgen.facade.core.AbilityCategoryFacade;
 import pcgen.core.utils.LastGroupSeparator.GroupingMismatchException;
-import pcgen.util.Logging;
+import pcgen.facade.core.AbilityCategoryFacade;
 import pcgen.system.LanguageBundle;
+import pcgen.util.Logging;
 import pcgen.util.enumeration.View;
 import pcgen.util.enumeration.Visibility;
 
@@ -787,7 +786,7 @@ public class AbilityCategory implements Category<Ability>, Loadable,
 		}
 		Collection<Ability> allObjects = parentCrm.getAllObjects();
 		// Don't add things twice or we'll get dupe messages :)
-		Set<Ability> added = new WrappedMapSet<>(IdentityHashMap.class);
+		Set<Ability> added = Collections.newSetFromMap(new IdentityHashMap<>());
 		/*
 		 * Pull in all the base objects... note this skips containsDirectly
 		 * because items haven't been resolved

--- a/code/src/java/pcgen/core/BonusManager.java
+++ b/code/src/java/pcgen/core/BonusManager.java
@@ -34,7 +34,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
 import pcgen.base.formula.Formula;
-import pcgen.base.util.WrappedMapSet;
 import pcgen.cdom.base.BonusContainer;
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.base.Constants;
@@ -311,8 +310,8 @@ public class BonusManager
 		cachedActiveBonusSumsMap = new ConcurrentHashMap<>();
 		Map<String, String> nonStackMap = new ConcurrentHashMap<>();
 		Map<String, String> stackMap = new ConcurrentHashMap<>();
-		Set<BonusObj> processedBonuses = new WrappedMapSet<>(
-                IdentityHashMap.class);
+		Set<BonusObj> processedBonuses =
+				Collections.newSetFromMap(new IdentityHashMap<>());
 
 		//Logging.log(Logging.INFO, "=== Start bonus processing.");
 		
@@ -388,8 +387,8 @@ public class BonusManager
 
 			try
 			{
-				processBonus(bonus, new WrappedMapSet<>(
-                        IdentityHashMap.class), processedBonuses, nonStackMap, stackMap);
+				processBonus(bonus, Collections.newSetFromMap(new IdentityHashMap<>()),
+					processedBonuses, nonStackMap, stackMap);
 			}
 			catch (Exception e)
 			{

--- a/code/src/java/pcgen/core/PlayerCharacter.java
+++ b/code/src/java/pcgen/core/PlayerCharacter.java
@@ -7321,10 +7321,7 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 		aClone.defaultDomainSource = defaultDomainSource;
 
 		aClone.ageSetKitSelections = new boolean[ageSetKitSelections.length];
-		for (int i = 0; i < ageSetKitSelections.length; i++)
-		{
-			aClone.ageSetKitSelections[i] = ageSetKitSelections[i];
-		}
+		System.arraycopy(ageSetKitSelections, 0, aClone.ageSetKitSelections, 0, ageSetKitSelections.length);
 
 		// Not sure what this is for
 		aClone.importing = false;

--- a/code/src/java/pcgen/core/PlayerCharacter.java
+++ b/code/src/java/pcgen/core/PlayerCharacter.java
@@ -40,6 +40,7 @@ import pcgen.base.formula.base.VarScoped;
 import pcgen.base.solver.DynamicSolverManager;
 import pcgen.base.solver.IndividualSetup;
 import pcgen.base.solver.SolverFactory;
+import pcgen.base.solver.SolverManager;
 import pcgen.base.solver.SplitFormulaSetup;
 import pcgen.base.util.HashMapToList;
 import pcgen.base.util.IdentityList;
@@ -529,6 +530,29 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 	 */
 	public PlayerCharacter() {
 		this(Collections.emptyList());
+	}
+
+	/**
+	 * Constructor.
+	 *
+	 * @param loadedCampaigns The currently loaded campaign objects.
+	 */
+	private PlayerCharacter(PlayerCharacter from)
+	{
+		LoadContext context = Globals.getContext();
+		id = CharID.getID(context.getDataSetID());
+
+		display = new CharacterDisplay(id);
+		SA_TO_STRING_PROC = new SAtoStringProcessor(this);
+		SA_PROC = new SAProcessor(this);
+		PlayerCharacterTrackingFacet trackingFacet =
+				FacetLibrary.getFacet(PlayerCharacterTrackingFacet.class);
+		trackingFacet.associatePlayerCharacter(id, this);
+
+		variableProcessor = new VariableProcessorPC(this);
+		controller = from.controller;
+
+		theUserPoolBonuses = new HashMap<>(from.theUserPoolBonuses);
 	}
 
 	/**
@@ -7225,8 +7249,7 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 		// new data instances for all the final variables and I won't
 		// be able to reset them. Need to call new PlayerCharacter()
 		// aClone = (PlayerCharacter)super.clone();
-		aClone = new PlayerCharacter(campaignFacet.getSet(id));
-		//aClone.variableProcessor = new VariableProcessorPC(aClone);
+		aClone = new PlayerCharacter(this);
 		try
 		{
 			aClone.assocSupt = assocSupt.clone();
@@ -7239,6 +7262,12 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 		for (AbstractStorageFacet bean : beans)
 		{
 			bean.copyContents(id, aClone.id);
+		}
+		SolverManager sm = solverManagerFacet.get(id);
+		if (sm != null)
+		{
+			SolverManager replacement = sm.createReplacement(variableStoreFacet.get(aClone.id));
+			solverManagerFacet.set(aClone.id, replacement);
 		}
 		aClone.bonusManager = bonusManager.buildDeepClone(aClone);
 
@@ -7289,10 +7318,13 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 		aClone.autoSortGear = autoSortGear;
 		aClone.outputSheetHTML = outputSheetHTML;
 		aClone.outputSheetPDF = outputSheetPDF;
-		aClone.ageSetKitSelections = new boolean[10];
 		aClone.defaultDomainSource = defaultDomainSource;
 
-		System.arraycopy(ageSetKitSelections, 0, aClone.ageSetKitSelections, 0, ageSetKitSelections.length);
+		aClone.ageSetKitSelections = new boolean[ageSetKitSelections.length];
+		for (int i = 0; i < ageSetKitSelections.length; i++)
+		{
+			aClone.ageSetKitSelections[i] = ageSetKitSelections[i];
+		}
 
 		// Not sure what this is for
 		aClone.importing = false;

--- a/code/src/java/pcgen/core/prereq/PrerequisiteUtilities.java
+++ b/code/src/java/pcgen/core/prereq/PrerequisiteUtilities.java
@@ -22,13 +22,13 @@ package pcgen.core.prereq;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Set;
 import java.util.StringTokenizer;
 
-import pcgen.base.util.WrappedMapSet;
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.base.CDOMReference;
 import pcgen.cdom.base.ChooseInformation;
@@ -479,7 +479,7 @@ public final class PrerequisiteUtilities
 		final PlayerCharacter character,
 		String categoryName)
 	{
-		final Set<Ability> abilityList = new WrappedMapSet<>(IdentityHashMap.class);
+		final Set<Ability> abilityList = Collections.newSetFromMap(new IdentityHashMap<>());
 		if (character != null)
 		{
 			AbilityCategory cat = SettingsHandler.getGame().getAbilityCategory(categoryName);

--- a/code/src/java/pcgen/output/actor/IsVisibleToActor.java
+++ b/code/src/java/pcgen/output/actor/IsVisibleToActor.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 (C) Tom Parker <thpr@users.sourceforge.net>
+ * 
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 59 Temple Place,
+ * Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.output.actor;
+
+import freemarker.template.TemplateModel;
+import freemarker.template.TemplateModelException;
+import pcgen.cdom.base.CDOMObject;
+import pcgen.cdom.enumeration.CharID;
+import pcgen.cdom.enumeration.ObjectKey;
+import pcgen.output.base.OutputActor;
+import pcgen.output.model.VisibleToModel;
+
+/**
+ * An IsVisibleToActor is designed to process an interpolation and convert the Visibility
+ * of a CDOMObject into a TemplateModel that can be queried based on the desired View.
+ * 
+ * Note that the actual name of the interpolation is stored externally to this Actor (in
+ * CDOMObjectWrapperInfo to be precise)
+ */
+public class IsVisibleToActor implements OutputActor<CDOMObject>
+{
+	@Override
+	public TemplateModel process(CharID id, CDOMObject d) throws TemplateModelException
+	{
+		return new VisibleToModel(d.getSafe(ObjectKey.VISIBILITY));
+	}
+}

--- a/code/src/java/pcgen/output/model/CNAbilitySelectionModel.java
+++ b/code/src/java/pcgen/output/model/CNAbilitySelectionModel.java
@@ -17,10 +17,12 @@
  */
 package pcgen.output.model;
 
+import pcgen.cdom.base.Category;
 import pcgen.cdom.enumeration.CharID;
 import pcgen.cdom.facet.FacetLibrary;
 import pcgen.cdom.facet.ObjectWrapperFacet;
 import pcgen.cdom.helper.CNAbilitySelection;
+import pcgen.core.Ability;
 import freemarker.template.TemplateHashModel;
 import freemarker.template.TemplateModel;
 import freemarker.template.TemplateModelException;
@@ -75,9 +77,15 @@ public class CNAbilitySelectionModel implements TemplateHashModel
 	public TemplateModel get(String key) throws TemplateModelException
 	{
 		Object towrap;
-		if ("category".equals(key))
+		if ("pool".equals(key))
 		{
 			towrap = cnas.getCNAbility().getAbilityCategory();
+		}
+		else if ("category".equals(key))
+		{
+			Category<Ability> cat = cnas.getCNAbility().getAbilityCategory();
+			Category<Ability> parent = cat.getParentCategory();
+			towrap = (parent == null) ? cat : parent;
 		}
 		else if ("nature".equals(key))
 		{

--- a/code/src/java/pcgen/output/model/VisibleToModel.java
+++ b/code/src/java/pcgen/output/model/VisibleToModel.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 (C) Tom Parker <thpr@users.sourceforge.net>
+ * 
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 59 Temple Place,
+ * Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.output.model;
+
+import java.util.List;
+import java.util.Objects;
+
+import freemarker.template.SimpleScalar;
+import freemarker.template.TemplateMethodModelEx;
+import freemarker.template.TemplateModelException;
+import pcgen.util.enumeration.View;
+import pcgen.util.enumeration.Visibility;
+
+/**
+ * VisibleToModel is a TemplateMethod for FreeMarker that takes in a view in order to
+ * determine whether an item is visible to that View. The View is received from FreeMarker
+ * in String format.
+ */
+public class VisibleToModel implements TemplateMethodModelEx
+{
+
+	/**
+	 * The underlying Visibility, which will be checked against a view.
+	 */
+	private final Visibility visibility;
+
+	/**
+	 * Constructs a new VisibleToModel with the given underlying Visibility
+	 * 
+	 * @param v
+	 *            The Visibility for this VisibleToModel
+	 */
+	public VisibleToModel(Visibility v)
+	{
+		visibility = Objects.requireNonNull(v);
+	}
+
+	@Override
+	public Object exec(@SuppressWarnings("rawtypes") List arguments)
+		throws TemplateModelException
+	{
+		if (arguments.size() != 1)
+		{
+			throw new TemplateModelException(
+				"Expected 1 argument but found: " + arguments.size());
+		}
+		View v = View.getViewFromName(((SimpleScalar) arguments.get(0)).getAsString());
+		return visibility.isVisibleTo(v);
+	}
+
+}

--- a/code/src/java/pcgen/output/wrapper/StringWrapper.java
+++ b/code/src/java/pcgen/output/wrapper/StringWrapper.java
@@ -17,6 +17,7 @@
  */
 package pcgen.output.wrapper;
 
+import pcgen.io.FileAccess;
 import pcgen.output.base.SimpleObjectWrapper;
 import pcgen.output.model.StringModel;
 import freemarker.template.TemplateModel;
@@ -33,7 +34,7 @@ public class StringWrapper implements SimpleObjectWrapper
 	{
 		if (o instanceof String)
 		{
-			return new StringModel(o.toString());
+			return new StringModel(FileAccess.filterString(o.toString()));
 		}
 		throw new TemplateModelException("Object was not a String");
 	}

--- a/code/src/java/pcgen/rules/context/TrackingManufacturer.java
+++ b/code/src/java/pcgen/rules/context/TrackingManufacturer.java
@@ -282,4 +282,10 @@ class TrackingManufacturer<T extends Loadable> implements ReferenceManufacturer<
 	{
 		return null;
 	}
+
+	@Override
+	public boolean isDirect()
+	{
+		return false;
+	}
 }

--- a/code/src/java/plugin/lsttokens/datacontrol/DefaultVariableValueToken.java
+++ b/code/src/java/plugin/lsttokens/datacontrol/DefaultVariableValueToken.java
@@ -86,7 +86,7 @@ public class DefaultVariableValueToken extends
 			fmtManager =
 					context.getReferenceContext().getFormatManager(formatName);
 		}
-		catch (IllegalArgumentException e)
+		catch (NullPointerException | IllegalArgumentException e)
 		{
 			return new ParseResult.Fail(getTokenName()
 				+ " found an unsupported format: " + formatName, context);

--- a/code/src/java/plugin/lsttokens/variable/GlobalToken.java
+++ b/code/src/java/plugin/lsttokens/variable/GlobalToken.java
@@ -67,7 +67,7 @@ public class GlobalToken extends AbstractNonEmptyToken<DatasetVariable>
 			formatManager =
 					context.getReferenceContext().getFormatManager(format);
 		}
-		catch (IllegalArgumentException e)
+		catch (NullPointerException | IllegalArgumentException e)
 		{
 			return new ParseResult.Fail(getTokenName()
 				+ " does not support format " + format + ", found in " + value

--- a/code/src/java/plugin/lsttokens/variable/LocalToken.java
+++ b/code/src/java/plugin/lsttokens/variable/LocalToken.java
@@ -89,7 +89,7 @@ public class LocalToken extends AbstractNonEmptyToken<DatasetVariable>
 			formatManager =
 					context.getReferenceContext().getFormatManager(format);
 		}
-		catch (IllegalArgumentException e)
+		catch (NullPointerException | IllegalArgumentException e)
 		{
 			return new ParseResult.Fail(getTokenName()
 				+ " does not support format " + format + ", found in " + value

--- a/code/src/java/plugin/pretokens/test/PreDeityTester.java
+++ b/code/src/java/plugin/pretokens/test/PreDeityTester.java
@@ -4,11 +4,11 @@
  */
 package plugin.pretokens.test;
 
+import java.util.Collections;
 import java.util.Set;
 
 import pcgen.base.util.CaseInsensitiveMap;
 import pcgen.base.util.Indirect;
-import pcgen.base.util.WrappedMapSet;
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.enumeration.FactSetKey;
 import pcgen.core.Deity;
@@ -43,8 +43,8 @@ public class PreDeityTester extends AbstractDisplayPrereqTest implements Prerequ
 			{
 				String pantheon = prereq.getKey().substring(9);
 				Deity deity = display.getDeity();
-				Set<String> charDeityPantheon =
-						new WrappedMapSet<>(CaseInsensitiveMap.class);
+				Set<Object> charDeityPantheon =
+						Collections.newSetFromMap(new CaseInsensitiveMap<>());
 				if (deity != null)
 				{
 					FactSetKey<String> fk = FactSetKey.valueOf("Pantheon");

--- a/code/src/utest/pcgen/rules/persistence/TableLoaderTest.java
+++ b/code/src/utest/pcgen/rules/persistence/TableLoaderTest.java
@@ -308,7 +308,7 @@ public class TableLoaderTest
 				"STARTTABLE:A\nName,Value\nSTRING,NIMBLER\nFoo,1\nENDTABLE:A\n");
 			fail("Expected Failure");
 		}
-		catch (PersistenceLayerException | IllegalArgumentException e)
+		catch (NullPointerException | PersistenceLayerException | IllegalArgumentException e)
 		{
 			//Yes
 		}

--- a/code/src/utest/plugin/function/AbstractFormulaTestCase.java
+++ b/code/src/utest/plugin/function/AbstractFormulaTestCase.java
@@ -296,7 +296,7 @@ public abstract class AbstractFormulaTestCase extends TestCase
 	protected WriteableVariableStore getVariableStore()
 	{
 		return (WriteableVariableStore) localSetup.getFormulaManager()
-			.getResolver();
+			.get(FormulaManager.RESULTS);
 	}
 
 	protected LegalScope getGlobalScope()

--- a/code/src/utest/plugin/function/testsupport/AbstractFormulaTestCase.java
+++ b/code/src/utest/plugin/function/testsupport/AbstractFormulaTestCase.java
@@ -192,7 +192,7 @@ public abstract class AbstractFormulaTestCase extends TestCase
 	protected WriteableVariableStore getVariableStore()
 	{
 		return (WriteableVariableStore) localSetup.getFormulaManager()
-			.getResolver();
+			.get(FormulaManager.RESULTS);
 	}
 
 	protected LegalScope getGlobalScope()

--- a/code/src/utest/plugin/lsttokens/datacontrol/DataTypeTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/datacontrol/DataTypeTokenTest.java
@@ -109,7 +109,7 @@ public class DataTypeTokenTest extends TestCase
 		{
 			assertFalse(token.parseToken(context, cd, "NotAType").passed());
 		}
-		catch (IllegalArgumentException e)
+		catch (NullPointerException | IllegalArgumentException e)
 		{
 			//This is ok too
 		}


### PR DESCRIPTION
Fixes a bug in PC's clone method (duped items added to facets in
constructor)
Changes how PC is cloned for output to ensure variables work correctly
Enhances output to check view of CDOMObjects
Escapes Strings on output (does it universally - may need a better
method since old export system didn't do it on equipment)
New Libraries (eliminates WrappedMapSet)