### PR TITLE
Bump launch4j to latest (2.4.1)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ plugins {
     id 'maven'
     id 'pmd'
     id "de.undercouch.download" version "3.2.0"
-    id 'edu.sc.seis.launch4j' version '2.3.0'
+    id 'edu.sc.seis.launch4j' version '2.4.1'
     id 'com.github.ben-manes.versions' version '0.15.0'
     id 'nebula.lint' version '7.9.5'
     id "com.dorongold.task-tree" version "1.3"


### PR DESCRIPTION
- basic Java 9 support
- newer xstream dep
- 64bit linux binaries
- minor bug fixes