### PR TITLE
moved player companions into player companion sub dir

### DIFF
--- a/data/pathfinder/paizo/player_companion/advanced_class_origins/_advanced_class_origins.pcc
+++ b/data/pathfinder/paizo/player_companion/advanced_class_origins/_advanced_class_origins.pcc
@@ -1,7 +1,7 @@
 ﻿# CVS $Revision$ $Author$ -- Wed Nov 20 08:25:04 2013 -- reformated by prettylst.pl v1.50 (build 21703)
 CAMPAIGN:Advanced Class Origins
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 STATUS:BETA
 RANK:3
 GENRE:Fantasy

--- a/data/pathfinder/paizo/player_companion/adventurers_armory/_adventurers_armory.pcc
+++ b/data/pathfinder/paizo/player_companion/adventurers_armory/_adventurers_armory.pcc
@@ -1,7 +1,7 @@
 # CVS $Revision: 13827 $ $Author: zaister $ -- Sat Nov 20 04:10:09 2004 -- reformated by prettylst.pl v1.34 (build 422)
 CAMPAIGN:Adventurer's Armory
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 STATUS:BETA
 GENRE:Fantasy

--- a/data/pathfinder/paizo/player_companion/alchemy_manual/_alchemy_manual.pcc
+++ b/data/pathfinder/paizo/player_companion/alchemy_manual/_alchemy_manual.pcc
@@ -1,7 +1,7 @@
 # CVS $Revision$ $Author$ -- Tue Dec 15 01:48:08 2015 -- reformated by PCGen PrettyLST v6.06.00
 CAMPAIGN:Alchemy Manual
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 STATUS:BETA
 GENRE:Fantasy

--- a/data/pathfinder/paizo/player_companion/andoran_spirit_of_liberty/andoran_spirit_of_liberty.pcc
+++ b/data/pathfinder/paizo/player_companion/andoran_spirit_of_liberty/andoran_spirit_of_liberty.pcc
@@ -2,7 +2,7 @@
 CAMPAIGN:Andoran, Spirit of Liberty
 KEY:Andoran - Spirit of Liberty
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 STATUS:BETA
 GENRE:Fantasy

--- a/data/pathfinder/paizo/player_companion/animal_archive/_animal_archive.pcc
+++ b/data/pathfinder/paizo/player_companion/animal_archive/_animal_archive.pcc
@@ -2,7 +2,7 @@
 # $Revision$ $Author$
 CAMPAIGN:Animal Archive
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 STATUS:BETA
 GENRE:Fantasy

--- a/data/pathfinder/paizo/player_companion/arcane_anthology/_arcane_anthology.pcc
+++ b/data/pathfinder/paizo/player_companion/arcane_anthology/_arcane_anthology.pcc
@@ -2,7 +2,7 @@
 CAMPAIGN:Arcane Anthology
 KEY:Arcane Anthology
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder RPG
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 STATUS:BETA
 RANK:1
 GENRE:Fantasy

--- a/data/pathfinder/paizo/player_companion/bastards_of_golarion/bastards_of_golarion.pcc
+++ b/data/pathfinder/paizo/player_companion/bastards_of_golarion/bastards_of_golarion.pcc
@@ -1,7 +1,7 @@
 # CVS $Revision$ $Author$ -- Fri Jun 17 21:51:56 2016 -- reformated by PCGen PrettyLST v6.06.00
 CAMPAIGN:Bastards of Golarion
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 STATUS:ALPHA
 GENRE:Fantasy

--- a/data/pathfinder/paizo/player_companion/blood_of_angels/blood_of_angels.pcc
+++ b/data/pathfinder/paizo/player_companion/blood_of_angels/blood_of_angels.pcc
@@ -1,7 +1,7 @@
 # CVS $Revision$ $Author$ -- Thu Jul 10 13:41:29 2014 -- reformated by prettylst.pl v1.51 (build 24365)
 CAMPAIGN:Blood of Angels
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 STATUS:BETA
 GENRE:Fantasy

--- a/data/pathfinder/paizo/player_companion/blood_of_fiends/blood_of_fiends.pcc
+++ b/data/pathfinder/paizo/player_companion/blood_of_fiends/blood_of_fiends.pcc
@@ -1,7 +1,7 @@
 # CVS $Revision$ $Author$ -- Sat Nov 23 14:46:39 2013 -- reformated by prettylst.pl v1.50 (build 22134)
 CAMPAIGN:Blood of Fiends
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 STATUS:BETA
 GENRE:Fantasy

--- a/data/pathfinder/paizo/player_companion/blood_of_shadows/_blood_of_shadows.pcc
+++ b/data/pathfinder/paizo/player_companion/blood_of_shadows/_blood_of_shadows.pcc
@@ -1,6 +1,6 @@
 CAMPAIGN:Blood of Shadows
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 GENRE:Fantasy
 BOOKTYPE:Supplement

--- a/data/pathfinder/paizo/player_companion/blood_of_the_elements/_blood_of_the_elements.pcc
+++ b/data/pathfinder/paizo/player_companion/blood_of_the_elements/_blood_of_the_elements.pcc
@@ -1,7 +1,7 @@
 # CVS $Revision$ $Author$ -- Tue Dec 15 01:48:08 2015 -- reformated by PCGen PrettyLST v6.06.00
 CAMPAIGN:Blood of the Elements
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 GENRE:Fantasy
 BOOKTYPE:Supplement

--- a/data/pathfinder/paizo/player_companion/blood_of_the_moon/_blood_of_the_moon.pcc
+++ b/data/pathfinder/paizo/player_companion/blood_of_the_moon/_blood_of_the_moon.pcc
@@ -6,7 +6,7 @@
 
 CAMPAIGN:Blood of the Moon
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 STATUS:BETA
 GENRE:Fantasy

--- a/data/pathfinder/paizo/player_companion/blood_of_the_night/_blood_of_the_night.pcc
+++ b/data/pathfinder/paizo/player_companion/blood_of_the_night/_blood_of_the_night.pcc
@@ -1,7 +1,7 @@
 # CVS $Revision$ $Author$ -- Tue Dec 15 01:48:08 2015 -- reformated by PCGen PrettyLST v6.06.00
 CAMPAIGN:Blood of the Night
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 GENRE:Fantasy
 BOOKTYPE:Supplement

--- a/data/pathfinder/paizo/player_companion/champions_of_balance/_champions_of_balance.pcc
+++ b/data/pathfinder/paizo/player_companion/champions_of_balance/_champions_of_balance.pcc
@@ -1,7 +1,7 @@
 # CVS $Revision$ $Author$ -- Tue Dec 15 01:48:08 2015 -- reformated by PCGen PrettyLST v6.06.00
 CAMPAIGN:Champions of Balance
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 STATUS:BETA
 GENRE:Fantasy

--- a/data/pathfinder/paizo/player_companion/champions_of_corruption/_champions_of_corruption.pcc
+++ b/data/pathfinder/paizo/player_companion/champions_of_corruption/_champions_of_corruption.pcc
@@ -1,7 +1,7 @@
 # CVS $Revision$ $Author$ -- Tue Dec 15 01:48:08 2015 -- reformated by PCGen PrettyLST v6.06.00
 CAMPAIGN:Champions of Corruption
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 GENRE:Fantasy
 BOOKTYPE:Supplement

--- a/data/pathfinder/paizo/player_companion/champions_of_purity/_champions_of_purity.pcc
+++ b/data/pathfinder/paizo/player_companion/champions_of_purity/_champions_of_purity.pcc
@@ -1,7 +1,7 @@
 # CVS $Revision$ $Author$ -- Tue Dec 15 01:48:08 2015 -- reformated by PCGen PrettyLST v6.06.00
 CAMPAIGN:Champions of Purity
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 STATUS:BETA
 GENRE:Fantasy

--- a/data/pathfinder/paizo/player_companion/cheliax_empire_of_devils/cheliax_empire_of_devils.pcc
+++ b/data/pathfinder/paizo/player_companion/cheliax_empire_of_devils/cheliax_empire_of_devils.pcc
@@ -2,7 +2,7 @@
 CAMPAIGN:Cheliax, Empire of Devils
 KEY:Cheliax - Empire of Devils
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 STATUS:RELEASE
 GENRE:Fantasy

--- a/data/pathfinder/paizo/player_companion/demon_hunters_handbook/_demon_hunters_handbook.pcc
+++ b/data/pathfinder/paizo/player_companion/demon_hunters_handbook/_demon_hunters_handbook.pcc
@@ -2,7 +2,7 @@
 CAMPAIGN:Demon Hunter's Handbook
 KEY:PF - Demon Hunter's Handbook
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 STATUS:BETA
 GENRE:Fantasy

--- a/data/pathfinder/paizo/player_companion/dirty_tactics_toolbox/_dirty_tactics_toolbox.pcc
+++ b/data/pathfinder/paizo/player_companion/dirty_tactics_toolbox/_dirty_tactics_toolbox.pcc
@@ -1,7 +1,7 @@
 CAMPAIGN:Dirty Tactics Toolbox
 KEY:PF - Dirty Tactics Toolbox
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 STATUS:BETA
 GENRE:Fantasy

--- a/data/pathfinder/paizo/player_companion/dragon_empires_primer/dragon_empires_primer.pcc
+++ b/data/pathfinder/paizo/player_companion/dragon_empires_primer/dragon_empires_primer.pcc
@@ -1,7 +1,7 @@
 # CVS $Revision$ $Author$ -- Fri Nov  8 13:07:25 2013 -- reformated by prettylst.pl v1.50 (build 21703)
 CAMPAIGN:Dragon Empires Primer
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 STATUS:BETA
 GENRE:Fantasy

--- a/data/pathfinder/paizo/player_companion/dragonslayers_handbook/_dragonslayers_handbook.pcc
+++ b/data/pathfinder/paizo/player_companion/dragonslayers_handbook/_dragonslayers_handbook.pcc
@@ -1,6 +1,6 @@
 CAMPAIGN:Dragonslayer's Handbook
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 STATUS:BETA
 GENRE:Fantasy

--- a/data/pathfinder/paizo/player_companion/dungeoneers_handbook/dungeoneers_handbook.pcc
+++ b/data/pathfinder/paizo/player_companion/dungeoneers_handbook/dungeoneers_handbook.pcc
@@ -1,7 +1,7 @@
 # CVS $Revision$ $Author$ -- Sat Nov 23 14:46:39 2013 -- reformated by prettylst.pl v1.50 (build 22134)
 CAMPAIGN:Dungeoneer's Handbook
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 STATUS:BETA
 GENRE:Fantasy

--- a/data/pathfinder/paizo/player_companion/dwarves_of_golarion/dwarves_of_golarion.pcc
+++ b/data/pathfinder/paizo/player_companion/dwarves_of_golarion/dwarves_of_golarion.pcc
@@ -1,7 +1,7 @@
 # CVS $Revision$ $Author$ -- Sat Nov 23 14:46:39 2013 -- reformated by prettylst.pl v1.50 (build 22134)
 CAMPAIGN:Dwarves of Golarion
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 STATUS:RELEASE
 GENRE:Fantasy

--- a/data/pathfinder/paizo/player_companion/faiths_and_philosophies/_faiths_and_philosophies.pcc
+++ b/data/pathfinder/paizo/player_companion/faiths_and_philosophies/_faiths_and_philosophies.pcc
@@ -1,7 +1,7 @@
 # CVS $Revision$ $Author$ -- Tue Dec 15 01:48:08 2015 -- #reformated by PCGen PrettyLST v6.06.00
 CAMPAIGN:Faiths and Philosophies
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 STATUS:BETA
 GENRE:Fantasy

--- a/data/pathfinder/paizo/player_companion/faiths_of_balance/faiths_of_balance.pcc
+++ b/data/pathfinder/paizo/player_companion/faiths_of_balance/faiths_of_balance.pcc
@@ -1,7 +1,7 @@
 # CVS $Revision$ $Author$ -- Sat Nov 23 14:46:39 2013 -- reformated by prettylst.pl v1.50 (build 22134)
 CAMPAIGN:Faiths of Balance
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 STATUS:BETA
 GENRE:Fantasy

--- a/data/pathfinder/paizo/player_companion/faiths_of_corruption/faiths_of_corruption.pcc
+++ b/data/pathfinder/paizo/player_companion/faiths_of_corruption/faiths_of_corruption.pcc
@@ -1,7 +1,7 @@
 # CVS $Revision$ $Author$ -- Sat Nov 23 14:46:39 2013 -- reformated by prettylst.pl v1.50 (build 22134)
 CAMPAIGN:Faiths of Corruption
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 STATUS:BETA
 GENRE:Fantasy

--- a/data/pathfinder/paizo/player_companion/faiths_of_purity/faiths_of_purity.pcc
+++ b/data/pathfinder/paizo/player_companion/faiths_of_purity/faiths_of_purity.pcc
@@ -1,7 +1,7 @@
 # CVS $Revision$ $Author$ -- Sat Nov 23 14:46:39 2013 -- reformated by prettylst.pl v1.50 (build 22134)
 CAMPAIGN:Faiths of Purity
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 STATUS:BETA
 GENRE:Fantasy

--- a/data/pathfinder/paizo/player_companion/gnomes_of_golarion/gnomes_of_golarion.pcc
+++ b/data/pathfinder/paizo/player_companion/gnomes_of_golarion/gnomes_of_golarion.pcc
@@ -1,7 +1,7 @@
 # CVS $Revision$ $Author$ -- Sat Nov 23 14:46:39 2013 -- reformated by prettylst.pl v1.50 (build 22134)
 CAMPAIGN:Gnomes of Golarion
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 STATUS:BETA
 GENRE:Fantasy

--- a/data/pathfinder/paizo/player_companion/goblins_of_golarion/goblins_of_golarion.pcc
+++ b/data/pathfinder/paizo/player_companion/goblins_of_golarion/goblins_of_golarion.pcc
@@ -1,7 +1,7 @@
 # CVS $Revision$ $Author$ -- Sat Nov 23 14:46:39 2013 -- reformated by prettylst.pl v1.50 (build 22134)
 CAMPAIGN:Goblins of Golarion
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 STATUS:BETA
 GENRE:Fantasy

--- a/data/pathfinder/paizo/player_companion/halflings_of_golarion/halflings_of_golarion.pcc
+++ b/data/pathfinder/paizo/player_companion/halflings_of_golarion/halflings_of_golarion.pcc
@@ -1,7 +1,7 @@
 # CVS $Revision$ $Author$ -- Sat Nov 23 14:46:39 2013 -- reformated by prettylst.pl v1.50 (build 22134)
 CAMPAIGN:Halflings of Golarion
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 STATUS:BETA
 GENRE:Fantasy

--- a/data/pathfinder/paizo/player_companion/heroes_of_the_street/_heroes_of_the_street.pcc
+++ b/data/pathfinder/paizo/player_companion/heroes_of_the_street/_heroes_of_the_street.pcc
@@ -1,7 +1,7 @@
 CAMPAIGN:Heroes of the Streets
 GAMEMODE:Pathfinder|Pathfinder_PFS
 RANK:3
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 GENRE:Fantasy
 BOOKTYPE:Supplement
 SETTING:Pathfinder|Golarion

--- a/data/pathfinder/paizo/player_companion/heroes_of_the_wild/_heroes_of_the_wild.pcc
+++ b/data/pathfinder/paizo/player_companion/heroes_of_the_wild/_heroes_of_the_wild.pcc
@@ -1,6 +1,6 @@
 CAMPAIGN:Heroes of the Wild
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 STATUS:BETA
 GENRE:Fantasy

--- a/data/pathfinder/paizo/player_companion/humans_of_golarion/_humans_of_golarion.pcc
+++ b/data/pathfinder/paizo/player_companion/humans_of_golarion/_humans_of_golarion.pcc
@@ -2,7 +2,7 @@
 CAMPAIGN:Humans of Golarion
 KEY:Humans of Golarion
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 STATUS:BETA
 GENRE:Fantasy

--- a/data/pathfinder/paizo/player_companion/inner_sea_primer/inner_sea_primer.pcc
+++ b/data/pathfinder/paizo/player_companion/inner_sea_primer/inner_sea_primer.pcc
@@ -1,7 +1,7 @@
 # CVS $Revision$ $Author$ -- Sat Nov 23 14:46:39 2013 -- reformated by prettylst.pl v1.50 (build 22134)
 CAMPAIGN:Inner Sea Primer
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 STATUS:RELEASE
 GENRE:Fantasy

--- a/data/pathfinder/paizo/player_companion/knights_of_the_inner_sea/knights_of_the_inner_sea.pcc
+++ b/data/pathfinder/paizo/player_companion/knights_of_the_inner_sea/knights_of_the_inner_sea.pcc
@@ -1,7 +1,7 @@
 # CVS $Revision$ $Author$ -- Thu Feb 18 13:31:06 2016 -- reformated by PCGen PrettyLST v6.06.00
 CAMPAIGN:Knights of the Inner Sea
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 STATUS:BETA
 GENRE:Fantasy

--- a/data/pathfinder/paizo/player_companion/kobolds_of_golarion/_kobolds_of_golarion.pcc
+++ b/data/pathfinder/paizo/player_companion/kobolds_of_golarion/_kobolds_of_golarion.pcc
@@ -1,6 +1,6 @@
 CAMPAIGN:Kobolds of Golarion
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 STATUS:BETA
 GENRE:Fantasy

--- a/data/pathfinder/paizo/player_companion/magical_marketplace/_magical_marketplace.pcc
+++ b/data/pathfinder/paizo/player_companion/magical_marketplace/_magical_marketplace.pcc
@@ -1,7 +1,7 @@
 # CVS $Revision$ $Author$ -- Tue Dec 15 01:48:08 2015 -- reformated by PCGen PrettyLST v6.06.00
 CAMPAIGN:Magical Marketplace
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 STATUS:BETA
 GENRE:Fantasy

--- a/data/pathfinder/paizo/player_companion/melee_tactics_toolbox/melee_tactics_toolbox.pcc
+++ b/data/pathfinder/paizo/player_companion/melee_tactics_toolbox/melee_tactics_toolbox.pcc
@@ -1,7 +1,7 @@
 # CVS $Revision$ $Author$ -- Thu May 12 14:50:48 2016 -- reformated by PCGen PrettyLST v6.06.00
 CAMPAIGN:Melee Tactics Toolbox
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 STATUS:BETA
 GENRE:Fantasy

--- a/data/pathfinder/paizo/player_companion/orcs_of_golarion/orcs_of_golarion.pcc
+++ b/data/pathfinder/paizo/player_companion/orcs_of_golarion/orcs_of_golarion.pcc
@@ -1,7 +1,7 @@
 # CVS $Revision$ $Author$ -- Sat Nov 23 14:46:39 2013 -- reformated by prettylst.pl v1.50 (build 22134)
 CAMPAIGN:Orcs of Golarion
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 STATUS:BETA
 GENRE:Fantasy

--- a/data/pathfinder/paizo/player_companion/pathfinder_society_primer/pathfinder_society_primer.pcc
+++ b/data/pathfinder/paizo/player_companion/pathfinder_society_primer/pathfinder_society_primer.pcc
@@ -1,6 +1,6 @@
 CAMPAIGN:Pathfinder Society Primer
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 STATUS:BETA
 GENRE:Fantasy

--- a/data/pathfinder/paizo/player_companion/people_of_the_north/_people_of_the_north.pcc
+++ b/data/pathfinder/paizo/player_companion/people_of_the_north/_people_of_the_north.pcc
@@ -1,7 +1,7 @@
 # CVS $Revision$ $Author$ -- Tue Dec 15 01:48:08 2015 -- reformated by PCGen PrettyLST v6.06.00
 CAMPAIGN:People of the North
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 GENRE:Fantasy
 BOOKTYPE:Supplement

--- a/data/pathfinder/paizo/player_companion/people_of_the_north/_pfs/_.pcc
+++ b/data/pathfinder/paizo/player_companion/people_of_the_north/_pfs/_.pcc
@@ -2,7 +2,7 @@
 CAMPAIGN:People of the North (PFS)
 KEY:PFS ~ People of the North
 #GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 GENRE:Fantasy
 BOOKTYPE:Supplement

--- a/data/pathfinder/paizo/player_companion/people_of_the_river/_people_of_the_river.pcc
+++ b/data/pathfinder/paizo/player_companion/people_of_the_river/_people_of_the_river.pcc
@@ -1,6 +1,6 @@
 CAMPAIGN:People of the River
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 GENRE:Fantasy
 STATUS:BETA

--- a/data/pathfinder/paizo/player_companion/people_of_the_sands/_people_of_the_sands.pcc
+++ b/data/pathfinder/paizo/player_companion/people_of_the_sands/_people_of_the_sands.pcc
@@ -1,6 +1,6 @@
 CAMPAIGN:People of the Sands
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 GENRE:Fantasy
 STATUS:BETA

--- a/data/pathfinder/paizo/player_companion/people_of_the_stars/_people_of_the_stars.pcc
+++ b/data/pathfinder/paizo/player_companion/people_of_the_stars/_people_of_the_stars.pcc
@@ -2,7 +2,7 @@
 CAMPAIGN:People of the Stars
 KEY:People of the Stars
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 STATUS:BETA
 GENRE:Fantasy

--- a/data/pathfinder/paizo/player_companion/pirates_of_the_inner_sea/pirates_of_the_inner_sea.pcc
+++ b/data/pathfinder/paizo/player_companion/pirates_of_the_inner_sea/pirates_of_the_inner_sea.pcc
@@ -1,7 +1,7 @@
 # CVS $Revision$ $Author$ -- Sat Nov 23 14:46:39 2013 -- reformated by prettylst.pl v1.50 (build 22134)
 CAMPAIGN:Pirates of the Inner Sea
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 STATUS:BETA
 GENRE:Fantasy

--- a/data/pathfinder/paizo/player_companion/qadira_gateway_to_the_east/qadira_gateway_to_the_east.pcc
+++ b/data/pathfinder/paizo/player_companion/qadira_gateway_to_the_east/qadira_gateway_to_the_east.pcc
@@ -2,7 +2,7 @@
 CAMPAIGN:Qadira, Gateway to the East
 KEY:Qadira - Gateway to the East
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 STATUS:RELEASE
 GENRE:Fantasy

--- a/data/pathfinder/paizo/player_companion/quests_and_campaigns/_quests_and_campaigns.pcc
+++ b/data/pathfinder/paizo/player_companion/quests_and_campaigns/_quests_and_campaigns.pcc
@@ -2,7 +2,7 @@
 CAMPAIGN:Quests and Campaigns
 KEY:PF - Quests and Campaigns
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 STATUS:BETA
 GENRE:Fantasy

--- a/data/pathfinder/paizo/player_companion/ranged_tactics_toolbox/ranged_tactics_toolbox.pcc
+++ b/data/pathfinder/paizo/player_companion/ranged_tactics_toolbox/ranged_tactics_toolbox.pcc
@@ -1,7 +1,7 @@
 # CVS $Revision$ $Author$ -- Thu May 12 14:50:48 2016 -- reformated by PCGen PrettyLST v6.06.00
 CAMPAIGN:Ranged Tactics Toolbox
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 STATUS:BETA
 GENRE:Fantasy

--- a/data/pathfinder/paizo/player_companion/sargava_the_lost_colony/sargava_the_lost_colony.pcc
+++ b/data/pathfinder/paizo/player_companion/sargava_the_lost_colony/sargava_the_lost_colony.pcc
@@ -1,7 +1,7 @@
 # CVS $Revision$ $Author$ -- Sat Nov 23 14:46:39 2013 -- reformated by prettylst.pl v1.50 (build 22134)
 CAMPAIGN:Sargava the Lost Colony
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 STATUS:RELEASE
 GENRE:Fantasy

--- a/data/pathfinder/paizo/player_companion/taldor_echoes_of_glory/_taldor_echoes_of_glory.pcc
+++ b/data/pathfinder/paizo/player_companion/taldor_echoes_of_glory/_taldor_echoes_of_glory.pcc
@@ -2,7 +2,7 @@
 CAMPAIGN:Taldor, Echoes of Glory
 KEY:Taldor - Echoes of Glory (Conversion)
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 STATUS:BETA
 GENRE:Fantasy

--- a/data/pathfinder/paizo/player_companion/undead_slayers_handbook/_undead_slayers_handbook.pcc
+++ b/data/pathfinder/paizo/player_companion/undead_slayers_handbook/_undead_slayers_handbook.pcc
@@ -1,7 +1,7 @@
 # CVS $Revision$ $Author$ -- Tue Dec 15 01:48:08 2015 -- #reformated by PCGen PrettyLST v6.06.00
 CAMPAIGN:Undead Slayer's Handbook
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 STATUS:BETA
 GENRE:Fantasy

--- a/data/pathfinder/paizo/player_companion/varisia_birthplace_of_legends/_varisia_birthplace_of_legends.pcc
+++ b/data/pathfinder/paizo/player_companion/varisia_birthplace_of_legends/_varisia_birthplace_of_legends.pcc
@@ -2,7 +2,7 @@
 CAMPAIGN:Varisia, Birthplace of Legends
 KEY:Varisia - Birthplace of Legends
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 STATUS:BETA
 GENRE:Fantasy

--- a/data/pathfinder/paizo/player_companion/weapon_masters_handbook/_weapon_masters_handbook.pcc
+++ b/data/pathfinder/paizo/player_companion/weapon_masters_handbook/_weapon_masters_handbook.pcc
@@ -2,7 +2,7 @@
 CAMPAIGN:Weapon Master's Handbook
 KEY:PF - Weapon Master's Handbook
 GAMEMODE:Pathfinder|Pathfinder_PFS
-TYPE:Paizo Publishing.Pathfinder Player Companion
+TYPE:Paizo Publishing.Pathfinder RPG.Player Companion
 RANK:3
 STATUS:BETA
 GENRE:Fantasy


### PR DESCRIPTION
currently there is one player companion in the player companion dir in the sources menu.  this moves all other books in the sources folder to that spot on the tree.