### PR TITLE
Fix #3453: Pathfinder: choose 'Aasimars' race got exception

### DIFF
--- a/code/src/java/pcgen/core/BioSet.java
+++ b/code/src/java/pcgen/core/BioSet.java
@@ -575,7 +575,6 @@ public final class BioSet extends PObject implements NonInteractive
 
 				break;
 			}
-			genderTok.nextToken(); // burn next token
 		}
 	}
 


### PR DESCRIPTION
Fix by removing unneccessary & unchecked call to genderTok.nextToken()