### PR TITLE
[CODE-3204] Fix handling of whitespace lines in class lst files.

### DIFF
--- a/code/src/java/pcgen/persistence/lst/LstObjectFileLoader.java
+++ b/code/src/java/pcgen/persistence/lst/LstObjectFileLoader.java
@@ -361,7 +361,7 @@ public abstract class LstObjectFileLoader<T extends CDOMObject> extends Observab
 		for (int i = 0; i < fileLines.length; i++)
 		{
 			String line = fileLines[i];
-			if ((line.isEmpty())
+			if ((line.trim().isEmpty())
 				|| (line.charAt(0) == LstFileLoader.LINE_COMMENT_CHAR))
 			{
 				continue;
@@ -399,10 +399,6 @@ public abstract class LstObjectFileLoader<T extends CDOMObject> extends Observab
 			if (line.startsWith("SOURCE")) //$NON-NLS-1$
 			{
 				SourceLoader.parseLine(context, line, uri);
-			}
-			else if (line.trim().isEmpty())
-			{
-				// Ignore the line
 			}
 			else if (firstToken.indexOf(COPY_SUFFIX) > 0)
 			{


### PR DESCRIPTION
Fix for issue #3369, CODE-3204.

Problem was caused by all non CLASS:/comment lines following a CLASS .MOD being picked up as part of the MOD.

Easy fix, ignore line consisting of just white space characters before any processing is done on them. There was already some code for this introduced to fix a similar problem in commit 7e0ccf5de131fa8090b3a3a7f8f515b51969a3aa but it was after the MOD handling code for some reason.