### PR TITLE
CODE-3218: Fixed feet tattoos being in their own slot

### DIFF
--- a/system/gameModes/Pathfinder/equipmentslots.lst
+++ b/system/gameModes/Pathfinder/equipmentslots.lst
@@ -4,7 +4,7 @@
 #
 # Lists the DEFAULT number of slots for each type
 #
-NUMSLOTS:DEFAULT	HEAD:1	HANDS:2	TORSO:1	LEGS:2	SHIELD:1	TATTOOFEET:2
+NUMSLOTS:DEFAULT	HEAD:1	HANDS:2	TORSO:1	LEGS:3	SHIELD:1
 #
 # Name of Slot	Type of items can contain	Where to get # from
 #								and number in each slot
@@ -59,5 +59,5 @@ EQSLOT:TattooBelt		CONTAINS:TattooBelt=1		NUMBER:TORSO
 EQSLOT:TattooWrist	CONTAINS:TattooWrist=1		NUMBER:HANDS
 EQSLOT:TattooHands	CONTAINS:TattooHands=1		NUMBER:HANDS
 EQSLOT:TattooRing		CONTAINS:TattooRing=2		NUMBER:TORSO
-EQSLOT:TattooFeet		CONTAINS:TattooFeet=1		NUMBER:TATTOOFEET
+EQSLOT:TattooFeet		CONTAINS:TattooFeet=1		NUMBER:LEGS
 #


### PR DESCRIPTION
Not really a code bug, but this should correct it.