### PR TITLE
Handle agesets without Height and Weight information [DATA-3455]

### DIFF
--- a/code/src/java/pcgen/core/BioSet.java
+++ b/code/src/java/pcgen/core/BioSet.java
@@ -520,7 +520,7 @@ public final class BioSet extends PObject implements NonInteractive
 		final String htwt = getTokenNumberInMaps("SEX", 0, pc.getDisplay().getRegionString(), pc
 			.getRace().getKeyName().trim());
 
-		if (htwt == null)
+		if (htwt == null || htwt == "0")
 		{
 			return;
 		}


### PR DESCRIPTION
This addresses an issue where races without Height and Weight information for certain agesets would fail to load properly.

This is due to the fact that the data for that ageset would be stored as "0" by BioSetLoader, but BioSet only checked for "null".
Addresses:
https://pcgenorg.atlassian.net/browse/DATA-3455
https://pcgenorg.atlassian.net/browse/DATA-3461
