### PR TITLE
Ultimate Magic Shaman familiars mod load fix

### DIFF
--- a/data/pathfinder/paizo/roleplaying_game/ultimate_magic/_ultimate_magic.pcc
+++ b/data/pathfinder/paizo/roleplaying_game/ultimate_magic/_ultimate_magic.pcc
@@ -83,6 +83,9 @@ WEAPONPROF:um_profs_weapon.lst
 
 HIDETYPE:FEAT|RevelationTargetOneOnly|FeatSkillFocusCraft|CrossbloodlineFeat|FeatSkillFocusPerform
 
+#Support
+ABILITY:support/um_abilities_class_acg.lst|PRECAMPAIGN:1,INCLUDES=Advanced Class Guide
+
 #MOVE TO CORE ESSENTIALS
 ABILITY:um_abilities_companion.lst
 CLASS:um_classes_companion.lst

--- a/data/pathfinder/paizo/roleplaying_game/ultimate_magic/support/um_abilities_class_acg.lst
+++ b/data/pathfinder/paizo/roleplaying_game/ultimate_magic/support/um_abilities_class_acg.lst
@@ -1,0 +1,4 @@
+###Block: Add new familiars
+# Ability Name							Allowed Companions
+#Block: Shaman Spirit Animal
+CATEGORY=Special Ability|Shaman ~ Spirit Animal.MOD		COMPANIONLIST:Familiar|Familiar (Blue-Ringed Octopus),Familiar (Centipede (House)),Familiar (Crab (Giant King)),Familiar (Donkey Rat),Familiar (Fox),Familiar (Goat),Familiar (Hedgehog),Familiar (Pig),Familiar (Scorpion (Greensting)),Familiar (Spider (Scarlet)),Familiar (Thrush),Familiar (Turtle)

--- a/data/pathfinder/paizo/roleplaying_game/ultimate_magic/um_abilities_class.lst
+++ b/data/pathfinder/paizo/roleplaying_game/ultimate_magic/um_abilities_class.lst
@@ -700,7 +700,7 @@ CATEGORY=Special Ability|Arcane Bond ~ Familiar.MOD	COMPANIONLIST:Familiar|Famil
 #Block: Witch familiar
 CATEGORY=Special Ability|Witch ~ Familiar.MOD		COMPANIONLIST:Familiar|Familiar (Blue-Ringed Octopus),Familiar (Centipede (House)),Familiar (Crab (Giant King)),Familiar (Donkey Rat),Familiar (Fox),Familiar (Goat),Familiar (Hedgehog),Familiar (Pig),Familiar (Scorpion (Greensting)),Familiar (Spider (Scarlet)),Familiar (Thrush),Familiar (Turtle)
 #Block: Shaman Spirit Animal
-CATEGORY=Special Ability|Shaman ~ Spirit Animal.MOD		COMPANIONLIST:Familiar|Familiar (Blue-Ringed Octopus),Familiar (Centipede (House)),Familiar (Crab (Giant King)),Familiar (Donkey Rat),Familiar (Fox),Familiar (Goat),Familiar (Hedgehog),Familiar (Pig),Familiar (Scorpion (Greensting)),Familiar (Spider (Scarlet)),Familiar (Thrush),Familiar (Turtle)
+#CATEGORY=Special Ability|Shaman ~ Spirit Animal.MOD		COMPANIONLIST:Familiar|Familiar (Blue-Ringed Octopus),Familiar (Centipede (House)),Familiar (Crab (Giant King)),Familiar (Donkey Rat),Familiar (Fox),Familiar (Goat),Familiar (Hedgehog),Familiar (Pig),Familiar (Scorpion (Greensting)),Familiar (Spider (Scarlet)),Familiar (Thrush),Familiar (Turtle)
 
 
 ###Block: Versatile Channeler Abilities


### PR DESCRIPTION
Fixes the missing ability error that pops up when loading Ultimate Magic without Advanced Class Guide.