### PR TITLE
NEWTAG-597 - turning off VariableProcessor caching

### DIFF
--- a/code/src/java/pcgen/core/VariableProcessor.java
+++ b/code/src/java/pcgen/core/VariableProcessor.java
@@ -99,7 +99,12 @@ public abstract class VariableProcessor
 		CachableResult(Float result, boolean cachable)
 		{
 			this.result = result;
-			this.cachable = cachable;
+			// following commented out by Bryan McRoberts 6-Jan-2018
+			// this.cachable = cachable; // unreliable!
+			// turning off caching here because it sometimes is based on values that haven't
+			// fully loaded yet. better to rely on the caching at the variable level in BonusManager
+			// because it knows if the data is loaded or not.
+			this.cachable = false;
 		}
 	}
 

--- a/code/src/java/pcgen/core/VariableProcessor.java
+++ b/code/src/java/pcgen/core/VariableProcessor.java
@@ -99,12 +99,7 @@ public abstract class VariableProcessor
 		CachableResult(Float result, boolean cachable)
 		{
 			this.result = result;
-			// following commented out by Bryan McRoberts 6-Jan-2018
-			// this.cachable = cachable; // unreliable!
-			// turning off caching here because it sometimes is based on values that haven't
-			// fully loaded yet. better to rely on the caching at the variable level in BonusManager
-			// because it knows if the data is loaded or not.
-			this.cachable = false;
+			this.cachable = cachable; // unreliable!
 		}
 	}
 

--- a/code/src/java/pcgen/system/CharacterManager.java
+++ b/code/src/java/pcgen/system/CharacterManager.java
@@ -185,6 +185,7 @@ public final class CharacterManager
 			ioHandler.read(newPC, file.getAbsolutePath());
 			// Ensure any custom equipment held by the character is added to the dataset's list
 			dataset.refreshEquipment();
+			newPC.calcActiveBonuses();
 
 			if (!showLoadNotices(true, ioHandler.getErrors(), file.getName(),
 				delegate))


### PR DESCRIPTION
VariableProcessor caching produces unreliable results because sometimes it will try to cache a variable used in a PREREQ that hasn't had all relevant BONUS values loaded.  It's better to rely on the caching in BonusManager.