### PR TITLE
CODE-3222 - sub choices might match the prereq with a delimiter

### DIFF
--- a/code/src/java/pcgen/core/prereq/PrerequisiteUtilities.java
+++ b/code/src/java/pcgen/core/prereq/PrerequisiteUtilities.java
@@ -369,7 +369,7 @@ public final class PrerequisiteUtilities
 		int numMatches = 0;
 		for (String s : assocs)
 		{
-			if (subKey.equalsIgnoreCase(s))
+			if (subKey.equalsIgnoreCase(s) || s.endsWith("|"+subKey))
 			{
 				numMatches++;
 			}
@@ -381,7 +381,7 @@ public final class PrerequisiteUtilities
 	{
 		for (String s : assocs)
 		{
-			if (subKey.equalsIgnoreCase(s))
+			if (subKey.equalsIgnoreCase(s) || s.endsWith("|"+subKey))
 			{
 				return true;
 			}


### PR DESCRIPTION
This resolves the PREABILITY issue because the sub-key (choice) didn't match exactly since the choice was from a category internal list.  In this case it should match the choice to the item that ends with a pipe in front of the name of the item we're matching.