### PR TITLE
NEWTAG-597 Add SET for Dice Format

### DIFF
--- a/code/pluginbuild.xml
+++ b/code/pluginbuild.xml
@@ -21,7 +21,6 @@ jar-all-plugins - Generate the plugin jar files
 	<property name="systemlstplugins.dir" value="${plugins.dir}/systemlstplugins" />
 	<property name="jepplugins.dir" value="${plugins.dir}/jepplugins" />
 	<property name="converterplugins.dir" value="${plugins.dir}/converterplugins" />
-
 	<target name="jar-all-plugins" depends="makeplugindirs,jar-gmgen-plugins,jar-export-plugins,jar-bonus-plugins,jar-pre-plugins,jar-lst-plugins,jar-modifier-plugins,jar-variable-plugins,jar-systemlst-plugins, jar-converter-plugins, jar-jep-plugins, jar-deprecated-plugin, jar-primitive-plugins, jar-qualifier-plugins, jar-function-plugins" description="Build (Link) plugin jar files">
 	</target>
 
@@ -6914,7 +6913,7 @@ jar-all-plugins - Generate the plugin jar files
 		</jar>
 	</target>
 
-	<target name="jar-modifier-plugins" depends="jar-modifier-bool-plugins, jar-modifier-cdom-plugins, jar-modifier-number-plugins, jar-modifier-orderedpair-plugins, jar-modifier-set-plugins, jar-modifier-string-plugins" description="Build (Link) Lst Modifier Token plugin jar files">
+	<target name="jar-modifier-plugins" depends="jar-modifier-bool-plugins, jar-modifier-cdom-plugins, jar-modifier-dice-plugins, jar-modifier-number-plugins, jar-modifier-orderedpair-plugins, jar-modifier-set-plugins, jar-modifier-string-plugins" description="Build (Link) Lst Modifier Token plugin jar files">
 	</target>
 
 	<target name="jar-modifier-bool-plugins" depends="makeplugindirs" description="Build (Link) Boolean Modifier Token plugin jar files">
@@ -6934,6 +6933,17 @@ jar-all-plugins - Generate the plugin jar files
 			<fileset dir="${build.classes.dir}">
 				<patternset>
 					<include name="plugin/modifier/cdom/SetModifierFactory.class" />
+				</patternset>
+			</fileset>
+		</jar>
+	</target>
+
+	<target name="jar-modifier-dice-plugins" depends="makeplugindirs" description="Build (Link) Dice Modifier Token plugin jar files">
+		<!-- Dice Modifier tokens-->
+		<jar jarfile="${lstplugins.dir}/DiceModifier-SET.jar" manifest="${src.java.dir}/plugin/lsttokens/manifest.mf">
+			<fileset dir="${build.classes.dir}">
+				<patternset>
+					<include name="plugin/modifier/dice/SetModifierFactory.class" />
 				</patternset>
 			</fileset>
 		</jar>

--- a/code/src/java/plugin/lsttokens/datacontrol/DefaultVariableValueToken.java
+++ b/code/src/java/plugin/lsttokens/datacontrol/DefaultVariableValueToken.java
@@ -107,10 +107,9 @@ public class DefaultVariableValueToken extends
 		}
 		catch (IllegalArgumentException e)
 		{
-			return new ParseResult.Fail("ModifierType "
-				+ fmtManager.getIdentifierType()
-				+ " could not be initialized to a default value of: "
-				+ defaultValue, context);
+			return new ParseResult.Fail("ModifierType " + fmtManager.getIdentifierType()
+				+ " could not be initialized to a default value of: " + defaultValue
+				+ " due to " + e.getLocalizedMessage(), context);
 		}
 		dvv.setModifier(defaultModifier);
 		varContext.addDefault(cl, defaultModifier);

--- a/code/src/java/plugin/modifier/dice/SetModifierFactory.java
+++ b/code/src/java/plugin/modifier/dice/SetModifierFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2014 (C) Tom Parker <thpr@users.sourceforge.net>
+ * 
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+package plugin.modifier.dice;
+
+import pcgen.base.format.dice.Dice;
+import pcgen.rules.persistence.token.AbstractFixedSetModifierFactory;
+
+/**
+ * An SetModifier is a {@code Modifier<Dice>} that returns a specific value
+ * (independent of the input) when the Modifier is processed.
+ */
+public class SetModifierFactory extends AbstractFixedSetModifierFactory<Dice>
+{
+	/**
+	 * Identifies that this SetModifier acts upon Dice objects.
+	 * 
+	 * @see pcgen.base.calculation.CalculationInfo#getVariableFormat()
+	 */
+	@Override
+	public Class<Dice> getVariableFormat()
+	{
+		return Dice.class;
+	}
+}


### PR DESCRIPTION
Improves error messaging and also adds the SET Modifier for DICE. This is needed for DEFAULTVARIABLEVALUE to be able to function.
