### PR TITLE
CODE-3225 Fix MODIFYOTHER so that it correctly filters for object type

### DIFF
--- a/code/src/java/plugin/lsttokens/ModifyOtherLst.java
+++ b/code/src/java/plugin/lsttokens/ModifyOtherLst.java
@@ -20,12 +20,12 @@ package plugin.lsttokens;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 
 import pcgen.base.calculation.PCGenModifier;
 import pcgen.base.formula.base.LegalScope;
 import pcgen.base.formula.base.ScopeInstance;
 import pcgen.base.formula.base.VarScoped;
-import pcgen.base.lang.ObjectUtil;
 import pcgen.base.text.ParsingSeparator;
 import pcgen.base.util.FormatManager;
 import pcgen.cdom.base.CDOMObject;
@@ -112,7 +112,7 @@ public class ModifyOtherLst extends AbstractTokenWithSeparator<CDOMObject>
 				@Override
 				public boolean contains(VarScoped item)
 				{
-					return ObjectUtil.compareWithNull(item.getLocalScopeName(), scope.getName())
+					return Objects.equals(item.getLocalScopeName(), scope.getName())
 						&& (item instanceof CDOMObject)
 						&& ((CDOMObject) item).containsInList(ListKey.GROUP, groupName);
 				}
@@ -137,8 +137,7 @@ public class ModifyOtherLst extends AbstractTokenWithSeparator<CDOMObject>
 				@Override
 				public boolean contains(VarScoped item)
 				{
-					return ObjectUtil.compareWithNull(item.getLocalScopeName(),
-						scope.getName());
+					return Objects.equals(item.getLocalScopeName(), scope.getName());
 				}
 
 				@Override
@@ -161,7 +160,7 @@ public class ModifyOtherLst extends AbstractTokenWithSeparator<CDOMObject>
 				@Override
 				public boolean contains(VarScoped item)
 				{
-					return ObjectUtil.compareWithNull(item.getLocalScopeName(), scope.getName())
+					return Objects.equals(item.getLocalScopeName(), scope.getName())
 						&& item.getKeyName().equalsIgnoreCase(groupingName);
 				}
 

--- a/code/src/java/plugin/lsttokens/ModifyOtherLst.java
+++ b/code/src/java/plugin/lsttokens/ModifyOtherLst.java
@@ -25,6 +25,7 @@ import pcgen.base.calculation.PCGenModifier;
 import pcgen.base.formula.base.LegalScope;
 import pcgen.base.formula.base.ScopeInstance;
 import pcgen.base.formula.base.VarScoped;
+import pcgen.base.lang.ObjectUtil;
 import pcgen.base.text.ParsingSeparator;
 import pcgen.base.util.FormatManager;
 import pcgen.cdom.base.CDOMObject;
@@ -111,9 +112,9 @@ public class ModifyOtherLst extends AbstractTokenWithSeparator<CDOMObject>
 				@Override
 				public boolean contains(VarScoped item)
 				{
-					return (item instanceof CDOMObject)
-						&& ((CDOMObject) item).containsInList(ListKey.GROUP,
-							groupName);
+					return ObjectUtil.compareWithNull(item.getLocalScopeName(), scope.getName())
+						&& (item instanceof CDOMObject)
+						&& ((CDOMObject) item).containsInList(ListKey.GROUP, groupName);
 				}
 
 				@Override
@@ -134,9 +135,10 @@ public class ModifyOtherLst extends AbstractTokenWithSeparator<CDOMObject>
 			group = new ObjectGrouping()
 			{
 				@Override
-				public boolean contains(VarScoped cdo)
+				public boolean contains(VarScoped item)
 				{
-					return true;
+					return ObjectUtil.compareWithNull(item.getLocalScopeName(),
+						scope.getName());
 				}
 
 				@Override
@@ -157,9 +159,10 @@ public class ModifyOtherLst extends AbstractTokenWithSeparator<CDOMObject>
 			group = new ObjectGrouping()
 			{
 				@Override
-				public boolean contains(VarScoped cdo)
+				public boolean contains(VarScoped item)
 				{
-					return cdo.getKeyName().equalsIgnoreCase(groupingName);
+					return ObjectUtil.compareWithNull(item.getLocalScopeName(), scope.getName())
+						&& item.getKeyName().equalsIgnoreCase(groupingName);
 				}
 
 				@Override


### PR DESCRIPTION
Note:
This structure of having inline classes like this is a bit of a hack to demonstrate the process works, but we still need it to work.  Longer term, there are ways to make this more sensible in how groupings are formed