### PR TITLE
Remove LST item from Loadable

### DIFF
--- a/code/src/java/pcgen/cdom/base/CDOMObject.java
+++ b/code/src/java/pcgen/cdom/base/CDOMObject.java
@@ -905,12 +905,6 @@ public abstract class CDOMObject extends ConcretePrereqObject implements
 			: cdomListMods.getKeySet();
 	}
 
-	@Override
-	public final String getLSTformat()
-	{
-		return getKeyName();
-	}
-
 	public final void overlayCDOMObject(CDOMObject cdo)
 	{
 		addAllPrerequisites(cdo.getPrerequisiteList());

--- a/code/src/java/pcgen/cdom/base/Loadable.java
+++ b/code/src/java/pcgen/cdom/base/Loadable.java
@@ -22,8 +22,6 @@ import java.net.URI;
 public interface Loadable extends Identified
 {
 
-	public String getLSTformat();
-
 	public void setName(String name);
 
 	public URI getSourceURI();

--- a/code/src/java/pcgen/cdom/content/BaseDice.java
+++ b/code/src/java/pcgen/cdom/content/BaseDice.java
@@ -66,12 +66,6 @@ public class BaseDice implements Loadable
 	}
 
 	@Override
-	public String getLSTformat()
-	{
-		return getDisplayName();
-	}
-
-	@Override
 	public boolean isInternal()
 	{
 		return false;

--- a/code/src/java/pcgen/cdom/content/BonusSpellInfo.java
+++ b/code/src/java/pcgen/cdom/content/BonusSpellInfo.java
@@ -74,12 +74,6 @@ public class BonusSpellInfo implements Loadable
 	}
 
 	@Override
-	public String getLSTformat()
-	{
-		return getKeyName();
-	}
-
-	@Override
 	public boolean isInternal()
 	{
 		return false;

--- a/code/src/java/pcgen/cdom/content/ContentDefinition.java
+++ b/code/src/java/pcgen/cdom/content/ContentDefinition.java
@@ -21,11 +21,9 @@ import java.util.Objects;
 
 import pcgen.base.util.FormatManager;
 import pcgen.cdom.base.CDOMObject;
-import pcgen.cdom.base.Constants;
 import pcgen.cdom.base.Loadable;
 import pcgen.cdom.enumeration.DataSetID;
 import pcgen.rules.context.LoadContext;
-import pcgen.util.StringPClassUtil;
 import pcgen.util.enumeration.View;
 import pcgen.util.enumeration.Visibility;
 
@@ -262,21 +260,6 @@ public abstract class ContentDefinition<T extends CDOMObject, F> extends UserCon
 	public Boolean getRequired()
 	{
 		return required;
-	}
-
-	@Override
-	public String getLSTformat()
-	{
-		String loc;
-		if (CDOMObject.class.equals(usableLocation))
-		{
-			loc = "GLOBAL";
-		}
-		else
-		{
-			loc = StringPClassUtil.getStringFor(usableLocation);
-		}
-		return loc + Constants.PIPE + getKeyName();
 	}
 
 	/**

--- a/code/src/java/pcgen/cdom/content/DatasetVariable.java
+++ b/code/src/java/pcgen/cdom/content/DatasetVariable.java
@@ -50,17 +50,6 @@ public class DatasetVariable extends UserContent
 	}
 
 	/**
-	 * Not designed to be used for this object.
-	 * 
-	 * @see pcgen.cdom.base.Loadable#getLSTformat()
-	 */
-	@Override
-	public String getLSTformat()
-	{
-		return null;
-	}
-
-	/**
 	 * Sets the scope name in which the variable is legal.
 	 * 
 	 * @param scope

--- a/code/src/java/pcgen/cdom/content/DefaultVarValue.java
+++ b/code/src/java/pcgen/cdom/content/DefaultVarValue.java
@@ -38,12 +38,6 @@ public class DefaultVarValue extends UserContent
 		return getKeyName();
 	}
 
-	@Override
-	public String getLSTformat()
-	{
-		return getDisplayName();
-	}
-
 	/**
 	 * Sets the FormatManager that manages the data format for which this object
 	 * holds the default value.

--- a/code/src/java/pcgen/cdom/content/RollMethod.java
+++ b/code/src/java/pcgen/cdom/content/RollMethod.java
@@ -59,12 +59,6 @@ public class RollMethod implements Loadable
 	}
 
 	@Override
-	public String getLSTformat()
-	{
-		return getDisplayName();
-	}
-
-	@Override
 	public boolean isInternal()
 	{
 		return false;

--- a/code/src/java/pcgen/cdom/content/Sponsor.java
+++ b/code/src/java/pcgen/cdom/content/Sponsor.java
@@ -74,12 +74,6 @@ public class Sponsor implements Loadable
 	}
 
 	@Override
-	public String getLSTformat()
-	{
-		return getKeyName();
-	}
-
-	@Override
 	public boolean isInternal()
 	{
 		return false;

--- a/code/src/java/pcgen/cdom/content/TabInfo.java
+++ b/code/src/java/pcgen/cdom/content/TabInfo.java
@@ -102,12 +102,6 @@ public class TabInfo implements Loadable
 	}
 
 	@Override
-	public String getLSTformat()
-	{
-		return getKeyName();
-	}
-
-	@Override
 	public boolean isInternal()
 	{
 		return false;

--- a/code/src/java/pcgen/cdom/content/UserFunction.java
+++ b/code/src/java/pcgen/cdom/content/UserFunction.java
@@ -70,8 +70,7 @@ public class UserFunction extends UserContent
 		}
 	}
 
-	@Override
-	public String getLSTformat()
+	public String getOriginalExpression()
 	{
 		return origExpression;
 	}

--- a/code/src/java/pcgen/cdom/format/table/DataTable.java
+++ b/code/src/java/pcgen/cdom/format/table/DataTable.java
@@ -335,12 +335,6 @@ public class DataTable implements Loadable
 	}
 
 	@Override
-	public String getLSTformat()
-	{
-		return name;
-	}
-
-	@Override
 	public URI getSourceURI()
 	{
 		return sourceURI;

--- a/code/src/java/pcgen/cdom/format/table/TableColumn.java
+++ b/code/src/java/pcgen/cdom/format/table/TableColumn.java
@@ -104,12 +104,6 @@ public class TableColumn implements Loadable
 	}
 
 	@Override
-	public String getLSTformat()
-	{
-		return name;
-	}
-
-	@Override
 	public URI getSourceURI()
 	{
 		return sourceURI;

--- a/code/src/java/pcgen/cdom/identifier/SpellSchool.java
+++ b/code/src/java/pcgen/cdom/identifier/SpellSchool.java
@@ -40,12 +40,6 @@ public class SpellSchool implements Loadable, Comparable<SpellSchool>
 	}
 
 	@Override
-	public String getLSTformat()
-	{
-		return name;
-	}
-
-	@Override
 	public boolean isInternal()
 	{
 		return false;

--- a/code/src/java/pcgen/cdom/inst/AbstractCategory.java
+++ b/code/src/java/pcgen/cdom/inst/AbstractCategory.java
@@ -76,12 +76,6 @@ public abstract class AbstractCategory<T extends Categorized<T>> implements
 	}
 
 	@Override
-	public String getLSTformat()
-	{
-		return categoryName;
-	}
-
-	@Override
 	public boolean isInternal()
 	{
 		return false;

--- a/code/src/java/pcgen/cdom/inst/Dynamic.java
+++ b/code/src/java/pcgen/cdom/inst/Dynamic.java
@@ -61,12 +61,6 @@ public class Dynamic implements VarScoped, Categorized<Dynamic>
 	}
 
 	@Override
-	public String getLSTformat()
-	{
-		return getKeyName();
-	}
-
-	@Override
 	public boolean isInternal()
 	{
 		return false;

--- a/code/src/java/pcgen/cdom/inst/EqSizePenalty.java
+++ b/code/src/java/pcgen/cdom/inst/EqSizePenalty.java
@@ -64,12 +64,6 @@ public class EqSizePenalty implements Loadable
 	}
 
 	@Override
-	public String getLSTformat()
-	{
-		return getKeyName();
-	}
-
-	@Override
 	public boolean isInternal()
 	{
 		return false;

--- a/code/src/java/pcgen/cdom/reference/CDOMCategorizedSingleRef.java
+++ b/code/src/java/pcgen/cdom/reference/CDOMCategorizedSingleRef.java
@@ -307,6 +307,6 @@ public class CDOMCategorizedSingleRef<T extends Categorized<T>> extends
 	@Override
 	public String getLSTCategory()
 	{
-		return category.getLSTformat();
+		return category.getKeyName();
 	}
 }

--- a/code/src/java/pcgen/cdom/reference/CDOMDirectSingleRef.java
+++ b/code/src/java/pcgen/cdom/reference/CDOMDirectSingleRef.java
@@ -57,7 +57,7 @@ public class CDOMDirectSingleRef<T extends Loadable> extends CDOMSingleRef<T>
 	 */
 	public CDOMDirectSingleRef(T item)
 	{
-		super((Class<T>) item.getClass(), item.getLSTformat());
+		super((Class<T>) item.getClass(), item.getKeyName());
 		referencedObject = item;
 	}
 
@@ -115,7 +115,7 @@ public class CDOMDirectSingleRef<T extends Loadable> extends CDOMSingleRef<T>
 	@Override
 	public String getLSTformat(boolean useAny)
 	{
-		return referencedObject.getLSTformat();
+		return referencedObject.getKeyName();
 	}
 
 	/**
@@ -141,7 +141,7 @@ public class CDOMDirectSingleRef<T extends Loadable> extends CDOMSingleRef<T>
 	@Override
 	public int hashCode()
 	{
-		return referencedObject.getLSTformat().hashCode();
+		return referencedObject.getKeyName().hashCode();
 	}
 
 	/**

--- a/code/src/java/pcgen/core/AbilityCategory.java
+++ b/code/src/java/pcgen/core/AbilityCategory.java
@@ -610,12 +610,6 @@ public class AbilityCategory implements Category<Ability>, Loadable,
 		sourceURI = source;
 	}
 
-    @Override
-	public String getLSTformat()
-	{
-		return getKeyName();
-	}
-
 	public void setInternal(boolean internal)
 	{
 		isInternal = internal;

--- a/code/src/java/pcgen/core/PaperInfo.java
+++ b/code/src/java/pcgen/core/PaperInfo.java
@@ -135,12 +135,6 @@ public final class PaperInfo implements Loadable
 	}
 
     @Override
-	public String getLSTformat()
-	{
-		return getDisplayName();
-	}
-
-    @Override
 	public boolean isInternal()
 	{
 		return false;

--- a/code/src/java/pcgen/core/PointBuyCost.java
+++ b/code/src/java/pcgen/core/PointBuyCost.java
@@ -70,12 +70,6 @@ public final class PointBuyCost extends ConcretePrereqObject implements
 	}
 
     @Override
-	public String getLSTformat()
-	{
-		return getDisplayName();
-	}
-
-    @Override
 	public boolean isInternal()
 	{
 		return false;

--- a/code/src/java/pcgen/core/PointBuyMethod.java
+++ b/code/src/java/pcgen/core/PointBuyMethod.java
@@ -142,12 +142,6 @@ public final class PointBuyMethod implements BonusContainer, Loadable
 	}
 
     @Override
-	public String getLSTformat()
-	{
-		return getDisplayName();
-	}
-
-    @Override
 	public boolean isInternal()
 	{
 		return false;

--- a/code/src/java/pcgen/core/RuleCheck.java
+++ b/code/src/java/pcgen/core/RuleCheck.java
@@ -101,12 +101,6 @@ public final class RuleCheck implements Loadable
 		return ruleKey;
 	}
 
-    @Override
-	public String getLSTformat()
-	{
-		return getKeyName();
-	}
-
 	/**
 	 * Sets the Name (and key if not already set)
 	 * 

--- a/code/src/java/pcgen/core/UnitSet.java
+++ b/code/src/java/pcgen/core/UnitSet.java
@@ -328,12 +328,6 @@ public final class UnitSet implements Loadable
 	}
 
     @Override
-	public String getLSTformat()
-	{
-		return getDisplayName();
-	}
-
-    @Override
 	public boolean isInternal()
 	{
 		return isInternal;

--- a/code/src/java/pcgen/core/character/WieldCategory.java
+++ b/code/src/java/pcgen/core/character/WieldCategory.java
@@ -83,12 +83,6 @@ public final class WieldCategory implements Loadable
 	}
 
     @Override
-	public String getLSTformat()
-	{
-		return getDisplayName();
-	}
-
-    @Override
 	public boolean isInternal()
 	{
 		return false;

--- a/code/src/java/pcgen/core/kit/BaseKit.java
+++ b/code/src/java/pcgen/core/kit/BaseKit.java
@@ -213,12 +213,6 @@ public abstract class BaseKit extends ConcretePrereqObject implements Loadable
 	}
 
     @Override
-	public String getLSTformat()
-	{
-		return null;
-	}
-
-    @Override
 	public boolean isInternal()
 	{
 		return false;

--- a/code/src/java/pcgen/core/kit/KitSkill.java
+++ b/code/src/java/pcgen/core/kit/KitSkill.java
@@ -251,7 +251,7 @@ public final class KitSkill extends BaseKit
 			if (!controller.conditionallyApply(pc, lang))
 			{
 				Logging.errorPrint("Failed to apply Language into Skill: "
-						+ lang.getLSTformat());
+						+ lang.getKeyName());
 			}
 		}
 

--- a/code/src/java/pcgen/core/system/LoadInfo.java
+++ b/code/src/java/pcgen/core/system/LoadInfo.java
@@ -326,12 +326,6 @@ public class LoadInfo implements Loadable
 	}
 
     @Override
-	public String getLSTformat()
-	{
-		return getDisplayName();
-	}
-
-    @Override
 	public boolean isInternal()
 	{
 		return false;

--- a/code/src/java/pcgen/io/PCGVer2Creator.java
+++ b/code/src/java/pcgen/io/PCGVer2Creator.java
@@ -2503,7 +2503,7 @@ public final class PCGVer2Creator
 			{
 				buffer.append(del);
 				buffer.append(IOConstants.TAG_WEAPON).append(':');
-				buffer.append(EntityEncoder.encode(profs.get(i).getLSTformat()));
+				buffer.append(EntityEncoder.encode(profs.get(i).getKeyName()));
 				del = "|"; //$NON-NLS-1$
 			}
 

--- a/code/src/java/plugin/lsttokens/SabLst.java
+++ b/code/src/java/plugin/lsttokens/SabLst.java
@@ -195,7 +195,7 @@ public class SabLst extends AbstractTokenWithSeparator<CDOMObject> implements
 			for (SpecialAbility ab : added)
 			{
 				StringBuilder sb = new StringBuilder();
-				sb.append(ab.getLSTformat());
+				sb.append(ab.getKeyName());
 				if (ab.hasPrerequisites())
 				{
 					sb.append(Constants.PIPE);

--- a/code/src/java/plugin/lsttokens/datacontrol/ValueToken.java
+++ b/code/src/java/plugin/lsttokens/datacontrol/ValueToken.java
@@ -37,7 +37,7 @@ public class ValueToken extends AbstractNonEmptyToken<UserFunction> implements
 	protected ParseResult parseNonEmptyToken(LoadContext context,
 		UserFunction ftn, String value)
 	{
-		String existing = ftn.getLSTformat();
+		String existing = ftn.getOriginalExpression();
 		if (existing != null)
 		{
 			if (!existing.equalsIgnoreCase(value))
@@ -65,7 +65,7 @@ public class ValueToken extends AbstractNonEmptyToken<UserFunction> implements
 	@Override
 	public String[] unparse(LoadContext context, UserFunction ftn)
 	{
-		return new String[]{ftn.getLSTformat()};
+		return new String[]{ftn.getOriginalExpression()};
 	}
 
 	@Override

--- a/code/src/java/plugin/lsttokens/spell/ClassesToken.java
+++ b/code/src/java/plugin/lsttokens/spell/ClassesToken.java
@@ -252,7 +252,7 @@ public class ClassesToken extends AbstractTokenWithSeparator<Spell> implements
 				{
 					for (Spell added : map.getKeySet())
 					{
-						if (!spell.getLSTformat().equals(added.getLSTformat()))
+						if (!spell.getKeyName().equals(added.getKeyName()))
 						{
 							context.addWriteMessage("Spell " + getTokenName()
 									+ " token cannot remove another Spell "
@@ -296,7 +296,7 @@ public class ClassesToken extends AbstractTokenWithSeparator<Spell> implements
 			{
 				for (Spell added : map.getKeySet())
 				{
-					if (!spell.getLSTformat().equals(added.getLSTformat()))
+					if (!spell.getKeyName().equals(added.getKeyName()))
 					{
 						context.addWriteMessage("Spell " + getTokenName()
 								+ " token cannot allow another Spell "

--- a/code/src/java/plugin/lsttokens/spell/DomainsToken.java
+++ b/code/src/java/plugin/lsttokens/spell/DomainsToken.java
@@ -243,7 +243,7 @@ public class DomainsToken extends AbstractTokenWithSeparator<Spell> implements
 				{
 					for (Spell added : map.getKeySet())
 					{
-						if (!spell.getLSTformat().equals(added.getLSTformat()))
+						if (!spell.getKeyName().equals(added.getKeyName()))
 						{
 							context.addWriteMessage("Spell " + getTokenName()
 									+ " token cannot remove another Spell "
@@ -287,7 +287,7 @@ public class DomainsToken extends AbstractTokenWithSeparator<Spell> implements
 			{
 				for (Spell added : map.getKeySet())
 				{
-					if (!spell.getLSTformat().equals(added.getLSTformat()))
+					if (!spell.getKeyName().equals(added.getKeyName()))
 					{
 						context.addWriteMessage("Spell " + getTokenName()
 								+ " token cannot allow another Spell "

--- a/code/src/java/plugin/primitive/pobject/AbilityToken.java
+++ b/code/src/java/plugin/primitive/pobject/AbilityToken.java
@@ -104,7 +104,7 @@ public class AbilityToken<T> implements PrimitiveToken<T>
 	@Override
 	public String getLSTformat(boolean useAny)
 	{
-		return "ABILITY=" + category.getLSTformat() + '['
+		return "ABILITY=" + category.getKeyName() + '['
 			+ ref.getLSTformat(useAny) + ']';
 	}
 

--- a/code/src/utest/plugin/lsttokens/datacontrol/DefaultVariableValueTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/datacontrol/DefaultVariableValueTokenTest.java
@@ -152,8 +152,8 @@ public class DefaultVariableValueTokenTest extends
 		boolean same =
 				ObjectUtil
 					.compareWithNull(cdo1.getKeyName(), cdo2.getKeyName())
-					&& ObjectUtil.compareWithNull(cdo1.getLSTformat(),
-						cdo2.getLSTformat());
+					&& ObjectUtil.compareWithNull(cdo1.getKeyName(),
+						cdo2.getKeyName());
 		if (!same)
 		{
 			fail("Mismatched");


### PR DESCRIPTION
Remove an otherwise unnecessary item from the Loadable interface that is often forcing objects not immediately LST format related to implement the method in a useless way