### PR TITLE
renamed items to avoid duplicate listings

### DIFF
--- a/data/pathfinder/paizo/player_companion/adventurers_armory/aa_equip.lst
+++ b/data/pathfinder/paizo/player_companion/adventurers_armory/aa_equip.lst
@@ -106,10 +106,10 @@ Bladeguard																					TYPE:Goods.Alchemical.Consumable						COST:40	WT:
 Bloodblock																					TYPE:Goods.Alchemical.Consumable						COST:25	WT:0
 Bodybalm																					TYPE:Goods.Alchemical.Consumable						COST:25	WT:0																		SOURCEPAGE:p.9								SPROP:Provides +5 alchemical bonus to Heal checks for long-term care, poison, disease.
 Distilled Terrap Sap																			TYPE:Goods.Alchemical.Consumable						COST:30	WT:0.5																	SOURCEPAGE:p.10								SPROP:Provides +5 alchemical bonus to saves against scent attacks within 20' for 1d6 rounds
-Desnan Candle Firework		NAMEISPI:YES	OUTPUTNAME:Firework, Desnan Candle								TYPE:Goods.Alchemical.Consumable						COST:5	WT:0																		SOURCEPAGE:p.10
-Paper Candle Firework						OUTPUTNAME:Firework, Paper Candle								TYPE:Goods.Alchemical.Consumable						COST:1	WT:0																		SOURCEPAGE:p.10
-Skyrocket Firework						OUTPUTNAME:Firework, Skyrocket								TYPE:Goods.Alchemical.Consumable						COST:50	WT:1																		SOURCEPAGE:p.10
-Starfountain Firework						OUTPUTNAME:Firework, Starfountain								TYPE:Goods.Alchemical.Consumable						COST:500	WT:100																	SOURCEPAGE:p.10
+Desnan Candle (Firework)		NAMEISPI:YES	OUTPUTNAME:Firework, Desnan Candle								TYPE:Goods.Alchemical.Consumable						COST:5	WT:0																		SOURCEPAGE:p.10
+Paper Candle (Firework)						OUTPUTNAME:Firework, Paper Candle								TYPE:Goods.Alchemical.Consumable						COST:1	WT:0																		SOURCEPAGE:p.10
+Skyrocket (Firework)						OUTPUTNAME:Firework, Skyrocket								TYPE:Goods.Alchemical.Consumable						COST:50	WT:1																		SOURCEPAGE:p.10
+Starfountain (Firework)						OUTPUTNAME:Firework, Starfountain								TYPE:Goods.Alchemical.Consumable						COST:500	WT:100																	SOURCEPAGE:p.10
 Flash Powder																				TYPE:Goods.Alchemical.Consumable						COST:50	WT:0																												SPROP:10-foot burst, Fortitude DC 13 to not be blinded for 1 round.
 Fuse Grenade																				TYPE:Goods.Alchemical.Consumable						COST:100	WT:1																		SOURCEPAGE:p.10								SPROP:Light 1d3 round then explodes for 2d6 bludgeon + 1d6 fire for 10' burst (DC15 reflex for 1/2)
 Glowing Ink (Vial)																			TYPE:Goods.General.Writing.Liquid.Vial					COST:5	WT:0																		SOURCEPAGE:p.10								SPROP:+2 perception check to locate item written with this ink

--- a/data/pathfinder/paizo/player_companion/adventurers_armory/aa_equip.lst
+++ b/data/pathfinder/paizo/player_companion/adventurers_armory/aa_equip.lst
@@ -19,28 +19,28 @@ Chest (Huge)							OUTPUTNAME:Chest, huge										TYPE:Goods.General								COS
 Collapsible Plank																				TYPE:Goods.General								COST:0.4	WT:10																		SOURCEPAGE:p.6
 Coffin (Common)																				TYPE:Goods.Container.General			CONTAINS:UNLIM|Any	COST:10	WT:30																		SOURCEPAGE:p.6
 Coffin (Ornate)																				TYPE:Goods.Container.General			CONTAINS:UNLIM|Any	COST:100	WT:50																		SOURCEPAGE:p.6
-Key (Copy)																					TYPE:Goods.General								COST:1	WT:0																		SOURCEPAGE:p.6
+Copy of a Key																					TYPE:Goods.General								COST:1	WT:0																		SOURCEPAGE:p.6
 Earplugs																					TYPE:Goods.General								COST:0.03	WT:0																		SOURCEPAGE:p.6								SPROP:+2 circumstance bonus to saves for effect requiring hearing but −5 on hearing-based Perception checks.
 False-Bottomed Chest																			TYPE:Goods.Container.General							COST:52	WT:25																		SOURCEPAGE:p.6
 False-Bottomed Cup																			TYPE:Goods.Container.General							COST:1	WT:0																		SOURCEPAGE:p.6
 False-Bottomed Scabbard																			TYPE:Goods.Container.General			CONTAINS:UNLIM|Potion=1	COST:45	WT:1																		SOURCEPAGE:p.6
 Manacles (False)																				TYPE:Goods.General								COST:65	WT:2																		SOURCEPAGE:p.6
-Chair (Folding)																				TYPE:Goods.General								COST:2	WT:10																		SOURCEPAGE:p.6
-Ladder (Folding)																				TYPE:Goods.General								COST:2	WT:16																		SOURCEPAGE:p.6
-Arrow (Grappling)																				TYPE:Goods.General								COST:1	WT:0.5																	SOURCEPAGE:p.7
-Bolt (Grappling)																				TYPE:Goods.General								COST:1	WT:0.5																	SOURCEPAGE:p.7
+Folding Chair																				TYPE:Goods.General								COST:2	WT:10																		SOURCEPAGE:p.6
+Folding Ladder																				TYPE:Goods.General								COST:2	WT:16																		SOURCEPAGE:p.6
+Grappling Arrow																				TYPE:Goods.General								COST:1	WT:0.5																	SOURCEPAGE:p.7
+Grappling Bolt																				TYPE:Goods.General								COST:1	WT:0.5																	SOURCEPAGE:p.7
 Hammock																					TYPE:Goods.General								COST:0.1	WT:3																		SOURCEPAGE:p.7
 Harrow Deck					NAMEISPI:YES														TYPE:Goods.General								COST:100	WT:0																		SOURCEPAGE:p.7
 Helmet Candle																				TYPE:Goods.General.Container			CONTAINS:UNLIM|Candle=1	COST:2	WT:4																		SOURCEPAGE:p.7
 #Hollowed Pommel is an EQMOD
 # the one hour hourglass is in Core. The line below doesn't work
-Hourglass.COPY=Hourglass (One Hour)
+Hourglass.COPY=Hourglass (1 Hour)
 Hourglass.FORGET
-Hourglass (One Hour).MOD																		TYPE:Goods.General								COST:25	WT:1																		SOURCEPAGE:p.7
-Hourglass (One minute)																			TYPE:Goods.General								COST:20	WT:0.5																	SOURCEPAGE:p.7
-Hourglass (Six seconds)																			TYPE:Goods.General								COST:10	WT:0																		SOURCEPAGE:p.7
+Hourglass (1 Hour).MOD																		TYPE:Goods.General								COST:25	WT:1																		SOURCEPAGE:p.7
+Hourglass (1 minute)																			TYPE:Goods.General								COST:20	WT:0.5																	SOURCEPAGE:p.7
+Hourglass (6 seconds)																			TYPE:Goods.General								COST:10	WT:0																		SOURCEPAGE:p.7
 Iron Spike																					TYPE:Goods.General								COST:0.05	WT:1																		SOURCEPAGE:p.7
-Vial (Iron)																					TYPE:Goods.General								COST:0.1	WT:1																		SOURCEPAGE:p.7								SPROP:hardness 5, 3 hit points, and break DC 14
+Iron Vial																					TYPE:Goods.General								COST:0.1	WT:1																		SOURCEPAGE:p.7								SPROP:hardness 5, 3 hit points, and break DC 14
 # Waterproof lantern is an EQMOD for Lantern (might be good to switch it to LightSource to apply to non core lantern?)
 Lantern (Bullseye).MOD																			TYPE:Lantern
 Lantern (Hooded).MOD																			TYPE:Lantern
@@ -77,10 +77,10 @@ String (50 feet)																				TYPE:Goods.General								COST:0.01	WT:0.5		
 Twine (50 feet)																				TYPE:Goods.General								COST:0.01	WT:0.5																	SOURCEPAGE:p.8
 #TODO this is supposed to vary by ink/size between 1cp to 10gp per color
 Tattoo																					TYPE:Goods.Service								COST:1	WT:0																		SOURCEPAGE:p.8
-Tent (Small) (1 person)						OUTPUTNAME:Tent, Small (1 person)								TYPE:Goods.General								COST:10	WT:5																		SOURCEPAGE:p.8								SPROP:Setup time of 20 min.
-Tent (Medium) (2 people)					OUTPUTNAME:Tent, Medium (2 people)								TYPE:Goods.General								COST:15	WT:10																		SOURCEPAGE:p.8								SPROP:Setup time of 30 min.
-Tent (Large) (4 people)						OUTPUTNAME:Tent, Large (4 people)								TYPE:Goods.General								COST:30	WT:20																		SOURCEPAGE:p.8								SPROP:Setup time of 45 min.
-Tent (Pavilion) (10 people)					OUTPUTNAME:Tent, Pavilion (10 people)							TYPE:Goods.General								COST:100	WT:50																		SOURCEPAGE:p.8								SPROP:Setup time of 90 min.
+Tent (Small)						OUTPUTNAME:Tent, Small (1 person)								TYPE:Goods.General								COST:10	WT:5																		SOURCEPAGE:p.8								SPROP:Setup time of 20 min.
+Tent (Medium)					OUTPUTNAME:Tent, Medium (2 people)								TYPE:Goods.General								COST:15	WT:10																		SOURCEPAGE:p.8								SPROP:Setup time of 30 min.
+Tent (Large)						OUTPUTNAME:Tent, Large (4 people)								TYPE:Goods.General								COST:30	WT:20																		SOURCEPAGE:p.8								SPROP:Setup time of 45 min.
+Tent (Pavilion)					OUTPUTNAME:Tent, Pavilion (10 people)							TYPE:Goods.General								COST:100	WT:50																		SOURCEPAGE:p.8								SPROP:Setup time of 90 min.
 #TODO: Done up to there VL
 Thurible (Censer)																				TYPE:Goods.General								COST:50	WT:3																		SOURCEPAGE:p.8								SPROP:When filled: 30ft smoke for 1 hr, +2 fortitude save
 Thurible Herbs																				TYPE:Goods.General.Consumable							COST:0.2	WT:0																		SOURCEPAGE:p.8								SPROP:Used to fill Thurible
@@ -106,10 +106,10 @@ Bladeguard																					TYPE:Goods.Alchemical.Consumable						COST:40	WT:
 Bloodblock																					TYPE:Goods.Alchemical.Consumable						COST:25	WT:0
 Bodybalm																					TYPE:Goods.Alchemical.Consumable						COST:25	WT:0																		SOURCEPAGE:p.9								SPROP:Provides +5 alchemical bonus to Heal checks for long-term care, poison, disease.
 Distilled Terrap Sap																			TYPE:Goods.Alchemical.Consumable						COST:30	WT:0.5																	SOURCEPAGE:p.10								SPROP:Provides +5 alchemical bonus to saves against scent attacks within 20' for 1d6 rounds
-Firework (Desnan Candle)		NAMEISPI:YES	OUTPUTNAME:Firework, Desnan Candle								TYPE:Goods.Alchemical.Consumable						COST:5	WT:0																		SOURCEPAGE:p.10
-Firework (Paper Candle)						OUTPUTNAME:Firework, Paper Candle								TYPE:Goods.Alchemical.Consumable						COST:1	WT:0																		SOURCEPAGE:p.10
-Firework (Skyrocket)						OUTPUTNAME:Firework, Skyrocket								TYPE:Goods.Alchemical.Consumable						COST:50	WT:1																		SOURCEPAGE:p.10
-Firework (Starfountain)						OUTPUTNAME:Firework, Starfountain								TYPE:Goods.Alchemical.Consumable						COST:500	WT:100																	SOURCEPAGE:p.10
+Desnan Candle Firework		NAMEISPI:YES	OUTPUTNAME:Firework, Desnan Candle								TYPE:Goods.Alchemical.Consumable						COST:5	WT:0																		SOURCEPAGE:p.10
+Paper Candle Firework						OUTPUTNAME:Firework, Paper Candle								TYPE:Goods.Alchemical.Consumable						COST:1	WT:0																		SOURCEPAGE:p.10
+Skyrocket Firework						OUTPUTNAME:Firework, Skyrocket								TYPE:Goods.Alchemical.Consumable						COST:50	WT:1																		SOURCEPAGE:p.10
+Starfountain Firework						OUTPUTNAME:Firework, Starfountain								TYPE:Goods.Alchemical.Consumable						COST:500	WT:100																	SOURCEPAGE:p.10
 Flash Powder																				TYPE:Goods.Alchemical.Consumable						COST:50	WT:0																												SPROP:10-foot burst, Fortitude DC 13 to not be blinded for 1 round.
 Fuse Grenade																				TYPE:Goods.Alchemical.Consumable						COST:100	WT:1																		SOURCEPAGE:p.10								SPROP:Light 1d3 round then explodes for 2d6 bludgeon + 1d6 fire for 10' burst (DC15 reflex for 1/2)
 Glowing Ink (Vial)																			TYPE:Goods.General.Writing.Liquid.Vial					COST:5	WT:0																		SOURCEPAGE:p.10								SPROP:+2 perception check to locate item written with this ink
@@ -142,7 +142,7 @@ Bellows																					TYPE:Goods.Tools									COST:1	WT:3																
 Compass																					TYPE:Goods.Tools									COST:10	WT:0.5																	SOURCEPAGE:p.12
 Cooking Kit																					TYPE:Goods.Tools									COST:1	WT:2																		SOURCEPAGE:p.12
 Doctor's Mask																				TYPE:Goods.Tools									COST:50	WT:2																		SOURCEPAGE:p.12
-Outfit (Doctor)							OUTPUTNAME:[NAME] Outfit									TYPE:Goods.Clothing.Resizable							COST:150	WT:6																		SOURCEPAGE:p.12
+Outfit (Doctor's)							OUTPUTNAME:[NAME] Outfit									TYPE:Goods.Clothing.Resizable							COST:150	WT:6																		SOURCEPAGE:p.12
 Drill																						TYPE:Goods.Tools									COST:0.5	WT:1																		SOURCEPAGE:p.???
 Eyeglasses																					TYPE:Goods.Tools									COST:5	WT:0																		SOURCEPAGE:p.12
 Flotation Device																				TYPE:Goods.Tools									COST:1	WT:2																		SOURCEPAGE:p.12
@@ -259,7 +259,7 @@ Kite (Exceptional)																			TYPE:Goods.Entertainment							COST:2000	WT
 Loaded Dice (Average)																			TYPE:Goods.Entertainment							COST:10	WT:0																		SOURCEPAGE:p.17
 Loaded Dice (Superior)																			TYPE:Goods.Entertainment							COST:50	WT:0																		SOURCEPAGE:p.17
 Marked Cards																				TYPE:Goods.General								COST:1	WT:1																		SOURCEPAGE:p.17
-Puzzle Box																					TYPE:Goods.Entertainment							COST:1	WT:1																		SOURCEPAGE:17
+Puzzle Box (Common)																					TYPE:Goods.Entertainment							COST:1	WT:1																		SOURCEPAGE:17
 Puzzle Box (Exceptional)																		TYPE:Goods.Entertainment							COST:1000	WT:5																		SOURCEPAGE:17
 
 #Blackmarket Items


### PR DESCRIPTION
renamed items to be consistent with other sources and avoid redundant entries of the same item but with slightly different names