### PR TITLE
Reduce use of Globals.getContext()

### DIFF
--- a/code/src/java/pcgen/cdom/enumeration/SkillArmorCheck.java
+++ b/code/src/java/pcgen/cdom/enumeration/SkillArmorCheck.java
@@ -21,7 +21,6 @@ import java.util.List;
 
 import pcgen.base.lang.UnreachableError;
 import pcgen.cdom.util.CControl;
-import pcgen.cdom.util.ControlUtilities;
 import pcgen.core.Equipment;
 import pcgen.core.Globals;
 import pcgen.core.PlayerCharacter;
@@ -144,9 +143,7 @@ public enum SkillArmorCheck
 
 	protected int calculateMax(PlayerCharacter pc)
 	{
-		String acCheckVar =
-				ControlUtilities.getControlToken(Globals.getContext(),
-					CControl.PCACCHECK);
+		String acCheckVar = pc.getControl(CControl.PCACCHECK);
 		if (acCheckVar == null)
 		{
 			return calculateMaxOld(pc);

--- a/code/src/java/pcgen/cdom/helper/CNAbilitySelection.java
+++ b/code/src/java/pcgen/cdom/helper/CNAbilitySelection.java
@@ -30,8 +30,8 @@ import pcgen.cdom.enumeration.Nature;
 import pcgen.cdom.enumeration.ObjectKey;
 import pcgen.core.Ability;
 import pcgen.core.AbilityCategory;
-import pcgen.core.Globals;
 import pcgen.core.SettingsHandler;
+import pcgen.rules.context.LoadContext;
 
 public class CNAbilitySelection extends ConcretePrereqObject implements
 		QualifyingObject, Reducible
@@ -103,7 +103,7 @@ public class CNAbilitySelection extends ConcretePrereqObject implements
 	}
 
 	public static CNAbilitySelection getAbilitySelectionFromPersistentFormat(
-		String persistentFormat)
+		LoadContext context, String persistentFormat)
 	{
 		StringTokenizer st =
 				new StringTokenizer(persistentFormat, Constants.PIPE);
@@ -133,7 +133,7 @@ public class CNAbilitySelection extends ConcretePrereqObject implements
 		Nature nat = Nature.valueOf(natString);
 		String ab = st.nextToken();
 		Ability a =
-				Globals.getContext().getReferenceContext().silentlyGetConstructedCDOMObject(
+				context.getReferenceContext().silentlyGetConstructedCDOMObject(
 					Ability.class, ac, ab);
 		if (a == null)
 		{

--- a/code/src/java/pcgen/cdom/helper/SpellLevel.java
+++ b/code/src/java/pcgen/cdom/helper/SpellLevel.java
@@ -16,8 +16,8 @@
  */
 package pcgen.cdom.helper;
 
-import pcgen.core.Globals;
 import pcgen.core.PCClass;
+import pcgen.rules.context.LoadContext;
 
 public class SpellLevel implements Comparable<SpellLevel>
 {
@@ -55,7 +55,7 @@ public class SpellLevel implements Comparable<SpellLevel>
 		return sb.toString();
 	}
 
-	public static SpellLevel decodeChoice(String persistentFormat)
+	public static SpellLevel decodeChoice(LoadContext context, String persistentFormat)
 	{
 		int loc = persistentFormat.indexOf(";LEVEL.");
 		String classString;
@@ -80,7 +80,7 @@ public class SpellLevel implements Comparable<SpellLevel>
 			levelString = persistentFormat.substring(loc + 7);
 		}
 		PCClass pcc =
-				Globals.getContext().getReferenceContext().silentlyGetConstructedCDOMObject(
+				context.getReferenceContext().silentlyGetConstructedCDOMObject(
 					PCClass.class, classString);
 		try
 		{

--- a/code/src/java/pcgen/core/term/EQACCheckTermEvaluator.java
+++ b/code/src/java/pcgen/core/term/EQACCheckTermEvaluator.java
@@ -22,9 +22,7 @@ package pcgen.core.term;
 
 import pcgen.cdom.enumeration.IntegerKey;
 import pcgen.cdom.util.CControl;
-import pcgen.cdom.util.ControlUtilities;
 import pcgen.core.Equipment;
-import pcgen.core.Globals;
 import pcgen.core.PlayerCharacter;
 import pcgen.util.Logging;
 
@@ -49,8 +47,7 @@ public class EQACCheckTermEvaluator extends BaseEQTermEvaluator implements TermE
 			Equipment eq,
 			boolean primary,
 			PlayerCharacter pc) {
-		if (ControlUtilities.hasControlToken(Globals.getContext(),
-			CControl.EQACCHECK))
+		if (pc.hasControl(CControl.EQACCHECK))
 		{
 			Logging.errorPrint("EQACCHECK term is deprecated (does not function)"
 				+ " when ACCHECK CodeControl is used");

--- a/code/src/java/pcgen/core/term/EQCritMultTermEvaluator.java
+++ b/code/src/java/pcgen/core/term/EQCritMultTermEvaluator.java
@@ -21,9 +21,7 @@
 package pcgen.core.term;
 
 import pcgen.cdom.util.CControl;
-import pcgen.cdom.util.ControlUtilities;
 import pcgen.core.Equipment;
-import pcgen.core.Globals;
 import pcgen.core.PlayerCharacter;
 import pcgen.io.exporttoken.EqToken;
 import pcgen.util.Logging;
@@ -41,8 +39,7 @@ public class EQCritMultTermEvaluator extends BaseEQTermEvaluator implements Term
 			boolean primary,
 			PlayerCharacter pc)
 	{
-		if (ControlUtilities.hasControlToken(Globals.getContext(),
-			CControl.CRITMULT))
+		if (pc.hasControl(CControl.CRITMULT))
 		{
 			Logging
 				.errorPrint("CRITMULT term is disabled when CRITMULT control is used");
@@ -60,8 +57,7 @@ public class EQCritMultTermEvaluator extends BaseEQTermEvaluator implements Term
 			Equipment eq,
 			boolean primary,
 			PlayerCharacter pc) {
-		if (ControlUtilities.hasControlToken(Globals.getContext(),
-			CControl.CRITMULT))
+		if (pc.hasControl(CControl.CRITMULT))
 		{
 			Logging
 				.errorPrint("CRITMULT term is disabled when CRITMULT control is used");

--- a/code/src/java/pcgen/core/term/EQRangeTermEvaluator.java
+++ b/code/src/java/pcgen/core/term/EQRangeTermEvaluator.java
@@ -22,9 +22,7 @@ package pcgen.core.term;
 
 import pcgen.cdom.enumeration.IntegerKey;
 import pcgen.cdom.util.CControl;
-import pcgen.cdom.util.ControlUtilities;
 import pcgen.core.Equipment;
-import pcgen.core.Globals;
 import pcgen.core.PlayerCharacter;
 import pcgen.util.Logging;
 
@@ -49,8 +47,7 @@ public class EQRangeTermEvaluator extends BaseEQTermEvaluator implements TermEva
 			Equipment eq,
 			boolean primary,
 			PlayerCharacter pc) {
-		if (ControlUtilities.hasControlToken(Globals.getContext(),
-			CControl.EQRANGE))
+		if (pc.hasControl(CControl.EQRANGE))
 		{
 			Logging.errorPrint("RANGE term is deprecated (does not function)"
 				+ " when RANGE CodeControl is used");

--- a/code/src/java/pcgen/core/term/PCACcheckTermEvaluator.java
+++ b/code/src/java/pcgen/core/term/PCACcheckTermEvaluator.java
@@ -19,8 +19,6 @@
 package pcgen.core.term;
 
 import pcgen.cdom.util.CControl;
-import pcgen.cdom.util.ControlUtilities;
-import pcgen.core.Globals;
 import pcgen.core.PlayerCharacter;
 import pcgen.util.Logging;
 
@@ -36,8 +34,7 @@ public class PCACcheckTermEvaluator
 	@Override
 	public Float resolve(PlayerCharacter pc)
 	{
-		if (ControlUtilities.hasControlToken(Globals.getContext(),
-			CControl.EQACCHECK))
+		if (pc.hasControl(CControl.EQACCHECK))
 		{
 			Logging.errorPrint(originalText
 				+ " term is deprecated (does not function)"

--- a/code/src/java/pcgen/core/term/PCArmourACcheckTermEvaluator.java
+++ b/code/src/java/pcgen/core/term/PCArmourACcheckTermEvaluator.java
@@ -21,8 +21,6 @@
 package pcgen.core.term;
 
 import pcgen.cdom.util.CControl;
-import pcgen.cdom.util.ControlUtilities;
-import pcgen.core.Globals;
 import pcgen.core.PlayerCharacter;
 import pcgen.util.Logging;
 
@@ -37,7 +35,7 @@ public class PCArmourACcheckTermEvaluator
 	@Override
 	public Float resolve(PlayerCharacter pc)
 	{
-		if (ControlUtilities.hasControlToken(Globals.getContext(), CControl.EQACCHECK))
+		if (pc.hasControl(CControl.EQACCHECK))
 		{
 			Logging.errorPrint(originalText
 				+ " term is deprecated (does not function)"

--- a/code/src/java/pcgen/core/term/PCHandsTermEvaluator.java
+++ b/code/src/java/pcgen/core/term/PCHandsTermEvaluator.java
@@ -23,8 +23,6 @@ package pcgen.core.term;
 import pcgen.cdom.facet.FacetLibrary;
 import pcgen.cdom.facet.analysis.HandsFacet;
 import pcgen.cdom.util.CControl;
-import pcgen.cdom.util.ControlUtilities;
-import pcgen.core.Globals;
 import pcgen.core.PlayerCharacter;
 import pcgen.util.Logging;
 
@@ -38,16 +36,15 @@ public class PCHandsTermEvaluator
 	}
 
 	@Override
-	public Float resolve(PlayerCharacter display)
+	public Float resolve(PlayerCharacter pc)
 	{
-		if (ControlUtilities.hasControlToken(Globals.getContext(),
-			CControl.CREATUREHANDS))
+		if (pc.hasControl(CControl.CREATUREHANDS))
 		{
 			Logging.errorPrint("HANDS term is deprecated (does not function) "
 				+ "when CREATUREHANDS CodeControl is used");
 		}
 		return (float) FacetLibrary.getFacet(HandsFacet.class).getHands(
-			display.getCharID());
+			pc.getCharID());
 	}
 
 	@Override

--- a/code/src/java/pcgen/core/term/PCLegsTermEvaluator.java
+++ b/code/src/java/pcgen/core/term/PCLegsTermEvaluator.java
@@ -21,13 +21,11 @@
 package pcgen.core.term;
 
 import pcgen.cdom.util.CControl;
-import pcgen.cdom.util.ControlUtilities;
-import pcgen.core.Globals;
-import pcgen.core.display.CharacterDisplay;
+import pcgen.core.PlayerCharacter;
 import pcgen.util.Logging;
 
 public class PCLegsTermEvaluator
-		extends BasePCDTermEvaluator implements TermEvaluator {
+		extends BasePCTermEvaluator implements TermEvaluator {
 
 	public PCLegsTermEvaluator(
 			String originalText)
@@ -36,15 +34,14 @@ public class PCLegsTermEvaluator
 	}
 
 	@Override
-	public Float resolve(CharacterDisplay display)
+	public Float resolve(PlayerCharacter pc)
 	{
-		if (ControlUtilities.hasControlToken(Globals.getContext(),
-			CControl.LEGS))
+		if (pc.hasControl(CControl.LEGS))
 		{
 			Logging
 				.errorPrint("LEGS term is deprecated (does not function) when LEGS CodeControl is used");
 		}
-		return (float) display.getPreFormulaLegs();
+		return (float) pc.getDisplay().getPreFormulaLegs();
 	}
 
 	@Override

--- a/code/src/java/pcgen/core/term/PCProfACCheckTermEvaluator.java
+++ b/code/src/java/pcgen/core/term/PCProfACCheckTermEvaluator.java
@@ -21,7 +21,6 @@
 package pcgen.core.term;
 
 import pcgen.cdom.util.CControl;
-import pcgen.cdom.util.ControlUtilities;
 import pcgen.core.Equipment;
 import pcgen.core.Globals;
 import pcgen.core.PlayerCharacter;
@@ -41,8 +40,7 @@ public class PCProfACCheckTermEvaluator
 	@Override
 	public Float resolve(PlayerCharacter pc)
 	{
-		if (ControlUtilities.hasControlToken(Globals.getContext(),
-			CControl.EQACCHECK))
+		if (pc.hasControl(CControl.EQACCHECK))
 		{
 			Logging.errorPrint(originalText
 				+ " term is deprecated (does not function)"

--- a/code/src/java/pcgen/core/term/PCShieldACcheckTermEvaluator.java
+++ b/code/src/java/pcgen/core/term/PCShieldACcheckTermEvaluator.java
@@ -21,9 +21,7 @@
 package pcgen.core.term;
 
 import pcgen.cdom.util.CControl;
-import pcgen.cdom.util.ControlUtilities;
 import pcgen.core.Equipment;
-import pcgen.core.Globals;
 import pcgen.core.PlayerCharacter;
 import pcgen.util.Logging;
 
@@ -40,8 +38,7 @@ public class PCShieldACcheckTermEvaluator
 	@Override
 	public Float resolve(PlayerCharacter pc)
 	{
-		if (ControlUtilities.hasControlToken(Globals.getContext(),
-			CControl.EQACCHECK))
+		if (pc.hasControl(CControl.EQACCHECK))
 		{
 			Logging.errorPrint(originalText
 				+ " term is deprecated (does not function)"

--- a/code/src/java/pcgen/io/PCGVer2Parser.java
+++ b/code/src/java/pcgen/io/PCGVer2Parser.java
@@ -4684,7 +4684,8 @@ final class PCGVer2Parser implements PCGParser
 							{
 								CNAbilitySelection as =
 										CNAbilitySelection
-											.getAbilitySelectionFromPersistentFormat(feat);
+											.getAbilitySelectionFromPersistentFormat(
+												Globals.getContext(), feat);
 								thePC.addTemplateFeat(subt, as);
 							}
 						}

--- a/code/src/java/plugin/lsttokens/NaturalattacksLst.java
+++ b/code/src/java/plugin/lsttokens/NaturalattacksLst.java
@@ -42,7 +42,6 @@ import pcgen.cdom.reference.CDOMSingleRef;
 import pcgen.cdom.util.CControl;
 import pcgen.cdom.util.ControlUtilities;
 import pcgen.core.Equipment;
-import pcgen.core.Globals;
 import pcgen.core.SizeAdjustment;
 import pcgen.core.SpecialProperty;
 import pcgen.core.WeaponProf;
@@ -421,7 +420,7 @@ public class NaturalattacksLst extends AbstractTokenWithSeparator<CDOMObject>
 			// If the size was just a default, check for a size prereq and use that instead.
 			if (obj.get(FormulaKey.SIZE) == null && obj.hasPreReqTypeOf("SIZE"))
 			{
-				Integer requiredSize = getRequiredSize(obj);
+				Integer requiredSize = getRequiredSize(context, obj);
 				if (requiredSize != null)
 				{
 					sizeFormula = FormulaFactory.getFormulaFor(requiredSize);
@@ -460,7 +459,7 @@ public class NaturalattacksLst extends AbstractTokenWithSeparator<CDOMObject>
 	 * @param obj The defining object. 
 	 * @return The size integer, or null if none (or multiple) specified.
 	 */
-	private Integer getRequiredSize(CDOMObject obj)
+	private Integer getRequiredSize(LoadContext context, CDOMObject obj)
 	{
 		Set<Prerequisite> sizePrereqs = new HashSet<>();
 		for (Prerequisite prereq : obj.getPrerequisiteList())
@@ -472,9 +471,7 @@ public class NaturalattacksLst extends AbstractTokenWithSeparator<CDOMObject>
 		for (Prerequisite prereq : sizePrereqs)
 		{
 			SizeAdjustment sa =
-					Globals
-						.getContext()
-						.getReferenceContext()
+						context.getReferenceContext()
 						.silentlyGetConstructedCDOMObject(SizeAdjustment.class,
 							prereq.getOperand());
 			final int targetSize = sa.get(IntegerKey.SIZEORDER);

--- a/code/src/java/plugin/lsttokens/add/AbilityToken.java
+++ b/code/src/java/plugin/lsttokens/add/AbilityToken.java
@@ -422,7 +422,7 @@ public class AbilityToken extends AbstractNonEmptyToken<CDOMObject> implements
 	@Override
 	public CNAbilitySelection decodeChoice(LoadContext context, String s)
 	{
-		return CNAbilitySelection.getAbilitySelectionFromPersistentFormat(s);
+		return CNAbilitySelection.getAbilitySelectionFromPersistentFormat(context, s);
 	}
 
 	@Override

--- a/code/src/java/plugin/lsttokens/choose/SpellLevelToken.java
+++ b/code/src/java/plugin/lsttokens/choose/SpellLevelToken.java
@@ -264,7 +264,7 @@ public class SpellLevelToken extends AbstractTokenWithSeparator<CDOMObject>
 	@Override
 	public SpellLevel decodeChoice(LoadContext context, String s)
 	{
-		return SpellLevel.decodeChoice(s);
+		return SpellLevel.decodeChoice(context, s);
 	}
 
 	@Override

--- a/code/src/java/plugin/lsttokens/deprecated/RemoveFeatToken.java
+++ b/code/src/java/plugin/lsttokens/deprecated/RemoveFeatToken.java
@@ -358,7 +358,7 @@ public class RemoveFeatToken extends AbstractNonEmptyToken<CDOMObject> implement
 	@Override
 	public CNAbilitySelection decodeChoice(LoadContext context, String s)
 	{
-		return CNAbilitySelection.getAbilitySelectionFromPersistentFormat(s);
+		return CNAbilitySelection.getAbilitySelectionFromPersistentFormat(context, s);
 	}
 
 	@Override

--- a/code/src/java/plugin/lsttokens/deprecated/TemplateFeatToken.java
+++ b/code/src/java/plugin/lsttokens/deprecated/TemplateFeatToken.java
@@ -193,7 +193,7 @@ public class TemplateFeatToken extends AbstractTokenWithSeparator<PCTemplate> im
 	@Override
 	public CNAbilitySelection decodeChoice(LoadContext context, String s)
 	{
-		return CNAbilitySelection.getAbilitySelectionFromPersistentFormat(s);
+		return CNAbilitySelection.getAbilitySelectionFromPersistentFormat(context, s);
 	}
 
 	@Override

--- a/code/src/java/plugin/lsttokens/equipment/RangeToken.java
+++ b/code/src/java/plugin/lsttokens/equipment/RangeToken.java
@@ -21,7 +21,6 @@ import pcgen.cdom.enumeration.IntegerKey;
 import pcgen.cdom.util.CControl;
 import pcgen.cdom.util.ControlUtilities;
 import pcgen.core.Equipment;
-import pcgen.core.Globals;
 import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.token.AbstractIntToken;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
@@ -63,7 +62,7 @@ public class RangeToken extends AbstractIntToken<Equipment> implements
 	public ParseResult parseToken(LoadContext context, Equipment obj,
 		String value)
 	{
-		if (ControlUtilities.hasControlToken(Globals.getContext(), CControl.EQRANGE))
+		if (ControlUtilities.hasControlToken(context, CControl.EQRANGE))
 		{
 			Logging.errorPrint("RANGE token is deprecated (does not function)"
 				+ " when RANGE CodeControl is used");


### PR DESCRIPTION

Background: Globals.getContext() is generally bad behavior, as it's a loader function, and really should be avoided at runtime.  While we have many uses of it, we want to reduce those over time, especially those in code we know to be strategic.  This is another pass at reducing the calls to Globals.getContext() and replacing it with alternative methods of accessing the context or go get the required information directly from another object.