### PR TITLE
Bug Fix CODE-3030

### DIFF
--- a/code/src/java/pcgen/gui2/solverview/SolverViewFrame.java
+++ b/code/src/java/pcgen/gui2/solverview/SolverViewFrame.java
@@ -112,6 +112,12 @@ public class SolverViewFrame extends JFrame
 	private void update()
 	{
 		updateObjects();
+		if ((activeObject == null) && (selectedScope.getParentScope() != null))
+		{
+			//scopeFacet will error if we continue...
+			tableModel.setSteps(Collections.emptyList());
+			return;
+		}
 		ScopeInstance scope =
 				scopeFacet.get(activeIdentifier, selectedScope.getName(), activeObject);
 		if (variableLibraryFacet


### PR DESCRIPTION
Fixes a problem in the Solver UI where it will dump stack if selections are not fully initialized (almost inevitable)