### PR TITLE
NEWTAG-615 Reduce Table Format to only the lookup column

### DIFF
--- a/code/src/java/pcgen/cdom/format/table/TableFormatFactory.java
+++ b/code/src/java/pcgen/cdom/format/table/TableFormatFactory.java
@@ -26,7 +26,7 @@ import pcgen.base.util.ObjectDatabase;
 
 /**
  * An TableFormatFactory builds a FormatManager supporting a DataTable from the
- * name of the formats of the component of the TableFormat.
+ * name of the format of the lookup column of the TableFormat.
  */
 public class TableFormatFactory implements FormatManagerFactory
 {
@@ -76,16 +76,7 @@ public class TableFormatFactory implements FormatManagerFactory
 				"Multidimensional Table format not supported: " + subFormatName
 					+ " may not contain brackets");
 		}
-		String[] parts = subFormatName.split(",");
-		if (parts.length != 2)
-		{
-			throw new IllegalArgumentException(
-				"Table format must have 2 sub parts (lookup and result), found: "
-					+ subFormatName);
-		}
-		return new TableFormatManager(database,
-			library.getFormatManager(parts[0]),
-			library.getFormatManager(parts[1]));
+		return new TableFormatManager(database, library.getFormatManager(subFormatName));
 	}
 
 	@Override

--- a/code/src/java/pcgen/cdom/format/table/TableFormatManager.java
+++ b/code/src/java/pcgen/cdom/format/table/TableFormatManager.java
@@ -26,11 +26,6 @@ import pcgen.base.util.ObjectDatabase;
 /**
  * A TableFormatManager is a FormatManager that defines the format of a
  * DataTable.
- * 
- * Note that a DataTable can have more than one TableFormatManager represent
- * that DataTable. This is possible because the Result format is only indicative
- * that such a column exists in the DataTable, not that it has a specific name
- * or that it is the only column.
  */
 public final class TableFormatManager implements FormatManager<DataTable>
 {
@@ -46,38 +41,27 @@ public final class TableFormatManager implements FormatManager<DataTable>
 	private final FormatManager<?> lookupFormat;
 
 	/**
-	 * The Format of any DataTable referred to by this TableFormatManager.
-	 */
-	private final FormatManager<?> resultFormat;
-
-	/**
 	 * Constructs a new TableFormatManager that will use the underlying
-	 * AbstractReferenceContext to construct and look up DataTable objects. The
-	 * DataTable should have the lookup and result formats matching the formats
-	 * of the given FormatManagers.
+	 * AbstractReferenceContext to construct and look up DataTable objects. The DataTable
+	 * should have the lookup format matching the format of the given FormatManager.
 	 * 
 	 * @param objDatabase
-	 *            The ObjectDatabase used to construct or look up DataTable
-	 *            objects
+	 *            The ObjectDatabase used to construct or look up DataTable objects
 	 * @param lookupFormat
-	 *            The FormatManager for the format of the Lookup column of the
-	 *            DataTable format represented by this TableFormatManager
-	 * @param resultFormat
-	 *            The FormatManager for the format of the Result column of the
-	 *            DataTable format represented by this TableFormatManager
+	 *            The FormatManager for the format of the Lookup column of the DataTable
+	 *            format represented by this TableFormatManager
 	 */
 	public TableFormatManager(ObjectDatabase objDatabase,
-		FormatManager<?> lookupFormat, FormatManager<?> resultFormat)
+		FormatManager<?> lookupFormat)
 	{
 		this.database = Objects.requireNonNull(objDatabase);
 		this.lookupFormat = Objects.requireNonNull(lookupFormat);
-		this.resultFormat = Objects.requireNonNull(resultFormat);
 	}
 
 	@Override
 	public DataTable convert(String inputStr)
 	{
-		//TODO Does this need validation that the lookup/result columns are appropriate?
+		//TODO Does this need validation that the lookup column is appropriate?
 		return database.get(DataTable.class, inputStr);
 	}
 
@@ -85,7 +69,7 @@ public final class TableFormatManager implements FormatManager<DataTable>
 	public Indirect<DataTable> convertIndirect(String inputStr)
 	{
 		/*
-		 * TODO Need validation that the lookup/result columns are appropriate?
+		 * TODO Need validation that the lookup column is appropriate?
 		 * Yes, probably during the initialization of these references, it will
 		 * need to be checked... but how? Does this need to be like Categorized
 		 * references? ugh
@@ -111,8 +95,6 @@ public final class TableFormatManager implements FormatManager<DataTable>
 		StringBuilder sb = new StringBuilder();
 		sb.append("TABLE[");
 		sb.append(lookupFormat.getIdentifierType());
-		sb.append(",");
-		sb.append(resultFormat.getIdentifierType());
 		sb.append("]");
 		return sb.toString();
 	}
@@ -126,7 +108,7 @@ public final class TableFormatManager implements FormatManager<DataTable>
 	@Override
 	public int hashCode()
 	{
-		return lookupFormat.hashCode() ^ resultFormat.hashCode();
+		return lookupFormat.hashCode() + 5;
 	}
 
 	@Override
@@ -135,8 +117,7 @@ public final class TableFormatManager implements FormatManager<DataTable>
 		if (o instanceof TableFormatManager)
 		{
 			TableFormatManager other = (TableFormatManager) o;
-			return lookupFormat.equals(other.lookupFormat)
-				&& resultFormat.equals(other.resultFormat);
+			return lookupFormat.equals(other.lookupFormat);
 		}
 		return false;
 	}
@@ -151,18 +132,6 @@ public final class TableFormatManager implements FormatManager<DataTable>
 	public FormatManager<?> getLookupFormat()
 	{
 		return lookupFormat;
-	}
-
-	/**
-	 * Returns the FormatManager for the format of the Result column of the
-	 * DataTable format represented by this TableFormatManager.
-	 * 
-	 * @return The FormatManager for the format of the Result column of the
-	 *         DataTable format represented by this TableFormatManager
-	 */
-	public FormatManager<?> getResultFormat()
-	{
-		return resultFormat;
 	}
 
 	@Override

--- a/code/src/java/plugin/function/LookupFunction.java
+++ b/code/src/java/plugin/function/LookupFunction.java
@@ -128,15 +128,7 @@ public class LookupFunction implements Function
 			return null;
 		}
 		ColumnFormatManager<?> cf = (ColumnFormatManager<?>) resultColumn;
-		FormatManager<?> rf = tableFormatManager.getResultFormat();
-		if (!rf.equals(cf.getComponentManager()))
-		{
-			semantics.setInvalid(
-				"Parse Error: Invalid Result Column Type: " + resultColumn.getClass()
-					+ " found in table that does not contain that type");
-			return null;
-		}
-		return rf;
+		return cf.getComponentManager();
 	}
 
 	@Override

--- a/code/src/utest/plugin/function/LookupFunctionTest.java
+++ b/code/src/utest/plugin/function/LookupFunctionTest.java
@@ -147,7 +147,7 @@ public class LookupFunctionTest extends AbstractFormulaTestCase
 		WriteableVariableStore vs = getVariableStore();
 
 		TableFormatFactory fac = new TableFormatFactory(finder);
-		FormatManager<?> tableMgr = fac.build("STRING,NUMBER", formatLibrary);
+		FormatManager<?> tableMgr = fac.build("STRING", formatLibrary);
 		vl.assertLegalVariableID("TableA", getGlobalScope(), tableMgr);
 
 		VariableID tableID = vl.getVariableID(getGlobalScopeInst(), "TableA");
@@ -177,7 +177,7 @@ public class LookupFunctionTest extends AbstractFormulaTestCase
 		WriteableVariableStore vs = getVariableStore();
 
 		TableFormatFactory fac = new TableFormatFactory(finder);
-		FormatManager<?> tableMgr = fac.build("STRING,NUMBER", formatLibrary);
+		FormatManager<?> tableMgr = fac.build("STRING", formatLibrary);
 		vl.assertLegalVariableID("TableA", getGlobalScope(), tableMgr);
 
 		VariableID tableID = vl.getVariableID(getGlobalScopeInst(), "TableA");
@@ -228,7 +228,7 @@ public class LookupFunctionTest extends AbstractFormulaTestCase
 		WriteableVariableStore vs = getVariableStore();
 
 		TableFormatFactory fac = new TableFormatFactory(finder);
-		FormatManager<?> tableMgr = fac.build("STRING,NUMBER", formatLibrary);
+		FormatManager<?> tableMgr = fac.build("STRING", formatLibrary);
 		vl.assertLegalVariableID("TableA", getGlobalScope(), tableMgr);
 
 		VariableID tableID = vl.getVariableID(getGlobalScopeInst(), "TableA");
@@ -262,7 +262,7 @@ public class LookupFunctionTest extends AbstractFormulaTestCase
 		WriteableVariableStore vs = getVariableStore();
 
 		TableFormatFactory fac = new TableFormatFactory(finder);
-		FormatManager<?> tableMgr = fac.build("STRING,NUMBER", formatLibrary);
+		FormatManager<?> tableMgr = fac.build("STRING", formatLibrary);
 		vl.assertLegalVariableID("TableA", getGlobalScope(), tableMgr);
 
 		VariableID tableID = vl.getVariableID(getGlobalScopeInst(), "TableA");
@@ -271,50 +271,6 @@ public class LookupFunctionTest extends AbstractFormulaTestCase
 		String formula = "lookup(TableA,\"That\",badf())";
 		SimpleNode node = TestUtilities.doParse(formula);
 		isNotValid(formula, node, numberManager, null);
-	}
-
-	@Test
-	public void testBadResultColumnFormat()
-	{
-		Finder finder = new Finder();
-		DataTable dt = doTableSetup();
-		finder.map.put(DataTable.class, "A", dt);
-		finder.map.put(TableColumn.class, "Name",
-			buildColumn("Name", stringManager));
-		finder.map.put(TableColumn.class, "Value",
-			buildColumn("Value", numberManager));
-		finder.map.put(TableColumn.class, "Result",
-			buildColumn("Result", stringManager));
-
-		VariableLibrary vl = getVariableLibrary();
-		WriteableVariableStore vs = getVariableStore();
-
-		TableFormatFactory fac = new TableFormatFactory(finder);
-		FormatManager<?> tableMgr = fac.build("STRING,NUMBER", formatLibrary);
-		vl.assertLegalVariableID("TableA", getGlobalScope(), tableMgr);
-
-		ColumnFormatFactory cfac = new ColumnFormatFactory(finder);
-		FormatManager<?> columnMgr = cfac.build("STRING", formatLibrary);
-		vl.assertLegalVariableID("ResultColumn", getGlobalScope(), columnMgr);
-
-		VariableID tableID = vl.getVariableID(getGlobalScopeInst(), "TableA");
-		vs.put(tableID, tableMgr.convert("A"));
-
-		VariableID columnID =
-				vl.getVariableID(getGlobalScopeInst(), "ResultColumn");
-		vs.put(columnID, columnMgr.convert("Result"));
-
-		String formula = "lookup(TableA,\"That\",ResultColumn)";
-		SimpleNode node = TestUtilities.doParse(formula);
-
-		SemanticsVisitor semanticsVisitor = new SemanticsVisitor();
-		FormulaSemantics semantics = getManagerFactory()
-			.generateFormulaSemantics(getFormulaManager(), getGlobalScope(), null);
-		semanticsVisitor.visit(node, semantics);
-		if (semantics.isValid())
-		{
-			TestCase.fail("Expected Invalid Formula: " + formula);
-		}
 	}
 
 	@Test
@@ -332,7 +288,7 @@ public class LookupFunctionTest extends AbstractFormulaTestCase
 		WriteableVariableStore vs = getVariableStore();
 
 		TableFormatFactory fac = new TableFormatFactory(finder);
-		FormatManager<?> tableMgr = fac.build("STRING,NUMBER", formatLibrary);
+		FormatManager<?> tableMgr = fac.build("STRING", formatLibrary);
 		vl.assertLegalVariableID("TableA", getGlobalScope(), tableMgr);
 
 		ColumnFormatFactory cfac = new ColumnFormatFactory(finder);
@@ -379,7 +335,7 @@ public class LookupFunctionTest extends AbstractFormulaTestCase
 				vl.getVariableID(getGlobalScopeInst(), "ResultColumn");
 		vs.put(columnID, columnMgr.convert("Value"));
 
-		String formula = "lookup(\"TABLE[NUMBER,NUMBER]\",\"A\",\"That\",ResultColumn)";
+		String formula = "lookup(\"TABLE[NUMBER]\",\"A\",\"That\",ResultColumn)";
 		SimpleNode node = TestUtilities.doParse(formula);
 		SemanticsVisitor semanticsVisitor = new SemanticsVisitor();
 		FormulaSemantics semantics = getManagerFactory()
@@ -449,7 +405,7 @@ public class LookupFunctionTest extends AbstractFormulaTestCase
 				vl.getVariableID(getGlobalScopeInst(), "ResultColumn");
 		vs.put(columnID, columnMgr.convert("Value"));
 
-		String formula = "lookup(\"TABLE[STRING,NUMBER]\",55,\"That\",ResultColumn)";
+		String formula = "lookup(\"TABLE[STRING]\",55,\"That\",ResultColumn)";
 		SimpleNode node = TestUtilities.doParse(formula);
 		SemanticsVisitor semanticsVisitor = new SemanticsVisitor();
 		FormulaSemantics semantics = getManagerFactory()
@@ -484,7 +440,7 @@ public class LookupFunctionTest extends AbstractFormulaTestCase
 				vl.getVariableID(getGlobalScopeInst(), "ResultColumn");
 		vs.put(columnID, columnMgr.convert("Value"));
 
-		String formula = "lookup(get(\"TABLE[STRING,NUMBER]\",\"A\"),\"That\",ResultColumn)";
+		String formula = "lookup(get(\"TABLE[STRING]\",\"A\"),\"That\",ResultColumn)";
 		SimpleNode node = TestUtilities.doParse(formula);
 		SemanticsVisitor semanticsVisitor = new SemanticsVisitor();
 		FormulaSemantics semantics = getManagerFactory()
@@ -524,7 +480,7 @@ public class LookupFunctionTest extends AbstractFormulaTestCase
 		VariableLibrary vl = getVariableLibrary();
 		vl.assertLegalVariableID("ResultColumn", getGlobalScope(), columnMgr);
 
-		String formula = "lookup(get(\"TABLE[STRING,NUMBER]\",\"A\"),\"That\",get(\"COLUMN[NUMBER]\",\"Value\"))";
+		String formula = "lookup(get(\"TABLE[STRING]\",\"A\"),\"That\",get(\"COLUMN[NUMBER]\",\"Value\"))";
 		SimpleNode node = TestUtilities.doParse(formula);
 		SemanticsVisitor semanticsVisitor = new SemanticsVisitor();
 		FormulaSemantics semantics = getManagerFactory()
@@ -565,7 +521,7 @@ public class LookupFunctionTest extends AbstractFormulaTestCase
 				vl.getVariableID(getGlobalScopeInst(), "ResultColumn");
 		vs.put(columnID, columnMgr.convert("Value"));
 
-		String formula = "lookup(\"TABLE[STRING,NUMBER]\",\"A\",\"That\",ResultColumn,\"TooMuch\")";
+		String formula = "lookup(\"TABLE[STRING]\",\"A\",\"That\",ResultColumn,\"TooMuch\")";
 		SimpleNode node = TestUtilities.doParse(formula);
 		SemanticsVisitor semanticsVisitor = new SemanticsVisitor();
 		FormulaSemantics semantics = getManagerFactory()
@@ -595,7 +551,7 @@ public class LookupFunctionTest extends AbstractFormulaTestCase
 		WriteableVariableStore vs = getVariableStore();
 
 		TableFormatFactory fac = new TableFormatFactory(finder);
-		FormatManager<?> tableMgr = fac.build("STRING,NUMBER", formatLibrary);
+		FormatManager<?> tableMgr = fac.build("STRING", formatLibrary);
 		vl.assertLegalVariableID("TableA", getGlobalScope(), tableMgr);
 
 		ColumnFormatFactory cfac = new ColumnFormatFactory(finder);
@@ -640,7 +596,7 @@ public class LookupFunctionTest extends AbstractFormulaTestCase
 		WriteableVariableStore vs = getVariableStore();
 
 		TableFormatFactory fac = new TableFormatFactory(finder);
-		FormatManager<?> tableMgr = fac.build("STRING,NUMBER", formatLibrary);
+		FormatManager<?> tableMgr = fac.build("STRING", formatLibrary);
 		vl.assertLegalVariableID("TableA", getGlobalScope(), tableMgr);
 
 		ColumnFormatFactory cfac = new ColumnFormatFactory(finder);


### PR DESCRIPTION
This reduces the TABLE[...] format syntax to only have one sub-argument.  Previously, it had both the lookup and result columns.  This now seems unnecessary.  The result column format is already provided in the COLUMN[...] format of the column used in lookup(...), so this is redundant information that is, at best, error catching.  

At worst, it is much more confusing since a table with 3 columns, NUMBER, STRING, and NUMBER, must be referred to as two different formats if the target column type is included in the TABLE format.  That confusion is unnecessary, as the information is available elsewhere, and there is no added value from providing the redundant format information.
