### PR TITLE
NEWTAG-615 Reduce Table Format to only the lookup column

### DIFF
--- a/code/src/java/pcgen/cdom/format/table/TableFormatFactory.java
+++ b/code/src/java/pcgen/cdom/format/table/TableFormatFactory.java
@@ -25,7 +25,7 @@ import pcgen.base.util.FormatManager;
 
 /**
  * An TableFormatFactory builds a FormatManager supporting a DataTable from the
- * name of the formats of the component of the TableFormat.
+ * name of the format of the lookup column of the TableFormat.
  */
 public class TableFormatFactory implements FormatManagerFactory
 {
@@ -75,16 +75,7 @@ public class TableFormatFactory implements FormatManagerFactory
 				"Multidimensional Table format not supported: " + subFormatName
 					+ " may not contain brackets");
 		}
-		String[] parts = subFormatName.split(",");
-		if (parts.length != 2)
-		{
-			throw new IllegalArgumentException(
-				"Table format must have 2 sub parts (lookup and result), found: "
-					+ subFormatName);
-		}
-		return new TableFormatManager(tableFormat,
-			library.getFormatManager(parts[0]),
-			library.getFormatManager(parts[1]));
+		return new TableFormatManager(tableFormat, library.getFormatManager(subFormatName));
 	}
 
 	@Override

--- a/code/src/java/pcgen/cdom/format/table/TableFormatManager.java
+++ b/code/src/java/pcgen/cdom/format/table/TableFormatManager.java
@@ -107,7 +107,7 @@ public final class TableFormatManager implements FormatManager<DataTable>
 	@Override
 	public int hashCode()
 	{
-		return lookupFormat.hashCode() + 5;
+		return lookupFormat.hashCode() + 33;
 	}
 
 	@Override

--- a/code/src/java/pcgen/cdom/format/table/TableFormatManager.java
+++ b/code/src/java/pcgen/cdom/format/table/TableFormatManager.java
@@ -25,11 +25,6 @@ import pcgen.base.util.Indirect;
 /**
  * A TableFormatManager is a FormatManager that defines the format of a
  * DataTable.
- * 
- * Note that a DataTable can have more than one TableFormatManager represent
- * that DataTable. This is possible because the Result format is only indicative
- * that such a column exists in the DataTable, not that it has a specific name
- * or that it is the only column.
  */
 public final class TableFormatManager implements FormatManager<DataTable>
 {
@@ -45,32 +40,21 @@ public final class TableFormatManager implements FormatManager<DataTable>
 	private final FormatManager<?> lookupFormat;
 
 	/**
-	 * The Format of any DataTable referred to by this TableFormatManager.
-	 */
-	private final FormatManager<?> resultFormat;
-
-	/**
-	 * Constructs a new TableFormatManager that will use the underlying
-	 * FormatManager to construct and look up DataTable objects. The
-	 * DataTable should have the lookup and result formats matching the formats
-	 * of the given FormatManagers.
+	 * Constructs a new TableFormatManager that will use the underlying FormatManager to
+	 * construct and look up DataTable objects. The DataTable should have the lookup
+	 * format matching the format of the given FormatManager.
 	 * 
 	 * @param tableFormat
-	 *            The FormatManager used to construct or look up DataTable
-	 *            objects
+	 *            The FormatManager used to construct or look up DataTable objects
 	 * @param lookupFormat
-	 *            The FormatManager for the format of the Lookup column of the
-	 *            DataTable format represented by this TableFormatManager
-	 * @param resultFormat
-	 *            The FormatManager for the format of the Result column of the
-	 *            DataTable format represented by this TableFormatManager
+	 *            The FormatManager for the format of the Lookup column of the DataTable
+	 *            format represented by this TableFormatManager
 	 */
 	public TableFormatManager(FormatManager<DataTable> tableFormat,
-		FormatManager<?> lookupFormat, FormatManager<?> resultFormat)
+		FormatManager<?> lookupFormat)
 	{
 		this.tableFormat = Objects.requireNonNull(tableFormat);
 		this.lookupFormat = Objects.requireNonNull(lookupFormat);
-		this.resultFormat = Objects.requireNonNull(resultFormat);
 	}
 
 	@Override
@@ -84,7 +68,7 @@ public final class TableFormatManager implements FormatManager<DataTable>
 	public Indirect<DataTable> convertIndirect(String inputStr)
 	{
 		/*
-		 * TODO Need validation that the lookup/result columns are appropriate?
+		 * TODO Need validation that the lookup column is appropriate?
 		 * Yes, probably during the initialization of these references, it will
 		 * need to be checked... but how? Does this need to be like Categorized
 		 * references? ugh
@@ -110,8 +94,6 @@ public final class TableFormatManager implements FormatManager<DataTable>
 		StringBuilder sb = new StringBuilder();
 		sb.append("TABLE[");
 		sb.append(lookupFormat.getIdentifierType());
-		sb.append(",");
-		sb.append(resultFormat.getIdentifierType());
 		sb.append("]");
 		return sb.toString();
 	}
@@ -125,7 +107,7 @@ public final class TableFormatManager implements FormatManager<DataTable>
 	@Override
 	public int hashCode()
 	{
-		return lookupFormat.hashCode() ^ resultFormat.hashCode();
+		return lookupFormat.hashCode() + 5;
 	}
 
 	@Override
@@ -134,8 +116,7 @@ public final class TableFormatManager implements FormatManager<DataTable>
 		if (o instanceof TableFormatManager)
 		{
 			TableFormatManager other = (TableFormatManager) o;
-			return lookupFormat.equals(other.lookupFormat)
-				&& resultFormat.equals(other.resultFormat);
+			return lookupFormat.equals(other.lookupFormat);
 		}
 		return false;
 	}
@@ -150,18 +131,6 @@ public final class TableFormatManager implements FormatManager<DataTable>
 	public FormatManager<?> getLookupFormat()
 	{
 		return lookupFormat;
-	}
-
-	/**
-	 * Returns the FormatManager for the format of the Result column of the
-	 * DataTable format represented by this TableFormatManager.
-	 * 
-	 * @return The FormatManager for the format of the Result column of the
-	 *         DataTable format represented by this TableFormatManager
-	 */
-	public FormatManager<?> getResultFormat()
-	{
-		return resultFormat;
 	}
 
 	@Override

--- a/code/src/java/plugin/function/LookupFunction.java
+++ b/code/src/java/plugin/function/LookupFunction.java
@@ -133,15 +133,7 @@ public class LookupFunction implements Function
 			return null;
 		}
 		ColumnFormatManager<?> cf = (ColumnFormatManager<?>) resultColumn;
-		FormatManager<?> rf = tableFormatManager.getResultFormat();
-		if (!rf.equals(cf.getComponentManager()))
-		{
-			semantics.setInvalid(
-				"Parse Error: Invalid Result Column Type: " + resultColumn.getClass()
-					+ " found in table that does not contain that type");
-			return null;
-		}
-		return rf;
+		return cf.getComponentManager();
 	}
 
 	@Override

--- a/code/src/utest/plugin/function/LookupFunctionTest.java
+++ b/code/src/utest/plugin/function/LookupFunctionTest.java
@@ -143,7 +143,7 @@ public class LookupFunctionTest extends AbstractFormulaTestCase
 		WriteableVariableStore vs = getVariableStore();
 
 		TableFormatFactory fac = new TableFormatFactory(tablefinder);
-		FormatManager<?> tableMgr = fac.build("STRING,NUMBER", formatLibrary);
+		FormatManager<?> tableMgr = fac.build("STRING", formatLibrary);
 		vl.assertLegalVariableID("TableA", getGlobalScope(), tableMgr);
 
 		VariableID tableID = vl.getVariableID(getGlobalScopeInst(), "TableA");
@@ -173,7 +173,7 @@ public class LookupFunctionTest extends AbstractFormulaTestCase
 		WriteableVariableStore vs = getVariableStore();
 
 		TableFormatFactory fac = new TableFormatFactory(tablefinder);
-		FormatManager<?> tableMgr = fac.build("STRING,NUMBER", formatLibrary);
+		FormatManager<?> tableMgr = fac.build("STRING", formatLibrary);
 		vl.assertLegalVariableID("TableA", getGlobalScope(), tableMgr);
 
 		VariableID tableID = vl.getVariableID(getGlobalScopeInst(), "TableA");
@@ -221,7 +221,7 @@ public class LookupFunctionTest extends AbstractFormulaTestCase
 		WriteableVariableStore vs = getVariableStore();
 
 		TableFormatFactory fac = new TableFormatFactory(tablefinder);
-		FormatManager<?> tableMgr = fac.build("STRING,NUMBER", formatLibrary);
+		FormatManager<?> tableMgr = fac.build("STRING", formatLibrary);
 		vl.assertLegalVariableID("TableA", getGlobalScope(), tableMgr);
 
 		VariableID tableID = vl.getVariableID(getGlobalScopeInst(), "TableA");
@@ -254,7 +254,7 @@ public class LookupFunctionTest extends AbstractFormulaTestCase
 		WriteableVariableStore vs = getVariableStore();
 
 		TableFormatFactory fac = new TableFormatFactory(tablefinder);
-		FormatManager<?> tableMgr = fac.build("STRING,NUMBER", formatLibrary);
+		FormatManager<?> tableMgr = fac.build("STRING", formatLibrary);
 		vl.assertLegalVariableID("TableA", getGlobalScope(), tableMgr);
 
 		VariableID tableID = vl.getVariableID(getGlobalScopeInst(), "TableA");
@@ -263,48 +263,6 @@ public class LookupFunctionTest extends AbstractFormulaTestCase
 		String formula = "lookup(TableA,\"That\",badf())";
 		SimpleNode node = TestUtilities.doParse(formula);
 		isNotValid(formula, node, numberManager, null);
-	}
-
-	@Test
-	public void testBadResultColumnFormat()
-	{
-		Finder finder = new Finder();
-		TableFinder tablefinder = new TableFinder();
-		DataTable dt = doTableSetup();
-		tablefinder.map.put("A", dt);
-		finder.map.put("Name", buildColumn("Name", stringManager));
-		finder.map.put("Value", buildColumn("Value", numberManager));
-		finder.map.put("Result", buildColumn("Result", stringManager));
-
-		VariableLibrary vl = getVariableLibrary();
-		WriteableVariableStore vs = getVariableStore();
-
-		TableFormatFactory fac = new TableFormatFactory(tablefinder);
-		FormatManager<?> tableMgr = fac.build("STRING,NUMBER", formatLibrary);
-		vl.assertLegalVariableID("TableA", getGlobalScope(), tableMgr);
-
-		ColumnFormatFactory cfac = new ColumnFormatFactory(finder);
-		FormatManager<?> columnMgr = cfac.build("STRING", formatLibrary);
-		vl.assertLegalVariableID("ResultColumn", getGlobalScope(), columnMgr);
-
-		VariableID tableID = vl.getVariableID(getGlobalScopeInst(), "TableA");
-		vs.put(tableID, tableMgr.convert("A"));
-
-		VariableID columnID =
-				vl.getVariableID(getGlobalScopeInst(), "ResultColumn");
-		vs.put(columnID, columnMgr.convert("Result"));
-
-		String formula = "lookup(TableA,\"That\",ResultColumn)";
-		SimpleNode node = TestUtilities.doParse(formula);
-
-		SemanticsVisitor semanticsVisitor = new SemanticsVisitor();
-		FormulaSemantics semantics = getManagerFactory()
-			.generateFormulaSemantics(getFormulaManager(), getGlobalScope(), null);
-		semanticsVisitor.visit(node, semantics);
-		if (semantics.isValid())
-		{
-			TestCase.fail("Expected Invalid Formula: " + formula);
-		}
 	}
 
 	@Test
@@ -321,7 +279,7 @@ public class LookupFunctionTest extends AbstractFormulaTestCase
 		WriteableVariableStore vs = getVariableStore();
 
 		TableFormatFactory fac = new TableFormatFactory(tablefinder);
-		FormatManager<?> tableMgr = fac.build("STRING,NUMBER", formatLibrary);
+		FormatManager<?> tableMgr = fac.build("STRING", formatLibrary);
 		vl.assertLegalVariableID("TableA", getGlobalScope(), tableMgr);
 
 		ColumnFormatFactory cfac = new ColumnFormatFactory(finder);
@@ -366,7 +324,7 @@ public class LookupFunctionTest extends AbstractFormulaTestCase
 				vl.getVariableID(getGlobalScopeInst(), "ResultColumn");
 		vs.put(columnID, columnMgr.convert("Value"));
 
-		String formula = "lookup(\"TABLE[NUMBER,NUMBER]\",\"A\",\"That\",ResultColumn)";
+		String formula = "lookup(\"TABLE[NUMBER]\",\"A\",\"That\",ResultColumn)";
 		SimpleNode node = TestUtilities.doParse(formula);
 		SemanticsVisitor semanticsVisitor = new SemanticsVisitor();
 		FormulaSemantics semantics = getManagerFactory()
@@ -432,7 +390,7 @@ public class LookupFunctionTest extends AbstractFormulaTestCase
 				vl.getVariableID(getGlobalScopeInst(), "ResultColumn");
 		vs.put(columnID, columnMgr.convert("Value"));
 
-		String formula = "lookup(\"TABLE[STRING,NUMBER]\",55,\"That\",ResultColumn)";
+		String formula = "lookup(\"TABLE[STRING]\",55,\"That\",ResultColumn)";
 		SimpleNode node = TestUtilities.doParse(formula);
 		SemanticsVisitor semanticsVisitor = new SemanticsVisitor();
 		FormulaSemantics semantics = getManagerFactory()
@@ -465,7 +423,7 @@ public class LookupFunctionTest extends AbstractFormulaTestCase
 				vl.getVariableID(getGlobalScopeInst(), "ResultColumn");
 		vs.put(columnID, columnMgr.convert("Value"));
 
-		String formula = "lookup(get(\"TABLE[STRING,NUMBER]\",\"A\"),\"That\",ResultColumn)";
+		String formula = "lookup(get(\"TABLE[STRING]\",\"A\"),\"That\",ResultColumn)";
 		SimpleNode node = TestUtilities.doParse(formula);
 		SemanticsVisitor semanticsVisitor = new SemanticsVisitor();
 		FormulaSemantics semantics = getManagerFactory()
@@ -503,7 +461,7 @@ public class LookupFunctionTest extends AbstractFormulaTestCase
 		VariableLibrary vl = getVariableLibrary();
 		vl.assertLegalVariableID("ResultColumn", getGlobalScope(), columnMgr);
 
-		String formula = "lookup(get(\"TABLE[STRING,NUMBER]\",\"A\"),\"That\",get(\"COLUMN[NUMBER]\",\"Value\"))";
+		String formula = "lookup(get(\"TABLE[STRING]\",\"A\"),\"That\",get(\"COLUMN[NUMBER]\",\"Value\"))";
 		SimpleNode node = TestUtilities.doParse(formula);
 		SemanticsVisitor semanticsVisitor = new SemanticsVisitor();
 		FormulaSemantics semantics = getManagerFactory()
@@ -542,7 +500,7 @@ public class LookupFunctionTest extends AbstractFormulaTestCase
 				vl.getVariableID(getGlobalScopeInst(), "ResultColumn");
 		vs.put(columnID, columnMgr.convert("Value"));
 
-		String formula = "lookup(\"TABLE[STRING,NUMBER]\",\"A\",\"That\",ResultColumn,\"TooMuch\")";
+		String formula = "lookup(\"TABLE[STRING]\",\"A\",\"That\",ResultColumn,\"TooMuch\")";
 		SimpleNode node = TestUtilities.doParse(formula);
 		SemanticsVisitor semanticsVisitor = new SemanticsVisitor();
 		FormulaSemantics semantics = getManagerFactory()
@@ -570,7 +528,7 @@ public class LookupFunctionTest extends AbstractFormulaTestCase
 		WriteableVariableStore vs = getVariableStore();
 
 		TableFormatFactory fac = new TableFormatFactory(tablefinder);
-		FormatManager<?> tableMgr = fac.build("STRING,NUMBER", formatLibrary);
+		FormatManager<?> tableMgr = fac.build("STRING", formatLibrary);
 		vl.assertLegalVariableID("TableA", getGlobalScope(), tableMgr);
 
 		ColumnFormatFactory cfac = new ColumnFormatFactory(finder);
@@ -613,7 +571,7 @@ public class LookupFunctionTest extends AbstractFormulaTestCase
 		WriteableVariableStore vs = getVariableStore();
 
 		TableFormatFactory fac = new TableFormatFactory(tablefinder);
-		FormatManager<?> tableMgr = fac.build("STRING,NUMBER", formatLibrary);
+		FormatManager<?> tableMgr = fac.build("STRING", formatLibrary);
 		vl.assertLegalVariableID("TableA", getGlobalScope(), tableMgr);
 
 		ColumnFormatFactory cfac = new ColumnFormatFactory(finder);


### PR DESCRIPTION
Replaces PR#3672

This reduces the TABLE[...] format syntax to only have one sub-argument. Previously, it had both the lookup and result columns. This now seems unnecessary. The result column format is already provided in the COLUMN[...] format of the column used in lookup(...), so this is redundant information that is, at best, error catching.

At worst, it is much more confusing since a table with 3 columns, NUMBER, STRING, and NUMBER, must be referred to as two different formats if the target column type is included in the TABLE format. That confusion is unnecessary, as the information is available elsewhere, and there is no added value from providing the redundant format information.