### PR TITLE
Convert User Priority |PRIORITY=x to a full association on MODIFY*

### DIFF
--- a/code/src/java/pcgen/base/calculation/AbstractPCGenModifier.java
+++ b/code/src/java/pcgen/base/calculation/AbstractPCGenModifier.java
@@ -16,8 +16,10 @@
 package pcgen.base.calculation;
 
 import java.util.Collection;
+import java.util.Collections;
 
 import pcgen.base.util.Indirect;
+import pcgen.cdom.formula.AssociationUtilities;
 
 /**
  * An AbstractPCGenModifier is a PCGenModifier that supports generalized management of
@@ -30,6 +32,12 @@ public abstract class AbstractPCGenModifier<T> implements PCGenModifier<T>
 {
 
 	/**
+	 * The user priority of this SetModifier. Stored as an Object so we can detect "null"
+	 * - meaning it was unset in the data and we should not write out PRIORITY=0
+	 */
+	private Integer userPriority;
+
+	/**
 	 * The object references referred to by the embedded AbstractPCGenModifier.
 	 * 
 	 * NOTE: DO NOT DELETE THIS EVEN THOUGH IT APPEARS UNUSED. Its use is holding the
@@ -37,6 +45,32 @@ public abstract class AbstractPCGenModifier<T> implements PCGenModifier<T>
 	 */
 	@SuppressWarnings("unused")
 	private Collection<Indirect<?>> references;
+	
+	protected int getUserPriority()
+	{
+		return (userPriority == null) ? 0 : userPriority;
+	}
+
+	@Override
+	public void addAssociation(String assocInstructions)
+	{
+		userPriority =
+				AssociationUtilities.processUserPriority(assocInstructions);
+	}
+
+	@Override
+	public Collection<String> getAssociationInstructions()
+	{
+		if (userPriority == null)
+		{
+			return Collections.emptyList();
+		}
+		else
+		{
+			String priority = AssociationUtilities.unprocessUserPriority(userPriority);
+			return Collections.singleton(priority);
+		}
+	}
 
 	@Override
 	public void addReferences(Collection<Indirect<?>> collection)

--- a/code/src/java/pcgen/base/calculation/CalculationModifier.java
+++ b/code/src/java/pcgen/base/calculation/CalculationModifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 (C) Tom Parker <thpr@users.sourceforge.net>
+ * Copyright 2014-18 (C) Tom Parker <thpr@users.sourceforge.net>
  * 
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -17,16 +17,13 @@
  */
 package pcgen.base.calculation;
 
-import java.util.Objects;
-
 import pcgen.base.formula.base.DependencyManager;
 import pcgen.base.formula.base.EvaluationManager;
 import pcgen.base.util.FormatManager;
 
 /**
- * A CalculationModifier is a Modifier that is a wrapper around a
- * NEPCalculation. A CalculationModifier also contains the user priority of the
- * Modifier.
+ * A CalculationModifier is a Modifier that is a wrapper around a NEPCalculation. A
+ * CalculationModifier also contains the user priority of the Modifier.
  * 
  * @see pcgen.base.calculation.NEPCalculation
  * 
@@ -37,11 +34,6 @@ public final class CalculationModifier<T> extends AbstractPCGenModifier<T>
 {
 
 	/**
-	 * The user priority for this CalculationModifier.
-	 */
-	private final int userPriority;
-
-	/**
 	 * The NEPCalculation to be performed by this CalculationModifier.
 	 */
 	private final NEPCalculation<T> toDo;
@@ -49,50 +41,47 @@ public final class CalculationModifier<T> extends AbstractPCGenModifier<T>
 	private final FormatManager<T> formatManager;
 
 	/**
-	 * Constructs a new CalculationModifier from the given NEPCalculation and
-	 * user priority.
+	 * Constructs a new CalculationModifier from the given NEPCalculation.
 	 * 
 	 * The intent is that a solver would process the Modifier with the lowest
 	 * user priority first.
 	 * 
 	 * @param calc
-	 *            The NEPCalculation to be performed by this CalculationModifier
-	 *            when it is processed
-	 * @param userPriority
-	 *            The user priority of this CalculationModifier.
+	 *            The NEPCalculation to be performed by this CalculationModifier when it
+	 *            is processed
 	 * @throws IllegalArgumentException
 	 *             if the given NEPCalculation is null
 	 */
-	public CalculationModifier(NEPCalculation<T> calc, int userPriority,
-		FormatManager<T> formatManager)
+	public CalculationModifier(NEPCalculation<T> calc, FormatManager<T> fmtManager)
 	{
-		toDo = Objects.requireNonNull(calc);
-		this.userPriority = userPriority;
-		this.formatManager = Objects.requireNonNull(formatManager);
-	}
-
-	@Override
-	public int getUserPriority()
-	{
-		return userPriority;
+		if (calc == null)
+		{
+			throw new IllegalArgumentException("Calculation cannot be null");
+		}
+		if (fmtManager == null)
+		{
+			throw new IllegalArgumentException("FormatManager cannot be null");
+		}
+		toDo = calc;
+		formatManager = fmtManager;
 	}
 
 	@Override
 	public long getPriority()
 	{
-		return ((long) userPriority << 32) + toDo.getInherentPriority();
+		return ((long) getUserPriority() << 32) + toDo.getInherentPriority();
 	}
 
 	@Override
-	public T process(EvaluationManager evalManager)
+	public T process(EvaluationManager manager)
 	{
-		return toDo.process(evalManager);
+		return toDo.process(manager);
 	}
 
 	@Override
-	public void getDependencies(DependencyManager fdm)
+	public void getDependencies(DependencyManager manager)
 	{
-		toDo.getDependencies(fdm);
+		toDo.getDependencies(manager);
 	}
 
 	@Override
@@ -116,7 +105,7 @@ public final class CalculationModifier<T> extends AbstractPCGenModifier<T>
 	@Override
 	public int hashCode()
 	{
-		return userPriority ^ toDo.hashCode();
+		return getUserPriority() ^ toDo.hashCode();
 	}
 
 	@Override
@@ -125,9 +114,14 @@ public final class CalculationModifier<T> extends AbstractPCGenModifier<T>
 		if (o instanceof CalculationModifier)
 		{
 			CalculationModifier<?> other = (CalculationModifier<?>) o;
-			return (other.userPriority == userPriority)
+			return (other.getUserPriority() == getUserPriority())
 				&& other.toDo.equals(toDo);
 		}
 		return false;
+	}
+
+	public boolean isCompatible(FormatManager<?> fm)
+	{
+		return formatManager.equals(fm);
 	}
 }

--- a/code/src/java/pcgen/base/calculation/PCGenModifier.java
+++ b/code/src/java/pcgen/base/calculation/PCGenModifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 (C) Tom Parker <thpr@users.sourceforge.net>
+ * Copyright 2016-18 (C) Tom Parker <thpr@users.sourceforge.net>
  * 
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -30,12 +30,10 @@ import pcgen.base.util.Indirect;
  */
 public interface PCGenModifier<T> extends Modifier<T>
 {
-	/**
-	 * Returns the user priority for this PCGenModifier.
-	 * 
-	 * @return The user priority for this PCGenModifier
-	 */
-	public int getUserPriority();
+
+	public void addAssociation(String assocInstructions);
+
+	public Collection<String> getAssociationInstructions();
 
 	/**
 	 * Add object references to this PCGenModifier. These are captured solely as
@@ -45,4 +43,5 @@ public interface PCGenModifier<T> extends Modifier<T>
 	 *            The Collection of Indirect objects that this PCGenModifier references.
 	 */
 	public void addReferences(Collection<Indirect<?>> collection);
+
 }

--- a/code/src/java/pcgen/cdom/formula/AssociationUtilities.java
+++ b/code/src/java/pcgen/cdom/formula/AssociationUtilities.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2016-18 (C) Tom Parker <thpr@users.sourceforge.net>
+ * 
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 59 Temple Place,
+ * Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.cdom.formula;
+
+/**
+ * AssociationUtilities is a set of utility functions related to associations (placed on
+ * formulas). The most common of these associations is PRIORITY=x
+ */
+public class AssociationUtilities
+{
+	private AssociationUtilities()
+	{
+		//Do not instantiate utility class
+	}
+
+	/**
+	 * Processes the user priority (PRIORITY=x) from the given String. Note this assumes
+	 * the String is well-structured, meaning starts with "PRIORITY=" and is followed by
+	 * an integer >= 0.
+	 * 
+	 * If the input String is not well structured, and exception will be thrown.
+	 */
+	public static int processUserPriority(String assocInstructions)
+	{
+		int equalLoc = assocInstructions.indexOf("=");
+		String assocName = assocInstructions.substring(0, equalLoc);
+		String assocValue = assocInstructions.substring(equalLoc + 1);
+		if ("PRIORITY".equalsIgnoreCase(assocName))
+		{
+			int priorityNumber;
+			try
+			{
+				priorityNumber = Integer.parseInt(assocValue);
+			}
+			catch (NumberFormatException e)
+			{
+				throw new IllegalArgumentException(
+					"Priority must be an integer: " + assocValue + " was not an integer");
+			}
+			if (priorityNumber < 0)
+			{
+				throw new IllegalArgumentException("Priority must be an integer >= 0. "
+					+ priorityNumber + " was not positive");
+			}
+			return priorityNumber;
+		}
+		throw new IllegalArgumentException(
+			"Association " + assocName + " not recognized");
+	}
+
+	/**
+	 * Unprocesses the user priority from the given user priority value. This reverses the
+	 * processing done in processUserPriority(String).
+	 */
+	public static String unprocessUserPriority(int userPriority)
+	{
+		return "PRIORITY=" + userPriority;
+	}
+
+}

--- a/code/src/java/pcgen/gui2/solverview/SolverViewFrame.java
+++ b/code/src/java/pcgen/gui2/solverview/SolverViewFrame.java
@@ -26,6 +26,7 @@ import java.awt.event.ActionListener;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JScrollPane;
@@ -34,6 +35,7 @@ import javax.swing.JTextField;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.table.AbstractTableModel;
+
 import pcgen.base.calculation.PCGenModifier;
 import pcgen.base.formula.base.LegalScope;
 import pcgen.base.formula.base.ScopeInstance;
@@ -356,7 +358,7 @@ public class SolverViewFrame extends JFrame
 				case 2:
 					return ps.getResult();
 				case 3:
-					return ((PCGenModifier<?>) ps.getModifier()).getUserPriority();
+					return ((PCGenModifier<?>) ps.getModifier()).getPriority();
 				case 4:
 					return ps.getSourceInfo();
 				default:

--- a/code/src/java/pcgen/rules/context/VariableContext.java
+++ b/code/src/java/pcgen/rules/context/VariableContext.java
@@ -90,10 +90,10 @@ public class VariableContext
 	 * For Tokens
 	 */
 	public <T> PCGenModifier<T> getModifier(String modType, String modValue,
-		int priorityNumber, LegalScope varScope, FormatManager<T> formatManager)
+		LegalScope varScope, FormatManager<T> formatManager)
 	{
 		return getModFactory().getModifier(modType, modValue, managerFactory,
-			priorityNumber, varScope, formatManager);
+			varScope, formatManager);
 	}
 
 	public Set<LegalScope> getKnownLegalScopes(String varName)

--- a/code/src/java/pcgen/rules/persistence/MasterModifierFactory.java
+++ b/code/src/java/pcgen/rules/persistence/MasterModifierFactory.java
@@ -56,27 +56,27 @@ public class MasterModifierFactory
 	}
 
 	/**
-	 * Returns a Modifier representing the information given in the parameters.
+	 * Returns a PCGenModifier representing the information given in the
+	 * parameters.
 	 * 
 	 * @param modIdentifier
 	 *            The Identifier of the Modifier (indicating the general
 	 *            function being performed, e.g. ADD)
 	 * @param modInstructions
 	 *            The Instructions of the Modifier (indicating the actual value
-	 *            the Modifier will use)
+	 *            the PCGenModifier will use)
 	 * @param managerFactory
 	 *            The ManagerFactory to be used to support analyzing the
 	 *            instructions
-	 * @param priorityNumber
-	 *            The user priority of the Modifier to be produced
 	 * @param varScope
-	 *            The VariableScope for the Modifier to be returned
+	 *            The VariableScope for the PCGenModifier to be returned
 	 * @param formatManager
-	 *            The FormatManager for the Modifier to be returned
-	 * @return a Modifier representing the information given in the parameters
+	 *            The FormatManager for the PCGenModifier to be returned
+	 * @return a PCGenModifier representing the information given in the
+	 *         parameters
 	 */
-	public <T> PCGenModifier<T> getModifier(String modIdentifier, String modInstructions,
-		ManagerFactory managerFactory, int priorityNumber, LegalScope varScope,
+	public <T> PCGenModifier<T> getModifier(String modIdentifier,
+		String modInstructions, ManagerFactory managerFactory, LegalScope varScope,
 		FormatManager<T> formatManager)
 	{
 		Class<T> varClass = formatManager.getManagedClass();
@@ -88,7 +88,7 @@ public class MasterModifierFactory
 				"Requested unknown ModifierType: " + varClass.getSimpleName()
 					+ " " + modIdentifier);
 		}
-		PCGenModifier<T> modifier = factory.getModifier(priorityNumber, modInstructions,
+		PCGenModifier<T> modifier = factory.getModifier(modInstructions,
 			managerFactory, formulaManager, varScope, formatManager);
 		/*
 		 * getDependencies needs to be called during LST load, so that object references are captured

--- a/code/src/java/pcgen/rules/persistence/token/AbstractFixedSetModifierFactory.java
+++ b/code/src/java/pcgen/rules/persistence/token/AbstractFixedSetModifierFactory.java
@@ -34,7 +34,7 @@ public abstract class AbstractFixedSetModifierFactory<T>
 {
 
 	@Override
-	public PCGenModifier<T> getModifier(int userPriority, String instructions,
+	public PCGenModifier<T> getModifier(String instructions,
 		ManagerFactory managerFactory, FormulaManager ignored, LegalScope varScope,
 		FormatManager<T> formatManager)
 	{
@@ -43,7 +43,7 @@ public abstract class AbstractFixedSetModifierFactory<T>
 			throw new IllegalArgumentException(
 				"FormatManager must manage " + getVariableFormat().getName());
 		}
-		return getFixedModifier(userPriority, formatManager, instructions);
+		return getFixedModifier(formatManager, instructions);
 	}
 
 }

--- a/code/src/java/pcgen/rules/persistence/token/AbstractNumberModifierFactory.java
+++ b/code/src/java/pcgen/rules/persistence/token/AbstractNumberModifierFactory.java
@@ -35,29 +35,29 @@ public abstract class AbstractNumberModifierFactory<T> implements
 {
 
 	@Override
-	public PCGenModifier<T> getModifier(int userPriority, String instructions,
+	public PCGenModifier<T> getModifier(String instructions,
 		ManagerFactory managerFactory, FormulaManager formulaManager, LegalScope varScope,
 		FormatManager<T> formatManager)
 	{
 		try
 		{
-			return getFixedModifier(userPriority, formatManager, instructions);
+			return getFixedModifier(formatManager, instructions);
 		}
 		catch (NumberFormatException e)
 		{
 			final NEPFormula<T> f = FormulaFactory.getValidFormula(instructions,
 				managerFactory, formulaManager, varScope, formatManager);
 			NEPCalculation<T> calc = new FormulaCalculation<>(f, this);
-			return new CalculationModifier<>(calc, userPriority, formatManager);
+			return new CalculationModifier<>(calc, formatManager);
 		}
 	}
 
 	@Override
-	public PCGenModifier<T> getFixedModifier(int userPriority,
+	public PCGenModifier<T> getFixedModifier(
 		FormatManager<T> formatManager, String instructions)
 	{
 		T n = formatManager.convert(instructions);
 		NEPCalculation<T> calc = new ProcessCalculation<>(n, this, formatManager);
-		return new CalculationModifier<>(calc, userPriority, formatManager);
+		return new CalculationModifier<>(calc, formatManager);
 	}
 }

--- a/code/src/java/pcgen/rules/persistence/token/AbstractSetModifierFactory.java
+++ b/code/src/java/pcgen/rules/persistence/token/AbstractSetModifierFactory.java
@@ -74,8 +74,8 @@ public abstract class AbstractSetModifierFactory<T> implements
 	}
 
 	@Override
-	public PCGenModifier<T> getFixedModifier(int userPriority,
-		FormatManager<T> formatManager, String instructions)
+	public PCGenModifier<T> getFixedModifier(FormatManager<T> formatManager,
+		String instructions)
 	{
 		if (!getVariableFormat().isAssignableFrom(formatManager.getManagedClass()))
 		{
@@ -84,7 +84,7 @@ public abstract class AbstractSetModifierFactory<T> implements
 		}
 		T n = formatManager.convert(instructions);
 		NEPCalculation<T> calc = new ProcessCalculation<>(n, this, formatManager);
-		return new CalculationModifier<>(calc, userPriority, formatManager);
+		return new CalculationModifier<>(calc, formatManager);
 	}
 
 }

--- a/code/src/java/pcgen/rules/persistence/token/ModifierFactory.java
+++ b/code/src/java/pcgen/rules/persistence/token/ModifierFactory.java
@@ -21,7 +21,6 @@ import pcgen.base.calculation.PCGenModifier;
 import pcgen.base.formula.base.FormulaManager;
 import pcgen.base.formula.base.LegalScope;
 import pcgen.base.formula.base.ManagerFactory;
-import pcgen.base.solver.Modifier;
 import pcgen.base.util.FormatManager;
 
 /**
@@ -54,30 +53,29 @@ public interface ModifierFactory<T>
 	public Class<T> getVariableFormat();
 
 	/**
-	 * Returns a Modifier with the given user priority and instructions. The
-	 * instructions will be parsed, and an IllegalArgumentException thrown if
-	 * the instructions are not valid for this type of ModifierFactory.
+	 * Returns a PCGenModifier with the given instructions. The instructions
+	 * will be parsed, and an IllegalArgumentException thrown if the
+	 * instructions are not valid for this type of ModifierFactory.
 	 * 
-	 * @param userPriority
-	 *            The User Priority for the Modifier to be returned
 	 * @param instructions
-	 *            The String form of the instructions of the Modifier to be
+	 *            The String form of the instructions of the PCGenModifier to be
 	 *            returned
 	 * @param managerFactory
 	 *            The ManagerFactory to be used to support analyzing the
 	 *            instructions
 	 * @param formulaManager
 	 *            The FormulaManager used, if necessary, to initialize the
-	 *            Modifier to be returned
+	 *            PCGenModifier to be returned
 	 * @param varScope
-	 *            The VariableScope for the Modifier to be returned
+	 *            The VariableScope for the PCGenModifier to be returned
 	 * @param formatManager
-	 *            The FormatManager for the Modifier to be returned
+	 *            The FormatManager for the PCGenModifier to be returned
+	 * @return a PCGenModifier with the given instructions
 	 */
-	public PCGenModifier<T> getModifier(int userPriority, String instructions,
+	public PCGenModifier<T> getModifier(String instructions,
 		ManagerFactory managerFactory, FormulaManager formulaManager, LegalScope varScope,
 		FormatManager<T> formatManager);
 
-	public Modifier<T> getFixedModifier(int userPriority,
-		FormatManager<T> formatManager, String instructions);
+	public PCGenModifier<T> getFixedModifier(FormatManager<T> formatManager,
+		String instructions);
 }

--- a/code/src/java/plugin/lsttokens/ModifyLst.java
+++ b/code/src/java/plugin/lsttokens/ModifyLst.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-15 (C) Thomas Parker <thpr@users.sourceforge.net>
+ * Copyright 2014-16 (C) Thomas Parker <thpr@users.sourceforge.net>
  * 
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -19,12 +19,16 @@ package plugin.lsttokens;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import pcgen.base.calculation.PCGenModifier;
 import pcgen.base.formula.base.LegalScope;
 import pcgen.base.formula.base.ScopeInstance;
+import pcgen.base.lang.StringUtil;
 import pcgen.base.text.ParsingSeparator;
+import pcgen.base.util.CaseInsensitiveMap;
 import pcgen.base.util.FormatManager;
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.base.Constants;
@@ -33,11 +37,13 @@ import pcgen.cdom.enumeration.ListKey;
 import pcgen.core.Campaign;
 import pcgen.rules.context.Changes;
 import pcgen.rules.context.LoadContext;
+import pcgen.rules.persistence.token.AbstractTokenWithSeparator;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import pcgen.rules.persistence.token.ParseResult;
 import pcgen.util.Logging;
 
-public class ModifyLst implements CDOMPrimaryToken<CDOMObject>
+public class ModifyLst extends AbstractTokenWithSeparator<CDOMObject>
+		implements CDOMPrimaryToken<CDOMObject>
 {
 
 	@Override
@@ -47,8 +53,14 @@ public class ModifyLst implements CDOMPrimaryToken<CDOMObject>
 	}
 
 	@Override
-	public ParseResult parseToken(LoadContext context, CDOMObject obj,
-		String value)
+	protected char separator()
+	{
+		return '|';
+	}
+
+	@Override
+	protected ParseResult parseTokenWithSeparator(LoadContext context,
+		CDOMObject obj, String value)
 	{
 		if (obj instanceof Campaign)
 		{
@@ -65,7 +77,17 @@ public class ModifyLst implements CDOMPrimaryToken<CDOMObject>
 			return new ParseResult.Fail(getTokenName() + " may not be empty",
 				context);
 		}
+
+		ScopeInstance scopeInst = context.getActiveScope();
+		LegalScope scope = scopeInst.getLegalScope();
 		String varName = sep.next();
+		if (!context.getVariableContext().isLegalVariableID(scope, varName))
+		{
+			return new ParseResult.Fail(getTokenName()
+				+ " found invalid var name: " + varName + " Modified on "
+				+ obj.getClass().getSimpleName() + " " + obj.getKeyName(),
+				context);
+		}
 		if (!sep.hasNext())
 		{
 			return new ParseResult.Fail(getTokenName()
@@ -78,75 +100,13 @@ public class ModifyLst implements CDOMPrimaryToken<CDOMObject>
 				+ " needed third argument: " + value, context);
 		}
 		String modInstructions = sep.next();
-		int priorityNumber = 0; //Defaults to zero
-		if (sep.hasNext())
-		{
-			String priority = sep.next();
-			if (priority.length() < 10)
-			{
-				return new ParseResult.Fail(getTokenName()
-					+ " was expecting PRIORITY= but got " + priority + " in "
-					+ value, context);
-			}
-			if ("PRIORITY=".equalsIgnoreCase(priority.substring(0, 9)))
-			{
-				try
-				{
-					priorityNumber = Integer.parseInt(priority.substring(9));
-				}
-				catch (NumberFormatException e)
-				{
-					return new ParseResult.Fail(getTokenName()
-						+ " requires Priority to be an integer: "
-						+ priority.substring(9) + " was not an integer");
-				}
-				if (priorityNumber < 0)
-				{
-					return new ParseResult.Fail(getTokenName()
-						+ " Priority requires an integer >= 0. "
-						+ priorityNumber + " was not positive");
-				}
-			}
-			else
-			{
-				return new ParseResult.Fail(getTokenName()
-					+ " was expecting PRIORITY=x but got " + priority + " in "
-					+ value, context);
-			}
-			if (sep.hasNext())
-			{
-				return new ParseResult.Fail(getTokenName()
-					+ " had too many arguments: " + value, context);
-			}
-		}
-		ScopeInstance scopeInst = context.getActiveScope();
-		LegalScope scope = scopeInst.getLegalScope();
-		if (!context.getVariableContext().isLegalVariableID(scope, varName))
-		{
-			return new ParseResult.Fail(
-				getTokenName() + " found invalid var name: " + varName
-					+ "(scope: " + scope.getName() + ") Modified on "
-					+ obj.getClass().getSimpleName() + ' ' + obj.getKeyName(),
-				context);
-		}
-		FormatManager<?> format =
-				context.getVariableContext().getVariableFormat(scope, varName);
-		return finishProcessing(context, obj, format, varName,
-			modIdentification, modInstructions, priorityNumber);
-	}
-
-	private <T> ParseResult finishProcessing(LoadContext context,
-		CDOMObject obj, FormatManager<T> formatManager, String varName,
-		String modIdentification, String modInstructions, int priorityNumber)
-	{
-		ScopeInstance scopeInst = context.getActiveScope();
-		LegalScope scope = scopeInst.getLegalScope();
-		PCGenModifier<T> modifier;
+		PCGenModifier<?> modifier;
 		try
 		{
-			modifier =
-					context.getVariableContext().getModifier(modIdentification,
-						modInstructions, priorityNumber, scope, formatManager);
+			FormatManager<?> format = context.getVariableContext()
+				.getVariableFormat(scope, varName);
+			modifier = context.getVariableContext().getModifier(
+				modIdentification, modInstructions.toString(), scope, format);
 		}
 		catch (IllegalArgumentException iae)
 		{
@@ -154,7 +114,31 @@ public class ModifyLst implements CDOMPrimaryToken<CDOMObject>
 				+ modIdentification + " had value " + modInstructions
 				+ " but it was not valid: " + iae.getMessage(), context);
 		}
-		VarModifier<T> vm = new VarModifier<>(varName, scope, modifier);
+		Set<Object> associationsVisited =
+				Collections.newSetFromMap(new CaseInsensitiveMap<>());
+		while (sep.hasNext())
+		{
+			String assoc = sep.next();
+			int equalLoc = assoc.indexOf('=');
+			if (equalLoc == -1)
+			{
+				return new ParseResult.Fail(getTokenName()
+					+ " was expecting = in an ASSOCIATION but got " + assoc
+					+ " in " + value, context);
+			}
+			String assocName = assoc.substring(0, equalLoc);
+			if (associationsVisited.contains(assocName))
+			{
+				return new ParseResult.Fail(
+					getTokenName()
+						+ " does not allow multiple asspociations with the same name.  "
+						+ "Found multiple: " + assocName + " in " + value,
+					context);
+			}
+			associationsVisited.add(assocName);
+			modifier.addAssociation(assoc);
+		}
+		VarModifier<?> vm = new VarModifier<>(varName, scope, modifier);
 		context.getObjectContext().addToList(obj, ListKey.MODIFY, vm);
 		return ParseResult.SUCCESS;
 	}
@@ -181,11 +165,10 @@ public class ModifyLst implements CDOMPrimaryToken<CDOMObject>
 		{
 			for (VarModifier<?> vm : added)
 			{
-				String modText = unparseModifier(vm);
 				StringBuilder sb = new StringBuilder();
 				sb.append(vm.getVarName());
 				sb.append(Constants.PIPE);
-				sb.append(modText);
+				sb.append(unparseModifier(vm));
 				modifiers.add(sb.toString());
 			}
 		}
@@ -201,16 +184,15 @@ public class ModifyLst implements CDOMPrimaryToken<CDOMObject>
 	{
 		PCGenModifier<?> modifier = vm.getModifier();
 		String type = modifier.getIdentification();
-		int userPriority = modifier.getUserPriority();
 		StringBuilder sb = new StringBuilder();
 		sb.append(type);
 		sb.append(Constants.PIPE);
 		sb.append(modifier.getInstructions());
-		if (userPriority > 0)
+		Collection<String> assocs = modifier.getAssociationInstructions();
+		if (assocs != null && assocs.size() > 0)
 		{
 			sb.append(Constants.PIPE);
-			sb.append("PRIORITY=");
-			sb.append(userPriority);
+			sb.append(StringUtil.join(assocs, Constants.PIPE));
 		}
 		return sb.toString();
 	}

--- a/code/src/java/plugin/lsttokens/ModifyOtherLst.java
+++ b/code/src/java/plugin/lsttokens/ModifyOtherLst.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 (C) Thomas Parker <thpr@users.sourceforge.net>
+ * Copyright 2014-18 (C) Thomas Parker <thpr@users.sourceforge.net>
  * 
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -19,14 +19,18 @@ package plugin.lsttokens;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 import pcgen.base.calculation.PCGenModifier;
 import pcgen.base.formula.base.LegalScope;
 import pcgen.base.formula.base.ScopeInstance;
 import pcgen.base.formula.base.VarScoped;
+import pcgen.base.lang.StringUtil;
 import pcgen.base.text.ParsingSeparator;
+import pcgen.base.util.CaseInsensitiveMap;
 import pcgen.base.util.FormatManager;
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.base.Constants;
@@ -99,7 +103,6 @@ public class ModifyOtherLst extends AbstractTokenWithSeparator<CDOMObject>
 		LoadContext context, CDOMObject obj, String value, ParsingSeparator sep)
 	{
 		ScopeInstance scopeInst = context.getActiveScope();
-		@SuppressWarnings("unchecked")
 		final LegalScope scope = scopeInst.getLegalScope();
 		final String groupingName = sep.next();
 		ObjectGrouping group;
@@ -196,69 +199,50 @@ public class ModifyOtherLst extends AbstractTokenWithSeparator<CDOMObject>
 			return new ParseResult.Fail(getTokenName()
 				+ " needed 4th argument: " + value, context);
 		}
-		String modType = sep.next();
+		String modIdentification = sep.next();
 		if (!sep.hasNext())
 		{
 			return new ParseResult.Fail(getTokenName()
 				+ " needed 5th argument: " + value, context);
 		}
-		String modValue = sep.next();
-		int priorityNumber = 0; //Defaults to zero
-		if (sep.hasNext())
-		{
-			String priority = sep.next();
-			if (priority.length() < 10)
-			{
-				return new ParseResult.Fail(getTokenName()
-					+ " was expecting PRIORITY= but got " + priority + " in "
-					+ value, context);
-			}
-			if ("PRIORITY=".equalsIgnoreCase(priority.substring(0, 9)))
-			{
-				try
-				{
-					priorityNumber = Integer.parseInt(priority.substring(9));
-				}
-				catch (NumberFormatException e)
-				{
-					return new ParseResult.Fail(getTokenName()
-						+ " requires Priority to be an integer: "
-						+ priority.substring(9) + " was not an integer");
-				}
-				if (priorityNumber < 0)
-				{
-					return new ParseResult.Fail(getTokenName()
-						+ " Priority requires an integer >= 0. "
-						+ priorityNumber + " was not positive");
-				}
-			}
-			else
-			{
-				return new ParseResult.Fail(getTokenName()
-					+ " was expecting PRIORITY=x but got " + priority + " in "
-					+ value, context);
-			}
-			if (sep.hasNext())
-			{
-				return new ParseResult.Fail(getTokenName()
-					+ " had too many arguments: " + value, context);
-			}
-		}
+		String modInstructions = sep.next();
 		PCGenModifier<?> modifier;
 		try
 		{
-			FormatManager<?> format =
-					context.getVariableContext().getVariableFormat(scope,
-						varName);
-			modifier =
-					context.getVariableContext().getModifier(modType, modValue,
-						priorityNumber, scope, format);
+			FormatManager<?> format = context.getVariableContext()
+				.getVariableFormat(scope, varName);
+			modifier = context.getVariableContext().getModifier(
+				modIdentification, modInstructions.toString(), scope, format);
 		}
 		catch (IllegalArgumentException iae)
 		{
-			return new ParseResult.Fail(getTokenName() + " Modifier " + modType
-				+ " had value " + modValue + " but it was not valid: "
-				+ iae.getMessage(), context);
+			return new ParseResult.Fail(getTokenName() + " Modifier "
+				+ modIdentification + " had value " + modInstructions
+				+ " but it was not valid: " + iae.getMessage(), context);
+		}
+		Set<Object> associationsVisited =
+				Collections.newSetFromMap(new CaseInsensitiveMap<>());
+		while (sep.hasNext())
+		{
+			String assoc = sep.next();
+			int equalLoc = assoc.indexOf('=');
+			if (equalLoc == -1)
+			{
+				return new ParseResult.Fail(getTokenName()
+					+ " was expecting = in an ASSOCIATION but got " + assoc
+					+ " in " + value, context);
+			}
+			String assocName = assoc.substring(0, equalLoc);
+			if (associationsVisited.contains(assocName))
+			{
+				return new ParseResult.Fail(
+					getTokenName()
+						+ " does not allow multiple asspociations with the same name.  "
+						+ "Found multiple: " + assocName + " in " + value,
+					context);
+			}
+			associationsVisited.add(assocName);
+			modifier.addAssociation(assoc);
 		}
 		VarModifier<?> vm = new VarModifier<>(varName, scope, modifier);
 		RemoteModifier<?> rm = new RemoteModifier<>(group, vm);
@@ -314,16 +298,15 @@ public class ModifyOtherLst extends AbstractTokenWithSeparator<CDOMObject>
 	{
 		PCGenModifier<?> modifier = vm.getModifier();
 		String type = modifier.getIdentification();
-		int userPriority = modifier.getUserPriority();
 		StringBuilder sb = new StringBuilder();
 		sb.append(type);
 		sb.append(Constants.PIPE);
 		sb.append(modifier.getInstructions());
-		if (userPriority > 0)
+		Collection<String> assocs = modifier.getAssociationInstructions();
+		if (assocs != null && assocs.size() > 0)
 		{
 			sb.append(Constants.PIPE);
-			sb.append("PRIORITY=");
-			sb.append(userPriority);
+			sb.append(StringUtil.join(assocs, Constants.PIPE));
 		}
 		return sb.toString();
 	}
@@ -333,5 +316,4 @@ public class ModifyOtherLst extends AbstractTokenWithSeparator<CDOMObject>
 	{
 		return CDOMObject.class;
 	}
-
 }

--- a/code/src/java/plugin/lsttokens/race/FaceToken.java
+++ b/code/src/java/plugin/lsttokens/race/FaceToken.java
@@ -74,10 +74,8 @@ public class FaceToken extends AbstractNonEmptyToken<Race> implements
 		PCGenModifier<OrderedPair> modifier;
 		try
 		{
-			modifier =
-					context.getVariableContext().getModifier(
-						MOD_IDENTIFICATION, value, MOD_PRIORITY, scope,
-						formatManager);
+			modifier = context.getVariableContext()
+				.getModifier(MOD_IDENTIFICATION, value, scope, formatManager);
 		}
 		catch (IllegalArgumentException iae)
 		{
@@ -85,6 +83,7 @@ public class FaceToken extends AbstractNonEmptyToken<Race> implements
 				+ MOD_IDENTIFICATION + " had value " + value
 				+ " but it was not valid: " + iae.getMessage(), context);
 		}
+		modifier.addAssociation("PRIORITY=" + MOD_PRIORITY);
 		OrderedPair pair = modifier.process(null);
 		if (pair.getPreciseX().doubleValue() < 0.0)
 		{
@@ -124,11 +123,10 @@ public class FaceToken extends AbstractNonEmptyToken<Race> implements
 				PCGenModifier<?> modifier = vm.getModifier();
 				if (VAR_NAME.equals(vm.getVarName())
 					&& (vm.getLegalScope().getParentScope() == null)
-					&& (modifier.getUserPriority() == MOD_PRIORITY)
-					&& (vm.getModifier().getIdentification()
+					&& (modifier.getIdentification()
 						.equals(MOD_IDENTIFICATION)))
 				{
-					face = vm.getModifier().getInstructions();
+					face = modifier.getInstructions();
 					if (face.endsWith(",0"))
 					{
 						face = face.substring(0, face.length() - 2);

--- a/code/src/java/plugin/lsttokens/template/FaceToken.java
+++ b/code/src/java/plugin/lsttokens/template/FaceToken.java
@@ -81,10 +81,8 @@ public class FaceToken extends AbstractNonEmptyToken<PCTemplate> implements
 		PCGenModifier<OrderedPair> modifier;
 		try
 		{
-			modifier =
-					context.getVariableContext().getModifier(
-						MOD_IDENTIFICATION, value, MOD_PRIORITY, scope,
-						formatManager);
+			modifier = context.getVariableContext()
+				.getModifier(MOD_IDENTIFICATION, value, scope, formatManager);
 		}
 		catch (IllegalArgumentException iae)
 		{
@@ -92,6 +90,7 @@ public class FaceToken extends AbstractNonEmptyToken<PCTemplate> implements
 				+ " Modifier SET had value " + value
 				+ " but it was not valid: " + iae.getMessage(), context);
 		}
+		modifier.addAssociation("PRIORITY=" + MOD_PRIORITY);
 		OrderedPair pair = modifier.process(null);
 		if (pair.getPreciseX().doubleValue() < 0.0)
 		{
@@ -131,11 +130,10 @@ public class FaceToken extends AbstractNonEmptyToken<PCTemplate> implements
 				PCGenModifier<?> modifier = vm.getModifier();
 				if (VAR_NAME.equals(vm.getVarName())
 					&& (vm.getLegalScope().getParentScope() == null)
-					&& (modifier.getUserPriority() == MOD_PRIORITY)
-					&& (vm.getModifier().getIdentification()
+					&& (modifier.getIdentification()
 						.equals(MOD_IDENTIFICATION)))
 				{
-					face = vm.getModifier().getInstructions();
+					face = modifier.getInstructions();
 					if (face.endsWith(",0"))
 					{
 						face = face.substring(0, face.length() - 2);

--- a/code/src/java/plugin/modifier/cdom/SetModifierFactory.java
+++ b/code/src/java/plugin/modifier/cdom/SetModifierFactory.java
@@ -37,7 +37,7 @@ public class SetModifierFactory extends AbstractSetModifierFactory<CDOMObject>
 {
 
 	@Override
-	public PCGenModifier<CDOMObject> getModifier(int userPriority, String instructions,
+	public PCGenModifier<CDOMObject> getModifier(String instructions,
 		ManagerFactory managerFactory, FormulaManager ignored, LegalScope varScope,
 		FormatManager<CDOMObject> formatManager)
 	{
@@ -48,7 +48,7 @@ public class SetModifierFactory extends AbstractSetModifierFactory<CDOMObject>
 		}
 		Indirect<CDOMObject> n = formatManager.convertIndirect(instructions);
 		NEPCalculation<CDOMObject> calc = new IndirectCalculation<>(n, this);
-		return new CalculationModifier<>(calc, userPriority, formatManager);
+		return new CalculationModifier<>(calc, formatManager);
 	}
 
 	/**

--- a/code/src/java/plugin/modifier/number/SetModifierFactory.java
+++ b/code/src/java/plugin/modifier/number/SetModifierFactory.java
@@ -50,7 +50,7 @@ public class SetModifierFactory extends AbstractFixedSetModifierFactory<Number>
 	}
 
 	@Override
-	public PCGenModifier<Number> getModifier(int userPriority, String instructions,
+	public PCGenModifier<Number> getModifier(String instructions,
 		ManagerFactory managerFactory, FormulaManager formulaManager, LegalScope varScope,
 		FormatManager<Number> formatManager)
 	{
@@ -61,7 +61,7 @@ public class SetModifierFactory extends AbstractFixedSetModifierFactory<Number>
 		}
 		try
 		{
-			return getFixedModifier(userPriority, formatManager, instructions);
+			return getFixedModifier(formatManager, instructions);
 		}
 		catch (NumberFormatException e)
 		{
@@ -70,7 +70,7 @@ public class SetModifierFactory extends AbstractFixedSetModifierFactory<Number>
 						formulaManager, varScope, formatManager);
 			NEPCalculation<Number> calc =
 					new FormulaCalculation<>(f, this);
-			return new CalculationModifier<>(calc, userPriority, formatManager);
+			return new CalculationModifier<>(calc, formatManager);
 		}
 	}
 

--- a/code/src/java/plugin/modifier/set/AddModifierFactory.java
+++ b/code/src/java/plugin/modifier/set/AddModifierFactory.java
@@ -29,7 +29,6 @@ import pcgen.base.formula.base.EvaluationManager;
 import pcgen.base.formula.base.FormulaManager;
 import pcgen.base.formula.base.LegalScope;
 import pcgen.base.formula.base.ManagerFactory;
-import pcgen.base.solver.Modifier;
 import pcgen.base.util.FormatManager;
 import pcgen.base.util.Indirect;
 import pcgen.rules.persistence.token.ModifierFactory;
@@ -63,21 +62,20 @@ public class AddModifierFactory<T> implements ModifierFactory<T[]>
 	}
 
 	@Override
-	public PCGenModifier<T[]> getModifier(int userPriority, String instructions,
+	public PCGenModifier<T[]> getModifier(String instructions,
 		ManagerFactory managerFactory, FormulaManager ignored, LegalScope varScope,
 		FormatManager<T[]> formatManager)
 	{
 		Indirect<T[]> indirect = formatManager.convertIndirect(instructions);
-		return new AddIndirectArrayModifier(formatManager, userPriority,
-			indirect);
+		return new AddIndirectArrayModifier(formatManager, indirect);
 	}
 
 	@Override
-	public Modifier<T[]> getFixedModifier(int userPriority,
-		FormatManager<T[]> fmtManager, String instructions)
+	public PCGenModifier<T[]> getFixedModifier(FormatManager<T[]> fmtManager,
+		String instructions)
 	{
 		T[] toAdd = fmtManager.convert(instructions);
-		return new AddDirectArrayModifier(fmtManager, userPriority, toAdd);
+		return new AddDirectArrayModifier(fmtManager, toAdd);
 	}
 
 	/**
@@ -93,9 +91,9 @@ public class AddModifierFactory<T> implements ModifierFactory<T[]>
 		private T[] toAdd;
 
 		private AddDirectArrayModifier(FormatManager<T[]> formatManager,
-			int userPriority, T[] toAdd)
+			T[] toAdd)
 		{
-			super(formatManager, userPriority);
+			super(formatManager);
 			this.toAdd = toAdd;
 		}
 
@@ -126,9 +124,9 @@ public class AddModifierFactory<T> implements ModifierFactory<T[]>
 		private Indirect<T[]> toAdd;
 
 		private AddIndirectArrayModifier(FormatManager<T[]> formatManager,
-			int userPriority, Indirect<T[]> toAdd)
+			Indirect<T[]> toAdd)
 		{
-			super(formatManager, userPriority);
+			super(formatManager);
 			this.toAdd = toAdd;
 		}
 
@@ -152,30 +150,17 @@ public class AddModifierFactory<T> implements ModifierFactory<T[]>
 	private abstract class AddArrayModifier extends AbstractPCGenModifier<T[]>
 	{
 
-		/**
-		 * The user priority of this AddModifier
-		 */
-		private final int userPriority;
-
 		private final FormatManager<T[]> fmtManager;
 
-		protected AddArrayModifier(FormatManager<T[]> formatManager,
-			int userPriority)
+		AddArrayModifier(FormatManager<T[]> formatManager)
 		{
 			this.fmtManager = formatManager;
-			this.userPriority = userPriority;
-		}
-
-		@Override
-		public int getUserPriority()
-		{
-			return userPriority;
 		}
 
 		@Override
 		public long getPriority()
 		{
-			return ((long) userPriority << 32) + 3;
+			return ((long) getUserPriority() << 32) + 3;
 		}
 
 		@Override

--- a/code/src/java/plugin/modifier/set/SetModifierFactory.java
+++ b/code/src/java/plugin/modifier/set/SetModifierFactory.java
@@ -57,21 +57,20 @@ public class SetModifierFactory<T> extends AbstractFixedSetModifierFactory<T[]>
 	}
 
 	@Override
-	public PCGenModifier<T[]> getModifier(int userPriority, String instructions,
+	public PCGenModifier<T[]> getModifier(String instructions,
 		ManagerFactory managerFactory, FormulaManager ignored, LegalScope varScope,
 		FormatManager<T[]> formatManager)
 	{
 		Indirect<T[]> indirect = formatManager.convertIndirect(instructions);
-		return new SetIndirectArrayModifier(formatManager, userPriority,
-			indirect);
+		return new SetIndirectArrayModifier(formatManager, indirect);
 	}
 
 	@Override
-	public PCGenModifier<T[]> getFixedModifier(int userPriority,
+	public PCGenModifier<T[]> getFixedModifier(
 		FormatManager<T[]> fmtManager, String instructions)
 	{
 		T[] toSet = fmtManager.convert(instructions);
-		return new SetDirectArrayModifier(fmtManager, userPriority, toSet);
+		return new SetDirectArrayModifier(fmtManager, toSet);
 	}
 
 	/**
@@ -87,9 +86,9 @@ public class SetModifierFactory<T> extends AbstractFixedSetModifierFactory<T[]>
 		private T[] toSet;
 
 		private SetDirectArrayModifier(FormatManager<T[]> formatManager,
-		                               int userPriority, T[] toSet)
+			T[] toSet)
 		{
-			super(formatManager, userPriority);
+			super(formatManager);
 			this.toSet = toSet;
 		}
 
@@ -104,7 +103,6 @@ public class SetModifierFactory<T> extends AbstractFixedSetModifierFactory<T[]>
 		{
 			return toSet;
 		}
-
 	}
 
 	/**
@@ -120,9 +118,9 @@ public class SetModifierFactory<T> extends AbstractFixedSetModifierFactory<T[]>
 		private Indirect<T[]> toSet;
 
 		private SetIndirectArrayModifier(FormatManager<T[]> formatManager,
-			int userPriority, Indirect<T[]> toSet)
+			Indirect<T[]> toSet)
 		{
-			super(formatManager, userPriority);
+			super(formatManager);
 			this.toSet = toSet;
 		}
 
@@ -137,7 +135,6 @@ public class SetModifierFactory<T> extends AbstractFixedSetModifierFactory<T[]>
 		{
 			return toSet.get();
 		}
-
 	}
 
 	/**
@@ -146,30 +143,17 @@ public class SetModifierFactory<T> extends AbstractFixedSetModifierFactory<T[]>
 	abstract class SetArrayModifier extends AbstractPCGenModifier<T[]>
 	{
 
-		/**
-		 * The user priority of this SetModifier
-		 */
-		private final int userPriority;
-
 		private final FormatManager<T[]> fmtManager;
 
-		SetArrayModifier(FormatManager<T[]> formatManager,
-		                 int userPriority)
+		SetArrayModifier(FormatManager<T[]> formatManager)
 		{
 			this.fmtManager = formatManager;
-			this.userPriority = userPriority;
-		}
-
-		@Override
-		public int getUserPriority()
-		{
-			return userPriority;
 		}
 
 		@Override
 		public long getPriority()
 		{
-			return ((long) userPriority << 32);
+			return ((long) getUserPriority() << 32);
 		}
 
 		@Override

--- a/code/src/utest/pcgen/base/solver/SetSolverManagerTest.java
+++ b/code/src/utest/pcgen/base/solver/SetSolverManagerTest.java
@@ -15,8 +15,16 @@
  */
 package pcgen.base.solver;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Arrays;
 import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
 
 import pcgen.base.calculation.BasicCalculation;
 import pcgen.base.calculation.CalculationModifier;
@@ -47,15 +55,7 @@ import pcgen.cdom.reference.CDOMFactory;
 import pcgen.cdom.reference.SimpleReferenceManufacturer;
 import pcgen.core.Equipment;
 import pcgen.rules.persistence.token.ModifierFactory;
-
-import org.junit.Before;
-import org.junit.Test;
 import plugin.function.DropIntoContext;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 public class SetSolverManagerTest
 {
@@ -114,23 +114,25 @@ public class SetSolverManagerTest
 		SolverFactory solverFactory = new SolverFactory();
 		ModifierFactory am1 = new plugin.modifier.set.SetModifierFactory<>();
 		PCGenModifier emptyArrayMod =
-				am1.getModifier(0, "", managerFactory, null, globalScope, arrayManager);
+				am1.getModifier("", managerFactory, null, globalScope, arrayManager);
 		solverFactory.addSolverFormat(arrayManager.getManagedClass(), emptyArrayMod);
 		
 		NEPCalculation calc = new ProcessCalculation<>(new Equipment(),
 				new BasicSet(), equipmentManager);
-		CalculationModifier em = new CalculationModifier<>(calc, 0, equipmentManager);
+		CalculationModifier em = new CalculationModifier<>(calc, equipmentManager);
 		solverFactory.addSolverFormat(Equipment.class, em);
 
 		manager = new DynamicSolverManager(fm, managerFactory, solverFactory, vc);
 		ModifierFactory mfn = new plugin.modifier.number.SetModifierFactory();
-		Modifier mod =
-				mfn.getModifier(0, "0", managerFactory, null, globalScope, numberManager);
+		PCGenModifier mod =
+				mfn.getModifier("0", managerFactory, null, globalScope, numberManager);
+		mod.addAssociation("PRIORITY=0");
 		solverFactory.addSolverFormat(numberManager.getManagedClass(), mod);
 		ModifierFactory mfs = new plugin.modifier.string.SetModifierFactory();
 		Modifier mods =
-				mfs.getModifier(0, "", managerFactory, null, globalScope, stringManager);
+				mfs.getModifier("", managerFactory, null, globalScope, stringManager);
 		solverFactory.addSolverFormat(stringManager.getManagedClass(), mods);
+
 	}
 
 	@Test
@@ -149,9 +151,10 @@ public class SetSolverManagerTest
 		vc.reset();
 
 		ModifierFactory am1 = new plugin.modifier.set.AddModifierFactory<>();
-		PCGenModifier mod = am1.getModifier(2000, "France,England", new ManagerFactory()
+		PCGenModifier mod = am1.getModifier("France,England", new ManagerFactory()
 		{
 		}, null, globalScope, arrayManager);
+		mod.addAssociation("PRIORITY=2000");
 		manager.addModifier(regions, mod, scopeInst);
 		array = vc.get(regions);
 		assertThat(2, is(array.length));
@@ -163,9 +166,10 @@ public class SetSolverManagerTest
 		vc.reset();
 
 		ModifierFactory am2 = new plugin.modifier.set.AddModifierFactory<>();
-		mod = am2.getModifier(3000, "Greece,England", new ManagerFactory()
+		mod = am2.getModifier("Greece,England", new ManagerFactory()
 		{
 		}, null, globalScope, arrayManager);
+		mod.addAssociation("PRIORITY=3000");
 		manager.addModifier(regions, mod, scopeInst);
 		array = vc.get(regions);
 		assertThat(3, is(array.length));
@@ -207,27 +211,31 @@ public class SetSolverManagerTest
 		
 		ModifierFactory am1 = new plugin.modifier.number.SetModifierFactory();
 		ModifierFactory amString = new plugin.modifier.string.SetModifierFactory();
-		PCGenModifier mod2 = am1.getModifier(2000, "2", new ManagerFactory()
+		PCGenModifier mod2 = am1.getModifier("2", new ManagerFactory()
 		{
 		}, fm, globalScope, numberManager);
-		PCGenModifier mod3 = am1.getModifier(2000, "3", new ManagerFactory()
+		mod2.addAssociation("PRIORITY=2000");
+		PCGenModifier mod3 = am1.getModifier("3", new ManagerFactory()
 		{
 		}, fm, globalScope, numberManager);
-		PCGenModifier mod4 = am1.getModifier(3000, "4", new ManagerFactory()
+		mod3.addAssociation("PRIORITY=2000");
+		PCGenModifier mod4 = am1.getModifier("4", new ManagerFactory()
 		{
 		}, fm, globalScope, numberManager);
+		mod4.addAssociation("PRIORITY=3000");
 		String formula = "dropIntoContext(\"EQUIPMENT\",EquipVar,LocalVar)";
-		PCGenModifier modf = am1.getModifier(2000, formula, new ManagerFactory()
+		PCGenModifier modf = am1.getModifier(formula, new ManagerFactory()
 		{
 		}, fm, globalScope, numberManager);
+		modf.addAssociation("PRIORITY=2000");
 		
 		NEPCalculation calc1 = new ProcessCalculation<>(equip,
 				new BasicSet(), equipmentManager);
-		CalculationModifier mod_e1 = new CalculationModifier<>(calc1, 2000, equipmentManager);
+		CalculationModifier mod_e1 = new CalculationModifier<>(calc1, equipmentManager);
 
 		NEPCalculation calc2 = new ProcessCalculation<>(equipalt,
 				new BasicSet(), equipmentManager);
-		CalculationModifier mod_e2 = new CalculationModifier<>(calc2, 3000, equipmentManager);
+		CalculationModifier mod_e2 = new CalculationModifier<>(calc2, equipmentManager);
 
 		manager.addModifier(varIDe, mod2, scopeInste);
 		manager.addModifier(varIDa, mod3, scopeInsta);

--- a/code/src/utest/plugin/modifier/bool/SetBooleanModifierTest.java
+++ b/code/src/utest/plugin/modifier/bool/SetBooleanModifierTest.java
@@ -17,17 +17,19 @@
  */
 package plugin.modifier.bool;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import pcgen.base.calculation.PCGenModifier;
 import pcgen.base.format.BooleanManager;
 import pcgen.base.formula.base.LegalScope;
 import pcgen.base.formula.base.ManagerFactory;
 import pcgen.base.formula.inst.SimpleLegalScope;
-import pcgen.base.solver.Modifier;
 import pcgen.base.util.FormatManager;
 import pcgen.rules.persistence.token.ModifierFactory;
-
-import org.junit.Test;
 import plugin.modifier.testsupport.EvalManagerUtilities;
-import static org.junit.Assert.*;
 
 public class SetBooleanModifierTest
 {
@@ -41,7 +43,7 @@ public class SetBooleanModifierTest
 		try
 		{
 			ModifierFactory m = new SetModifierFactory();
-			m.getModifier(100, null, new ManagerFactory(){}, null, null, null);
+			m.getModifier(null, new ManagerFactory(){}, null, null, null);
 			fail("Expected SetModifier with null set value to fail");
 		}
 		catch (IllegalArgumentException | NullPointerException e)
@@ -54,8 +56,9 @@ public class SetBooleanModifierTest
 	public void testGetModifier()
 	{
 		ModifierFactory factory = new SetModifierFactory();
-		Modifier<Boolean> modifier =
-				factory.getModifier(5, "True", new ManagerFactory(){}, null, varScope, booleanManager);
+		PCGenModifier<Boolean> modifier =
+				factory.getModifier("True", new ManagerFactory(){}, null, varScope, booleanManager);
+		modifier.addAssociation("PRIORITY=5");
 		assertEquals(5L <<32, modifier.getPriority());
 		assertEquals(booleanManager, modifier.getVariableFormat());
 		assertEquals(Boolean.TRUE, modifier.process(EvalManagerUtilities.getInputEM(Boolean.FALSE)));

--- a/code/src/utest/plugin/modifier/number/AddNumberModifierTest.java
+++ b/code/src/utest/plugin/modifier/number/AddNumberModifierTest.java
@@ -17,18 +17,20 @@
  */
 package plugin.modifier.number;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
 import pcgen.base.calculation.BasicCalculation;
+import pcgen.base.calculation.PCGenModifier;
 import pcgen.base.format.NumberManager;
 import pcgen.base.formula.base.LegalScope;
 import pcgen.base.formula.base.ManagerFactory;
 import pcgen.base.formula.inst.SimpleLegalScope;
-import pcgen.base.solver.Modifier;
 import pcgen.base.util.FormatManager;
 import pcgen.rules.persistence.token.ModifierFactory;
-
-import org.junit.Test;
 import plugin.modifier.testsupport.EvalManagerUtilities;
-import static org.junit.Assert.*;
 
 public class AddNumberModifierTest
 {
@@ -41,7 +43,7 @@ public class AddNumberModifierTest
 		try
 		{
 			ModifierFactory m = new AddModifierFactory();
-			m.getModifier(100, null, new ManagerFactory(){}, null, null, null);
+			m.getModifier(null, new ManagerFactory(){}, null, null, null);
 			fail("Expected AddModifier with null adder to fail");
 		}
 		catch (IllegalArgumentException | NullPointerException e)
@@ -194,8 +196,9 @@ public class AddNumberModifierTest
 	public void testGetModifier()
 	{
 		AddModifierFactory factory = new AddModifierFactory();
-		Modifier<Number> modifier =
-				factory.getModifier(35, "6.5", new ManagerFactory(){}, null, varScope, numManager);
+		PCGenModifier<Number> modifier =
+				factory.getModifier("6.5", new ManagerFactory(){}, null, varScope, numManager);
+		modifier.addAssociation("PRIORITY=35");
 		assertEquals((35L <<32)+factory.getInherentPriority(), modifier.getPriority());
 		assertEquals(numManager, modifier.getVariableFormat());
 		assertEquals(10.8, modifier.process(EvalManagerUtilities.getInputEM(4.3)));

--- a/code/src/utest/plugin/modifier/number/DivideNumberModifierTest.java
+++ b/code/src/utest/plugin/modifier/number/DivideNumberModifierTest.java
@@ -17,17 +17,19 @@
  */
 package plugin.modifier.number;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
 import pcgen.base.calculation.BasicCalculation;
+import pcgen.base.calculation.PCGenModifier;
 import pcgen.base.format.NumberManager;
 import pcgen.base.formula.base.LegalScope;
 import pcgen.base.formula.base.ManagerFactory;
 import pcgen.base.formula.inst.SimpleLegalScope;
-import pcgen.base.solver.Modifier;
 import pcgen.base.util.FormatManager;
-
-import org.junit.Test;
 import plugin.modifier.testsupport.EvalManagerUtilities;
-import static org.junit.Assert.*;
 
 public class DivideNumberModifierTest
 {
@@ -41,7 +43,7 @@ public class DivideNumberModifierTest
 		try
 		{
 			DivideModifierFactory m = new DivideModifierFactory();
-			m.getModifier(100, null, new ManagerFactory(){}, null, null, null);
+			m.getModifier(null, new ManagerFactory(){}, null, null, null);
 			fail("Expected DivideModifierFactory with null divide value to fail");
 		}
 		catch (IllegalArgumentException | NullPointerException e)
@@ -194,8 +196,9 @@ public class DivideNumberModifierTest
 	public void testGetModifier()
 	{
 		DivideModifierFactory factory = new DivideModifierFactory();
-		Modifier<Number> modifier =
-				factory.getModifier(35, "4.3", new ManagerFactory(){}, null, varScope, numManager);
+		PCGenModifier<Number> modifier =
+				factory.getModifier("4.3", new ManagerFactory(){}, null, varScope, numManager);
+		modifier.addAssociation("PRIORITY=35");
 		assertEquals((35L <<32)+factory.getInherentPriority(), modifier.getPriority());
 		assertEquals(numManager, modifier.getVariableFormat());
 		assertEquals(3.2, modifier.process(EvalManagerUtilities.getInputEM(13.76)));

--- a/code/src/utest/plugin/modifier/number/MaxNumberModifierTest.java
+++ b/code/src/utest/plugin/modifier/number/MaxNumberModifierTest.java
@@ -17,17 +17,17 @@
  */
 package plugin.modifier.number;
 
+import org.junit.Test;
+
+import junit.framework.TestCase;
 import pcgen.base.calculation.BasicCalculation;
+import pcgen.base.calculation.PCGenModifier;
 import pcgen.base.format.NumberManager;
 import pcgen.base.formula.base.LegalScope;
 import pcgen.base.formula.base.ManagerFactory;
 import pcgen.base.formula.inst.SimpleLegalScope;
-import pcgen.base.solver.Modifier;
 import pcgen.base.util.FormatManager;
 import pcgen.rules.persistence.token.ModifierFactory;
-
-import junit.framework.TestCase;
-import org.junit.Test;
 import plugin.modifier.testsupport.EvalManagerUtilities;
 
 public class MaxNumberModifierTest extends TestCase
@@ -41,7 +41,7 @@ public class MaxNumberModifierTest extends TestCase
 		try
 		{
 			ModifierFactory m = new MaxModifierFactory();
-			m.getModifier(100, null, null, null, null, null);
+			m.getModifier(null, null, null, null, null);
 			fail("Expected MaxModifier with null compare value to fail");
 		}
 		catch (IllegalArgumentException | NullPointerException e)
@@ -194,8 +194,9 @@ public class MaxNumberModifierTest extends TestCase
 	public void testGetModifier()
 	{
 		MaxModifierFactory factory = new MaxModifierFactory();
-		Modifier<Number> modifier =
-				factory.getModifier(35, "6.5", new ManagerFactory(){}, null, varScope, numManager);
+		PCGenModifier<Number> modifier =
+				factory.getModifier("6.5", new ManagerFactory(){}, null, varScope, numManager);
+		modifier.addAssociation("PRIORITY=35");
 		assertEquals((35L <<32)+factory.getInherentPriority(), modifier.getPriority());
 		assertEquals(numManager, modifier.getVariableFormat());
 		assertEquals(6.5, modifier.process(EvalManagerUtilities.getInputEM(4.3)));

--- a/code/src/utest/plugin/modifier/number/MinNumberModifierTest.java
+++ b/code/src/utest/plugin/modifier/number/MinNumberModifierTest.java
@@ -17,17 +17,17 @@
  */
 package plugin.modifier.number;
 
+import org.junit.Test;
+
+import junit.framework.TestCase;
 import pcgen.base.calculation.BasicCalculation;
+import pcgen.base.calculation.PCGenModifier;
 import pcgen.base.format.NumberManager;
 import pcgen.base.formula.base.LegalScope;
 import pcgen.base.formula.base.ManagerFactory;
 import pcgen.base.formula.inst.SimpleLegalScope;
-import pcgen.base.solver.Modifier;
 import pcgen.base.util.FormatManager;
 import pcgen.rules.persistence.token.ModifierFactory;
-
-import junit.framework.TestCase;
-import org.junit.Test;
 import plugin.modifier.testsupport.EvalManagerUtilities;
 
 public class MinNumberModifierTest extends TestCase
@@ -42,7 +42,7 @@ public class MinNumberModifierTest extends TestCase
 		try
 		{
 			ModifierFactory m = new MinModifierFactory();
-			m.getModifier(100, null, new ManagerFactory(){}, null, null, null);
+			m.getModifier(null, new ManagerFactory(){}, null, null, null);
 			fail("Expected MaxModifier with null compare value to fail");
 		}
 		catch (IllegalArgumentException | NullPointerException e)
@@ -195,8 +195,9 @@ public class MinNumberModifierTest extends TestCase
 	public void testGetModifier()
 	{
 		MinModifierFactory factory = new MinModifierFactory();
-		Modifier<Number> modifier =
-				factory.getModifier(35, "6.5", new ManagerFactory(){}, null, varScope, numManager);
+		PCGenModifier<Number> modifier =
+				factory.getModifier("6.5", new ManagerFactory(){}, null, varScope, numManager);
+		modifier.addAssociation("PRIORITY=35");
 		assertEquals((35L <<32)+factory.getInherentPriority(), modifier.getPriority());
 		assertEquals(numManager, modifier.getVariableFormat());
 		assertEquals(4.3, modifier.process(EvalManagerUtilities.getInputEM(4.3)));

--- a/code/src/utest/plugin/modifier/number/MultiplyNumberModifierTest.java
+++ b/code/src/utest/plugin/modifier/number/MultiplyNumberModifierTest.java
@@ -17,18 +17,20 @@
  */
 package plugin.modifier.number;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
 import pcgen.base.calculation.BasicCalculation;
+import pcgen.base.calculation.PCGenModifier;
 import pcgen.base.format.NumberManager;
 import pcgen.base.formula.base.LegalScope;
 import pcgen.base.formula.base.ManagerFactory;
 import pcgen.base.formula.inst.SimpleLegalScope;
-import pcgen.base.solver.Modifier;
 import pcgen.base.util.FormatManager;
 import pcgen.rules.persistence.token.ModifierFactory;
-
-import org.junit.Test;
 import plugin.modifier.testsupport.EvalManagerUtilities;
-import static org.junit.Assert.*;
 
 public class MultiplyNumberModifierTest
 {
@@ -42,7 +44,7 @@ public class MultiplyNumberModifierTest
 		try
 		{
 			ModifierFactory m = new MultiplyModifierFactory();
-			m.getModifier(100, null, new ManagerFactory(){}, null, null, null);
+			m.getModifier(null, new ManagerFactory(){}, null, null, null);
 			fail("Expected MultiplyModifier with null multiply value to fail");
 		}
 		catch (IllegalArgumentException | NullPointerException e)
@@ -195,8 +197,9 @@ public class MultiplyNumberModifierTest
 	public void testGetModifier()
 	{
 		MultiplyModifierFactory factory = new MultiplyModifierFactory();
-		Modifier<Number> modifier =
-				factory.getModifier(35, "6.5", new ManagerFactory(){}, null, varScope, numManager);
+		PCGenModifier<Number> modifier =
+				factory.getModifier("6.5", new ManagerFactory(){}, null, varScope, numManager);
+		modifier.addAssociation("PRIORITY=35");
 		assertEquals((35L <<32)+factory.getInherentPriority(), modifier.getPriority());
 		assertEquals(numManager, modifier.getVariableFormat());
 		assertEquals(27.95, modifier.process(EvalManagerUtilities.getInputEM(4.3)));

--- a/code/src/utest/plugin/modifier/number/SetNumberModifierTest.java
+++ b/code/src/utest/plugin/modifier/number/SetNumberModifierTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.fail;
 
 import org.junit.Test;
 
+import pcgen.base.calculation.PCGenModifier;
 import pcgen.base.format.NumberManager;
 import pcgen.base.formula.base.EvaluationManager;
 import pcgen.base.formula.base.LegalScope;
@@ -29,7 +30,6 @@ import pcgen.base.formula.base.ManagerFactory;
 import pcgen.base.formula.inst.SimpleLegalScope;
 import pcgen.base.formula.inst.SimpleVariableStore;
 import pcgen.base.solver.IndividualSetup;
-import pcgen.base.solver.Modifier;
 import pcgen.base.solver.SplitFormulaSetup;
 import pcgen.base.util.FormatManager;
 import plugin.modifier.testsupport.EvalManagerUtilities;
@@ -46,7 +46,7 @@ public class SetNumberModifierTest
 		try
 		{
 			SetModifierFactory m = new SetModifierFactory();
-			m.getModifier(100, null, new ManagerFactory(){}, null, null, null);
+			m.getModifier(null, new ManagerFactory(){}, null, null, null);
 			fail("Expected SetModifier with null set value to fail");
 		}
 		catch (IllegalArgumentException | NullPointerException e)
@@ -199,8 +199,9 @@ public class SetNumberModifierTest
 	public void testGetModifier()
 	{
 		SetModifierFactory factory = new SetModifierFactory();
-		Modifier<Number> modifier =
-				factory.getModifier(35, "6.5", new ManagerFactory(){}, null, varScope, numManager);
+		PCGenModifier<Number> modifier =
+				factory.getModifier("6.5", new ManagerFactory(){}, null, varScope, numManager);
+		modifier.addAssociation("PRIORITY=35");
 		assertEquals((35L<<32)+factory.getInherentPriority(), modifier.getPriority());
 		assertEquals(numManager, modifier.getVariableFormat());
 		assertEquals(6.5, modifier.process(EvalManagerUtilities.getInputEM(4.3)));
@@ -214,8 +215,9 @@ public class SetNumberModifierTest
 		setup.getLegalScopeLibrary().registerScope(varScope);
 		IndividualSetup iSetup = new IndividualSetup(setup, "Global", new SimpleVariableStore());
 		SetModifierFactory factory = new SetModifierFactory();
-		Modifier<Number> modifier =
-				factory.getModifier(35, "6+5", new ManagerFactory(){}, iSetup.getFormulaManager(), varScope, numManager);
+		PCGenModifier<Number> modifier =
+				factory.getModifier("6+5", new ManagerFactory(){}, iSetup.getFormulaManager(), varScope, numManager);
+		modifier.addAssociation("PRIORITY=35");
 		assertEquals((35L<<32)+factory.getInherentPriority(), modifier.getPriority());
 		assertEquals(numManager, modifier.getVariableFormat());
 		EvaluationManager evalManager = EvalManagerUtilities.getInputEM(4.3);

--- a/code/src/utest/plugin/modifier/orderedpair/SetOrderedPairModifierTest.java
+++ b/code/src/utest/plugin/modifier/orderedpair/SetOrderedPairModifierTest.java
@@ -17,18 +17,20 @@
  */
 package plugin.modifier.orderedpair;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import pcgen.base.calculation.PCGenModifier;
 import pcgen.base.format.OrderedPairManager;
 import pcgen.base.formula.base.LegalScope;
 import pcgen.base.formula.base.ManagerFactory;
 import pcgen.base.formula.inst.SimpleLegalScope;
 import pcgen.base.math.OrderedPair;
-import pcgen.base.solver.Modifier;
 import pcgen.base.util.FormatManager;
 import pcgen.rules.persistence.token.ModifierFactory;
-
-import org.junit.Test;
 import plugin.modifier.testsupport.EvalManagerUtilities;
-import static org.junit.Assert.*;
 
 public class SetOrderedPairModifierTest
 {
@@ -42,7 +44,7 @@ public class SetOrderedPairModifierTest
 		try
 		{
 			SetModifierFactory m = new SetModifierFactory();
-			m.getModifier(100, null, new ManagerFactory(){}, null, null, null);
+			m.getModifier(null, new ManagerFactory(){}, null, null, null);
 			fail("Expected SetModifier with null set value to fail");
 		}
 		catch (IllegalArgumentException | NullPointerException e)
@@ -55,8 +57,9 @@ public class SetOrderedPairModifierTest
 	public void testGetModifier()
 	{
 		ModifierFactory<OrderedPair> factory = new SetModifierFactory();
-		Modifier<OrderedPair> modifier =
-				factory.getModifier(5, "3,2", new ManagerFactory(){}, null, varScope, opManager);
+		PCGenModifier<OrderedPair> modifier =
+				factory.getModifier("3,2", new ManagerFactory(){}, null, varScope, opManager);
+		modifier.addAssociation("PRIORITY=5");
 		assertEquals(5L <<32, modifier.getPriority());
 		assertEquals(opManager, modifier.getVariableFormat());
 		assertEquals(new OrderedPair(3, 2),

--- a/code/src/utest/plugin/modifier/string/SetStringModifierTest.java
+++ b/code/src/utest/plugin/modifier/string/SetStringModifierTest.java
@@ -17,17 +17,19 @@
  */
 package plugin.modifier.string;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import pcgen.base.calculation.PCGenModifier;
 import pcgen.base.format.StringManager;
 import pcgen.base.formula.base.LegalScope;
 import pcgen.base.formula.base.ManagerFactory;
 import pcgen.base.formula.inst.SimpleLegalScope;
-import pcgen.base.solver.Modifier;
 import pcgen.base.util.FormatManager;
 import pcgen.rules.persistence.token.ModifierFactory;
-
-import org.junit.Test;
 import plugin.modifier.testsupport.EvalManagerUtilities;
-import static org.junit.Assert.*;
 
 public class SetStringModifierTest
 {
@@ -41,7 +43,7 @@ public class SetStringModifierTest
 		try
 		{
 			SetModifierFactory m = new SetModifierFactory();
-			m.getModifier(100, null, new ManagerFactory(){}, null, null, null);
+			m.getModifier(null, new ManagerFactory(){}, null, null, null);
 			fail("Expected SetModifier with null set value to fail");
 		}
 		catch (IllegalArgumentException | NullPointerException e)
@@ -54,8 +56,9 @@ public class SetStringModifierTest
 	public void testGetModifier()
 	{
 		ModifierFactory<String> factory = new SetModifierFactory();
-		Modifier<String> modifier =
-				factory.getModifier(5, "MyString", new ManagerFactory(){}, null, varScope, stringManager);
+		PCGenModifier<String> modifier =
+				factory.getModifier("MyString", new ManagerFactory(){}, null, varScope, stringManager);
+		modifier.addAssociation("PRIORITY=5");
 		assertEquals(5L <<32, modifier.getPriority());
 		assertEquals(stringManager, modifier.getVariableFormat());
 		assertEquals("MyString", modifier.process(EvalManagerUtilities.getInputEM("Wrong Answer")));


### PR DESCRIPTION
This converts "user priority" to a full-fledged association. Previously it was a special case of trailing information on a MODIFY or MODIFYOTHER. This prepares for additional use cases of associations (which are now merged in -base and making their way to the main repo.