### PR TITLE
EMH - Load Error Corrections

### DIFF
--- a/data/pathfinder/paizo/player_companion/elemental_masters_handbook/_elemental_masters_handbook.pcc
+++ b/data/pathfinder/paizo/player_companion/elemental_masters_handbook/_elemental_masters_handbook.pcc
@@ -48,7 +48,6 @@ ABILITY:support/emh_abilities_race_pu.lst|PRECAMPAIGN:1,INCLUDES=Pathfinder Unch
 CLASS:support/emh_classes_pu.lst|PRECAMPAIGN:1,INCLUDES=Pathfinder Unchained
 
 
-FORWARDREF:ABILITY=Special Ability|Varisian Tattoo ~ Ragario,Wild Talent ~ Void Healer
 FORWARDREF:SPELL|Wall of Ectoplasm
 
 


### PR DESCRIPTION
Removed FORWARDREF; it's not needed for PREABILITY. Wild Talent ~ Void Healer does not yet exist in any source, and as such was causing an unconstructed reference error even in only for FORWARDREF.