### PR TITLE
Load Error Corrections

### DIFF
--- a/data/pathfinder/paizo/adventure_path/curse_of_the_crimson_throne/ap11/ap11.pcc
+++ b/data/pathfinder/paizo/adventure_path/curse_of_the_crimson_throne/ap11/ap11.pcc
@@ -51,4 +51,4 @@ KIT:ap11_kits_race.lst
 RACE:ap11_races.lst
 
 # Prevent unconstructed reference errors
-FORWARDREF:EQMOD|BANE_M
+#FORWARDREF:EQMOD|BANE_M

--- a/data/pathfinder/paizo/adventure_path/curse_of_the_crimson_throne/ap8/ap8_kits.lst
+++ b/data/pathfinder/paizo/adventure_path/curse_of_the_crimson_throne/ap8/ap8_kits.lst
@@ -164,7 +164,7 @@ ABILITY:CATEGORY=Rogue Talent|Rogue Talent ~ Trap Spotter
 ABILITY:CATEGORY=Rogue Talent|Rogue Talent ~ Surprise Attack
 ABILITY:CATEGORY=Rogue Talent|Rogue Talent ~ Finesse Rogue
 CLASS:Sorcerer	LEVEL:2
-ABILITY:CATEGORY=Sorcerer Bloodline|Sorcerer Bloodline ~ Undead
+ABILITY:CATEGORY=Special Ability|Sorcerer Bloodline ~ Undead
 STAT:STR=12|DEX=14|CON=16|INT=10|WIS=8|CHA=14
 SKILL:Acrobatics		RANK:8
 SKILL:Bluff			RANK:8

--- a/data/pathfinder/paizo/roleplaying_game/advanced_players_guide/apg_equip_general.lst
+++ b/data/pathfinder/paizo/roleplaying_game/advanced_players_guide/apg_equip_general.lst
@@ -17,7 +17,7 @@ Chest (Medium)			OUTPUTNAME:Chest, Medium			TYPE:Goods.General.Container			CONTA
 Chest (Large)			OUTPUTNAME:Chest, Large				TYPE:Goods.General.Container			CONTAINS:UNLIM|Any		COST:10	WT:100	SOURCEPAGE:p.182
 Chest (Huge)			OUTPUTNAME:Chest, Huge				TYPE:Goods.General.Container			CONTAINS:UNLIM|Any		COST:25	WT:250	SOURCEPAGE:p.182
 Earplugs											TYPE:Goods.General									COST:0.03	WT:0		SOURCEPAGE:p.182
-Hourglass (1 hour)		OUTPUTNAME:Hourglass, 1 hour			TYPE:Goods.General									COST:25	WT:1		SOURCEPAGE:p.182
+Hourglass (1 Hour)		OUTPUTNAME:Hourglass, 1 hour			TYPE:Goods.General									COST:25	WT:1		SOURCEPAGE:p.182
 Hourglass (1 minute)		OUTPUTNAME:Hourglass, 1 minute		TYPE:Goods.General									COST:20	WT:0.5	SOURCEPAGE:p.182
 Hourglass (6 seconds)		OUTPUTNAME:Hourglass, 6 seconds		TYPE:Goods.General									COST:10	WT:0		SOURCEPAGE:p.182
 Iron Spike											TYPE:Goods.General									COST:0.05	WT:1		SOURCEPAGE:p.182


### PR DESCRIPTION
Removed bad FOREWARDREF; I can't figure out what it's supposed to be forwarding. Source loads fine without it.
Changed ability reference in kit to match others. It's still wrong, but it needs the ability chooser reference fix, and this way it doesn't cause loading errors. I'm not sure where it was changed earlier that I'm only now noticing it.
Fixed a capitalization error that was causing a mismatch error on load.