### PR TITLE
Create a general method for grabbing "direct" children

### DIFF
--- a/code/src/java/pcgen/cdom/base/CDOMObject.java
+++ b/code/src/java/pcgen/cdom/base/CDOMObject.java
@@ -1214,4 +1214,11 @@ public abstract class CDOMObject extends ConcretePrereqObject implements
 		return null;
 	}
 
+	@SuppressWarnings("PMD.EmptyMethodInAbstractClassShouldBeAbstract")
+	public CDOMObject getLocalChild(String childType, String childName)
+	{
+		//I don't have any children by default
+		return null;
+	}
+
 }

--- a/code/src/java/pcgen/core/Equipment.java
+++ b/code/src/java/pcgen/core/Equipment.java
@@ -6086,6 +6086,7 @@ public final class Equipment extends PObject implements Serializable,
 				heads.add(null);
 			}
 			head = new EquipmentHead(this, index);
+			head.setName(Integer.toString(index));
 			heads.add(head);
 		}
 		else
@@ -6094,6 +6095,7 @@ public final class Equipment extends PObject implements Serializable,
 			if (head == null)
 			{
 				head = new EquipmentHead(this, index);
+				head.setName(Integer.toString(index));
 				heads.set(headsIndex, head);
 			}
 		}
@@ -6666,5 +6668,21 @@ public final class Equipment extends PObject implements Serializable,
 	{
 		ResultFacet resultFacet = FacetLibrary.getFacet(ResultFacet.class);
 		return resultFacet.getLocalVariable(id, this, varName);
+	}
+
+	@Override
+	public CDOMObject getLocalChild(String childType, String childName)
+	{
+		if ("PART".equalsIgnoreCase(childType))
+		{
+			for(EquipmentHead head : heads)
+			{
+				if (head.getKeyName().equals(childName))
+				{
+					return head;
+				}
+			}
+		}
+		return null;
 	}
 }


### PR DESCRIPTION
Currently this impacts EquipmentHead, but it is likely this will
impact other things in the variable system (think Skill Situations)