### PR TITLE
Simplify how LoadContext works to avoid a dummy object. 

### DIFF
--- a/code/src/itest/plugin/lsttokens/editcontext/race/FaceIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/race/FaceIntegrationTest.java
@@ -50,9 +50,9 @@ public class FaceIntegrationTest extends AbstractIntegrationTestCase<Race>
 		super.setUp();
 		TokenRegistration.register(m);
 		primaryContext.getVariableContext().assertLegalVariableID(
-			primaryContext.getActiveScope().getLegalScope(), opManager, "Face");
+			primaryContext.getActiveScope(), opManager, "Face");
 		secondaryContext.getVariableContext().assertLegalVariableID(
-			secondaryContext.getActiveScope().getLegalScope(), opManager, "Face");
+			secondaryContext.getActiveScope(), opManager, "Face");
 	}
 
 	@Override

--- a/code/src/itest/plugin/lsttokens/editcontext/template/FaceIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/template/FaceIntegrationTest.java
@@ -52,9 +52,9 @@ public class FaceIntegrationTest extends
 		super.setUp();
 		TokenRegistration.register(m);
 		primaryContext.getVariableContext().assertLegalVariableID(
-			primaryContext.getActiveScope().getLegalScope(), opManager, "Face");
+			primaryContext.getActiveScope(), opManager, "Face");
 		secondaryContext.getVariableContext().assertLegalVariableID(
-			secondaryContext.getActiveScope().getLegalScope(), opManager, "Face");
+			secondaryContext.getActiveScope(), opManager, "Face");
 	}
 
 	@Override

--- a/code/src/java/pcgen/rules/context/LoadContext.java
+++ b/code/src/java/pcgen/rules/context/LoadContext.java
@@ -21,7 +21,7 @@ import java.net.URI;
 import java.util.Collection;
 import java.util.List;
 
-import pcgen.base.formula.base.ScopeInstance;
+import pcgen.base.formula.base.LegalScope;
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.base.CDOMReference;
 import pcgen.cdom.base.GroupDefinition;
@@ -150,11 +150,31 @@ public interface LoadContext
 	 */
 	public void loadLocalToken(Object token);
 	
-	public <T> GroupDefinition<T> getGroup(Class<T> cl, String s);
+	/**
+	 * Returns a GroupDefinition<T> based on the given Class and Group instructions
+	 * 
+	 * Note: This is used to convert dynamic groups (produced by FACT/FACTSET) into primitives that 
+	 * can be used in tokens like CHOOSE.
+	 * 
+	 * @param cl The class of object used for the GroupDefinition
+	 * @param instructions The instructions used to determine the contents of the GroupDefinition
+	 * @return A GroupDefinition<T> based on the given Class and Group instructions
+	 */
+	public <T> GroupDefinition<T> getGroup(Class<T> cl, String instructions);
 
 	LoadContext dropIntoContext(String scope);
 
+	/**
+	 * Returns the VariableContext for this LoadContext.
+	 * 
+	 * @return The VariableContext for this LoadContext
+	 */
 	VariableContext getVariableContext();
 
-	public ScopeInstance getActiveScope();
+	/**
+	 * Returns the currently active LegalScope.
+	 * 
+	 * @return The currently active LegalScope
+	 */
+	public LegalScope getActiveScope();
 }

--- a/code/src/java/pcgen/rules/context/LoadContextInst.java
+++ b/code/src/java/pcgen/rules/context/LoadContextInst.java
@@ -24,9 +24,6 @@ import java.util.Collections;
 import java.util.List;
 
 import pcgen.base.formula.base.LegalScope;
-import pcgen.base.formula.base.ScopeInstance;
-import pcgen.base.formula.base.VarScoped;
-import pcgen.base.formula.inst.SimpleScopeInstance;
 import pcgen.base.text.ParsingSeparator;
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.base.CDOMReference;
@@ -84,7 +81,7 @@ abstract class LoadContextInst implements LoadContext
 	//Per file
 	private CDOMObject stateful;
 	
-	private ScopeInstance scopeInst = null;
+	private LegalScope legalScope = null;
 
 	static
 	{
@@ -529,15 +526,13 @@ abstract class LoadContextInst implements LoadContext
 	}
 
 	@Override
-	public ScopeInstance getActiveScope()
+	public LegalScope getActiveScope()
 	{
-		if (scopeInst == null)
+		if (legalScope == null)
 		{
-			LegalScope legalScope = var.getScope("Global");
-			scopeInst = new SimpleScopeInstance(null, legalScope,
-				new DummyVarScoped(legalScope));
+			legalScope = var.getScope("Global");
 		}
-		return scopeInst;
+		return legalScope;
 	}
 
 	@Override
@@ -561,50 +556,25 @@ abstract class LoadContextInst implements LoadContext
 			return this;
 		}
 		LoadContext parentLC = dropIntoContext(parent);
-		SimpleScopeInstance localInst = new SimpleScopeInstance(parentLC.getActiveScope(),
-			lvs, new DummyVarScoped(lvs));
-		return new DerivedLoadContext(parentLC, localInst);
-	}
-
-	private static class DummyVarScoped implements VarScoped
-	{
-
-		private LegalScope lvs;
-
-		private DummyVarScoped(LegalScope lvs)
-		{
-			this.lvs = lvs;
-		}
-
-		@Override
-		public String getKeyName()
-		{
-			return "Context (during Load)";
-		}
-
-		@Override
-		public String getLocalScopeName()
-		{
-			return lvs.getName();
-		}
-
-		@Override
-		public VarScoped getVariableParent()
-		{
-			return null;
-		}
-		
+		return new DerivedLoadContext(parentLC, parentLC.getActiveScope());
 	}
 
 	private class DerivedLoadContext implements LoadContext
 	{
 
+		/**
+		 * The parent LoadContext for this DerivedLoadContext
+		 */
 		private final LoadContext parent;
-		private final ScopeInstance scopeInst;
 
-		public DerivedLoadContext(LoadContext parent, ScopeInstance lvs)
+		/**
+		 * The derived Scope for this DerivedLoadContext
+		 */
+		private final LegalScope derivedScope;
+
+		public DerivedLoadContext(LoadContext parent, LegalScope scope)
 		{
-			this.scopeInst = lvs;
+			this.derivedScope = scope;
 			this.parent = parent;
 		}
 
@@ -822,9 +792,9 @@ abstract class LoadContextInst implements LoadContext
 		}
 
 		@Override
-		public ScopeInstance getActiveScope()
+		public LegalScope getActiveScope()
 		{
-			return scopeInst;
+			return derivedScope;
 		}
 
 		@Override
@@ -836,22 +806,19 @@ abstract class LoadContextInst implements LoadContext
 				throw new IllegalArgumentException("LegalVariableScope "
 					+ scope + " does not exist");
 			}
-			LegalScope currentScope = scopeInst.getLegalScope();
-			if (currentScope.equals(toScope))
+			if (derivedScope.equals(toScope))
 			{
 				return this;
 			}
-			else if (currentScope.getParentScope().equals(toScope))
+			else if (derivedScope.getParentScope().equals(toScope))
 			{
 				//Jump up from here
 				return parent;
 			}
-			else if (toScope.getParentScope().equals(currentScope))
+			else if (toScope.getParentScope().equals(derivedScope))
 			{
 				//Direct drop from this
-				SimpleScopeInstance localInst = new SimpleScopeInstance(scopeInst,
-					toScope, new DummyVarScoped(toScope));
-				return new DerivedLoadContext(this, localInst);
+				return new DerivedLoadContext(this, derivedScope);
 			}
 			//Random jump to somewhere else...
 			return LoadContextInst.this.dropIntoContext(toScope);

--- a/code/src/java/pcgen/rules/context/LoadContextInst.java
+++ b/code/src/java/pcgen/rules/context/LoadContextInst.java
@@ -538,13 +538,13 @@ abstract class LoadContextInst implements LoadContext
 	@Override
 	public LoadContext dropIntoContext(String scope)
 	{
-		LegalScope legalScope = var.getScope(scope);
-		if (legalScope == null)
+		LegalScope subScope = var.getScope(scope);
+		if (subScope == null)
 		{
 			throw new IllegalArgumentException("LegalVariableScope " + scope
 				+ " does not exist");
 		}
-		return dropIntoContext(legalScope);
+		return dropIntoContext(subScope);
 	}
 
 	private LoadContext dropIntoContext(LegalScope lvs)
@@ -556,7 +556,7 @@ abstract class LoadContextInst implements LoadContext
 			return this;
 		}
 		LoadContext parentLC = dropIntoContext(parent);
-		return new DerivedLoadContext(parentLC, parentLC.getActiveScope());
+		return new DerivedLoadContext(parentLC, lvs);
 	}
 
 	private class DerivedLoadContext implements LoadContext

--- a/code/src/java/plugin/lsttokens/InfoVarsLst.java
+++ b/code/src/java/plugin/lsttokens/InfoVarsLst.java
@@ -65,7 +65,7 @@ public class InfoVarsLst extends AbstractTokenWithSeparator<CDOMObject>
 		VariableContext varContext = context.getVariableContext();
 		for (String name : val)
 		{
-			LegalScope scope = context.getActiveScope().getLegalScope();
+			LegalScope scope = context.getActiveScope();
 			if (!varContext.isLegalVariableID(scope, name))
 			{
 				return new ParseResult.Fail(getTokenName()

--- a/code/src/java/plugin/lsttokens/ModifyLst.java
+++ b/code/src/java/plugin/lsttokens/ModifyLst.java
@@ -25,7 +25,6 @@ import java.util.Set;
 
 import pcgen.base.calculation.PCGenModifier;
 import pcgen.base.formula.base.LegalScope;
-import pcgen.base.formula.base.ScopeInstance;
 import pcgen.base.lang.StringUtil;
 import pcgen.base.text.ParsingSeparator;
 import pcgen.base.util.CaseInsensitiveMap;
@@ -82,8 +81,7 @@ public class ModifyLst extends AbstractTokenWithSeparator<CDOMObject>
 				context);
 		}
 
-		ScopeInstance scopeInst = context.getActiveScope();
-		LegalScope scope = scopeInst.getLegalScope();
+		LegalScope scope = context.getActiveScope();
 		String varName = sep.next();
 		if (!context.getVariableContext().isLegalVariableID(scope, varName))
 		{

--- a/code/src/java/plugin/lsttokens/ModifyOtherLst.java
+++ b/code/src/java/plugin/lsttokens/ModifyOtherLst.java
@@ -26,7 +26,6 @@ import java.util.Set;
 
 import pcgen.base.calculation.PCGenModifier;
 import pcgen.base.formula.base.LegalScope;
-import pcgen.base.formula.base.ScopeInstance;
 import pcgen.base.formula.base.VarScoped;
 import pcgen.base.lang.StringUtil;
 import pcgen.base.text.ParsingSeparator;
@@ -102,8 +101,7 @@ public class ModifyOtherLst extends AbstractTokenWithSeparator<CDOMObject>
 	private <GT extends VarScoped> ParseResult continueParsing(
 		LoadContext context, CDOMObject obj, String value, ParsingSeparator sep)
 	{
-		ScopeInstance scopeInst = context.getActiveScope();
-		final LegalScope scope = scopeInst.getLegalScope();
+		final LegalScope scope = context.getActiveScope();
 		final String groupingName = sep.next();
 		ObjectGrouping group;
 		if (groupingName.startsWith("GROUP="))

--- a/code/src/java/plugin/lsttokens/race/FaceToken.java
+++ b/code/src/java/plugin/lsttokens/race/FaceToken.java
@@ -21,7 +21,6 @@ import java.util.Collection;
 
 import pcgen.base.calculation.PCGenModifier;
 import pcgen.base.formula.base.LegalScope;
-import pcgen.base.formula.base.ScopeInstance;
 import pcgen.base.math.OrderedPair;
 import pcgen.base.util.FormatManager;
 import pcgen.cdom.content.VarModifier;
@@ -69,8 +68,7 @@ public class FaceToken extends AbstractNonEmptyToken<Race> implements
 		FormatManager<OrderedPair> formatManager =
 				(FormatManager<OrderedPair>) context.getReferenceContext()
 					.getFormatManager("ORDEREDPAIR");
-		ScopeInstance scopeInst = context.getActiveScope();
-		LegalScope scope = scopeInst.getLegalScope();
+		LegalScope scope = context.getActiveScope();
 		PCGenModifier<OrderedPair> modifier;
 		try
 		{

--- a/code/src/java/plugin/lsttokens/template/FaceToken.java
+++ b/code/src/java/plugin/lsttokens/template/FaceToken.java
@@ -21,7 +21,6 @@ import java.util.Collection;
 
 import pcgen.base.calculation.PCGenModifier;
 import pcgen.base.formula.base.LegalScope;
-import pcgen.base.formula.base.ScopeInstance;
 import pcgen.base.math.OrderedPair;
 import pcgen.base.util.FormatManager;
 import pcgen.cdom.content.VarModifier;
@@ -76,8 +75,7 @@ public class FaceToken extends AbstractNonEmptyToken<PCTemplate> implements
 		FormatManager<OrderedPair> formatManager =
 				(FormatManager<OrderedPair>) context.getReferenceContext()
 					.getFormatManager("ORDEREDPAIR");
-		ScopeInstance scopeInst = context.getActiveScope();
-		LegalScope scope = scopeInst.getLegalScope();
+		LegalScope scope = context.getActiveScope();
 		PCGenModifier<OrderedPair> modifier;
 		try
 		{

--- a/code/src/java/plugin/lsttokens/variable/ChannelToken.java
+++ b/code/src/java/plugin/lsttokens/variable/ChannelToken.java
@@ -99,7 +99,7 @@ public class ChannelToken extends AbstractNonEmptyToken<DatasetVariable>
 		LegalScope lvs;
 		if ("GLOBAL".equals(fullscope))
 		{
-			lvs = context.getActiveScope().getLegalScope();
+			lvs = context.getActiveScope();
 		}
 		else
 		{

--- a/code/src/java/plugin/lsttokens/variable/GlobalToken.java
+++ b/code/src/java/plugin/lsttokens/variable/GlobalToken.java
@@ -73,7 +73,7 @@ public class GlobalToken extends AbstractNonEmptyToken<DatasetVariable>
 				+ " does not support format " + format + ", found in " + value
 				+ " due to " + e.getMessage());
 		}
-		LegalScope scope = context.getActiveScope().getLegalScope();
+		LegalScope scope = context.getActiveScope();
 
 		if (!DatasetVariable.isLegalName(varName))
 		{

--- a/code/src/test/pcgen/core/PObjectTest.java
+++ b/code/src/test/pcgen/core/PObjectTest.java
@@ -148,7 +148,7 @@ public class PObjectTest extends AbstractCharacterTestCase
 		OrderedPairManager opManager = new OrderedPairManager();
 		LoadContext context = Globals.getContext();
 		context.getVariableContext().assertLegalVariableID(
-			context.getActiveScope().getLegalScope(), opManager, "Face");
+			context.getActiveScope(), opManager, "Face");
 		Race race = new Race();
 		race.setName("TestRace");
 		race.put(ObjectKey.CHALLENGE_RATING, new ChallengeRating(FormulaFactory.getFormulaFor(5)));

--- a/code/src/utest/plugin/lsttokens/ModifyLstTest.java
+++ b/code/src/utest/plugin/lsttokens/ModifyLstTest.java
@@ -46,8 +46,8 @@ public class ModifyLstTest extends AbstractGlobalTokenTestCase
 		TokenRegistration.register(new plugin.modifier.number.AddModifierFactory());
 		TokenRegistration.register(new plugin.modifier.number.MultiplyModifierFactory());
 		FormatManager<?> formatManager = primaryContext.getReferenceContext().getFormatManager("NUMBER");
-		LegalScope pscope = primaryContext.getActiveScope().getLegalScope();
-		LegalScope sscope = primaryContext.getActiveScope().getLegalScope();
+		LegalScope pscope = primaryContext.getActiveScope();
+		LegalScope sscope = primaryContext.getActiveScope();
 		primaryContext.getVariableContext().assertLegalVariableID(pscope, formatManager, "MyVar");
 		secondaryContext.getVariableContext().assertLegalVariableID(sscope, formatManager, "MyVar");
 		primaryContext.getVariableContext().assertLegalVariableID(pscope, formatManager, "OtherVar");

--- a/code/src/utest/plugin/lsttokens/ModifyOtherLstTest.java
+++ b/code/src/utest/plugin/lsttokens/ModifyOtherLstTest.java
@@ -46,8 +46,8 @@ public class ModifyOtherLstTest extends AbstractGlobalTokenTestCase
 		TokenRegistration.register(new plugin.modifier.number.AddModifierFactory());
 		TokenRegistration.register(new plugin.modifier.number.MultiplyModifierFactory());
 		FormatManager<?> formatManager = primaryContext.getReferenceContext().getFormatManager("NUMBER");
-		LegalScope pscope = primaryContext.getActiveScope().getLegalScope();
-		LegalScope sscope = primaryContext.getActiveScope().getLegalScope();
+		LegalScope pscope = primaryContext.getActiveScope();
+		LegalScope sscope = primaryContext.getActiveScope();
 		primaryContext.getVariableContext().assertLegalVariableID(pscope, formatManager, "MyVar");
 		secondaryContext.getVariableContext().assertLegalVariableID(sscope, formatManager, "MyVar");
 		primaryContext.getVariableContext().assertLegalVariableID(pscope, formatManager, "OtherVar");

--- a/code/src/utest/plugin/lsttokens/race/FaceTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/race/FaceTokenTest.java
@@ -50,9 +50,9 @@ public class FaceTokenTest extends AbstractCDOMTokenTestCase<Race>
 		super.setUp();
 		TokenRegistration.register(m);
 		primaryContext.getVariableContext().assertLegalVariableID(
-			primaryContext.getActiveScope().getLegalScope(), opManager, "Face");
+			primaryContext.getActiveScope(), opManager, "Face");
 		secondaryContext.getVariableContext().assertLegalVariableID(
-			secondaryContext.getActiveScope().getLegalScope(), opManager, "Face");
+			secondaryContext.getActiveScope(), opManager, "Face");
 	}
 
 	@Override

--- a/code/src/utest/plugin/lsttokens/template/FaceTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/template/FaceTokenTest.java
@@ -50,9 +50,9 @@ public class FaceTokenTest extends AbstractCDOMTokenTestCase<PCTemplate>
 		super.setUp();
 		TokenRegistration.register(m);
 		primaryContext.getVariableContext().assertLegalVariableID(
-			primaryContext.getActiveScope().getLegalScope(), opManager, "Face");
+			primaryContext.getActiveScope(), opManager, "Face");
 		secondaryContext.getVariableContext().assertLegalVariableID(
-			secondaryContext.getActiveScope().getLegalScope(), opManager, "Face");
+			secondaryContext.getActiveScope(), opManager, "Face");
 	}
 
 	@Override


### PR DESCRIPTION
This reduces the necessary information in LoadContext to get a LegalScope (the embedded Dummy ScopeInstance is not necessary now that the formula system can run processing for Dependencies without needing a scope instance