### PR TITLE
Change name from PCGenModifier to FormulaModifier

### DIFF
--- a/code/src/java/pcgen/base/calculation/AbstractPCGenModifier.java
+++ b/code/src/java/pcgen/base/calculation/AbstractPCGenModifier.java
@@ -22,13 +22,13 @@ import pcgen.base.util.Indirect;
 import pcgen.cdom.formula.AssociationUtilities;
 
 /**
- * An AbstractPCGenModifier is a PCGenModifier that supports generalized management of
+ * An AbstractPCGenModifier is a FormulaModifier that supports generalized management of
  * references.
  * 
  * @param <T>
  *            The format that this AbstractPCGenModifier acts upon
  */
-public abstract class AbstractPCGenModifier<T> implements PCGenModifier<T>
+public abstract class AbstractPCGenModifier<T> implements FormulaModifier<T>
 {
 
 	/**

--- a/code/src/java/pcgen/base/calculation/FormulaModifier.java
+++ b/code/src/java/pcgen/base/calculation/FormulaModifier.java
@@ -23,46 +23,46 @@ import pcgen.base.solver.Modifier;
 import pcgen.base.util.Indirect;
 
 /**
- * PCGenModifier is a Modifier that has additional characteristics to support PCGen
+ * FormulaModifier is a Modifier that has additional characteristics to support PCGen
  * 
  * @param <T>
- *            The format that this PCGenModifier acts upon
+ *            The format that this FormulaModifier acts upon
  */
-public interface PCGenModifier<T> extends Modifier<T>
+public interface FormulaModifier<T> extends Modifier<T>
 {
 
 	/**
-	 * Adds an Association to this PCGenModifier.
+	 * Adds an Association to this FormulaModifier.
 	 * 
 	 * @param assocInstructions
-	 *            The instructions of the Association to be added to this PCGenModifier
+	 *            The instructions of the Association to be added to this FormulaModifier
 	 * 
 	 * @throws IllegalArgumentException
 	 *             if the given instructions are not valid or are not a supported
-	 *             Association for this PCGenModifier
+	 *             Association for this FormulaModifier
 	 */
 	public void addAssociation(String assocInstructions);
 
 	/**
 	 * Returns a Collection of the instructions (String format) for the Associations on
-	 * this PCGenModifier.
+	 * this FormulaModifier.
 	 * 
 	 * Ownership of the returned Collection should be transferred to the calling object,
-	 * and no reference to the underlying contents of the PCGenModifier should be
-	 * maintained. (There should be no way for the PCGenModifier to alter this Collection
+	 * and no reference to the underlying contents of the FormulaModifier should be
+	 * maintained. (There should be no way for the FormulaModifier to alter this Collection
 	 * after it is returned and no method for the returned Collection to modify the
-	 * PCGenModifier)
+	 * FormulaModifier)
 	 * 
-	 * @return the instructions (String format) for the Associations on this PCGenModifier
+	 * @return the instructions (String format) for the Associations on this FormulaModifier
 	 */
 	public Collection<String> getAssociationInstructions();
 
 	/**
-	 * Add object references to this PCGenModifier. These are captured solely as
+	 * Add object references to this FormulaModifier. These are captured solely as
 	 * dependency management.
 	 * 
 	 * @param collection
-	 *            The Collection of Indirect objects that this PCGenModifier references.
+	 *            The Collection of Indirect objects that this FormulaModifier references.
 	 */
 	public void addReferences(Collection<Indirect<?>> collection);
 

--- a/code/src/java/pcgen/cdom/content/IndirectCalculation.java
+++ b/code/src/java/pcgen/cdom/content/IndirectCalculation.java
@@ -15,6 +15,8 @@
  */
 package pcgen.cdom.content;
 
+import java.util.Objects;
+
 import pcgen.base.calculation.AbstractNEPCalculation;
 import pcgen.base.calculation.BasicCalculation;
 import pcgen.base.formula.base.EvaluationManager;
@@ -48,7 +50,7 @@ public final class IndirectCalculation<T> extends AbstractNEPCalculation<T>
 	public IndirectCalculation(Indirect<T> object, BasicCalculation<T> calc)
 	{
 		super(calc);
-		this.obj = object;
+		this.obj = Objects.requireNonNull(object);
 	}
 
 	@Override

--- a/code/src/java/pcgen/cdom/content/ProcessCalculation.java
+++ b/code/src/java/pcgen/cdom/content/ProcessCalculation.java
@@ -17,6 +17,8 @@
  */
 package pcgen.cdom.content;
 
+import java.util.Objects;
+
 import pcgen.base.calculation.AbstractNEPCalculation;
 import pcgen.base.calculation.BasicCalculation;
 import pcgen.base.formula.base.EvaluationManager;
@@ -53,13 +55,15 @@ public final class ProcessCalculation<T> extends AbstractNEPCalculation<T>
 	 * @param calc
 	 *            The BasicCalculation which defines the operation to be
 	 *            performed when this ProcessCalculation is processed
+	 * @param fmtManager
+	 *            The FormatManager for the calculation this can perform
 	 */
 	public ProcessCalculation(T object, BasicCalculation<T> calc,
 		FormatManager<T> fmtManager)
 	{
 		super(calc);
-		this.obj = object;
-		this.formatManager = fmtManager;
+		this.obj = Objects.requireNonNull(object);
+		this.formatManager = Objects.requireNonNull(fmtManager);
 	}
 
 	@Override

--- a/code/src/java/pcgen/cdom/content/VarModifier.java
+++ b/code/src/java/pcgen/cdom/content/VarModifier.java
@@ -17,17 +17,17 @@
  */
 package pcgen.cdom.content;
 
-import pcgen.base.calculation.PCGenModifier;
+import pcgen.base.calculation.FormulaModifier;
 import pcgen.base.formula.base.LegalScope;
 
 /**
  * A VarModifier is a container for all the information necessary to modify a
- * variable. This includes the scope, the variable name, and the PCGenModifier
+ * variable. This includes the scope, the variable name, and the FormulaModifier
  * to be applied. This allows that grouping of information to be passed as a
  * single unit of information.
  * 
  * @param <T>
- *            The format of the variable modified by the PCGenModifier in this
+ *            The format of the variable modified by the FormulaModifier in this
  *            VarModifier
  */
 public class VarModifier<T>
@@ -45,10 +45,10 @@ public class VarModifier<T>
 	private final LegalScope legalScope;
 
 	/**
-	 * The PCGenModifier to be applied to the Variable when this VarModifier is
+	 * The FormulaModifier to be applied to the Variable when this VarModifier is
 	 * applied.
 	 */
-	private final PCGenModifier<T> modifier;
+	private final FormulaModifier<T> modifier;
 
 	/**
 	 * Constructs a new VarModifier containing all the information necessary to
@@ -60,13 +60,13 @@ public class VarModifier<T>
 	 * @param legalScope
 	 *            the LegalScope in which the Modifier is applied
 	 * @param modifier
-	 *            The PCGenModifier to be applied to the Variable when this
+	 *            The FormulaModifier to be applied to the Variable when this
 	 *            VarModifier is applied
 	 * @throws IllegalArgumentException
 	 *             if any of the parameters are null
 	 */
 	public VarModifier(String varName, LegalScope legalScope,
-		PCGenModifier<T> modifier)
+		FormulaModifier<T> modifier)
 	{
 		if (varName == null)
 		{
@@ -106,11 +106,11 @@ public class VarModifier<T>
 	}
 
 	/**
-	 * Retrieves the PCGenModifier for this VarModifier.
+	 * Retrieves the FormulaModifier for this VarModifier.
 	 * 
-	 * @return the PCGenModifier for this VarModifier
+	 * @return the FormulaModifier for this VarModifier
 	 */
-	public PCGenModifier<T> getModifier()
+	public FormulaModifier<T> getModifier()
 	{
 		return modifier;
 	}

--- a/code/src/java/pcgen/gui2/solverview/SolverViewFrame.java
+++ b/code/src/java/pcgen/gui2/solverview/SolverViewFrame.java
@@ -36,7 +36,7 @@ import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.table.AbstractTableModel;
 
-import pcgen.base.calculation.PCGenModifier;
+import pcgen.base.calculation.FormulaModifier;
 import pcgen.base.formula.base.LegalScope;
 import pcgen.base.formula.base.ScopeInstance;
 import pcgen.base.formula.base.VarScoped;
@@ -358,7 +358,7 @@ public class SolverViewFrame extends JFrame
 				case 2:
 					return ps.getResult();
 				case 3:
-					return ((PCGenModifier<?>) ps.getModifier()).getPriority();
+					return ((FormulaModifier<?>) ps.getModifier()).getPriority();
 				case 4:
 					return ps.getSourceInfo();
 				default:

--- a/code/src/java/pcgen/rules/context/TrackingManufacturer.java
+++ b/code/src/java/pcgen/rules/context/TrackingManufacturer.java
@@ -286,6 +286,6 @@ class TrackingManufacturer<T extends Loadable> implements ReferenceManufacturer<
 	@Override
 	public boolean isDirect()
 	{
-		return false;
+		return rm.isDirect();
 	}
 }

--- a/code/src/java/pcgen/rules/context/VariableContext.java
+++ b/code/src/java/pcgen/rules/context/VariableContext.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
-import pcgen.base.calculation.PCGenModifier;
+import pcgen.base.calculation.FormulaModifier;
 import pcgen.base.formula.base.Function;
 import pcgen.base.formula.base.LegalScope;
 import pcgen.base.formula.base.ManagerFactory;
@@ -89,7 +89,7 @@ public class VariableContext
 	/*
 	 * For Tokens
 	 */
-	public <T> PCGenModifier<T> getModifier(String modType, String modValue,
+	public <T> FormulaModifier<T> getModifier(String modType, String modValue,
 		LegalScope varScope, FormatManager<T> formatManager)
 	{
 		return getModFactory().getModifier(modType, modValue, managerFactory,

--- a/code/src/java/pcgen/rules/persistence/MasterModifierFactory.java
+++ b/code/src/java/pcgen/rules/persistence/MasterModifierFactory.java
@@ -18,7 +18,7 @@
 package pcgen.rules.persistence;
 
 import pcgen.base.calculation.IgnoreVariables;
-import pcgen.base.calculation.PCGenModifier;
+import pcgen.base.calculation.FormulaModifier;
 import pcgen.base.formula.base.DependencyManager;
 import pcgen.base.formula.base.FormulaManager;
 import pcgen.base.formula.base.LegalScope;
@@ -56,7 +56,7 @@ public class MasterModifierFactory
 	}
 
 	/**
-	 * Returns a PCGenModifier representing the information given in the
+	 * Returns a FormulaModifier representing the information given in the
 	 * parameters.
 	 * 
 	 * @param modIdentifier
@@ -64,18 +64,18 @@ public class MasterModifierFactory
 	 *            function being performed, e.g. ADD)
 	 * @param modInstructions
 	 *            The Instructions of the Modifier (indicating the actual value
-	 *            the PCGenModifier will use)
+	 *            the FormulaModifier will use)
 	 * @param managerFactory
 	 *            The ManagerFactory to be used to support analyzing the
 	 *            instructions
 	 * @param varScope
-	 *            The VariableScope for the PCGenModifier to be returned
+	 *            The VariableScope for the FormulaModifier to be returned
 	 * @param formatManager
-	 *            The FormatManager for the PCGenModifier to be returned
-	 * @return a PCGenModifier representing the information given in the
+	 *            The FormatManager for the FormulaModifier to be returned
+	 * @return a FormulaModifier representing the information given in the
 	 *         parameters
 	 */
-	public <T> PCGenModifier<T> getModifier(String modIdentifier,
+	public <T> FormulaModifier<T> getModifier(String modIdentifier,
 		String modInstructions, ManagerFactory managerFactory, LegalScope varScope,
 		FormatManager<T> formatManager)
 	{
@@ -88,7 +88,7 @@ public class MasterModifierFactory
 				"Requested unknown ModifierType: " + varClass.getSimpleName()
 					+ " " + modIdentifier);
 		}
-		PCGenModifier<T> modifier = factory.getModifier(modInstructions,
+		FormulaModifier<T> modifier = factory.getModifier(modInstructions,
 			managerFactory, formulaManager, varScope, formatManager);
 		/*
 		 * getDependencies needs to be called during LST load, so that object references are captured

--- a/code/src/java/pcgen/rules/persistence/token/AbstractFixedSetModifierFactory.java
+++ b/code/src/java/pcgen/rules/persistence/token/AbstractFixedSetModifierFactory.java
@@ -15,7 +15,7 @@
  */
 package pcgen.rules.persistence.token;
 
-import pcgen.base.calculation.PCGenModifier;
+import pcgen.base.calculation.FormulaModifier;
 import pcgen.base.formula.base.FormulaManager;
 import pcgen.base.formula.base.LegalScope;
 import pcgen.base.formula.base.ManagerFactory;
@@ -34,7 +34,7 @@ public abstract class AbstractFixedSetModifierFactory<T>
 {
 
 	@Override
-	public PCGenModifier<T> getModifier(String instructions,
+	public FormulaModifier<T> getModifier(String instructions,
 		ManagerFactory managerFactory, FormulaManager ignored, LegalScope varScope,
 		FormatManager<T> formatManager)
 	{

--- a/code/src/java/pcgen/rules/persistence/token/AbstractNumberModifierFactory.java
+++ b/code/src/java/pcgen/rules/persistence/token/AbstractNumberModifierFactory.java
@@ -21,7 +21,7 @@ import pcgen.base.calculation.BasicCalculation;
 import pcgen.base.calculation.CalculationModifier;
 import pcgen.base.calculation.FormulaCalculation;
 import pcgen.base.calculation.NEPCalculation;
-import pcgen.base.calculation.PCGenModifier;
+import pcgen.base.calculation.FormulaModifier;
 import pcgen.base.formula.base.FormulaManager;
 import pcgen.base.formula.base.LegalScope;
 import pcgen.base.formula.base.ManagerFactory;
@@ -30,12 +30,12 @@ import pcgen.base.util.FormatManager;
 import pcgen.cdom.base.FormulaFactory;
 import pcgen.cdom.content.ProcessCalculation;
 
-public abstract class AbstractNumberModifierFactory<T> implements
-		ModifierFactory<T>, BasicCalculation<T>
+public abstract class AbstractNumberModifierFactory<T>
+		implements ModifierFactory<T>, BasicCalculation<T>
 {
 
 	@Override
-	public PCGenModifier<T> getModifier(String instructions,
+	public FormulaModifier<T> getModifier(String instructions,
 		ManagerFactory managerFactory, FormulaManager formulaManager, LegalScope varScope,
 		FormatManager<T> formatManager)
 	{
@@ -53,7 +53,7 @@ public abstract class AbstractNumberModifierFactory<T> implements
 	}
 
 	@Override
-	public PCGenModifier<T> getFixedModifier(
+	public FormulaModifier<T> getFixedModifier(
 		FormatManager<T> formatManager, String instructions)
 	{
 		T n = formatManager.convert(instructions);

--- a/code/src/java/pcgen/rules/persistence/token/AbstractSetModifierFactory.java
+++ b/code/src/java/pcgen/rules/persistence/token/AbstractSetModifierFactory.java
@@ -20,7 +20,7 @@ package pcgen.rules.persistence.token;
 import pcgen.base.calculation.BasicCalculation;
 import pcgen.base.calculation.CalculationModifier;
 import pcgen.base.calculation.NEPCalculation;
-import pcgen.base.calculation.PCGenModifier;
+import pcgen.base.calculation.FormulaModifier;
 import pcgen.base.util.FormatManager;
 import pcgen.cdom.content.ProcessCalculation;
 
@@ -74,7 +74,7 @@ public abstract class AbstractSetModifierFactory<T> implements
 	}
 
 	@Override
-	public PCGenModifier<T> getFixedModifier(FormatManager<T> formatManager,
+	public FormulaModifier<T> getFixedModifier(FormatManager<T> formatManager,
 		String instructions)
 	{
 		if (!getVariableFormat().isAssignableFrom(formatManager.getManagedClass()))

--- a/code/src/java/pcgen/rules/persistence/token/ModifierFactory.java
+++ b/code/src/java/pcgen/rules/persistence/token/ModifierFactory.java
@@ -17,7 +17,7 @@
  */
 package pcgen.rules.persistence.token;
 
-import pcgen.base.calculation.PCGenModifier;
+import pcgen.base.calculation.FormulaModifier;
 import pcgen.base.formula.base.FormulaManager;
 import pcgen.base.formula.base.LegalScope;
 import pcgen.base.formula.base.ManagerFactory;
@@ -53,31 +53,31 @@ public interface ModifierFactory<T>
 	public Class<T> getVariableFormat();
 
 	/**
-	 * Returns a PCGenModifier with the given instructions. The instructions
+	 * Returns a FormulaModifier with the given instructions. The instructions
 	 * will be parsed, and an IllegalArgumentException thrown if the
 	 * instructions are not valid for this type of ModifierFactory.
 	 * 
 	 * @param instructions
-	 *            The String form of the instructions of the PCGenModifier to be
+	 *            The String form of the instructions of the FormulaModifier to be
 	 *            returned
 	 * @param managerFactory
 	 *            The ManagerFactory to be used to support analyzing the
 	 *            instructions
 	 * @param formulaManager
 	 *            The FormulaManager used, if necessary, to initialize the
-	 *            PCGenModifier to be returned
+	 *            FormulaModifier to be returned
 	 * @param varScope
-	 *            The VariableScope for the PCGenModifier to be returned
+	 *            The VariableScope for the FormulaModifier to be returned
 	 * @param formatManager
-	 *            The FormatManager for the PCGenModifier to be returned
-	 * @return a PCGenModifier with the given instructions
+	 *            The FormatManager for the FormulaModifier to be returned
+	 * @return a FormulaModifier with the given instructions
 	 */
-	public PCGenModifier<T> getModifier(String instructions,
+	public FormulaModifier<T> getModifier(String instructions,
 		ManagerFactory managerFactory, FormulaManager formulaManager, LegalScope varScope,
 		FormatManager<T> formatManager);
 
 	/**
-	 * Returns a PCGenModifier with the given instructions.
+	 * Returns a FormulaModifier with the given instructions.
 	 * 
 	 * The instructions must be Fixed (does not require a calculation to determine what it
 	 * means), or this method will throw an exception.
@@ -86,12 +86,12 @@ public interface ModifierFactory<T>
 	 * instructions are not valid for this type of ModifierFactory.
 	 * 
 	 * @param formatManager
-	 *            The FormatManager for the PCGenModifier to be returned
+	 *            The FormatManager for the FormulaModifier to be returned
 	 * @param instructions
-	 *            The String form of the instructions of the PCGenModifier to be returned
+	 *            The String form of the instructions of the FormulaModifier to be returned
 	 * 
-	 * @return a PCGenModifier with the given instructions
+	 * @return a FormulaModifier with the given instructions
 	 */
-	public PCGenModifier<T> getFixedModifier(FormatManager<T> formatManager,
+	public FormulaModifier<T> getFixedModifier(FormatManager<T> formatManager,
 		String instructions);
 }

--- a/code/src/java/plugin/lsttokens/ModifyLst.java
+++ b/code/src/java/plugin/lsttokens/ModifyLst.java
@@ -23,7 +23,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-import pcgen.base.calculation.PCGenModifier;
+import pcgen.base.calculation.FormulaModifier;
 import pcgen.base.formula.base.LegalScope;
 import pcgen.base.lang.StringUtil;
 import pcgen.base.text.ParsingSeparator;
@@ -85,9 +85,10 @@ public class ModifyLst extends AbstractTokenWithSeparator<CDOMObject>
 		String varName = sep.next();
 		if (!context.getVariableContext().isLegalVariableID(scope, varName))
 		{
-			return new ParseResult.Fail(getTokenName()
-				+ " found invalid var name: " + varName + " Modified on "
-				+ obj.getClass().getSimpleName() + " " + obj.getKeyName(),
+			return new ParseResult.Fail(
+				getTokenName() + " found invalid var name: " + varName
+					+ "(scope: " + scope.getName() + ") Modified on "
+					+ obj.getClass().getSimpleName() + ' ' + obj.getKeyName(),
 				context);
 		}
 		if (!sep.hasNext())
@@ -102,7 +103,7 @@ public class ModifyLst extends AbstractTokenWithSeparator<CDOMObject>
 				+ " needed third argument: " + value, context);
 		}
 		String modInstructions = sep.next();
-		PCGenModifier<?> modifier;
+		FormulaModifier<?> modifier;
 		try
 		{
 			FormatManager<?> format = context.getVariableContext()
@@ -184,7 +185,7 @@ public class ModifyLst extends AbstractTokenWithSeparator<CDOMObject>
 
 	private String unparseModifier(VarModifier<?> vm)
 	{
-		PCGenModifier<?> modifier = vm.getModifier();
+		FormulaModifier<?> modifier = vm.getModifier();
 		String type = modifier.getIdentification();
 		StringBuilder sb = new StringBuilder();
 		sb.append(type);

--- a/code/src/java/plugin/lsttokens/ModifyOtherLst.java
+++ b/code/src/java/plugin/lsttokens/ModifyOtherLst.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
-import pcgen.base.calculation.PCGenModifier;
+import pcgen.base.calculation.FormulaModifier;
 import pcgen.base.formula.base.LegalScope;
 import pcgen.base.formula.base.VarScoped;
 import pcgen.base.lang.StringUtil;
@@ -187,9 +187,10 @@ public class ModifyOtherLst extends AbstractTokenWithSeparator<CDOMObject>
 		String varName = sep.next();
 		if (!context.getVariableContext().isLegalVariableID(scope, varName))
 		{
-			return new ParseResult.Fail(getTokenName()
-				+ " found invalid var name: " + varName + " Modified on "
-				+ obj.getClass().getSimpleName() + ' ' + obj.getKeyName(),
+			return new ParseResult.Fail(
+				getTokenName() + " found invalid var name: " + varName
+					+ "(scope: " + scope.getName() + ") Modified on "
+					+ obj.getClass().getSimpleName() + ' ' + obj.getKeyName(),
 				context);
 		}
 		if (!sep.hasNext())
@@ -204,7 +205,7 @@ public class ModifyOtherLst extends AbstractTokenWithSeparator<CDOMObject>
 				+ " needed 5th argument: " + value, context);
 		}
 		String modInstructions = sep.next();
-		PCGenModifier<?> modifier;
+		FormulaModifier<?> modifier;
 		try
 		{
 			FormatManager<?> format = context.getVariableContext()
@@ -294,7 +295,7 @@ public class ModifyOtherLst extends AbstractTokenWithSeparator<CDOMObject>
 
 	private String unparseModifier(VarModifier<?> vm)
 	{
-		PCGenModifier<?> modifier = vm.getModifier();
+		FormulaModifier<?> modifier = vm.getModifier();
 		String type = modifier.getIdentification();
 		StringBuilder sb = new StringBuilder();
 		sb.append(type);

--- a/code/src/java/plugin/lsttokens/datacontrol/DefaultVariableValueToken.java
+++ b/code/src/java/plugin/lsttokens/datacontrol/DefaultVariableValueToken.java
@@ -17,7 +17,7 @@
  */
 package plugin.lsttokens.datacontrol;
 
-import pcgen.base.calculation.PCGenModifier;
+import pcgen.base.calculation.FormulaModifier;
 import pcgen.base.util.FormatManager;
 import pcgen.cdom.base.Constants;
 import pcgen.cdom.content.DefaultVarValue;
@@ -106,7 +106,7 @@ public class DefaultVariableValueToken extends
 				+ fmtManager.getIdentifierType() + " requires a SET modifier",
 				context);
 		}
-		PCGenModifier<T> defaultModifier;
+		FormulaModifier<T> defaultModifier;
 		try
 		{
 			defaultModifier = m.getFixedModifier(fmtManager, defaultValue);

--- a/code/src/java/plugin/lsttokens/race/FaceToken.java
+++ b/code/src/java/plugin/lsttokens/race/FaceToken.java
@@ -19,7 +19,7 @@ package plugin.lsttokens.race;
 
 import java.util.Collection;
 
-import pcgen.base.calculation.PCGenModifier;
+import pcgen.base.calculation.FormulaModifier;
 import pcgen.base.formula.base.LegalScope;
 import pcgen.base.math.OrderedPair;
 import pcgen.base.util.FormatManager;
@@ -69,7 +69,7 @@ public class FaceToken extends AbstractNonEmptyToken<Race> implements
 				(FormatManager<OrderedPair>) context.getReferenceContext()
 					.getFormatManager("ORDEREDPAIR");
 		LegalScope scope = context.getActiveScope();
-		PCGenModifier<OrderedPair> modifier;
+		FormulaModifier<OrderedPair> modifier;
 		try
 		{
 			modifier = context.getVariableContext()
@@ -118,7 +118,7 @@ public class FaceToken extends AbstractNonEmptyToken<Race> implements
 		{
 			for (VarModifier<?> vm : added)
 			{
-				PCGenModifier<?> modifier = vm.getModifier();
+				FormulaModifier<?> modifier = vm.getModifier();
 				if (VAR_NAME.equals(vm.getVarName())
 					&& (vm.getLegalScope().getParentScope() == null)
 					&& (modifier.getIdentification()

--- a/code/src/java/plugin/lsttokens/template/FaceToken.java
+++ b/code/src/java/plugin/lsttokens/template/FaceToken.java
@@ -19,7 +19,7 @@ package plugin.lsttokens.template;
 
 import java.util.Collection;
 
-import pcgen.base.calculation.PCGenModifier;
+import pcgen.base.calculation.FormulaModifier;
 import pcgen.base.formula.base.LegalScope;
 import pcgen.base.math.OrderedPair;
 import pcgen.base.util.FormatManager;
@@ -76,7 +76,7 @@ public class FaceToken extends AbstractNonEmptyToken<PCTemplate> implements
 				(FormatManager<OrderedPair>) context.getReferenceContext()
 					.getFormatManager("ORDEREDPAIR");
 		LegalScope scope = context.getActiveScope();
-		PCGenModifier<OrderedPair> modifier;
+		FormulaModifier<OrderedPair> modifier;
 		try
 		{
 			modifier = context.getVariableContext()
@@ -125,7 +125,7 @@ public class FaceToken extends AbstractNonEmptyToken<PCTemplate> implements
 		{
 			for (VarModifier<?> vm : added)
 			{
-				PCGenModifier<?> modifier = vm.getModifier();
+				FormulaModifier<?> modifier = vm.getModifier();
 				if (VAR_NAME.equals(vm.getVarName())
 					&& (vm.getLegalScope().getParentScope() == null)
 					&& (modifier.getIdentification()

--- a/code/src/java/plugin/modifier/bool/SetModifierFactory.java
+++ b/code/src/java/plugin/modifier/bool/SetModifierFactory.java
@@ -28,7 +28,8 @@ public class SetModifierFactory extends AbstractFixedSetModifierFactory<Boolean>
 	/**
 	 * Identifies that this SetModifier acts upon Boolean objects.
 	 * 
-	 * @see pcgen.base.calculation.CalculationInfo#getVariableFormat()
+	 * @return The Format (Boolean.class) of object upon which Modifiers built by this
+	 *         SetModifierFactory can operate
 	 */
 	@Override
 	public Class<Boolean> getVariableFormat()

--- a/code/src/java/plugin/modifier/cdom/SetModifierFactory.java
+++ b/code/src/java/plugin/modifier/cdom/SetModifierFactory.java
@@ -19,7 +19,7 @@ package plugin.modifier.cdom;
 
 import pcgen.base.calculation.CalculationModifier;
 import pcgen.base.calculation.NEPCalculation;
-import pcgen.base.calculation.PCGenModifier;
+import pcgen.base.calculation.FormulaModifier;
 import pcgen.base.formula.base.FormulaManager;
 import pcgen.base.formula.base.LegalScope;
 import pcgen.base.formula.base.ManagerFactory;
@@ -37,7 +37,7 @@ public class SetModifierFactory extends AbstractSetModifierFactory<CDOMObject>
 {
 
 	@Override
-	public PCGenModifier<CDOMObject> getModifier(String instructions,
+	public FormulaModifier<CDOMObject> getModifier(String instructions,
 		ManagerFactory managerFactory, FormulaManager ignored, LegalScope varScope,
 		FormatManager<CDOMObject> formatManager)
 	{

--- a/code/src/java/plugin/modifier/number/AddModifierFactory.java
+++ b/code/src/java/plugin/modifier/number/AddModifierFactory.java
@@ -32,7 +32,8 @@ public class AddModifierFactory extends AbstractNumberModifierFactory<Number>
 	 * Identifies that the Modifier objects built by this AddModifierFactory act
 	 * upon java.lang.Number objects.
 	 * 
-	 * @see pcgen.base.calculation.CalculationInfo#getVariableFormat()
+	 * @return The Format (Number.class) of object upon which Modifiers built by this
+	 *         AddModifierFactory can operate
 	 */
 	@Override
 	public Class<Number> getVariableFormat()
@@ -40,20 +41,12 @@ public class AddModifierFactory extends AbstractNumberModifierFactory<Number>
 		return Number.class;
 	}
 
-	/**
-	 * Returns an Identifier for this type of Modifier
-	 * 
-	 * @see pcgen.base.calculation.CalculationInfo#getIdentification()
-	 */
 	@Override
 	public String getIdentification()
 	{
 		return "ADD";
 	}
 
-	/**
-	 * @see pcgen.base.calculation.CalculationInfo#getInherentPriority()
-	 */
 	@Override
 	public int getInherentPriority()
 	{
@@ -62,10 +55,15 @@ public class AddModifierFactory extends AbstractNumberModifierFactory<Number>
 
 	/**
 	 * Performs addition of two Numbers, used by Modifiers produced by this
-	 * AddModifierFactory
+	 * AddModifierFactory.
 	 * 
-	 * @see pcgen.base.calculation.BasicCalculation#process(java.lang.Object,
-	 *      java.lang.Object)
+	 * @param previousValue
+	 *            The first input value used to determine the appropriate result of a
+	 *            Modifier produced by this ModifierFactory.
+	 * @param argument
+	 *            The second input value used to determine the appropriate result of a
+	 *            Modifier produced by this ModifierFactory.
+	 * @return The resulting value of the Modifier when processed
 	 */
 	@Override
 	public Number process(Number previousValue, Number argument)

--- a/code/src/java/plugin/modifier/number/DivideModifierFactory.java
+++ b/code/src/java/plugin/modifier/number/DivideModifierFactory.java
@@ -33,7 +33,8 @@ public class DivideModifierFactory extends AbstractNumberModifierFactory<Number>
 	 * Identifies that the Modifier objects built by this DivideModifierFactory
 	 * act upon java.lang.Number objects.
 	 * 
-	 * @see pcgen.base.calculation.CalculationInfo#getVariableFormat()
+	 * @return The Format (Number.class) of object upon which Modifiers built by this
+	 *         DivideModifierFactory can operate
 	 */
 	@Override
 	public Class<Number> getVariableFormat()
@@ -45,8 +46,13 @@ public class DivideModifierFactory extends AbstractNumberModifierFactory<Number>
 	 * Performs Division of two values, used by Modifiers produced by this
 	 * DivideModifierFactory
 	 * 
-	 * @see pcgen.base.calculation.BasicCalculation#process(java.lang.Object,
-	 *      java.lang.Object)
+	 * @param previousValue
+	 *            The first input value used to determine the appropriate result of a
+	 *            Modifier produced by this ModifierFactory.
+	 * @param argument
+	 *            The second input value used to determine the appropriate result of a
+	 *            Modifier produced by this ModifierFactory.
+	 * @return The resulting value of the Modifier when processed
 	 */
 	@Override
 	public Number process(Number previousValue, Number argument)
@@ -54,23 +60,12 @@ public class DivideModifierFactory extends AbstractNumberModifierFactory<Number>
 		return NumberUtilities.divide(previousValue, argument);
 	}
 
-	/**
-	 * Returns the inherent priority of an DivideModifier. This is used if two
-	 * Modifiers have the same User Priority. Lower values are processed first.
-	 * 
-	 * @see pcgen.base.calculation.CalculationInfo#getInherentPriority()
-	 */
 	@Override
 	public int getInherentPriority()
 	{
 		return 2;
 	}
 
-	/**
-	 * Returns an Identifier for this type of Modifier
-	 * 
-	 * @see pcgen.base.calculation.CalculationInfo#getIdentification()
-	 */
 	@Override
 	public String getIdentification()
 	{

--- a/code/src/java/plugin/modifier/number/MaxModifierFactory.java
+++ b/code/src/java/plugin/modifier/number/MaxModifierFactory.java
@@ -33,7 +33,8 @@ public class MaxModifierFactory extends AbstractNumberModifierFactory<Number>
 	 * Identifies that the Modifier objects built by this MaxModifierFactory act
 	 * upon java.lang.Number objects.
 	 * 
-	 * @see pcgen.base.calculation.CalculationInfo#getVariableFormat()
+	 * @return The Format (Number.class) of object upon which Modifiers built by this
+	 *         MaxModifierFactory can operate
 	 */
 	@Override
 	public Class<Number> getVariableFormat()
@@ -45,8 +46,13 @@ public class MaxModifierFactory extends AbstractNumberModifierFactory<Number>
 	 * Returns the higher of the two input values, used by Modifiers produced by
 	 * this MaxModifierFactory
 	 * 
-	 * @see pcgen.base.calculation.BasicCalculation#process(java.lang.Object,
-	 *      java.lang.Object)
+	 * @param previousValue
+	 *            The first input value used to determine the appropriate result of a
+	 *            Modifier produced by this ModifierFactory.
+	 * @param argument
+	 *            The second input value used to determine the appropriate result of a
+	 *            Modifier produced by this ModifierFactory.
+	 * @return The resulting value of the Modifier when processed
 	 */
 	@Override
 	public Number process(Number previousValue, Number argument)
@@ -54,23 +60,12 @@ public class MaxModifierFactory extends AbstractNumberModifierFactory<Number>
 		return NumberUtilities.max(previousValue, argument);
 	}
 
-	/**
-	 * Returns the inherent priority of an MaxModifier. This is used if two
-	 * Modifiers have the same User Priority. Lower values are processed first.
-	 * 
-	 * @see pcgen.base.calculation.CalculationInfo#getInherentPriority()
-	 */
 	@Override
 	public int getInherentPriority()
 	{
 		return 4;
 	}
 
-	/**
-	 * Returns an Identifier for this type of Modifier
-	 * 
-	 * @see pcgen.base.calculation.CalculationInfo#getIdentification()
-	 */
 	@Override
 	public String getIdentification()
 	{

--- a/code/src/java/plugin/modifier/number/MinModifierFactory.java
+++ b/code/src/java/plugin/modifier/number/MinModifierFactory.java
@@ -33,7 +33,8 @@ public class MinModifierFactory extends AbstractNumberModifierFactory<Number>
 	 * Identifies that the Modifier objects built by this MinModifierFactory act
 	 * upon java.lang.Number objects.
 	 * 
-	 * @see pcgen.base.calculation.CalculationInfo#getVariableFormat()
+	 * @return The Format (Number.class) of object upon which Modifiers built by this
+	 *         MinModifierFactory can operate
 	 */
 	@Override
 	public Class<Number> getVariableFormat()
@@ -45,8 +46,13 @@ public class MinModifierFactory extends AbstractNumberModifierFactory<Number>
 	 * Returns the lower of the two input values, used by Modifiers produced by
 	 * this MinModifierFactory
 	 * 
-	 * @see pcgen.base.calculation.BasicCalculation#process(java.lang.Object,
-	 *      java.lang.Object)
+	 * @param previousValue
+	 *            The first input value used to determine the appropriate result of a
+	 *            Modifier produced by this ModifierFactory.
+	 * @param argument
+	 *            The second input value used to determine the appropriate result of a
+	 *            Modifier produced by this ModifierFactory.
+	 * @return The resulting value of the Modifier when processed
 	 */
 	@Override
 	public Number process(Number previousValue, Number argument)
@@ -54,23 +60,12 @@ public class MinModifierFactory extends AbstractNumberModifierFactory<Number>
 		return NumberUtilities.min(previousValue, argument);
 	}
 
-	/**
-	 * Returns the inherent priority of an MinModifier. This is used if two
-	 * Modifiers have the same User Priority. Lower values are processed first.
-	 * 
-	 * @see pcgen.base.calculation.CalculationInfo#getInherentPriority()
-	 */
 	@Override
 	public int getInherentPriority()
 	{
 		return 5;
 	}
 
-	/**
-	 * Returns an Identifier for this type of Modifier
-	 * 
-	 * @see pcgen.base.calculation.CalculationInfo#getIdentification()
-	 */
 	@Override
 	public String getIdentification()
 	{

--- a/code/src/java/plugin/modifier/number/MultiplyModifierFactory.java
+++ b/code/src/java/plugin/modifier/number/MultiplyModifierFactory.java
@@ -34,7 +34,8 @@ public class MultiplyModifierFactory extends
 	 * Identifies that the Modifier objects built by this
 	 * MultiplyModifierFactory act upon java.lang.Number objects.
 	 * 
-	 * @see pcgen.base.calculation.CalculationInfo#getVariableFormat()
+	 * @return The Format (Number.class) of object upon which Modifiers built by this
+	 *         MultiplyModifierFactory can operate
 	 */
 	@Override
 	public Class<Number> getVariableFormat()
@@ -46,8 +47,13 @@ public class MultiplyModifierFactory extends
 	 * Returns the product of the two input values, used by Modifiers produced
 	 * by this MultiplyModifierFactory
 	 * 
-	 * @see pcgen.base.calculation.BasicCalculation#process(java.lang.Object,
-	 *      java.lang.Object)
+	 * @param previousValue
+	 *            The first input value used to determine the appropriate result of a
+	 *            Modifier produced by this ModifierFactory.
+	 * @param argument
+	 *            The second input value used to determine the appropriate result of a
+	 *            Modifier produced by this ModifierFactory.
+	 * @return The resulting value of the Modifier when processed
 	 */
 	@Override
 	public Number process(Number previousValue, Number argument)
@@ -55,23 +61,12 @@ public class MultiplyModifierFactory extends
 		return NumberUtilities.multiply(previousValue, argument);
 	}
 
-	/**
-	 * Returns the inherent priority of an MultiplyModifier. This is used if two
-	 * Modifiers have the same User Priority. Lower values are processed first.
-	 * 
-	 * @see pcgen.base.calculation.CalculationInfo#getInherentPriority()
-	 */
 	@Override
 	public int getInherentPriority()
 	{
 		return 1;
 	}
 
-	/**
-	 * Returns an Identifier for this type of Modifier
-	 * 
-	 * @see pcgen.base.calculation.CalculationInfo#getIdentification()
-	 */
 	@Override
 	public String getIdentification()
 	{

--- a/code/src/java/plugin/modifier/number/SetModifierFactory.java
+++ b/code/src/java/plugin/modifier/number/SetModifierFactory.java
@@ -20,7 +20,7 @@ package plugin.modifier.number;
 import pcgen.base.calculation.CalculationModifier;
 import pcgen.base.calculation.FormulaCalculation;
 import pcgen.base.calculation.NEPCalculation;
-import pcgen.base.calculation.PCGenModifier;
+import pcgen.base.calculation.FormulaModifier;
 import pcgen.base.formula.base.FormulaManager;
 import pcgen.base.formula.base.LegalScope;
 import pcgen.base.formula.base.ManagerFactory;
@@ -41,7 +41,8 @@ public class SetModifierFactory extends AbstractFixedSetModifierFactory<Number>
 	 * Identifies that the Modifier objects built by this SetModifierFactory act
 	 * upon java.lang.Number objects.
 	 * 
-	 * @see pcgen.base.calculation.CalculationInfo#getVariableFormat()
+	 * @return The Format (Number.class) of object upon which Modifiers built by this
+	 *         SetModifierFactory can operate
 	 */
 	@Override
 	public Class<Number> getVariableFormat()
@@ -50,7 +51,7 @@ public class SetModifierFactory extends AbstractFixedSetModifierFactory<Number>
 	}
 
 	@Override
-	public PCGenModifier<Number> getModifier(String instructions,
+	public FormulaModifier<Number> getModifier(String instructions,
 		ManagerFactory managerFactory, FormulaManager formulaManager, LegalScope varScope,
 		FormatManager<Number> formatManager)
 	{

--- a/code/src/java/plugin/modifier/orderedpair/SetModifierFactory.java
+++ b/code/src/java/plugin/modifier/orderedpair/SetModifierFactory.java
@@ -31,7 +31,8 @@ public class SetModifierFactory extends AbstractFixedSetModifierFactory<OrderedP
 	 * Identifies that this SetModifier acts upon pcgen.base.math.OrderedPair
 	 * objects.
 	 * 
-	 * @see pcgen.base.calculation.CalculationInfo#getVariableFormat()
+	 * @return The Format (OrderedPair.class) of object upon which Modifiers built by this
+	 *         SetModifierFactory can operate
 	 */
 	@Override
 	public Class<OrderedPair> getVariableFormat()

--- a/code/src/java/plugin/modifier/set/AddModifierFactory.java
+++ b/code/src/java/plugin/modifier/set/AddModifierFactory.java
@@ -23,7 +23,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import pcgen.base.calculation.AbstractPCGenModifier;
-import pcgen.base.calculation.PCGenModifier;
+import pcgen.base.calculation.FormulaModifier;
 import pcgen.base.formula.base.DependencyManager;
 import pcgen.base.formula.base.EvaluationManager;
 import pcgen.base.formula.base.FormulaManager;
@@ -62,7 +62,7 @@ public class AddModifierFactory<T> implements ModifierFactory<T[]>
 	}
 
 	@Override
-	public PCGenModifier<T[]> getModifier(String instructions,
+	public FormulaModifier<T[]> getModifier(String instructions,
 		ManagerFactory managerFactory, FormulaManager ignored, LegalScope varScope,
 		FormatManager<T[]> formatManager)
 	{
@@ -71,7 +71,7 @@ public class AddModifierFactory<T> implements ModifierFactory<T[]>
 	}
 
 	@Override
-	public PCGenModifier<T[]> getFixedModifier(FormatManager<T[]> fmtManager,
+	public FormulaModifier<T[]> getFixedModifier(FormatManager<T[]> fmtManager,
 		String instructions)
 	{
 		T[] toAdd = fmtManager.convert(instructions);
@@ -79,7 +79,7 @@ public class AddModifierFactory<T> implements ModifierFactory<T[]>
 	}
 
 	/**
-	 * An AddDirectArrayModifier is a PCGenModifier that contains a set of objects to be
+	 * An AddDirectArrayModifier is a FormulaModifier that contains a set of objects to be
 	 * used by the Modifier when executed.
 	 */
 	private final class AddDirectArrayModifier extends AddArrayModifier
@@ -112,7 +112,7 @@ public class AddModifierFactory<T> implements ModifierFactory<T[]>
 	}
 
 	/**
-	 * An AddIndirectArrayModifier is a PCGenModifier that contains a set of Indirect
+	 * An AddIndirectArrayModifier is a FormulaModifier that contains a set of Indirect
 	 * objects to be resolved and used by the Modifier when executed.
 	 */
 	private final class AddIndirectArrayModifier extends AddArrayModifier

--- a/code/src/java/plugin/modifier/set/SetModifierFactory.java
+++ b/code/src/java/plugin/modifier/set/SetModifierFactory.java
@@ -18,7 +18,7 @@
 package plugin.modifier.set;
 
 import pcgen.base.calculation.AbstractPCGenModifier;
-import pcgen.base.calculation.PCGenModifier;
+import pcgen.base.calculation.FormulaModifier;
 import pcgen.base.formula.base.DependencyManager;
 import pcgen.base.formula.base.EvaluationManager;
 import pcgen.base.formula.base.FormulaManager;
@@ -44,12 +44,6 @@ public class SetModifierFactory<T> extends AbstractFixedSetModifierFactory<T[]>
 	private static final Class ARRAY_CLASS = Object[].class;
 
 	@Override
-	public String getIdentification()
-	{
-		return "SET";
-	}
-
-	@Override
 	@SuppressWarnings("unchecked")
 	public Class<T[]> getVariableFormat()
 	{
@@ -57,7 +51,7 @@ public class SetModifierFactory<T> extends AbstractFixedSetModifierFactory<T[]>
 	}
 
 	@Override
-	public PCGenModifier<T[]> getModifier(String instructions,
+	public FormulaModifier<T[]> getModifier(String instructions,
 		ManagerFactory managerFactory, FormulaManager ignored, LegalScope varScope,
 		FormatManager<T[]> formatManager)
 	{
@@ -66,15 +60,15 @@ public class SetModifierFactory<T> extends AbstractFixedSetModifierFactory<T[]>
 	}
 
 	@Override
-	public PCGenModifier<T[]> getFixedModifier(
-		FormatManager<T[]> fmtManager, String instructions)
+	public FormulaModifier<T[]> getFixedModifier(FormatManager<T[]> fmtManager,
+		String instructions)
 	{
 		T[] toSet = fmtManager.convert(instructions);
 		return new SetDirectArrayModifier(fmtManager, toSet);
 	}
 
 	/**
-	 * A SetDirectArrayModifier is a PCGenModifier that contains a set of objects 
+	 * A SetDirectArrayModifier is a FormulaModifier that contains a set of objects 
 	 * to be used by the Modifier.
 	 */
 	private final class SetDirectArrayModifier extends SetArrayModifier
@@ -106,7 +100,7 @@ public class SetModifierFactory<T> extends AbstractFixedSetModifierFactory<T[]>
 	}
 
 	/**
-	 * A SetIndirectArrayModifier is a PCGenModifier that contains a set of Indirect objects
+	 * A SetIndirectArrayModifier is a FormulaModifier that contains a set of Indirect objects
 	 * to be resolved and used by the Modifier when executed.
 	 */
 	private final class SetIndirectArrayModifier extends SetArrayModifier

--- a/code/src/java/plugin/modifier/string/SetModifierFactory.java
+++ b/code/src/java/plugin/modifier/string/SetModifierFactory.java
@@ -31,7 +31,8 @@ public class SetModifierFactory extends AbstractFixedSetModifierFactory<String>
 	 * Identifies that the Modifier objects built by this SetModifierFactory act
 	 * upon java.lang.String objects.
 	 * 
-	 * @see pcgen.base.calculation.CalculationInfo#getVariableFormat()
+	 * @return The Format (String.class) of object upon which Modifiers built by this
+	 *         SetModifierFactory can operate
 	 */
 	@Override
 	public Class<String> getVariableFormat()

--- a/code/src/utest/pcgen/base/solver/SetSolverManagerTest.java
+++ b/code/src/utest/pcgen/base/solver/SetSolverManagerTest.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 import pcgen.base.calculation.BasicCalculation;
 import pcgen.base.calculation.CalculationModifier;
 import pcgen.base.calculation.NEPCalculation;
-import pcgen.base.calculation.PCGenModifier;
+import pcgen.base.calculation.FormulaModifier;
 import pcgen.base.format.ArrayFormatManager;
 import pcgen.base.format.NumberManager;
 import pcgen.base.format.StringManager;
@@ -113,7 +113,7 @@ public class SetSolverManagerTest
 		fm = fm.getWith(FormulaManager.FUNCTION, fl);
 		SolverFactory solverFactory = new SolverFactory();
 		ModifierFactory am1 = new plugin.modifier.set.SetModifierFactory<>();
-		PCGenModifier emptyArrayMod =
+		FormulaModifier emptyArrayMod =
 				am1.getModifier("", managerFactory, null, globalScope, arrayManager);
 		solverFactory.addSolverFormat(arrayManager.getManagedClass(), emptyArrayMod);
 		
@@ -124,7 +124,7 @@ public class SetSolverManagerTest
 
 		manager = new DynamicSolverManager(fm, managerFactory, solverFactory, vc);
 		ModifierFactory mfn = new plugin.modifier.number.SetModifierFactory();
-		PCGenModifier mod =
+		FormulaModifier mod =
 				mfn.getModifier("0", managerFactory, null, globalScope, numberManager);
 		mod.addAssociation("PRIORITY=0");
 		solverFactory.addSolverFormat(numberManager.getManagedClass(), mod);
@@ -151,7 +151,7 @@ public class SetSolverManagerTest
 		vc.reset();
 
 		ModifierFactory am1 = new plugin.modifier.set.AddModifierFactory<>();
-		PCGenModifier mod = am1.getModifier("France,England", new ManagerFactory()
+		FormulaModifier mod = am1.getModifier("France,England", new ManagerFactory()
 		{
 		}, null, globalScope, arrayManager);
 		mod.addAssociation("PRIORITY=2000");
@@ -211,20 +211,20 @@ public class SetSolverManagerTest
 		
 		ModifierFactory am1 = new plugin.modifier.number.SetModifierFactory();
 		ModifierFactory amString = new plugin.modifier.string.SetModifierFactory();
-		PCGenModifier mod2 = am1.getModifier("2", new ManagerFactory()
+		FormulaModifier mod2 = am1.getModifier("2", new ManagerFactory()
 		{
 		}, fm, globalScope, numberManager);
 		mod2.addAssociation("PRIORITY=2000");
-		PCGenModifier mod3 = am1.getModifier("3", new ManagerFactory()
+		FormulaModifier mod3 = am1.getModifier("3", new ManagerFactory()
 		{
 		}, fm, globalScope, numberManager);
 		mod3.addAssociation("PRIORITY=2000");
-		PCGenModifier mod4 = am1.getModifier("4", new ManagerFactory()
+		FormulaModifier mod4 = am1.getModifier("4", new ManagerFactory()
 		{
 		}, fm, globalScope, numberManager);
 		mod4.addAssociation("PRIORITY=3000");
 		String formula = "dropIntoContext(\"EQUIPMENT\",EquipVar,LocalVar)";
-		PCGenModifier modf = am1.getModifier(formula, new ManagerFactory()
+		FormulaModifier modf = am1.getModifier(formula, new ManagerFactory()
 		{
 		}, fm, globalScope, numberManager);
 		modf.addAssociation("PRIORITY=2000");

--- a/code/src/utest/plugin/modifier/bool/SetBooleanModifierTest.java
+++ b/code/src/utest/plugin/modifier/bool/SetBooleanModifierTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.fail;
 
 import org.junit.Test;
 
-import pcgen.base.calculation.PCGenModifier;
+import pcgen.base.calculation.FormulaModifier;
 import pcgen.base.format.BooleanManager;
 import pcgen.base.formula.base.LegalScope;
 import pcgen.base.formula.base.ManagerFactory;
@@ -56,7 +56,7 @@ public class SetBooleanModifierTest
 	public void testGetModifier()
 	{
 		ModifierFactory factory = new SetModifierFactory();
-		PCGenModifier<Boolean> modifier =
+		FormulaModifier<Boolean> modifier =
 				factory.getModifier("True", new ManagerFactory(){}, null, varScope, booleanManager);
 		modifier.addAssociation("PRIORITY=5");
 		assertEquals(5L <<32, modifier.getPriority());

--- a/code/src/utest/plugin/modifier/number/AddNumberModifierTest.java
+++ b/code/src/utest/plugin/modifier/number/AddNumberModifierTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.fail;
 import org.junit.Test;
 
 import pcgen.base.calculation.BasicCalculation;
-import pcgen.base.calculation.PCGenModifier;
+import pcgen.base.calculation.FormulaModifier;
 import pcgen.base.format.NumberManager;
 import pcgen.base.formula.base.LegalScope;
 import pcgen.base.formula.base.ManagerFactory;
@@ -196,7 +196,7 @@ public class AddNumberModifierTest
 	public void testGetModifier()
 	{
 		AddModifierFactory factory = new AddModifierFactory();
-		PCGenModifier<Number> modifier =
+		FormulaModifier<Number> modifier =
 				factory.getModifier("6.5", new ManagerFactory(){}, null, varScope, numManager);
 		modifier.addAssociation("PRIORITY=35");
 		assertEquals((35L <<32)+factory.getInherentPriority(), modifier.getPriority());

--- a/code/src/utest/plugin/modifier/number/DivideNumberModifierTest.java
+++ b/code/src/utest/plugin/modifier/number/DivideNumberModifierTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.fail;
 import org.junit.Test;
 
 import pcgen.base.calculation.BasicCalculation;
-import pcgen.base.calculation.PCGenModifier;
+import pcgen.base.calculation.FormulaModifier;
 import pcgen.base.format.NumberManager;
 import pcgen.base.formula.base.LegalScope;
 import pcgen.base.formula.base.ManagerFactory;
@@ -196,7 +196,7 @@ public class DivideNumberModifierTest
 	public void testGetModifier()
 	{
 		DivideModifierFactory factory = new DivideModifierFactory();
-		PCGenModifier<Number> modifier =
+		FormulaModifier<Number> modifier =
 				factory.getModifier("4.3", new ManagerFactory(){}, null, varScope, numManager);
 		modifier.addAssociation("PRIORITY=35");
 		assertEquals((35L <<32)+factory.getInherentPriority(), modifier.getPriority());

--- a/code/src/utest/plugin/modifier/number/MaxNumberModifierTest.java
+++ b/code/src/utest/plugin/modifier/number/MaxNumberModifierTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 
 import junit.framework.TestCase;
 import pcgen.base.calculation.BasicCalculation;
-import pcgen.base.calculation.PCGenModifier;
+import pcgen.base.calculation.FormulaModifier;
 import pcgen.base.format.NumberManager;
 import pcgen.base.formula.base.LegalScope;
 import pcgen.base.formula.base.ManagerFactory;
@@ -194,7 +194,7 @@ public class MaxNumberModifierTest extends TestCase
 	public void testGetModifier()
 	{
 		MaxModifierFactory factory = new MaxModifierFactory();
-		PCGenModifier<Number> modifier =
+		FormulaModifier<Number> modifier =
 				factory.getModifier("6.5", new ManagerFactory(){}, null, varScope, numManager);
 		modifier.addAssociation("PRIORITY=35");
 		assertEquals((35L <<32)+factory.getInherentPriority(), modifier.getPriority());

--- a/code/src/utest/plugin/modifier/number/MinNumberModifierTest.java
+++ b/code/src/utest/plugin/modifier/number/MinNumberModifierTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 
 import junit.framework.TestCase;
 import pcgen.base.calculation.BasicCalculation;
-import pcgen.base.calculation.PCGenModifier;
+import pcgen.base.calculation.FormulaModifier;
 import pcgen.base.format.NumberManager;
 import pcgen.base.formula.base.LegalScope;
 import pcgen.base.formula.base.ManagerFactory;
@@ -195,7 +195,7 @@ public class MinNumberModifierTest extends TestCase
 	public void testGetModifier()
 	{
 		MinModifierFactory factory = new MinModifierFactory();
-		PCGenModifier<Number> modifier =
+		FormulaModifier<Number> modifier =
 				factory.getModifier("6.5", new ManagerFactory(){}, null, varScope, numManager);
 		modifier.addAssociation("PRIORITY=35");
 		assertEquals((35L <<32)+factory.getInherentPriority(), modifier.getPriority());

--- a/code/src/utest/plugin/modifier/number/MultiplyNumberModifierTest.java
+++ b/code/src/utest/plugin/modifier/number/MultiplyNumberModifierTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.fail;
 import org.junit.Test;
 
 import pcgen.base.calculation.BasicCalculation;
-import pcgen.base.calculation.PCGenModifier;
+import pcgen.base.calculation.FormulaModifier;
 import pcgen.base.format.NumberManager;
 import pcgen.base.formula.base.LegalScope;
 import pcgen.base.formula.base.ManagerFactory;
@@ -197,7 +197,7 @@ public class MultiplyNumberModifierTest
 	public void testGetModifier()
 	{
 		MultiplyModifierFactory factory = new MultiplyModifierFactory();
-		PCGenModifier<Number> modifier =
+		FormulaModifier<Number> modifier =
 				factory.getModifier("6.5", new ManagerFactory(){}, null, varScope, numManager);
 		modifier.addAssociation("PRIORITY=35");
 		assertEquals((35L <<32)+factory.getInherentPriority(), modifier.getPriority());

--- a/code/src/utest/plugin/modifier/number/SetNumberModifierTest.java
+++ b/code/src/utest/plugin/modifier/number/SetNumberModifierTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.fail;
 
 import org.junit.Test;
 
-import pcgen.base.calculation.PCGenModifier;
+import pcgen.base.calculation.FormulaModifier;
 import pcgen.base.format.NumberManager;
 import pcgen.base.formula.base.EvaluationManager;
 import pcgen.base.formula.base.LegalScope;
@@ -199,7 +199,7 @@ public class SetNumberModifierTest
 	public void testGetModifier()
 	{
 		SetModifierFactory factory = new SetModifierFactory();
-		PCGenModifier<Number> modifier =
+		FormulaModifier<Number> modifier =
 				factory.getModifier("6.5", new ManagerFactory(){}, null, varScope, numManager);
 		modifier.addAssociation("PRIORITY=35");
 		assertEquals((35L<<32)+factory.getInherentPriority(), modifier.getPriority());
@@ -215,7 +215,7 @@ public class SetNumberModifierTest
 		setup.getLegalScopeLibrary().registerScope(varScope);
 		IndividualSetup iSetup = new IndividualSetup(setup, "Global", new SimpleVariableStore());
 		SetModifierFactory factory = new SetModifierFactory();
-		PCGenModifier<Number> modifier =
+		FormulaModifier<Number> modifier =
 				factory.getModifier("6+5", new ManagerFactory(){}, iSetup.getFormulaManager(), varScope, numManager);
 		modifier.addAssociation("PRIORITY=35");
 		assertEquals((35L<<32)+factory.getInherentPriority(), modifier.getPriority());

--- a/code/src/utest/plugin/modifier/orderedpair/SetOrderedPairModifierTest.java
+++ b/code/src/utest/plugin/modifier/orderedpair/SetOrderedPairModifierTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.fail;
 
 import org.junit.Test;
 
-import pcgen.base.calculation.PCGenModifier;
+import pcgen.base.calculation.FormulaModifier;
 import pcgen.base.format.OrderedPairManager;
 import pcgen.base.formula.base.LegalScope;
 import pcgen.base.formula.base.ManagerFactory;
@@ -57,7 +57,7 @@ public class SetOrderedPairModifierTest
 	public void testGetModifier()
 	{
 		ModifierFactory<OrderedPair> factory = new SetModifierFactory();
-		PCGenModifier<OrderedPair> modifier =
+		FormulaModifier<OrderedPair> modifier =
 				factory.getModifier("3,2", new ManagerFactory(){}, null, varScope, opManager);
 		modifier.addAssociation("PRIORITY=5");
 		assertEquals(5L <<32, modifier.getPriority());

--- a/code/src/utest/plugin/modifier/string/SetStringModifierTest.java
+++ b/code/src/utest/plugin/modifier/string/SetStringModifierTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.fail;
 
 import org.junit.Test;
 
-import pcgen.base.calculation.PCGenModifier;
+import pcgen.base.calculation.FormulaModifier;
 import pcgen.base.format.StringManager;
 import pcgen.base.formula.base.LegalScope;
 import pcgen.base.formula.base.ManagerFactory;
@@ -56,7 +56,7 @@ public class SetStringModifierTest
 	public void testGetModifier()
 	{
 		ModifierFactory<String> factory = new SetModifierFactory();
-		PCGenModifier<String> modifier =
+		FormulaModifier<String> modifier =
 				factory.getModifier("MyString", new ManagerFactory(){}, null, varScope, stringManager);
 		modifier.addAssociation("PRIORITY=5");
 		assertEquals(5L <<32, modifier.getPriority());


### PR DESCRIPTION
Also some document cleanups and minor bug fixes

This performs a global rename of PCGenModifier to FormulaModifier in order to improve semantics.  This is also a preparatory PR for a much larger change that I wanted to avoid this "rename pollution" in a much more functional change.