### PR TITLE
NEWTAG-617 First ALLOW Implementation

### DIFF
--- a/code/pluginbuild.xml
+++ b/code/pluginbuild.xml
@@ -2323,10 +2323,24 @@ jar-all-plugins - Generate the plugin jar files
 				</patternset>
 			</fileset>
 		</jar>
+		<jar jarfile="${lstplugins.dir}/LstToken-PREREQUISITE.jar" manifest="${src.java.dir}/plugin/lsttokens/manifest.mf">
+			<fileset dir="${build.classes.dir}">
+				<patternset>
+					<include name="plugin/lsttokens/PrerequisiteLst.class" />
+				</patternset>
+			</fileset>
+		</jar>
 		<jar jarfile="${lstplugins.dir}/LstToken-QUALIFY.jar" manifest="${src.java.dir}/plugin/lsttokens/manifest.mf">
 			<fileset dir="${build.classes.dir}">
 				<patternset>
 					<include name="plugin/lsttokens/QualifyToken.class" />
+				</patternset>
+			</fileset>
+		</jar>
+		<jar jarfile="${lstplugins.dir}/LstToken-REQUIREMENT.jar" manifest="${src.java.dir}/plugin/lsttokens/manifest.mf">
+			<fileset dir="${build.classes.dir}">
+				<patternset>
+					<include name="plugin/lsttokens/RequirementLst.class" />
 				</patternset>
 			</fileset>
 		</jar>

--- a/code/pluginbuild.xml
+++ b/code/pluginbuild.xml
@@ -2120,6 +2120,13 @@ jar-all-plugins - Generate the plugin jar files
 				</patternset>
 			</fileset>
 		</jar>
+		<jar jarfile="${lstplugins.dir}/LstToken-ALLOW.jar" manifest="${src.java.dir}/plugin/lsttokens/manifest.mf">
+			<fileset dir="${build.classes.dir}">
+				<patternset>
+					<include name="plugin/lsttokens/AllowLst.class" />
+				</patternset>
+			</fileset>
+		</jar>
 		<jar jarfile="${lstplugins.dir}/LstToken-AUTO.jar" manifest="${src.java.dir}/plugin/lsttokens/manifest.mf">
 			<fileset dir="${build.classes.dir}">
 				<patternset>
@@ -2201,6 +2208,13 @@ jar-all-plugins - Generate the plugin jar files
 			<fileset dir="${build.classes.dir}">
 				<patternset>
 					<include name="plugin/lsttokens/DrLst.class" />
+				</patternset>
+			</fileset>
+		</jar>
+		<jar jarfile="${lstplugins.dir}/LstToken-ENABLE.jar" manifest="${src.java.dir}/plugin/lsttokens/manifest.mf">
+			<fileset dir="${build.classes.dir}">
+				<patternset>
+					<include name="plugin/lsttokens/EnableLst.class" />
 				</patternset>
 			</fileset>
 		</jar>
@@ -2323,24 +2337,10 @@ jar-all-plugins - Generate the plugin jar files
 				</patternset>
 			</fileset>
 		</jar>
-		<jar jarfile="${lstplugins.dir}/LstToken-PREREQUISITE.jar" manifest="${src.java.dir}/plugin/lsttokens/manifest.mf">
-			<fileset dir="${build.classes.dir}">
-				<patternset>
-					<include name="plugin/lsttokens/PrerequisiteLst.class" />
-				</patternset>
-			</fileset>
-		</jar>
 		<jar jarfile="${lstplugins.dir}/LstToken-QUALIFY.jar" manifest="${src.java.dir}/plugin/lsttokens/manifest.mf">
 			<fileset dir="${build.classes.dir}">
 				<patternset>
 					<include name="plugin/lsttokens/QualifyToken.class" />
-				</patternset>
-			</fileset>
-		</jar>
-		<jar jarfile="${lstplugins.dir}/LstToken-REQUIREMENT.jar" manifest="${src.java.dir}/plugin/lsttokens/manifest.mf">
-			<fileset dir="${build.classes.dir}">
-				<patternset>
-					<include name="plugin/lsttokens/RequirementLst.class" />
 				</patternset>
 			</fileset>
 		</jar>

--- a/code/src/java/pcgen/cdom/base/CDOMObject.java
+++ b/code/src/java/pcgen/cdom/base/CDOMObject.java
@@ -1218,14 +1218,14 @@ public abstract class CDOMObject extends ConcretePrereqObject implements
 	@Override
 	public boolean hasPrerequisites()
 	{
-		return super.hasPrerequisites() || (getListFor(ListKey.PREREQUISITE) != null)
-			|| (getListFor(ListKey.REQUIREMENT) != null);
+		return super.hasPrerequisites() || (getListFor(ListKey.ALLOW) != null)
+			|| (getListFor(ListKey.ENABLE) != null);
 	}
 
 	@Override
 	public boolean isAvailable(PlayerCharacter aPC)
 	{
-		List<NEPFormula<Boolean>> prerequisites = getListFor(ListKey.PREREQUISITE);
+		List<NEPFormula<Boolean>> prerequisites = getListFor(ListKey.ALLOW);
 		if ((prerequisites == null) || prerequisites.isEmpty())
 		{
 			return true;
@@ -1243,7 +1243,7 @@ public abstract class CDOMObject extends ConcretePrereqObject implements
 	@Override
 	public boolean isActive(PlayerCharacter aPC)
 	{
-		List<NEPFormula<Boolean>> requirements = getListFor(ListKey.REQUIREMENT);
+		List<NEPFormula<Boolean>> requirements = getListFor(ListKey.ENABLE);
 		if ((requirements == null) || requirements.isEmpty())
 		{
 			return true;

--- a/code/src/java/pcgen/cdom/base/CDOMObject.java
+++ b/code/src/java/pcgen/cdom/base/CDOMObject.java
@@ -1218,7 +1218,7 @@ public abstract class CDOMObject extends ConcretePrereqObject implements
 	@Override
 	public boolean hasPrerequisites()
 	{
-		return hasPrerequisites() || (getListFor(ListKey.PREREQUISITE) != null)
+		return super.hasPrerequisites() || (getListFor(ListKey.PREREQUISITE) != null)
 			|| (getListFor(ListKey.REQUIREMENT) != null);
 	}
 

--- a/code/src/java/pcgen/cdom/base/CDOMObject.java
+++ b/code/src/java/pcgen/cdom/base/CDOMObject.java
@@ -31,6 +31,7 @@ import java.util.Set;
 
 import pcgen.base.formula.Formula;
 import pcgen.base.formula.base.VarScoped;
+import pcgen.base.formula.inst.NEPFormula;
 import pcgen.base.lang.StringUtil;
 import pcgen.base.util.DoubleKeyMapToList;
 import pcgen.base.util.Indirect;
@@ -1214,4 +1215,46 @@ public abstract class CDOMObject extends ConcretePrereqObject implements
 		return null;
 	}
 
+	@Override
+	public boolean hasPrerequisites()
+	{
+		return hasPrerequisites() || (getListFor(ListKey.PREREQUISITE) != null)
+			|| (getListFor(ListKey.REQUIREMENT) != null);
+	}
+
+	@Override
+	public boolean isAvailable(PlayerCharacter aPC)
+	{
+		List<NEPFormula<Boolean>> prerequisites = getListFor(ListKey.PREREQUISITE);
+		if ((prerequisites == null) || prerequisites.isEmpty())
+		{
+			return true;
+		}
+		for (NEPFormula<Boolean> formula : prerequisites)
+		{
+			if (!aPC.solve(formula))
+			{
+				return false;
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public boolean isActive(PlayerCharacter aPC)
+	{
+		List<NEPFormula<Boolean>> requirements = getListFor(ListKey.REQUIREMENT);
+		if ((requirements == null) || requirements.isEmpty())
+		{
+			return true;
+		}
+		for (NEPFormula<Boolean> formula : requirements)
+		{
+			if (!aPC.solve(formula))
+			{
+				return false;
+			}
+		}
+		return false;
+	}
 }

--- a/code/src/java/pcgen/cdom/base/ConcretePrereqObject.java
+++ b/code/src/java/pcgen/cdom/base/ConcretePrereqObject.java
@@ -260,7 +260,18 @@ public class ConcretePrereqObject implements Cloneable, PrereqObject
 	 */
 	public boolean qualifies(final PlayerCharacter aPC, Object owner)
 	{
-		return !hasPrerequisites()
-				|| PrereqHandler.passesAll(getPrerequisiteList(), aPC, owner);
+		return !hasPrerequisites() || PrereqHandler.passesAll(this, aPC, owner);
+	}
+
+	@Override
+	public boolean isAvailable(PlayerCharacter aPC)
+	{
+		return true;
+	}
+
+	@Override
+	public boolean isActive(PlayerCharacter aPC)
+	{
+		return true;
 	}
 }

--- a/code/src/java/pcgen/cdom/base/PrereqObject.java
+++ b/code/src/java/pcgen/cdom/base/PrereqObject.java
@@ -23,6 +23,7 @@ package pcgen.cdom.base;
 import java.util.Collection;
 import java.util.List;
 
+import pcgen.core.PlayerCharacter;
 import pcgen.core.prereq.Prerequisite;
 
 /**
@@ -82,4 +83,28 @@ public interface PrereqObject
 	 * @return the number of Prerequisites contained in the PrereqObject.
 	 */
 	public int getPrerequisiteCount();
+
+	/**
+	 * Indicates of the current object is Available for selection. This is controlled by
+	 * "new formula" Prerequisites.
+	 * 
+	 * @param aPC
+	 *            The PlayerCharaceter on which to check whether the calling object is
+	 *            available for selection.
+	 * @return true if this object is available for selection for the given
+	 *         PlayerCharacter; false otherwise
+	 */
+	public boolean isAvailable(PlayerCharacter aPC);
+
+	/**
+	 * Indicates of the current object is allowed to be active on the PlayerCharacter.
+	 * This is controlled by "new formula" Requirements.
+	 * 
+	 * @param aPC
+	 *            The PlayerCharaceter on which to check whether the calling object is
+	 *            allowed to be active.
+	 * @return true if this object is allowed to be active for the given PlayerCharacter;
+	 *         false otherwise
+	 */
+	public boolean isActive(PlayerCharacter aPC);
 }

--- a/code/src/java/pcgen/cdom/enumeration/ListKey.java
+++ b/code/src/java/pcgen/cdom/enumeration/ListKey.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.Map;
 
 import pcgen.base.formula.Formula;
+import pcgen.base.formula.inst.NEPFormula;
 import pcgen.base.lang.UnreachableError;
 import pcgen.base.util.CaseInsensitiveMap;
 import pcgen.cdom.base.CDOMReference;
@@ -283,6 +284,8 @@ public final class ListKey<T>
 	public static final ListKey<CampaignSourceEntry> FILE_DYNAMIC = new ListKey<>();
 	public static final ListKey<CDOMReference<Dynamic>> GRANTED = new ListKey<>();
 	public static final ListKey<CampaignSourceEntry> FILE_DATATABLE = new ListKey<>();
+	public static final ListKey<NEPFormula<Boolean>> REQUIREMENT = new ListKey<>();
+	public static final ListKey<NEPFormula<Boolean>> PREREQUISITE = new ListKey<>();
 
 	private static CaseInsensitiveMap<ListKey<?>> map = null;
 

--- a/code/src/java/pcgen/cdom/enumeration/ListKey.java
+++ b/code/src/java/pcgen/cdom/enumeration/ListKey.java
@@ -284,8 +284,8 @@ public final class ListKey<T>
 	public static final ListKey<CampaignSourceEntry> FILE_DYNAMIC = new ListKey<>();
 	public static final ListKey<CDOMReference<Dynamic>> GRANTED = new ListKey<>();
 	public static final ListKey<CampaignSourceEntry> FILE_DATATABLE = new ListKey<>();
-	public static final ListKey<NEPFormula<Boolean>> REQUIREMENT = new ListKey<>();
-	public static final ListKey<NEPFormula<Boolean>> PREREQUISITE = new ListKey<>();
+	public static final ListKey<NEPFormula<Boolean>> ENABLE = new ListKey<>();
+	public static final ListKey<NEPFormula<Boolean>> ALLOW = new ListKey<>();
 
 	private static CaseInsensitiveMap<ListKey<?>> map = null;
 

--- a/code/src/java/pcgen/core/Equipment.java
+++ b/code/src/java/pcgen/core/Equipment.java
@@ -2157,8 +2157,7 @@ public final class Equipment extends PObject implements Serializable,
 		if (Visibility.QUALIFY.equals(vis))
 		{
 			bonusPrimary = true;
-			if (PrereqHandler
-				.passesAll(eqMod.getPrerequisiteList(), this, null))
+			if (PrereqHandler.passesAll(eqMod, this, null))
 			{
 				return true;
 			}
@@ -2169,8 +2168,7 @@ public final class Equipment extends PObject implements Serializable,
 			if (isDouble())
 			{
 				bonusPrimary = false;
-				return PrereqHandler.passesAll(eqMod.getPrerequisiteList(),
-					this, null);
+				return PrereqHandler.passesAll(eqMod, this, null);
 			}
 			return false;
 		}
@@ -2195,8 +2193,7 @@ public final class Equipment extends PObject implements Serializable,
 		if (Visibility.QUALIFY.equals(vis))
 		{
 			bonusPrimary = primaryHead;
-			return PrereqHandler.passesAll(eqMod.getPrerequisiteList(),
-				this, pc);
+			return PrereqHandler.passesAll(eqMod, this, pc);
 		}
 
 		return vis.isVisibleTo(v);
@@ -2783,7 +2780,7 @@ public final class Equipment extends PObject implements Serializable,
 		bonusPrimary = bPrimary;
 
 		return getSafe(ObjectKey.MOD_CONTROL).getModifiersAllowed()
-			&& PrereqHandler.passesAll(eqMod.getPrerequisiteList(), this, pc);
+			&& PrereqHandler.passesAll(eqMod, this, pc);
 	}
 
 	/**
@@ -3247,7 +3244,7 @@ public final class Equipment extends PObject implements Serializable,
 	 */
 	public boolean meetsPreReqs(PlayerCharacter pc)
 	{
-		return PrereqHandler.passesAll(getPrerequisiteList(), this, pc);
+		return PrereqHandler.passesAll(this, this, pc);
 	}
 
 	/**
@@ -5068,8 +5065,7 @@ public final class Equipment extends PObject implements Serializable,
 	{
 		for (final BonusObj bonus : getRawBonusList(aPC))
 		{
-			aPC.setApplied(bonus, PrereqHandler.passesAll(bonus
-				.getPrerequisiteList(), this, aPC));
+			aPC.setApplied(bonus, PrereqHandler.passesAll(bonus, this, aPC));
 		}
 	}
 

--- a/code/src/java/pcgen/core/EquipmentList.java
+++ b/code/src/java/pcgen/core/EquipmentList.java
@@ -576,7 +576,7 @@ public final class EquipmentList {
 				{
 					if (eqMod.isType(t)) {
 						// Type matches, passes prereqs?
-						if (PrereqHandler.passesAll(eqMod.getPrerequisiteList(), eq, null)) { return eqMod; }
+						if (PrereqHandler.passesAll(eqMod, eq, null)) { return eqMod; }
 					}
 				}
 			}

--- a/code/src/java/pcgen/core/EquipmentModifier.java
+++ b/code/src/java/pcgen/core/EquipmentModifier.java
@@ -67,8 +67,7 @@ public final class EquipmentModifier extends PObject implements Comparable<Objec
 
 		for (BonusObj bonus : getBonusList(caller))
 		{
-			if (PrereqHandler.passesAll(bonus.getPrerequisiteList(), caller,
-					aPC))
+			if (PrereqHandler.passesAll(bonus, caller, aPC))
 			{
 				aPC.setApplied(bonus, true);
 				aList.add(bonus);

--- a/code/src/java/pcgen/core/Kit.java
+++ b/code/src/java/pcgen/core/Kit.java
@@ -305,8 +305,7 @@ public final class Kit extends PObject implements Comparable<Object>, KitFacade
 
 		for (BaseKit bk : getSafeListFor(ListKey.KIT_TASKS))
 		{
-			if (!PrereqHandler
-				.passesAll(bk.getPrerequisiteList(), tempPC, this))
+			if (!PrereqHandler.passesAll(bk, tempPC, this))
 			{
 				continue;
 			}

--- a/code/src/java/pcgen/core/PlayerCharacter.java
+++ b/code/src/java/pcgen/core/PlayerCharacter.java
@@ -39,6 +39,7 @@ import org.jetbrains.annotations.TestOnly;
 import pcgen.base.formula.Formula;
 import pcgen.base.formula.base.ScopeInstance;
 import pcgen.base.formula.base.VarScoped;
+import pcgen.base.formula.inst.NEPFormula;
 import pcgen.base.solver.DynamicSolverManager;
 import pcgen.base.solver.IndividualSetup;
 import pcgen.base.solver.SolverFactory;
@@ -10237,5 +10238,18 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 	public boolean hasControl(String string)
 	{
 		return controller.get(ObjectKey.getKeyFor(String.class, '*' + string)) != null;
+	}
+
+	/**
+	 * Directly solves the given NEPFormula in context to this PlayerCharacter.
+	 * 
+	 * @param formula
+	 *            The NEPFormula to be solved
+	 * @return The result of solving the given NEPFormula in context to this
+	 *         PlayerCharacter
+	 */
+	public <T> T solve(NEPFormula<T> formula)
+	{
+		return solverManagerFacet.get(id).solve(formula);
 	}
 }

--- a/code/src/java/pcgen/core/analysis/BonusCalc.java
+++ b/code/src/java/pcgen/core/analysis/BonusCalc.java
@@ -285,7 +285,7 @@ public final class BonusCalc
 		}
 		else
 		{
-			if (!PrereqHandler.passesAll(aBonusObj.getPrerequisiteList(), (Equipment) obj, aPC))
+			if (!PrereqHandler.passesAll(aBonusObj, (Equipment) obj, aPC))
 			{
 				return 0;
 			}

--- a/code/src/java/pcgen/core/analysis/DomainApplication.java
+++ b/code/src/java/pcgen/core/analysis/DomainApplication.java
@@ -100,7 +100,7 @@ public final class DomainApplication
 			Collection<AssociatedPrereqObject> assoc = d.getListAssociations(Spell.SPELLS, ref);
 			for (AssociatedPrereqObject apo : assoc)
 			{
-				if (!PrereqHandler.passesAll(apo.getPrerequisiteList(), pc, d))
+				if (!PrereqHandler.passesAll(apo, pc, d))
 				{
 					continue;
 				}

--- a/code/src/java/pcgen/core/analysis/SpellLevel.java
+++ b/code/src/java/pcgen/core/analysis/SpellLevel.java
@@ -128,8 +128,7 @@ public final class SpellLevel
 			{
 				for (AssociatedPrereqObject apo : assoc)
 				{
-					if (PrereqHandler.passesAll(apo.getPrerequisiteList(), aPC,
-							sp))
+					if (PrereqHandler.passesAll(apo, aPC, sp))
 					{
 						if (levelKey.equals(apo
 								.getAssociation(AssociationKey.SPELL_LEVEL)))
@@ -149,8 +148,7 @@ public final class SpellLevel
 			{
 				for (AssociatedPrereqObject apo : assoc)
 				{
-					if (PrereqHandler.passesAll(apo.getPrerequisiteList(), aPC,
-							sp))
+					if (PrereqHandler.passesAll(apo, aPC, sp))
 					{
 						if (levelKey.equals(apo
 								.getAssociation(AssociationKey.SPELL_LEVEL)))

--- a/code/src/java/pcgen/core/analysis/SubClassApplication.java
+++ b/code/src/java/pcgen/core/analysis/SubClassApplication.java
@@ -62,7 +62,7 @@ public final class SubClassApplication
 	
 		for (SubClass sc : subClassList)
 		{
-			if (!PrereqHandler.passesAll(sc.getPrerequisiteList(), aPC, cl))
+			if (!PrereqHandler.passesAll(sc, aPC, cl))
 			{
 				continue;
 			}
@@ -149,7 +149,7 @@ public final class SubClassApplication
 					//Skip the selected specialist school
 					continue;
 				}
-				if (!PrereqHandler.passesAll(sub.getPrerequisiteList(), aPC, cl))
+				if (!PrereqHandler.passesAll(sub, aPC, cl))
 				{
 					continue;
 				}

--- a/code/src/java/pcgen/core/analysis/SubstitutionClassApplication.java
+++ b/code/src/java/pcgen/core/analysis/SubstitutionClassApplication.java
@@ -114,7 +114,7 @@ public final class SubstitutionClassApplication
 
 		for (SubstitutionClass sc : cl.getListFor(ListKey.SUBSTITUTION_CLASS))
 		{
-			if (!PrereqHandler.passesAll(sc.getPrerequisiteList(), aPC, cl))
+			if (!PrereqHandler.passesAll(sc, aPC, cl))
 			{
 				continue;
 			}

--- a/code/src/java/pcgen/core/character/WieldCategory.java
+++ b/code/src/java/pcgen/core/character/WieldCategory.java
@@ -223,7 +223,7 @@ public final class WieldCategory implements Loadable
 		// TODO what if more than one matches??
 		for (QualifiedObject<CDOMSingleRef<WieldCategory>> qo : categorySwitches)
 		{
-			if (PrereqHandler.passesAll(qo.getPrerequisiteList(), eq, pc))
+			if (PrereqHandler.passesAll(qo, eq, pc))
 			{
 				pcWCat = qo.getRawObject().get();
 			}

--- a/code/src/java/pcgen/core/kit/KitClass.java
+++ b/code/src/java/pcgen/core/kit/KitClass.java
@@ -73,7 +73,7 @@ public class KitClass extends BaseKit
 		theOrigSubClass = aPC.getSubClassName(theClass);
 		applySubClass(aPC);
 
-		if (!PrereqHandler.passesAll(theClass.getPrerequisiteList(), aPC, aKit))
+		if (!PrereqHandler.passesAll(theClass, aPC, aKit))
 		{
 			PrereqHandler.toHtmlString(theClass.getPrerequisiteList());
 			warnings.add("CLASS: Not qualified for class \""

--- a/code/src/java/pcgen/core/npcgen/ClassDataParser.java
+++ b/code/src/java/pcgen/core/npcgen/ClassDataParser.java
@@ -630,8 +630,7 @@ class ClassDataHandler extends DefaultHandler
 				{
 					// TODO This null for source is incorrect!
 					// TODO Not sure if effect of null for PC
-					if (PrereqHandler.passesAll(apo.getPrerequisiteList(), (PlayerCharacter) null,
-							null))
+					if (PrereqHandler.passesAll(apo, (PlayerCharacter) null, null))
 					{
 						int lvl = apo
 								.getAssociation(AssociationKey.SPELL_LEVEL);

--- a/code/src/java/pcgen/core/prereq/PrereqHandler.java
+++ b/code/src/java/pcgen/core/prereq/PrereqHandler.java
@@ -21,9 +21,11 @@ package pcgen.core.prereq;
 
 
 import java.util.Collection;
+import java.util.List;
 
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.base.Constants;
+import pcgen.cdom.base.PrereqObject;
 import pcgen.core.Ability;
 import pcgen.core.AbilityUtilities;
 import pcgen.core.Equipment;
@@ -92,6 +94,44 @@ public final class PrereqHandler
 		return true;
 	}
 
+	public static boolean passesAll(PrereqObject prereqObject, PlayerCharacter aPC,
+		Object caller)
+	{
+		if (!prereqObject.isAvailable(aPC) || !prereqObject.isActive(aPC))
+		{
+			return false;
+		}
+		Collection<Prerequisite> prereqList = prereqObject.getPrerequisiteList();
+		if (prereqList == null || prereqList.isEmpty())
+		{
+			return true;
+		}
+
+		if ((caller instanceof Ability) && (AbilityUtilities.isFeat(caller))
+			&& Globals.checkRule(RuleConstants.FEATPRE))
+		{
+			return true;
+		}
+
+		if (caller instanceof CDOMObject && aPC != null)
+		{
+			// Check for QUALIFY:
+			if (aPC.checkQualifyList((CDOMObject) caller))
+			{
+				return true;
+			}
+		}
+
+		for (Prerequisite prereq : prereqList)
+		{
+			if (!passes(prereq, aPC, caller))
+			{
+				return false;
+			}
+		}
+		return true;
+	}
+
 	/**
 	 *
 	 * @param prereqList The list of prerequisites to be tested.
@@ -104,6 +144,24 @@ public final class PrereqHandler
 		final Equipment equip,
 		PlayerCharacter aPC)
 	{
+		if (prereqList == null)
+		{
+			return true;
+		}
+		for (Prerequisite prereq : prereqList)
+		{
+			if (!passes(prereq, equip, aPC))
+			{
+				return false;
+			}
+		}
+		return true;
+	}
+
+	public static boolean passesAll(PrereqObject prereqObject, Equipment equip,
+		PlayerCharacter aPC)
+	{
+		List<Prerequisite> prereqList = prereqObject.getPrerequisiteList();
 		if (prereqList == null)
 		{
 			return true;

--- a/code/src/java/pcgen/core/prereq/PrerequisiteUtilities.java
+++ b/code/src/java/pcgen/core/prereq/PrerequisiteUtilities.java
@@ -72,6 +72,7 @@ public final class PrerequisiteUtilities
 	 * @param includeHeader Whether to wrap the generated string in html tags.
 	 * @return An HTML representation of whether a set of PreRequisites passed for a given PC and Source.
 	 */
+	//TODO All uses of this miss PRE REQ
 	public static String preReqHTMLStringsForList(
 		final PlayerCharacter aPC,
 		final CDOMObject aObj,

--- a/code/src/java/pcgen/gui2/facade/CharacterFacadeImpl.java
+++ b/code/src/java/pcgen/gui2/facade/CharacterFacadeImpl.java
@@ -3679,7 +3679,7 @@ public class CharacterFacadeImpl implements CharacterFacade, EquipmentListListen
 	public boolean isQualifiedFor(EquipmentFacade equipment)
 	{
 		final Equipment equip = (Equipment) equipment;
-		final boolean accept = PrereqHandler.passesAll(equip.getPrerequisiteList(), theCharacter, equip);
+		final boolean accept = PrereqHandler.passesAll(equip, theCharacter, equip);
 
 		if (accept && (equip.isShield() || equip.isWeapon() || equip.isArmor()))
 		{
@@ -3973,7 +3973,7 @@ public class CharacterFacadeImpl implements CharacterFacade, EquipmentListListen
 			return false;
 		}
 		Deity aDeity = (Deity) deityFacade;
-		return PrereqHandler.passesAll(aDeity.getPrerequisiteList(), theCharacter, aDeity)
+		return PrereqHandler.passesAll(aDeity, theCharacter, aDeity)
 				&& theCharacter.isQualified(aDeity);
 	}
 	
@@ -3990,7 +3990,7 @@ public class CharacterFacadeImpl implements CharacterFacade, EquipmentListListen
 
 		DomainFacadeImpl domainFI = (DomainFacadeImpl) domainFacade;
 		Domain domain = domainFI.getRawObject();
-		if (!PrereqHandler.passesAll(domainFI.getPrerequisiteList(), theCharacter, domain)
+		if (!PrereqHandler.passesAll(domainFI, theCharacter, domain)
 				|| !theCharacter.isQualified(domain))
 		{
 			return false;
@@ -4069,7 +4069,7 @@ public class CharacterFacadeImpl implements CharacterFacade, EquipmentListListen
 
 		PCTemplate template = (PCTemplate) templateFacade;
 
-		if (!PrereqHandler.passesAll(template.getPrerequisiteList(), theCharacter, template))
+		if (!PrereqHandler.passesAll(template, theCharacter, template))
 		{
 			return;
 		}

--- a/code/src/java/pcgen/gui2/facade/TempBonusHelper.java
+++ b/code/src/java/pcgen/gui2/facade/TempBonusHelper.java
@@ -256,7 +256,7 @@ public class TempBonusHelper
 				// if Target was this PC, then add
 				// bonus to TempBonusMap
 				theCharacter.setApplied(newB, PrereqHandler.passesAll(
-					newB.getPrerequisiteList(), aEq, theCharacter));
+					newB, aEq, theCharacter));
 				aEq.addTempBonus(newB);
 				TempBonusInfo tempBonusInfo =
 						theCharacter.addTempBonus(newB, originObj, aEq);

--- a/code/src/java/pcgen/rules/context/LoadContext.java
+++ b/code/src/java/pcgen/rules/context/LoadContext.java
@@ -22,6 +22,8 @@ import java.util.Collection;
 import java.util.List;
 
 import pcgen.base.formula.base.LegalScope;
+import pcgen.base.formula.inst.NEPFormula;
+import pcgen.base.util.FormatManager;
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.base.CDOMReference;
 import pcgen.cdom.base.GroupDefinition;
@@ -177,4 +179,17 @@ public interface LoadContext
 	 * @return The currently active LegalScope
 	 */
 	public LegalScope getActiveScope();
+
+	/**
+	 * Directly returns a valid formula with the Format of the given FormatManager.
+	 * 
+	 * @param formatManager
+	 *            The FormatManager to indicate the format of the NEPFormula to be
+	 *            returned
+	 * @param instructions
+	 *            The instructions for the NEPFormula to process when it is solved
+	 * @return A NEPFormula that implements the given Format and instructions
+	 */
+	public <T> NEPFormula<T> getValidFormula(FormatManager<T> formatManager,
+		String instructions);
 }

--- a/code/src/java/pcgen/rules/context/LoadContextInst.java
+++ b/code/src/java/pcgen/rules/context/LoadContextInst.java
@@ -24,9 +24,12 @@ import java.util.Collections;
 import java.util.List;
 
 import pcgen.base.formula.base.LegalScope;
+import pcgen.base.formula.inst.NEPFormula;
 import pcgen.base.text.ParsingSeparator;
+import pcgen.base.util.FormatManager;
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.base.CDOMReference;
+import pcgen.cdom.base.FormulaFactory;
 import pcgen.cdom.base.GroupDefinition;
 import pcgen.cdom.base.Loadable;
 import pcgen.cdom.base.PrimitiveCollection;
@@ -559,6 +562,13 @@ abstract class LoadContextInst implements LoadContext
 		return new DerivedLoadContext(parentLC, lvs);
 	}
 
+	@Override
+	public <T> NEPFormula<T> getValidFormula(FormatManager<T> formatManager, String instructions)
+	{
+		return FormulaFactory.getValidFormula(instructions, var.getManagerFactory(),
+			var.getDummySetup().getFormulaManager(), getActiveScope(), formatManager);
+	}
+
 	private class DerivedLoadContext implements LoadContext
 	{
 
@@ -841,5 +851,12 @@ abstract class LoadContextInst implements LoadContext
 		{
 			parent.resolvePostValidationTokens();
 		}
-	}
+
+		@Override
+		public <T> NEPFormula<T> getValidFormula(FormatManager<T> formatManager,
+			String instructions)
+		{
+			return parent.getValidFormula(formatManager, instructions);
+		}
+}
 }

--- a/code/src/java/pcgen/rules/context/VariableContext.java
+++ b/code/src/java/pcgen/rules/context/VariableContext.java
@@ -63,7 +63,7 @@ public class VariableContext
 	 * Lazy instantiation to avoid trying to pull the "Global" scope before it
 	 * is loaded from plugins
 	 */
-	private IndividualSetup getDummySetup()
+	IndividualSetup getDummySetup()
 	{
 		if (dummySetup == null)
 		{

--- a/code/src/java/plugin/lsttokens/AllowLst.java
+++ b/code/src/java/plugin/lsttokens/AllowLst.java
@@ -1,5 +1,6 @@
 package plugin.lsttokens;
 
+import pcgen.base.formatmanager.FormatUtilities;
 import pcgen.base.formula.inst.NEPFormula;
 import pcgen.base.lang.StringUtil;
 import pcgen.cdom.base.CDOMObject;
@@ -11,14 +12,19 @@ import pcgen.rules.persistence.token.AbstractNonEmptyToken;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import pcgen.rules.persistence.token.ParseResult;
 
-public class RequirementLst extends AbstractNonEmptyToken<CDOMObject>
+/**
+ * Processes the ALLOW token, which is the "new formula token" for Prerequisites.
+ * This is designed to control ONLY situations at a user selection - it does not do
+ * ongoing enforcement. For ongoing enforcement, ENABLE is used.
+ */
+public class AllowLst extends AbstractNonEmptyToken<CDOMObject>
 		implements CDOMPrimaryToken<CDOMObject>
 {
 
 	@Override
 	public String getTokenName()
 	{
-		return "REQUIREMENT";
+		return "ALLOW";
 	}
 
 	@Override
@@ -31,22 +37,22 @@ public class RequirementLst extends AbstractNonEmptyToken<CDOMObject>
 	protected ParseResult parseNonEmptyToken(LoadContext context, CDOMObject obj,
 		String value)
 	{
-		return new ParseResult.Fail("Not supported since it is not monitored in an ongoing fashion");
-//		NEPFormula<Boolean> formula =
-//				context.getValidFormula(FormatUtilities.BOOLEAN_MANAGER, value);
-//		obj.addToListFor(ListKey.REQUIREMENT, formula);
-//		return ParseResult.SUCCESS;
+		NEPFormula<Boolean> formula =
+				context.getValidFormula(FormatUtilities.BOOLEAN_MANAGER, value);
+		obj.addToListFor(ListKey.ALLOW, formula);
+		return ParseResult.SUCCESS;
 	}
 
 	@Override
 	public String[] unparse(LoadContext context, CDOMObject obj)
 	{
 		Changes<NEPFormula<Boolean>> changes =
-				context.getObjectContext().getListChanges(obj, ListKey.REQUIREMENT);
+				context.getObjectContext().getListChanges(obj, ListKey.ALLOW);
 		if (changes == null || changes.isEmpty())
 		{
 			return null;
 		}
+		//This is correct - NEPFormula unparses to its instructions with toString()
 		return new String[]{StringUtil.join(changes.getAdded(), Constants.PIPE)};
 	}
 }

--- a/code/src/java/plugin/lsttokens/EnableLst.java
+++ b/code/src/java/plugin/lsttokens/EnableLst.java
@@ -1,6 +1,5 @@
 package plugin.lsttokens;
 
-import pcgen.base.formatmanager.FormatUtilities;
 import pcgen.base.formula.inst.NEPFormula;
 import pcgen.base.lang.StringUtil;
 import pcgen.cdom.base.CDOMObject;
@@ -13,18 +12,18 @@ import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import pcgen.rules.persistence.token.ParseResult;
 
 /**
- * Processes the PREREQUISITE token, which is the "new formula token" for Prerequisites.
- * This is designed to control ONLY situations at a user selection - it does not do
- * ongoing enforcement. For ongoing enforcement, REQUIREMENT is used.
+ * Processes the ENABLE token, which is the "new formula token" for Requirements. This is
+ * designed to control ONLY ongoing enforcement. It does not do enforcement at user
+ * selection. For enforcement at user selection, ALLOW is used.
  */
-public class PrerequisiteLst extends AbstractNonEmptyToken<CDOMObject>
+public class EnableLst extends AbstractNonEmptyToken<CDOMObject>
 		implements CDOMPrimaryToken<CDOMObject>
 {
 
 	@Override
 	public String getTokenName()
 	{
-		return "PREREQUISITE";
+		return "ENABLE";
 	}
 
 	@Override
@@ -37,22 +36,22 @@ public class PrerequisiteLst extends AbstractNonEmptyToken<CDOMObject>
 	protected ParseResult parseNonEmptyToken(LoadContext context, CDOMObject obj,
 		String value)
 	{
-		NEPFormula<Boolean> formula =
-				context.getValidFormula(FormatUtilities.BOOLEAN_MANAGER, value);
-		obj.addToListFor(ListKey.PREREQUISITE, formula);
-		return ParseResult.SUCCESS;
+		return new ParseResult.Fail("Not supported since it is not monitored in an ongoing fashion");
+//		NEPFormula<Boolean> formula =
+//				context.getValidFormula(FormatUtilities.BOOLEAN_MANAGER, value);
+//		obj.addToListFor(ListKey.ENABLE, formula);
+//		return ParseResult.SUCCESS;
 	}
 
 	@Override
 	public String[] unparse(LoadContext context, CDOMObject obj)
 	{
 		Changes<NEPFormula<Boolean>> changes =
-				context.getObjectContext().getListChanges(obj, ListKey.PREREQUISITE);
+				context.getObjectContext().getListChanges(obj, ListKey.ENABLE);
 		if (changes == null || changes.isEmpty())
 		{
 			return null;
 		}
-		//This is correct - NEPFormula unparses to its instructions with toString()
 		return new String[]{StringUtil.join(changes.getAdded(), Constants.PIPE)};
 	}
 }

--- a/code/src/java/plugin/lsttokens/PrerequisiteLst.java
+++ b/code/src/java/plugin/lsttokens/PrerequisiteLst.java
@@ -1,0 +1,58 @@
+package plugin.lsttokens;
+
+import pcgen.base.formatmanager.FormatUtilities;
+import pcgen.base.formula.inst.NEPFormula;
+import pcgen.base.lang.StringUtil;
+import pcgen.cdom.base.CDOMObject;
+import pcgen.cdom.base.Constants;
+import pcgen.cdom.enumeration.ListKey;
+import pcgen.rules.context.Changes;
+import pcgen.rules.context.LoadContext;
+import pcgen.rules.persistence.token.AbstractNonEmptyToken;
+import pcgen.rules.persistence.token.CDOMPrimaryToken;
+import pcgen.rules.persistence.token.ParseResult;
+
+/**
+ * Processes the PREREQUISITE token, which is the "new formula token" for Prerequisites.
+ * This is designed to control ONLY situations at a user selection - it does not do
+ * ongoing enforcement. For ongoing enforcement, REQUIREMENT is used.
+ */
+public class PrerequisiteLst extends AbstractNonEmptyToken<CDOMObject>
+		implements CDOMPrimaryToken<CDOMObject>
+{
+
+	@Override
+	public String getTokenName()
+	{
+		return "PREREQUISITE";
+	}
+
+	@Override
+	public Class<CDOMObject> getTokenClass()
+	{
+		return CDOMObject.class;
+	}
+
+	@Override
+	protected ParseResult parseNonEmptyToken(LoadContext context, CDOMObject obj,
+		String value)
+	{
+		NEPFormula<Boolean> formula =
+				context.getValidFormula(FormatUtilities.BOOLEAN_MANAGER, value);
+		obj.addToListFor(ListKey.PREREQUISITE, formula);
+		return ParseResult.SUCCESS;
+	}
+
+	@Override
+	public String[] unparse(LoadContext context, CDOMObject obj)
+	{
+		Changes<NEPFormula<Boolean>> changes =
+				context.getObjectContext().getListChanges(obj, ListKey.PREREQUISITE);
+		if (changes == null || changes.isEmpty())
+		{
+			return null;
+		}
+		//This is correct - NEPFormula unparses to its instructions with toString()
+		return new String[]{StringUtil.join(changes.getAdded(), Constants.PIPE)};
+	}
+}

--- a/code/src/java/plugin/lsttokens/RequirementLst.java
+++ b/code/src/java/plugin/lsttokens/RequirementLst.java
@@ -1,0 +1,56 @@
+package plugin.lsttokens;
+
+import pcgen.base.formatmanager.FormatUtilities;
+import pcgen.base.formula.inst.NEPFormula;
+import pcgen.base.lang.StringUtil;
+import pcgen.cdom.base.CDOMObject;
+import pcgen.cdom.base.Constants;
+import pcgen.cdom.enumeration.ListKey;
+import pcgen.rules.context.Changes;
+import pcgen.rules.context.LoadContext;
+import pcgen.rules.persistence.token.AbstractNonEmptyToken;
+import pcgen.rules.persistence.token.CDOMPrimaryToken;
+import pcgen.rules.persistence.token.ParseResult;
+
+public class RequirementLst extends AbstractNonEmptyToken<CDOMObject>
+		implements CDOMPrimaryToken<CDOMObject>
+{
+
+	@Override
+	public String getTokenName()
+	{
+		return "REQUIREMENT";
+	}
+
+	@Override
+	public Class<CDOMObject> getTokenClass()
+	{
+		return CDOMObject.class;
+	}
+
+	@Override
+	protected ParseResult parseNonEmptyToken(LoadContext context, CDOMObject obj,
+		String value)
+	{
+		if (true)
+		{
+			return new ParseResult.Fail("Not supported since it is not monitored in an ongoing fashion");
+		}
+		NEPFormula<Boolean> formula =
+				context.getValidFormula(FormatUtilities.BOOLEAN_MANAGER, value);
+		obj.addToListFor(ListKey.REQUIREMENT, formula);
+		return ParseResult.SUCCESS;
+	}
+
+	@Override
+	public String[] unparse(LoadContext context, CDOMObject obj)
+	{
+		Changes<NEPFormula<Boolean>> changes =
+				context.getObjectContext().getListChanges(obj, ListKey.REQUIREMENT);
+		if (changes == null || changes.isEmpty())
+		{
+			return null;
+		}
+		return new String[]{StringUtil.join(changes.getAdded(), Constants.PIPE)};
+	}
+}

--- a/code/src/java/plugin/lsttokens/RequirementLst.java
+++ b/code/src/java/plugin/lsttokens/RequirementLst.java
@@ -1,6 +1,5 @@
 package plugin.lsttokens;
 
-import pcgen.base.formatmanager.FormatUtilities;
 import pcgen.base.formula.inst.NEPFormula;
 import pcgen.base.lang.StringUtil;
 import pcgen.cdom.base.CDOMObject;
@@ -32,14 +31,11 @@ public class RequirementLst extends AbstractNonEmptyToken<CDOMObject>
 	protected ParseResult parseNonEmptyToken(LoadContext context, CDOMObject obj,
 		String value)
 	{
-		if (true)
-		{
-			return new ParseResult.Fail("Not supported since it is not monitored in an ongoing fashion");
-		}
-		NEPFormula<Boolean> formula =
-				context.getValidFormula(FormatUtilities.BOOLEAN_MANAGER, value);
-		obj.addToListFor(ListKey.REQUIREMENT, formula);
-		return ParseResult.SUCCESS;
+		return new ParseResult.Fail("Not supported since it is not monitored in an ongoing fashion");
+//		NEPFormula<Boolean> formula =
+//				context.getValidFormula(FormatUtilities.BOOLEAN_MANAGER, value);
+//		obj.addToListFor(ListKey.REQUIREMENT, formula);
+//		return ParseResult.SUCCESS;
 	}
 
 	@Override

--- a/code/src/java/plugin/primitive/domain/DeityToken.java
+++ b/code/src/java/plugin/primitive/domain/DeityToken.java
@@ -100,8 +100,7 @@ public class DeityToken implements PrimitiveToken<Domain>
 					.getListAssociations(list, ref);
 			for (AssociatedPrereqObject apo : assoc)
 			{
-				if (PrereqHandler
-						.passesAll(apo.getPrerequisiteList(), pc, deity))
+				if (PrereqHandler.passesAll(apo, pc, deity))
 				{
 					returnSet.addAll(c.convert(ref));
 					break;


### PR DESCRIPTION
Includes framework (token at this point) for ENABLE, but the ENABLE token is guaranteed to fail at LST load.

This is the first in a series of items that provides for interaction of the new formula system to data control of allowed/granted. This implements (a beta version as it is subject to negotiation with the data team) of ALLOW:

This should enable certain items (e.g. VISION) to be fully converted to Dynamic/Formula items.

Note there are certain deficiencies with this system as it is currently designed. The following features still work with PRExxx, but this new token will not:

    Build Ability Prerequisites for the Prerequisite Tree view for the UI
    Display in the UI of what the ALLOWsituation is (in the HTML description of an object)

In addition, there is some existing items where I think it is debate-able as to how they should actually be implemented, which is why the "new" system doesn't assume it should solve them automagically. The following features still work with PRExxx, but this new token will not:

    Enforce any Race / Alignment common restrictions for UI display
    Perform Equipment auto-resizing based on PRESIZE
    Leverage EqMod EQMODTYPE=MagicalEnhancement to automatically trigger COSTDOUBLE
    Automatically impact NATURALATTACKS SIZE on an object with PRESIZE:
