### PR TITLE
Change minor method semantics on Reference Manufacturer

### DIFF
--- a/code/src/java/pcgen/cdom/base/GroupableFormatManager.java
+++ b/code/src/java/pcgen/cdom/base/GroupableFormatManager.java
@@ -22,20 +22,22 @@ import pcgen.base.util.FormatManager;
  * "Groupable" FormatManager.
  * 
  * @param <T>
- *            The format of object for which this ObjectManager provides services
+ *            The format of object for which this GroupableFormatManager provides services
  */
-public interface ObjectManager<T extends Loadable> extends FormatManager<T>
+public interface GroupableFormatManager<T extends Loadable> extends FormatManager<T>
 {
 	/**
-	 * Returns true if this ObjectManager contains the given object.
+	 * Returns true if this GroupableFormatManager contains the given object.
 	 * 
 	 * Note that this is testing *object* presence. This will not return true if a
 	 * reference for the given object has been requested; it will only return true if the
-	 * object has actually been constructed by or imported into this ObjectManager.
+	 * object has actually been constructed by or imported into this
+	 * GroupableFormatManager.
 	 * 
 	 * @param o
-	 *            The object to be checked if it is present in this ObjectManager.
-	 * @return true if this ObjectManager contains the object; false otherwise.
+	 *            The object to be checked if it is present in this
+	 *            GroupableFormatManager.
+	 * @return true if this GroupableFormatManager contains the object; false otherwise.
 	 */
 	public boolean containsObject(Object o);
 }

--- a/code/src/java/pcgen/cdom/base/ObjectManager.java
+++ b/code/src/java/pcgen/cdom/base/ObjectManager.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 (C) Thomas Parker <thpr@users.sourceforge.net>
+ * 
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 59 Temple Place,
+ * Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.cdom.base;
+
+import pcgen.base.util.FormatManager;
+
+/**
+ * An ObjectManager is an extension of a FormatManager used in PCGen to serve as a
+ * "Groupable" FormatManager.
+ * 
+ * @param <T>
+ *            The format of object for which this ObjectManager provides services
+ */
+public interface ObjectManager<T extends Loadable> extends FormatManager<T>
+{
+	/**
+	 * Returns true if this ObjectManager contains the given object.
+	 * 
+	 * Note that this is testing *object* presence. This will not return true if a
+	 * reference for the given object has been requested; it will only return true if the
+	 * object has actually been constructed by or imported into this ObjectManager.
+	 * 
+	 * @param o
+	 *            The object to be checked if it is present in this ObjectManager.
+	 * @return true if this ObjectManager contains the object; false otherwise.
+	 */
+	public boolean containsObject(Object o);
+}

--- a/code/src/java/pcgen/cdom/reference/AbstractReferenceManufacturer.java
+++ b/code/src/java/pcgen/cdom/reference/AbstractReferenceManufacturer.java
@@ -623,9 +623,15 @@ public abstract class AbstractReferenceManufacturer<T extends Loadable>
 	 *         AbstractReferenceManufacturer; false otherwise.
 	 */
 	@Override
-	public boolean containsObject(String key)
+	public boolean containsObjectKeyed(String key)
 	{
 		return active.containsKey(key);
+	}
+
+	@Override
+	public boolean containsObject(Object o)
+	{
+		return active.containsValue(o);
 	}
 
 	/**

--- a/code/src/java/pcgen/cdom/reference/ReferenceManufacturer.java
+++ b/code/src/java/pcgen/cdom/reference/ReferenceManufacturer.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 import pcgen.cdom.base.CDOMReference;
 import pcgen.cdom.base.Loadable;
-import pcgen.cdom.base.ObjectManager;
+import pcgen.cdom.base.GroupableFormatManager;
 
 /**
  * A ReferenceManufacturer is an object capable of creating CDOMReferences of a
@@ -52,7 +52,7 @@ import pcgen.cdom.base.ObjectManager;
  *            The Class of object this ReferenceManufacturer can manufacture
  */
 public interface ReferenceManufacturer<T extends Loadable> extends
-		SelectionCreator<T>, ObjectManager<T>
+		SelectionCreator<T>, GroupableFormatManager<T>
 {
 	/**
 	 * Constructs a new CDOMObject of the Class or Class/Category represented by

--- a/code/src/java/pcgen/cdom/reference/ReferenceManufacturer.java
+++ b/code/src/java/pcgen/cdom/reference/ReferenceManufacturer.java
@@ -19,9 +19,9 @@ package pcgen.cdom.reference;
 import java.util.Collection;
 import java.util.List;
 
-import pcgen.base.util.FormatManager;
 import pcgen.cdom.base.CDOMReference;
 import pcgen.cdom.base.Loadable;
+import pcgen.cdom.base.ObjectManager;
 
 /**
  * A ReferenceManufacturer is an object capable of creating CDOMReferences of a
@@ -52,7 +52,7 @@ import pcgen.cdom.base.Loadable;
  *            The Class of object this ReferenceManufacturer can manufacture
  */
 public interface ReferenceManufacturer<T extends Loadable> extends
-		SelectionCreator<T>, FormatManager<T>
+		SelectionCreator<T>, ObjectManager<T>
 {
 	/**
 	 * Constructs a new CDOMObject of the Class or Class/Category represented by
@@ -105,7 +105,7 @@ public interface ReferenceManufacturer<T extends Loadable> extends
 	 *         Class or Class/Category represented by this
 	 *         ReferenceManufacturer; false otherwise.
 	 */
-	public boolean containsObject(String key);
+	public boolean containsObjectKeyed(String key);
 
 	/**
 	 * Gets the object represented by the given identifier. Will return null if

--- a/code/src/java/pcgen/rules/context/AbstractReferenceContext.java
+++ b/code/src/java/pcgen/rules/context/AbstractReferenceContext.java
@@ -361,7 +361,7 @@ public abstract class AbstractReferenceContext
 	public <T extends Loadable> boolean containsConstructedCDOMObject(
 			Class<T> c, String s)
 	{
-		return getManufacturer(c).containsObject(s);
+		return getManufacturer(c).containsObjectKeyed(s);
 	}
 
 	public void buildDerivedObjects()

--- a/code/src/java/pcgen/rules/context/ReferenceContextUtilities.java
+++ b/code/src/java/pcgen/rules/context/ReferenceContextUtilities.java
@@ -81,7 +81,7 @@ public final class ReferenceContextUtilities
 						ReferenceManufacturer<? extends Loadable> mfg =
 								refContext
 									.getManufacturer((ClassIdentity<? extends Loadable>) clIdentity);
-						if (!mfg.containsObject(choice)
+						if (!mfg.containsObjectKeyed(choice)
 							&& (TokenLibrary.getPrimitive(cl, choice) == null)
 							&& !report(validator, clIdentity.getChoiceClass(),
 								choice))

--- a/code/src/java/pcgen/rules/context/TrackingManufacturer.java
+++ b/code/src/java/pcgen/rules/context/TrackingManufacturer.java
@@ -81,9 +81,15 @@ class TrackingManufacturer<T extends Loadable> implements ReferenceManufacturer<
 	}
 
 	@Override
-	public boolean containsObject(String key)
+	public boolean containsObjectKeyed(String key)
 	{
-		return rm.containsObject(key);
+		return rm.containsObjectKeyed(key);
+	}
+
+	@Override
+	public boolean containsObject(Object o)
+	{
+		return rm.containsObject(o);
 	}
 
 	@Override
@@ -190,7 +196,7 @@ class TrackingManufacturer<T extends Loadable> implements ReferenceManufacturer<
 
 	public boolean containsUnconstructed(String name)
 	{
-		return rm.containsObject(name);
+		return rm.containsObjectKeyed(name);
 	}
 
 	@Override

--- a/code/src/java/pcgen/rules/context/TrackingManufacturer.java
+++ b/code/src/java/pcgen/rules/context/TrackingManufacturer.java
@@ -194,11 +194,6 @@ class TrackingManufacturer<T extends Loadable> implements ReferenceManufacturer<
 		return rm.validate(validator);
 	}
 
-	public boolean containsUnconstructed(String name)
-	{
-		return rm.containsObjectKeyed(name);
-	}
-
 	@Override
 	public String getReferenceDescription()
 	{


### PR DESCRIPTION
Effectively this introduces a new (slightly more powerful) FormatManager
derivative called an ObjectManager, and then uses that for
ReferenceManufacturer objects.  This additional capability will be
expanded and leveraged for a number of items in the formula system going
forward.

Also removes one (confusing and likely buggy) unused method
