### PR TITLE
Pushes ParseResult deeper into the processing for certain tokens.

### DIFF
--- a/code/src/java/pcgen/rules/persistence/token/AbstractSimpleChooseToken.java
+++ b/code/src/java/pcgen/rules/persistence/token/AbstractSimpleChooseToken.java
@@ -102,9 +102,10 @@ public abstract class AbstractSimpleChooseToken<T extends Loadable> extends
 		}
 		else
 		{
-			if (hasIllegalSeparator('|', activeValue))
+			ParseResult pr = checkForIllegalSeparator('|', activeValue);
+			if (!pr.passed())
 			{
-				return ParseResult.INTERNAL_ERROR;
+				return pr;
 			}
 			Set<PrimitiveCollection<T>> set =
                     new HashSet<>();

--- a/code/src/java/pcgen/rules/persistence/token/AbstractToken.java
+++ b/code/src/java/pcgen/rules/persistence/token/AbstractToken.java
@@ -114,16 +114,6 @@ public abstract class AbstractToken
 		return ParseResult.SUCCESS;
 	}
 
-	protected boolean hasIllegalSeparator(char separator, String value)
-	{
-		ParseResult pr = checkForIllegalSeparator(separator, value);
-		if (pr.passed())
-		{
-			pr.addMessagesToLog();
-		}
-		return !pr.passed();
-	}
-
 	/**
 	 * Checks that a string is non-empty.
 	 * @param value The string to check.
@@ -142,16 +132,6 @@ public abstract class AbstractToken
 				+ " may not have empty argument");
 		}
 		return ParseResult.SUCCESS;
-	}
-
-	protected boolean isEmpty(String value)
-	{
-		ParseResult pr = checkNonEmpty(value);
-		if (pr.passed())
-		{
-			pr.addMessagesToLog();
-		}
-		return !pr.passed();
 	}
 
 	/**

--- a/code/src/java/plugin/converter/FavClassConvertPlugin.java
+++ b/code/src/java/plugin/converter/FavClassConvertPlugin.java
@@ -36,6 +36,7 @@ import pcgen.gui2.converter.event.TokenProcessEvent;
 import pcgen.gui2.converter.event.TokenProcessorPlugin;
 import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.token.AbstractToken;
+import pcgen.rules.persistence.token.ParseResult;
 
 public class FavClassConvertPlugin extends AbstractToken implements
 		TokenProcessorPlugin
@@ -54,9 +55,15 @@ public class FavClassConvertPlugin extends AbstractToken implements
 		}
 
 		String choices = value.substring(7);
-		if (isEmpty(choices) || hasIllegalSeparator('|', choices))
+		ParseResult pr = checkNonEmpty(choices);
+		if (!pr.passed())
 		{
-			return "Empty Token";
+			return "Empty";
+		}
+		pr = checkForIllegalSeparator('|', choices);
+		if (!pr.passed())
+		{
+			return "Illegal Separator";
 		}
 		boolean foundAny = false;
 		boolean foundOther = false;

--- a/code/src/java/plugin/lsttokens/SpellknownLst.java
+++ b/code/src/java/plugin/lsttokens/SpellknownLst.java
@@ -42,7 +42,6 @@ import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.token.AbstractSpellListToken;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import pcgen.rules.persistence.token.ParseResult;
-import pcgen.util.Logging;
 
 /**
  * The Class {@code SpellknownLst} is responsible for parsing and
@@ -122,12 +121,12 @@ public class SpellknownLst extends AbstractSpellListToken implements
 
 			if (tagType.equalsIgnoreCase("CLASS"))
 			{
-				if (!subParse(context, obj, ClassSpellList.class, tokString,
-						spellString, prereqs))
+				ParseResult pr = subParse(context, obj, ClassSpellList.class, tokString,
+					spellString, prereqs);
+				if (!pr.passed())
 				{
-					return ParseResult.INTERNAL_ERROR;
-					//return new ParseResult.Fail("  " + getTokenName()
-					//		+ " error - entire token was " + value, context);
+					return new ParseResult.Fail(getTokenName() + " failed due to " + pr
+						+ ".  Entire token was: " + value, context);
 				}
 			}
 			else
@@ -152,16 +151,15 @@ public class SpellknownLst extends AbstractSpellListToken implements
 	 *
 	 * @return true, if successful
 	 */
-	private <CL extends Loadable & CDOMList<Spell>> boolean subParse(
+	private <CL extends Loadable & CDOMList<Spell>> ParseResult subParse(
 			LoadContext context, CDOMObject obj, Class<CL> tagType,
 			String tokString, String spellString, List<Prerequisite> prereqs)
 	{
 		int equalLoc = tokString.indexOf(Constants.EQUALS);
 		if (equalLoc == -1)
 		{
-			Logging.errorPrint("Expected an = in SPELLKNOWN " + "definition: "
-					+ tokString);
-			return false;
+			return new ParseResult.Fail(
+				"Expected an = in SPELLKNOWN " + "definition: " + tokString, context);
 		}
 
 		String casterString = tokString.substring(0, equalLoc);
@@ -173,14 +171,14 @@ public class SpellknownLst extends AbstractSpellListToken implements
 		}
 		catch (NumberFormatException nfe)
 		{
-			Logging.errorPrint("Expected a number for SPELLKNOWN, found: "
-					+ spellLevel);
-			return false;
+			return new ParseResult.Fail(
+				"Expected a number for SPELLKNOWN, found: " + spellLevel, context);
 		}
 
-		if (isEmpty(casterString) || hasIllegalSeparator(',', casterString))
+		ParseResult pr = checkSeparatorsAndNonEmpty(',', casterString);
+		if (!pr.passed())
 		{
-			return false;
+			return pr;
 		}
 
 		StringTokenizer clTok = new StringTokenizer(casterString,
@@ -206,9 +204,10 @@ public class SpellknownLst extends AbstractSpellListToken implements
 			slList.add(ref);
 		}
 
-		if (hasIllegalSeparator(',', spellString))
+		pr = checkForIllegalSeparator(',', spellString);
+		if (!pr.passed())
 		{
-			return false;
+			return pr;
 		}
 
 		StringTokenizer spTok = new StringTokenizer(spellString, ",");
@@ -227,7 +226,7 @@ public class SpellknownLst extends AbstractSpellListToken implements
 				tpr.addAllPrerequisites(prereqs);
 			}
 		}
-		return true;
+		return ParseResult.SUCCESS;
 	}
 
 	/**

--- a/code/src/java/plugin/lsttokens/TemplateLst.java
+++ b/code/src/java/plugin/lsttokens/TemplateLst.java
@@ -87,9 +87,10 @@ public class TemplateLst extends AbstractToken implements
 			remaining = value;
 			specialLegal = true;
 		}
-		if (isEmpty(remaining) || hasIllegalSeparator('|', remaining))
+		ParseResult pr = checkSeparatorsAndNonEmpty('|', remaining);
+		if (!pr.passed())
 		{
-			return ParseResult.INTERNAL_ERROR;
+			return pr;
 		}
 
 		StringTokenizer tok = new StringTokenizer(remaining, Constants.PIPE);

--- a/code/src/java/plugin/lsttokens/TypeLst.java
+++ b/code/src/java/plugin/lsttokens/TypeLst.java
@@ -57,7 +57,8 @@ public class TypeLst extends AbstractNonEmptyToken<CDOMObject> implements
 			else if (value.charAt(6) == '.')
 			{
 				value = value.substring(7);
-				if (isEmpty(value))
+				ParseResult pr = checkNonEmpty(value);
+				if (!pr.passed())
 				{
 					return new ParseResult.Fail(getTokenName()
 							+ "started with .CLEAR. but expected to have a Type after .: "

--- a/code/src/java/plugin/lsttokens/ability/BenefitToken.java
+++ b/code/src/java/plugin/lsttokens/ability/BenefitToken.java
@@ -1,19 +1,17 @@
 /*
  * Copyright 2008 (C) Thomas Parker <thpr@users.sourceforge.net>
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
  *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 59 Temple Place,
+ * Suite 330, Boston, MA 02111-1307 USA
  */
 package plugin.lsttokens.ability;
 
@@ -35,7 +33,6 @@ import pcgen.rules.context.PatternChanges;
 import pcgen.rules.persistence.token.AbstractNonEmptyToken;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import pcgen.rules.persistence.token.ParseResult;
-import pcgen.util.Logging;
 
 /**
  * This class deals with the BENEFIT Token
@@ -66,11 +63,59 @@ public class BenefitToken extends AbstractNonEmptyToken<Ability> implements
 			return ParseResult.SUCCESS;
 		}
 
-		Description ben = parseBenefit(value);
-		if (ben == null)
+		ParseResult pr = checkNonEmpty(value);
+		if (!pr.passed())
 		{
-			return ParseResult.INTERNAL_ERROR;
+			return pr;
 		}
+		pr = checkForIllegalSeparator('|', value);
+		if (!pr.passed())
+		{
+			return pr;
+		}
+		final StringTokenizer tok = new StringTokenizer(value, Constants.PIPE);
+
+		String firstToken = tok.nextToken();
+		if (PreParserFactory.isPreReqString(firstToken))
+		{
+			return new ParseResult.Fail(
+				"Invalid " + getTokenName() + "(PRExxx can not be only value): " + value, context);
+		}
+		String ds = EntityEncoder.decode(firstToken);
+		if (!StringUtil.hasBalancedParens(ds))
+		{
+			return new ParseResult.Fail(
+				getTokenName() + " encountered imbalanced Parenthesis: " + value, context);
+		}
+
+		Description ben = new Description(ds);
+
+		boolean isPre = false;
+		while (tok.hasMoreTokens())
+		{
+			final String token = tok.nextToken();
+			if (PreParserFactory.isPreReqString(token))
+			{
+				Prerequisite prereq = getPrerequisite(token);
+				if (prereq == null)
+				{
+					return new ParseResult.Fail(
+						getTokenName() + " had invalid prerequisite : " + token, context);
+				}
+				ben.addPrerequisite(prereq);
+				isPre = true;
+			}
+			else
+			{
+				if (isPre)
+				{
+					return new ParseResult.Fail("Invalid " + getTokenName()
+						+ "(PRExxx must be at the END of the Token): " + value, context);
+				}
+				ben.addVariable(token);
+			}
+		}
+
 		context.getObjectContext().addToList(ability, ListKey.BENEFIT, ben);
 		return ParseResult.SUCCESS;
 	}
@@ -117,70 +162,6 @@ public class BenefitToken extends AbstractNonEmptyToken<Ability> implements
 			return null;
 		}
 		return list.toArray(new String[list.size()]);
-	}
-
-	/**
-	 * Parses the BENEFIT tag into a Description object.
-	 * 
-	 * @param aDesc
-	 *            The LST tag
-	 * @return A <tt>Description</tt> object
-	 */
-	public Description parseBenefit(final String aDesc)
-	{
-		if (isEmpty(aDesc) || hasIllegalSeparator('|', aDesc))
-		{
-			return null;
-		}
-		final StringTokenizer tok = new StringTokenizer(aDesc, Constants.PIPE);
-
-		String firstToken = tok.nextToken();
-		if (PreParserFactory.isPreReqString(firstToken))
-		{
-			Logging.errorPrint("Invalid " + getTokenName() + ": " + aDesc);
-			Logging.errorPrint("  PRExxx can not be only value");
-			return null;
-		}
-		String ds = EntityEncoder.decode(firstToken);
-		if (!StringUtil.hasBalancedParens(ds))
-		{
-			Logging.log(Logging.LST_ERROR, getTokenName()
-					+ " encountered imbalanced Parenthesis: " + aDesc);
-			return null;
-		}
-		Description desc = new Description(ds);
-
-		boolean isPre = false;
-		while (tok.hasMoreTokens())
-		{
-			final String token = tok.nextToken();
-			if (PreParserFactory.isPreReqString(token))
-			{
-				Prerequisite prereq = getPrerequisite(token);
-				if (prereq == null)
-				{
-					Logging.errorPrint(getTokenName()
-							+ " had invalid prerequisite : " + token);
-					return null;
-				}
-				desc.addPrerequisite(prereq);
-				isPre = true;
-			}
-			else
-			{
-				if (isPre)
-				{
-					Logging.errorPrint("Invalid " + getTokenName() + ": "
-							+ aDesc);
-					Logging
-							.errorPrint("  PRExxx must be at the END of the Token");
-					return null;
-				}
-				desc.addVariable(token);
-			}
-		}
-
-		return desc;
 	}
 
 	@Override

--- a/code/src/java/plugin/lsttokens/add/AbilityToken.java
+++ b/code/src/java/plugin/lsttokens/add/AbilityToken.java
@@ -108,11 +108,6 @@ public class AbilityToken extends AbstractNonEmptyToken<CDOMObject> implements
 	protected ParseResult parseNonEmptyToken(LoadContext context,
 		CDOMObject obj, String value)
 	{
-		if (isEmpty(value))
-		{
-			return new ParseResult.Fail("Value in " + getFullName()
-					+ " may not be empty", context);
-		}
 		ParsingSeparator sep = new ParsingSeparator(value, '|');
 		sep.addGroupingPair('[', ']');
 		sep.addGroupingPair('(', ')');

--- a/code/src/java/plugin/lsttokens/add/SkillToken.java
+++ b/code/src/java/plugin/lsttokens/add/SkillToken.java
@@ -42,11 +42,11 @@ import pcgen.core.analysis.SkillRankControl;
 import pcgen.rules.context.Changes;
 import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.TokenUtilities;
-import pcgen.rules.persistence.token.AbstractToken;
+import pcgen.rules.persistence.token.AbstractNonEmptyToken;
 import pcgen.rules.persistence.token.CDOMSecondaryToken;
 import pcgen.rules.persistence.token.ParseResult;
 
-public class SkillToken extends AbstractToken implements
+public class SkillToken extends AbstractNonEmptyToken<CDOMObject> implements
 		CDOMSecondaryToken<CDOMObject>, PersistentChoiceActor<Skill>
 {
 	private static final Class<Skill> SKILL_CLASS = Skill.class;
@@ -69,14 +69,9 @@ public class SkillToken extends AbstractToken implements
 	}
 
 	@Override
-	public ParseResult parseToken(LoadContext context, CDOMObject obj,
+	public ParseResult parseNonEmptyToken(LoadContext context, CDOMObject obj,
 		String value)
 	{
-		if (isEmpty(value))
-		{
-			return new ParseResult.Fail("Value in " + getFullName()
-					+ " may not be empty", context);
-		}
 		ParsingSeparator sep = new ParsingSeparator(value, '|');
 		sep.addGroupingPair('[', ']');
 		sep.addGroupingPair('(', ')');

--- a/code/src/java/plugin/lsttokens/add/SpellCasterToken.java
+++ b/code/src/java/plugin/lsttokens/add/SpellCasterToken.java
@@ -44,11 +44,11 @@ import pcgen.core.analysis.BonusAddition;
 import pcgen.rules.context.Changes;
 import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.TokenUtilities;
-import pcgen.rules.persistence.token.AbstractToken;
+import pcgen.rules.persistence.token.AbstractNonEmptyToken;
 import pcgen.rules.persistence.token.CDOMSecondaryToken;
 import pcgen.rules.persistence.token.ParseResult;
 
-public class SpellCasterToken extends AbstractToken implements
+public class SpellCasterToken extends AbstractNonEmptyToken<CDOMObject> implements
 		CDOMSecondaryToken<CDOMObject>, PersistentChoiceActor<PCClass>
 {
 
@@ -72,14 +72,9 @@ public class SpellCasterToken extends AbstractToken implements
 	}
 
 	@Override
-	public ParseResult parseToken(LoadContext context, CDOMObject obj,
+	public ParseResult parseNonEmptyToken(LoadContext context, CDOMObject obj,
 		String value)
 	{
-		if (isEmpty(value))
-		{
-			return new ParseResult.Fail("Value in " + getFullName()
-					+ " may not be empty", context);
-		}
 		ParsingSeparator sep = new ParsingSeparator(value, '|');
 		sep.addGroupingPair('[', ']');
 		sep.addGroupingPair('(', ')');

--- a/code/src/java/plugin/lsttokens/campaign/ForwardRefToken.java
+++ b/code/src/java/plugin/lsttokens/campaign/ForwardRefToken.java
@@ -86,10 +86,10 @@ public class ForwardRefToken extends AbstractTokenWithSeparator<Campaign>
 		}
 
 		String rest = value.substring(pipeLoc + 1);
-		if (hasIllegalSeparator(',', rest))
+		ParseResult pr = checkForIllegalSeparator(',', rest);
+		if (!pr.passed())
 		{
-			return new ParseResult.Fail(getTokenName()
-					+ " keys are comma separated", context);
+			return pr;
 		}
 		StringTokenizer st = new StringTokenizer(rest, Constants.COMMA);
 		while (st.hasMoreTokens())

--- a/code/src/java/plugin/lsttokens/deprecated/RemoveFeatToken.java
+++ b/code/src/java/plugin/lsttokens/deprecated/RemoveFeatToken.java
@@ -132,9 +132,10 @@ public class RemoveFeatToken extends AbstractNonEmptyToken<CDOMObject> implement
 			return new ParseResult.Fail(getFullName()
 					+ " had too many pipe separated items: " + value, context);
 		}
-		if (isEmpty(activeValue) || hasIllegalSeparator(',', activeValue))
+		ParseResult pr = checkSeparatorsAndNonEmpty(',', activeValue);
+		if (!pr.passed())
 		{
-			return ParseResult.INTERNAL_ERROR;
+			return pr;
 		}
 
 		List<CDOMReference<Ability>> refs = new ArrayList<>();

--- a/code/src/java/plugin/lsttokens/equipment/AlttypeToken.java
+++ b/code/src/java/plugin/lsttokens/equipment/AlttypeToken.java
@@ -60,7 +60,8 @@ public class AlttypeToken extends AbstractNonEmptyToken<Equipment> implements
 			else if (value.charAt(6) == '.')
 			{
 				value = value.substring(7);
-				if (isEmpty(value))
+				ParseResult pr = checkNonEmpty(value);
+				if (!pr.passed())
 				{
 					return new ParseResult.Fail(getTokenName()
 						+ "started with .CLEAR. but expected to have a Type after .: "

--- a/code/src/java/plugin/lsttokens/kit/ability/AbilityToken.java
+++ b/code/src/java/plugin/lsttokens/kit/ability/AbilityToken.java
@@ -98,7 +98,8 @@ public class AbilityToken extends AbstractNonEmptyToken<KitAbilities> implements
 		kitAbil.setCategory(acRef);
 
 		String rest = value.substring(pipeLoc + 1);
-		if (isEmpty(rest) || hasIllegalSeparator('|', rest))
+		ParseResult pr = checkSeparatorsAndNonEmpty('|', rest);
+		if (!pr.passed())
 		{
 			return new ParseResult.Fail(
 				"No abilities found.  ABILITY token "


### PR DESCRIPTION
For items that are trying to shortcut a good report on the location of
an error, this will help reduce that problem.  It forces a slightly more
verbose syntax in a few places, but in general helps standardize
behavior and improve error reporting.