### PR TITLE
Convert ParseResult.Fail to not take in the context

### DIFF
--- a/code/src/itest/pcgen/io/testsupport/AbstractSaveRestoreTest.java
+++ b/code/src/itest/pcgen/io/testsupport/AbstractSaveRestoreTest.java
@@ -17,12 +17,12 @@
  */
 package pcgen.io.testsupport;
 
-import compare.InequalityTesterInst;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.math.BigDecimal;
-import java.net.URI;
 import java.util.Collections;
+
+import compare.InequalityTesterInst;
 import junit.framework.TestCase;
 import pcgen.base.test.InequalityTester;
 import pcgen.cdom.base.Constants;
@@ -82,6 +82,7 @@ import pcgen.util.chooser.RandomChooser;
 import plugin.bonustokens.Feat;
 import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.lsttokens.testsupport.TokenRegistration;
+import util.TestURI;
 
 public abstract class AbstractSaveRestoreTest extends TestCase
 {
@@ -90,7 +91,6 @@ public abstract class AbstractSaveRestoreTest extends TestCase
 	protected PlayerCharacter pc;
 	protected PlayerCharacter reloadedPC;
 	protected CharID id;
-	private static URI URI;
 	private static boolean setup = false;
 
 	public static void setUpBeforeClass() throws Exception
@@ -109,7 +109,7 @@ public abstract class AbstractSaveRestoreTest extends TestCase
 				.parseLine(
 					mode,
 					"LEVEL:LEVEL	MINXP:(LEVEL*LEVEL-LEVEL)*500		CSKILLMAX:LEVEL+ClassSkillMax+3	CCSKILLMAX:(LEVEL+CrossClassSkillMax+3)/2",
-					0, URI, "Default");
+					0, TestURI.getURI(), "Default");
 			mode.setAlignmentText("Alignment");
 		}
 	}
@@ -117,7 +117,6 @@ public abstract class AbstractSaveRestoreTest extends TestCase
 	@Override
 	protected void setUp() throws Exception
 	{
-		URI = new URI("file:/Test%20Case");
 		super.setUp();
 		setUpBeforeClass();
 		setUpContext();

--- a/code/src/itest/plugin/lsttokens/datacontrol/SelectableTokenIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/datacontrol/SelectableTokenIntegrationTest.java
@@ -26,6 +26,8 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import plugin.lsttokens.testsupport.TokenRegistration;
+import util.TestURI;
+
 import static org.junit.Assert.*;
 
 public class SelectableTokenIntegrationTest
@@ -45,8 +47,7 @@ public class SelectableTokenIntegrationTest
 	public static void classSetUp() throws URISyntaxException
 	{
 		testCampaign =
-				new CampaignSourceEntry(new Campaign(), new URI(
-					"file:/Test%20Case"));
+				new CampaignSourceEntry(new Campaign(), TestURI.getURI());
 	}
 
 	@Before

--- a/code/src/itest/plugin/lsttokens/editcontext/pcclass/level/AbstractPCClassLevelTokenTestCase.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/pcclass/level/AbstractPCClassLevelTokenTestCase.java
@@ -17,14 +17,12 @@
  */
 package plugin.lsttokens.editcontext.pcclass.level;
 
-import java.net.URI;
 import java.net.URISyntaxException;
-
-import junit.framework.TestCase;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
 
+import junit.framework.TestCase;
 import pcgen.cdom.inst.PCClassLevel;
 import pcgen.core.Campaign;
 import pcgen.persistence.PersistenceLayerException;
@@ -36,6 +34,7 @@ import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.testsupport.CDOMTokenLoader;
 import plugin.lsttokens.testsupport.TokenRegistration;
+import util.TestURI;
 
 public abstract class AbstractPCClassLevelTokenTestCase extends TestCase
 {
@@ -55,8 +54,7 @@ public abstract class AbstractPCClassLevelTokenTestCase extends TestCase
 	@BeforeClass
 	public static final void classSetUp() throws URISyntaxException
 	{
-		testCampaign = new CampaignSourceEntry(new Campaign(), new URI(
-				"file:/Test%20Case"));
+		testCampaign = new CampaignSourceEntry(new Campaign(), TestURI.getURI());
 		classSetUpFired = true;
 	}
 

--- a/code/src/itest/plugin/lsttokens/editcontext/testsupport/AbstractIntegrationTestCase.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/testsupport/AbstractIntegrationTestCase.java
@@ -42,6 +42,7 @@ import junit.framework.TestCase;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import plugin.lsttokens.testsupport.TokenRegistration;
+import util.TestURI;
 
 public abstract class AbstractIntegrationTestCase<T extends ConcretePrereqObject & Loadable> extends
 		TestCase
@@ -65,8 +66,7 @@ public abstract class AbstractIntegrationTestCase<T extends ConcretePrereqObject
 	public static final void classSetUp() throws URISyntaxException
 	{
 		OutputDB.reset();
-		testCampaign = new CampaignSourceEntry(new Campaign(), new URI(
-				"file:/Test%20Case"));
+		testCampaign = new CampaignSourceEntry(new Campaign(), TestURI.getURI());
 		modCampaign = new CampaignSourceEntry(new Campaign(), new URI(
 				"file:/Test%20Case%20Modifier"));
 		classSetUpFired = true;

--- a/code/src/itest/tokencontent/DomainCSkillTest.java
+++ b/code/src/itest/tokencontent/DomainCSkillTest.java
@@ -38,6 +38,7 @@ import plugin.lsttokens.domain.CskillToken;
 
 import org.junit.Test;
 import tokenmodel.testsupport.AbstractTokenModelTest;
+import util.TestURI;
 
 public class DomainCSkillTest extends AbstractTokenModelTest
 {
@@ -70,7 +71,7 @@ public class DomainCSkillTest extends AbstractTokenModelTest
 		ParseResult result = token.parseToken(context, source, "MySkill");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();
@@ -91,13 +92,13 @@ public class DomainCSkillTest extends AbstractTokenModelTest
 		ParseResult result = token.parseToken(context, source, "LIST");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		result = CHOOSE_SKILL_TOKEN.parseToken(context, source, "MySkill");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();

--- a/code/src/itest/tokencontent/DomainCcSkillTest.java
+++ b/code/src/itest/tokencontent/DomainCcSkillTest.java
@@ -39,6 +39,7 @@ import plugin.lsttokens.skill.ExclusiveToken;
 
 import org.junit.Test;
 import tokenmodel.testsupport.AbstractTokenModelTest;
+import util.TestURI;
 
 public class DomainCcSkillTest extends AbstractTokenModelTest
 {
@@ -71,7 +72,7 @@ public class DomainCcSkillTest extends AbstractTokenModelTest
 		ParseResult result = token.parseToken(context, source, "MySkill");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		new ExclusiveToken().parseToken(context, sk, "Yes");
@@ -93,13 +94,13 @@ public class DomainCcSkillTest extends AbstractTokenModelTest
 		ParseResult result = token.parseToken(context, source, "LIST");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		result = CHOOSE_SKILL_TOKEN.parseToken(context, source, "MySkill");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		new ExclusiveToken().parseToken(context, sk, "Yes");

--- a/code/src/itest/tokencontent/GlobalCSkillTest.java
+++ b/code/src/itest/tokencontent/GlobalCSkillTest.java
@@ -33,6 +33,7 @@ import plugin.lsttokens.choose.SkillToken;
 
 import org.junit.Test;
 import tokencontent.testsupport.AbstractContentTokenTest;
+import util.TestURI;
 
 public class GlobalCSkillTest extends AbstractContentTokenTest
 {
@@ -60,7 +61,7 @@ public class GlobalCSkillTest extends AbstractContentTokenTest
 		ParseResult result = token.parseToken(context, source, "Granted");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();
@@ -73,13 +74,13 @@ public class GlobalCSkillTest extends AbstractContentTokenTest
 		ParseResult result = token.parseToken(context, source, "LIST");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		result = CHOOSE_SKILL_TOKEN.parseToken(context, source, "Granted");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		PCClass wizard = create(PCClass.class, "Wizard");

--- a/code/src/itest/tokencontent/GlobalCcSkillTest.java
+++ b/code/src/itest/tokencontent/GlobalCcSkillTest.java
@@ -34,6 +34,7 @@ import plugin.lsttokens.skill.ExclusiveToken;
 
 import org.junit.Test;
 import tokencontent.testsupport.AbstractContentTokenTest;
+import util.TestURI;
 
 public class GlobalCcSkillTest extends AbstractContentTokenTest
 {
@@ -61,7 +62,7 @@ public class GlobalCcSkillTest extends AbstractContentTokenTest
 		ParseResult result = token.parseToken(context, source, "Granted");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();
@@ -74,13 +75,13 @@ public class GlobalCcSkillTest extends AbstractContentTokenTest
 		ParseResult result = token.parseToken(context, source, "LIST");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		result = CHOOSE_SKILL_TOKEN.parseToken(context, source, "Granted");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		PCClass wizard = create(PCClass.class, "Wizard");

--- a/code/src/itest/tokencontent/GlobalChangeProfTest.java
+++ b/code/src/itest/tokencontent/GlobalChangeProfTest.java
@@ -29,6 +29,7 @@ import pcgen.rules.persistence.token.ParseResult;
 import plugin.lsttokens.ChangeprofLst;
 
 import tokencontent.testsupport.AbstractContentTokenTest;
+import util.TestURI;
 
 public class GlobalChangeProfTest extends AbstractContentTokenTest
 {
@@ -53,7 +54,7 @@ public class GlobalChangeProfTest extends AbstractContentTokenTest
 		ParseResult result = token.parseToken(context, source, "Axe=Martial");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();

--- a/code/src/itest/tokencontent/GlobalCompanionListTest.java
+++ b/code/src/itest/tokencontent/GlobalCompanionListTest.java
@@ -30,6 +30,7 @@ import pcgen.rules.persistence.token.ParseResult;
 import plugin.lsttokens.CompanionListLst;
 
 import tokencontent.testsupport.AbstractContentTokenTest;
+import util.TestURI;
 
 public class GlobalCompanionListTest extends AbstractContentTokenTest
 {
@@ -53,7 +54,7 @@ public class GlobalCompanionListTest extends AbstractContentTokenTest
 					"Animal Companion|Ape|FOLLOWERADJUSTMENT:-3");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();

--- a/code/src/itest/tokencontent/GlobalDefineUnlockedStatTest.java
+++ b/code/src/itest/tokencontent/GlobalDefineUnlockedStatTest.java
@@ -25,6 +25,7 @@ import pcgen.rules.persistence.token.ParseResult;
 import plugin.lsttokens.DefineStatLst;
 
 import tokencontent.testsupport.AbstractContentTokenTest;
+import util.TestURI;
 
 public class GlobalDefineUnlockedStatTest extends AbstractContentTokenTest
 {
@@ -45,7 +46,7 @@ public class GlobalDefineUnlockedStatTest extends AbstractContentTokenTest
 		ParseResult result = token.parseToken(context, source, "UNLOCK|INT");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();

--- a/code/src/itest/tokencontent/GlobalDefineVariableTest.java
+++ b/code/src/itest/tokencontent/GlobalDefineVariableTest.java
@@ -26,6 +26,7 @@ import pcgen.rules.persistence.token.ParseResult;
 import plugin.lsttokens.DefineLst;
 
 import tokencontent.testsupport.AbstractContentTokenTest;
+import util.TestURI;
 
 public class GlobalDefineVariableTest extends AbstractContentTokenTest
 {
@@ -46,7 +47,7 @@ public class GlobalDefineVariableTest extends AbstractContentTokenTest
 		ParseResult result = token.parseToken(context, source, "This|0");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();

--- a/code/src/itest/tokencontent/GlobalDrTest.java
+++ b/code/src/itest/tokencontent/GlobalDrTest.java
@@ -28,6 +28,7 @@ import pcgen.rules.persistence.token.ParseResult;
 import plugin.lsttokens.DrLst;
 
 import tokencontent.testsupport.AbstractContentTokenTest;
+import util.TestURI;
 
 public class GlobalDrTest extends AbstractContentTokenTest
 {
@@ -49,7 +50,7 @@ public class GlobalDrTest extends AbstractContentTokenTest
 		ParseResult result = token.parseToken(context, source, "5/Light");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();

--- a/code/src/itest/tokencontent/GlobalFollowersTest.java
+++ b/code/src/itest/tokencontent/GlobalFollowersTest.java
@@ -26,6 +26,7 @@ import pcgen.rules.persistence.token.ParseResult;
 import plugin.lsttokens.FollowersLst;
 
 import tokencontent.testsupport.AbstractContentTokenTest;
+import util.TestURI;
 
 public class GlobalFollowersTest extends AbstractContentTokenTest
 {
@@ -49,7 +50,7 @@ public class GlobalFollowersTest extends AbstractContentTokenTest
 				token.parseToken(context, source, "Animal Companion|3");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();

--- a/code/src/itest/tokencontent/GlobalMoveCloneTest.java
+++ b/code/src/itest/tokencontent/GlobalMoveCloneTest.java
@@ -26,6 +26,7 @@ import pcgen.rules.persistence.token.ParseResult;
 import plugin.lsttokens.MovecloneLst;
 
 import tokencontent.testsupport.AbstractContentTokenTest;
+import util.TestURI;
 
 public class GlobalMoveCloneTest extends AbstractContentTokenTest
 {
@@ -46,7 +47,7 @@ public class GlobalMoveCloneTest extends AbstractContentTokenTest
 		ParseResult result = token.parseToken(context, source, "Walk,Fly,*2");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();

--- a/code/src/itest/tokencontent/GlobalMoveTest.java
+++ b/code/src/itest/tokencontent/GlobalMoveTest.java
@@ -26,6 +26,7 @@ import pcgen.rules.persistence.token.ParseResult;
 import plugin.lsttokens.MoveLst;
 
 import tokencontent.testsupport.AbstractContentTokenTest;
+import util.TestURI;
 
 public class GlobalMoveTest extends AbstractContentTokenTest
 {
@@ -46,7 +47,7 @@ public class GlobalMoveTest extends AbstractContentTokenTest
 		ParseResult result = token.parseToken(context, source, "Fly,30");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();

--- a/code/src/itest/tokencontent/GlobalQualifyTest.java
+++ b/code/src/itest/tokencontent/GlobalQualifyTest.java
@@ -34,6 +34,7 @@ import plugin.lsttokens.QualifyToken;
 
 import org.junit.Test;
 import tokencontent.testsupport.AbstractContentTokenTest;
+import util.TestURI;
 
 public class GlobalQualifyTest extends AbstractContentTokenTest
 {
@@ -55,7 +56,7 @@ public class GlobalQualifyTest extends AbstractContentTokenTest
 		ParseResult result = token.parseToken(context, source, "RACE|Dwarf");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();

--- a/code/src/itest/tokencontent/GlobalSABTest.java
+++ b/code/src/itest/tokencontent/GlobalSABTest.java
@@ -26,6 +26,7 @@ import pcgen.rules.persistence.token.ParseResult;
 import plugin.lsttokens.SabLst;
 
 import tokencontent.testsupport.AbstractContentTokenTest;
+import util.TestURI;
 
 public class GlobalSABTest extends AbstractContentTokenTest
 {
@@ -46,7 +47,7 @@ public class GlobalSABTest extends AbstractContentTokenTest
 		ParseResult result = token.parseToken(context, source, "Special Ability Text");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();

--- a/code/src/itest/tokencontent/GlobalSRTest.java
+++ b/code/src/itest/tokencontent/GlobalSRTest.java
@@ -26,6 +26,7 @@ import pcgen.rules.persistence.token.ParseResult;
 import plugin.lsttokens.SrLst;
 
 import tokencontent.testsupport.AbstractContentTokenTest;
+import util.TestURI;
 
 public class GlobalSRTest extends AbstractContentTokenTest
 {
@@ -46,7 +47,7 @@ public class GlobalSRTest extends AbstractContentTokenTest
 		ParseResult result = token.parseToken(context, source, "25+INT");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();

--- a/code/src/itest/tokencontent/GlobalSpellKnownTest.java
+++ b/code/src/itest/tokencontent/GlobalSpellKnownTest.java
@@ -42,6 +42,7 @@ import plugin.pretokens.parser.PreVariableParser;
 import plugin.pretokens.test.PreVariableTester;
 
 import tokencontent.testsupport.AbstractContentTokenTest;
+import util.TestURI;
 
 public class GlobalSpellKnownTest extends AbstractContentTokenTest
 {
@@ -79,7 +80,7 @@ public class GlobalSpellKnownTest extends AbstractContentTokenTest
 		ParseResult result = token.parseToken(context, source, "CLASS|Wizard=2|Fireball");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();
@@ -137,7 +138,7 @@ public class GlobalSpellKnownTest extends AbstractContentTokenTest
 				token.parseToken(context, source, "CLASS|Wizard=2|Fireball|PREVARLTEQ:3,MyCasterLevel");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();

--- a/code/src/itest/tokencontent/GlobalUdamTest.java
+++ b/code/src/itest/tokencontent/GlobalUdamTest.java
@@ -29,6 +29,7 @@ import plugin.lsttokens.UdamLst;
 
 import org.junit.Test;
 import tokencontent.testsupport.AbstractContentTokenTest;
+import util.TestURI;
 
 public class GlobalUdamTest extends AbstractContentTokenTest
 {
@@ -49,7 +50,7 @@ public class GlobalUdamTest extends AbstractContentTokenTest
 		ParseResult result = token.parseToken(context, source, "7");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();

--- a/code/src/itest/tokencontent/GlobalUnencumberedMoveArmorTest.java
+++ b/code/src/itest/tokencontent/GlobalUnencumberedMoveArmorTest.java
@@ -26,6 +26,7 @@ import pcgen.util.enumeration.Load;
 import plugin.lsttokens.UnencumberedmoveLst;
 
 import tokencontent.testsupport.AbstractContentTokenTest;
+import util.TestURI;
 
 public class GlobalUnencumberedMoveArmorTest extends AbstractContentTokenTest
 {
@@ -46,7 +47,7 @@ public class GlobalUnencumberedMoveArmorTest extends AbstractContentTokenTest
 		ParseResult result = token.parseToken(context, source, "LightArmor");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();

--- a/code/src/itest/tokencontent/GlobalUnencumberedMoveLoadTest.java
+++ b/code/src/itest/tokencontent/GlobalUnencumberedMoveLoadTest.java
@@ -26,6 +26,7 @@ import pcgen.util.enumeration.Load;
 import plugin.lsttokens.UnencumberedmoveLst;
 
 import tokencontent.testsupport.AbstractContentTokenTest;
+import util.TestURI;
 
 public class GlobalUnencumberedMoveLoadTest extends AbstractContentTokenTest
 {
@@ -46,7 +47,7 @@ public class GlobalUnencumberedMoveLoadTest extends AbstractContentTokenTest
 		ParseResult result = token.parseToken(context, source, "LightLoad");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();

--- a/code/src/itest/tokencontent/GlobalVisionTest.java
+++ b/code/src/itest/tokencontent/GlobalVisionTest.java
@@ -27,6 +27,7 @@ import pcgen.rules.persistence.token.ParseResult;
 import plugin.lsttokens.VisionLst;
 
 import tokencontent.testsupport.AbstractContentTokenTest;
+import util.TestURI;
 
 public class GlobalVisionTest extends AbstractContentTokenTest
 {
@@ -47,7 +48,7 @@ public class GlobalVisionTest extends AbstractContentTokenTest
 		ParseResult result = token.parseToken(context, source, "Normal (40)");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();

--- a/code/src/itest/tokencontent/PCClassLevelCCSkillTest.java
+++ b/code/src/itest/tokencontent/PCClassLevelCCSkillTest.java
@@ -35,6 +35,7 @@ import plugin.lsttokens.skill.ExclusiveToken;
 
 import org.junit.Test;
 import tokenmodel.testsupport.AbstractTokenModelTest;
+import util.TestURI;
 
 public class PCClassLevelCCSkillTest extends AbstractTokenModelTest
 {
@@ -62,7 +63,7 @@ public class PCClassLevelCCSkillTest extends AbstractTokenModelTest
 		ParseResult result = token.parseToken(context, pcl, "MySkill");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		new ExclusiveToken().parseToken(context, sk, "Yes");

--- a/code/src/itest/tokencontent/PCClassLevelCSkillTest.java
+++ b/code/src/itest/tokencontent/PCClassLevelCSkillTest.java
@@ -34,6 +34,7 @@ import plugin.lsttokens.pcclass.level.CskillToken;
 
 import org.junit.Test;
 import tokenmodel.testsupport.AbstractTokenModelTest;
+import util.TestURI;
 
 public class PCClassLevelCSkillTest extends AbstractTokenModelTest
 {
@@ -61,7 +62,7 @@ public class PCClassLevelCSkillTest extends AbstractTokenModelTest
 		ParseResult result = token.parseToken(context, pcl, "MySkill");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();

--- a/code/src/itest/tokencontent/RaceFavClassTest.java
+++ b/code/src/itest/tokencontent/RaceFavClassTest.java
@@ -33,6 +33,7 @@ import plugin.lsttokens.testsupport.TokenRegistration;
 
 import org.junit.Test;
 import tokenmodel.testsupport.AbstractTokenModelTest;
+import util.TestURI;
 
 public class RaceFavClassTest extends AbstractTokenModelTest
 {
@@ -61,7 +62,7 @@ public class RaceFavClassTest extends AbstractTokenModelTest
 		ParseResult result = token.parseToken(context, source, "Favorite");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();
@@ -80,13 +81,13 @@ public class RaceFavClassTest extends AbstractTokenModelTest
 		ParseResult result = token.parseToken(context, source, "%LIST");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		result = CHOOSE_CLASS_TOKEN.parseToken(context, source, "Favorite");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();

--- a/code/src/itest/tokencontent/RaceMonCCSkillTest.java
+++ b/code/src/itest/tokencontent/RaceMonCCSkillTest.java
@@ -40,6 +40,7 @@ import plugin.lsttokens.testsupport.TokenRegistration;
 
 import org.junit.Test;
 import tokenmodel.testsupport.AbstractTokenModelTest;
+import util.TestURI;
 
 public class RaceMonCCSkillTest extends AbstractTokenModelTest
 {
@@ -73,7 +74,7 @@ public class RaceMonCCSkillTest extends AbstractTokenModelTest
 		ParseResult result = token.parseToken(context, source, "MySkill");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		new ExclusiveToken().parseToken(context, sk, "Yes");

--- a/code/src/itest/tokencontent/RaceMonCSkillTest.java
+++ b/code/src/itest/tokencontent/RaceMonCSkillTest.java
@@ -41,6 +41,7 @@ import plugin.lsttokens.testsupport.TokenRegistration;
 
 import org.junit.Test;
 import tokenmodel.testsupport.AbstractTokenModelTest;
+import util.TestURI;
 
 public class RaceMonCSkillTest extends AbstractTokenModelTest
 {
@@ -77,7 +78,7 @@ public class RaceMonCSkillTest extends AbstractTokenModelTest
 		ParseResult result = token.parseToken(context, source, "MySkill");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();
@@ -100,13 +101,13 @@ public class RaceMonCSkillTest extends AbstractTokenModelTest
 		ParseResult result = token.parseToken(context, source, "LIST");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		result = CHOOSE_SKILL_TOKEN.parseToken(context, source, "MySkill");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();

--- a/code/src/itest/tokencontent/RaceMoveTest.java
+++ b/code/src/itest/tokencontent/RaceMoveTest.java
@@ -28,6 +28,7 @@ import plugin.lsttokens.race.MoveToken;
 
 import org.junit.Test;
 import tokenmodel.testsupport.AbstractTokenModelTest;
+import util.TestURI;
 
 public class RaceMoveTest extends AbstractTokenModelTest
 {
@@ -60,7 +61,7 @@ public class RaceMoveTest extends AbstractTokenModelTest
 		ParseResult result = token.parseToken(context, source, "Fly,30");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();

--- a/code/src/itest/tokencontent/SkillClassesTest.java
+++ b/code/src/itest/tokencontent/SkillClassesTest.java
@@ -33,6 +33,7 @@ import plugin.lsttokens.skill.ClassesToken;
 
 import org.junit.Test;
 import tokenmodel.testsupport.AbstractTokenModelTest;
+import util.TestURI;
 
 public class SkillClassesTest extends AbstractTokenModelTest
 {
@@ -59,7 +60,7 @@ public class SkillClassesTest extends AbstractTokenModelTest
 		ParseResult result = token.parseToken(context, sk, "Dragon");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();

--- a/code/src/itest/tokencontent/SpellClassesTest.java
+++ b/code/src/itest/tokencontent/SpellClassesTest.java
@@ -36,6 +36,7 @@ import plugin.lsttokens.spell.ClassesToken;
 
 import org.junit.Test;
 import tokenmodel.testsupport.AbstractTokenModelTest;
+import util.TestURI;
 
 public class SpellClassesTest extends AbstractTokenModelTest
 {
@@ -62,7 +63,7 @@ public class SpellClassesTest extends AbstractTokenModelTest
 		ParseResult result = token.parseToken(context, sp, "Dragon=1");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();

--- a/code/src/itest/tokencontent/SpellDomainsTest.java
+++ b/code/src/itest/tokencontent/SpellDomainsTest.java
@@ -38,6 +38,7 @@ import plugin.lsttokens.spell.DomainsToken;
 
 import org.junit.Test;
 import tokenmodel.testsupport.AbstractTokenModelTest;
+import util.TestURI;
 
 public class SpellDomainsTest extends AbstractTokenModelTest
 {
@@ -68,7 +69,7 @@ public class SpellDomainsTest extends AbstractTokenModelTest
 		ParseResult result = token.parseToken(context, sp, "Source=1");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();

--- a/code/src/itest/tokencontent/TemplateFavoredClassTest.java
+++ b/code/src/itest/tokencontent/TemplateFavoredClassTest.java
@@ -32,6 +32,7 @@ import plugin.lsttokens.testsupport.TokenRegistration;
 
 import org.junit.Test;
 import tokenmodel.testsupport.AbstractTokenModelTest;
+import util.TestURI;
 
 public class TemplateFavoredClassTest extends AbstractTokenModelTest
 {
@@ -58,7 +59,7 @@ public class TemplateFavoredClassTest extends AbstractTokenModelTest
 		ParseResult result = token.parseToken(context, source, "Favorite");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();
@@ -77,13 +78,13 @@ public class TemplateFavoredClassTest extends AbstractTokenModelTest
 		ParseResult result = token.parseToken(context, source, "%LIST");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		result = CHOOSE_CLASS_TOKEN.parseToken(context, source, "Favorite");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();

--- a/code/src/itest/tokenmodel/AbilityDepthTest.java
+++ b/code/src/itest/tokenmodel/AbilityDepthTest.java
@@ -41,6 +41,7 @@ import junit.framework.TestSuite;
 import tokenmodel.testsupport.AbstractTokenModelTest;
 import tokenmodel.testsupport.AssocCheck;
 import tokenmodel.testsupport.NoAssociations;
+import util.TestURI;
 
 public class AbilityDepthTest extends AbstractTokenModelTest
 {
@@ -120,7 +121,7 @@ public class AbilityDepthTest extends AbstractTokenModelTest
 					firstPrefix + mid.getKeyName());
 		if (!result.passed())
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail();
 		}
 		result =
@@ -128,7 +129,7 @@ public class AbilityDepthTest extends AbstractTokenModelTest
 					secondPrefix + target.getKeyName());
 		if (!result.passed())
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail();
 		}
 

--- a/code/src/itest/tokenmodel/AddAbilityNormalTest.java
+++ b/code/src/itest/tokenmodel/AddAbilityNormalTest.java
@@ -41,6 +41,7 @@ import org.junit.Test;
 import tokenmodel.testsupport.AbstractAddListTokenTest;
 import tokenmodel.testsupport.AssocCheck;
 import tokenmodel.testsupport.NoAssociations;
+import util.TestURI;
 
 public class AddAbilityNormalTest extends AbstractAddListTokenTest<Ability>
 {
@@ -63,7 +64,7 @@ public class AddAbilityNormalTest extends AbstractAddListTokenTest<Ability>
 		ParseResult result = runToken(source);
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();

--- a/code/src/itest/tokenmodel/AddAbilityVirtualTest.java
+++ b/code/src/itest/tokenmodel/AddAbilityVirtualTest.java
@@ -41,6 +41,7 @@ import org.junit.Test;
 import tokenmodel.testsupport.AbstractAddListTokenTest;
 import tokenmodel.testsupport.AssocCheck;
 import tokenmodel.testsupport.NoAssociations;
+import util.TestURI;
 
 public class AddAbilityVirtualTest extends AbstractAddListTokenTest<Ability>
 {
@@ -64,7 +65,7 @@ public class AddAbilityVirtualTest extends AbstractAddListTokenTest<Ability>
 		ParseResult result = runToken(source);
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();

--- a/code/src/itest/tokenmodel/AddTargetedAbilityNormalTest.java
+++ b/code/src/itest/tokenmodel/AddTargetedAbilityNormalTest.java
@@ -33,6 +33,7 @@ import pcgen.rules.persistence.token.ParseResult;
 import plugin.lsttokens.add.AbilityToken;
 
 import tokenmodel.testsupport.AbstractAddListTokenTest;
+import util.TestURI;
 
 public class AddTargetedAbilityNormalTest extends AbstractAddListTokenTest<Ability>
 {
@@ -48,7 +49,7 @@ public class AddTargetedAbilityNormalTest extends AbstractAddListTokenTest<Abili
 				ADD_ABILITY_TOKEN.parseToken(context, source, "FEAT|NORMAL|Granted (English)");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();
@@ -126,19 +127,19 @@ public class AddTargetedAbilityNormalTest extends AbstractAddListTokenTest<Abili
 		ParseResult result = AUTO_LANG_TOKEN.parseToken(context, a, "%LIST");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		result = ABILITY_MULT_TOKEN.parseToken(context, a, "YES");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		result = CHOOSE_LANG_TOKEN.parseToken(context, a, "ALL");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		context.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, a);

--- a/code/src/itest/tokenmodel/AddTargetedAbilityVirtualTest.java
+++ b/code/src/itest/tokenmodel/AddTargetedAbilityVirtualTest.java
@@ -33,6 +33,7 @@ import pcgen.rules.persistence.token.ParseResult;
 import plugin.lsttokens.add.AbilityToken;
 
 import tokenmodel.testsupport.AbstractAddListTokenTest;
+import util.TestURI;
 
 public class AddTargetedAbilityVirtualTest extends AbstractAddListTokenTest<Ability>
 {
@@ -48,7 +49,7 @@ public class AddTargetedAbilityVirtualTest extends AbstractAddListTokenTest<Abil
 				ADD_ABILITY_TOKEN.parseToken(context, source, "FEAT|VIRTUAL|Granted (English)");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();
@@ -126,19 +127,19 @@ public class AddTargetedAbilityVirtualTest extends AbstractAddListTokenTest<Abil
 		ParseResult result = AUTO_LANG_TOKEN.parseToken(context, a, "%LIST");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		result = ABILITY_MULT_TOKEN.parseToken(context, a, "YES");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		result = CHOOSE_LANG_TOKEN.parseToken(context, a, "ALL");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		context.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, a);

--- a/code/src/itest/tokenmodel/AutoArmorProfTest.java
+++ b/code/src/itest/tokenmodel/AutoArmorProfTest.java
@@ -29,6 +29,7 @@ import pcgen.rules.persistence.token.ParseResult;
 import plugin.lsttokens.auto.ArmorProfToken;
 
 import tokenmodel.testsupport.AbstractGrantedListTokenTest;
+import util.TestURI;
 
 public class AutoArmorProfTest extends AbstractGrantedListTokenTest<ArmorProf>
 {
@@ -45,7 +46,7 @@ public class AutoArmorProfTest extends AbstractGrantedListTokenTest<ArmorProf>
 				AUTO_ARMORPROF_TOKEN.parseToken(context, source, "Granted");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();

--- a/code/src/itest/tokenmodel/AutoLangListTest.java
+++ b/code/src/itest/tokenmodel/AutoLangListTest.java
@@ -35,6 +35,7 @@ import plugin.lsttokens.ability.MultToken;
 
 import org.junit.Test;
 import tokenmodel.testsupport.AbstractTokenModelTest;
+import util.TestURI;
 
 public class AutoLangListTest extends AbstractTokenModelTest
 {
@@ -47,7 +48,7 @@ public class AutoLangListTest extends AbstractTokenModelTest
 				new MultToken().parseToken(context, source, "YES");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		context.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, source);
@@ -110,13 +111,13 @@ public class AutoLangListTest extends AbstractTokenModelTest
 		ParseResult result = AUTO_LANG_TOKEN.parseToken(context, source, "%LIST");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		result = CHOOSE_LANG_TOKEN.parseToken(context, source, "Granted");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();

--- a/code/src/itest/tokenmodel/AutoLangTest.java
+++ b/code/src/itest/tokenmodel/AutoLangTest.java
@@ -24,6 +24,7 @@ import pcgen.rules.persistence.token.CDOMToken;
 import pcgen.rules.persistence.token.ParseResult;
 
 import tokenmodel.testsupport.AbstractGrantedListTokenTest;
+import util.TestURI;
 
 public class AutoLangTest extends AbstractGrantedListTokenTest<Language>
 {
@@ -34,7 +35,7 @@ public class AutoLangTest extends AbstractGrantedListTokenTest<Language>
 		ParseResult result = AUTO_LANG_TOKEN.parseToken(context, source, "Granted");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();

--- a/code/src/itest/tokenmodel/AutoShieldProfTest.java
+++ b/code/src/itest/tokenmodel/AutoShieldProfTest.java
@@ -29,6 +29,7 @@ import pcgen.rules.persistence.token.ParseResult;
 import plugin.lsttokens.auto.ShieldProfToken;
 
 import tokenmodel.testsupport.AbstractGrantedListTokenTest;
+import util.TestURI;
 
 public class AutoShieldProfTest extends
 		AbstractGrantedListTokenTest<ShieldProf>
@@ -46,7 +47,7 @@ public class AutoShieldProfTest extends
 				AUTO_SHIELDPROF_TOKEN.parseToken(context, source, "Granted");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();

--- a/code/src/itest/tokenmodel/AutoWeaponProfListTargetTest.java
+++ b/code/src/itest/tokenmodel/AutoWeaponProfListTargetTest.java
@@ -41,6 +41,7 @@ import plugin.lsttokens.testsupport.TokenRegistration;
 
 import org.junit.Test;
 import tokenmodel.testsupport.AbstractTokenModelTest;
+import util.TestURI;
 
 public class AutoWeaponProfListTargetTest extends AbstractTokenModelTest
 {
@@ -57,25 +58,25 @@ public class AutoWeaponProfListTargetTest extends AbstractTokenModelTest
 				new MultToken().parseToken(context, granted, "YES");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		result = new LangToken().parseToken(context, granted, "ALL");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		result = new LangToken().parseToken(context, source, "ALL");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		result = token.parseToken(context, source, "FEAT|Granted (%LIST)");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();
@@ -99,31 +100,31 @@ public class AutoWeaponProfListTargetTest extends AbstractTokenModelTest
 				new MultToken().parseToken(context, granted, "YES");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		result = new MultToken().parseToken(context, source, "YES");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		result = new LangToken().parseToken(context, granted, "ALL");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		result = new LangToken().parseToken(context, source, "ALL");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		result = token.parseToken(context, source, "FEAT|Granted (%LIST)");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();

--- a/code/src/itest/tokenmodel/AutoWeaponProfTest.java
+++ b/code/src/itest/tokenmodel/AutoWeaponProfTest.java
@@ -25,6 +25,7 @@ import pcgen.rules.persistence.token.ParseResult;
 import plugin.lsttokens.auto.WeaponProfToken;
 
 import tokenmodel.testsupport.AbstractGrantedListTokenTest;
+import util.TestURI;
 
 public class AutoWeaponProfTest extends
 		AbstractGrantedListTokenTest<WeaponProf>
@@ -40,7 +41,7 @@ public class AutoWeaponProfTest extends
 				AUTO_WEAPONPROF_TOKEN.parseToken(context, source, "Granted");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();

--- a/code/src/itest/tokenmodel/GlobalAbilityTest.java
+++ b/code/src/itest/tokenmodel/GlobalAbilityTest.java
@@ -31,6 +31,7 @@ import pcgen.rules.persistence.token.ParseResult;
 import plugin.lsttokens.AbilityLst;
 
 import tokenmodel.testsupport.AbstractGrantedListTokenTest;
+import util.TestURI;
 
 public class GlobalAbilityTest extends AbstractGrantedListTokenTest<Ability>
 {
@@ -43,7 +44,7 @@ public class GlobalAbilityTest extends AbstractGrantedListTokenTest<Ability>
 		ParseResult result = token.parseToken(context, source, "FEAT|VIRTUAL|Granted");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();

--- a/code/src/itest/tokenmodel/GlobalTemplateTest.java
+++ b/code/src/itest/tokenmodel/GlobalTemplateTest.java
@@ -34,6 +34,7 @@ import plugin.lsttokens.choose.TemplateToken;
 
 import org.junit.Test;
 import tokenmodel.testsupport.AbstractGrantedListTokenTest;
+import util.TestURI;
 
 public class GlobalTemplateTest extends AbstractGrantedListTokenTest<PCTemplate>
 {
@@ -58,7 +59,7 @@ public class GlobalTemplateTest extends AbstractGrantedListTokenTest<PCTemplate>
 		ParseResult result = token.parseToken(context, source, "CHOOSE:Granted");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();
@@ -78,13 +79,13 @@ public class GlobalTemplateTest extends AbstractGrantedListTokenTest<PCTemplate>
 		ParseResult result = token.parseToken(context, source, "%LIST");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		result = CHOOSE_TEMPLATE_TOKEN.parseToken(context, source, "Granted");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		source.put(ObjectKey.MULTIPLE_ALLOWED, Boolean.TRUE);
@@ -103,7 +104,7 @@ public class GlobalTemplateTest extends AbstractGrantedListTokenTest<PCTemplate>
 		ParseResult result = token.parseToken(context, source, "Granted");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();

--- a/code/src/itest/tokenmodel/PCClassDomainTest.java
+++ b/code/src/itest/tokenmodel/PCClassDomainTest.java
@@ -27,6 +27,7 @@ import plugin.lsttokens.pcclass.DomainToken;
 
 import org.junit.Test;
 import tokenmodel.testsupport.AbstractTokenModelTest;
+import util.TestURI;
 
 public class PCClassDomainTest extends AbstractTokenModelTest
 {
@@ -41,7 +42,7 @@ public class PCClassDomainTest extends AbstractTokenModelTest
 		ParseResult result = token.parseToken(context, source, "Granted");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();

--- a/code/src/itest/tokenmodel/PCClassLangbonusTest.java
+++ b/code/src/itest/tokenmodel/PCClassLangbonusTest.java
@@ -28,6 +28,7 @@ import plugin.lsttokens.pcclass.LangbonusToken;
 
 import org.junit.Test;
 import tokenmodel.testsupport.AbstractTokenModelTest;
+import util.TestURI;
 
 public class PCClassLangbonusTest extends AbstractTokenModelTest
 {
@@ -44,7 +45,7 @@ public class PCClassLangbonusTest extends AbstractTokenModelTest
 		ParseResult result = token.parseToken(context, source, "Granted");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();

--- a/code/src/itest/tokenmodel/PCClassLevelDomainTest.java
+++ b/code/src/itest/tokenmodel/PCClassLevelDomainTest.java
@@ -28,6 +28,7 @@ import plugin.lsttokens.pcclass.level.DomainToken;
 
 import org.junit.Test;
 import tokenmodel.testsupport.AbstractTokenModelTest;
+import util.TestURI;
 
 public class PCClassLevelDomainTest extends AbstractTokenModelTest
 {
@@ -43,7 +44,7 @@ public class PCClassLevelDomainTest extends AbstractTokenModelTest
 		ParseResult result = token.parseToken(context, pcl, "Granted");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();

--- a/code/src/itest/tokenmodel/RaceLangbonusTest.java
+++ b/code/src/itest/tokenmodel/RaceLangbonusTest.java
@@ -28,6 +28,7 @@ import plugin.lsttokens.race.LangbonusToken;
 
 import org.junit.Test;
 import tokenmodel.testsupport.AbstractTokenModelTest;
+import util.TestURI;
 
 public class RaceLangbonusTest extends AbstractTokenModelTest
 {
@@ -44,7 +45,7 @@ public class RaceLangbonusTest extends AbstractTokenModelTest
 		ParseResult result = token.parseToken(context, source, "Granted");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();

--- a/code/src/itest/tokenmodel/RaceMonsterClassTest.java
+++ b/code/src/itest/tokenmodel/RaceMonsterClassTest.java
@@ -28,6 +28,7 @@ import plugin.lsttokens.testsupport.TokenRegistration;
 
 import org.junit.Test;
 import tokenmodel.testsupport.AbstractTokenModelTest;
+import util.TestURI;
 
 public class RaceMonsterClassTest extends AbstractTokenModelTest
 {
@@ -43,7 +44,7 @@ public class RaceMonsterClassTest extends AbstractTokenModelTest
 		ParseResult result = token.parseToken(context, source, "Granted:3");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();

--- a/code/src/itest/tokenmodel/TemplateAddLevelTest.java
+++ b/code/src/itest/tokenmodel/TemplateAddLevelTest.java
@@ -26,6 +26,7 @@ import plugin.lsttokens.template.AddLevelToken;
 
 import org.junit.Test;
 import tokenmodel.testsupport.AbstractTokenModelTest;
+import util.TestURI;
 
 public class TemplateAddLevelTest extends AbstractTokenModelTest
 {
@@ -40,7 +41,7 @@ public class TemplateAddLevelTest extends AbstractTokenModelTest
 		ParseResult result = token.parseToken(context, source, "Granted|3");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();

--- a/code/src/itest/tokenmodel/TemplateLangbonusTest.java
+++ b/code/src/itest/tokenmodel/TemplateLangbonusTest.java
@@ -28,6 +28,7 @@ import plugin.lsttokens.template.LangbonusToken;
 
 import org.junit.Test;
 import tokenmodel.testsupport.AbstractTokenModelTest;
+import util.TestURI;
 
 public class TemplateLangbonusTest extends AbstractTokenModelTest
 {
@@ -44,7 +45,7 @@ public class TemplateLangbonusTest extends AbstractTokenModelTest
 		ParseResult result = token.parseToken(context, source, "Granted");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		finishLoad();

--- a/code/src/itest/tokenmodel/testsupport/AbstractAbilityGrantCheckTest.java
+++ b/code/src/itest/tokenmodel/testsupport/AbstractAbilityGrantCheckTest.java
@@ -29,6 +29,7 @@ import pcgen.rules.persistence.token.ParseResult;
 import plugin.lsttokens.ability.StackToken;
 import plugin.lsttokens.choose.NoChoiceToken;
 import plugin.lsttokens.testsupport.TokenRegistration;
+import util.TestURI;
 
 public abstract class AbstractAbilityGrantCheckTest extends AbstractTokenModelTest
 {
@@ -59,7 +60,7 @@ public abstract class AbstractAbilityGrantCheckTest extends AbstractTokenModelTe
 		ParseResult result = TYPE_TOKEN.parseToken(context, a, "Selectable");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		return a;
@@ -72,19 +73,19 @@ public abstract class AbstractAbilityGrantCheckTest extends AbstractTokenModelTe
 		ParseResult result = AUTO_FEAT_TOKEN.parseToken(context, a, "FEAT|%LIST");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		result = ABILITY_MULT_TOKEN.parseToken(context, a, "YES");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		result = CHOOSE_FEATSELECTION_TOKEN.parseToken(context, a, target);
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		return a;
@@ -97,25 +98,25 @@ public abstract class AbstractAbilityGrantCheckTest extends AbstractTokenModelTe
 		ParseResult result = AUTO_FEAT_TOKEN.parseToken(context, a, "FEAT|%LIST");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		result = ABILITY_MULT_TOKEN.parseToken(context, a, "YES");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		result = ABILITY_STACK_TOKEN.parseToken(context, a, "YES");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		result = CHOOSE_FEATSELECTION_TOKEN.parseToken(context, a, target);
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		return a;
@@ -128,13 +129,13 @@ public abstract class AbstractAbilityGrantCheckTest extends AbstractTokenModelTe
 		ParseResult result = ABILITY_MULT_TOKEN.parseToken(context, a, "YES");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		result = CHOOSE_NOCHOICE_TOKEN.parseToken(context, a, null);
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		return a;
@@ -147,19 +148,19 @@ public abstract class AbstractAbilityGrantCheckTest extends AbstractTokenModelTe
 		ParseResult result = ABILITY_MULT_TOKEN.parseToken(context, a, "YES");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		result = ABILITY_STACK_TOKEN.parseToken(context, a, "YES");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		result = CHOOSE_NOCHOICE_TOKEN.parseToken(context, a, null);
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		return a;
@@ -273,7 +274,7 @@ public abstract class AbstractAbilityGrantCheckTest extends AbstractTokenModelTe
 					getGrantPrefix() + "Grantor (" + s + ")");
 		if (result != ParseResult.SUCCESS)
 		{
-			result.printMessages();
+			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
 		return parent;

--- a/code/src/java/pcgen/cdom/content/factset/FactSetParser.java
+++ b/code/src/java/pcgen/cdom/content/factset/FactSetParser.java
@@ -95,8 +95,7 @@ public class FactSetParser<T extends CDOMObject, F> extends
 					return new ParseResult.Fail("Non-sensical situation was "
 						+ "encountered while parsing " + getParentToken()
 						+ Constants.PIPE + getTokenName()
-						+ ": When used, .CLEARALL must be the first argument",
-						context);
+						+ ": When used, .CLEARALL must be the first argument");
 				}
 				objContext.removeSet(obj, fsk);
 			}

--- a/code/src/java/pcgen/io/Compatibility.java
+++ b/code/src/java/pcgen/io/Compatibility.java
@@ -136,7 +136,7 @@ public final class Compatibility
 		}
 		PCClass applied = new PCClass();
 		ParseResult pr = context.processSubToken(applied, "ADD", key, count + choices);
-		pr.printMessages();
+		pr.printMessages(context.getSourceURI());
 		if (!pr.passed())
 		{
 			return null;

--- a/code/src/java/pcgen/rules/persistence/TokenSupport.java
+++ b/code/src/java/pcgen/rules/persistence/TokenSupport.java
@@ -82,7 +82,7 @@ public class TokenSupport
 					parse = new ParseResult.Fail("Token processing failed");
 				}
 				// Need to add messages as there may be warnings.
-				parse.addMessagesToLog();
+				parse.addMessagesToLog(context.getSourceURI());
 				if (parse.passed())
 				{
 					return true;

--- a/code/src/java/pcgen/rules/persistence/token/AbstractQualifiedChooseToken.java
+++ b/code/src/java/pcgen/rules/persistence/token/AbstractQualifiedChooseToken.java
@@ -77,7 +77,7 @@ public abstract class AbstractQualifiedChooseToken<T extends CDOMObject>
 				if (title == null || title.isEmpty())
 				{
 					return new ParseResult.Fail(getParentToken() + ":"
-						+ getTokenName() + " had TITLE= but no title: " + value, context);
+						+ getTokenName() + " had TITLE= but no title: " + value);
 				}
 			}
 			else

--- a/code/src/java/pcgen/rules/persistence/token/AbstractSimpleChooseToken.java
+++ b/code/src/java/pcgen/rules/persistence/token/AbstractSimpleChooseToken.java
@@ -84,7 +84,7 @@ public abstract class AbstractSimpleChooseToken<T extends Loadable> extends
 				if (title == null || title.isEmpty())
 				{
 					return new ParseResult.Fail(getParentToken() + ':'
-						+ getTokenName() + " had TITLE= but no title: " + value, context);
+						+ getTokenName() + " had TITLE= but no title: " + value);
 				}
 			}
 			else
@@ -120,17 +120,17 @@ public abstract class AbstractSimpleChooseToken<T extends Loadable> extends
 				{
 					return new ParseResult.Fail(
 						"Error: Count not get Reference for " + tok + " in "
-							+ getTokenName(), context);
+							+ getTokenName());
 				}
 				if (!set.add(ref))
 				{
 					return new ParseResult.Fail("Error, Found item: " + ref
-						+ " twice while parsing " + getTokenName(), context);
+						+ " twice while parsing " + getTokenName());
 				}
 			}
 			if (set.isEmpty())
 			{
-				return new ParseResult.Fail("No items in set.", context);
+				return new ParseResult.Fail("No items in set.");
 			}
 			prim = new CompoundOrPrimitive<>(set);
 		}

--- a/code/src/java/pcgen/rules/persistence/token/AbstractYesNoToken.java
+++ b/code/src/java/pcgen/rules/persistence/token/AbstractYesNoToken.java
@@ -42,7 +42,7 @@ public abstract class AbstractYesNoToken<T extends CDOMObject> extends
 			if (value.length() > 1 && !value.equalsIgnoreCase("YES"))
 			{
 				return new ParseResult.Fail("You should use 'YES' as the "
-					+ getTokenName() + ": " + value, context);
+					+ getTokenName() + ": " + value);
 			}
 			set = Boolean.TRUE;
 		}
@@ -52,13 +52,13 @@ public abstract class AbstractYesNoToken<T extends CDOMObject> extends
 			{
 				return new ParseResult.Fail(
 					"You should use 'YES' or 'NO' as the " + getTokenName()
-						+ ": " + value, context);
+						+ ": " + value);
 			}
 			if (value.length() > 1 && !value.equalsIgnoreCase("NO"))
 			{
 				return new ParseResult.Fail(
 					"You should use 'YES' or 'NO' as the " + getTokenName()
-						+ ": " + value, context);
+						+ ": " + value);
 			}
 			set = Boolean.FALSE;
 		}

--- a/code/src/java/pcgen/rules/persistence/token/ClassWrappedToken.java
+++ b/code/src/java/pcgen/rules/persistence/token/ClassWrappedToken.java
@@ -81,13 +81,13 @@ public class ClassWrappedToken implements CDOMCompatibilityToken<PCClassLevel>
 				return new ParseResult.Fail("Data used token: " + value
 						+ " which is a Class token, "
 						+ "but it was used in a class level for a "
-						+ parent.getClass().getSimpleName(), context);
+						+ parent.getClass().getSimpleName());
 			}
 			return wrappedToken.parseToken(context, parent, value);
 		}
 		return new ParseResult.Fail("Data used token: " + value
 				+ " which is a Class token, "
-				+ "but it was used in a class level line other than level 1", context);
+				+ "but it was used in a class level line other than level 1");
 	}
 
 	@Override

--- a/code/src/java/pcgen/rules/persistence/token/ComplexParseResult.java
+++ b/code/src/java/pcgen/rules/persistence/token/ComplexParseResult.java
@@ -17,6 +17,9 @@
  */
 package pcgen.rules.persistence.token;
 
+import static pcgen.rules.persistence.token.ParseResult.generateText;
+
+import java.net.URI;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.logging.Level;
@@ -76,20 +79,20 @@ public class ComplexParseResult implements ParseResult
 	}
 
 	@Override
-	public void printMessages()
+	public void printMessages(URI uri)
 	{
 		for (QueuedMessage msg : queuedMessages)
 		{
-			Logging.log(msg.level, msg.message, msg.stackTrace);
+			Logging.log(msg.level, generateText(msg, uri), msg.stackTrace);
 		}
 	}
 
 	@Override
-	public void addMessagesToLog()
+	public void addMessagesToLog(URI uri)
 	{
 		for (QueuedMessage msg : queuedMessages)
 		{
-			Logging.addParseMessage(msg.level, msg.message, msg.stackTrace);
+			Logging.addParseMessage(msg.level, generateText(msg, uri), msg.stackTrace);
 		}
 	}
 

--- a/code/src/java/pcgen/rules/persistence/token/ParseResult.java
+++ b/code/src/java/pcgen/rules/persistence/token/ParseResult.java
@@ -17,9 +17,9 @@
  */
 package pcgen.rules.persistence.token;
 
+import java.net.URI;
 import java.util.logging.Level;
 
-import pcgen.rules.context.LoadContext;
 import pcgen.util.Logging;
 
 /**
@@ -47,13 +47,13 @@ public interface ParseResult
 	/**
 	 * Log any messages associated with the operation.
 	 */
-	public void printMessages();
+	public void printMessages(URI uri);
 
 	/*
 	 * Temporary method for aiding conversion to use of ParseResult.
 	 * See pcgen.rules.persistence.token.ErrorParsingWrapper for use.
 	 */
-	public void addMessagesToLog();
+	public void addMessagesToLog(URI uri);
 
 	/**
 	 * Class representing a message from the parser.
@@ -85,13 +85,13 @@ public interface ParseResult
 		}
 
 		@Override
-		public void addMessagesToLog()
+		public void addMessagesToLog(URI uri)
 		{
 			//No messages because we passed
 		}
 
 		@Override
-		public void printMessages()
+		public void printMessages(URI uri)
 		{
 			//No messages because we passed
 		}
@@ -109,21 +109,6 @@ public interface ParseResult
 			this.error = new QueuedMessage(Logging.LST_ERROR, error);
 		}
 
-		public Fail(String error, LoadContext context)
-		{
-			if (context == null || context.getSourceURI() == null)
-			{
-				this.error = new QueuedMessage(Logging.LST_ERROR, error);
-			}
-			else
-			{
-				this.error =
-						new QueuedMessage(Logging.LST_ERROR, error
-							+ " (Source: "
-							+ context.getSourceURI() + " )");
-			}
-		}
-
 		@Override
 		public boolean passed()
 		{
@@ -136,16 +121,15 @@ public interface ParseResult
 		}
 
 		@Override
-		public void addMessagesToLog()
+		public void addMessagesToLog(URI uri)
 		{
-			Logging.addParseMessage(error.level, error.message,
-				error.stackTrace);
+			Logging.addParseMessage(error.level, generateText(error, uri), error.stackTrace);
 		}
 
 		@Override
-		public void printMessages()
+		public void printMessages(URI uri)
 		{
-			Logging.log(error.level, error.message, error.stackTrace);
+			Logging.log(error.level, generateText(error, uri), error.stackTrace);
 		}
 
 		@Override
@@ -154,4 +138,10 @@ public interface ParseResult
 			return error.message;
 		}
 	}
+
+	public static String generateText(QueuedMessage message, URI uri)
+	{
+		return message.message + " (Source: " + uri + " )";
+	}
+	
 }

--- a/code/src/java/pcgen/rules/persistence/token/ParseResult.java
+++ b/code/src/java/pcgen/rules/persistence/token/ParseResult.java
@@ -139,6 +139,17 @@ public interface ParseResult
 		}
 	}
 
+	/**
+	 * Generate the text for a given QueuedMessage and URI, which is the text of the
+	 * QueuedMessed indicating the URI as the source of the message.
+	 * 
+	 * @param message
+	 *            The QueuedMessage to be processed
+	 * @param uri
+	 *            The URI indicating the source of the message
+	 * @return The text of the QueuedMessed indicating the URI as the source of the
+	 *         message
+	 */
 	public static String generateText(QueuedMessage message, URI uri)
 	{
 		return message.message + " (Source: " + uri + " )";

--- a/code/src/java/pcgen/rules/persistence/token/PreCompatibilityToken.java
+++ b/code/src/java/pcgen/rules/persistence/token/PreCompatibilityToken.java
@@ -81,7 +81,7 @@ public class PreCompatibilityToken implements
 		}
 		catch (PersistenceLayerException e)
 		{
-			return new ParseResult.Fail(e.getMessage(), context);
+			return new ParseResult.Fail(e.getMessage());
 		}
 	}
 

--- a/code/src/java/plugin/lsttokens/AbilityLst.java
+++ b/code/src/java/plugin/lsttokens/AbilityLst.java
@@ -127,7 +127,7 @@ public class AbilityLst extends AbstractTokenWithSeparator<CDOMObject>
 		{
 			return new ParseResult.Fail("Cannot use " + getTokenName()
 				+ " on an Ungranted object type: "
-				+ obj.getClass().getSimpleName(), context);
+				+ obj.getClass().getSimpleName());
 		}
 		StringTokenizer tok = new StringTokenizer(value, Constants.PIPE);
 		String cat = tok.nextToken();
@@ -136,7 +136,7 @@ public class AbilityLst extends AbstractTokenWithSeparator<CDOMObject>
 		if (!tok.hasMoreTokens())
 		{
 			return new ParseResult.Fail(getTokenName() + " must have a Nature, "
-				+ "Format is: CATEGORY|NATURE|AbilityName: " + value, context);
+				+ "Format is: CATEGORY|NATURE|AbilityName: " + value);
 		}
 		final String natureKey = tok.nextToken();
 		Nature nature;
@@ -147,19 +147,19 @@ public class AbilityLst extends AbstractTokenWithSeparator<CDOMObject>
 		catch (IllegalArgumentException iae)
 		{
 			return new ParseResult.Fail(getTokenName()
-				+ " refers to invalid Ability Nature: " + natureKey, context);
+				+ " refers to invalid Ability Nature: " + natureKey);
 		}
 		if (Nature.ANY.equals(nature))
 		{
 			return new ParseResult.Fail(getTokenName()
 					+ " refers to ANY Ability Nature, cannot be used in "
-					+ getTokenName() + ": " + value, context);
+					+ getTokenName() + ": " + value);
 		}
 		if (!tok.hasMoreTokens())
 		{
 			return new ParseResult.Fail(getTokenName()
 				+ " must have abilities, Format is: "
-				+ "CATEGORY|NATURE|AbilityName: " + value, context);
+				+ "CATEGORY|NATURE|AbilityName: " + value);
 		}
 
 		String token = tok.nextToken();
@@ -167,7 +167,7 @@ public class AbilityLst extends AbstractTokenWithSeparator<CDOMObject>
 		if (looksLikeAPrerequisite(token))
 		{
 			return new ParseResult.Fail("Cannot have only PRExxx subtoken in "
-				+ getTokenName() + ": " + value, context);
+				+ getTokenName() + ": " + value);
 		}
 
 		String lkString = "GA_CA_" + cat + '_' + natureKey;
@@ -187,8 +187,7 @@ public class AbilityLst extends AbstractTokenWithSeparator<CDOMObject>
 		if (rm == null)
 		{
 			return new ParseResult.Fail(
-				"Could not get Reference Manufacturer for Category: " + cat,
-				context);
+				"Could not get Reference Manufacturer for Category: " + cat);
 		}
 
 		boolean prereqsAllowed = true;
@@ -200,7 +199,7 @@ public class AbilityLst extends AbstractTokenWithSeparator<CDOMObject>
 				if (!first)
 				{
 					return new ParseResult.Fail("  Non-sensical " + getTokenName()
-						+ ": .CLEAR was not the first list item: " + value, context);
+						+ ": .CLEAR was not the first list item: " + value);
 				}
 				context.getListContext().removeAllFromList(getTokenName(), obj,
 					abilList);
@@ -290,7 +289,7 @@ public class AbilityLst extends AbstractTokenWithSeparator<CDOMObject>
 		{
 			return new ParseResult.Fail(
 				"Cannot use PREREQs when using .CLEAR, .CLEAR., or %LIST in "
-					+ getTokenName(), context);
+					+ getTokenName());
 		}
 
 		while (true)
@@ -299,7 +298,7 @@ public class AbilityLst extends AbstractTokenWithSeparator<CDOMObject>
 			if (prereq == null)
 			{
 				return new ParseResult.Fail("   (Did you put feats after the "
-					+ "PRExxx tags in " + getTokenName() + ":?)", context);
+					+ "PRExxx tags in " + getTokenName() + ":?)");
 			}
 			for (PrereqObject edge : edgeList)
 			{

--- a/code/src/java/plugin/lsttokens/AddLst.java
+++ b/code/src/java/plugin/lsttokens/AddLst.java
@@ -55,13 +55,13 @@ public class AddLst extends AbstractNonEmptyToken<CDOMObject> implements
 		{
 			return new ParseResult.Fail("Cannot use " + getTokenName()
 				+ " on an Ungranted object type: "
-				+ obj.getClass().getSimpleName(), context);
+				+ obj.getClass().getSimpleName());
 		}
 		if (obj instanceof NonInteractive)
 		{
 			return new ParseResult.Fail("Cannot use " + getTokenName()
 				+ " on an Non-Interactive object type: "
-				+ obj.getClass().getSimpleName(), context);
+				+ obj.getClass().getSimpleName());
 		}
 		int pipeLoc = value.indexOf(Constants.PIPE);
 		if (pipeLoc == -1)
@@ -122,7 +122,7 @@ public class AddLst extends AbstractNonEmptyToken<CDOMObject> implements
 			else
 			{
 				return new ParseResult.Fail(getTokenName()
-						+ " requires a SubToken and argument, found: " + value, context);
+						+ " requires a SubToken and argument, found: " + value);
 			}
 			context.getObjectContext().removeList(obj, ListKey.ADD);
 			return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/AutoLst.java
+++ b/code/src/java/plugin/lsttokens/AutoLst.java
@@ -44,13 +44,13 @@ public class AutoLst extends AbstractNonEmptyToken<CDOMObject> implements
 		{
 			return new ParseResult.Fail("Cannot use " + getTokenName()
 				+ " on an Ungranted object type: "
-				+ obj.getClass().getSimpleName(), context);
+				+ obj.getClass().getSimpleName());
 		}
 		int pipeLoc = value.indexOf(Constants.PIPE);
 		if (pipeLoc == -1)
 		{
 			return new ParseResult.Fail(getTokenName()
-					+ " requires a SubToken", context);
+					+ " requires a SubToken");
 		}
 		return context.processSubToken(obj, getTokenName(), value.substring(0,
 				pipeLoc), value.substring(pipeLoc + 1));

--- a/code/src/java/plugin/lsttokens/BonusLst.java
+++ b/code/src/java/plugin/lsttokens/BonusLst.java
@@ -67,7 +67,7 @@ public class BonusLst implements CDOMPrimaryToken<CDOMObject>,
 		{
 			return new ParseResult.Fail("Cannot use " + getTokenName()
 				+ " on an Ungranted object type: "
-				+ obj.getClass().getSimpleName(), context);
+				+ obj.getClass().getSimpleName());
 		}
 		if (value.indexOf("PREAPPLY:") != -1)
 		{
@@ -81,7 +81,7 @@ public class BonusLst implements CDOMPrimaryToken<CDOMObject>,
 		if (bon == null)
 		{
 			return new ParseResult.Fail(getTokenName()
-					+ " was given invalid bonus: " + value, context);
+					+ " was given invalid bonus: " + value);
 		}
 		bon.setTokenSource(getTokenName());
 		context.getObjectContext().addToList(obj, ListKey.BONUS, bon);

--- a/code/src/java/plugin/lsttokens/CcskillLst.java
+++ b/code/src/java/plugin/lsttokens/CcskillLst.java
@@ -69,7 +69,7 @@ public class CcskillLst extends AbstractTokenWithSeparator<CDOMObject>
 		{
 			return new ParseResult.Fail("Cannot use " + getTokenName()
 				+ " on an Ungranted object type: "
-				+ obj.getClass().getSimpleName(), context);
+				+ obj.getClass().getSimpleName());
 		}
 		boolean first = true;
 		boolean foundAny = false;
@@ -85,7 +85,7 @@ public class CcskillLst extends AbstractTokenWithSeparator<CDOMObject>
 				{
 					return new ParseResult.Fail("  Non-sensical "
 							+ getTokenName()
-							+ ": .CLEAR was not the first list item", context);
+							+ ": .CLEAR was not the first list item");
 				}
 				context.getObjectContext().removeList(obj, ListKey.CCSKILL);
 			}
@@ -111,7 +111,7 @@ public class CcskillLst extends AbstractTokenWithSeparator<CDOMObject>
 					{
 						return new ParseResult.Fail(
 								"  Error was encountered while parsing "
-										+ getTokenName(), context);
+										+ getTokenName());
 					}
 					context.getObjectContext().removeFromList(obj,
 							ListKey.CCSKILL, ref);
@@ -146,7 +146,7 @@ public class CcskillLst extends AbstractTokenWithSeparator<CDOMObject>
 						if (ref == null)
 						{
 							return new ParseResult.Fail("  Error was encountered "
-								+ "while parsing " + getTokenName(), context);
+								+ "while parsing " + getTokenName());
 						}
 						context.getObjectContext().addToList(obj,
 								ListKey.CCSKILL, ref);
@@ -158,7 +158,7 @@ public class CcskillLst extends AbstractTokenWithSeparator<CDOMObject>
 		if (foundAny && foundOther)
 		{
 			return new ParseResult.Fail("Non-sensical " + getTokenName()
-					+ ": Contains ANY and a specific reference: " + value, context);
+					+ ": Contains ANY and a specific reference: " + value);
 		}
 		return ParseResult.SUCCESS;
 	}

--- a/code/src/java/plugin/lsttokens/ChangeprofLst.java
+++ b/code/src/java/plugin/lsttokens/ChangeprofLst.java
@@ -71,7 +71,7 @@ public class ChangeprofLst extends AbstractTokenWithSeparator<CDOMObject>
 		{
 			return new ParseResult.Fail("Cannot use " + getTokenName()
 				+ " on an Ungranted object type: "
-				+ obj.getClass().getSimpleName(), context);
+				+ obj.getClass().getSimpleName());
 		}
 		// value should be of the format:
 		// Name1,TYPE.type1,Name3=Prof1|Name4,Name5=Prof2

--- a/code/src/java/plugin/lsttokens/ChooseLst.java
+++ b/code/src/java/plugin/lsttokens/ChooseLst.java
@@ -64,13 +64,13 @@ public class ChooseLst extends AbstractNonEmptyToken<CDOMObject> implements
 		{
 			return new ParseResult.Fail("Cannot use " + getTokenName()
 				+ " on an Ungranted object type: "
-				+ obj.getClass().getSimpleName(), context);
+				+ obj.getClass().getSimpleName());
 		}
 		if (obj instanceof NonInteractive)
 		{
 			return new ParseResult.Fail("Cannot use " + getTokenName()
 				+ " on an Non-Interactive object type: "
-				+ obj.getClass().getSimpleName(), context);
+				+ obj.getClass().getSimpleName());
 		}
 		String key;
 		String val;
@@ -104,7 +104,7 @@ public class ChooseLst extends AbstractNonEmptyToken<CDOMObject> implements
 			{
 				return new ParseResult.Fail(
 					getTokenName() + " is not supported for "
-						+ obj.getClass().getSimpleName(), context);
+						+ obj.getClass().getSimpleName());
 			}
 		}
 
@@ -114,13 +114,13 @@ public class ChooseLst extends AbstractNonEmptyToken<CDOMObject> implements
 			if (maxCount == null || maxCount.isEmpty())
 			{
 				return new ParseResult.Fail(
-					"NUMCHOICES in CHOOSE must be a formula: " + value, context);
+					"NUMCHOICES in CHOOSE must be a formula: " + value);
 			}
 			Formula f = FormulaFactory.getFormulaFor(maxCount);
 			if (!f.isValid())
 			{
 				return new ParseResult.Fail("Number of Choices in "
-						+ getTokenName() + " was not valid: " + f.toString(), context);
+						+ getTokenName() + " was not valid: " + f.toString());
 			}
 			context.getObjectContext().put(obj, FormulaKey.NUMCHOICES, f);
 			pipeLoc = val.indexOf(Constants.PIPE);

--- a/code/src/java/plugin/lsttokens/CompanionListLst.java
+++ b/code/src/java/plugin/lsttokens/CompanionListLst.java
@@ -124,7 +124,7 @@ public class CompanionListLst extends AbstractTokenWithSeparator<CDOMObject>
 		{
 			return new ParseResult.Fail("Cannot use " + getTokenName()
 				+ " on an Ungranted object type: "
-				+ obj.getClass().getSimpleName(), context);
+				+ obj.getClass().getSimpleName());
 		}
 		StringTokenizer tok = new StringTokenizer(value, LstUtils.PIPE);
 
@@ -133,7 +133,7 @@ public class CompanionListLst extends AbstractTokenWithSeparator<CDOMObject>
 		if (!tok.hasMoreTokens())
 		{
 			return new ParseResult.Fail(getTokenName()
-					+ " requires more than just a Type: " + value, context);
+					+ " requires more than just a Type: " + value);
 		}
 
 		String list = tok.nextToken();
@@ -162,7 +162,7 @@ public class CompanionListLst extends AbstractTokenWithSeparator<CDOMObject>
 				if (raceType.isEmpty())
 				{
 					return new ParseResult.Fail(getTokenName()
-							+ " Error: RaceType was not specified.", context);
+							+ " Error: RaceType was not specified.");
 				}
 				races.add(new ObjectMatchingReference<>(tokString,
 						Race.class,
@@ -175,7 +175,7 @@ public class CompanionListLst extends AbstractTokenWithSeparator<CDOMObject>
 				if (raceSubType.isEmpty())
 				{
 					return new ParseResult.Fail(getTokenName()
-							+ " Error: RaceSubType was not specified.", context);
+							+ " Error: RaceSubType was not specified.");
 				}
 				races.add(new ListMatchingReference<>(tokString,
 						Race.class,
@@ -185,7 +185,7 @@ public class CompanionListLst extends AbstractTokenWithSeparator<CDOMObject>
 			else if (looksLikeAPrerequisite(tokString))
 			{
 				return new ParseResult.Fail(getTokenName()
-					+ " Error: " + tokString + " found where companion race expected.", context);
+					+ " Error: " + tokString + " found where companion race expected.");
 			}
 			else
 			{
@@ -195,7 +195,7 @@ public class CompanionListLst extends AbstractTokenWithSeparator<CDOMObject>
 		if (foundAny && races.size() > 1)
 		{
 			return new ParseResult.Fail("Non-sensical Race List includes Any and specific races: "
-							+ value, context);
+							+ value);
 		}
 
 		if (!tok.hasMoreTokens())
@@ -215,14 +215,14 @@ public class CompanionListLst extends AbstractTokenWithSeparator<CDOMObject>
 				if (followerAdjustment != null)
 				{
 					return new ParseResult.Fail(getTokenName() + " Error: Multiple "
-							+ FOLLOWERADJUSTMENT + " tags specified.", context);
+							+ FOLLOWERADJUSTMENT + " tags specified.");
 				}
 
 				int faStringLength = FOLLOWERADJUSTMENT.length();
 				if (optArg.length() <= faStringLength + 1)
 				{
 					return new ParseResult.Fail("Empty FOLLOWERADJUSTMENT value in "
-							+ getTokenName() + " is prohibited", context);
+							+ getTokenName() + " is prohibited");
 				}
 				String adj = optArg.substring(faStringLength + 1);
 
@@ -248,7 +248,7 @@ public class CompanionListLst extends AbstractTokenWithSeparator<CDOMObject>
 				return new ParseResult.Fail(
 					getTokenName()
 						+ ": Unknown argument (was expecting FOLLOWERADJUSTMENT: or PRExxx): "
-						+ optArg, context);
+						+ optArg);
 			}
 			if (!tok.hasMoreTokens())
 			{
@@ -268,7 +268,7 @@ public class CompanionListLst extends AbstractTokenWithSeparator<CDOMObject>
 			if (prereq == null)
 			{
 				return new ParseResult.Fail("   (Did you put items after the "
-						+ "PRExxx tags in " + getTokenName() + ":?)", context);
+						+ "PRExxx tags in " + getTokenName() + ":?)");
 			}
 			prereqs.add(prereq);
 			if (!tok.hasMoreTokens())

--- a/code/src/java/plugin/lsttokens/CskillLst.java
+++ b/code/src/java/plugin/lsttokens/CskillLst.java
@@ -71,7 +71,7 @@ public class CskillLst extends AbstractTokenWithSeparator<CDOMObject> implements
 		{
 			return new ParseResult.Fail("Cannot use " + getTokenName()
 				+ " on an Ungranted object type: "
-				+ obj.getClass().getSimpleName(), context);
+				+ obj.getClass().getSimpleName());
 		}
 		boolean first = true;
 		boolean foundAny = false;
@@ -87,7 +87,7 @@ public class CskillLst extends AbstractTokenWithSeparator<CDOMObject> implements
 				{
 					return new ParseResult.Fail("  Non-sensical "
 							+ getTokenName()
-							+ ": .CLEAR was not the first list item", context);
+							+ ": .CLEAR was not the first list item");
 				}
 				context.getObjectContext().removeList(obj, ListKey.CSKILL);
 			}
@@ -113,7 +113,7 @@ public class CskillLst extends AbstractTokenWithSeparator<CDOMObject> implements
 					{
 						return new ParseResult.Fail(
 								"  Error was encountered while parsing "
-										+ getTokenName(), context);
+										+ getTokenName());
 					}
 					context.getObjectContext().removeFromList(obj,
 							ListKey.CSKILL, ref);
@@ -148,7 +148,7 @@ public class CskillLst extends AbstractTokenWithSeparator<CDOMObject> implements
 						if (ref == null)
 						{
 							return new ParseResult.Fail("  Error was encountered "
-								+ "while parsing " + getTokenName(), context);
+								+ "while parsing " + getTokenName());
 						}
 						context.getObjectContext().addToList(obj,
 								ListKey.CSKILL, ref);
@@ -160,7 +160,7 @@ public class CskillLst extends AbstractTokenWithSeparator<CDOMObject> implements
 		if (foundAny && foundOther)
 		{
 			return new ParseResult.Fail("Non-sensical " + getTokenName()
-					+ ": Contains ANY and a specific reference: " + value, context);
+					+ ": Contains ANY and a specific reference: " + value);
 		}
 		return ParseResult.SUCCESS;
 	}

--- a/code/src/java/plugin/lsttokens/DefineLst.java
+++ b/code/src/java/plugin/lsttokens/DefineLst.java
@@ -53,7 +53,7 @@ public class DefineLst implements CDOMPrimaryToken<CDOMObject>
 		{
 			return new ParseResult.Fail("Cannot use " + getTokenName()
 				+ " on an Ungranted object type: "
-				+ obj.getClass().getSimpleName(), context);
+				+ obj.getClass().getSimpleName());
 		}
 		ParsingSeparator sep = new ParsingSeparator(value, '|');
 		sep.addGroupingPair('[', ']');
@@ -61,25 +61,25 @@ public class DefineLst implements CDOMPrimaryToken<CDOMObject>
 
 		if (!sep.hasNext())
 		{
-			return new ParseResult.Fail(getTokenName() + " may not be empty", context);
+			return new ParseResult.Fail(getTokenName() + " may not be empty");
 		}
 		String firstItem = sep.next();
 
 		if (firstItem.startsWith("UNLOCK."))
 		{
 			return new ParseResult.Fail("DEFINE:UNLOCK. has been deprecated, "
-				+ "please use DEFINESTAT:STAT| or DEFINESTAT:UNLOCK|", context);
+				+ "please use DEFINESTAT:STAT| or DEFINESTAT:UNLOCK|");
 		}
 		if (!sep.hasNext())
 		{
 			return new ParseResult.Fail(getTokenName() + " varName|varFormula"
-					+ "or LOCK.<stat>|value syntax requires an argument", context);
+					+ "or LOCK.<stat>|value syntax requires an argument");
 		}
 		String var = firstItem;
 		if (var.isEmpty())
 		{
 			return new ParseResult.Fail("Empty Variable Name found in "
-					+ getTokenName() + ": " + value, context);
+					+ getTokenName() + ": " + value);
 		}
 		try
 		{
@@ -87,7 +87,7 @@ public class DefineLst implements CDOMPrimaryToken<CDOMObject>
 			if (!f.isValid())
 			{
 				return new ParseResult.Fail("Formula in " + getTokenName()
-						+ " was not valid: " + f.toString(), context);
+						+ " was not valid: " + f.toString());
 			}
 			if ((!f.isStatic() || f.resolveStatic().intValue() != 0) && !(var.startsWith("MAXLEVELSTAT=")))
 			{
@@ -100,12 +100,12 @@ public class DefineLst implements CDOMPrimaryToken<CDOMObject>
 			if (sep.hasNext())
 			{
 				return new ParseResult.Fail(getTokenName() + ' ' + firstItem
-						+ " syntax requires only one argument: " + value, context);
+						+ " syntax requires only one argument: " + value);
 			}
 			if (value.startsWith("LOCK."))
 			{
 				return new ParseResult.Fail("DEFINE:LOCK. has been deprecated, "
-						+ "please use DEFINESTAT:LOCL| or DEFINESTAT:NONSTAT|", context);
+						+ "please use DEFINESTAT:LOCL| or DEFINESTAT:NONSTAT|");
 			}
 			else
 			{
@@ -118,7 +118,7 @@ public class DefineLst implements CDOMPrimaryToken<CDOMObject>
 		{
 			return new ParseResult.Fail("Illegal Formula found in "
 					+ getTokenName() + ": " + value + ' '
-					+ e.getLocalizedMessage(), context);
+					+ e.getLocalizedMessage());
 		}
 	}
 

--- a/code/src/java/plugin/lsttokens/DefineStatLst.java
+++ b/code/src/java/plugin/lsttokens/DefineStatLst.java
@@ -71,7 +71,7 @@ public class DefineStatLst implements CDOMPrimaryToken<CDOMObject>
 		{
 			return new ParseResult.Fail("Cannot use " + getTokenName()
 				+ " on an Ungranted object type: "
-				+ obj.getClass().getSimpleName(), context);
+				+ obj.getClass().getSimpleName());
 		}
 		ParsingSeparator sep = new ParsingSeparator(value, '|');
 		sep.addGroupingPair('[', ']');
@@ -79,7 +79,7 @@ public class DefineStatLst implements CDOMPrimaryToken<CDOMObject>
 
 		if (!sep.hasNext())
 		{
-			return new ParseResult.Fail(getTokenName() + " may not be empty", context);
+			return new ParseResult.Fail(getTokenName() + " may not be empty");
 		}
 		String firstItem = sep.next();
 		
@@ -92,14 +92,13 @@ public class DefineStatLst implements CDOMPrimaryToken<CDOMObject>
 		{
 			return new ParseResult.Fail("Found unexpected sub tag " + firstItem + " in "
 				+ getTokenName() + Constants.COLON + value + ". Must be one of "
-				+ StringUtils.join(DefineStatSubToken.values(), ", ") + Constants.DOT,
-				context);
+				+ StringUtils.join(DefineStatSubToken.values(), ", ") + Constants.DOT);
 		}
 
 		if (!sep.hasNext())
 		{
 			return new ParseResult.Fail(getTokenName()
-				+ Constants.COLON+subToken+"| must be followed by a stat.", context);
+				+ Constants.COLON+subToken+"| must be followed by a stat.");
 		}
 		String statKey = sep.next();
 		CDOMSingleRef<PCStat> stat =
@@ -114,21 +113,21 @@ public class DefineStatLst implements CDOMPrimaryToken<CDOMObject>
 			if (!sep.hasNext())
 			{
 				return new ParseResult.Fail(getTokenName() + Constants.COLON + subToken
-					+ "| must be followed by both a stat and a value.", context);
+					+ "| must be followed by both a stat and a value.");
 			}
 			String formula = sep.next();
 			f = FormulaFactory.getFormulaFor(formula);
 			if (!f.isValid())
 			{
 				return new ParseResult.Fail("Formula in " + getTokenName()
-						+ " was not valid: " + f.toString(), context);
+						+ " was not valid: " + f.toString());
 			}
 		}
 		
 		if (sep.hasNext())
 		{
 			return new ParseResult.Fail(getTokenName() + Constants.COLON + value
-				+ " has too many pipe separated item.", context);
+				+ " has too many pipe separated item.");
 		}
 
 		switch (subToken)

--- a/code/src/java/plugin/lsttokens/DescLst.java
+++ b/code/src/java/plugin/lsttokens/DescLst.java
@@ -76,13 +76,13 @@ public class DescLst extends AbstractTokenWithSeparator<CDOMObject> implements
 		if (looksLikeAPrerequisite(descString))
 		{
 			return new ParseResult.Fail(getTokenName() + " encountered only a PRExxx: "
-				+ aDesc, context);
+				+ aDesc);
 		}
 		String ds = EntityEncoder.decode(descString);
 		if (!StringUtil.hasBalancedParens(ds))
 		{
 			return new ParseResult.Fail(getTokenName()
-					+ " encountered imbalanced Parenthesis: " + aDesc, context);
+					+ " encountered imbalanced Parenthesis: " + aDesc);
 		}
 		ParseResult pr = checkForInvalidXMLChars(ds);
 		if (!pr.passed())
@@ -100,7 +100,7 @@ public class DescLst extends AbstractTokenWithSeparator<CDOMObject> implements
 				{
 					return new ParseResult.Fail(getTokenName()
 						+ " tag confused by '.CLEAR' as a " + "middle token: "
-						+ aDesc, context);
+						+ aDesc);
 				}
 				else if (looksLikeAPrerequisite(token))
 				{
@@ -127,7 +127,7 @@ public class DescLst extends AbstractTokenWithSeparator<CDOMObject> implements
 				{
 					return new ParseResult.Fail(
 						"   (Did you put Abilities after the "
-							+ "PRExxx tags in " + getTokenName() + ":?)", context);
+							+ "PRExxx tags in " + getTokenName() + ":?)");
 				}
 				desc.addPrerequisite(prereq);
 				if (!tok.hasMoreTokens())

--- a/code/src/java/plugin/lsttokens/DrLst.java
+++ b/code/src/java/plugin/lsttokens/DrLst.java
@@ -64,7 +64,7 @@ public class DrLst extends AbstractTokenWithSeparator<CDOMObject> implements
 		{
 			return new ParseResult.Fail("Cannot use " + getTokenName()
 				+ " on an Ungranted object type: "
-				+ obj.getClass().getSimpleName(), context);
+				+ obj.getClass().getSimpleName());
 		}
 		if (Constants.LST_DOT_CLEAR.equals(value))
 		{
@@ -93,7 +93,7 @@ public class DrLst extends AbstractTokenWithSeparator<CDOMObject> implements
 		if (!formula.isValid())
 		{
 			return new ParseResult.Fail("Formula in " + getTokenName()
-					+ " was not valid: " + formula.toString(), context);
+					+ " was not valid: " + formula.toString());
 		}
 		DamageReduction dr = new DamageReduction(formula, values[1]);
 

--- a/code/src/java/plugin/lsttokens/FactLst.java
+++ b/code/src/java/plugin/lsttokens/FactLst.java
@@ -54,26 +54,26 @@ public class FactLst extends AbstractTokenWithSeparator<CDOMObject> implements
 		if (pipeLoc == -1)
 		{
 			return new ParseResult.Fail(getTokenName() + " expecting '|', format is: "
-				+ "Fact identification|Fact value ... was: " + value, context);
+				+ "Fact identification|Fact value ... was: " + value);
 		}
 		else if (pipeLoc != value.lastIndexOf(Constants.PIPE))
 		{
 			return new ParseResult.Fail(getTokenName()
 				+ " expecting only one '|', format is: "
-				+ "Fact identification|Fact value ... was: " + value, context);
+				+ "Fact identification|Fact value ... was: " + value);
 		}
 		String factID = value.substring(0, pipeLoc);
 		if (factID.isEmpty())
 		{
 			return new ParseResult.Fail(getTokenName()
 				+ " expecting non-empty identification, "
-				+ "format is: Fact identification|Fact value ... was: " + value, context);
+				+ "format is: Fact identification|Fact value ... was: " + value);
 		}
 		String factStr = value.substring(pipeLoc + 1);
 		if (factStr.isEmpty())
 		{
 			return new ParseResult.Fail(getTokenName() + " expecting non-empty value, "
-				+ "format is: Fact identification|Fact value ... was: " + value, context);
+				+ "format is: Fact identification|Fact value ... was: " + value);
 		}
 		return context.processSubToken(cdo, getTokenName(), factID, factStr);
 	}

--- a/code/src/java/plugin/lsttokens/FactSetLst.java
+++ b/code/src/java/plugin/lsttokens/FactSetLst.java
@@ -54,20 +54,20 @@ public class FactSetLst extends AbstractTokenWithSeparator<CDOMObject> implement
 		if (pipeLoc == -1)
 		{
 			return new ParseResult.Fail(getTokenName() + " expecting '|', format is: "
-				+ "Fact identification|Fact value ... was: " + value, context);
+				+ "Fact identification|Fact value ... was: " + value);
 		}
 		String factID = value.substring(0, pipeLoc);
 		if (factID.isEmpty())
 		{
 			return new ParseResult.Fail(getTokenName()
 				+ " expecting non-empty identification, "
-				+ "format is: Fact identification|Fact value ... was: " + value, context);
+				+ "format is: Fact identification|Fact value ... was: " + value);
 		}
 		String factStr = value.substring(pipeLoc + 1);
 		if (factStr.isEmpty())
 		{
 			return new ParseResult.Fail(getTokenName() + " expecting non-empty value, "
-				+ "format is: Fact identification|Fact value ... was: " + value, context);
+				+ "format is: Fact identification|Fact value ... was: " + value);
 		}
 		return context.processSubToken(cdo, getTokenName(), factID, factStr);
 	}

--- a/code/src/java/plugin/lsttokens/FollowersLst.java
+++ b/code/src/java/plugin/lsttokens/FollowersLst.java
@@ -82,12 +82,12 @@ public class FollowersLst implements CDOMPrimaryToken<CDOMObject>
 		{
 			return new ParseResult.Fail("Cannot use " + getTokenName()
 				+ " on an Ungranted object type: "
-				+ obj.getClass().getSimpleName(), context);
+				+ obj.getClass().getSimpleName());
 		}
 		if ((value == null) || value.isEmpty())
 		{
 			return new ParseResult.Fail("Argument in " + getTokenName()
-					+ " cannot be empty", context);
+					+ " cannot be empty");
 		}
 		ParsingSeparator sep = new ParsingSeparator(value, '|');
 		sep.addGroupingPair('[', ']');
@@ -97,24 +97,24 @@ public class FollowersLst implements CDOMPrimaryToken<CDOMObject>
 		if (followerType.isEmpty())
 		{
 			return new ParseResult.Fail("Follower Type in " + getTokenName()
-					+ " cannot be empty", context);
+					+ " cannot be empty");
 		}
 		if (!sep.hasNext())
 		{
 			return new ParseResult.Fail(getTokenName() + " has no PIPE character: "
-				+ "Must be of the form <follower type>|<formula>", context);
+				+ "Must be of the form <follower type>|<formula>");
 		}
 		String followerNumber = sep.next();
 		if (sep.hasNext())
 		{
 			return new ParseResult.Fail(getTokenName()
 					+ " has too many PIPE characters: "
-					+ "Must be of the form <follower type>|<formula", context);
+					+ "Must be of the form <follower type>|<formula");
 		}
 		if (followerNumber.isEmpty())
 		{
 			return new ParseResult.Fail("Follower Count in " + getTokenName()
-					+ " cannot be empty", context);
+					+ " cannot be empty");
 		}
 		CDOMSingleRef<CompanionList> cl = context.getReferenceContext().getCDOMReference(
 				CompanionList.class, followerType);
@@ -122,7 +122,7 @@ public class FollowersLst implements CDOMPrimaryToken<CDOMObject>
 		if (!num.isValid())
 		{
 			return new ParseResult.Fail("Number of Followers in "
-					+ getTokenName() + " was not valid: " + num.toString(), context);
+					+ getTokenName() + " was not valid: " + num.toString());
 		}
 		context.getObjectContext().addToList(obj, ListKey.FOLLOWERS,
 				new FollowerLimit(cl, num));

--- a/code/src/java/plugin/lsttokens/GrantLst.java
+++ b/code/src/java/plugin/lsttokens/GrantLst.java
@@ -69,7 +69,7 @@ public class GrantLst extends AbstractTokenWithSeparator<CDOMObject> implements
 		{
 			return new ParseResult.Fail("Cannot use " + getTokenName()
 				+ " on an Ungranted object type: "
-				+ obj.getClass().getSimpleName(), context);
+				+ obj.getClass().getSimpleName());
 		}
 		StringTokenizer tok = new StringTokenizer(value, Constants.PIPE);
 		String scope = tok.nextToken();
@@ -77,7 +77,7 @@ public class GrantLst extends AbstractTokenWithSeparator<CDOMObject> implements
 		{
 			return new ParseResult.Fail(getTokenName()
 				+ " must have identifier(s), "
-				+ "Format is: DYNAMICSCOPE|DynamicName: " + value, context);
+				+ "Format is: DYNAMICSCOPE|DynamicName: " + value);
 		}
 
 		ReferenceManufacturer<Dynamic> rm =
@@ -87,17 +87,13 @@ public class GrantLst extends AbstractTokenWithSeparator<CDOMObject> implements
 		{
 			return new ParseResult.Fail(
 				"Could not get Reference Manufacturer for Dynamic Scope: "
-					+ scope, context);
+					+ scope);
 		}
 
 		while (tok.hasMoreTokens())
 		{
 			String token = tok.nextToken();
 			CDOMReference<Dynamic> dynamic = rm.getReference(token);
-			if (dynamic == null)
-			{
-				return ParseResult.INTERNAL_ERROR;
-			}
 			context.getObjectContext().addToList(obj, ListKey.GRANTED, dynamic);
 		}
 

--- a/code/src/java/plugin/lsttokens/InfoLst.java
+++ b/code/src/java/plugin/lsttokens/InfoLst.java
@@ -63,7 +63,7 @@ public class InfoLst extends AbstractNonEmptyToken<CDOMObject> implements
 		{
 			return new ParseResult.Fail(getTokenName()
 				+ " expecting '|', format is: InfoName|Info value was: "
-				+ value, context);
+				+ value);
 		}
 		String key = value.substring(0, pipeLoc);
 		//key length 0 caught by charAt(0) test above
@@ -72,13 +72,13 @@ public class InfoLst extends AbstractNonEmptyToken<CDOMObject> implements
 		{
 			return new ParseResult.Fail(getTokenName()
 				+ " expecting non-empty value, "
-				+ "format is: InfoName|Info value was: " + value, context);
+				+ "format is: InfoName|Info value was: " + value);
 		}
 		if (val.startsWith(Constants.PIPE))
 		{
 			return new ParseResult.Fail(getTokenName()
 				+ " expecting non-empty value, "
-				+ "format is: InfoName|Info value was: " + value, context);
+				+ "format is: InfoName|Info value was: " + value);
 		}
 		try
 		{
@@ -90,7 +90,7 @@ public class InfoLst extends AbstractNonEmptyToken<CDOMObject> implements
 		{
 			return new ParseResult.Fail(getTokenName()
 				+ " expected a valid MessageFormat, but received error: "
-				+ e.getMessage() + " when parsing: " + value, context);
+				+ e.getMessage() + " when parsing: " + value);
 		}
 		return ParseResult.SUCCESS;
 	}

--- a/code/src/java/plugin/lsttokens/InfoVarsLst.java
+++ b/code/src/java/plugin/lsttokens/InfoVarsLst.java
@@ -57,7 +57,7 @@ public class InfoVarsLst extends AbstractTokenWithSeparator<CDOMObject>
 		{
 			return new ParseResult.Fail(getTokenName()
 				+ " expecting '|', format is: InfoName|Info value was: "
-				+ value, context);
+				+ value);
 		}
 		String key = value.substring(0, pipeLoc);
 		//key length 0 caught by charAt(0) test above
@@ -72,7 +72,7 @@ public class InfoVarsLst extends AbstractTokenWithSeparator<CDOMObject>
 					+ " found an error. " + name
 					+ " is not a legal variable name in scope "
 					+ scope.getName() + " in " + cdo.getClass().getSimpleName()
-					+ ' ' + cdo.getKeyName(), context);
+					+ ' ' + cdo.getKeyName());
 			}
 		}
 		CaseInsensitiveString cis = new CaseInsensitiveString(key);

--- a/code/src/java/plugin/lsttokens/KitLst.java
+++ b/code/src/java/plugin/lsttokens/KitLst.java
@@ -73,36 +73,36 @@ public class KitLst extends AbstractTokenWithSeparator<CDOMObject> implements
 		{
 			return new ParseResult.Fail("Cannot use " + getTokenName()
 				+ " on an Ungranted object type: "
-				+ obj.getClass().getSimpleName(), context);
+				+ obj.getClass().getSimpleName());
 		}
 		if (obj instanceof NonInteractive)
 		{
 			return new ParseResult.Fail("Cannot use " + getTokenName()
 				+ " on an Non-Interactive object type: "
-				+ obj.getClass().getSimpleName(), context);
+				+ obj.getClass().getSimpleName());
 		}
 		StringTokenizer tok = new StringTokenizer(value, Constants.PIPE);
 		Formula count = FormulaFactory.getFormulaFor(tok.nextToken());
 		if (!count.isValid())
 		{
 			return new ParseResult.Fail("Count in " + getTokenName()
-					+ " was not valid: " + count.toString(), context);
+					+ " was not valid: " + count.toString());
 		}
 		if (!count.isStatic())
 		{
 			return new ParseResult.Fail("Count in "
-					+ getTokenName() + " must be a number", context);
+					+ getTokenName() + " must be a number");
 		}
 		if (count.resolveStatic().intValue() <= 0)
 		{
 			return new ParseResult.Fail("Count in "
-					+ getTokenName() + " must be > 0", context);
+					+ getTokenName() + " must be > 0");
 		}
 		if (!tok.hasMoreTokens())
 		{
 			return new ParseResult.Fail(getTokenName()
 					+ " must have a | separating "
-					+ "count from the list of possible values: " + value, context);
+					+ "count from the list of possible values: " + value);
 		}
 		List<CDOMReference<Kit>> refs = new ArrayList<>();
 
@@ -126,7 +126,7 @@ public class KitLst extends AbstractTokenWithSeparator<CDOMObject> implements
 		{
 			return new ParseResult.Fail("Non-sensical "
 					+ getTokenName()
-					+ ": Contains ANY and a specific reference: " + value, context);
+					+ ": Contains ANY and a specific reference: " + value);
 		}
 		ChoiceSet<Kit> cs = new ChoiceSet<>(getTokenName(),
 				new QualifiedDecorator<>(rcs));

--- a/code/src/java/plugin/lsttokens/ModifyLst.java
+++ b/code/src/java/plugin/lsttokens/ModifyLst.java
@@ -69,7 +69,7 @@ public class ModifyLst extends AbstractTokenWithSeparator<CDOMObject>
 		{
 			return new ParseResult.Fail(getTokenName()
 				+ " may not be used in Campaign Files.  "
-				+ "Please use the Global Modifier file", context);
+				+ "Please use the Global Modifier file");
 		}
 		ParsingSeparator sep = new ParsingSeparator(value, '|');
 		sep.addGroupingPair('[', ']');
@@ -77,8 +77,7 @@ public class ModifyLst extends AbstractTokenWithSeparator<CDOMObject>
 
 		if (!sep.hasNext())
 		{
-			return new ParseResult.Fail(getTokenName() + " may not be empty",
-				context);
+			return new ParseResult.Fail(getTokenName() + " may not be empty");
 		}
 
 		LegalScope scope = context.getActiveScope();
@@ -88,19 +87,18 @@ public class ModifyLst extends AbstractTokenWithSeparator<CDOMObject>
 			return new ParseResult.Fail(
 				getTokenName() + " found invalid var name: " + varName
 					+ "(scope: " + scope.getName() + ") Modified on "
-					+ obj.getClass().getSimpleName() + ' ' + obj.getKeyName(),
-				context);
+					+ obj.getClass().getSimpleName() + ' ' + obj.getKeyName());
 		}
 		if (!sep.hasNext())
 		{
 			return new ParseResult.Fail(getTokenName()
-				+ " needed 2nd argument: " + value, context);
+				+ " needed 2nd argument: " + value);
 		}
 		String modIdentification = sep.next();
 		if (!sep.hasNext())
 		{
 			return new ParseResult.Fail(getTokenName()
-				+ " needed third argument: " + value, context);
+				+ " needed third argument: " + value);
 		}
 		String modInstructions = sep.next();
 		FormulaModifier<?> modifier;
@@ -115,7 +113,7 @@ public class ModifyLst extends AbstractTokenWithSeparator<CDOMObject>
 		{
 			return new ParseResult.Fail(getTokenName() + " Modifier "
 				+ modIdentification + " had value " + modInstructions
-				+ " but it was not valid: " + iae.getMessage(), context);
+				+ " but it was not valid: " + iae.getMessage());
 		}
 		Set<Object> associationsVisited =
 				Collections.newSetFromMap(new CaseInsensitiveMap<>());
@@ -127,7 +125,7 @@ public class ModifyLst extends AbstractTokenWithSeparator<CDOMObject>
 			{
 				return new ParseResult.Fail(getTokenName()
 					+ " was expecting = in an ASSOCIATION but got " + assoc
-					+ " in " + value, context);
+					+ " in " + value);
 			}
 			String assocName = assoc.substring(0, equalLoc);
 			if (associationsVisited.contains(assocName))
@@ -135,8 +133,7 @@ public class ModifyLst extends AbstractTokenWithSeparator<CDOMObject>
 				return new ParseResult.Fail(
 					getTokenName()
 						+ " does not allow multiple asspociations with the same name.  "
-						+ "Found multiple: " + assocName + " in " + value,
-					context);
+						+ "Found multiple: " + assocName + " in " + value);
 			}
 			associationsVisited.add(assocName);
 			modifier.addAssociation(assoc);

--- a/code/src/java/plugin/lsttokens/ModifyOtherLst.java
+++ b/code/src/java/plugin/lsttokens/ModifyOtherLst.java
@@ -70,7 +70,7 @@ public class ModifyOtherLst extends AbstractTokenWithSeparator<CDOMObject>
 		{
 			return new ParseResult.Fail(getTokenName()
 				+ " may not be used in Campaign Files.  "
-				+ "Please use the Global Modifier file", context);
+				+ "Please use the Global Modifier file");
 		}
 		ParsingSeparator sep = new ParsingSeparator(value, '|');
 		sep.addGroupingPair('[', ']');
@@ -87,12 +87,12 @@ public class ModifyOtherLst extends AbstractTokenWithSeparator<CDOMObject>
 		{
 			return new ParseResult.Fail(getTokenName()
 				+ " found illegal variable scope: " + scopeName
-				+ " as first argument: " + value, context);
+				+ " as first argument: " + value);
 		}
 		if (!sep.hasNext())
 		{
 			return new ParseResult.Fail(getTokenName()
-				+ " needed 2nd argument: " + value, context);
+				+ " needed 2nd argument: " + value);
 		}
 		LoadContext subContext = context.dropIntoContext(lvs.getName());
 		return continueParsing(subContext, obj, value, sep);
@@ -182,7 +182,7 @@ public class ModifyOtherLst extends AbstractTokenWithSeparator<CDOMObject>
 		if (!sep.hasNext())
 		{
 			return new ParseResult.Fail(getTokenName()
-				+ " needed 3rd argument: " + value, context);
+				+ " needed 3rd argument: " + value);
 		}
 		String varName = sep.next();
 		if (!context.getVariableContext().isLegalVariableID(scope, varName))
@@ -190,19 +190,18 @@ public class ModifyOtherLst extends AbstractTokenWithSeparator<CDOMObject>
 			return new ParseResult.Fail(
 				getTokenName() + " found invalid var name: " + varName
 					+ "(scope: " + scope.getName() + ") Modified on "
-					+ obj.getClass().getSimpleName() + ' ' + obj.getKeyName(),
-				context);
+					+ obj.getClass().getSimpleName() + ' ' + obj.getKeyName());
 		}
 		if (!sep.hasNext())
 		{
 			return new ParseResult.Fail(getTokenName()
-				+ " needed 4th argument: " + value, context);
+				+ " needed 4th argument: " + value);
 		}
 		String modIdentification = sep.next();
 		if (!sep.hasNext())
 		{
 			return new ParseResult.Fail(getTokenName()
-				+ " needed 5th argument: " + value, context);
+				+ " needed 5th argument: " + value);
 		}
 		String modInstructions = sep.next();
 		FormulaModifier<?> modifier;
@@ -217,7 +216,7 @@ public class ModifyOtherLst extends AbstractTokenWithSeparator<CDOMObject>
 		{
 			return new ParseResult.Fail(getTokenName() + " Modifier "
 				+ modIdentification + " had value " + modInstructions
-				+ " but it was not valid: " + iae.getMessage(), context);
+				+ " but it was not valid: " + iae.getMessage());
 		}
 		Set<Object> associationsVisited =
 				Collections.newSetFromMap(new CaseInsensitiveMap<>());
@@ -229,7 +228,7 @@ public class ModifyOtherLst extends AbstractTokenWithSeparator<CDOMObject>
 			{
 				return new ParseResult.Fail(getTokenName()
 					+ " was expecting = in an ASSOCIATION but got " + assoc
-					+ " in " + value, context);
+					+ " in " + value);
 			}
 			String assocName = assoc.substring(0, equalLoc);
 			if (associationsVisited.contains(assocName))
@@ -237,8 +236,7 @@ public class ModifyOtherLst extends AbstractTokenWithSeparator<CDOMObject>
 				return new ParseResult.Fail(
 					getTokenName()
 						+ " does not allow multiple asspociations with the same name.  "
-						+ "Found multiple: " + assocName + " in " + value,
-					context);
+						+ "Found multiple: " + assocName + " in " + value);
 			}
 			associationsVisited.add(assocName);
 			modifier.addAssociation(assoc);

--- a/code/src/java/plugin/lsttokens/MoveLst.java
+++ b/code/src/java/plugin/lsttokens/MoveLst.java
@@ -78,7 +78,7 @@ public class MoveLst extends AbstractTokenWithSeparator<CDOMObject> implements
 		{
 			return new ParseResult.Fail("Cannot use " + getTokenName()
 				+ " on an Ungranted object type: "
-				+ obj.getClass().getSimpleName(), context);
+				+ obj.getClass().getSimpleName());
 		}
 		StringTokenizer moves = new StringTokenizer(value, Constants.COMMA);
 		Movement cm;
@@ -114,7 +114,7 @@ public class MoveLst extends AbstractTokenWithSeparator<CDOMObject> implements
 			{
 				return new ParseResult.Fail(
 						"Badly formed MOVE token "
-								+ "(extra value at end of list): " + value, context);
+								+ "(extra value at end of list): " + value);
 			}
 		}
 		cm.setMoveRatesFlag(0);

--- a/code/src/java/plugin/lsttokens/MovecloneLst.java
+++ b/code/src/java/plugin/lsttokens/MovecloneLst.java
@@ -57,7 +57,7 @@ public class MovecloneLst extends AbstractTokenWithSeparator<CDOMObject>
 		{
 			return new ParseResult.Fail("Cannot use " + getTokenName()
 				+ " on an Ungranted object type: "
-				+ obj.getClass().getSimpleName(), context);
+				+ obj.getClass().getSimpleName());
 		}
 		StringTokenizer moves = new StringTokenizer(value, Constants.COMMA);
 
@@ -66,7 +66,7 @@ public class MovecloneLst extends AbstractTokenWithSeparator<CDOMObject>
 			return new ParseResult.Fail(
 					"Invalid Version of MOVECLONE detected: " + value
 							+ "\n  MOVECLONE has 3 arguments: "
-							+ "SourceMove,DestinationMove,Modifier", context);
+							+ "SourceMove,DestinationMove,Modifier");
 		}
 
 		String oldType = moves.nextToken();
@@ -83,14 +83,14 @@ public class MovecloneLst extends AbstractTokenWithSeparator<CDOMObject>
 					return new ParseResult.Fail(getTokenName()
 							+ " was expecting a Positive Integer "
 							+ "for dividing Movement, was : "
-							+ formulaString.substring(1), context);
+							+ formulaString.substring(1));
 				}
 			}
 			catch (NumberFormatException e)
 			{
 				return new ParseResult.Fail(getTokenName()
 						+ " was expecting an integer to follow /, was : "
-						+ formulaString, context);
+						+ formulaString);
 			}
 		}
 		else if (formulaString.startsWith("*"))
@@ -103,14 +103,14 @@ public class MovecloneLst extends AbstractTokenWithSeparator<CDOMObject>
 					return new ParseResult.Fail(getTokenName()
 							+ " was expecting a "
 							+ "Float >= 0 for multiplying Movement, was : "
-							+ formulaString.substring(1), context);
+							+ formulaString.substring(1));
 				}
 			}
 			catch (NumberFormatException e)
 			{
 				return new ParseResult.Fail(getTokenName()
 						+ " was expecting an integer to follow *, was : "
-						+ formulaString, context);
+						+ formulaString);
 			}
 		}
 		else if (formulaString.startsWith("+"))
@@ -123,14 +123,14 @@ public class MovecloneLst extends AbstractTokenWithSeparator<CDOMObject>
 					return new ParseResult.Fail(getTokenName()
 							+ " was expecting a Non-Negative "
 							+ "Integer for adding Movement, was : "
-							+ formulaString.substring(1), context);
+							+ formulaString.substring(1));
 				}
 			}
 			catch (NumberFormatException e)
 			{
 				return new ParseResult.Fail(getTokenName()
 						+ " was expecting an integer to follow +, was : "
-						+ formulaString, context);
+						+ formulaString);
 			}
 		}
 		else
@@ -143,7 +143,7 @@ public class MovecloneLst extends AbstractTokenWithSeparator<CDOMObject>
 			{
 				return new ParseResult.Fail(getTokenName()
 						+ " was expecting a Formula as the final value, was : "
-						+ formulaString, context);
+						+ formulaString);
 			}
 		}
 		Movement cm = new Movement(2);

--- a/code/src/java/plugin/lsttokens/NaturalattacksLst.java
+++ b/code/src/java/plugin/lsttokens/NaturalattacksLst.java
@@ -94,7 +94,7 @@ public class NaturalattacksLst extends AbstractTokenWithSeparator<CDOMObject>
 		{
 			return new ParseResult.Fail("Cannot use " + getTokenName()
 				+ " on an Ungranted object type: "
-				+ obj.getClass().getSimpleName(), context);
+				+ obj.getClass().getSimpleName());
 		}
 		// Currently, this isn't going to work with monk attacks
 		// - their unarmed stuff won't be affected.
@@ -128,7 +128,7 @@ public class NaturalattacksLst extends AbstractTokenWithSeparator<CDOMObject>
 			if (numTokens < MIN_TOKEN_COUNT)
 			{
 				return new ParseResult.Fail("Invalid Build of " + "Natural Weapon in "
-						+ getTokenName() + ": " + wpn, context);
+						+ getTokenName() + ": " + wpn);
 			}
 
 			String attackName = commaTok.nextToken();
@@ -136,7 +136,7 @@ public class NaturalattacksLst extends AbstractTokenWithSeparator<CDOMObject>
 			if (attackName.equalsIgnoreCase(Constants.LST_NONE))
 			{
 				return new ParseResult.Fail("Attempt to Build 'None' as a "
-						+ "Natural Weapon in " + getTokenName() + ": " + wpn, context);
+						+ "Natural Weapon in " + getTokenName() + ": " + wpn);
 			}
 
 			attackName = attackName.intern();
@@ -192,14 +192,14 @@ public class NaturalattacksLst extends AbstractTokenWithSeparator<CDOMObject>
 				{
 					return new ParseResult.Fail(getTokenName()
 							+ " was given invalid number of attacks: "
-							+ bonusAttacks, context);
+							+ bonusAttacks);
 				}
 				naturalWeapon.addToListFor(ListKey.BONUS, aBonus);
 			}
 			catch (NumberFormatException exc)
 			{
 				return new ParseResult.Fail("Non-numeric value for number of attacks in "
-						+ getTokenName() + ": '" + numAttacks + '\'', context);
+						+ getTokenName() + ": '" + numAttacks + '\'');
 			}
 
 			equipHead.put(StringKey.DAMAGE, commaTok.nextToken());
@@ -225,7 +225,7 @@ public class NaturalattacksLst extends AbstractTokenWithSeparator<CDOMObject>
 					catch (NumberFormatException exc)
 					{
 						return new ParseResult.Fail("Non-numeric value for hands required: '"
-								+ handsOrSpropString + '\'', context);
+								+ handsOrSpropString + '\'');
 					}
 				}
 			}

--- a/code/src/java/plugin/lsttokens/QualifyToken.java
+++ b/code/src/java/plugin/lsttokens/QualifyToken.java
@@ -81,12 +81,12 @@ public class QualifyToken extends AbstractTokenWithSeparator<CDOMObject>
 		{
 			return new ParseResult.Fail("Cannot use " + getTokenName()
 				+ " on an Ungranted object type: "
-				+ obj.getClass().getSimpleName(), context);
+				+ obj.getClass().getSimpleName());
 		}
 		if (!getLegalTypes().contains(obj.getClass()))
 		{
 			return new ParseResult.Fail("Cannot use QUALIFY on a "
-					+ obj.getClass(), context);
+					+ obj.getClass());
 		}
 		return super.parseNonEmptyToken(context, obj, value);
 	}
@@ -105,7 +105,7 @@ public class QualifyToken extends AbstractTokenWithSeparator<CDOMObject>
 		{
 			return new ParseResult.Fail(getTokenName()
 					+ " requires at least two arguments, QualifyType and Key: "
-					+ value, context);
+					+ value);
 		}
 		StringTokenizer st = new StringTokenizer(value, Constants.PIPE);
 		String firstToken = st.nextToken();
@@ -114,7 +114,7 @@ public class QualifyToken extends AbstractTokenWithSeparator<CDOMObject>
 		if (rm == null)
 		{
 			return new ParseResult.Fail(getTokenName()
-					+ " unable to generate manufacturer for type: " + value, context);
+					+ " unable to generate manufacturer for type: " + value);
 		}
 
 		while (st.hasMoreTokens())

--- a/code/src/java/plugin/lsttokens/RegionLst.java
+++ b/code/src/java/plugin/lsttokens/RegionLst.java
@@ -48,13 +48,13 @@ public class RegionLst extends AbstractTokenWithSeparator<CDOMObject> implements
 		{
 			return new ParseResult.Fail("Cannot use " + getTokenName()
 				+ " on an Ungranted object type: "
-				+ obj.getClass().getSimpleName(), context);
+				+ obj.getClass().getSimpleName());
 		}
 		if (obj instanceof NonInteractive)
 		{
 			return new ParseResult.Fail("Cannot use " + getTokenName()
 				+ " on an Non-Interactive object type: "
-				+ obj.getClass().getSimpleName(), context);
+				+ obj.getClass().getSimpleName());
 		}
 		StringTokenizer tok = new StringTokenizer(value, Constants.PIPE);
 		String item = tok.nextToken();
@@ -62,20 +62,20 @@ public class RegionLst extends AbstractTokenWithSeparator<CDOMObject> implements
 		if (!count.isValid())
 		{
 			return new ParseResult.Fail("Count in " + getTokenName()
-					+ " was not valid: " + count.toString(), context);
+					+ " was not valid: " + count.toString());
 		}
 		if (count.isStatic())
 		{
 			if (!tok.hasMoreTokens())
 			{
 				return new ParseResult.Fail(getTokenName()
-						+ " cannot have only a count: " + value, context);
+						+ " cannot have only a count: " + value);
 			}
 			item = tok.nextToken();
 			if (count.resolveStatic().intValue() <= 0)
 			{
 				return new ParseResult.Fail("Count in "
-						+ getTokenName() + " must be > 0: " + value, context);
+						+ getTokenName() + " must be > 0: " + value);
 			}
 		}
 		else

--- a/code/src/java/plugin/lsttokens/SabLst.java
+++ b/code/src/java/plugin/lsttokens/SabLst.java
@@ -68,7 +68,7 @@ public class SabLst extends AbstractTokenWithSeparator<CDOMObject> implements
 		{
 			return new ParseResult.Fail("Cannot use " + getTokenName()
 				+ " on an Ungranted object type: "
-				+ obj.getClass().getSimpleName(), context);
+				+ obj.getClass().getSimpleName());
 		}
 		StringTokenizer tok = new StringTokenizer(aString, Constants.PIPE);
 
@@ -76,7 +76,7 @@ public class SabLst extends AbstractTokenWithSeparator<CDOMObject> implements
 		if (looksLikeAPrerequisite(firstToken))
 		{
 			return new ParseResult.Fail("Cannot have only PRExxx subtoken in "
-					+ getTokenName(), context);
+					+ getTokenName());
 		}
 
 		boolean foundClear = false;
@@ -96,13 +96,13 @@ public class SabLst extends AbstractTokenWithSeparator<CDOMObject> implements
 		{
 			return new ParseResult.Fail(
 					"Cannot use PREREQs when using .CLEAR in "
-							+ getTokenName(), context);
+							+ getTokenName());
 		}
 
 		if (Constants.LST_DOT_CLEAR.equals(firstToken))
 		{
 			return new ParseResult.Fail("SA tag confused by redundant '.CLEAR'"
-					+ aString, context);
+					+ aString);
 		}
 
 		SpecialAbility sa = new SpecialAbility(firstToken.intern());
@@ -123,7 +123,7 @@ public class SabLst extends AbstractTokenWithSeparator<CDOMObject> implements
 			if (Constants.LST_DOT_CLEAR.equals(token))
 			{
 				return new ParseResult.Fail("SA tag confused by '.CLEAR' as a "
-						+ "middle token: " + aString, context);
+						+ "middle token: " + aString);
 			}
 			else if (looksLikeAPrerequisite(token))
 			{
@@ -152,7 +152,7 @@ public class SabLst extends AbstractTokenWithSeparator<CDOMObject> implements
 		{
 			return new ParseResult.Fail(
 					"Cannot use PREREQs when using .CLEAR and a Special Ability in "
-							+ getTokenName(), context);
+							+ getTokenName());
 		}
 
 		while (true)
@@ -161,7 +161,7 @@ public class SabLst extends AbstractTokenWithSeparator<CDOMObject> implements
 			if (prereq == null)
 			{
 				return new ParseResult.Fail("   (Did you put Abilities after the "
-						+ "PRExxx tags in " + getTokenName() + ":?)", context);
+						+ "PRExxx tags in " + getTokenName() + ":?)");
 			}
 			sa.addPrerequisite(prereq);
 			if (!tok.hasMoreTokens())

--- a/code/src/java/plugin/lsttokens/SelectLst.java
+++ b/code/src/java/plugin/lsttokens/SelectLst.java
@@ -46,13 +46,13 @@ public class SelectLst implements CDOMPrimaryToken<CDOMObject>
 		{
 			return new ParseResult.Fail("Cannot use " + getTokenName()
 				+ " on an Ungranted object type: "
-				+ cdo.getClass().getSimpleName(), context);
+				+ cdo.getClass().getSimpleName());
 		}
 		Formula formula = FormulaFactory.getFormulaFor(value);
 		if (!formula.isValid())
 		{
 			return new ParseResult.Fail("Formula in " + getTokenName()
-					+ " was not valid: " + formula.toString(), context);
+					+ " was not valid: " + formula.toString());
 		}
 		context.getObjectContext().put(cdo, FormulaKey.SELECT, formula);
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/ServesAsToken.java
+++ b/code/src/java/plugin/lsttokens/ServesAsToken.java
@@ -104,19 +104,19 @@ public class ServesAsToken extends AbstractTokenWithSeparator<CDOMObject>
 		if (rm == null)
 		{
 			return new ParseResult.Fail(getTokenName()
-					+ " unable to generate manufacturer for type: " + value, context);
+					+ " unable to generate manufacturer for type: " + value);
 		}
 		if (!st.hasMoreTokens())
 		{
 			return new ParseResult.Fail(getTokenName()
-					+ " must include at least one target object", context);
+					+ " must include at least one target object");
 		}
 		if (!rm.getReferenceClass().equals(obj.getClass()))
 		{
 			return new ParseResult.Fail(getTokenName()
 					+ " expecting a POBJECT Type valid for "
 					+ obj.getClass().getSimpleName() + ", found: "
-							+ firstToken, context);
+							+ firstToken);
 		}
 
 		String servekey = StringPClassUtil.getStringFor(obj.getClass());

--- a/code/src/java/plugin/lsttokens/SpellknownLst.java
+++ b/code/src/java/plugin/lsttokens/SpellknownLst.java
@@ -70,7 +70,7 @@ public class SpellknownLst extends AbstractSpellListToken implements
 		{
 			return new ParseResult.Fail("Cannot use " + getTokenName()
 				+ " on an Ungranted object type: "
-				+ obj.getClass().getSimpleName(), context);
+				+ obj.getClass().getSimpleName());
 		}
 		String workingValue = value;
 		List<Prerequisite> prereqs = new ArrayList<>();
@@ -80,7 +80,7 @@ public class SpellknownLst extends AbstractSpellListToken implements
 			if (lastPipeLoc == -1)
 			{
 				return new ParseResult.Fail("Invalid " + getTokenName()
-						+ " not enough tokens: " + value, context);
+						+ " not enough tokens: " + value);
 			}
 			String lastToken = workingValue.substring(lastPipeLoc + 1);
 			if (looksLikeAPrerequisite(lastToken))
@@ -91,7 +91,7 @@ public class SpellknownLst extends AbstractSpellListToken implements
 				{
 					return new ParseResult.Fail("Invalid prerequisite "
 						+ lastToken + " in " + getTokenName() + " tag: "
-						+ value, context);
+						+ value);
 				}
 				prereqs.add(prerequisite);
 			}
@@ -106,7 +106,7 @@ public class SpellknownLst extends AbstractSpellListToken implements
 		if (tok.countTokens() < 3)
 		{
 			return new ParseResult.Fail("Insufficient values in SPELLKNOWN tag: "
-					+ value, context);
+					+ value);
 		}
 
 		String tagType = tok.nextToken(); // CLASS only
@@ -123,13 +123,13 @@ public class SpellknownLst extends AbstractSpellListToken implements
 				if (!pr.passed())
 				{
 					return new ParseResult.Fail(getTokenName() + " failed due to " + pr
-						+ ".  Entire token was: " + value, context);
+						+ ".  Entire token was: " + value);
 				}
 			}
 			else
 			{
 				return new ParseResult.Fail("First token of " + getTokenName()
-						+ " must be CLASS: " + value, context);
+						+ " must be CLASS: " + value);
 			}
 		}
 
@@ -156,7 +156,7 @@ public class SpellknownLst extends AbstractSpellListToken implements
 		if (equalLoc == -1)
 		{
 			return new ParseResult.Fail(
-				"Expected an = in SPELLKNOWN " + "definition: " + tokString, context);
+				"Expected an = in SPELLKNOWN " + "definition: " + tokString);
 		}
 
 		String casterString = tokString.substring(0, equalLoc);
@@ -169,7 +169,7 @@ public class SpellknownLst extends AbstractSpellListToken implements
 		catch (NumberFormatException nfe)
 		{
 			return new ParseResult.Fail(
-				"Expected a number for SPELLKNOWN, found: " + spellLevel, context);
+				"Expected a number for SPELLKNOWN, found: " + spellLevel);
 		}
 
 		ParseResult pr = checkSeparatorsAndNonEmpty(',', casterString);

--- a/code/src/java/plugin/lsttokens/SpelllevelLst.java
+++ b/code/src/java/plugin/lsttokens/SpelllevelLst.java
@@ -61,7 +61,7 @@ public class SpelllevelLst extends AbstractSpellListToken implements
 		{
 			return new ParseResult.Fail("Cannot use " + getTokenName()
 				+ " on an Ungranted object type: "
-				+ obj.getClass().getSimpleName(), context);
+				+ obj.getClass().getSimpleName());
 		}
 		// SPELLLEVEL:CLASS|Name1,Name2=Level1|Spell1,Spell2,Spell3|Name3=Level2|Spell4,Spell5|PRExxx|PRExxx
 
@@ -73,7 +73,7 @@ public class SpelllevelLst extends AbstractSpellListToken implements
 			if (lastPipeLoc == -1)
 			{
 				return new ParseResult.Fail("Invalid " + getTokenName()
-						+ " not enough tokens: " + value, context);
+						+ " not enough tokens: " + value);
 			}
 			String lastToken = workingValue.substring(lastPipeLoc + 1);
 			if (looksLikeAPrerequisite(lastToken))
@@ -84,7 +84,7 @@ public class SpelllevelLst extends AbstractSpellListToken implements
 				{
 					return new ParseResult.Fail("Invalid prerequisite "
 							+ lastToken + " in " + getTokenName() + " tag: "
-							+ value, context);
+							+ value);
 				}
 				prereqs.add(prerequisite);
 			}
@@ -99,7 +99,7 @@ public class SpelllevelLst extends AbstractSpellListToken implements
 		if (tok.countTokens() < 3)
 		{
 			return new ParseResult.Fail("Insufficient values in SPELLLEVEL tag: "
-					+ value, context);
+					+ value);
 		}
 
 		String tagType = tok.nextToken(); // CLASS or DOMAIN
@@ -116,7 +116,7 @@ public class SpelllevelLst extends AbstractSpellListToken implements
 				if (!pr.passed())
 				{
 					return new ParseResult.Fail(getTokenName() + " failed due to " + pr
-						+ ".  Entire token was: " + value, context);
+						+ ".  Entire token was: " + value);
 				}
 			}
 			else if (tagType.equalsIgnoreCase("DOMAIN"))
@@ -125,14 +125,14 @@ public class SpelllevelLst extends AbstractSpellListToken implements
 					spellString, prereqs);
 				if (!pr.passed())
 				{
-					return new ParseResult.Fail("  " + getTokenName()
-							+ " error - entire token was " + value, context);
+					return new ParseResult.Fail(getTokenName() + " failed due to " + pr
+						+ ".  Entire token was: " + value);
 				}
 			}
 			else
 			{
 				return new ParseResult.Fail("First token of " + getTokenName()
-						+ " must be CLASS or DOMAIN:" + value, context);
+						+ " must be CLASS or DOMAIN:" + value);
 			}
 		}
 
@@ -147,7 +147,7 @@ public class SpelllevelLst extends AbstractSpellListToken implements
 		if (equalLoc == -1)
 		{
 			return new ParseResult.Fail(
-				"Expected an = in SPELLLEVEL " + "definition: " + tokString, context);
+				"Expected an = in SPELLLEVEL " + "definition: " + tokString);
 		}
 
 		String casterString = tokString.substring(0, equalLoc);
@@ -160,7 +160,7 @@ public class SpelllevelLst extends AbstractSpellListToken implements
 		catch (NumberFormatException nfe)
 		{
 			return new ParseResult.Fail(
-				"Expected a number for SPELLLEVEL, found: " + spellLevel, context);
+				"Expected a number for SPELLLEVEL, found: " + spellLevel);
 		}
 
 		ParseResult pr = checkSeparatorsAndNonEmpty(',', casterString);

--- a/code/src/java/plugin/lsttokens/SpellsLst.java
+++ b/code/src/java/plugin/lsttokens/SpellsLst.java
@@ -80,12 +80,12 @@ public class SpellsLst extends AbstractNonEmptyToken<CDOMObject> implements
 		{
 			return new ParseResult.Fail("Cannot use " + getTokenName()
 				+ " on an Ungranted object type: "
-				+ obj.getClass().getSimpleName(), context);
+				+ obj.getClass().getSimpleName());
 		}
 		if ((sourceLine == null) || sourceLine.isEmpty())
 		{
 			return new ParseResult.Fail("Argument in " + getTokenName()
-					+ " cannot be empty", context);
+					+ " cannot be empty");
 		}
 		if (sourceLine.equals(Constants.LST_DOT_CLEAR_ALL))
 		{
@@ -100,7 +100,7 @@ public class SpellsLst extends AbstractNonEmptyToken<CDOMObject> implements
 		if (spellBook.isEmpty())
 		{
 			return new ParseResult.Fail("SpellBook in " + getTokenName()
-					+ " cannot be empty", context);
+					+ " cannot be empty");
 		}
 		// Formula casterLevel = null;
 		String casterLevel = null;
@@ -110,7 +110,7 @@ public class SpellsLst extends AbstractNonEmptyToken<CDOMObject> implements
 		if (!sep.hasNext())
 		{
 			return new ParseResult.Fail(getTokenName()
-					+ ": minimally requires a Spell Name", context);
+					+ ": minimally requires a Spell Name");
 		}
 		String token = sep.next();
 
@@ -122,20 +122,20 @@ public class SpellsLst extends AbstractNonEmptyToken<CDOMObject> implements
 				{
 					return new ParseResult.Fail(
 							"Found two TIMES entries in " + getTokenName()
-									+ ": invalid: " + sourceLine, context);
+									+ ": invalid: " + sourceLine);
 				}
 				times = token.substring(6);
 				if (times.isEmpty())
 				{
 					return new ParseResult.Fail(
 							"Error in Times in " + getTokenName()
-									+ ": argument was empty", context);
+									+ ": argument was empty");
 				}
 				if (!sep.hasNext())
 				{
 					return new ParseResult.Fail(getTokenName()
 							+ ": minimally requires "
-							+ "a Spell Name (after TIMES=)", context);
+							+ "a Spell Name (after TIMES=)");
 				}
 				token = sep.next();
 			}
@@ -145,20 +145,20 @@ public class SpellsLst extends AbstractNonEmptyToken<CDOMObject> implements
 				{
 					return new ParseResult.Fail(
 							"Found two TIMEUNIT entries in " + getTokenName()
-									+ ": invalid: " + sourceLine, context);
+									+ ": invalid: " + sourceLine);
 				}
 				timeunit = token.substring(9);
 				if (timeunit.isEmpty())
 				{
 					return new ParseResult.Fail(
 							"Error in TimeUnit in " + getTokenName()
-									+ ": argument was empty", context);
+									+ ": argument was empty");
 				}
 				if (!sep.hasNext())
 				{
 					return new ParseResult.Fail(getTokenName()
 							+ ": minimally requires "
-							+ "a Spell Name (after TIMEUNIT=)", context);
+							+ "a Spell Name (after TIMEUNIT=)");
 				}
 				token = sep.next();
 			}
@@ -169,20 +169,20 @@ public class SpellsLst extends AbstractNonEmptyToken<CDOMObject> implements
 					return new ParseResult.Fail(
 							"Found two CASTERLEVEL entries in "
 									+ getTokenName() + ": invalid: "
-									+ sourceLine, context);
+									+ sourceLine);
 				}
 				casterLevel = token.substring(12);
 				if (casterLevel.isEmpty())
 				{
 					return new ParseResult.Fail(
 							"Error in Caster Level in " + getTokenName()
-									+ ": argument was empty", context);
+									+ ": argument was empty");
 				}
 				if (!sep.hasNext())
 				{
 					return new ParseResult.Fail(getTokenName()
 							+ ": minimally requires a "
-							+ "Spell Name (after CASTERLEVEL=)", context);
+							+ "Spell Name (after CASTERLEVEL=)");
 				}
 				token = sep.next();
 			}
@@ -199,22 +199,22 @@ public class SpellsLst extends AbstractNonEmptyToken<CDOMObject> implements
 		if (token.isEmpty())
 		{
 			return new ParseResult.Fail("Spell arguments may not be empty in "
-					+ getTokenName() + ": " + sourceLine, context);
+					+ getTokenName() + ": " + sourceLine);
 		}
 		if (token.charAt(0) == ',')
 		{
 			return new ParseResult.Fail(getTokenName()
-					+ " Spell arguments may not start with , : " + token, context);
+					+ " Spell arguments may not start with , : " + token);
 		}
 		if (token.charAt(token.length() - 1) == ',')
 		{
 			return new ParseResult.Fail(getTokenName()
-					+ " Spell arguments may not end with , : " + token, context);
+					+ " Spell arguments may not end with , : " + token);
 		}
 		if (token.indexOf(",,") != -1)
 		{
 			return new ParseResult.Fail(getTokenName()
-					+ " Spell arguments uses double separator ,, : " + token, context);
+					+ " Spell arguments uses double separator ,, : " + token);
 		}
 
 		/*
@@ -232,7 +232,7 @@ public class SpellsLst extends AbstractNonEmptyToken<CDOMObject> implements
 			if (token.isEmpty())
 			{
 				return new ParseResult.Fail("Spell arguments may not end with comma or pipe in "
-						+ getTokenName() + ": " + sourceLine, context);
+						+ getTokenName() + ": " + sourceLine);
 			}
 			int commaLoc = token.indexOf(',');
 			String name = commaLoc == -1 ? token : token.substring(0, commaLoc);
@@ -243,7 +243,7 @@ public class SpellsLst extends AbstractNonEmptyToken<CDOMObject> implements
 			if (!timesFormula.isValid())
 			{
 				return new ParseResult.Fail("Times in " + getTokenName()
-						+ " was not valid: " + timesFormula.toString(), context);
+						+ " was not valid: " + timesFormula.toString());
 			}
 			dkm.put(spell, AssociationKey.TIMES_PER_UNIT, timesFormula);
 			if (timeunit != null)
@@ -278,7 +278,7 @@ public class SpellsLst extends AbstractNonEmptyToken<CDOMObject> implements
 			{
 				return new ParseResult.Fail(
 						"   (Did you put spells after the "
-								+ "PRExxx tags in SPELLS:?)", context);
+								+ "PRExxx tags in SPELLS:?)");
 			}
 			prereqs.add(prereq);
 			if (!sep.hasNext())

--- a/code/src/java/plugin/lsttokens/SrLst.java
+++ b/code/src/java/plugin/lsttokens/SrLst.java
@@ -49,7 +49,7 @@ public class SrLst implements CDOMPrimaryToken<CDOMObject>
 		{
 			return new ParseResult.Fail("Cannot use " + getTokenName()
 				+ " on an Ungranted object type: "
-				+ obj.getClass().getSimpleName(), context);
+				+ obj.getClass().getSimpleName());
 		}
 		if (Constants.LST_DOT_CLEAR.equals(value))
 		{
@@ -61,7 +61,7 @@ public class SrLst implements CDOMPrimaryToken<CDOMObject>
 			if (!formula.isValid())
 			{
 				return new ParseResult.Fail("Formula in " + getTokenName()
-						+ " was not valid: " + formula.toString(), context);
+						+ " was not valid: " + formula.toString());
 			}
 			context.getObjectContext().put(obj, ObjectKey.SR,
 					new SpellResistance(formula));

--- a/code/src/java/plugin/lsttokens/TempBonusLst.java
+++ b/code/src/java/plugin/lsttokens/TempBonusLst.java
@@ -46,7 +46,7 @@ public class TempBonusLst extends AbstractNonEmptyToken<CDOMObject> implements
 		{
 			return new ParseResult.Fail("Cannot use " + getTokenName()
 				+ " on an Ungranted object type: "
-				+ obj.getClass().getSimpleName(), context);
+				+ obj.getClass().getSimpleName());
 		}
 		final String v =
 				value.replaceAll(Pattern.quote("<this>"), obj.getKeyName());
@@ -54,7 +54,7 @@ public class TempBonusLst extends AbstractNonEmptyToken<CDOMObject> implements
 		if (pipeLoc == -1)
 		{
 			return new ParseResult.Fail(
-				getTokenName() + " requires a SubToken", context);
+				getTokenName() + " requires a SubToken");
 		}
 		return context.processSubToken(obj, getTokenName(),
 			v.substring(0, pipeLoc), v.substring(pipeLoc + 1));

--- a/code/src/java/plugin/lsttokens/TempValueLst.java
+++ b/code/src/java/plugin/lsttokens/TempValueLst.java
@@ -55,8 +55,7 @@ public class TempValueLst extends AbstractTokenWithSeparator<CDOMObject>
 		if (pipeLoc == -1)
 		{
 			return new ParseResult.Fail(getTokenName()
-				+ " must have three | delimited arguments : " + value,
-				context);
+				+ " must have three | delimited arguments : " + value);
 		}
 		StringTokenizer tok = new StringTokenizer(value, Constants.PIPE);
 		if (tok.countTokens() != 3)
@@ -64,22 +63,22 @@ public class TempValueLst extends AbstractTokenWithSeparator<CDOMObject>
 			return new ParseResult.Fail(
 				getTokenName()
 					+ " requires three arguments, MIN=, MAX= and TITLE= : "
-					+ value, context);
+					+ value);
 		}
 		if (!tok.nextToken().startsWith("MIN="))
 		{
 			return new ParseResult.Fail(getTokenName()
-				+ " first argument was not MIN=", context);
+				+ " first argument was not MIN=");
 		}
 		if (!tok.nextToken().startsWith("MAX="))
 		{
 			return new ParseResult.Fail(getTokenName()
-				+ " second argument was not MAX=", context);
+				+ " second argument was not MAX=");
 		}
 		if (!tok.nextToken().startsWith("TITLE="))
 		{
 			return new ParseResult.Fail(getTokenName()
-				+ " third argument was not TITLE=", context);
+				+ " third argument was not TITLE=");
 		}
 		StringBuilder sb = new StringBuilder(value.length() + 20);
 		sb.append(value);

--- a/code/src/java/plugin/lsttokens/TempdescLst.java
+++ b/code/src/java/plugin/lsttokens/TempdescLst.java
@@ -51,7 +51,7 @@ public class TempdescLst extends AbstractNonEmptyToken<CDOMObject> implements
 		{
 			return new ParseResult.Fail("Cannot use " + getTokenName()
 				+ " on an Ungranted object type: "
-				+ obj.getClass().getSimpleName(), context);
+				+ obj.getClass().getSimpleName());
 		}
 		context.getObjectContext().put(obj, StringKey.TEMP_DESCRIPTION,
 				EntityEncoder.decode(value));

--- a/code/src/java/plugin/lsttokens/TemplateLst.java
+++ b/code/src/java/plugin/lsttokens/TemplateLst.java
@@ -64,7 +64,7 @@ public class TemplateLst extends AbstractToken implements
 		{
 			return new ParseResult.Fail("Cannot use " + getTokenName()
 				+ " on an Ungranted object type: "
-				+ cdo.getClass().getSimpleName(), context);
+				+ cdo.getClass().getSimpleName());
 		}
 		ListKey<CDOMReference<PCTemplate>> lk;
 		String remaining;

--- a/code/src/java/plugin/lsttokens/TypeLst.java
+++ b/code/src/java/plugin/lsttokens/TypeLst.java
@@ -61,15 +61,15 @@ public class TypeLst extends AbstractNonEmptyToken<CDOMObject> implements
 				if (!pr.passed())
 				{
 					return new ParseResult.Fail(getTokenName()
-							+ "started with .CLEAR. but expected to have a Type after .: "
-							+ value, context);
+						+ "started with .CLEAR. but expected to have a Type after .: "
+						+ value);
 				}
 			}
 			else
 			{
 				return new ParseResult.Fail(getTokenName()
 						+ "started with .CLEAR but expected next character to be .: "
-						+ value, context);
+						+ value);
 			}
 		}
 		ParseResult pr = checkForIllegalSeparator('.', value);
@@ -91,7 +91,7 @@ public class TypeLst extends AbstractNonEmptyToken<CDOMObject> implements
 				{
 					return new ParseResult.Fail(
 							"Non-sensical use of .REMOVE.ADD. in "
-									+ getTokenName() + ": " + value, context);
+									+ getTokenName() + ": " + value);
 				}
 				bRemove = false;
 				bAdd = true;
@@ -102,14 +102,14 @@ public class TypeLst extends AbstractNonEmptyToken<CDOMObject> implements
 				{
 					return new ParseResult.Fail(
 							"Non-sensical use of .ADD.REMOVE. in "
-									+ getTokenName() + ": " + value, context);
+									+ getTokenName() + ": " + value);
 				}
 				bRemove = true;
 			}
 			else if ("CLEAR".equals(aType))
 			{
 				return new ParseResult.Fail("Non-sensical use of .CLEAR in "
-						+ getTokenName() + ": " + value, context);
+						+ getTokenName() + ": " + value);
 			}
 			else if (bRemove)
 			{
@@ -135,13 +135,13 @@ public class TypeLst extends AbstractNonEmptyToken<CDOMObject> implements
 		{
 			return new ParseResult.Fail(getTokenName()
 					+ "ended with REMOVE, so didn't have any Type to remove: "
-					+ value, context);
+					+ value);
 		}
 		if (bAdd)
 		{
 			return new ParseResult.Fail(getTokenName()
 					+ "ended with ADD, so didn't have any Type to add: "
-					+ value, context);
+					+ value);
 		}
 		return ParseResult.SUCCESS;
 	}

--- a/code/src/java/plugin/lsttokens/UdamLst.java
+++ b/code/src/java/plugin/lsttokens/UdamLst.java
@@ -59,7 +59,7 @@ public class UdamLst extends AbstractToken implements CDOMPrimaryToken<CDOMObjec
 		{
 			return new ParseResult.Fail("Cannot use " + getTokenName()
 				+ " on an Ungranted object type: "
-				+ obj.getClass().getSimpleName(), context);
+				+ obj.getClass().getSimpleName());
 		}
 		ParseResult pr = ParseResult.SUCCESS;
 		if (Constants.LST_DOT_CLEAR.equals(value))

--- a/code/src/java/plugin/lsttokens/UmultLst.java
+++ b/code/src/java/plugin/lsttokens/UmultLst.java
@@ -59,7 +59,7 @@ public class UmultLst extends AbstractIntToken<CDOMObject> implements
 		{
 			return new ParseResult.Fail("Cannot use " + getTokenName()
 				+ " on an Ungranted object type: "
-				+ obj.getClass().getSimpleName(), context);
+				+ obj.getClass().getSimpleName());
 		}
 		if (Constants.LST_DOT_CLEAR.equals(value))
 		{

--- a/code/src/java/plugin/lsttokens/UnencumberedmoveLst.java
+++ b/code/src/java/plugin/lsttokens/UnencumberedmoveLst.java
@@ -54,7 +54,7 @@ public class UnencumberedmoveLst extends AbstractTokenWithSeparator<CDOMObject>
 		{
 			return new ParseResult.Fail("Cannot use " + getTokenName()
 				+ " on an Ungranted object type: "
-				+ obj.getClass().getSimpleName(), context);
+				+ obj.getClass().getSimpleName());
 		}
 		StringTokenizer tok = new StringTokenizer(value, Constants.PIPE);
 
@@ -141,7 +141,7 @@ public class UnencumberedmoveLst extends AbstractTokenWithSeparator<CDOMObject>
 			{
 				return new ParseResult.Fail("Invalid value of \""
 						+ loadString + "\" for UNENCUMBEREDMOVE in \""
-						+ obj.getDisplayName() + "\".", context);
+						+ obj.getDisplayName() + "\".");
 			}
 		}
 		context.getObjectContext().put(obj, ObjectKey.UNENCUMBERED_LOAD,

--- a/code/src/java/plugin/lsttokens/VisionLst.java
+++ b/code/src/java/plugin/lsttokens/VisionLst.java
@@ -74,7 +74,7 @@ public class VisionLst extends AbstractTokenWithSeparator<CDOMObject> implements
 		{
 			return new ParseResult.Fail("Cannot use " + getTokenName()
 				+ " on an Ungranted object type: "
-				+ obj.getClass().getSimpleName(), context);
+				+ obj.getClass().getSimpleName());
 		}
 		StringTokenizer aTok = new StringTokenizer(value, Constants.PIPE);
 		String visionString = aTok.nextToken();
@@ -82,7 +82,7 @@ public class VisionLst extends AbstractTokenWithSeparator<CDOMObject> implements
 		{
 			return new ParseResult.Fail(
 					"Cannot have only PRExxx subtoken in " + getTokenName()
-							+ ": " + value, context);
+							+ ": " + value);
 		}
 
 		ArrayList<AssociatedPrereqObject> edgeList = new ArrayList<>();
@@ -151,7 +151,7 @@ public class VisionLst extends AbstractTokenWithSeparator<CDOMObject> implements
 		{
 			return new ParseResult.Fail(
 					"Cannot use PREREQs when using .CLEAR or .CLEAR. in "
-							+ getTokenName(), context);
+							+ getTokenName());
 		}
 
 		while (true)
@@ -161,7 +161,7 @@ public class VisionLst extends AbstractTokenWithSeparator<CDOMObject> implements
 			{
 				return new ParseResult.Fail(
 						"   (Did you put vision after the " + "PRExxx tags in "
-								+ getTokenName() + ":?)", context);
+								+ getTokenName() + ":?)");
 			}
 			for (AssociatedPrereqObject edge : edgeList)
 			{

--- a/code/src/java/plugin/lsttokens/ability/AddspelllevelToken.java
+++ b/code/src/java/plugin/lsttokens/ability/AddspelllevelToken.java
@@ -52,7 +52,7 @@ public class AddspelllevelToken extends AbstractNonEmptyToken<Ability>
 		{
 			return new ParseResult.Fail(getTokenName()
 					+ " expected an integer.  Tag must be of the form: "
-					+ getTokenName() + ":<int>", context);
+					+ getTokenName() + ":<int>");
 		}
 	}
 

--- a/code/src/java/plugin/lsttokens/ability/AspectToken.java
+++ b/code/src/java/plugin/lsttokens/ability/AspectToken.java
@@ -72,7 +72,7 @@ public class AspectToken extends AbstractNonEmptyToken<Ability> implements
 		{
 			return new ParseResult.Fail(getTokenName()
 					+ " expecting '|', format is: "
-					+ "AspectName|Aspect value|Variable|... was: " + value, context);
+					+ "AspectName|Aspect value|Variable|... was: " + value);
 		}
 		String key = value.substring(0, pipeLoc);
 		if (key.isEmpty())
@@ -80,7 +80,7 @@ public class AspectToken extends AbstractNonEmptyToken<Ability> implements
 			return new ParseResult.Fail(getTokenName()
 					+ " expecting non-empty type, "
 					+ "format is: AspectName|Aspect value|Variable|... was: "
-					+ value, context);
+					+ value);
 		}
 		String val = value.substring(pipeLoc + 1);
 		if (val.isEmpty())
@@ -88,14 +88,14 @@ public class AspectToken extends AbstractNonEmptyToken<Ability> implements
 			return new ParseResult.Fail(getTokenName()
 					+ " expecting non-empty value, "
 					+ "format is: AspectName|Aspect value|Variable|... was: "
-					+ value, context);
+					+ value);
 		}
 		if (val.startsWith(Constants.PIPE))
 		{
 			return new ParseResult.Fail(getTokenName()
 					+ " expecting non-empty value, "
 					+ "format is: AspectName|Aspect value|Variable|... was: "
-					+ value, context);
+					+ value);
 		}
 		Aspect a = parseAspect(key, val);
 		MapChanges<AspectName, List<Aspect>> mc =

--- a/code/src/java/plugin/lsttokens/ability/BenefitToken.java
+++ b/code/src/java/plugin/lsttokens/ability/BenefitToken.java
@@ -37,8 +37,8 @@ import pcgen.rules.persistence.token.ParseResult;
 /**
  * This class deals with the BENEFIT Token
  */
-public class BenefitToken extends AbstractNonEmptyToken<Ability> implements
-		CDOMPrimaryToken<Ability>
+public class BenefitToken extends AbstractNonEmptyToken<Ability>
+		implements CDOMPrimaryToken<Ability>
 {
 
 	@Override
@@ -58,8 +58,8 @@ public class BenefitToken extends AbstractNonEmptyToken<Ability> implements
 		}
 		if (value.startsWith(Constants.LST_DOT_CLEAR_DOT))
 		{
-			context.getObjectContext().removePatternFromList(ability,
-					ListKey.BENEFIT, value.substring(7));
+			context.getObjectContext().removePatternFromList(ability, ListKey.BENEFIT,
+				value.substring(7));
 			return ParseResult.SUCCESS;
 		}
 
@@ -79,13 +79,13 @@ public class BenefitToken extends AbstractNonEmptyToken<Ability> implements
 		if (PreParserFactory.isPreReqString(firstToken))
 		{
 			return new ParseResult.Fail(
-				"Invalid " + getTokenName() + "(PRExxx can not be only value): " + value, context);
+				"Invalid " + getTokenName() + "(PRExxx can not be only value): " + value);
 		}
 		String ds = EntityEncoder.decode(firstToken);
 		if (!StringUtil.hasBalancedParens(ds))
 		{
 			return new ParseResult.Fail(
-				getTokenName() + " encountered imbalanced Parenthesis: " + value, context);
+				getTokenName() + " encountered imbalanced Parenthesis: " + value);
 		}
 
 		Description ben = new Description(ds);
@@ -100,7 +100,7 @@ public class BenefitToken extends AbstractNonEmptyToken<Ability> implements
 				if (prereq == null)
 				{
 					return new ParseResult.Fail(
-						getTokenName() + " had invalid prerequisite : " + token, context);
+						getTokenName() + " had invalid prerequisite : " + token);
 				}
 				ben.addPrerequisite(prereq);
 				isPre = true;
@@ -110,7 +110,7 @@ public class BenefitToken extends AbstractNonEmptyToken<Ability> implements
 				if (isPre)
 				{
 					return new ParseResult.Fail("Invalid " + getTokenName()
-						+ "(PRExxx must be at the END of the Token): " + value, context);
+						+ "(PRExxx must be at the END of the Token): " + value);
 				}
 				ben.addVariable(token);
 			}
@@ -124,7 +124,7 @@ public class BenefitToken extends AbstractNonEmptyToken<Ability> implements
 	public String[] unparse(LoadContext context, Ability ability)
 	{
 		PatternChanges<Description> changes = context.getObjectContext()
-				.getListPatternChanges(ability, ListKey.BENEFIT);
+			.getListPatternChanges(ability, ListKey.BENEFIT);
 		if (changes == null || changes.isEmpty())
 		{
 			return null;
@@ -135,9 +135,8 @@ public class BenefitToken extends AbstractNonEmptyToken<Ability> implements
 		{
 			if (removedItems != null && !removedItems.isEmpty())
 			{
-				context.addWriteMessage("Non-sensical relationship in "
-						+ getTokenName()
-						+ ": global .CLEAR and local .CLEAR. performed");
+				context.addWriteMessage("Non-sensical relationship in " + getTokenName()
+					+ ": global .CLEAR and local .CLEAR. performed");
 				return null;
 			}
 			list.add(Constants.LST_DOT_CLEAR);

--- a/code/src/java/plugin/lsttokens/ability/CategoryToken.java
+++ b/code/src/java/plugin/lsttokens/ability/CategoryToken.java
@@ -49,7 +49,7 @@ public class CategoryToken extends AbstractNonEmptyToken<Ability> implements
 				.silentlyGetConstructedCDOMObject(ABILITY_CATEGORY_CLASS, value);
 		if (cat == null)
 		{
-			return new ParseResult.Fail("Cannot find Ability Category: " + value, context);
+			return new ParseResult.Fail("Cannot find Ability Category: " + value);
 		}
 		context.getReferenceContext().reassociateCategory(cat, ability);
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/ability/CostToken.java
+++ b/code/src/java/plugin/lsttokens/ability/CostToken.java
@@ -51,7 +51,7 @@ public class CostToken extends AbstractNonEmptyToken<Ability> implements
 		}
 		catch (NumberFormatException e)
 		{
-			return new ParseResult.Fail(getTokenName() + " expected a number: " + value, context);
+			return new ParseResult.Fail(getTokenName() + " expected a number: " + value);
 		}
 	}
 

--- a/code/src/java/plugin/lsttokens/ability/VisibleToken.java
+++ b/code/src/java/plugin/lsttokens/ability/VisibleToken.java
@@ -65,7 +65,7 @@ public class VisibleToken extends AbstractNonEmptyToken<Ability> implements
 		else
 		{
 			return new ParseResult.Fail("Unable to understand " + getTokenName()
-					+ " tag: " + value, context);
+					+ " tag: " + value);
 		}
 		context.getObjectContext().put(ability, ObjectKey.VISIBILITY, vis);
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/add/AbilityToken.java
+++ b/code/src/java/plugin/lsttokens/add/AbilityToken.java
@@ -116,13 +116,13 @@ public class AbilityToken extends AbstractNonEmptyToken<CDOMObject> implements
 		if (!sep.hasNext())
 		{
 			return new ParseResult.Fail("Syntax of ADD:" + getTokenName()
-					+ " requires 3 to 4 |: " + value, context);
+					+ " requires 3 to 4 |: " + value);
 		}
 		String second = sep.next();
 		if (!sep.hasNext())
 		{
 			return new ParseResult.Fail("Syntax of ADD:" + getTokenName()
-					+ " requires a minimum of three | : " + value, context);
+					+ " requires a minimum of three | : " + value);
 		}
 		String third = sep.next();
 		Formula count;
@@ -132,12 +132,12 @@ public class AbilityToken extends AbstractNonEmptyToken<CDOMObject> implements
 			if (!count.isValid())
 			{
 				return new ParseResult.Fail("Count in " + getTokenName()
-						+ " was not valid: " + count.toString(), context);
+						+ " was not valid: " + count.toString());
 			}
 			if (count.isStatic() && (count.resolveStatic().doubleValue() <= 0))
 			{
 				return new ParseResult.Fail("Count in " + getFullName()
-						+ " must be > 0", context);
+						+ " must be > 0");
 			}
 			first = second;
 			second = third;
@@ -151,7 +151,7 @@ public class AbilityToken extends AbstractNonEmptyToken<CDOMObject> implements
 		{
 			return new ParseResult.Fail("Syntax of ADD:" + getTokenName()
 					+ " has max of four | when a count is not present: "
-					+ value, context);
+					+ value);
 		}
 
 		CDOMSingleRef<AbilityCategory> acRef = context.getReferenceContext()
@@ -161,7 +161,7 @@ public class AbilityToken extends AbstractNonEmptyToken<CDOMObject> implements
 		if (nature == null)
 		{
 			return new ParseResult.Fail(getFullName() + ": Invalid ability nature: "
-					+ second, context);
+					+ second);
 		}
 		if (Nature.ANY.equals(nature))
 		{
@@ -173,7 +173,7 @@ public class AbilityToken extends AbstractNonEmptyToken<CDOMObject> implements
 		{
 			return new ParseResult.Fail(getTokenName()
 					+ " refers to AUTOMATIC Ability Nature, cannot be used in "
-					+ getTokenName() + ": " + value, context);
+					+ getTokenName() + ": " + value);
 		}
 
 		ParseResult pr = checkSeparatorsAndNonEmpty(',', third);
@@ -194,8 +194,7 @@ public class AbilityToken extends AbstractNonEmptyToken<CDOMObject> implements
 		if (rm == null)
 		{
 			return new ParseResult.Fail(
-				"Could not get Reference Manufacturer for Category: " + first,
-				context);
+				"Could not get Reference Manufacturer for Category: " + first);
 		}
 
 		while (tok.hasNext())
@@ -208,7 +207,7 @@ public class AbilityToken extends AbstractNonEmptyToken<CDOMObject> implements
 				{
 					return new ParseResult.Fail(getFullName()
 							+ " found second stacking specification in value: "
-							+ value, context);
+							+ value);
 				}
 				allowStack = true;
 				continue;
@@ -219,7 +218,7 @@ public class AbilityToken extends AbstractNonEmptyToken<CDOMObject> implements
 				{
 					return new ParseResult.Fail(getFullName()
 							+ " found second stacking specification in value: "
-							+ value, context);
+							+ value);
 				}
 				allowStack = true;
 				try
@@ -229,12 +228,12 @@ public class AbilityToken extends AbstractNonEmptyToken<CDOMObject> implements
 				catch (NumberFormatException nfe)
 				{
 					return new ParseResult.Fail("Invalid Stack number in "
-							+ getFullName() + ": " + value, context);
+							+ getFullName() + ": " + value);
 				}
 				if (dupChoices <= 0)
 				{
 					return new ParseResult.Fail("Invalid (less than 1) Stack number in "
-							+ getFullName() + ": " + value, context);
+							+ getFullName() + ": " + value);
 				}
 				continue;
 			}
@@ -253,7 +252,7 @@ public class AbilityToken extends AbstractNonEmptyToken<CDOMObject> implements
 			{
 				return new ParseResult.Fail("  Error was encountered while parsing "
 						+ getTokenName() + ": " + value
-						+ " had an invalid reference: " + token, context);
+						+ " had an invalid reference: " + token);
 			}
 			refs.add(ab);
 		}
@@ -261,7 +260,7 @@ public class AbilityToken extends AbstractNonEmptyToken<CDOMObject> implements
 		if (refs.isEmpty())
 		{
 			return new ParseResult.Fail("Non-sensical " + getFullName()
-					+ ": Contains no ability reference: " + value, context);
+					+ ": Contains no ability reference: " + value);
 		}
 
 		AbilityRefChoiceSet rcs = new AbilityRefChoiceSet(acRef, refs,
@@ -269,7 +268,7 @@ public class AbilityToken extends AbstractNonEmptyToken<CDOMObject> implements
 		if (!rcs.getGroupingState().isValid())
 		{
 			return new ParseResult.Fail("Non-sensical " + getFullName()
-					+ ": Contains ANY and a specific reference: " + value, context);
+					+ ": Contains ANY and a specific reference: " + value);
 		}
 		AbilityChoiceSet cs = new AbilityChoiceSet(getTokenName(), rcs);
 		StringBuilder title = new StringBuilder(50);

--- a/code/src/java/plugin/lsttokens/add/ClassSkillsLevelToken.java
+++ b/code/src/java/plugin/lsttokens/add/ClassSkillsLevelToken.java
@@ -90,19 +90,19 @@ public class ClassSkillsLevelToken extends AbstractNonEmptyToken<PCClassLevel> i
 			if (!count.isValid())
 			{
 				return new ParseResult.Fail("Count in " + getTokenName()
-						+ " was not valid: " + count.toString(), context);
+						+ " was not valid: " + count.toString());
 			}
 			if (count.isStatic() && count.resolveStatic().doubleValue() <= 0)
 			{
 				return new ParseResult.Fail("Count in " + getFullName()
-								+ " must be > 0", context);
+								+ " must be > 0");
 			}
 			activeValue = sep.next();
 		}
 		if (sep.hasNext())
 		{
 			return new ParseResult.Fail(getFullName()
-					+ " had too many pipe separated items: " + value, context);
+					+ " had too many pipe separated items: " + value);
 		}
 		ParseResult pr = checkSeparatorsAndNonEmpty(',', activeValue);
 		if (!pr.passed())
@@ -160,8 +160,7 @@ public class ClassSkillsLevelToken extends AbstractNonEmptyToken<PCClassLevel> i
 					if (autoRank != null)
 					{
 						return new ParseResult.Fail("Cannot have two "
-							+ "AUTORANK= items in " + getFullName() + ": " + value,
-							context);
+							+ "AUTORANK= items in " + getFullName() + ": " + value);
 					}
 					String rankString = tokText.substring(9);
 					try
@@ -171,13 +170,13 @@ public class ClassSkillsLevelToken extends AbstractNonEmptyToken<PCClassLevel> i
 						{
 							return new ParseResult.Fail("Expected AUTORANK= to be"
 									+ " greater than zero, found: "
-									+ autoRank, context);
+									+ autoRank);
 						}
 					}
 					catch (NumberFormatException e)
 					{
 						return new ParseResult.Fail("Expected AUTORANK= to have"
-								+ " an integer value, found: " + rankString, context);
+								+ " an integer value, found: " + rankString);
 					}
 				}
 				else
@@ -191,7 +190,7 @@ public class ClassSkillsLevelToken extends AbstractNonEmptyToken<PCClassLevel> i
 										+ ": "
 										+ value
 										+ " had an invalid reference: "
-										+ tokText, context);
+										+ tokText);
 					}
 					refs.add(skref);
 				}
@@ -201,14 +200,14 @@ public class ClassSkillsLevelToken extends AbstractNonEmptyToken<PCClassLevel> i
 		if (refs.isEmpty())
 		{
 			return new ParseResult.Fail("Non-sensical " + getFullName()
-					+ ": Contains no skill reference: " + value, context);
+					+ ": Contains no skill reference: " + value);
 		}
 
 		ReferenceChoiceSet<Skill> rcs = new ReferenceChoiceSet<>(refs);
 		if (!rcs.getGroupingState().isValid())
 		{
 			return new ParseResult.Fail("Non-sensical " + getFullName()
-					+ ": Contains ANY and a specific reference: " + value, context);
+					+ ": Contains ANY and a specific reference: " + value);
 		}
 		ChoiceSet<Skill> cs = new ChoiceSet<>(getTokenName(), rcs, true);
 		PersistentTransitionChoice<Skill> tc = new ConcretePersistentTransitionChoice<>(

--- a/code/src/java/plugin/lsttokens/add/ClassSkillsToken.java
+++ b/code/src/java/plugin/lsttokens/add/ClassSkillsToken.java
@@ -89,19 +89,19 @@ public class ClassSkillsToken extends AbstractNonEmptyToken<PCClass> implements
 			if (!count.isValid())
 			{
 				return new ParseResult.Fail("Count in " + getTokenName()
-						+ " was not valid: " + count.toString(), context);
+						+ " was not valid: " + count.toString());
 			}
 			if (count.isStatic() && count.resolveStatic().doubleValue() <= 0)
 			{
 				return new ParseResult.Fail("Count in " + getFullName()
-								+ " must be > 0", context);
+								+ " must be > 0");
 			}
 			activeValue = sep.next();
 		}
 		if (sep.hasNext())
 		{
 			return new ParseResult.Fail(getFullName()
-					+ " had too many pipe separated items: " + value, context);
+					+ " had too many pipe separated items: " + value);
 		}
 		ParseResult pr = checkSeparatorsAndNonEmpty(',', activeValue);
 		if (!pr.passed())
@@ -159,8 +159,7 @@ public class ClassSkillsToken extends AbstractNonEmptyToken<PCClass> implements
 					if (autoRank != null)
 					{
 						return new ParseResult.Fail("Cannot have two "
-							+ "AUTORANK= items in " + getFullName() + ": " + value,
-							context);
+							+ "AUTORANK= items in " + getFullName() + ": " + value);
 					}
 					String rankString = tokText.substring(9);
 					try
@@ -170,13 +169,13 @@ public class ClassSkillsToken extends AbstractNonEmptyToken<PCClass> implements
 						{
 							return new ParseResult.Fail("Expected AUTORANK= to be"
 									+ " greater than zero, found: "
-									+ autoRank, context);
+									+ autoRank);
 						}
 					}
 					catch (NumberFormatException e)
 					{
 						return new ParseResult.Fail("Expected AUTORANK= to have"
-								+ " an integer value, found: " + rankString, context);
+								+ " an integer value, found: " + rankString);
 					}
 				}
 				else
@@ -190,7 +189,7 @@ public class ClassSkillsToken extends AbstractNonEmptyToken<PCClass> implements
 										+ ": "
 										+ value
 										+ " had an invalid reference: "
-										+ tokText, context);
+										+ tokText);
 					}
 					refs.add(skref);
 				}
@@ -200,14 +199,14 @@ public class ClassSkillsToken extends AbstractNonEmptyToken<PCClass> implements
 		if (refs.isEmpty())
 		{
 			return new ParseResult.Fail("Non-sensical " + getFullName()
-					+ ": Contains no skill reference: " + value, context);
+					+ ": Contains no skill reference: " + value);
 		}
 
 		ReferenceChoiceSet<Skill> rcs = new ReferenceChoiceSet<>(refs);
 		if (!rcs.getGroupingState().isValid())
 		{
 			return new ParseResult.Fail("Non-sensical " + getFullName()
-					+ ": Contains ANY and a specific reference: " + value, context);
+					+ ": Contains ANY and a specific reference: " + value);
 		}
 		ChoiceSet<Skill> cs = new ChoiceSet<>(getTokenName(), rcs, true);
 		PersistentTransitionChoice<Skill> tc = new ConcretePersistentTransitionChoice<>(

--- a/code/src/java/plugin/lsttokens/add/EquipToken.java
+++ b/code/src/java/plugin/lsttokens/add/EquipToken.java
@@ -89,19 +89,19 @@ public class EquipToken extends AbstractNonEmptyToken<CDOMObject> implements
 			if (!count.isValid())
 			{
 				return new ParseResult.Fail("Count in " + getTokenName()
-						+ " was not valid: " + count.toString(), context);
+						+ " was not valid: " + count.toString());
 			}
 			if (count.isStatic() && count.resolveStatic().doubleValue() <= 0)
 			{
 				return new ParseResult.Fail("Count in " + getFullName()
-								+ " must be > 0", context);
+								+ " must be > 0");
 			}
 			activeValue = sep.next();
 		}
 		if (sep.hasNext())
 		{
 			return new ParseResult.Fail(getFullName()
-					+ " had too many pipe separated items: " + value, context);
+					+ " had too many pipe separated items: " + value);
 		}
 		ParseResult pr = checkSeparatorsAndNonEmpty(',', activeValue);
 		if (!pr.passed())
@@ -120,7 +120,7 @@ public class EquipToken extends AbstractNonEmptyToken<CDOMObject> implements
 			{
 				return new ParseResult.Fail("  Error was encountered while parsing "
 						+ getFullName() + ": " + value
-						+ " had an invalid reference: " + tokText, context);
+						+ " had an invalid reference: " + tokText);
 			}
 			refs.add(lang);
 		}

--- a/code/src/java/plugin/lsttokens/add/LanguageToken.java
+++ b/code/src/java/plugin/lsttokens/add/LanguageToken.java
@@ -88,19 +88,19 @@ public class LanguageToken extends AbstractNonEmptyToken<CDOMObject> implements
 			if (!count.isValid())
 			{
 				return new ParseResult.Fail("Count in " + getTokenName()
-						+ " was not valid: " + count.toString(), context);
+						+ " was not valid: " + count.toString());
 			}
 			if (count.isStatic() && count.resolveStatic().doubleValue() <= 0)
 			{
 				return new ParseResult.Fail("Count in " + getFullName()
-								+ " must be > 0", context);
+								+ " must be > 0");
 			}
 			activeValue = sep.next();
 		}
 		if (sep.hasNext())
 		{
 			return new ParseResult.Fail(getFullName()
-					+ " had too many pipe separated items: " + value, context);
+					+ " had too many pipe separated items: " + value);
 		}
 		ParseResult pr = checkSeparatorsAndNonEmpty(',', activeValue);
 		if (!pr.passed())
@@ -119,7 +119,7 @@ public class LanguageToken extends AbstractNonEmptyToken<CDOMObject> implements
 			{
 				return new ParseResult.Fail("  Error was encountered while parsing "
 						+ getFullName() + ": " + value
-						+ " had an invalid reference: " + tokText, context);
+						+ " had an invalid reference: " + tokText);
 			}
 			refs.add(lang);
 		}
@@ -129,7 +129,7 @@ public class LanguageToken extends AbstractNonEmptyToken<CDOMObject> implements
 		if (!rcs.getGroupingState().isValid())
 		{
 			return new ParseResult.Fail("Non-sensical " + getFullName()
-					+ ": Contains ANY and a specific reference: " + value, context);
+					+ ": Contains ANY and a specific reference: " + value);
 		}
 
 		ChoiceSet<Language> cs = new ChoiceSet<>(getTokenName(), rcs);

--- a/code/src/java/plugin/lsttokens/add/SkillToken.java
+++ b/code/src/java/plugin/lsttokens/add/SkillToken.java
@@ -88,19 +88,19 @@ public class SkillToken extends AbstractNonEmptyToken<CDOMObject> implements
 			if (!count.isValid())
 			{
 				return new ParseResult.Fail("Count in " + getTokenName()
-						+ " was not valid: " + count.toString(), context);
+						+ " was not valid: " + count.toString());
 			}
 			if (count.isStatic() && count.resolveStatic().doubleValue() <= 0)
 			{
 				return new ParseResult.Fail("Count in " + getFullName()
-								+ " must be > 0", context);
+								+ " must be > 0");
 			}
 			activeValue = sep.next();
 		}
 		if (sep.hasNext())
 		{
 			return new ParseResult.Fail(getFullName()
-					+ " had too many pipe separated items: " + value, context);
+					+ " had too many pipe separated items: " + value);
 		}
 		ParseResult pr = checkSeparatorsAndNonEmpty(',', activeValue);
 		if (!pr.passed())
@@ -127,7 +127,7 @@ public class SkillToken extends AbstractNonEmptyToken<CDOMObject> implements
 				{
 					return new ParseResult.Fail("  Error was encountered while parsing "
 							+ getFullName() + ": " + token
-							+ " is not a valid reference: " + value, context);
+							+ " is not a valid reference: " + value);
 				}
 			}
 			refs.add(ref);
@@ -137,7 +137,7 @@ public class SkillToken extends AbstractNonEmptyToken<CDOMObject> implements
 		if (!rcs.getGroupingState().isValid())
 		{
 			return new ParseResult.Fail("Non-sensical " + getFullName()
-					+ ": Contains ANY and a specific reference: " + value, context);
+					+ ": Contains ANY and a specific reference: " + value);
 		}
 
 		ChoiceSet<Skill> cs = new ChoiceSet<>("SKILL", rcs, true);

--- a/code/src/java/plugin/lsttokens/add/SpellCasterToken.java
+++ b/code/src/java/plugin/lsttokens/add/SpellCasterToken.java
@@ -91,19 +91,19 @@ public class SpellCasterToken extends AbstractNonEmptyToken<CDOMObject> implemen
 			if (!count.isValid())
 			{
 				return new ParseResult.Fail("Count in " + getTokenName()
-						+ " was not valid: " + count.toString(), context);
+						+ " was not valid: " + count.toString());
 			}
 			if (count.isStatic() && count.resolveStatic().doubleValue() <= 0)
 			{
 				return new ParseResult.Fail("Count in " + getFullName()
-								+ " must be > 0", context);
+								+ " must be > 0");
 			}
 			activeValue = sep.next();
 		}
 		if (sep.hasNext())
 		{
 			return new ParseResult.Fail(getFullName()
-					+ " had too many pipe separated items: " + value, context);
+					+ " had too many pipe separated items: " + value);
 		}
 		ParseResult pr = checkSeparatorsAndNonEmpty(',', activeValue);
 		if (!pr.passed())
@@ -145,8 +145,7 @@ public class SpellCasterToken extends AbstractNonEmptyToken<CDOMObject> implemen
 					{
 						return new ParseResult.Fail(
 							"  Error was encountered while parsing " + getFullName()
-								+ ": " + token + " is not a valid reference: " + value,
-							context);
+								+ ": " + token + " is not a valid reference: " + value);
 					}
 					groups.add(ref);
 				}
@@ -161,7 +160,7 @@ public class SpellCasterToken extends AbstractNonEmptyToken<CDOMObject> implemen
 		if (foundAny && foundOther)
 		{
 			return new ParseResult.Fail("Non-sensical " + getFullName()
-					+ ": Contains ANY and a specific reference: " + value, context);
+					+ ": Contains ANY and a specific reference: " + value);
 		}
 
 		ReferenceChoiceSet<PCClass> grcs = groups.isEmpty() ? null

--- a/code/src/java/plugin/lsttokens/add/TemplateToken.java
+++ b/code/src/java/plugin/lsttokens/add/TemplateToken.java
@@ -87,19 +87,19 @@ public class TemplateToken extends AbstractNonEmptyToken<CDOMObject> implements
 			if (!count.isValid())
 			{
 				return new ParseResult.Fail("Count in " + getTokenName()
-						+ " was not valid: " + count.toString(), context);
+						+ " was not valid: " + count.toString());
 			}
 			if (count.isStatic() && count.resolveStatic().doubleValue() <= 0)
 			{
 				return new ParseResult.Fail("Count in " + getFullName()
-								+ " must be > 0", context);
+								+ " must be > 0");
 			}
 			activeValue = sep.next();
 		}
 		if (sep.hasNext())
 		{
 			return new ParseResult.Fail(getFullName()
-					+ " had too many pipe separated items: " + value, context);
+					+ " had too many pipe separated items: " + value);
 		}
 		ParseResult pr = checkSeparatorsAndNonEmpty(',', activeValue);
 		if (!pr.passed())

--- a/code/src/java/plugin/lsttokens/auto/ArmorProfToken.java
+++ b/code/src/java/plugin/lsttokens/auto/ArmorProfToken.java
@@ -97,13 +97,13 @@ public class ArmorProfToken extends AbstractNonEmptyToken<CDOMObject> implements
 								"Invalid " + getTokenName() + ": " + value
 									+ "  PRExxx must be at the END of the Token";
 						Logging.errorPrint(errorText);
-						return new ParseResult.Fail(errorText, context);
+						return new ParseResult.Fail(errorText);
 					}
 					prereq = getPrerequisite(token);
 					if (prereq == null)
 					{
 						return new ParseResult.Fail("Error generating Prerequisite "
-								+ prereq + " in " + getFullName(), context);
+								+ prereq + " in " + getFullName());
 					}
 					int preStart = value.indexOf(token) - 1;
 					armorProf = value.substring(0, preStart);
@@ -115,7 +115,7 @@ public class ArmorProfToken extends AbstractNonEmptyToken<CDOMObject> implements
 		{
 			return new ParseResult.Fail(
 				"Use of [] for Prerequisites has been removed. "
-					+ "Please use | based standard", context);
+					+ "Please use | based standard");
 		}
 
 		ParseResult pr = checkSeparatorsAndNonEmpty('|', armorProf);
@@ -183,7 +183,7 @@ public class ArmorProfToken extends AbstractNonEmptyToken<CDOMObject> implements
 		if (foundAny && foundOther)
 		{
 			return new ParseResult.Fail("Non-sensical " + getFullName()
-					+ ": Contains ANY and a specific reference: " + value, context);
+					+ ": Contains ANY and a specific reference: " + value);
 		}
 
 		if (!armorProfs.isEmpty() || !equipTypes.isEmpty())

--- a/code/src/java/plugin/lsttokens/auto/EquipToken.java
+++ b/code/src/java/plugin/lsttokens/auto/EquipToken.java
@@ -102,13 +102,13 @@ public class EquipToken extends AbstractNonEmptyToken<CDOMObject> implements
 								"Invalid " + getTokenName() + ": " + value
 									+ "  PRExxx must be at the END of the Token";
 						Logging.errorPrint(errorText);
-						return new ParseResult.Fail(errorText, context);
+						return new ParseResult.Fail(errorText);
 					}
 					prereq = getPrerequisite(token);
 					if (prereq == null)
 					{
 						return new ParseResult.Fail("Error generating Prerequisite "
-								+ prereq + " in " + getFullName(), context);
+								+ prereq + " in " + getFullName());
 					}
 					int preStart = value.indexOf(token) - 1;
 					equipItems = value.substring(0, preStart);
@@ -119,7 +119,7 @@ public class EquipToken extends AbstractNonEmptyToken<CDOMObject> implements
 		else
 		{
 			return new ParseResult.Fail("Use of [] for Prerequisites is no longer supported, "
-					+ "please use | based standard", context);
+					+ "please use | based standard");
 		}
 
 		ParseResult pr = checkForIllegalSeparator('|', equipItems);

--- a/code/src/java/plugin/lsttokens/auto/LangToken.java
+++ b/code/src/java/plugin/lsttokens/auto/LangToken.java
@@ -96,13 +96,13 @@ public class LangToken extends AbstractNonEmptyToken<CDOMObject> implements
 					String errorText = "Invalid " + getTokenName() + ": " + value
 							+ "  PRExxx must be at the END of the Token";
 					Logging.errorPrint(errorText);
-					return new ParseResult.Fail(errorText, context);
+					return new ParseResult.Fail(errorText);
 				}
 				prereq = getPrerequisite(token);
 				if (prereq == null)
 				{
 					return new ParseResult.Fail("Error generating Prerequisite " + prereq
-						+ " in " + getFullName(), context);
+						+ " in " + getFullName());
 				}
 				int preStart = value.indexOf(token) - 1;
 				lang = value.substring(0, preStart);
@@ -121,7 +121,7 @@ public class LangToken extends AbstractNonEmptyToken<CDOMObject> implements
 				{
 					return new ParseResult.Fail("Non-sensical situation was "
 						+ "encountered while parsing " + getTokenName()
-						+ ": When used, .CLEAR must be the first argument", context);
+						+ ": When used, .CLEAR must be the first argument");
 				}
 				context.getObjectContext().removeList(obj, ListKey.AUTO_LANGUAGE);
 			}
@@ -160,7 +160,7 @@ public class LangToken extends AbstractNonEmptyToken<CDOMObject> implements
 				if (ref == null)
 				{
 					return new ParseResult.Fail("  Error was encountered while parsing "
-						+ getTokenName(), context);
+						+ getTokenName());
 				}
 				context.getObjectContext().addToList(obj, ListKey.AUTO_LANGUAGE,
 						new QualifiedObject<>(ref, prereq));
@@ -171,7 +171,7 @@ public class LangToken extends AbstractNonEmptyToken<CDOMObject> implements
 		if (foundAny && foundOther)
 		{
 			return new ParseResult.Fail("Non-sensical " + getFullName()
-				+ ": Contains ANY and a specific reference: " + value, context);
+				+ ": Contains ANY and a specific reference: " + value);
 		}
 
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/auto/ShieldProfToken.java
+++ b/code/src/java/plugin/lsttokens/auto/ShieldProfToken.java
@@ -97,13 +97,13 @@ public class ShieldProfToken extends AbstractNonEmptyToken<CDOMObject> implement
 								"Invalid " + getTokenName() + ": " + value
 									+ "  PRExxx must be at the END of the Token";
 						Logging.errorPrint(errorText);
-						return new ParseResult.Fail(errorText, context);
+						return new ParseResult.Fail(errorText);
 					}
 					prereq = getPrerequisite(token);
 					if (prereq == null)
 					{
 						return new ParseResult.Fail("Error generating Prerequisite "
-								+ prereq + " in " + getFullName(), context);
+								+ prereq + " in " + getFullName());
 					}
 					int preStart = value.indexOf(token) - 1;
 					shieldProf = value.substring(0, preStart);
@@ -115,7 +115,7 @@ public class ShieldProfToken extends AbstractNonEmptyToken<CDOMObject> implement
 		{
 			return new ParseResult.Fail(
 				"Use of [] for Prerequisites has been removed. "
-					+ "Please use | based standard", context);
+					+ "Please use | based standard");
 		}
 
 		ParseResult pr = checkForIllegalSeparator('|', shieldProf);
@@ -182,7 +182,7 @@ public class ShieldProfToken extends AbstractNonEmptyToken<CDOMObject> implement
 		if (foundAny && foundOther)
 		{
 			return new ParseResult.Fail("Non-sensical " + getFullName()
-					+ ": Contains ANY and a specific reference: " + value, context);
+					+ ": Contains ANY and a specific reference: " + value);
 		}
 
 		if (!shieldProfs.isEmpty() || !equipTypes.isEmpty())

--- a/code/src/java/plugin/lsttokens/auto/WeaponProfToken.java
+++ b/code/src/java/plugin/lsttokens/auto/WeaponProfToken.java
@@ -95,13 +95,13 @@ public class WeaponProfToken extends AbstractNonEmptyToken<CDOMObject> implement
 								"Invalid " + getTokenName() + ": " + value
 									+ "  PRExxx must be at the END of the Token";
 						Logging.errorPrint(errorText);
-						return new ParseResult.Fail(errorText, context);
+						return new ParseResult.Fail(errorText);
 					}
 					prereq = getPrerequisite(token);
 					if (prereq == null)
 					{
 						return new ParseResult.Fail("Error generating Prerequisite "
-								+ prereq + " in " + getFullName(), context);
+								+ prereq + " in " + getFullName());
 					}
 					int preStart = value.indexOf(token) - 1;
 					weaponProfs = value.substring(0, preStart);
@@ -119,7 +119,7 @@ public class WeaponProfToken extends AbstractNonEmptyToken<CDOMObject> implement
 		{
 			return new ParseResult.Fail(
 				"Use of [] for Prerequisites has been removed. "
-					+ "Please use | based standard", context);
+					+ "Please use | based standard");
 		}
 
 		ParseResult pr = checkForIllegalSeparator('|', weaponProfs);
@@ -197,7 +197,7 @@ public class WeaponProfToken extends AbstractNonEmptyToken<CDOMObject> implement
 		if (foundAny && foundOther)
 		{
 			return new ParseResult.Fail("Non-sensical " + getFullName()
-					+ ": Contains ANY and a specific reference: " + value, context);
+					+ ": Contains ANY and a specific reference: " + value);
 		}
 		if (!wpp.isEmpty())
 		{
@@ -224,7 +224,7 @@ public class WeaponProfToken extends AbstractNonEmptyToken<CDOMObject> implement
 			if (prereq.getKey().startsWith("TYPE"))
 			{
 				return new ParseResult.Fail("AUTO:WEAPONPROF may not use PREWEAPONPROF requirements "
-						+ " other than specific named proficiencies.", context);
+						+ " other than specific named proficiencies.");
 			}
 		}
 

--- a/code/src/java/plugin/lsttokens/campaign/AllowDupesToken.java
+++ b/code/src/java/plugin/lsttokens/campaign/AllowDupesToken.java
@@ -60,7 +60,7 @@ public class AllowDupesToken extends AbstractNonEmptyToken<Campaign> implements
 		}
 		else
 		{
-			return new ParseResult.Fail("Token must be SPELL or LANGUAGE", context);
+			return new ParseResult.Fail("Token must be SPELL or LANGUAGE");
 		}
 	}
 

--- a/code/src/java/plugin/lsttokens/campaign/BiosetToken.java
+++ b/code/src/java/plugin/lsttokens/campaign/BiosetToken.java
@@ -62,12 +62,12 @@ public class BiosetToken extends AbstractTokenWithSeparator<Campaign> implements
 		if (!cse.getIncludeItems().isEmpty())
 		{
 			return new ParseResult.Fail(getTokenName() + " does not allow INCLUDE: "
-				+ value, context);
+				+ value);
 		}
 		if (!cse.getExcludeItems().isEmpty())
 		{
 			return new ParseResult.Fail(getTokenName() + " does not allow EXCLUDE: "
-				+ value, context);
+				+ value);
 		}
 		context.getObjectContext().addToList(campaign, ListKey.FILE_BIO_SET, cse);
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/campaign/CompanionmodToken.java
+++ b/code/src/java/plugin/lsttokens/campaign/CompanionmodToken.java
@@ -64,12 +64,12 @@ public class CompanionmodToken extends AbstractTokenWithSeparator<Campaign>
 		if (!cse.getIncludeItems().isEmpty())
 		{
 			return new ParseResult.Fail(getTokenName() + " does not allow INCLUDE: "
-				+ value, context);
+				+ value);
 		}
 		if (!cse.getExcludeItems().isEmpty())
 		{
 			return new ParseResult.Fail(getTokenName() + " does not allow EXCLUDE: "
-				+ value, context);
+				+ value);
 		}
 		context.getObjectContext().addToList(campaign, ListKey.FILE_COMPANION_MOD, cse);
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/campaign/CoverToken.java
+++ b/code/src/java/plugin/lsttokens/campaign/CoverToken.java
@@ -72,12 +72,12 @@ public class CoverToken extends AbstractTokenWithSeparator<Campaign> implements
 		if (!cse.getIncludeItems().isEmpty())
 		{
 			return new ParseResult.Fail(getTokenName() + " does not allow INCLUDE: "
-				+ value, context);
+				+ value);
 		}
 		if (!cse.getExcludeItems().isEmpty())
 		{
 			return new ParseResult.Fail(getTokenName() + " does not allow EXCLUDE: "
-				+ value, context);
+				+ value);
 		}
 		context.getObjectContext().addToList(campaign, ListKey.FILE_COVER, cse);
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/campaign/DataTableToken.java
+++ b/code/src/java/plugin/lsttokens/campaign/DataTableToken.java
@@ -50,12 +50,12 @@ public class DataTableToken extends AbstractBasicCampaignToken implements
 		if (!cse.getIncludeItems().isEmpty())
 		{
 			return new ParseResult.Fail(getTokenName() + " does not allow INCLUDE: "
-				+ value, context);
+				+ value);
 		}
 		if (!cse.getExcludeItems().isEmpty())
 		{
 			return new ParseResult.Fail(getTokenName() + " does not allow EXCLUDE: "
-				+ value, context);
+				+ value);
 		}
 		context.getObjectContext().addToList(campaign, ListKey.FILE_DATATABLE, cse);
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/campaign/ForwardRefToken.java
+++ b/code/src/java/plugin/lsttokens/campaign/ForwardRefToken.java
@@ -65,7 +65,7 @@ public class ForwardRefToken extends AbstractTokenWithSeparator<Campaign>
 		{
 			return new ParseResult.Fail(getTokenName()
 					+ " requires at least two arguments, "
-					+ "ReferenceType and Key: " + value, context);
+					+ "ReferenceType and Key: " + value);
 		}
 		if (value.lastIndexOf('|') != pipeLoc)
 		{
@@ -82,7 +82,7 @@ public class ForwardRefToken extends AbstractTokenWithSeparator<Campaign>
 		if (rm == null)
 		{
 			return new ParseResult.Fail(getTokenName()
-					+ " unable to generate manufacturer for type: " + value, context);
+					+ " unable to generate manufacturer for type: " + value);
 		}
 
 		String rest = value.substring(pipeLoc + 1);

--- a/code/src/java/plugin/lsttokens/campaign/HidetypeToken.java
+++ b/code/src/java/plugin/lsttokens/campaign/HidetypeToken.java
@@ -76,7 +76,7 @@ public class HidetypeToken extends AbstractTokenWithSeparator<Campaign>
 		{
 			return new ParseResult.Fail(getTokenName()
 					+ " did not understand: " + value + " in "
-					+ campaign.getKeyName(), context);
+					+ campaign.getKeyName());
 		}
 		StringTokenizer st = new StringTokenizer(types, Constants.PIPE);
 		while (st.hasMoreTokens())

--- a/code/src/java/plugin/lsttokens/campaign/LicenseToken.java
+++ b/code/src/java/plugin/lsttokens/campaign/LicenseToken.java
@@ -53,7 +53,7 @@ public class LicenseToken extends AbstractNonEmptyToken<Campaign> implements
 			if (fileURI.isEmpty())
 			{
 				return new ParseResult.Fail("Cannot have empty FILE in "
-						+ getTokenName(), context);
+						+ getTokenName());
 			}
 			CampaignSourceEntry cse = context.getCampaignSourceEntry(campaign, fileURI);
 			if (cse == null)

--- a/code/src/java/plugin/lsttokens/campaign/LogoToken.java
+++ b/code/src/java/plugin/lsttokens/campaign/LogoToken.java
@@ -72,12 +72,12 @@ public class LogoToken extends AbstractTokenWithSeparator<Campaign> implements
 		if (!cse.getIncludeItems().isEmpty())
 		{
 			return new ParseResult.Fail(getTokenName() + " does not allow INCLUDE: "
-				+ value, context);
+				+ value);
 		}
 		if (!cse.getExcludeItems().isEmpty())
 		{
 			return new ParseResult.Fail(getTokenName() + " does not allow EXCLUDE: "
-				+ value, context);
+				+ value);
 		}
 		context.getObjectContext().addToList(campaign, ListKey.FILE_LOGO, cse);
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/campaign/OptionToken.java
+++ b/code/src/java/plugin/lsttokens/campaign/OptionToken.java
@@ -51,7 +51,7 @@ public class OptionToken extends AbstractNonEmptyToken<Campaign> implements
 		if (equalsPos < 0)
 		{
 			return new ParseResult.Fail("Invalid option line in campaign "
-					+ campaign.getKeyName() + " : " + value, context);
+					+ campaign.getKeyName() + " : " + value);
 		}
 		String optName = value.substring(0, equalsPos);
 

--- a/code/src/java/plugin/lsttokens/campaign/ShowinmenuToken.java
+++ b/code/src/java/plugin/lsttokens/campaign/ShowinmenuToken.java
@@ -49,7 +49,7 @@ public class ShowinmenuToken extends AbstractNonEmptyToken<Campaign> implements
 			if (value.length() > 1 && !value.equalsIgnoreCase("YES"))
 			{
 				return new ParseResult.Fail("You should use 'YES' as the "
-						+ getTokenName() + ": " + value, context);
+						+ getTokenName() + ": " + value);
 			}
 			set = Boolean.TRUE;
 		}
@@ -70,12 +70,12 @@ public class ShowinmenuToken extends AbstractNonEmptyToken<Campaign> implements
 			if (firstChar != 'N' && firstChar != 'n')
 			{
 				return new ParseResult.Fail("You should use 'YES' or 'NO' as the "
-						+ getTokenName() + ": " + value, context);
+						+ getTokenName() + ": " + value);
 			}
 			if (value.length() > 1 && !value.equalsIgnoreCase("NO"))
 			{
 				return new ParseResult.Fail("You should use 'YES' or 'NO' as the "
-						+ getTokenName() + ": " + value, context);
+						+ getTokenName() + ": " + value);
 			}
 			set = Boolean.FALSE;
 		}

--- a/code/src/java/plugin/lsttokens/campaign/StatusToken.java
+++ b/code/src/java/plugin/lsttokens/campaign/StatusToken.java
@@ -60,7 +60,7 @@ public class StatusToken implements CDOMPrimaryToken<Campaign>
 		else
 		{
 			return new ParseResult.Fail("You should use 'RELEASE', 'ALPHA', 'BETA', or 'TESTONLY' as the "
-				+ getTokenName() + ": " + value, context);
+				+ getTokenName() + ": " + value);
 		}
 		context.getObjectContext().put(campaign, ObjectKey.STATUS, set);
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/campaign/TypeToken.java
+++ b/code/src/java/plugin/lsttokens/campaign/TypeToken.java
@@ -86,7 +86,7 @@ public class TypeToken extends AbstractTokenWithSeparator<Campaign> implements
 		{
 			return new ParseResult.Fail(getTokenName()
 				+ " in Campaign may have a"
-				+ " maximum of 3 items, value is invalid: " + value, context);
+				+ " maximum of 3 items, value is invalid: " + value);
 		}
 		return ParseResult.SUCCESS;
 	}

--- a/code/src/java/plugin/lsttokens/campaign/UrlToken.java
+++ b/code/src/java/plugin/lsttokens/campaign/UrlToken.java
@@ -62,7 +62,7 @@ public class UrlToken implements CDOMPrimaryToken<Campaign>
 		if (tok.countTokens() != 3)
 		{
 			return new ParseResult.Fail("URL token requires three arguments. Link kind, "
-							+ "link and description.  : " + value, context);
+							+ "link and description.  : " + value);
 		}
 		String urlTypeName = tok.nextToken();
 		String urlText = tok.nextToken();
@@ -102,7 +102,7 @@ public class UrlToken implements CDOMPrimaryToken<Campaign>
 		catch (URISyntaxException e)
 		{
 			return new ParseResult.Fail("Invalid URL (" + e.getMessage()
-					+ ") : " + value, context);
+					+ ") : " + value);
 		}
 		// Create URL object
 		CampaignURL campUrl = new CampaignURL(urlType, urlTypeName, uri,

--- a/code/src/java/plugin/lsttokens/choose/AbilitySelectionToken.java
+++ b/code/src/java/plugin/lsttokens/choose/AbilitySelectionToken.java
@@ -91,7 +91,7 @@ public class AbilitySelectionToken extends AbstractTokenWithSeparator<CDOMObject
 				if ((title == null) || title.isEmpty())
 				{
 					return new ParseResult.Fail(getParentToken() + Constants.COLON
-						+ getTokenName() + " had TITLE= but no title: " + value, context);
+						+ getTokenName() + " had TITLE= but no title: " + value);
 				}
 				activeValue = value.substring(0, pipeLoc);
 			}
@@ -110,7 +110,7 @@ public class AbilitySelectionToken extends AbstractTokenWithSeparator<CDOMObject
 		if (!prim.getGroupingState().isValid())
 		{
 			return new ParseResult.Fail("Non-sensical " + getFullName()
-				+ ": Contains ANY and a specific reference: " + value, context);
+				+ ": Contains ANY and a specific reference: " + value);
 		}
 		CollectionToAbilitySelection pcs =
 				new CollectionToAbilitySelection(acRef, prim);
@@ -247,7 +247,7 @@ public class AbilitySelectionToken extends AbstractTokenWithSeparator<CDOMObject
 		if (barLoc == -1)
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-				+ " requires a CATEGORY and arguments : " + value, context);
+				+ " requires a CATEGORY and arguments : " + value);
 		}
 		String cat = value.substring(0, barLoc);
 		CDOMSingleRef<AbilityCategory> acRef =
@@ -260,8 +260,7 @@ public class AbilitySelectionToken extends AbstractTokenWithSeparator<CDOMObject
 		if (rm == null)
 		{
 			return new ParseResult.Fail(
-				"Could not get Reference Manufacturer for Category: " + cat,
-				context);
+				"Could not get Reference Manufacturer for Category: " + cat);
 		}
 		return parseTokenWithSeparator(context, rm, acRef, obj, abilities);
 	}

--- a/code/src/java/plugin/lsttokens/choose/AbilityToken.java
+++ b/code/src/java/plugin/lsttokens/choose/AbilityToken.java
@@ -93,7 +93,7 @@ public class AbilityToken extends AbstractTokenWithSeparator<CDOMObject>
 				if ((title == null) || title.isEmpty())
 				{
 					return new ParseResult.Fail(getParentToken() + Constants.COLON
-						+ getTokenName() + " had TITLE= but no title: " + value, context);
+						+ getTokenName() + " had TITLE= but no title: " + value);
 				}
 			}
 			else
@@ -238,7 +238,7 @@ public class AbilityToken extends AbstractTokenWithSeparator<CDOMObject>
 		if (barLoc == -1)
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-				+ " requires a CATEGORY and arguments : " + value, context);
+				+ " requires a CATEGORY and arguments : " + value);
 		}
 		String cat = value.substring(0, barLoc);
 		CDOMSingleRef<AbilityCategory> acRef =
@@ -251,8 +251,7 @@ public class AbilityToken extends AbstractTokenWithSeparator<CDOMObject>
 		if (rm == null)
 		{
 			return new ParseResult.Fail(
-				"Could not get Reference Manufacturer for Category: " + cat,
-				context);
+				"Could not get Reference Manufacturer for Category: " + cat);
 		}
 		return parseTokenWithSeparator(context, rm, acRef, obj, abilities);
 	}

--- a/code/src/java/plugin/lsttokens/choose/NoChoiceToken.java
+++ b/code/src/java/plugin/lsttokens/choose/NoChoiceToken.java
@@ -75,7 +75,7 @@ public class NoChoiceToken implements CDOMSecondaryToken<CDOMObject>,
 			return ParseResult.SUCCESS;
 		}
 		return new ParseResult.Fail("CHOOSE:" + getTokenName()
-			+ " will ignore arguments: " + value, context);
+			+ " will ignore arguments: " + value);
 	}
 
 	@Override

--- a/code/src/java/plugin/lsttokens/choose/SpellLevelToken.java
+++ b/code/src/java/plugin/lsttokens/choose/SpellLevelToken.java
@@ -101,7 +101,7 @@ public class SpellLevelToken extends AbstractTokenWithSeparator<CDOMObject>
 		if (!sep.hasNext())
 		{
 			return new ParseResult.Fail("Found no arguments in "
-				+ getFullName() + ": " + value, context);
+				+ getFullName() + ": " + value);
 		}
 		List<SpellLevelInfo> sliList = new ArrayList<>();
 		while (sep.hasNext())
@@ -114,7 +114,7 @@ public class SpellLevelToken extends AbstractTokenWithSeparator<CDOMObject>
 			{
 				return new ParseResult.Fail(
 					"Expected minimum level argument after " + token + " in "
-						+ getFullName() + ": " + value, context);
+						+ getFullName() + ": " + value);
 			}
 			String minLevelString = sep.next();
 			Formula minLevel = FormulaFactory.getFormulaFor(minLevelString);
@@ -122,14 +122,14 @@ public class SpellLevelToken extends AbstractTokenWithSeparator<CDOMObject>
 			{
 				return new ParseResult.Fail(
 					"Expected maximum level argument after " + minLevelString
-						+ " in " + getFullName() + ": " + value, context);
+						+ " in " + getFullName() + ": " + value);
 			}
 			String maxLevelString = sep.next();
 			Formula maxLevel = FormulaFactory.getFormulaFor(maxLevelString);
 			if (!maxLevel.isValid())
 			{
 				return new ParseResult.Fail("Max Level Formula in "
-					+ getTokenName() + " was not valid: " + maxLevel.toString(), context);
+					+ getTokenName() + " was not valid: " + maxLevel.toString());
 			}
 			SpellLevelInfo sli = new SpellLevelInfo(pcf, minLevel, maxLevel);
 			sliList.add(sli);

--- a/code/src/java/plugin/lsttokens/choose/StringToken.java
+++ b/code/src/java/plugin/lsttokens/choose/StringToken.java
@@ -63,32 +63,32 @@ public class StringToken implements CDOMSecondaryToken<CDOMObject>,
 		if (value == null || value.isEmpty())
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-				+ " must have arguments", context);
+				+ " must have arguments");
 		}
 		if (value.indexOf(',') != -1)
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-				+ " arguments may not contain , : " + value, context);
+				+ " arguments may not contain , : " + value);
 		}
 		if (value.indexOf('[') != -1)
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-				+ " arguments may not contain [] : " + value, context);
+				+ " arguments may not contain [] : " + value);
 		}
 		if (value.charAt(0) == '|')
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-				+ " arguments may not start with | : " + value, context);
+				+ " arguments may not start with | : " + value);
 		}
 		if (value.charAt(value.length() - 1) == '|')
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-				+ " arguments may not end with | : " + value, context);
+				+ " arguments may not end with | : " + value);
 		}
 		if (value.indexOf("||") != -1)
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-				+ " arguments uses double separator || : " + value, context);
+				+ " arguments uses double separator || : " + value);
 		}
 
 		StringTokenizer tok = new StringTokenizer(value, Constants.PIPE);

--- a/code/src/java/plugin/lsttokens/choose/UserInputToken.java
+++ b/code/src/java/plugin/lsttokens/choose/UserInputToken.java
@@ -75,7 +75,7 @@ public class UserInputToken implements CDOMSecondaryToken<CDOMObject>
 				{
 					return new ParseResult.Fail("If CHOOSE:" + getTokenName()
 						+ " contains a pipe, "
-						+ "first argument must be an Integer : " + value, context);
+						+ "first argument must be an Integer : " + value);
 				}
 				Formula count = FormulaFactory.getFormulaFor(firstarg);
 				context.getObjectContext().put(obj, FormulaKey.NUMCHOICES, count);
@@ -86,7 +86,7 @@ public class UserInputToken implements CDOMSecondaryToken<CDOMObject>
 			{
 				return new ParseResult.Fail("CHOOSE:" + getTokenName() + " in "
 					+ obj.getClass() + ' ' + obj.getKeyName()
-					+ " had invalid arguments: " + value, context);
+					+ " had invalid arguments: " + value);
 			}
 			String title = titleString.substring(6);
 			if (title.startsWith("\""))

--- a/code/src/java/plugin/lsttokens/companionmod/FollowerToken.java
+++ b/code/src/java/plugin/lsttokens/companionmod/FollowerToken.java
@@ -67,11 +67,11 @@ public class FollowerToken extends AbstractTokenWithSeparator<CompanionMod>
 		int equalLoc = value.indexOf('=');
 		if (equalLoc == -1)
 		{
-			return new ParseResult.Fail("No = in token.", context);
+			return new ParseResult.Fail("No = in token.");
 		}
 		if (equalLoc != value.lastIndexOf('='))
 		{
-			return new ParseResult.Fail("Too many = in token.", context);
+			return new ParseResult.Fail("Too many = in token.");
 		}
 		String classString = value.substring(0, equalLoc);
 		String levelString = value.substring(equalLoc + 1);

--- a/code/src/java/plugin/lsttokens/companionmod/TypeToken.java
+++ b/code/src/java/plugin/lsttokens/companionmod/TypeToken.java
@@ -56,7 +56,7 @@ public class TypeToken extends AbstractNonEmptyToken<CompanionMod> implements
 		if (cat == null)
 		{
 			return new ParseResult.Fail("Cannot find Companion List: "
-				+ value, context);
+				+ value);
 		}
 		context.getReferenceContext().reassociateCategory(cat, mod);
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/datacontrol/DefaultVariableValueToken.java
+++ b/code/src/java/plugin/lsttokens/datacontrol/DefaultVariableValueToken.java
@@ -68,7 +68,7 @@ public class DefaultVariableValueToken extends
 		if (value.lastIndexOf(separator) != pipeLoc)
 		{
 			return new ParseResult.Fail(getTokenName()
-				+ " requires only a type and a value, found: " + value, context);
+				+ " requires only a type and a value, found: " + value);
 		}
 		String formatName = value.substring(0, pipeLoc);
 		String formatValue;
@@ -89,7 +89,7 @@ public class DefaultVariableValueToken extends
 		catch (NullPointerException | IllegalArgumentException e)
 		{
 			return new ParseResult.Fail(getTokenName()
-				+ " found an unsupported format: " + formatName, context);
+				+ " found an unsupported format: " + formatName);
 		}
 		dvv.setFormatManager(fmtManager);
 		return subProcess(context, dvv, formatValue, fmtManager);
@@ -103,8 +103,7 @@ public class DefaultVariableValueToken extends
 		if (m == null)
 		{
 			return new ParseResult.Fail("ModifierType "
-				+ fmtManager.getIdentifierType() + " requires a SET modifier",
-				context);
+				+ fmtManager.getIdentifierType() + " requires a SET modifier");
 		}
 		FormulaModifier<T> defaultModifier;
 		try
@@ -115,7 +114,7 @@ public class DefaultVariableValueToken extends
 		{
 			return new ParseResult.Fail("ModifierType " + fmtManager.getIdentifierType()
 				+ " could not be initialized to a default value of: " + defaultValue
-				+ " due to " + e.getLocalizedMessage(), context);
+				+ " due to " + e.getLocalizedMessage());
 		}
 		defaultModifier.addAssociation("PRIORITY=0");
 		dvv.setModifier(defaultModifier);

--- a/code/src/java/plugin/lsttokens/datacontrol/FactDefToken.java
+++ b/code/src/java/plugin/lsttokens/datacontrol/FactDefToken.java
@@ -52,15 +52,14 @@ public class FactDefToken extends AbstractTokenWithSeparator<FactDefinition>
 		if (!aTok.hasMoreTokens())
 		{
 			return new ParseResult.Fail(getTokenName()
-				+ " expects 2 PIPE separated values, found 1 in: " + value,
-				context);
+				+ " expects 2 PIPE separated values, found 1 in: " + value);
 		}
 		String factName = aTok.nextToken();
 		if (aTok.hasMoreTokens())
 		{
 			return new ParseResult.Fail(getTokenName()
 				+ " expects 3 PIPE separated values, found too many in: "
-				+ value, context);
+				+ value);
 		}
 		Class<? extends Loadable> cl;
 		if ("GLOBAL".equals(usableLocation))

--- a/code/src/java/plugin/lsttokens/datacontrol/FactSetDefToken.java
+++ b/code/src/java/plugin/lsttokens/datacontrol/FactSetDefToken.java
@@ -53,15 +53,14 @@ public class FactSetDefToken extends
 		if (!aTok.hasMoreTokens())
 		{
 			return new ParseResult.Fail(getTokenName()
-				+ " expects 2 PIPE separated values, found 1 in: " + value,
-				context);
+				+ " expects 2 PIPE separated values, found 1 in: " + value);
 		}
 		String identifier = aTok.nextToken();
 		if (aTok.hasMoreTokens())
 		{
 			return new ParseResult.Fail(getTokenName()
 				+ " expects 3 PIPE separated values, found too many in: "
-				+ value, context);
+				+ value);
 		}
 		Class<? extends Loadable> cl;
 		if ("GLOBAL".equals(fileType))

--- a/code/src/java/plugin/lsttokens/datacontrol/RequiredToken.java
+++ b/code/src/java/plugin/lsttokens/datacontrol/RequiredToken.java
@@ -42,7 +42,7 @@ public class RequiredToken extends AbstractNonEmptyToken<ContentDefinition>
 			if (value.length() > 1 && !value.equalsIgnoreCase("YES"))
 			{
 				return new ParseResult.Fail("You should use 'YES' as the "
-					+ getTokenName() + ": " + value, context);
+					+ getTokenName() + ": " + value);
 			}
 			set = true;
 		}
@@ -52,13 +52,13 @@ public class RequiredToken extends AbstractNonEmptyToken<ContentDefinition>
 			{
 				return new ParseResult.Fail(
 					"You should use 'YES' or 'NO' as the " + getTokenName()
-						+ ": " + value, context);
+						+ ": " + value);
 			}
 			if (value.length() > 1 && !value.equalsIgnoreCase("NO"))
 			{
 				return new ParseResult.Fail(
 					"You should use 'YES' or 'NO' as the " + getTokenName()
-						+ ": " + value, context);
+						+ ": " + value);
 			}
 			set = false;
 		}

--- a/code/src/java/plugin/lsttokens/datacontrol/SelectableToken.java
+++ b/code/src/java/plugin/lsttokens/datacontrol/SelectableToken.java
@@ -42,7 +42,7 @@ public class SelectableToken extends AbstractNonEmptyToken<ContentDefinition>
 			if (value.length() > 1 && !value.equalsIgnoreCase("YES"))
 			{
 				return new ParseResult.Fail("You should use 'YES' as the "
-					+ getTokenName() + ": " + value, context);
+					+ getTokenName() + ": " + value);
 			}
 			set = true;
 		}
@@ -52,13 +52,13 @@ public class SelectableToken extends AbstractNonEmptyToken<ContentDefinition>
 			{
 				return new ParseResult.Fail(
 					"You should use 'YES' or 'NO' as the " + getTokenName()
-						+ ": " + value, context);
+						+ ": " + value);
 			}
 			if (value.length() > 1 && !value.equalsIgnoreCase("NO"))
 			{
 				return new ParseResult.Fail(
 					"You should use 'YES' or 'NO' as the " + getTokenName()
-						+ ": " + value, context);
+						+ ": " + value);
 			}
 			set = false;
 		}

--- a/code/src/java/plugin/lsttokens/datacontrol/ValueToken.java
+++ b/code/src/java/plugin/lsttokens/datacontrol/ValueToken.java
@@ -44,7 +44,7 @@ public class ValueToken extends AbstractNonEmptyToken<UserFunction> implements
 			{
 				return new ParseResult.Fail("Parse of Function: "
 					+ ftn.getKeyName() + " with value: " + value
-					+ " attempted to reassign from: " + existing, context);
+					+ " attempted to reassign from: " + existing);
 			}
 			return ParseResult.SUCCESS;
 		}
@@ -56,7 +56,7 @@ public class ValueToken extends AbstractNonEmptyToken<UserFunction> implements
 		{
 			return new ParseResult.Fail("Parse of Function: "
 				+ ftn.getKeyName() + " with value: " + value
-				+ " failed due to: " + e.getMessage(), context);
+				+ " failed due to: " + e.getMessage());
 		}
 		context.getVariableContext().addFunction(ftn.getFunction());
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/datacontrol/VisibleToken.java
+++ b/code/src/java/plugin/lsttokens/datacontrol/VisibleToken.java
@@ -56,7 +56,7 @@ public class VisibleToken extends AbstractNonEmptyToken<ContentDefinition>
 		else
 		{
 			return new ParseResult.Fail("Unable to understand "
-				+ getTokenName() + " tag: " + value, context);
+				+ getTokenName() + " tag: " + value);
 		}
 		factDef.setVisibility(vis);
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/deity/DeityweapToken.java
+++ b/code/src/java/plugin/lsttokens/deity/DeityweapToken.java
@@ -74,7 +74,7 @@ public class DeityweapToken extends AbstractTokenWithSeparator<Deity> implements
 				{
 					return new ParseResult.Fail("  Non-sensical "
 							+ getTokenName()
-							+ ": .CLEAR was not the first list item", context);
+							+ ": .CLEAR was not the first list item");
 				}
 				context.getObjectContext().removeList(deity, ListKey.DEITYWEAPON);
 			}
@@ -99,7 +99,7 @@ public class DeityweapToken extends AbstractTokenWithSeparator<Deity> implements
 		if (foundAny && foundOther)
 		{
 			return new ParseResult.Fail("Non-sensical " + getTokenName()
-					+ ": Contains ANY and a specific reference: " + value, context);
+					+ ": Contains ANY and a specific reference: " + value);
 		}
 		return ParseResult.SUCCESS;
 	}

--- a/code/src/java/plugin/lsttokens/deity/DomainsToken.java
+++ b/code/src/java/plugin/lsttokens/deity/DomainsToken.java
@@ -84,14 +84,14 @@ public class DomainsToken extends AbstractTokenWithSeparator<Deity> implements
 			if (looksLikeAPrerequisite(tokString))
 			{
 				return new ParseResult.Fail("Invalid " + getTokenName()
-						+ ": PRExxx was comma delimited : " + value, context);
+						+ ": PRExxx was comma delimited : " + value);
 			}
 			if (Constants.LST_DOT_CLEAR.equals(tokString))
 			{
 				if (!first)
 				{
 					return new ParseResult.Fail("  Non-sensical " + getTokenName()
-							+ ": .CLEAR was not the first list item: " + value, context);
+							+ ": .CLEAR was not the first list item: " + value);
 				}
 				context.getListContext().removeAllFromList(getTokenName(),
 						deity, dl);
@@ -137,7 +137,7 @@ public class DomainsToken extends AbstractTokenWithSeparator<Deity> implements
 		if (foundAll && foundOther)
 		{
 			return new ParseResult.Fail("Non-sensical " + getTokenName()
-					+ ": Contains ALL and a specific reference: " + value, context);
+					+ ": Contains ALL and a specific reference: " + value);
 		}
 
 		while (pipeTok.hasMoreTokens())
@@ -145,14 +145,14 @@ public class DomainsToken extends AbstractTokenWithSeparator<Deity> implements
 			if (foundClear)
 			{
 				return new ParseResult.Fail("Cannot use PREREQs when using .CLEAR or .CLEAR. in "
-								+ getTokenName(), context);
+								+ getTokenName());
 			}
 			String tokString = pipeTok.nextToken();
 			Prerequisite prereq = getPrerequisite(tokString);
 			if (prereq == null)
 			{
 				return new ParseResult.Fail("   (Did you put items after the "
-						+ "PRExxx tags in " + getTokenName() + ":?)", context);
+						+ "PRExxx tags in " + getTokenName() + ":?)");
 			}
 			for (AssociatedPrereqObject ao : proList)
 			{

--- a/code/src/java/plugin/lsttokens/deprecated/AddFeatToken.java
+++ b/code/src/java/plugin/lsttokens/deprecated/AddFeatToken.java
@@ -63,19 +63,18 @@ public class AddFeatToken extends AbstractNonEmptyToken<CDOMObject> implements
 			if (!count.isValid())
 			{
 				return new ParseResult.Fail("Count in " + getTokenName()
-					+ " was not valid: " + count.toString(), context);
+					+ " was not valid: " + count.toString());
 			}
 			if (count.isStatic() && count.resolveStatic().doubleValue() <= 0)
 			{
-				return new ParseResult.Fail("Count in ADD:FEAT must be > 0",
-					context);
+				return new ParseResult.Fail("Count in ADD:FEAT must be > 0");
 			}
 			activeValue = sep.next();
 		}
 		if (sep.hasNext())
 		{
 			return new ParseResult.Fail(
-				"ADD:FEAT had too many pipe separated items: " + value, context);
+				"ADD:FEAT had too many pipe separated items: " + value);
 		}
 		try
 		{

--- a/code/src/java/plugin/lsttokens/deprecated/AddVFeatToken.java
+++ b/code/src/java/plugin/lsttokens/deprecated/AddVFeatToken.java
@@ -62,20 +62,18 @@ public class AddVFeatToken extends AbstractNonEmptyToken<CDOMObject> implements
 			if (!count.isValid())
 			{
 				return new ParseResult.Fail("Count in " + getTokenName()
-					+ " was not valid: " + count.toString(), context);
+					+ " was not valid: " + count.toString());
 			}
 			if (count.isStatic() && count.resolveStatic().doubleValue() <= 0)
 			{
-				return new ParseResult.Fail("Count in ADD:VFEAT must be > 0",
-					context);
+				return new ParseResult.Fail("Count in ADD:VFEAT must be > 0");
 			}
 			activeValue = sep.next();
 		}
 		if (sep.hasNext())
 		{
 			return new ParseResult.Fail(
-				"ADD:VFEAT had too many pipe separated items: " + value,
-				context);
+				"ADD:VFEAT had too many pipe separated items: " + value);
 		}
 		try
 		{

--- a/code/src/java/plugin/lsttokens/deprecated/ChooseFeatSelectionToken.java
+++ b/code/src/java/plugin/lsttokens/deprecated/ChooseFeatSelectionToken.java
@@ -88,7 +88,7 @@ public class ChooseFeatSelectionToken extends AbstractTokenWithSeparator<CDOMObj
 				{
 					return new ParseResult.Fail(
 						getParentToken() + Constants.COLON + getTokenName()
-							+ " had TITLE= but no title: " + value, context);
+							+ " had TITLE= but no title: " + value);
 				}
 				activeValue = value.substring(0, pipeLoc);
 			}
@@ -108,7 +108,7 @@ public class ChooseFeatSelectionToken extends AbstractTokenWithSeparator<CDOMObj
 		if (!prim.getGroupingState().isValid())
 		{
 			return new ParseResult.Fail("Non-sensical " + getFullName()
-				+ ": Contains ANY and a specific reference: " + value, context);
+				+ ": Contains ANY and a specific reference: " + value);
 		}
 		PrimitiveChoiceSet<AbilitySelection> pcs =
 				new CollectionToAbilitySelection(CDOMDirectSingleRef.getRef(AbilityCategory.FEAT), prim);

--- a/code/src/java/plugin/lsttokens/deprecated/ChooseFeatToken.java
+++ b/code/src/java/plugin/lsttokens/deprecated/ChooseFeatToken.java
@@ -85,7 +85,7 @@ public class ChooseFeatToken extends AbstractTokenWithSeparator<CDOMObject> impl
 				if (title == null || title.isEmpty())
 				{
 					return new ParseResult.Fail(getParentToken() + Constants.COLON
-						+ getTokenName() + " had TITLE= but no title: " + value, context);
+						+ getTokenName() + " had TITLE= but no title: " + value);
 				}
 			}
 			else

--- a/code/src/java/plugin/lsttokens/deprecated/ClassDomainBracketToken.java
+++ b/code/src/java/plugin/lsttokens/deprecated/ClassDomainBracketToken.java
@@ -71,7 +71,7 @@ public class ClassDomainBracketToken extends AbstractTokenWithSeparator<PCClass>
 				if (!first)
 				{
 					return new ParseResult.Fail("  Non-sensical " + getTokenName()
-							+ ": .CLEAR was not the first list item", context);
+							+ ": .CLEAR was not the first list item");
 				}
 				context.getObjectContext().removeList(pcc, ListKey.DOMAIN);
 				continue;
@@ -86,7 +86,7 @@ public class ClassDomainBracketToken extends AbstractTokenWithSeparator<PCClass>
 				if (tok.indexOf(']') != -1)
 				{
 					return new ParseResult.Fail("Invalid " + getTokenName()
-							+ " must have '[' if it contains a PREREQ tag", context);
+							+ " must have '[' if it contains a PREREQ tag");
 				}
 				domainKey = tok;
 			}
@@ -95,7 +95,7 @@ public class ClassDomainBracketToken extends AbstractTokenWithSeparator<PCClass>
 				if (tok.lastIndexOf(']') != tok.length() - 1)
 				{
 					return new ParseResult.Fail("Invalid " + getTokenName()
-							+ " must end with ']' if it contains a PREREQ tag", context);
+							+ " must end with ']' if it contains a PREREQ tag");
 				}
 				domainKey = tok.substring(0, openBracketLoc);
 				String prereqString = tok.substring(openBracketLoc + 1, tok
@@ -103,13 +103,13 @@ public class ClassDomainBracketToken extends AbstractTokenWithSeparator<PCClass>
 				if (prereqString.isEmpty())
 				{
 					return new ParseResult.Fail(getTokenName()
-							+ " cannot have empty prerequisite : " + value, context);
+							+ " cannot have empty prerequisite : " + value);
 				}
 				prereq = getPrerequisite(prereqString);
 				if (prereq == null)
 				{
 					return new ParseResult.Fail(getTokenName()
-							+ " had invalid prerequisite : " + prereqString, context);
+							+ " had invalid prerequisite : " + prereqString);
 				}
 			}
 			CDOMSingleRef<Domain> domain = context.getReferenceContext().getCDOMReference(

--- a/code/src/java/plugin/lsttokens/deprecated/ClassLevelDomainBracketToken.java
+++ b/code/src/java/plugin/lsttokens/deprecated/ClassLevelDomainBracketToken.java
@@ -71,7 +71,7 @@ public class ClassLevelDomainBracketToken extends AbstractTokenWithSeparator<PCC
 				if (!first)
 				{
 					return new ParseResult.Fail("  Non-sensical " + getTokenName()
-							+ ": .CLEAR was not the first list item", context);
+							+ ": .CLEAR was not the first list item");
 				}
 				context.getObjectContext().removeList(level, ListKey.DOMAIN);
 				continue;
@@ -86,7 +86,7 @@ public class ClassLevelDomainBracketToken extends AbstractTokenWithSeparator<PCC
 				if (tok.indexOf(']') != -1)
 				{
 					return new ParseResult.Fail("Invalid " + getTokenName()
-							+ " must have '[' if it contains a PREREQ tag", context);
+							+ " must have '[' if it contains a PREREQ tag");
 				}
 				domainKey = tok;
 			}
@@ -95,7 +95,7 @@ public class ClassLevelDomainBracketToken extends AbstractTokenWithSeparator<PCC
 				if (tok.lastIndexOf(']') != tok.length() - 1)
 				{
 					return new ParseResult.Fail("Invalid " + getTokenName()
-							+ " must end with ']' if it contains a PREREQ tag", context);
+							+ " must end with ']' if it contains a PREREQ tag");
 				}
 				domainKey = tok.substring(0, openBracketLoc);
 				String prereqString = tok.substring(openBracketLoc + 1, tok
@@ -103,13 +103,13 @@ public class ClassLevelDomainBracketToken extends AbstractTokenWithSeparator<PCC
 				if (prereqString.isEmpty())
 				{
 					return new ParseResult.Fail(getTokenName()
-							+ " cannot have empty prerequisite : " + value, context);
+							+ " cannot have empty prerequisite : " + value);
 				}
 				prereq = getPrerequisite(prereqString);
 				if (prereq == null)
 				{
 					return new ParseResult.Fail(getTokenName()
-							+ " had invalid prerequisite : " + prereqString, context);
+							+ " had invalid prerequisite : " + prereqString);
 				}
 			}
 			CDOMSingleRef<Domain> domain = context.getReferenceContext().getCDOMReference(

--- a/code/src/java/plugin/lsttokens/deprecated/KitFeatToken.java
+++ b/code/src/java/plugin/lsttokens/deprecated/KitFeatToken.java
@@ -88,7 +88,7 @@ public class KitFeatToken extends AbstractTokenWithSeparator<KitAbilities>
 			{
 				return new ParseResult.Fail(
 					"Attempting to change the Category of a Feat to '" + token
-						+ '\'', context);
+						+ '\'');
 			}
 			CDOMReference<Ability> ref =
 					TokenUtilities.getTypeOrPrimitive(rm, token);

--- a/code/src/java/plugin/lsttokens/deprecated/NumberToken.java
+++ b/code/src/java/plugin/lsttokens/deprecated/NumberToken.java
@@ -51,8 +51,7 @@ public class NumberToken implements CDOMCompatibilityToken<CDOMObject>
 			{
 				Logging.replayParsedMessages();
 				return new ParseResult.Fail(
-					"Internal Error in delegation of CHOOSE:NUMBER to TEMPVALUE",
-					context);
+					"Internal Error in delegation of CHOOSE:NUMBER to TEMPVALUE");
 			}
 		}
 		catch (PersistenceLayerException e)
@@ -60,7 +59,7 @@ public class NumberToken implements CDOMCompatibilityToken<CDOMObject>
 			Logging.replayParsedMessages();
 			return new ParseResult.Fail(
 				"Error in delegation of CHOOSE:NUMBER to TEMPVALUE: "
-					+ e.getLocalizedMessage(), context);
+					+ e.getLocalizedMessage());
 		}
 
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/deprecated/PenaltyvarToken.java
+++ b/code/src/java/plugin/lsttokens/deprecated/PenaltyvarToken.java
@@ -40,7 +40,7 @@ public class PenaltyvarToken implements CDOMCompatibilityToken<PCStat>,
 	@Override
 	public ParseResult parseToken(LoadContext context, PCStat obj, String value)
 	{
-		return new ParseResult.Fail(getMessage(obj, value), context);
+		return new ParseResult.Fail(getMessage(obj, value));
 	}
 
 	@Override

--- a/code/src/java/plugin/lsttokens/deprecated/RaceChooseLangautoToken.java
+++ b/code/src/java/plugin/lsttokens/deprecated/RaceChooseLangautoToken.java
@@ -58,8 +58,7 @@ public class RaceChooseLangautoToken extends AbstractTokenWithSeparator<Race>
 			{
 				Logging.replayParsedMessages();
 				return new ParseResult.Fail(
-					"Internal Error in delegation of CHOOSE:LANGAUTO to CHOOSE:LANGUAGE",
-					context);
+					"Internal Error in delegation of CHOOSE:LANGAUTO to CHOOSE:LANGUAGE");
 			}
 		}
 		catch (PersistenceLayerException e)
@@ -67,7 +66,7 @@ public class RaceChooseLangautoToken extends AbstractTokenWithSeparator<Race>
 			Logging.replayParsedMessages();
 			return new ParseResult.Fail(
 				"Error in delegation of CHOOSE:LANGAUTO to CHOOSE:LANG: "
-					+ e.getLocalizedMessage(), context);
+					+ e.getLocalizedMessage());
 		}
 		try
 		{
@@ -75,8 +74,7 @@ public class RaceChooseLangautoToken extends AbstractTokenWithSeparator<Race>
 			{
 				Logging.replayParsedMessages();
 				return new ParseResult.Fail(
-					"Internal Error in delegation of CHOOSE:LANGAUTO to AUTO:LANG",
-					context);
+					"Internal Error in delegation of CHOOSE:LANGAUTO to AUTO:LANG");
 			}
 		}
 		catch (PersistenceLayerException e)
@@ -84,7 +82,7 @@ public class RaceChooseLangautoToken extends AbstractTokenWithSeparator<Race>
 			Logging.replayParsedMessages();
 			return new ParseResult.Fail(
 				"Error in delegation of CHOOSE:LANGAUTO to AUTO:LANG: "
-					+ e.getLocalizedMessage(), context);
+					+ e.getLocalizedMessage());
 		}
 		return ParseResult.SUCCESS;
 	}

--- a/code/src/java/plugin/lsttokens/deprecated/RemoveFeatToken.java
+++ b/code/src/java/plugin/lsttokens/deprecated/RemoveFeatToken.java
@@ -113,24 +113,24 @@ public class RemoveFeatToken extends AbstractNonEmptyToken<CDOMObject> implement
 			if (!count.isValid())
 			{
 				return new ParseResult.Fail("Count in " + getTokenName()
-						+ " was not valid: " + count.toString(), context);
+						+ " was not valid: " + count.toString());
 			}
 			if (!count.isValid())
 			{
 				return new ParseResult.Fail("Count in " + getTokenName()
-						+ " was not valid: " + count.toString(), context);
+						+ " was not valid: " + count.toString());
 			}
 			if (count.isStatic() && count.resolveStatic().doubleValue() <= 0)
 			{
 				return new ParseResult.Fail("Count in " + getFullName()
-								+ " must be > 0", context);
+								+ " must be > 0");
 			}
 			activeValue = sep.next();
 		}
 		if (sep.hasNext())
 		{
 			return new ParseResult.Fail(getFullName()
-					+ " had too many pipe separated items: " + value, context);
+					+ " had too many pipe separated items: " + value);
 		}
 		ParseResult pr = checkSeparatorsAndNonEmpty(',', activeValue);
 		if (!pr.passed())
@@ -168,7 +168,7 @@ public class RemoveFeatToken extends AbstractNonEmptyToken<CDOMObject> implement
 				if (className.isEmpty())
 				{
 					return new ParseResult.Fail(getTokenName()
-							+ " must have Class name after " + token, context);
+							+ " must have Class name after " + token);
 				}
 				CDOMSingleRef<PCClass> pcc = context.getReferenceContext().getCDOMReference(
 						PCCLASS_CLASS, className);
@@ -184,7 +184,7 @@ public class RemoveFeatToken extends AbstractNonEmptyToken<CDOMObject> implement
 				{
 					return new ParseResult.Fail("  Error was encountered while parsing "
 							+ getTokenName() + ": " + value
-							+ " had an invalid reference: " + token, context);
+							+ " had an invalid reference: " + token);
 				}
 			}
 			if (ab != null)
@@ -196,7 +196,7 @@ public class RemoveFeatToken extends AbstractNonEmptyToken<CDOMObject> implement
 		if (foundAny && foundOther)
 		{
 			return new ParseResult.Fail("Non-sensical " + getFullName()
-					+ ": Contains ANY and a specific reference: " + value, context);
+					+ ": Contains ANY and a specific reference: " + value);
 		}
 
 		if (!refs.isEmpty())
@@ -208,7 +208,7 @@ public class RemoveFeatToken extends AbstractNonEmptyToken<CDOMObject> implement
 		if (pcs.isEmpty())
 		{
 			return new ParseResult.Fail("Internal Error: " + getFullName()
-					+ " did not have any references: " + value, context);
+					+ " did not have any references: " + value);
 		}
 		PrimitiveChoiceSet<CNAbilitySelection> ascs;
 		if (pcs.size() == 1)

--- a/code/src/java/plugin/lsttokens/deprecated/RemoveLst.java
+++ b/code/src/java/plugin/lsttokens/deprecated/RemoveLst.java
@@ -43,7 +43,7 @@ public class RemoveLst extends AbstractNonEmptyToken<CDOMObject> implements
 		if (pipeLoc == -1)
 		{
 			return new ParseResult.Fail(getTokenName()
-					+ " requires a SubToken", context);
+					+ " requires a SubToken");
 		}
 		String key = value.substring(0, pipeLoc);
 		return context.processSubToken(obj, getTokenName(), key, value.substring(pipeLoc + 1));

--- a/code/src/java/plugin/lsttokens/deprecated/TemplateChooseLangautoToken.java
+++ b/code/src/java/plugin/lsttokens/deprecated/TemplateChooseLangautoToken.java
@@ -60,8 +60,7 @@ public class TemplateChooseLangautoToken extends
 			{
 				Logging.replayParsedMessages();
 				return new ParseResult.Fail(
-					"Internal Error in delegation of CHOOSE:LANGAUTO to CHOOSE:LANG",
-					context);
+					"Internal Error in delegation of CHOOSE:LANGAUTO to CHOOSE:LANG");
 			}
 		}
 		catch (PersistenceLayerException e)
@@ -69,7 +68,7 @@ public class TemplateChooseLangautoToken extends
 			Logging.replayParsedMessages();
 			return new ParseResult.Fail(
 				"Error in delegation of CHOOSE:LANGAUTO to CHOOSE:LANG: "
-					+ e.getLocalizedMessage(), context);
+					+ e.getLocalizedMessage());
 		}
 		try
 		{
@@ -77,8 +76,7 @@ public class TemplateChooseLangautoToken extends
 			{
 				Logging.replayParsedMessages();
 				return new ParseResult.Fail(
-					"Internal Error in delegation of CHOOSE:LANGAUTO to AUTO:LANG",
-					context);
+					"Internal Error in delegation of CHOOSE:LANGAUTO to AUTO:LANG");
 			}
 		}
 		catch (PersistenceLayerException e)
@@ -86,7 +84,7 @@ public class TemplateChooseLangautoToken extends
 			Logging.replayParsedMessages();
 			return new ParseResult.Fail(
 				"Error in delegation of CHOOSE:LANGAUTO to AUTO:LANG: "
-					+ e.getLocalizedMessage(), context);
+					+ e.getLocalizedMessage());
 		}
 		return ParseResult.SUCCESS;
 	}

--- a/code/src/java/plugin/lsttokens/deprecated/TemplateFeatToken.java
+++ b/code/src/java/plugin/lsttokens/deprecated/TemplateFeatToken.java
@@ -95,7 +95,7 @@ public class TemplateFeatToken extends AbstractTokenWithSeparator<PCTemplate> im
 				if (!first)
 				{
 					return new ParseResult.Fail("  Non-sensical " + getTokenName()
-							+ ": .CLEAR was not the first list item: " + value, context);
+							+ ": .CLEAR was not the first list item: " + value);
 				}
 			}
 			else

--- a/code/src/java/plugin/lsttokens/domain/CcskillToken.java
+++ b/code/src/java/plugin/lsttokens/domain/CcskillToken.java
@@ -79,7 +79,7 @@ public class CcskillToken extends AbstractTokenWithSeparator<Domain> implements
 				{
 					return new ParseResult.Fail("  Non-sensical "
 							+ getTokenName()
-							+ ": .CLEAR was not the first list item", context);
+							+ ": .CLEAR was not the first list item");
 				}
 				context.getObjectContext().removeList(obj,
 						ListKey.LOCALCCSKILL);
@@ -106,7 +106,7 @@ public class CcskillToken extends AbstractTokenWithSeparator<Domain> implements
 					{
 						return new ParseResult.Fail(
 								"  Error was encountered while parsing "
-										+ getTokenName(), context);
+										+ getTokenName());
 					}
 					context.getObjectContext().removeFromList(obj,
 							ListKey.LOCALCCSKILL, ref);
@@ -143,7 +143,7 @@ public class CcskillToken extends AbstractTokenWithSeparator<Domain> implements
 						{
 							return new ParseResult.Fail(
 									"  Error was encountered while parsing "
-											+ getTokenName(), context);
+											+ getTokenName());
 						}
 						context.getObjectContext().addToList(obj,
 								ListKey.LOCALCCSKILL, ref);
@@ -155,7 +155,7 @@ public class CcskillToken extends AbstractTokenWithSeparator<Domain> implements
 		if (foundAny && foundOther)
 		{
 			return new ParseResult.Fail("Non-sensical " + getTokenName()
-					+ ": Contains ANY and a specific reference: " + value, context);
+					+ ": Contains ANY and a specific reference: " + value);
 		}
 		return ParseResult.SUCCESS;
 	}

--- a/code/src/java/plugin/lsttokens/domain/CskillToken.java
+++ b/code/src/java/plugin/lsttokens/domain/CskillToken.java
@@ -78,7 +78,7 @@ public class CskillToken extends AbstractTokenWithSeparator<Domain> implements
 				{
 					return new ParseResult.Fail("  Non-sensical "
 							+ getTokenName()
-							+ ": .CLEAR was not the first list item", context);
+							+ ": .CLEAR was not the first list item");
 				}
 				context.getObjectContext()
 						.removeList(obj, ListKey.LOCALCSKILL);
@@ -105,7 +105,7 @@ public class CskillToken extends AbstractTokenWithSeparator<Domain> implements
 					{
 						return new ParseResult.Fail(
 								"  Error was encountered while parsing "
-										+ getTokenName(), context);
+										+ getTokenName());
 					}
 					context.getObjectContext().removeFromList(obj,
 							ListKey.LOCALCSKILL, ref);
@@ -142,7 +142,7 @@ public class CskillToken extends AbstractTokenWithSeparator<Domain> implements
 						{
 							return new ParseResult.Fail(
 									"  Error was encountered while parsing "
-											+ getTokenName(), context);
+											+ getTokenName());
 						}
 						context.getObjectContext().addToList(obj,
 								ListKey.LOCALCSKILL, ref);
@@ -154,7 +154,7 @@ public class CskillToken extends AbstractTokenWithSeparator<Domain> implements
 		if (foundAny && foundOther)
 		{
 			return new ParseResult.Fail("Non-sensical " + getTokenName()
-					+ ": Contains ANY and a specific reference: " + value, context);
+					+ ": Contains ANY and a specific reference: " + value);
 		}
 		return ParseResult.SUCCESS;
 	}

--- a/code/src/java/plugin/lsttokens/equipment/AccheckToken.java
+++ b/code/src/java/plugin/lsttokens/equipment/AccheckToken.java
@@ -63,8 +63,7 @@ public class AccheckToken extends AbstractIntToken<Equipment> implements
 		if (ControlUtilities.hasControlToken(context, CControl.EQACCHECK))
 		{
 			return new ParseResult.Fail(getTokenName()
-				+ " is disabled when EQACCHECK control is used: " + value,
-				context);
+				+ " is disabled when EQACCHECK control is used: " + value);
 		}
 		return super.parseToken(context, obj, value);
 	}

--- a/code/src/java/plugin/lsttokens/equipment/AltcritmultToken.java
+++ b/code/src/java/plugin/lsttokens/equipment/AltcritmultToken.java
@@ -47,8 +47,7 @@ public class AltcritmultToken extends AbstractNonEmptyToken<Equipment>
 		if (ControlUtilities.hasControlToken(context, CControl.CRITMULT))
 		{
 			return new ParseResult.Fail(getTokenName()
-				+ " is disabled when CRITMULT control is used: " + value,
-				context);
+				+ " is disabled when CRITMULT control is used: " + value);
 		}
 		Integer cm = null;
 		if ((!value.isEmpty()) && (value.charAt(0) == 'x'))
@@ -58,13 +57,13 @@ public class AltcritmultToken extends AbstractNonEmptyToken<Equipment>
 				cm = Integer.valueOf(value.substring(1));
 				if (cm.intValue() <= 0)
 				{
-					return new ParseResult.Fail(getTokenName() + " cannot be <= 0", context);
+					return new ParseResult.Fail(getTokenName() + " cannot be <= 0");
 				}
 			}
 			catch (NumberFormatException nfe)
 			{
 				return new ParseResult.Fail(getTokenName()
-						+ " was expecting an Integer: " + value, context);
+						+ " was expecting an Integer: " + value);
 			}
 		}
 		else if ("-".equals(value))
@@ -75,7 +74,7 @@ public class AltcritmultToken extends AbstractNonEmptyToken<Equipment>
 		{
 			return new ParseResult.Fail(getTokenName()
 					+ " was expecting x followed by an integer "
-					+ "or the special value '-' (representing no value)", context);
+					+ "or the special value '-' (representing no value)");
 		}
 		EquipmentHead altHead = eq.getEquipmentHead(2);
 		context.getObjectContext().put(altHead, IntegerKey.CRIT_MULT, cm);

--- a/code/src/java/plugin/lsttokens/equipment/AltcritrangeToken.java
+++ b/code/src/java/plugin/lsttokens/equipment/AltcritrangeToken.java
@@ -45,15 +45,14 @@ public class AltcritrangeToken implements CDOMPrimaryToken<Equipment>
 		if (ControlUtilities.hasControlToken(context, CControl.CRITRANGE))
 		{
 			return new ParseResult.Fail(getTokenName()
-				+ " is disabled when CRITRANGE control is used: " + value,
-				context);
+				+ " is disabled when CRITRANGE control is used: " + value);
 		}
 		try
 		{
 			Integer cr = Integer.valueOf(value);
 			if (cr.intValue() < 0)
 			{
-				return new ParseResult.Fail(getTokenName() + " cannot be < 0", context);
+				return new ParseResult.Fail(getTokenName() + " cannot be < 0");
 			}
 			context.getObjectContext().put(eq.getEquipmentHead(2),
 					IntegerKey.CRIT_RANGE, cr);
@@ -63,7 +62,7 @@ public class AltcritrangeToken implements CDOMPrimaryToken<Equipment>
 		{
 			return new ParseResult.Fail(getTokenName()
 					+ " expected an integer. " + "Tag must be of the form: "
-					+ getTokenName() + ":<int>", context);
+					+ getTokenName() + ":<int>");
 		}
 	}
 

--- a/code/src/java/plugin/lsttokens/equipment/AltdamageToken.java
+++ b/code/src/java/plugin/lsttokens/equipment/AltdamageToken.java
@@ -51,7 +51,7 @@ public class AltdamageToken extends AbstractNonEmptyToken<Equipment> implements
 			if (!StringUtils.isBlank(errorMessage))
 			{
 				return new ParseResult.Fail(getTokenName()
-						+ " is invalid: " + errorMessage, context);
+						+ " is invalid: " + errorMessage);
 			}
 		}
 		context.getObjectContext().put(eq.getEquipmentHead(2),

--- a/code/src/java/plugin/lsttokens/equipment/AlttypeToken.java
+++ b/code/src/java/plugin/lsttokens/equipment/AlttypeToken.java
@@ -65,7 +65,7 @@ public class AlttypeToken extends AbstractNonEmptyToken<Equipment> implements
 				{
 					return new ParseResult.Fail(getTokenName()
 						+ "started with .CLEAR. but expected to have a Type after .: "
-						+ value, context);
+						+ value);
 				}
 			}
 			else
@@ -73,7 +73,7 @@ public class AlttypeToken extends AbstractNonEmptyToken<Equipment> implements
 				return new ParseResult.Fail(
 					getTokenName()
 						+ "started with .CLEAR but expected next character to be .: "
-						+ value, context);
+						+ value);
 			}
 		}
 		ParseResult pr = checkForIllegalSeparator('.', value);
@@ -94,7 +94,7 @@ public class AlttypeToken extends AbstractNonEmptyToken<Equipment> implements
 				if (bRemove)
 				{
 					return new ParseResult.Fail("Non-sensical use of .REMOVE.ADD. in "
-									+ getTokenName() + ": " + value, context);
+									+ getTokenName() + ": " + value);
 				}
 				bRemove = false;
 				bAdd = true;
@@ -104,14 +104,14 @@ public class AlttypeToken extends AbstractNonEmptyToken<Equipment> implements
 				if (bAdd)
 				{
 					return new ParseResult.Fail("Non-sensical use of .ADD.REMOVE. in "
-									+ getTokenName() + ": " + value, context);
+									+ getTokenName() + ": " + value);
 				}
 				bRemove = true;
 			}
 			else if ("CLEAR".equals(aType))
 			{
 				return new ParseResult.Fail("Non-sensical use of .CLEAR in "
-						+ getTokenName() + ": " + value, context);
+						+ getTokenName() + ": " + value);
 			}
 			else if (bRemove)
 			{
@@ -131,13 +131,13 @@ public class AlttypeToken extends AbstractNonEmptyToken<Equipment> implements
 		{
 			return new ParseResult.Fail(getTokenName()
 					+ "ended with REMOVE, so didn't have any Type to remove: "
-					+ value, context);
+					+ value);
 		}
 		if (bAdd)
 		{
 			return new ParseResult.Fail(getTokenName()
 					+ "ended with ADD, so didn't have any Type to add: "
-					+ value, context);
+					+ value);
 		}
 		return ParseResult.SUCCESS;
 	}

--- a/code/src/java/plugin/lsttokens/equipment/ContainsToken.java
+++ b/code/src/java/plugin/lsttokens/equipment/ContainsToken.java
@@ -75,7 +75,7 @@ public class ContainsToken extends AbstractTokenWithSeparator<Equipment>
 		if (percentLoc != weightCapacity.lastIndexOf(Constants.PERCENT))
 		{
 			return new ParseResult.Fail("Cannot have two weight reduction "
-							+ "characters (indicated by %): " + value, context);
+							+ "characters (indicated by %): " + value);
 		}
 		if (percentLoc != -1)
 		{
@@ -83,7 +83,7 @@ public class ContainsToken extends AbstractTokenWithSeparator<Equipment>
 			{
 				return new ParseResult.Fail("Cannot have Constant Weight (indicated by *) "
 								+ "and weight reduction (indicated by %): "
-								+ value, context);
+								+ value);
 			}
 			String redString = weightCapacity.substring(0, percentLoc);
 			weightCapacity = weightCapacity.substring(percentLoc + 1);
@@ -97,7 +97,7 @@ public class ContainsToken extends AbstractTokenWithSeparator<Equipment>
 			catch (NumberFormatException ex)
 			{
 				return new ParseResult.Fail("Weight Reduction (indicated by %) must be an integer: "
-								+ value, context);
+								+ value);
 			}
 		}
 
@@ -116,13 +116,13 @@ public class ContainsToken extends AbstractTokenWithSeparator<Equipment>
 				{
 					return new ParseResult.Fail(
 						"Weight Capacity must be >= 0: " + weightCapacity
-							+ "\n  Use 'UNLIM' (not -1) for unlimited Count", context);
+							+ "\n  Use 'UNLIM' (not -1) for unlimited Count");
 				}
 			}
 			catch (NumberFormatException ex)
 			{
 				return new ParseResult.Fail("Weight Capacity must be 'UNLIM or a number >= 0: "
-								+ weightCapacity, context);
+								+ weightCapacity);
 			}
 		}
 		context.getObjectContext().put(eq, ObjectKey.CONTAINER_WEIGHT_CAPACITY,
@@ -144,7 +144,7 @@ public class ContainsToken extends AbstractTokenWithSeparator<Equipment>
 			int equalLoc = typeString.indexOf(Constants.EQUALS);
 			if (equalLoc != typeString.lastIndexOf(Constants.EQUALS))
 			{
-				return new ParseResult.Fail("Two many = signs", context);
+				return new ParseResult.Fail("Two many = signs");
 			}
 			if (equalLoc == -1)
 			{
@@ -173,12 +173,12 @@ public class ContainsToken extends AbstractTokenWithSeparator<Equipment>
 					{
 						return new ParseResult.Fail("Item Number for " + itemType
 										+ " must be 'UNLIM' or a number > 0: "
-										+ itemNumString, context);
+										+ itemNumString);
 					}
 					if (BigDecimal.ZERO.compareTo(itemNumber) >= 0)
 					{
 						return new ParseResult.Fail("Cannot have negative quantity of "
-							+ itemType + ": " + value, context);
+							+ itemType + ": " + value);
 					}
 				}
 				if (limited)

--- a/code/src/java/plugin/lsttokens/equipment/CostToken.java
+++ b/code/src/java/plugin/lsttokens/equipment/CostToken.java
@@ -60,7 +60,7 @@ public class CostToken extends AbstractNonEmptyToken<Equipment> implements
 		}
 		catch (NumberFormatException e)
 		{
-			return new ParseResult.Fail(getTokenName() + " expected a number: " + value, context);
+			return new ParseResult.Fail(getTokenName() + " expected a number: " + value);
 		}
 	}
 

--- a/code/src/java/plugin/lsttokens/equipment/CritmultToken.java
+++ b/code/src/java/plugin/lsttokens/equipment/CritmultToken.java
@@ -46,8 +46,7 @@ public class CritmultToken extends AbstractNonEmptyToken<Equipment> implements
 		if (ControlUtilities.hasControlToken(context, CControl.CRITMULT))
 		{
 			return new ParseResult.Fail(getTokenName()
-				+ " is disabled when CRITMULT control is used: " + value,
-				context);
+				+ " is disabled when CRITMULT control is used: " + value);
 		}
 		Integer cm = null;
 		if ((!value.isEmpty()) && (value.charAt(0) == 'x'))
@@ -57,13 +56,13 @@ public class CritmultToken extends AbstractNonEmptyToken<Equipment> implements
 				cm = Integer.valueOf(value.substring(1));
 				if (cm.intValue() <= 0)
 				{
-					return new ParseResult.Fail(getTokenName() + " cannot be <= 0", context);
+					return new ParseResult.Fail(getTokenName() + " cannot be <= 0");
 				}
 			}
 			catch (NumberFormatException nfe)
 			{
 				return new ParseResult.Fail(getTokenName()
-						+ " was expecting an Integer: " + value, context);
+						+ " was expecting an Integer: " + value);
 			}
 		}
 		else if ("-".equals(value))
@@ -74,7 +73,7 @@ public class CritmultToken extends AbstractNonEmptyToken<Equipment> implements
 		{
 			return new ParseResult.Fail(getTokenName()
 					+ " was expecting x followed by an integer "
-					+ "or the special value '-' (representing no value)", context);
+					+ "or the special value '-' (representing no value)");
 		}
 		EquipmentHead primHead = eq.getEquipmentHead(1);
 		context.getObjectContext().put(primHead, IntegerKey.CRIT_MULT, cm);

--- a/code/src/java/plugin/lsttokens/equipment/CritrangeToken.java
+++ b/code/src/java/plugin/lsttokens/equipment/CritrangeToken.java
@@ -45,8 +45,7 @@ public class CritrangeToken implements CDOMPrimaryToken<Equipment>
 		if (ControlUtilities.hasControlToken(context, CControl.CRITRANGE))
 		{
 			return new ParseResult.Fail(getTokenName()
-				+ " is disabled when CRITRANGE control is used: " + value,
-				context);
+				+ " is disabled when CRITRANGE control is used: " + value);
 		}
 		try
 		{
@@ -54,7 +53,7 @@ public class CritrangeToken implements CDOMPrimaryToken<Equipment>
 			if (cr.intValue() < 0)
 			{
 				return new ParseResult.Fail(getTokenName()
-						+ " cannot be < 0", context);
+						+ " cannot be < 0");
 			}
 			context.getObjectContext().put(eq.getEquipmentHead(1),
 					IntegerKey.CRIT_RANGE, cr);
@@ -64,7 +63,7 @@ public class CritrangeToken implements CDOMPrimaryToken<Equipment>
 		{
 			return new ParseResult.Fail(getTokenName()
 					+ " expected an integer. " + "Tag must be of the form: "
-					+ getTokenName() + ":<int>", context);
+					+ getTokenName() + ":<int>");
 		}
 	}
 

--- a/code/src/java/plugin/lsttokens/equipment/DamageToken.java
+++ b/code/src/java/plugin/lsttokens/equipment/DamageToken.java
@@ -50,7 +50,7 @@ public class DamageToken extends AbstractNonEmptyToken<Equipment> implements
 			if (!StringUtils.isBlank(errorMessage))
 			{
 				return new ParseResult.Fail(getTokenName()
-						+ " is invalid: " + errorMessage, context);
+						+ " is invalid: " + errorMessage);
 			}
 		}
 		context.getObjectContext().put(eq.getEquipmentHead(1),

--- a/code/src/java/plugin/lsttokens/equipment/EdrToken.java
+++ b/code/src/java/plugin/lsttokens/equipment/EdrToken.java
@@ -64,8 +64,7 @@ public class EdrToken extends AbstractIntToken<Equipment> implements
 		if (ControlUtilities.hasControlToken(context, CControl.EDR))
 		{
 			return new ParseResult.Fail(getTokenName()
-				+ " is disabled when EDR control is used: " + value,
-				context);
+				+ " is disabled when EDR control is used: " + value);
 		}
 		return super.parseToken(context, obj, value);
 	}

--- a/code/src/java/plugin/lsttokens/equipment/FumblerangeToken.java
+++ b/code/src/java/plugin/lsttokens/equipment/FumblerangeToken.java
@@ -50,8 +50,7 @@ public class FumblerangeToken extends AbstractNonEmptyToken<Equipment>
 		if (ControlUtilities.hasControlToken(context, CControl.FUMBLERANGE))
 		{
 			return new ParseResult.Fail(getTokenName()
-				+ " is disabled when FUMBLERANGE control is used: " + value,
-				context);
+				+ " is disabled when FUMBLERANGE control is used: " + value);
 		}
 		if (Constants.LST_DOT_CLEAR.equals(value))
 		{

--- a/code/src/java/plugin/lsttokens/equipment/IconToken.java
+++ b/code/src/java/plugin/lsttokens/equipment/IconToken.java
@@ -51,7 +51,7 @@ public class IconToken extends AbstractNonEmptyToken<Equipment> implements
 		URI uri = new URIFactory(eq.getSourceURI(), value).getURI();
 		if (uri == URIFactory.FAILED_URI)
 		{
-			return new ParseResult.Fail(getTokenName() + " must be a valid URI.", context);
+			return new ParseResult.Fail(getTokenName() + " must be a valid URI.");
 		}
 		context.getObjectContext().put(eq, StringKey.ICON, value);
 		context.getObjectContext().put(eq, ObjectKey.ICON_URI, uri);

--- a/code/src/java/plugin/lsttokens/equipment/MaxdexToken.java
+++ b/code/src/java/plugin/lsttokens/equipment/MaxdexToken.java
@@ -58,8 +58,7 @@ public class MaxdexToken extends AbstractIntToken<Equipment> implements
 		if (ControlUtilities.hasControlToken(context, CControl.EQMAXDEX))
 		{
 			return new ParseResult.Fail(getTokenName()
-				+ " is disabled when MAXDEX control is used: " + value,
-				context);
+				+ " is disabled when MAXDEX control is used: " + value);
 		}
 		return super.parseToken(context, obj, value);
 	}

--- a/code/src/java/plugin/lsttokens/equipment/ModsToken.java
+++ b/code/src/java/plugin/lsttokens/equipment/ModsToken.java
@@ -50,7 +50,7 @@ public class ModsToken extends AbstractNonEmptyToken<Equipment> implements
 		catch (IllegalArgumentException iae)
 		{
 			return new ParseResult.Fail("Invalid Mod Control provided in "
-					+ getTokenName() + ": " + value, context);
+					+ getTokenName() + ": " + value);
 		}
 		context.getObjectContext().put(eq, ObjectKey.MOD_CONTROL, ctrl);
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/equipment/PageUsageToken.java
+++ b/code/src/java/plugin/lsttokens/equipment/PageUsageToken.java
@@ -51,7 +51,7 @@ public class PageUsageToken extends AbstractNonEmptyToken<Equipment> implements
 		if (!formula.isValid())
 		{
 			return new ParseResult.Fail("Formula in " + getTokenName()
-					+ " was not valid: " + formula.toString(), context);
+					+ " was not valid: " + formula.toString());
 		}
 		context.getObjectContext().put(eq, FormulaKey.PAGE_USAGE, formula);
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/equipment/ProficiencyToken.java
+++ b/code/src/java/plugin/lsttokens/equipment/ProficiencyToken.java
@@ -53,20 +53,20 @@ public class ProficiencyToken extends AbstractNonEmptyToken<Equipment>
 		if (pipeLoc == -1)
 		{
 			return new ParseResult.Fail("Equipment Token PROFICIENCY syntax "
-				+ "without a Subtoken is invalid: PROFICIENCY:" + value, context);
+				+ "without a Subtoken is invalid: PROFICIENCY:" + value);
 		}
 		if (pipeLoc != value.lastIndexOf(Constants.PIPE))
 		{
 			return new ParseResult.Fail(getTokenName()
 					+ " expecting only one '|', "
-					+ "format is: SubToken|ProfName value was: " + value, context);
+					+ "format is: SubToken|ProfName value was: " + value);
 		}
 		String subtoken = value.substring(0, pipeLoc);
 		String prof = value.substring(pipeLoc + 1);
 		if (prof == null || prof.isEmpty())
 		{
 			return new ParseResult.Fail("PROFICIENCY cannot have "
-				+ "empty second argument: " + value, context);
+				+ "empty second argument: " + value);
 		}
 		if (subtoken.equals("WEAPON"))
 		{

--- a/code/src/java/plugin/lsttokens/equipment/QualityToken.java
+++ b/code/src/java/plugin/lsttokens/equipment/QualityToken.java
@@ -51,24 +51,24 @@ public class QualityToken extends AbstractNonEmptyToken<Equipment> implements
 		if (pipeLoc == -1)
 		{
 			return new ParseResult.Fail(getTokenName() + " expecting '|', format is: "
-					+ "QualityType|Quality value was: " + value, context);
+					+ "QualityType|Quality value was: " + value);
 		}
 		if (pipeLoc != value.lastIndexOf(Constants.PIPE))
 		{
 			return new ParseResult.Fail(getTokenName() + " expecting only one '|', "
-					+ "format is: QualityType|Quality value was: " + value, context);
+					+ "format is: QualityType|Quality value was: " + value);
 		}
 		String key = value.substring(0, pipeLoc);
 		if (key.isEmpty())
 		{
 			return new ParseResult.Fail(getTokenName() + " expecting non-empty type, "
-					+ "format is: QualityType|Quality value was: " + value, context);
+					+ "format is: QualityType|Quality value was: " + value);
 		}
 		String val = value.substring(pipeLoc + 1);
 		if (val.isEmpty())
 		{
 			return new ParseResult.Fail(getTokenName() + " expecting non-empty value, "
-					+ "format is: QualityType|Quality value was: " + value, context);
+					+ "format is: QualityType|Quality value was: " + value);
 		}
 		context.getObjectContext().put(eq, MapKey.QUALITY, key, val);
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/equipment/ReachMultToken.java
+++ b/code/src/java/plugin/lsttokens/equipment/ReachMultToken.java
@@ -62,8 +62,7 @@ public class ReachMultToken extends AbstractIntToken<Equipment> implements
 		if (ControlUtilities.hasControlToken(context, CControl.EQREACH))
 		{
 			return new ParseResult.Fail(getTokenName()
-				+ " is disabled when EQREACH control is used: " + value,
-				context);
+				+ " is disabled when EQREACH control is used: " + value);
 		}
 		return super.parseToken(context, obj, value);
 	}

--- a/code/src/java/plugin/lsttokens/equipment/ReachToken.java
+++ b/code/src/java/plugin/lsttokens/equipment/ReachToken.java
@@ -63,8 +63,7 @@ public class ReachToken extends AbstractIntToken<Equipment> implements
 		if (ControlUtilities.hasControlToken(context, CControl.EQREACH))
 		{
 			return new ParseResult.Fail(getTokenName()
-				+ " is disabled when EQREACH control is used: " + value,
-				context);
+				+ " is disabled when EQREACH control is used: " + value);
 		}
 		return super.parseToken(context, obj, value);
 	}

--- a/code/src/java/plugin/lsttokens/equipment/SpellfailureToken.java
+++ b/code/src/java/plugin/lsttokens/equipment/SpellfailureToken.java
@@ -82,8 +82,7 @@ public class SpellfailureToken extends AbstractIntToken<Equipment> implements
 		if (ControlUtilities.hasControlToken(context, CControl.EQSPELLFAILURE))
 		{
 			return new ParseResult.Fail(getTokenName()
-				+ " is disabled when EQSPELLFAILURE control is used: " + value,
-				context);
+				+ " is disabled when EQSPELLFAILURE control is used: " + value);
 		}
 		return super.parseToken(context, obj, value);
 	}

--- a/code/src/java/plugin/lsttokens/equipment/WieldToken.java
+++ b/code/src/java/plugin/lsttokens/equipment/WieldToken.java
@@ -53,7 +53,7 @@ public class WieldToken extends AbstractNonEmptyToken<Equipment> implements
 		if (wc == null)
 		{
 			return new ParseResult.Fail("In " + getTokenName()
-					+ " unable to find WieldCategory for " + value, context);
+					+ " unable to find WieldCategory for " + value);
 		}
 		context.getObjectContext().put(eq, ObjectKey.WIELD, wc);
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/equipment/WtToken.java
+++ b/code/src/java/plugin/lsttokens/equipment/WtToken.java
@@ -53,7 +53,7 @@ public class WtToken extends AbstractNonEmptyToken<Equipment> implements
 			if (weight.compareTo(BigDecimal.ZERO) < 0)
 			{
 				return new ParseResult.Fail(getTokenName()
-						+ " was expecting a decimal value >= 0 : " + value, context);
+						+ " was expecting a decimal value >= 0 : " + value);
 			}
 			context.getObjectContext().put(eq, ObjectKey.WEIGHT, weight);
 			return ParseResult.SUCCESS;
@@ -61,7 +61,7 @@ public class WtToken extends AbstractNonEmptyToken<Equipment> implements
 		catch (NumberFormatException nfe)
 		{
 			return new ParseResult.Fail("Expected a Double for "
-					+ getTokenName() + ": " + value, context);
+					+ getTokenName() + ": " + value);
 		}
 	}
 

--- a/code/src/java/plugin/lsttokens/equipmentmodifier/ArmortypeToken.java
+++ b/code/src/java/plugin/lsttokens/equipmentmodifier/ArmortypeToken.java
@@ -59,13 +59,13 @@ public class ArmortypeToken extends
 		if (pipeLoc == -1)
 		{
 			return new ParseResult.Fail(getTokenName()
-					+ " has no PIPE character: Must be of the form old|new", context);
+					+ " has no PIPE character: Must be of the form old|new");
 		}
 		else if (pipeLoc != value.lastIndexOf(Constants.PIPE))
 		{
 			return new ParseResult.Fail(getTokenName()
 					+ " has too many PIPE characters: "
-					+ "Must be of the form old|new", context);
+					+ "Must be of the form old|new");
 		}
 		else
 		{

--- a/code/src/java/plugin/lsttokens/equipmentmodifier/BonusToken.java
+++ b/code/src/java/plugin/lsttokens/equipmentmodifier/BonusToken.java
@@ -50,7 +50,7 @@ public class BonusToken implements CDOMPrimaryToken<EquipmentModifier>
 		if (bon == null)
 		{
 			return new ParseResult.Fail(getTokenName() + " was given invalid bonus: "
-					+ value, context);
+					+ value);
 		}
 		bon.setTokenSource(getTokenName());
 		context.getObjectContext().addToList(mod, ListKey.BONUS, bon);

--- a/code/src/java/plugin/lsttokens/equipmentmodifier/ChargesToken.java
+++ b/code/src/java/plugin/lsttokens/equipmentmodifier/ChargesToken.java
@@ -47,13 +47,13 @@ public class ChargesToken extends AbstractNonEmptyToken<EquipmentModifier>
 		{
 			return new ParseResult.Fail(getTokenName()
 							+ " has no | : must be of format <min charges>|<max charges>: "
-							+ value, context);
+							+ value);
 		}
 		if (value.lastIndexOf(Constants.PIPE) != pipeLoc)
 		{
 			return new ParseResult.Fail(getTokenName()
 							+ " has two | : must be of format <min charges>|<max charges>: "
-							+ value, context);
+							+ value);
 		}
 		String minChargeString = value.substring(0, pipeLoc);
 		int minCharges;
@@ -63,13 +63,13 @@ public class ChargesToken extends AbstractNonEmptyToken<EquipmentModifier>
 			if (minCharges < 0)
 			{
 				return new ParseResult.Fail(getTokenName()
-						+ " min charges must be >= zero: " + value, context);
+						+ " min charges must be >= zero: " + value);
 			}
 		}
 		catch (NumberFormatException nfe)
 		{
 			return new ParseResult.Fail(getTokenName()
-					+ " min charges is not an integer: " + value, context);
+					+ " min charges is not an integer: " + value);
 		}
 
 		String maxChargeString = value.substring(pipeLoc + 1);
@@ -85,13 +85,13 @@ public class ChargesToken extends AbstractNonEmptyToken<EquipmentModifier>
 		catch (NumberFormatException nfe)
 		{
 			return new ParseResult.Fail(getTokenName()
-					+ " max charges is not an integer: " + value, context);
+					+ " max charges is not an integer: " + value);
 		}
 
 		if (minCharges > maxCharges)
 		{
 			return new ParseResult.Fail(getTokenName()
-					+ " max charges must be >= min charges: " + value, context);
+					+ " max charges must be >= min charges: " + value);
 		}
 
 		context.getObjectContext().put(mod, IntegerKey.MIN_CHARGES,

--- a/code/src/java/plugin/lsttokens/equipmentmodifier/CostToken.java
+++ b/code/src/java/plugin/lsttokens/equipmentmodifier/CostToken.java
@@ -47,7 +47,7 @@ public class CostToken extends AbstractNonEmptyToken<EquipmentModifier>
 		if (!formula.isValid())
 		{
 			return new ParseResult.Fail("Formula in " + getTokenName()
-					+ " was not valid: " + formula.toString(), context);
+					+ " was not valid: " + formula.toString());
 		}
 		context.getObjectContext().put(mod, FormulaKey.COST, formula);
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/equipmentmodifier/CostpreToken.java
+++ b/code/src/java/plugin/lsttokens/equipmentmodifier/CostpreToken.java
@@ -47,7 +47,7 @@ public class CostpreToken extends AbstractNonEmptyToken<EquipmentModifier>
 		if (!formula.isValid())
 		{
 			return new ParseResult.Fail("Formula in " + getTokenName()
-					+ " was not valid: " + formula.toString(), context);
+					+ " was not valid: " + formula.toString());
 		}
 		context.getObjectContext().put(mod, FormulaKey.BASECOST, formula);
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/equipmentmodifier/FormatcatToken.java
+++ b/code/src/java/plugin/lsttokens/equipmentmodifier/FormatcatToken.java
@@ -53,7 +53,7 @@ public class FormatcatToken extends AbstractNonEmptyToken<EquipmentModifier>
 		catch (IllegalArgumentException iae)
 		{
 			return new ParseResult.Fail("Invalid Format provided in " + getTokenName()
-					+ ": " + value, context);
+					+ ": " + value);
 		}
 		return ParseResult.SUCCESS;
 	}

--- a/code/src/java/plugin/lsttokens/equipmentmodifier/FumblerangeToken.java
+++ b/code/src/java/plugin/lsttokens/equipmentmodifier/FumblerangeToken.java
@@ -58,8 +58,7 @@ public class FumblerangeToken extends AbstractStringToken<EquipmentModifier>
 		if (ControlUtilities.hasControlToken(context, CControl.FUMBLERANGE))
 		{
 			return new ParseResult.Fail(getTokenName()
-				+ " is disabled when FUMBLERANGE control is used: " + value,
-				context);
+				+ " is disabled when FUMBLERANGE control is used: " + value);
 		}
 		return super.parseNonEmptyToken(context, obj, value);
 	}

--- a/code/src/java/plugin/lsttokens/equipmentmodifier/ItypeToken.java
+++ b/code/src/java/plugin/lsttokens/equipmentmodifier/ItypeToken.java
@@ -62,7 +62,7 @@ public class ItypeToken extends AbstractTokenWithSeparator<EquipmentModifier>
 			{
 				return new ParseResult.Fail(
 					"IType must not be double. Ignoring occurrence in "
-						+ getTokenName() + Constants.COLON + value, context);
+						+ getTokenName() + Constants.COLON + value);
 			}
 			else
 			{

--- a/code/src/java/plugin/lsttokens/equipmentmodifier/NameoptToken.java
+++ b/code/src/java/plugin/lsttokens/equipmentmodifier/NameoptToken.java
@@ -49,7 +49,7 @@ public class NameoptToken extends AbstractNonEmptyToken<EquipmentModifier>
 			if (optString.length() < 6 || optString.charAt(4) != '=')
 			{
 				return new ParseResult.Fail(getTokenName()
-						+ " has invalid TEXT argument: " + value, context);
+						+ " has invalid TEXT argument: " + value);
 			}
 			optString = "TEXT";
 			context.getObjectContext().put(mod, StringKey.NAME_TEXT,
@@ -64,7 +64,7 @@ public class NameoptToken extends AbstractNonEmptyToken<EquipmentModifier>
 		catch (IllegalArgumentException iae)
 		{
 			return new ParseResult.Fail("Invalid Naming Option provided in "
-					+ getTokenName() + ": " + value, context);
+					+ getTokenName() + ": " + value);
 		}
 	}
 

--- a/code/src/java/plugin/lsttokens/equipmentmodifier/VisibleToken.java
+++ b/code/src/java/plugin/lsttokens/equipmentmodifier/VisibleToken.java
@@ -60,7 +60,7 @@ public class VisibleToken extends AbstractNonEmptyToken<EquipmentModifier>
 		}
 		else
 		{
-			return new ParseResult.Fail("Can't understand Visibility: " + value, context);
+			return new ParseResult.Fail("Can't understand Visibility: " + value);
 		}
 		context.getObjectContext().put(eqm, ObjectKey.VISIBILITY, vis);
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/equipmentmodifier/choose/AbilityToken.java
+++ b/code/src/java/plugin/lsttokens/equipmentmodifier/choose/AbilityToken.java
@@ -49,33 +49,33 @@ public class AbilityToken implements CDOMSecondaryToken<EquipmentModifier>
 		if (value == null)
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " requires arguments", context);
+					+ " requires arguments");
 		}
 		if (value.indexOf('[') != -1)
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " arguments may not contain [] : " + value, context);
+					+ " arguments may not contain [] : " + value);
 		}
 		if (value.charAt(0) == '|')
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " arguments may not start with | : " + value, context);
+					+ " arguments may not start with | : " + value);
 		}
 		if (value.charAt(value.length() - 1) == '|')
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " arguments may not end with | : " + value, context);
+					+ " arguments may not end with | : " + value);
 		}
 		if (value.indexOf("||") != -1)
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " arguments uses double separator || : " + value, context);
+					+ " arguments uses double separator || : " + value);
 		}
 		int barLoc = value.indexOf('|');
 		if (barLoc == -1)
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " requires a CATEGORY and arguments : " + value, context);
+					+ " requires a CATEGORY and arguments : " + value);
 		}
 		String cat = value.substring(0, barLoc);
 		Category<Ability> category = context.getReferenceContext()
@@ -84,7 +84,7 @@ public class AbilityToken implements CDOMSecondaryToken<EquipmentModifier>
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
 							+ " found invalid CATEGORY: " + cat + " in value: "
-							+ value, context);
+							+ value);
 		}
 
 		StringBuilder sb = new StringBuilder(value.length() + 20);

--- a/code/src/java/plugin/lsttokens/equipmentmodifier/choose/EqBuilderEqTypeToken.java
+++ b/code/src/java/plugin/lsttokens/equipmentmodifier/choose/EqBuilderEqTypeToken.java
@@ -61,53 +61,53 @@ public class EqBuilderEqTypeToken implements
 		if (value.indexOf(',') != -1)
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " arguments may not contain , : " + value, context);
+					+ " arguments may not contain , : " + value);
 		}
 		if (value.indexOf('[') != -1)
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " arguments may not contain [] : " + value, context);
+					+ " arguments may not contain [] : " + value);
 		}
 		if (value.charAt(0) == '|')
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " arguments may not start with | : " + value, context);
+					+ " arguments may not start with | : " + value);
 		}
 		if (value.charAt(value.length() - 1) == '|')
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " arguments may not end with | : " + value, context);
+					+ " arguments may not end with | : " + value);
 		}
 		if (value.contains("||"))
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " arguments uses double separator || : " + value, context);
+					+ " arguments uses double separator || : " + value);
 		}
 		int pipeLoc = value.indexOf(Constants.PIPE);
 		if (pipeLoc == -1)
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
 							+ " must have two or more | delimited arguments : "
-							+ value, context);
+							+ value);
 		}
 		StringTokenizer tok = new StringTokenizer(value, Constants.PIPE);
 		if (tok.countTokens() != 2)
 		{
 			return new ParseResult.Fail("COUNT:" + getTokenName()
-					+ " requires two arguments: " + value, context);
+					+ " requires two arguments: " + value);
 		}
 		// New format: CHOOSE:EQBUILDER.EQTYPE|COUNT=ALL|TITLE=desired TYPE(s)
 		String first = tok.nextToken();
 		if (!first.startsWith("COUNT="))
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " must have COUNT= as its first argument : " + value, context);
+					+ " must have COUNT= as its first argument : " + value);
 		}
 		String second = tok.nextToken();
 		if (!second.startsWith("TITLE="))
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " must have TITLE= as its second argument : " + value, context);
+					+ " must have TITLE= as its second argument : " + value);
 		}
 		StringBuilder sb = new StringBuilder(value.length() + 20);
 		sb.append(first).append('|').append(second.substring(6));

--- a/code/src/java/plugin/lsttokens/equipmentmodifier/choose/EqBuilderSpellToken.java
+++ b/code/src/java/plugin/lsttokens/equipmentmodifier/choose/EqBuilderSpellToken.java
@@ -54,28 +54,28 @@ public class EqBuilderSpellToken implements
 		if (value.indexOf('[') != -1)
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " arguments may not contain [] : " + value, context);
+					+ " arguments may not contain [] : " + value);
 		}
 		if (value.charAt(0) == '|')
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " arguments may not start with | : " + value, context);
+					+ " arguments may not start with | : " + value);
 		}
 		if (value.charAt(value.length() - 1) == '|')
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " arguments may not end with | : " + value, context);
+					+ " arguments may not end with | : " + value);
 		}
 		if (value.indexOf("||") != -1)
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " arguments uses double separator || : " + value, context);
+					+ " arguments uses double separator || : " + value);
 		}
 		StringTokenizer tok = new StringTokenizer(value, Constants.PIPE);
 		if (tok.countTokens() != 3)
 		{
 			return new ParseResult.Fail("COUNT:" + getTokenName()
-					+ " requires three arguments: " + value, context);
+					+ " requires three arguments: " + value);
 		}
 		tok.nextToken();
 		if (tok.hasMoreTokens())
@@ -88,7 +88,7 @@ public class EqBuilderSpellToken implements
 			catch (NumberFormatException nfe)
 			{
 				return new ParseResult.Fail("CHOOSE:" + getTokenName()
-						+ " second argument must be an Integer : " + value, context);
+						+ " second argument must be an Integer : " + value);
 			}
 		}
 		if (tok.hasMoreTokens())
@@ -103,15 +103,14 @@ public class EqBuilderSpellToken implements
 				catch (NumberFormatException nfe)
 				{
 					return new ParseResult.Fail("CHOOSE:" + getTokenName()
-						+ " third argument must be an Integer or 'MAXLEVEL': " + value,
-						context);
+						+ " third argument must be an Integer or 'MAXLEVEL': " + value);
 				}
 			}
 		}
 		if (tok.hasMoreTokens())
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " must have 1 to 3 | delimited arguments: " + value, context);
+					+ " must have 1 to 3 | delimited arguments: " + value);
 		}
 		StringBuilder sb = new StringBuilder(value.length() + 20);
 		sb.append(getTokenName()).append('|').append(value);

--- a/code/src/java/plugin/lsttokens/equipmentmodifier/choose/EquipmentToken.java
+++ b/code/src/java/plugin/lsttokens/equipmentmodifier/choose/EquipmentToken.java
@@ -45,27 +45,27 @@ public class EquipmentToken implements CDOMSecondaryToken<EquipmentModifier>
 		if (value == null)
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " requires arguments", context);
+					+ " requires arguments");
 		}
 		if (value.indexOf('[') != -1)
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " arguments may not contain [] : " + value, context);
+					+ " arguments may not contain [] : " + value);
 		}
 		if (value.charAt(0) == '|')
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " arguments may not start with | : " + value, context);
+					+ " arguments may not start with | : " + value);
 		}
 		if (value.charAt(value.length() - 1) == '|')
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " arguments may not end with | : " + value, context);
+					+ " arguments may not end with | : " + value);
 		}
 		if (value.indexOf("||") != -1)
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " arguments uses double separator || : " + value, context);
+					+ " arguments uses double separator || : " + value);
 		}
 		StringBuilder sb = new StringBuilder(value.length() + 20);
 		sb.append(getTokenName()).append('|').append(value);

--- a/code/src/java/plugin/lsttokens/equipmentmodifier/choose/FeatToken.java
+++ b/code/src/java/plugin/lsttokens/equipmentmodifier/choose/FeatToken.java
@@ -45,27 +45,27 @@ public class FeatToken implements CDOMSecondaryToken<EquipmentModifier>
 		if (value == null)
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " requires arguments", context);
+					+ " requires arguments");
 		}
 		if (value.indexOf('[') != -1)
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " arguments may not contain [] : " + value, context);
+					+ " arguments may not contain [] : " + value);
 		}
 		if (value.charAt(0) == '|')
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " arguments may not start with | : " + value, context);
+					+ " arguments may not start with | : " + value);
 		}
 		if (value.charAt(value.length() - 1) == '|')
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " arguments may not end with | : " + value, context);
+					+ " arguments may not end with | : " + value);
 		}
 		if (value.indexOf("||") != -1)
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " arguments uses double separator || : " + value, context);
+					+ " arguments uses double separator || : " + value);
 		}
 		StringBuilder sb = new StringBuilder(value.length() + 20);
 		sb.append(getTokenName()).append('|').append(value);

--- a/code/src/java/plugin/lsttokens/equipmentmodifier/choose/NoChoiceToken.java
+++ b/code/src/java/plugin/lsttokens/equipmentmodifier/choose/NoChoiceToken.java
@@ -49,7 +49,7 @@ public class NoChoiceToken implements CDOMSecondaryToken<EquipmentModifier>
 			return ParseResult.SUCCESS;
 		}
 		return new ParseResult.Fail("CHOOSE:" + getTokenName()
-				+ " must not have arguments: " + value, context);
+				+ " must not have arguments: " + value);
 	}
 
 	@Override

--- a/code/src/java/plugin/lsttokens/equipmentmodifier/choose/NumberToken.java
+++ b/code/src/java/plugin/lsttokens/equipmentmodifier/choose/NumberToken.java
@@ -48,34 +48,34 @@ public class NumberToken implements CDOMSecondaryToken<EquipmentModifier>
 		if (value == null)
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " requires additional arguments", context);
+					+ " requires additional arguments");
 		}
 		if (value.indexOf('[') != -1)
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " arguments may not contain [] : " + value, context);
+					+ " arguments may not contain [] : " + value);
 		}
 		if (value.charAt(0) == '|')
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " arguments may not start with | : " + value, context);
+					+ " arguments may not start with | : " + value);
 		}
 		if (value.charAt(value.length() - 1) == '|')
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " arguments may not end with | : " + value, context);
+					+ " arguments may not end with | : " + value);
 		}
 		if (value.indexOf("||") != -1)
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " arguments uses double separator || : " + value, context);
+					+ " arguments uses double separator || : " + value);
 		}
 		int pipeLoc = value.indexOf(Constants.PIPE);
 		if (pipeLoc == -1)
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
 							+ " must have two or more | delimited arguments : "
-							+ value, context);
+							+ value);
 		}
 		StringTokenizer tok = new StringTokenizer(value, Constants.PIPE);
 		Integer min = null;
@@ -124,7 +124,7 @@ public class NumberToken implements CDOMSecondaryToken<EquipmentModifier>
 			if (min != null)
 			{
 				return new ParseResult.Fail("Cannot have MIN=n without MAX=m in CHOOSE:NUMBER: "
-								+ value, context);
+								+ value);
 			}
 		}
 		else
@@ -132,12 +132,12 @@ public class NumberToken implements CDOMSecondaryToken<EquipmentModifier>
 			if (min == null)
 			{
 				return new ParseResult.Fail("Cannot have MAX=n without MIN=m in CHOOSE:NUMBER: "
-								+ value, context);
+								+ value);
 			}
 			if (max < min)
 			{
 				return new ParseResult.Fail("Cannot have MAX= less than MIN= in CHOOSE:NUMBER: "
-								+ value, context);
+								+ value);
 			}
 		}
 		StringBuilder sb = new StringBuilder(value.length() + 20);

--- a/code/src/java/plugin/lsttokens/equipmentmodifier/choose/SkillBonusToken.java
+++ b/code/src/java/plugin/lsttokens/equipmentmodifier/choose/SkillBonusToken.java
@@ -48,34 +48,34 @@ public class SkillBonusToken implements CDOMSecondaryToken<EquipmentModifier>
 		if (value == null)
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " requires additional arguments", context);
+					+ " requires additional arguments");
 		}
 		if (value.indexOf('[') != -1)
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " arguments may not contain [] : " + value, context);
+					+ " arguments may not contain [] : " + value);
 		}
 		if (value.charAt(0) == '|')
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " arguments may not start with | : " + value, context);
+					+ " arguments may not start with | : " + value);
 		}
 		if (value.charAt(value.length() - 1) == '|')
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " arguments may not end with | : " + value, context);
+					+ " arguments may not end with | : " + value);
 		}
 		if (value.indexOf("||") != -1)
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " arguments uses double separator || : " + value, context);
+					+ " arguments uses double separator || : " + value);
 		}
 		int pipeLoc = value.indexOf(Constants.PIPE);
 		if (pipeLoc == -1)
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
 							+ " must have two or more | delimited arguments : "
-							+ value, context);
+							+ value);
 		}
 		StringTokenizer tok = new StringTokenizer(value, Constants.PIPE);
 		Integer min = null;
@@ -112,7 +112,7 @@ public class SkillBonusToken implements CDOMSecondaryToken<EquipmentModifier>
 			if (min != null)
 			{
 				return new ParseResult.Fail("Cannot have MIN=n without MAX=m in CHOOSE:STATBONUS: "
-								+ value, context);
+								+ value);
 			}
 		}
 		else
@@ -120,12 +120,12 @@ public class SkillBonusToken implements CDOMSecondaryToken<EquipmentModifier>
 			if (min == null)
 			{
 				return new ParseResult.Fail("Cannot have MAX=n without MIN=m in CHOOSE:STATBONUS: "
-								+ value, context);
+								+ value);
 			}
 			if (max < min)
 			{
 				return new ParseResult.Fail("Cannot have MAX= less than MIN= in CHOOSE:STATBONUS: "
-								+ value, context);
+								+ value);
 			}
 		}
 		StringBuilder sb = new StringBuilder(value.length() + 20);

--- a/code/src/java/plugin/lsttokens/equipmentmodifier/choose/SkillToken.java
+++ b/code/src/java/plugin/lsttokens/equipmentmodifier/choose/SkillToken.java
@@ -51,22 +51,22 @@ public class SkillToken implements CDOMSecondaryToken<EquipmentModifier>
 		if (value.indexOf('[') != -1)
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " arguments may not contain [] : " + value, context);
+					+ " arguments may not contain [] : " + value);
 		}
 		if (value.charAt(0) == '|')
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " arguments may not start with | : " + value, context);
+					+ " arguments may not start with | : " + value);
 		}
 		if (value.charAt(value.length() - 1) == '|')
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " arguments may not end with | : " + value, context);
+					+ " arguments may not end with | : " + value);
 		}
 		if (value.indexOf("||") != -1)
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " arguments uses double separator || : " + value, context);
+					+ " arguments uses double separator || : " + value);
 		}
 		// StringTokenizer tok = new StringTokenizer(value, Constants.PIPE);
 		// while (tok.hasMoreTokens())

--- a/code/src/java/plugin/lsttokens/equipmentmodifier/choose/StatBonusToken.java
+++ b/code/src/java/plugin/lsttokens/equipmentmodifier/choose/StatBonusToken.java
@@ -50,34 +50,34 @@ public class StatBonusToken implements CDOMSecondaryToken<EquipmentModifier>
 		if (value == null)
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " requires additional arguments", context);
+					+ " requires additional arguments");
 		}
 		if (value.indexOf('[') != -1)
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " arguments may not contain [] : " + value, context);
+					+ " arguments may not contain [] : " + value);
 		}
 		if (value.charAt(0) == '|')
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " arguments may not start with | : " + value, context);
+					+ " arguments may not start with | : " + value);
 		}
 		if (value.charAt(value.length() - 1) == '|')
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " arguments may not end with | : " + value, context);
+					+ " arguments may not end with | : " + value);
 		}
 		if (value.indexOf("||") != -1)
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " arguments uses double separator || : " + value, context);
+					+ " arguments uses double separator || : " + value);
 		}
 		int pipeLoc = value.indexOf(Constants.PIPE);
 		if (pipeLoc == -1)
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
 							+ " must have two or more | delimited arguments : "
-							+ value, context);
+							+ value);
 		}
 		StringTokenizer tok = new StringTokenizer(value, Constants.PIPE);
 		Collection<PCStat> list = context.getReferenceContext().getConstructedCDOMObjects(PCStat.class);
@@ -120,7 +120,7 @@ public class StatBonusToken implements CDOMSecondaryToken<EquipmentModifier>
 				if (!found)
 				{
 					return new ParseResult.Fail("Did not find STAT: " + tokString
-							+ " used in CHOOSE:STATBONUS " + value, context);
+							+ " used in CHOOSE:STATBONUS " + value);
 				}
 			}
 		}
@@ -129,7 +129,7 @@ public class StatBonusToken implements CDOMSecondaryToken<EquipmentModifier>
 			if (min != null)
 			{
 				return new ParseResult.Fail("Cannot have MIN=n without MAX=m in CHOOSE:STATBONUS: "
-								+ value, context);
+								+ value);
 			}
 		}
 		else
@@ -137,12 +137,12 @@ public class StatBonusToken implements CDOMSecondaryToken<EquipmentModifier>
 			if (min == null)
 			{
 				return new ParseResult.Fail("Cannot have MAX=n without MIN=m in CHOOSE:STATBONUS: "
-								+ value, context);
+								+ value);
 			}
 			if (max < min)
 			{
 				return new ParseResult.Fail("Cannot have MAX= less than MIN= in CHOOSE:STATBONUS: "
-								+ value, context);
+								+ value);
 			}
 		}
 		StringBuilder sb = new StringBuilder(value.length() + 20);

--- a/code/src/java/plugin/lsttokens/equipmentmodifier/choose/StringToken.java
+++ b/code/src/java/plugin/lsttokens/equipmentmodifier/choose/StringToken.java
@@ -45,27 +45,27 @@ public class StringToken implements CDOMSecondaryToken<EquipmentModifier>
 		if (value.indexOf(',') != -1)
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " arguments may not contain , : " + value, context);
+					+ " arguments may not contain , : " + value);
 		}
 		if (value.indexOf('[') != -1)
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " arguments may not contain [] : " + value, context);
+					+ " arguments may not contain [] : " + value);
 		}
 		if (value.charAt(0) == '|')
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " arguments may not start with | : " + value, context);
+					+ " arguments may not start with | : " + value);
 		}
 		if (value.charAt(value.length() - 1) == '|')
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " arguments may not end with | : " + value, context);
+					+ " arguments may not end with | : " + value);
 		}
 		if (value.indexOf("||") != -1)
 		{
 			return new ParseResult.Fail("CHOOSE:" + getTokenName()
-					+ " arguments uses double separator || : " + value, context);
+					+ " arguments uses double separator || : " + value);
 		}
 		StringBuilder sb = new StringBuilder(value.length() + 20);
 		sb.append(getTokenName()).append('|').append(value);

--- a/code/src/java/plugin/lsttokens/gamemode/abilitycategory/EditPoolToken.java
+++ b/code/src/java/plugin/lsttokens/gamemode/abilitycategory/EditPoolToken.java
@@ -43,7 +43,7 @@ public class EditPoolToken extends AbstractNonEmptyToken<AbilityCategory>
 			if (value.length() > 1 && !value.equalsIgnoreCase("YES"))
 			{
 				return new ParseResult.Fail("You should use 'YES' as the "
-						+ getTokenName() + ": " + value, context);
+						+ getTokenName() + ": " + value);
 			}
 			set = Boolean.TRUE;
 		}
@@ -53,13 +53,13 @@ public class EditPoolToken extends AbstractNonEmptyToken<AbilityCategory>
 			{
 				return new ParseResult.Fail(
 						"You should use 'YES' or 'NO' as the " + getTokenName()
-								+ ": " + value, context);
+								+ ": " + value);
 			}
 			if (value.length() > 1 && !value.equalsIgnoreCase("NO"))
 			{
 				return new ParseResult.Fail(
 						"You should use 'YES' or 'NO' as the " + getTokenName()
-								+ ": " + value, context);
+								+ ": " + value);
 			}
 			set = Boolean.FALSE;
 		}

--- a/code/src/java/plugin/lsttokens/gamemode/abilitycategory/EditableToken.java
+++ b/code/src/java/plugin/lsttokens/gamemode/abilitycategory/EditableToken.java
@@ -43,7 +43,7 @@ public class EditableToken extends AbstractNonEmptyToken<AbilityCategory>
 			if (value.length() > 1 && !value.equalsIgnoreCase("YES"))
 			{
 				return new ParseResult.Fail("You should use 'YES' as the "
-						+ getTokenName() + ": " + value, context);
+						+ getTokenName() + ": " + value);
 			}
 			set = Boolean.TRUE;
 		}
@@ -53,13 +53,13 @@ public class EditableToken extends AbstractNonEmptyToken<AbilityCategory>
 			{
 				return new ParseResult.Fail(
 						"You should use 'YES' or 'NO' as the " + getTokenName()
-								+ ": " + value, context);
+								+ ": " + value);
 			}
 			if (value.length() > 1 && !value.equalsIgnoreCase("NO"))
 			{
 				return new ParseResult.Fail(
 						"You should use 'YES' or 'NO' as the " + getTokenName()
-								+ ": " + value, context);
+								+ ": " + value);
 			}
 			set = Boolean.FALSE;
 		}

--- a/code/src/java/plugin/lsttokens/gamemode/abilitycategory/FractionalPoolToken.java
+++ b/code/src/java/plugin/lsttokens/gamemode/abilitycategory/FractionalPoolToken.java
@@ -43,7 +43,7 @@ public class FractionalPoolToken extends AbstractNonEmptyToken<AbilityCategory>
 			if (value.length() > 1 && !value.equalsIgnoreCase("YES"))
 			{
 				return new ParseResult.Fail("You should use 'YES' as the "
-						+ getTokenName() + ": " + value, context);
+						+ getTokenName() + ": " + value);
 			}
 			set = Boolean.TRUE;
 		}
@@ -53,13 +53,13 @@ public class FractionalPoolToken extends AbstractNonEmptyToken<AbilityCategory>
 			{
 				return new ParseResult.Fail(
 						"You should use 'YES' or 'NO' as the " + getTokenName()
-								+ ": " + value, context);
+								+ ": " + value);
 			}
 			if (value.length() > 1 && !value.equalsIgnoreCase("NO"))
 			{
 				return new ParseResult.Fail(
 						"You should use 'YES' or 'NO' as the " + getTokenName()
-								+ ": " + value, context);
+								+ ": " + value);
 			}
 			set = Boolean.FALSE;
 		}

--- a/code/src/java/plugin/lsttokens/gamemode/abilitycategory/PoolToken.java
+++ b/code/src/java/plugin/lsttokens/gamemode/abilitycategory/PoolToken.java
@@ -42,7 +42,7 @@ public class PoolToken extends AbstractNonEmptyToken<AbilityCategory> implements
 		if (!formula.isValid())
 		{
 			return new ParseResult.Fail("Formula in " + getTokenName()
-					+ " was not valid: " + formula.toString(), context);
+					+ " was not valid: " + formula.toString());
 		}
 		ac.setPoolFormula(formula);
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/gamemode/abilitycategory/TypeToken.java
+++ b/code/src/java/plugin/lsttokens/gamemode/abilitycategory/TypeToken.java
@@ -66,7 +66,7 @@ public class TypeToken extends AbstractNonEmptyToken<AbilityCategory> implements
 				return new ParseResult.Fail(
 						"Use of named types along with TYPE:* in category "
 								+ ac.getDisplayName() + " is invalid.  Found: "
-								+ value, context);
+								+ value);
 			}
 			else
 			{

--- a/code/src/java/plugin/lsttokens/gamemode/abilitycategory/VisibleToken.java
+++ b/code/src/java/plugin/lsttokens/gamemode/abilitycategory/VisibleToken.java
@@ -58,7 +58,7 @@ public class VisibleToken extends AbstractNonEmptyToken<AbilityCategory>
 		else
 		{
 			return new ParseResult.Fail("Unable to understand "
-					+ getTokenName() + " tag: " + value, context);
+					+ getTokenName() + " tag: " + value);
 		}
 		ac.setVisible(vis);
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/gamemode/basedice/DownToken.java
+++ b/code/src/java/plugin/lsttokens/gamemode/basedice/DownToken.java
@@ -53,7 +53,7 @@ public class DownToken extends AbstractTokenWithSeparator<BaseDice> implements
 			catch (IllegalArgumentException e)
 			{
 				return new ParseResult.Fail("Invalid Roll provided: " + roll
-						+ " in " + value, context);
+						+ " in " + value);
 			}
 		}
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/gamemode/basedice/UpToken.java
+++ b/code/src/java/plugin/lsttokens/gamemode/basedice/UpToken.java
@@ -53,7 +53,7 @@ public class UpToken extends AbstractTokenWithSeparator<BaseDice> implements
 			catch (IllegalArgumentException e)
 			{
 				return new ParseResult.Fail("Invalid Roll provided: " + roll
-						+ " in " + value, context);
+						+ " in " + value);
 			}
 		}
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/gamemode/codecontrol/ACVarToken.java
+++ b/code/src/java/plugin/lsttokens/gamemode/codecontrol/ACVarToken.java
@@ -42,7 +42,7 @@ public class ACVarToken extends AbstractNonEmptyToken<CodeControl> implements
 		if (pipeLoc == -1)
 		{
 			return new ParseResult.Fail(
-				getTokenName() + " requires a SubToken", context);
+				getTokenName() + " requires a SubToken");
 		}
 		String acType = value.substring(0, pipeLoc);
 		String varName = value.substring(pipeLoc + 1);

--- a/code/src/java/plugin/lsttokens/gamemode/eqsizepenalty/BonusToken.java
+++ b/code/src/java/plugin/lsttokens/gamemode/eqsizepenalty/BonusToken.java
@@ -45,7 +45,7 @@ public class BonusToken implements CDOMPrimaryToken<EqSizePenalty>
 		if (bon == null)
 		{
 			return new ParseResult.Fail(getTokenName()
-					+ " was given invalid bonus: " + value, context);
+					+ " was given invalid bonus: " + value);
 		}
 		bon.setTokenSource(getTokenName());
 		esp.addBonus(bon);

--- a/code/src/java/plugin/lsttokens/gamemode/tab/SkilltablehiddencolumnsToken.java
+++ b/code/src/java/plugin/lsttokens/gamemode/tab/SkilltablehiddencolumnsToken.java
@@ -48,7 +48,7 @@ public class SkilltablehiddencolumnsToken extends
 		if (!Tab.SKILLS.equals(ti.getTab()))
 		{
 			return new ParseResult.Fail(getTokenName()
-					+ " may only be used on the " + Tab.SKILLS + " Tab", context);
+					+ " may only be used on the " + Tab.SKILLS + " Tab");
 		}
 		ti.clearHiddenColumns();
 
@@ -63,7 +63,7 @@ public class SkilltablehiddencolumnsToken extends
 			catch (NumberFormatException nfe)
 			{
 				return new ParseResult.Fail(getTokenName()
-						+ " misunderstood Integer: " + token + " in " + value, context);
+						+ " misunderstood Integer: " + token + " in " + value);
 			}
 		}
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/gamemode/tab/StattablehiddencolumnsToken.java
+++ b/code/src/java/plugin/lsttokens/gamemode/tab/StattablehiddencolumnsToken.java
@@ -48,7 +48,7 @@ public class StattablehiddencolumnsToken extends
 		if (!Tab.SUMMARY.equals(ti.getTab()))
 		{
 			return new ParseResult.Fail(getTokenName()
-					+ " may only be used on the " + Tab.SUMMARY + " Tab", context);
+					+ " may only be used on the " + Tab.SUMMARY + " Tab");
 		}
 		ti.clearHiddenColumns();
 
@@ -63,7 +63,7 @@ public class StattablehiddencolumnsToken extends
 			catch (NumberFormatException nfe)
 			{
 				return new ParseResult.Fail(getTokenName()
-						+ " misunderstood Integer: " + token + " in " + value, context);
+						+ " misunderstood Integer: " + token + " in " + value);
 			}
 		}
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/gamemode/tab/VisibleToken.java
+++ b/code/src/java/plugin/lsttokens/gamemode/tab/VisibleToken.java
@@ -44,7 +44,7 @@ public class VisibleToken extends AbstractNonEmptyToken<TabInfo> implements
 			if (value.length() > 1 && !value.equalsIgnoreCase("YES"))
 			{
 				return new ParseResult.Fail("You should use 'YES' as the "
-						+ getTokenName() + ": " + value, context);
+						+ getTokenName() + ": " + value);
 			}
 			set = Boolean.TRUE;
 		}
@@ -54,13 +54,13 @@ public class VisibleToken extends AbstractNonEmptyToken<TabInfo> implements
 			{
 				return new ParseResult.Fail(
 						"You should use 'YES' or 'NO' as the " + getTokenName()
-								+ ": " + value, context);
+								+ ": " + value);
 			}
 			if (value.length() > 1 && !value.equalsIgnoreCase("NO"))
 			{
 				return new ParseResult.Fail(
 						"You should use 'YES' or 'NO' as the " + getTokenName()
-								+ ": " + value, context);
+								+ ": " + value);
 			}
 			set = Boolean.FALSE;
 		}

--- a/code/src/java/plugin/lsttokens/gamemode/unitset/DistancefactorToken.java
+++ b/code/src/java/plugin/lsttokens/gamemode/unitset/DistancefactorToken.java
@@ -46,7 +46,7 @@ public class DistancefactorToken extends AbstractNonEmptyToken<UnitSet>
 		}
 		catch (NumberFormatException nfe)
 		{
-			return new ParseResult.Fail("Misunderstood Double in Tag: " + value, context);
+			return new ParseResult.Fail("Misunderstood Double in Tag: " + value);
 		}
 	}
 

--- a/code/src/java/plugin/lsttokens/gamemode/unitset/DistancepatternToken.java
+++ b/code/src/java/plugin/lsttokens/gamemode/unitset/DistancepatternToken.java
@@ -47,7 +47,7 @@ public class DistancepatternToken extends AbstractNonEmptyToken<UnitSet>
 		catch (IllegalArgumentException e)
 		{
 			return new ParseResult.Fail("Invalid Decimal Format in "
-					+ getTokenName() + ": " + value + ": " + e.getMessage(), context);
+					+ getTokenName() + ": " + value + ": " + e.getMessage());
 		}
 	}
 

--- a/code/src/java/plugin/lsttokens/gamemode/unitset/HeightfactorToken.java
+++ b/code/src/java/plugin/lsttokens/gamemode/unitset/HeightfactorToken.java
@@ -46,7 +46,7 @@ public class HeightfactorToken extends AbstractNonEmptyToken<UnitSet> implements
 		}
 		catch (NumberFormatException nfe)
 		{
-			return new ParseResult.Fail("Misunderstood Double in Tag: " + value, context);
+			return new ParseResult.Fail("Misunderstood Double in Tag: " + value);
 		}
 	}
 

--- a/code/src/java/plugin/lsttokens/gamemode/unitset/HeightpatternToken.java
+++ b/code/src/java/plugin/lsttokens/gamemode/unitset/HeightpatternToken.java
@@ -47,7 +47,7 @@ public class HeightpatternToken extends AbstractNonEmptyToken<UnitSet>
 		catch (IllegalArgumentException e)
 		{
 			return new ParseResult.Fail("Invalid Decimal Format in "
-					+ getTokenName() + ": " + value + ": " + e.getMessage(), context);
+					+ getTokenName() + ": " + value + ": " + e.getMessage());
 		}
 	}
 

--- a/code/src/java/plugin/lsttokens/gamemode/unitset/WeightfactorToken.java
+++ b/code/src/java/plugin/lsttokens/gamemode/unitset/WeightfactorToken.java
@@ -46,7 +46,7 @@ public class WeightfactorToken extends AbstractNonEmptyToken<UnitSet> implements
 		}
 		catch (NumberFormatException nfe)
 		{
-			return new ParseResult.Fail("Misunderstood Double in Tag: " + value, context);
+			return new ParseResult.Fail("Misunderstood Double in Tag: " + value);
 		}
 	}
 

--- a/code/src/java/plugin/lsttokens/gamemode/unitset/WeightpatternToken.java
+++ b/code/src/java/plugin/lsttokens/gamemode/unitset/WeightpatternToken.java
@@ -47,7 +47,7 @@ public class WeightpatternToken extends AbstractNonEmptyToken<UnitSet>
 		catch (IllegalArgumentException e)
 		{
 			return new ParseResult.Fail("Invalid Decimal Format in "
-					+ getTokenName() + ": " + value + ": " + e.getMessage(), context);
+					+ getTokenName() + ": " + value + ": " + e.getMessage());
 		}
 	}
 

--- a/code/src/java/plugin/lsttokens/gamemode/wieldcategory/DamagemultToken.java
+++ b/code/src/java/plugin/lsttokens/gamemode/wieldcategory/DamagemultToken.java
@@ -55,13 +55,13 @@ public class DamagemultToken extends AbstractTokenWithSeparator<WieldCategory>
 			if (equalLoc == -1)
 			{
 				return new ParseResult.Fail("No = in part of token, found: "
-						+ set + " in " + value, context);
+						+ set + " in " + value);
 			}
 			if (equalLoc != set.lastIndexOf('='))
 			{
 				return new ParseResult.Fail(
 						"Too many = in part of token, found: " + set + " in "
-								+ value, context);
+								+ value);
 			}
 			String hands = set.substring(0, equalLoc);
 			int numHands;
@@ -73,7 +73,7 @@ public class DamagemultToken extends AbstractTokenWithSeparator<WieldCategory>
 			{
 				return new ParseResult.Fail(getTokenName()
 						+ " expected an integer before '='.  Found: " + hands
-						+ " in " + value, context);
+						+ " in " + value);
 			}
 			String multiplier = set.substring(equalLoc + 1);
 			float mult;
@@ -85,7 +85,7 @@ public class DamagemultToken extends AbstractTokenWithSeparator<WieldCategory>
 			{
 				return new ParseResult.Fail(getTokenName()
 						+ " expected an float after '='.  Found: " + hands
-						+ " in " + value, context);
+						+ " in " + value);
 			}
 			wc.addDamageMult(numHands, mult);
 		}

--- a/code/src/java/plugin/lsttokens/gamemode/wieldcategory/FinessableToken.java
+++ b/code/src/java/plugin/lsttokens/gamemode/wieldcategory/FinessableToken.java
@@ -44,7 +44,7 @@ public class FinessableToken extends AbstractNonEmptyToken<WieldCategory>
 			if (value.length() > 1 && !value.equalsIgnoreCase("YES"))
 			{
 				return new ParseResult.Fail("You should use 'YES' as the "
-						+ getTokenName() + ": " + value, context);
+						+ getTokenName() + ": " + value);
 			}
 			set = Boolean.TRUE;
 		}
@@ -54,13 +54,13 @@ public class FinessableToken extends AbstractNonEmptyToken<WieldCategory>
 			{
 				return new ParseResult.Fail(
 						"You should use 'YES' or 'NO' as the " + getTokenName()
-								+ ": " + value, context);
+								+ ": " + value);
 			}
 			if (value.length() > 1 && !value.equalsIgnoreCase("NO"))
 			{
 				return new ParseResult.Fail(
 						"You should use 'YES' or 'NO' as the " + getTokenName()
-								+ ": " + value, context);
+								+ ": " + value);
 			}
 			set = Boolean.FALSE;
 		}

--- a/code/src/java/plugin/lsttokens/gamemode/wieldcategory/HandsToken.java
+++ b/code/src/java/plugin/lsttokens/gamemode/wieldcategory/HandsToken.java
@@ -44,7 +44,7 @@ public class HandsToken extends AbstractNonEmptyToken<WieldCategory> implements
 			if (intValue < 0)
 			{
 				return new ParseResult.Fail(getTokenName()
-						+ " must be an integer >= " + 0, context);
+						+ " must be an integer >= " + 0);
 			}
 			wc.setHandsRequired(Integer.parseInt(value));
 			return ParseResult.SUCCESS;
@@ -53,7 +53,7 @@ public class HandsToken extends AbstractNonEmptyToken<WieldCategory> implements
 		{
 			return new ParseResult.Fail(getTokenName()
 					+ " expected an integer.  Tag must be of the form: "
-					+ getTokenName() + ":<int>", context);
+					+ getTokenName() + ":<int>");
 		}
 	}
 

--- a/code/src/java/plugin/lsttokens/gamemode/wieldcategory/SizediffToken.java
+++ b/code/src/java/plugin/lsttokens/gamemode/wieldcategory/SizediffToken.java
@@ -46,7 +46,7 @@ public class SizediffToken extends AbstractNonEmptyToken<WieldCategory>
 		{
 			return new ParseResult.Fail(getTokenName()
 					+ " expected an integer.  Tag must be of the form: "
-					+ getTokenName() + ":<int>", context);
+					+ getTokenName() + ":<int>");
 		}
 	}
 

--- a/code/src/java/plugin/lsttokens/kit/AgeToken.java
+++ b/code/src/java/plugin/lsttokens/kit/AgeToken.java
@@ -57,7 +57,7 @@ public class AgeToken extends AbstractNonEmptyToken<KitBio> implements
 		}
 		catch(NumberFormatException e)
 		{
-			return new ParseResult.Fail("Illegal value for AGE: " + value, context);
+			return new ParseResult.Fail("Illegal value for AGE: " + value);
 		}
 		return ParseResult.SUCCESS;
 	}

--- a/code/src/java/plugin/lsttokens/kit/SelectToken.java
+++ b/code/src/java/plugin/lsttokens/kit/SelectToken.java
@@ -57,7 +57,7 @@ public class SelectToken extends AbstractNonEmptyToken<KitSelect> implements
 		if (!formula.isValid())
 		{
 			return new ParseResult.Fail("Formula in " + getTokenName()
-					+ " was not valid: " + formula.toString(), context);
+					+ " was not valid: " + formula.toString());
 		}
 		kitSelect.setFormula(formula);
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/kit/StatToken.java
+++ b/code/src/java/plugin/lsttokens/kit/StatToken.java
@@ -78,20 +78,20 @@ public class StatToken extends AbstractTokenWithSeparator<KitStat> implements
 			if (equalLoc == -1)
 			{
 				return new ParseResult.Fail("Illegal " + getTokenName()
-						+ " did not have Stat=X format: " + value, context);
+						+ " did not have Stat=X format: " + value);
 			}
 			if (equalLoc != token.lastIndexOf('='))
 			{
 				return new ParseResult.Fail("Illegal " + getTokenName()
 						+ " had two equal signs, is not Stat=X format: "
-						+ value, context);
+						+ value);
 			}
 			String statName = token.substring(0, equalLoc);
 			if (statName.isEmpty())
 			{
 				return new ParseResult.Fail("Illegal " + getTokenName()
 					+ " had no stat, is not Stat=X format: "
-					+ value, context);
+					+ value);
 			}
 			CDOMSingleRef<PCStat> stat =
 					context.getReferenceContext().getCDOMReference(
@@ -99,13 +99,13 @@ public class StatToken extends AbstractTokenWithSeparator<KitStat> implements
 			String formula = token.substring(equalLoc + 1);
 			if (formula.isEmpty())
 			{
-				return new ParseResult.Fail("Unable to find STAT value: " + value, context);
+				return new ParseResult.Fail("Unable to find STAT value: " + value);
 			}
 			Formula statValue = FormulaFactory.getFormulaFor(formula);
 			if (!statValue.isValid())
 			{
 				return new ParseResult.Fail("StatValue in " + getTokenName()
-						+ " was not valid: " + statValue.toString(), context);
+						+ " was not valid: " + statValue.toString());
 			}
 			kitStat.addStat(stat, statValue);
 		}

--- a/code/src/java/plugin/lsttokens/kit/TemplateToken.java
+++ b/code/src/java/plugin/lsttokens/kit/TemplateToken.java
@@ -112,7 +112,7 @@ public class TemplateToken extends AbstractTokenWithSeparator<KitTemplate>
 					{
 						return new ParseResult.Fail("Did not understand "
 							+ getTokenName() + " option: " + subStr
-							+ " in line: " + value, context);
+							+ " in line: " + value);
 					}
 				}
 			}

--- a/code/src/java/plugin/lsttokens/kit/ability/AbilityToken.java
+++ b/code/src/java/plugin/lsttokens/kit/ability/AbilityToken.java
@@ -69,20 +69,20 @@ public class AbilityToken extends AbstractNonEmptyToken<KitAbilities> implements
 		{
 			return new ParseResult.Fail(
 				"No pipe found.  ABILITY token "
-					+ "in a Kit requires CATEGORY=<cat>|<ability>,<ability>", context);
+					+ "in a Kit requires CATEGORY=<cat>|<ability>,<ability>");
 		}
 		String catString = value.substring(0, pipeLoc);
 		if (!catString.startsWith("CATEGORY="))
 		{
 			return new ParseResult.Fail(
 				"No CATEGORY= found.  ABILITY token "
-					+ "in a Kit requires CATEGORY=<cat>|<abilities>", context);
+					+ "in a Kit requires CATEGORY=<cat>|<abilities>");
 		}
 		if (catString.length() < 10)
 		{
 			return new ParseResult.Fail(
 				"No category found.  ABILITY token "
-					+ "in a Kit requires CATEGORY=<cat>|<abilities>", context);
+					+ "in a Kit requires CATEGORY=<cat>|<abilities>");
 		}
 		String acName = catString.substring(9);
 		
@@ -112,8 +112,7 @@ public class AbilityToken extends AbstractNonEmptyToken<KitAbilities> implements
 		if (rm == null)
 		{
 			return new ParseResult.Fail(
-				"Could not get Reference Manufacturer for Category: " + acName,
-				context);
+				"Could not get Reference Manufacturer for Category: " + acName);
 		}
 
 		while (st.hasMoreTokens())

--- a/code/src/java/plugin/lsttokens/kit/ability/CountToken.java
+++ b/code/src/java/plugin/lsttokens/kit/ability/CountToken.java
@@ -56,7 +56,7 @@ public class CountToken extends AbstractToken implements
 			Integer quan = Integer.valueOf(value);
 			if (quan.intValue() <= 0)
 			{
-				return new ParseResult.Fail(getTokenName() + " expected an integer > 0", context);
+				return new ParseResult.Fail(getTokenName() + " expected an integer > 0");
 			}
 			kitAbil.setCount(quan);
 			return ParseResult.SUCCESS;
@@ -65,7 +65,7 @@ public class CountToken extends AbstractToken implements
 		{
 			return new ParseResult.Fail(getTokenName()
 				+ " expected an integer.  Tag must be of the form: "
-				+ getTokenName() + ":<int>", context);
+				+ getTokenName() + ":<int>");
 		}
 	}
 

--- a/code/src/java/plugin/lsttokens/kit/ability/FreeToken.java
+++ b/code/src/java/plugin/lsttokens/kit/ability/FreeToken.java
@@ -58,7 +58,7 @@ public class FreeToken extends AbstractNonEmptyToken<KitAbilities> implements
 			if (value.length() > 1 && !value.equalsIgnoreCase("YES"))
 			{
 				return new ParseResult.Fail("You should use 'YES' as the "
-					+ getTokenName() + ": " + value, context);
+					+ getTokenName() + ": " + value);
 			}
 			set = Boolean.TRUE;
 		}
@@ -67,12 +67,12 @@ public class FreeToken extends AbstractNonEmptyToken<KitAbilities> implements
 			if (firstChar != 'N' && firstChar != 'n')
 			{
 				return new ParseResult.Fail("You should use 'YES' or 'NO' as the "
-						+ getTokenName() + ": " + value, context);
+						+ getTokenName() + ": " + value);
 			}
 			if (value.length() > 1 && !value.equalsIgnoreCase("NO"))
 			{
 				return new ParseResult.Fail("You should use 'YES' or 'NO' as the "
-						+ getTokenName() + ": " + value, context);
+						+ getTokenName() + ": " + value);
 			}
 			set = Boolean.FALSE;
 		}

--- a/code/src/java/plugin/lsttokens/kit/basekit/LookupToken.java
+++ b/code/src/java/plugin/lsttokens/kit/basekit/LookupToken.java
@@ -65,18 +65,18 @@ public class LookupToken extends AbstractToken implements
 		String first = sep.next();
 		if (!sep.hasNext())
 		{
-			return new ParseResult.Fail("Token must contain separator ','", context);
+			return new ParseResult.Fail("Token must contain separator ','");
 		}
 		String second = sep.next();
 		if (sep.hasNext())
 		{
-			return new ParseResult.Fail("Token cannot have more than one separator ','", context);
+			return new ParseResult.Fail("Token cannot have more than one separator ','");
 		}
 		Formula formula = FormulaFactory.getFormulaFor(second);
 		if (!formula.isValid())
 		{
 			return new ParseResult.Fail("Formula in " + getTokenName()
-					+ " was not valid: " + formula.toString(), context);
+					+ " was not valid: " + formula.toString());
 		}
 		kitGear.loadLookup(first, formula);
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/kit/basekit/OptionToken.java
+++ b/code/src/java/plugin/lsttokens/kit/basekit/OptionToken.java
@@ -68,7 +68,7 @@ public class OptionToken extends AbstractNonEmptyToken<BaseKit> implements
 			if (subTok.isEmpty())
 			{
 				return new ParseResult.Fail(getTokenName()
-						+ " arguments has invalid pipe separator: " + value, context);
+						+ " arguments has invalid pipe separator: " + value);
 			}
 			ParseResult pr = checkForIllegalSeparator(',', subTok);
 			if (!pr.passed())
@@ -90,19 +90,19 @@ public class OptionToken extends AbstractNonEmptyToken<BaseKit> implements
 			}
 			if (commaSep.hasNext())
 			{
-				return new ParseResult.Fail("Token cannot have more than one separator ','", context);
+				return new ParseResult.Fail("Token cannot have more than one separator ','");
 			}
 			Formula min = FormulaFactory.getFormulaFor(minString);
 			if (!min.isValid())
 			{
 				return new ParseResult.Fail("Min Formula in " + getTokenName()
-						+ " was not valid: " + min.toString(), context);
+						+ " was not valid: " + min.toString());
 			}
 			Formula max = FormulaFactory.getFormulaFor(maxString);
 			if (!max.isValid())
 			{
 				return new ParseResult.Fail("Max Formula in " + getTokenName()
-						+ " was not valid: " + max.toString(), context);
+						+ " was not valid: " + max.toString());
 			}
 			kit.setOptionBounds(min, max);
 		}

--- a/code/src/java/plugin/lsttokens/kit/clazz/LevelToken.java
+++ b/code/src/java/plugin/lsttokens/kit/clazz/LevelToken.java
@@ -58,7 +58,7 @@ public class LevelToken extends AbstractNonEmptyToken<KitClass> implements
 		if (!formula.isValid())
 		{
 			return new ParseResult.Fail("Formula in " + getTokenName()
-					+ " was not valid: " + formula.toString(), context);
+					+ " was not valid: " + formula.toString());
 		}
 		kitClass.setLevel(formula);
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/kit/deity/CountToken.java
+++ b/code/src/java/plugin/lsttokens/kit/deity/CountToken.java
@@ -58,7 +58,7 @@ public class CountToken extends AbstractNonEmptyToken<KitDeity> implements
 		if (!formula.isValid())
 		{
 			return new ParseResult.Fail("Formula in " + getTokenName()
-					+ " was not valid: " + formula.toString(), context);
+					+ " was not valid: " + formula.toString());
 		}
 		kitDeity.setCount(formula);
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/kit/funds/QtyToken.java
+++ b/code/src/java/plugin/lsttokens/kit/funds/QtyToken.java
@@ -57,7 +57,7 @@ public class QtyToken extends AbstractNonEmptyToken<KitFunds> implements
 		if (!formula.isValid())
 		{
 			return new ParseResult.Fail("Formula in " + getTokenName()
-					+ " was not valid: " + formula.toString(), context);
+					+ " was not valid: " + formula.toString());
 		}
 		kitFunds.setQuantity(formula);
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/kit/gear/EqmodToken.java
+++ b/code/src/java/plugin/lsttokens/kit/gear/EqmodToken.java
@@ -78,7 +78,7 @@ public class EqmodToken extends AbstractTokenWithSeparator<KitGear> implements
 			if (aEqModName.equalsIgnoreCase(Constants.LST_NONE))
 			{
 				return new ParseResult.Fail("Embedded " + Constants.LST_NONE
-					+ " is prohibited in " + getTokenName(), context);
+					+ " is prohibited in " + getTokenName());
 			}
 			ParseResult pr = checkForIllegalSeparator('|', aEqModName);
 			if (!pr.passed())
@@ -104,7 +104,7 @@ public class EqmodToken extends AbstractTokenWithSeparator<KitGear> implements
 					if (assocTok.indexOf("[]") != -1)
 					{
 						return new ParseResult.Fail("Found empty assocation in "
-							+ getTokenName() + ": " + value, context);
+							+ getTokenName() + ": " + value);
 					}
 					StringTokenizer bracketTok =
 							new StringTokenizer(assocTok, "]");
@@ -116,15 +116,13 @@ public class EqmodToken extends AbstractTokenWithSeparator<KitGear> implements
 						{
 							return new ParseResult.Fail(
 								"Found close bracket without open bracket "
-									+ "in assocation in " + getTokenName() + ": " + value,
-								context);
+									+ "in assocation in " + getTokenName() + ": " + value);
 						}
 						if (openBracketLoc != assoc.lastIndexOf('['))
 						{
 							return new ParseResult.Fail(
 								"Found open bracket without close bracket "
-									+ "in assocation in " + getTokenName() + ": " + value,
-								context);
+									+ "in assocation in " + getTokenName() + ": " + value);
 						}
 					}
 				}

--- a/code/src/java/plugin/lsttokens/kit/gear/MaxCostToken.java
+++ b/code/src/java/plugin/lsttokens/kit/gear/MaxCostToken.java
@@ -55,7 +55,7 @@ public class MaxCostToken extends AbstractToken implements
 			Integer quan = Integer.valueOf(value);
 			if (quan.intValue() <= 0)
 			{
-				return new ParseResult.Fail(getTokenName() + " expected an integer > 0", context);
+				return new ParseResult.Fail(getTokenName() + " expected an integer > 0");
 			}
 			kitGear.setMaxCost(quan);
 			return ParseResult.SUCCESS;
@@ -64,7 +64,7 @@ public class MaxCostToken extends AbstractToken implements
 		{
 			return new ParseResult.Fail(getTokenName()
 				+ " expected an integer.  Tag must be of the form: "
-				+ getTokenName() + ":<int>", context);
+				+ getTokenName() + ":<int>");
 		}
 	}
 

--- a/code/src/java/plugin/lsttokens/kit/gear/QtyToken.java
+++ b/code/src/java/plugin/lsttokens/kit/gear/QtyToken.java
@@ -57,7 +57,7 @@ public class QtyToken extends AbstractNonEmptyToken<KitGear> implements
 		if (!formula.isValid())
 		{
 			return new ParseResult.Fail("Formula in " + getTokenName()
-					+ " was not valid: " + formula.toString(), context);
+					+ " was not valid: " + formula.toString());
 		}
 		kitGear.setQuantity(formula);
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/kit/levelability/AbilityToken.java
+++ b/code/src/java/plugin/lsttokens/kit/levelability/AbilityToken.java
@@ -60,7 +60,7 @@ public class AbilityToken extends AbstractToken implements
 		if (!value.startsWith("PROMPT:"))
 		{
 			return new ParseResult.Fail("Expected " + getTokenName()
-				+ " to start with PROMPT: " + value, context);
+				+ " to start with PROMPT: " + value);
 		}
 		StringTokenizer st = new StringTokenizer(value, Constants.PIPE);
 		String first = st.nextToken();
@@ -72,11 +72,11 @@ public class AbilityToken extends AbstractToken implements
 		}
 		catch (PersistenceLayerException e)
 		{
-			return new ParseResult.Fail(e.getMessage(), context);
+			return new ParseResult.Fail(e.getMessage());
 		}
 		if (ptc == null)
 		{
-			return new ParseResult.Fail("Error was in " + getTokenName() + ' ' + value, context);
+			return new ParseResult.Fail("Error was in " + getTokenName() + ' ' + value);
 		}
 		kitAbility.setAdd(ptc);
 
@@ -86,7 +86,7 @@ public class AbilityToken extends AbstractToken implements
 			if (!choiceString.startsWith("CHOICE:"))
 			{
 				return new ParseResult.Fail("Expected " + getTokenName()
-					+ " choice string to start with CHOICE: " + value, context);
+					+ " choice string to start with CHOICE: " + value);
 			}
 			String choice = choiceString.substring(7);
 			if (first.equals("FEAT") && !choice.startsWith("CATEGORY="))
@@ -104,7 +104,7 @@ public class AbilityToken extends AbstractToken implements
 			if (ptc.decodeChoice(context, choice) == null)
 			{
 				return new ParseResult.Fail(choiceString
-					+ " is not a valid selection for ADD:" + first, context);
+					+ " is not a valid selection for ADD:" + first);
 			}
 			kitAbility.addChoice(choice);
 		}

--- a/code/src/java/plugin/lsttokens/kit/levelability/LevelAbilityToken.java
+++ b/code/src/java/plugin/lsttokens/kit/levelability/LevelAbilityToken.java
@@ -61,18 +61,18 @@ public class LevelAbilityToken extends AbstractNonEmptyToken<KitLevelAbility>
 		int equalLoc = value.indexOf('=');
 		if (equalLoc == -1)
 		{
-			return new ParseResult.Fail(getTokenName() + " requires an =: " + value, context);
+			return new ParseResult.Fail(getTokenName() + " requires an =: " + value);
 		}
 		if (equalLoc != value.lastIndexOf('='))
 		{
 			return new ParseResult.Fail(getTokenName() + " requires a single =: "
-					+ value, context);
+					+ value);
 		}
 		String className = value.substring(0, equalLoc);
 		if (className.isEmpty())
 		{
 			return new ParseResult.Fail(getTokenName()
-					+ " requires a class name before =: " + value, context);
+					+ " requires a class name before =: " + value);
 		}
 		String level = value.substring(equalLoc + 1);
 		CDOMSingleRef<PCClass> cl = context.getReferenceContext().getCDOMReference(PCClass.class,
@@ -90,7 +90,7 @@ public class LevelAbilityToken extends AbstractNonEmptyToken<KitLevelAbility>
 		{
 			return new ParseResult.Fail(getTokenName()
 					+ " expected an integer.  Tag must be of the form: "
-					+ getTokenName() + ":<int>", context);
+					+ getTokenName() + ":<int>");
 		}
 		kitLA.setClass(cl);
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/kit/prof/CountToken.java
+++ b/code/src/java/plugin/lsttokens/kit/prof/CountToken.java
@@ -55,7 +55,7 @@ public class CountToken extends AbstractToken implements
 			Integer quan = Integer.valueOf(value);
 			if (quan.intValue() <= 0)
 			{
-				return new ParseResult.Fail(getTokenName() + " expected an integer > 0", context);
+				return new ParseResult.Fail(getTokenName() + " expected an integer > 0");
 			}
 			kitProf.setCount(quan);
 			return ParseResult.SUCCESS;
@@ -64,7 +64,7 @@ public class CountToken extends AbstractToken implements
 		{
 			return new ParseResult.Fail(getTokenName()
 				+ " expected an integer.  Tag must be of the form: "
-				+ getTokenName() + ":<int>", context);
+				+ getTokenName() + ":<int>");
 		}
 	}
 

--- a/code/src/java/plugin/lsttokens/kit/prof/RacialToken.java
+++ b/code/src/java/plugin/lsttokens/kit/prof/RacialToken.java
@@ -55,7 +55,7 @@ public class RacialToken extends AbstractNonEmptyToken<KitProf> implements
 			if (value.length() > 1 && !value.equalsIgnoreCase("YES"))
 			{
 				return new ParseResult.Fail("You should use 'YES' as the "
-					+ getTokenName() + ": " + value, context);
+					+ getTokenName() + ": " + value);
 			}
 			set = Boolean.TRUE;
 		}
@@ -64,12 +64,12 @@ public class RacialToken extends AbstractNonEmptyToken<KitProf> implements
 			if (firstChar != 'N' && firstChar != 'n')
 			{
 				return new ParseResult.Fail("You should use 'YES' or 'NO' as the "
-						+ getTokenName() + ": " + value, context);
+						+ getTokenName() + ": " + value);
 			}
 			if (value.length() > 1 && !value.equalsIgnoreCase("NO"))
 			{
 				return new ParseResult.Fail("You should use 'YES' or 'NO' as the "
-						+ getTokenName() + ": " + value, context);
+						+ getTokenName() + ": " + value);
 			}
 			set = Boolean.FALSE;
 		}

--- a/code/src/java/plugin/lsttokens/kit/skill/CountToken.java
+++ b/code/src/java/plugin/lsttokens/kit/skill/CountToken.java
@@ -56,7 +56,7 @@ public class CountToken extends AbstractToken implements
 			Integer quan = Integer.valueOf(value);
 			if (quan.intValue() <= 0)
 			{
-				return new ParseResult.Fail(getTokenName() + " expected an integer > 0", context);
+				return new ParseResult.Fail(getTokenName() + " expected an integer > 0");
 			}
 			kitSkill.setCount(quan);
 			return ParseResult.SUCCESS;
@@ -65,7 +65,7 @@ public class CountToken extends AbstractToken implements
 		{
 			return new ParseResult.Fail(getTokenName()
 				+ " expected an integer.  Tag must be of the form: "
-				+ getTokenName() + ":<int>", context);
+				+ getTokenName() + ":<int>");
 		}
 	}
 

--- a/code/src/java/plugin/lsttokens/kit/skill/FreeToken.java
+++ b/code/src/java/plugin/lsttokens/kit/skill/FreeToken.java
@@ -58,7 +58,7 @@ public class FreeToken extends AbstractNonEmptyToken<KitSkill> implements
 			if (value.length() > 1 && !value.equalsIgnoreCase("YES"))
 			{
 				return new ParseResult.Fail("You should use 'YES' as the "
-						+ getTokenName() + ": " + value, context);
+						+ getTokenName() + ": " + value);
 			}
 			set = Boolean.TRUE;
 		}
@@ -67,12 +67,12 @@ public class FreeToken extends AbstractNonEmptyToken<KitSkill> implements
 			if (firstChar != 'N' && firstChar != 'n')
 			{
 				return new ParseResult.Fail("You should use 'YES' or 'NO' as the "
-						+ getTokenName() + ": " + value, context);
+						+ getTokenName() + ": " + value);
 			}
 			if (value.length() > 1 && !value.equalsIgnoreCase("NO"))
 			{
 				return new ParseResult.Fail("You should use 'YES' or 'NO' as the "
-						+ getTokenName() + ": " + value, context);
+						+ getTokenName() + ": " + value);
 			}
 			set = Boolean.FALSE;
 		}

--- a/code/src/java/plugin/lsttokens/kit/skill/RankToken.java
+++ b/code/src/java/plugin/lsttokens/kit/skill/RankToken.java
@@ -59,14 +59,14 @@ public class RankToken extends AbstractNonEmptyToken<KitSkill> implements
 			if (rank.compareTo(BigDecimal.ZERO) < 0)
 			{
 				return new ParseResult.Fail(getTokenName()
-					+ " must be a positive number: " + value, context);
+					+ " must be a positive number: " + value);
 			}
 			kitSkill.setRank(rank);
 			return ParseResult.SUCCESS;
 		}
 		catch (NumberFormatException e)
 		{
-			return new ParseResult.Fail(getTokenName() + " expected a number: " + value, context);
+			return new ParseResult.Fail(getTokenName() + " expected a number: " + value);
 		}
 	}
 

--- a/code/src/java/plugin/lsttokens/kit/spells/CountToken.java
+++ b/code/src/java/plugin/lsttokens/kit/spells/CountToken.java
@@ -56,7 +56,7 @@ public class CountToken extends AbstractNonEmptyToken<KitSpells> implements
 		if (!formula.isValid())
 		{
 			return new ParseResult.Fail("Formula in " + getTokenName()
-					+ " was not valid: " + formula.toString(), context);
+					+ " was not valid: " + formula.toString());
 		}
 		kitSpells.setCount(formula);
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/kit/spells/SpellsToken.java
+++ b/code/src/java/plugin/lsttokens/kit/spells/SpellsToken.java
@@ -81,13 +81,13 @@ public class SpellsToken extends AbstractNonEmptyToken<KitSpells> implements
 				if (kitSpell.getSpellBook() != null)
 				{
 					return new ParseResult.Fail("Cannot reset SPELLBOOK in SPELLS: "
-							+ value, context);
+							+ value);
 				}
 				String spellBook = field.substring(10);
 				if (spellBook.isEmpty())
 				{
 					return new ParseResult.Fail("Cannot set SPELLBOOK "
-							+ "to empty value in SPELLS: " + value, context);
+							+ "to empty value in SPELLS: " + value);
 				}
 				kitSpell.setSpellBook(spellBook);
 			}
@@ -96,13 +96,13 @@ public class SpellsToken extends AbstractNonEmptyToken<KitSpells> implements
 				if (kitSpell.getCastingClass() != null)
 				{
 					return new ParseResult.Fail("Cannot reset CLASS" + " in SPELLS: "
-							+ value, context);
+							+ value);
 				}
 				String className = field.substring(6);
 				if (className.isEmpty())
 				{
 					return new ParseResult.Fail("Cannot set CLASS "
-							+ "to empty value in SPELLS: " + value, context);
+							+ "to empty value in SPELLS: " + value);
 				}
 				else if (className.equalsIgnoreCase("Default"))
 				{
@@ -129,14 +129,14 @@ public class SpellsToken extends AbstractNonEmptyToken<KitSpells> implements
 					catch (NumberFormatException e)
 					{
 						return new ParseResult.Fail("Expected an Integer COUNT,"
-								+ " but found: " + countStr + " in " + value, context);
+								+ " but found: " + countStr + " in " + value);
 					}
 					field = field.substring(0, equalLoc);
 				}
 				if (field.isEmpty())
 				{
 					return new ParseResult.Fail("Expected an Spell in SPELLS"
-							+ " but found: " + value, context);
+							+ " but found: " + value);
 				}
 				StringTokenizer subTok = new StringTokenizer(field, "[]");
 				String filterString = subTok.nextToken();
@@ -149,7 +149,7 @@ public class SpellsToken extends AbstractNonEmptyToken<KitSpells> implements
 				if (sp == null)
 				{
 					return new ParseResult.Fail("  encountered Invalid limit in "
-							+ getTokenName() + ": " + value, context);
+							+ getTokenName() + ": " + value);
 				}
 
 				KnownSpellIdentifier ksi = new KnownSpellIdentifier(sp, null);

--- a/code/src/java/plugin/lsttokens/kit/startpack/ApplyToken.java
+++ b/code/src/java/plugin/lsttokens/kit/startpack/ApplyToken.java
@@ -62,7 +62,7 @@ public class ApplyToken extends AbstractNonEmptyToken<Kit> implements
 		catch (IllegalArgumentException e)
 		{
 			return new ParseResult.Fail(getTokenName()
-					+ " encountered unexpected application type: " + value, context);
+					+ " encountered unexpected application type: " + value);
 		}
 	}
 

--- a/code/src/java/plugin/lsttokens/kit/startpack/EquipBuyToken.java
+++ b/code/src/java/plugin/lsttokens/kit/startpack/EquipBuyToken.java
@@ -69,13 +69,13 @@ public class EquipBuyToken extends AbstractNonEmptyToken<Kit> implements
 		if (looksLikeAPrerequisite(activeValue))
 		{
 			return new ParseResult.Fail("Cannot have only PRExxx subtoken in "
-					+ getTokenName(), context);
+					+ getTokenName());
 		}
 		Formula f = FormulaFactory.getFormulaFor(activeValue);
 		if (!f.isValid())
 		{
 			return new ParseResult.Fail("Formula in " + getTokenName()
-					+ " was not valid: " + f.toString(), context);
+					+ " was not valid: " + f.toString());
 		}
 		List<Prerequisite> prereqs = new ArrayList<>();
 
@@ -86,7 +86,7 @@ public class EquipBuyToken extends AbstractNonEmptyToken<Kit> implements
 			if (prereq == null)
 			{
 				return new ParseResult.Fail("   (Did you put feats after the "
-					+ "PRExxx tags in " + getTokenName() + ":?)", context);
+					+ "PRExxx tags in " + getTokenName() + ":?)");
 			}
 			prereqs.add(prereq);
 		}

--- a/code/src/java/plugin/lsttokens/kit/startpack/TotalCostToken.java
+++ b/code/src/java/plugin/lsttokens/kit/startpack/TotalCostToken.java
@@ -70,13 +70,13 @@ public class TotalCostToken extends AbstractNonEmptyToken<Kit> implements
 		if (looksLikeAPrerequisite(activeValue))
 		{
 			return new ParseResult.Fail("Cannot have only PRExxx subtoken in "
-					+ getTokenName(), context);
+					+ getTokenName());
 		}
 		Formula f = FormulaFactory.getFormulaFor(activeValue);
 		if (!f.isValid())
 		{
 			return new ParseResult.Fail("Formula in " + getTokenName()
-					+ " was not valid: " + f.toString(), context);
+					+ " was not valid: " + f.toString());
 		}
 		List<Prerequisite> prereqs = new ArrayList<>();
 
@@ -87,7 +87,7 @@ public class TotalCostToken extends AbstractNonEmptyToken<Kit> implements
 			if (prereq == null)
 			{
 				return new ParseResult.Fail("   (Did you put total costs after the "
-					+ "PRExxx tags in " + getTokenName() + ":?)", context);
+					+ "PRExxx tags in " + getTokenName() + ":?)");
 			}
 			prereqs.add(prereq);
 		}

--- a/code/src/java/plugin/lsttokens/kit/startpack/VisibleToken.java
+++ b/code/src/java/plugin/lsttokens/kit/startpack/VisibleToken.java
@@ -68,7 +68,7 @@ public class VisibleToken extends AbstractNonEmptyToken<Kit> implements
 		}
 		else
 		{
-			return new ParseResult.Fail("Can't understand Visibility: " + value, context);
+			return new ParseResult.Fail("Can't understand Visibility: " + value);
 		}
 		kit.put(ObjectKey.VISIBILITY, vis);
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/kit/table/ValuesToken.java
+++ b/code/src/java/plugin/lsttokens/kit/table/ValuesToken.java
@@ -71,7 +71,7 @@ public class ValuesToken extends AbstractNonEmptyToken<KitTable> implements
 			if (thing.isEmpty())
 			{
 				return new ParseResult.Fail(getTokenName()
-						+ " arguments has invalid pipe separator: " + value, context);
+						+ " arguments has invalid pipe separator: " + value);
 			}
 			KitGear optionInfo = new KitGear();
 			for (String s : thing.split("[\\[\\]]"))
@@ -84,7 +84,7 @@ public class ValuesToken extends AbstractNonEmptyToken<KitTable> implements
 				if (colonLoc == -1)
 				{
 					return new ParseResult.Fail("Expected colon in Value item: " + s
-							+ " within: " + value, context);
+							+ " within: " + value);
 				}
 				String key = s.substring(0, colonLoc);
 				String thingValue = s.substring(colonLoc + 1);
@@ -94,33 +94,33 @@ public class ValuesToken extends AbstractNonEmptyToken<KitTable> implements
 							thingValue);
 					if (!passed)
 					{
-						return new ParseResult.Fail("Failure in token: " + key, context);
+						return new ParseResult.Fail("Failure in token: " + key);
 					}
 				}
 				catch (PersistenceLayerException e)
 				{
 					return new ParseResult.Fail("Failure in token: " + key
-							+ ' ' + e.getMessage(), context);
+							+ ' ' + e.getMessage());
 				}
 			}
 			if (!sep.hasNext())
 			{
-				return new ParseResult.Fail("Odd token count in Value: " + value, context);
+				return new ParseResult.Fail("Odd token count in Value: " + value);
 			}
 			String range = sep.next();
-			ParseResult pr = processRange(context, kitTable, optionInfo, range);
+			ParseResult pr = processRange(kitTable, optionInfo, range);
 			if (!pr.passed())
 			{
 				return new ParseResult.Fail("Invalid Range in Value: " + range
-						+ " within " + value, context);
+						+ " within " + value + " report was: " + pr);
 			}
 		}
 
 		return ParseResult.SUCCESS;
 	}
 
-	private ParseResult processRange(LoadContext context, KitTable kitTable,
-		KitGear optionInfo, String range)
+	private ParseResult processRange(KitTable kitTable, KitGear optionInfo,
+			String range)
 	{
 		ParseResult pr = checkSeparatorsAndNonEmpty(',', range);
 		if (!pr.passed())
@@ -144,19 +144,19 @@ public class ValuesToken extends AbstractNonEmptyToken<KitTable> implements
 		if (sep.hasNext())
 		{
 			return new ParseResult.Fail(
-				"Expected more than one value in a range, found: " + range, context);
+				"Expected more than one value in a range, found: " + range);
 		}
 		Formula min = FormulaFactory.getFormulaFor(minString);
 		if (!min.isValid())
 		{
 			return new ParseResult.Fail(
-				"Min Formula in " + getTokenName() + " was not valid: " + min.toString(), context);
+				"Min Formula in " + getTokenName() + " was not valid: " + min.toString());
 		}
 		Formula max = FormulaFactory.getFormulaFor(maxString);
 		if (!max.isValid())
 		{
 			return new ParseResult.Fail(
-				"Max Formula in " + getTokenName() + " was not valid: " + max.toString(), context);
+				"Max Formula in " + getTokenName() + " was not valid: " + max.toString());
 		}
 		kitTable.addGear(optionInfo, min, max);
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/load/EncumbranceToken.java
+++ b/code/src/java/plugin/lsttokens/load/EncumbranceToken.java
@@ -49,7 +49,7 @@ public class EncumbranceToken extends AbstractNonEmptyToken<LoadInfo> implements
 		if ((tokenCount != 2) && (tokenCount != 4))
 		{
 			return new ParseResult.Fail("Expected " + getTokenName()
-					+ " to have 2 or 4 arguments, found: " + value, context);
+					+ " to have 2 or 4 arguments, found: " + value);
 		}
 
 		String multString = tokens[1];
@@ -65,7 +65,7 @@ public class EncumbranceToken extends AbstractNonEmptyToken<LoadInfo> implements
 			{
 				return new ParseResult.Fail("Expected " + getTokenName()
 						+ " multiple to be a decimal (or a fraction), found: "
-						+ multString, context);
+						+ multString);
 			}
 		}
 		else
@@ -74,7 +74,7 @@ public class EncumbranceToken extends AbstractNonEmptyToken<LoadInfo> implements
 			{
 				return new ParseResult.Fail("Expected " + getTokenName()
 						+ " multiple to be a decimal or a fraction, found: "
-						+ multString, context);
+						+ multString);
 			}
 			mult = Double.parseDouble(multString.substring(0, divLoc))
 					/ Double.parseDouble(multString.substring(divLoc + 1));
@@ -92,7 +92,7 @@ public class EncumbranceToken extends AbstractNonEmptyToken<LoadInfo> implements
 			catch (NumberFormatException e)
 			{
 				return new ParseResult.Fail("Expected " + getTokenName()
-						+ " penalty to be an integer, found: " + tokens[3], context);
+						+ " penalty to be an integer, found: " + tokens[3]);
 			}
 		}
 		else

--- a/code/src/java/plugin/lsttokens/load/LoadToken.java
+++ b/code/src/java/plugin/lsttokens/load/LoadToken.java
@@ -48,12 +48,12 @@ public class LoadToken extends AbstractTokenWithSeparator<LoadInfo> implements
 		if (pipeLoc == -1)
 		{
 			return new ParseResult.Fail(getTokenName()
-					+ " requires a pipe, found : " + value, context);
+					+ " requires a pipe, found : " + value);
 		}
 		if (pipeLoc != value.lastIndexOf('|'))
 		{
 			return new ParseResult.Fail(getTokenName()
-					+ " requires only one pipe, found : " + value, context);
+					+ " requires only one pipe, found : " + value);
 		}
 		String strengthString = value.substring(0, pipeLoc);
 
@@ -66,7 +66,7 @@ public class LoadToken extends AbstractTokenWithSeparator<LoadInfo> implements
 		{
 			return new ParseResult.Fail(getTokenName()
 					+ " expected an Integer strength value : " + strengthString
-					+ " in value: " + value, context);
+					+ " in value: " + value);
 		}
 		String loadString = value.substring(pipeLoc + 1);
 		try
@@ -76,7 +76,7 @@ public class LoadToken extends AbstractTokenWithSeparator<LoadInfo> implements
 			{
 				return new ParseResult.Fail(getTokenName()
 						+ " requires a non-negative load value, found : "
-						+ loadString, context);
+						+ loadString);
 			}
 			info.addLoadScoreValue(strength, load);
 		}
@@ -84,7 +84,7 @@ public class LoadToken extends AbstractTokenWithSeparator<LoadInfo> implements
 		{
 			return new ParseResult.Fail(getTokenName()
 					+ " misunderstood load value : " + loadString
-					+ " in value: " + value, context);
+					+ " in value: " + value);
 		}
 		return ParseResult.SUCCESS;
 	}

--- a/code/src/java/plugin/lsttokens/load/LoadmultToken.java
+++ b/code/src/java/plugin/lsttokens/load/LoadmultToken.java
@@ -51,14 +51,14 @@ public class LoadmultToken extends AbstractNonEmptyToken<LoadInfo> implements
 			{
 				return new ParseResult.Fail(getTokenName()
 						+ " requires a positive load multiplier, found : "
-						+ value, context);
+						+ value);
 			}
 			info.setLoadScoreMultiplier(mult);
 			return ParseResult.SUCCESS;
 		}
 		catch (NumberFormatException nfe)
 		{
-			return new ParseResult.Fail("Misunderstood Double in Tag: " + value, context);
+			return new ParseResult.Fail("Misunderstood Double in Tag: " + value);
 		}
 	}
 

--- a/code/src/java/plugin/lsttokens/load/LoadmultstepToken.java
+++ b/code/src/java/plugin/lsttokens/load/LoadmultstepToken.java
@@ -43,7 +43,7 @@ public class LoadmultstepToken extends AbstractNonEmptyToken<LoadInfo>
 			if (step <= 0)
 			{
 				return new ParseResult.Fail(getTokenName()
-						+ " expected a positive integer, found : " + value, context);
+						+ " expected a positive integer, found : " + value);
 			}
 			info.setLoadMultStep(Integer.parseInt(value));
 			return ParseResult.SUCCESS;
@@ -52,7 +52,7 @@ public class LoadmultstepToken extends AbstractNonEmptyToken<LoadInfo>
 		{
 			return new ParseResult.Fail(getTokenName()
 					+ " expected an integer.  Tag must be of the form: "
-					+ getTokenName() + ":<int>", context);
+					+ getTokenName() + ":<int>");
 		}
 	}
 

--- a/code/src/java/plugin/lsttokens/load/SizemultToken.java
+++ b/code/src/java/plugin/lsttokens/load/SizemultToken.java
@@ -51,12 +51,12 @@ public class SizemultToken extends AbstractTokenWithSeparator<LoadInfo>
 		if (pipeLoc == -1)
 		{
 			return new ParseResult.Fail(getTokenName()
-					+ " requires a pipe, found : " + value, context);
+					+ " requires a pipe, found : " + value);
 		}
 		if (pipeLoc != value.lastIndexOf('|'))
 		{
 			return new ParseResult.Fail(getTokenName()
-					+ " requires only one pipe, found : " + value, context);
+					+ " requires only one pipe, found : " + value);
 		}
 		String sizeName = value.substring(0, pipeLoc);
 		String multiplierString = value.substring(pipeLoc + 1);
@@ -74,7 +74,7 @@ public class SizemultToken extends AbstractTokenWithSeparator<LoadInfo>
 			{
 				return new ParseResult.Fail(getTokenName()
 						+ " requires a positive multiplier : "
-						+ multiplierString + " in value: " + value, context);
+						+ multiplierString + " in value: " + value);
 			}
 			info.addSizeAdjustment(size, multiplier);
 		}
@@ -82,7 +82,7 @@ public class SizemultToken extends AbstractTokenWithSeparator<LoadInfo>
 		{
 			return new ParseResult.Fail(getTokenName()
 					+ " misunderstood multiplier : " + multiplierString
-					+ " in value: " + value, context);
+					+ " in value: " + value);
 		}
 		return ParseResult.SUCCESS;
 	}

--- a/code/src/java/plugin/lsttokens/pcclass/AdddomainsToken.java
+++ b/code/src/java/plugin/lsttokens/pcclass/AdddomainsToken.java
@@ -90,7 +90,7 @@ public class AdddomainsToken extends AbstractTokenWithSeparator<PCClass>
 				if (tokString.indexOf(']') != -1)
 				{
 					return new ParseResult.Fail("Invalid " + getTokenName()
-							+ " must have '[' if it contains a PREREQ tag", context);
+							+ " must have '[' if it contains a PREREQ tag");
 				}
 				domainKey = tokString;
 			}
@@ -99,7 +99,7 @@ public class AdddomainsToken extends AbstractTokenWithSeparator<PCClass>
 				if (tokString.indexOf(']') != tokString.length() - 1)
 				{
 					return new ParseResult.Fail("Invalid " + getTokenName()
-							+ " must end with ']' if it contains a PREREQ tag", context);
+							+ " must end with ']' if it contains a PREREQ tag");
 				}
 				domainKey = tokString.substring(0, openBracketLoc);
 				String prereqString = tokString.substring(openBracketLoc + 1,
@@ -107,13 +107,13 @@ public class AdddomainsToken extends AbstractTokenWithSeparator<PCClass>
 				if (prereqString.isEmpty())
 				{
 					return new ParseResult.Fail(getTokenName()
-							+ " cannot have empty prerequisite : " + value, context);
+							+ " cannot have empty prerequisite : " + value);
 				}
 				prereq = getPrerequisite(prereqString);
 				if (prereq == null)
 				{
 					return new ParseResult.Fail(getTokenName()
-							+ " had invalid prerequisite : " + prereqString, context);
+							+ " had invalid prerequisite : " + prereqString);
 				}
 				Logging.deprecationPrint(getTokenName()
 					+ " using PRExxx in brackets is deprecated: " + value
@@ -157,7 +157,7 @@ public class AdddomainsToken extends AbstractTokenWithSeparator<PCClass>
 			if (prereq == null)
 			{
 				return new ParseResult.Fail(getTokenName()
-						+ " had invalid prerequisite : " + tokString, context);
+						+ " had invalid prerequisite : " + tokString);
 			}
 			for (AssociatedPrereqObject apo : apoList)
 			{

--- a/code/src/java/plugin/lsttokens/pcclass/AttackcycleToken.java
+++ b/code/src/java/plugin/lsttokens/pcclass/AttackcycleToken.java
@@ -60,7 +60,7 @@ public class AttackcycleToken extends AbstractTokenWithSeparator<PCClass>
 		if (aTok.countTokens() % 2 != 0)
 		{
 			return new ParseResult.Fail(getTokenName()
-					+ " must have an even number of arguments.", context);
+					+ " must have an even number of arguments.");
 		}
 
 		while (aTok.hasMoreTokens())
@@ -69,7 +69,7 @@ public class AttackcycleToken extends AbstractTokenWithSeparator<PCClass>
 			if (AttackType.GRAPPLE.equals(at))
 			{
 				return new ParseResult.Fail("Error: Cannot Set Attack Cycle "
-						+ "for GRAPPLE Attack Type", context);
+						+ "for GRAPPLE Attack Type");
 			}
 			String cycle = aTok.nextToken();
 			try
@@ -78,7 +78,7 @@ public class AttackcycleToken extends AbstractTokenWithSeparator<PCClass>
 				if (i <= 0)
 				{
 					return new ParseResult.Fail("Invalid " + getTokenName() + ": " + value
-							+ " Cycle " + cycle + " must be a positive integer.", context);
+							+ " Cycle " + cycle + " must be a positive integer.");
 				}
 				context.getObjectContext().put(pcc, MapKey.ATTACK_CYCLE, at, i);
 				/*
@@ -102,7 +102,7 @@ public class AttackcycleToken extends AbstractTokenWithSeparator<PCClass>
 			catch (NumberFormatException e)
 			{
 				return new ParseResult.Fail("Invalid " + getTokenName() + ": " + value
-						+ " Cycle " + cycle + " must be a (positive) integer.", context);
+						+ " Cycle " + cycle + " must be a (positive) integer.");
 			}
 		}
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/pcclass/BonusspellstatToken.java
+++ b/code/src/java/plugin/lsttokens/pcclass/BonusspellstatToken.java
@@ -64,7 +64,7 @@ public class BonusspellstatToken extends AbstractNonEmptyToken<PCClass>
 		if (pcs == null)
 		{
 			return new ParseResult.Fail("Invalid Stat Abbreviation in " + getTokenName()
-					+ ": " + value, context);
+					+ ": " + value);
 		}
 		context.getObjectContext().put(pcc, ObjectKey.BONUS_SPELL_STAT, pcs);
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/pcclass/CcskillToken.java
+++ b/code/src/java/plugin/lsttokens/pcclass/CcskillToken.java
@@ -73,7 +73,7 @@ public class CcskillToken extends AbstractTokenWithSeparator<PCClass> implements
 				{
 					return new ParseResult.Fail("  Non-sensical "
 							+ getTokenName()
-							+ ": .CLEAR was not the first list item", context);
+							+ ": .CLEAR was not the first list item");
 				}
 				context.getObjectContext().removeList(obj, ListKey.LOCALCCSKILL);
 			}
@@ -94,7 +94,7 @@ public class CcskillToken extends AbstractTokenWithSeparator<PCClass> implements
 					{
 						return new ParseResult.Fail(
 								"  Error was encountered while parsing "
-										+ getTokenName(), context);
+										+ getTokenName());
 					}
 					context.getObjectContext().removeFromList(obj,
 							ListKey.LOCALCCSKILL, ref);
@@ -124,7 +124,7 @@ public class CcskillToken extends AbstractTokenWithSeparator<PCClass> implements
 					{
 						return new ParseResult.Fail(
 								"  Error was encountered while parsing "
-										+ getTokenName(), context);
+										+ getTokenName());
 					}
 					context.getObjectContext().addToList(obj,
 							ListKey.LOCALCCSKILL, ref);
@@ -135,7 +135,7 @@ public class CcskillToken extends AbstractTokenWithSeparator<PCClass> implements
 		if (foundAny && foundOther)
 		{
 			return new ParseResult.Fail("Non-sensical " + getTokenName()
-					+ ": Contains ANY and a specific reference: " + value, context);
+					+ ": Contains ANY and a specific reference: " + value);
 		}
 		return ParseResult.SUCCESS;
 	}

--- a/code/src/java/plugin/lsttokens/pcclass/CrformulaToken.java
+++ b/code/src/java/plugin/lsttokens/pcclass/CrformulaToken.java
@@ -47,7 +47,7 @@ public class CrformulaToken extends AbstractNonEmptyToken<PCClass> implements
 		if (!formula.isValid())
 		{
 			return new ParseResult.Fail("Formula in " + getTokenName()
-					+ " was not valid: " + formula.toString(), context);
+					+ " was not valid: " + formula.toString());
 		}
 		context.getObjectContext().put(pcc, FormulaKey.CR, formula);
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/pcclass/CskillToken.java
+++ b/code/src/java/plugin/lsttokens/pcclass/CskillToken.java
@@ -76,7 +76,7 @@ public class CskillToken extends AbstractTokenWithSeparator<PCClass> implements
 				{
 					return new ParseResult.Fail("  Non-sensical "
 							+ getTokenName()
-							+ ": .CLEAR was not the first list item", context);
+							+ ": .CLEAR was not the first list item");
 				}
 				context.getObjectContext().removeList(obj, ListKey.CLASS_SKILL);
 			}
@@ -97,7 +97,7 @@ public class CskillToken extends AbstractTokenWithSeparator<PCClass> implements
 					{
 						return new ParseResult.Fail(
 								"  Error was encountered while parsing "
-										+ getTokenName(), context);
+										+ getTokenName());
 					}
 					context.getObjectContext().removeFromList(obj,
 							ListKey.CLASS_SKILL, ref);
@@ -127,7 +127,7 @@ public class CskillToken extends AbstractTokenWithSeparator<PCClass> implements
 					{
 						return new ParseResult.Fail(
 								"  Error was encountered while parsing "
-										+ getTokenName(), context);
+										+ getTokenName());
 					}
 					context.getObjectContext().addToList(obj,
 							ListKey.CLASS_SKILL, ref);
@@ -138,7 +138,7 @@ public class CskillToken extends AbstractTokenWithSeparator<PCClass> implements
 		if (foundAny && foundOther)
 		{
 			return new ParseResult.Fail("Non-sensical " + getTokenName()
-					+ ": Contains ANY and a specific reference: " + value, context);
+					+ ": Contains ANY and a specific reference: " + value);
 		}
 		return ParseResult.SUCCESS;
 	}

--- a/code/src/java/plugin/lsttokens/pcclass/DomainToken.java
+++ b/code/src/java/plugin/lsttokens/pcclass/DomainToken.java
@@ -73,7 +73,7 @@ public class DomainToken extends AbstractTokenWithSeparator<PCClass> implements
 		if (looksLikeAPrerequisite(tok))
 		{
 			return new ParseResult.Fail("Cannot have only PRExxx subtoken in "
-				+ getTokenName() + ": " + value, context);
+				+ getTokenName() + ": " + value);
 		}
 
 		List<QualifiedObject<CDOMSingleRef<Domain>>> toAdd =
@@ -86,7 +86,7 @@ public class DomainToken extends AbstractTokenWithSeparator<PCClass> implements
 				if (!first)
 				{
 					return new ParseResult.Fail("  Non-sensical " + getTokenName()
-							+ ": .CLEAR was not the first list item", context);
+							+ ": .CLEAR was not the first list item");
 				}
 				context.getObjectContext().removeList(pcc, ListKey.DOMAIN);
 				foundClear = true;
@@ -116,7 +116,7 @@ public class DomainToken extends AbstractTokenWithSeparator<PCClass> implements
 		{
 			return new ParseResult.Fail(
 					"Cannot use PREREQs when using .CLEAR in "
-							+ getTokenName(), context);
+							+ getTokenName());
 		}
 
 		while (true)
@@ -125,7 +125,7 @@ public class DomainToken extends AbstractTokenWithSeparator<PCClass> implements
 			if (prereq == null)
 			{
 				return new ParseResult.Fail("   (Did you put feats after the "
-						+ "PRExxx tags in " + getTokenName() + ":?)", context);
+						+ "PRExxx tags in " + getTokenName() + ":?)");
 			}
 			for (PrereqObject pro : toAdd)
 			{

--- a/code/src/java/plugin/lsttokens/pcclass/ExchangelevelToken.java
+++ b/code/src/java/plugin/lsttokens/pcclass/ExchangelevelToken.java
@@ -57,7 +57,7 @@ public class ExchangelevelToken extends AbstractTokenWithSeparator<PCClass>
 		if (tok.countTokens() != 4)
 		{
 			return new ParseResult.Fail(getTokenName()
-					+ " must have 4 | delimited arguments : " + value, context);
+					+ " must have 4 | delimited arguments : " + value);
 		}
 
 		String classString = tok.nextToken();
@@ -72,7 +72,7 @@ public class ExchangelevelToken extends AbstractTokenWithSeparator<PCClass>
 		catch (NumberFormatException nfe)
 		{
 			return new ParseResult.Fail(getTokenName() + " expected an integer: "
-					+ mindlString, context);
+					+ mindlString);
 		}
 		String maxdlString = tok.nextToken();
 		int maxdl;
@@ -83,7 +83,7 @@ public class ExchangelevelToken extends AbstractTokenWithSeparator<PCClass>
 		catch (NumberFormatException nfe)
 		{
 			return new ParseResult.Fail(getTokenName() + " expected an integer: "
-					+ maxdlString, context);
+					+ maxdlString);
 		}
 		String minremString = tok.nextToken();
 		int minrem;
@@ -94,7 +94,7 @@ public class ExchangelevelToken extends AbstractTokenWithSeparator<PCClass>
 		catch (NumberFormatException nfe)
 		{
 			return new ParseResult.Fail(getTokenName() + " expected an integer: "
-					+ minremString, context);
+					+ minremString);
 		}
 		try
 		{

--- a/code/src/java/plugin/lsttokens/pcclass/HdToken.java
+++ b/code/src/java/plugin/lsttokens/pcclass/HdToken.java
@@ -44,7 +44,7 @@ public class HdToken implements CDOMPrimaryToken<PCClass>
 			Integer in = Integer.valueOf(value);
 			if (in.intValue() <= 0)
 			{
-				return new ParseResult.Fail(getTokenName() + " must be an integer > 0", context);
+				return new ParseResult.Fail(getTokenName() + " must be an integer > 0");
 			}
 			context.getObjectContext().put(pcc, ObjectKey.LEVEL_HITDIE,
 					new HitDie(in));
@@ -54,7 +54,7 @@ public class HdToken implements CDOMPrimaryToken<PCClass>
 		{
 			return new ParseResult.Fail(getTokenName()
 					+ " expected an integer.  Tag must be of the form: "
-					+ getTokenName() + ":<int>", context);
+					+ getTokenName() + ":<int>");
 		}
 	}
 

--- a/code/src/java/plugin/lsttokens/pcclass/KnownspellsToken.java
+++ b/code/src/java/plugin/lsttokens/pcclass/KnownspellsToken.java
@@ -76,7 +76,7 @@ public class KnownspellsToken extends AbstractTokenWithSeparator<PCClass>
 				{
 					return new ParseResult.Fail("Non-sensical situation was "
 						+ "encountered while parsing " + getTokenName()
-						+ ": When used, .CLEARALL must be the first argument", context);
+						+ ": When used, .CLEARALL must be the first argument");
 				}
 				context.getObjectContext()
 						.removeList(pcc, ListKey.KNOWN_SPELLS);
@@ -114,7 +114,7 @@ public class KnownspellsToken extends AbstractTokenWithSeparator<PCClass>
 					{
 						return new ParseResult.Fail(
 							"Cannot have more than one Level limit in " + getTokenName()
-								+ ": " + value, context);
+								+ ": " + value);
 					}
 					// if the argument starts with LEVEL=, compare the level to
 					// the desired spellLevel
@@ -146,14 +146,14 @@ public class KnownspellsToken extends AbstractTokenWithSeparator<PCClass>
 					{
 						return new ParseResult.Fail(
 							"Cannot have more than one Type/Spell limit in "
-								+ getTokenName() + ": " + value, context);
+								+ getTokenName() + ": " + value);
 					}
 					sp = TokenUtilities.getTypeOrPrimitive(context,
 							SPELL_CLASS, filterString);
 					if (sp == null)
 					{
 						return new ParseResult.Fail("  encountered Invalid limit in "
-								+ getTokenName() + ": " + value, context);
+								+ getTokenName() + ": " + value);
 					}
 				}
 				firstToken = false;

--- a/code/src/java/plugin/lsttokens/pcclass/LangbonusToken.java
+++ b/code/src/java/plugin/lsttokens/pcclass/LangbonusToken.java
@@ -73,7 +73,7 @@ public class LangbonusToken extends AbstractTokenWithSeparator<PCClass>
 				{
 					return new ParseResult.Fail("Non-sensical situation was "
 							+ "encountered while parsing " + getTokenName()
-							+ ": When used, .CLEAR must be the first argument", context);
+							+ ": When used, .CLEAR must be the first argument");
 				}
 				context.getListContext().removeAllFromList(getTokenName(), cl,
 						Language.STARTING_LIST);
@@ -98,7 +98,7 @@ public class LangbonusToken extends AbstractTokenWithSeparator<PCClass>
 									+ ": "
 									+ value
 									+ " had an invalid .CLEAR. reference: "
-									+ clearText, context);
+									+ clearText);
 				}
 				context.getListContext().removeFromList(getTokenName(), cl,
 						Language.STARTING_LIST, lang);
@@ -129,7 +129,7 @@ public class LangbonusToken extends AbstractTokenWithSeparator<PCClass>
 				{
 					return new ParseResult.Fail("  Error was encountered while parsing "
 							+ getTokenName() + ": " + value
-							+ " had an invalid reference: " + tokText, context);
+							+ " had an invalid reference: " + tokText);
 				}
 				context.getListContext().addToList(getTokenName(), cl,
 						Language.STARTING_LIST, lang);
@@ -139,7 +139,7 @@ public class LangbonusToken extends AbstractTokenWithSeparator<PCClass>
 		if (foundAny && foundOther)
 		{
 			return new ParseResult.Fail("Non-sensical " + getTokenName()
-					+ ": Contains ANY and a specific reference: " + value, context);
+					+ ": Contains ANY and a specific reference: " + value);
 		}
 		return ParseResult.SUCCESS;
 	}

--- a/code/src/java/plugin/lsttokens/pcclass/LevelsperfeatToken.java
+++ b/code/src/java/plugin/lsttokens/pcclass/LevelsperfeatToken.java
@@ -71,7 +71,7 @@ public class LevelsperfeatToken extends AbstractTokenWithSeparator<PCClass>
 						+ " must be of the form: " + getTokenName()
 						+ ":<int> or " + getTokenName()
 						+ ":<int>|LEVELTYPE=<string>" + " Got "
-						+ getTokenName() + Constants.COLON + value, context);
+						+ getTokenName() + Constants.COLON + value);
 			}
 			numLevels = value.substring(0, pipeLoc);
 			String levelTypeTag = value.substring(pipeLoc + 1);
@@ -80,7 +80,7 @@ public class LevelsperfeatToken extends AbstractTokenWithSeparator<PCClass>
 				return new ParseResult.Fail("If " + getTokenName()
 						+ " has a | it must be of the form: " + getTokenName()
 						+ ":<int>|LEVELTYPE=<string>" + " Got "
-						+ getTokenName() + Constants.COLON + value, context);
+						+ getTokenName() + Constants.COLON + value);
 			}
 			String levelType = levelTypeTag.substring(10);
 			if (levelType == null || levelType.isEmpty())
@@ -88,7 +88,7 @@ public class LevelsperfeatToken extends AbstractTokenWithSeparator<PCClass>
 				return new ParseResult.Fail("If " + getTokenName()
 						+ " has a | it must be of the form: " + getTokenName()
 						+ ":<int>|LEVELTYPE=<string>"
-						+ " Got an empty leveltype", context);
+						+ " Got an empty leveltype");
 			}
 			context.getObjectContext()
 					.put(pcc, StringKey.LEVEL_TYPE, levelType);
@@ -100,7 +100,7 @@ public class LevelsperfeatToken extends AbstractTokenWithSeparator<PCClass>
 			if (in.intValue() < 0)
 			{
 				return new ParseResult.Fail(getTokenName()
-						+ " must be an integer >= 0", context);
+						+ " must be an integer >= 0");
 			}
 			context.getObjectContext().put(pcc, IntegerKey.LEVELS_PER_FEAT, in);
 		}
@@ -109,7 +109,7 @@ public class LevelsperfeatToken extends AbstractTokenWithSeparator<PCClass>
 			return new ParseResult.Fail(getTokenName()
 					+ " expected an integer.  Tag must be of the form: "
 					+ getTokenName() + ":<int> or " + getTokenName()
-					+ ":<int>|LEVELTYPE=<string>", context);
+					+ ":<int>|LEVELTYPE=<string>");
 		}
 
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/pcclass/MaxlevelToken.java
+++ b/code/src/java/plugin/lsttokens/pcclass/MaxlevelToken.java
@@ -52,13 +52,13 @@ public class MaxlevelToken implements CDOMPrimaryToken<PCClass>
 				if (lim.intValue() <= 0)
 				{
 					return new ParseResult.Fail("Value less than 1 is not valid for "
-							+ getTokenName() + ": " + value, context);
+							+ getTokenName() + ": " + value);
 				}
 			}
 			catch (NumberFormatException nfe)
 			{
 				return new ParseResult.Fail("Value was not a number for "
-						+ getTokenName() + ": " + value, context);
+						+ getTokenName() + ": " + value);
 			}
 		}
 		context.getObjectContext().put(pcc, IntegerKey.LEVEL_LIMIT, lim);

--- a/code/src/java/plugin/lsttokens/pcclass/MonnonskillhdToken.java
+++ b/code/src/java/plugin/lsttokens/pcclass/MonnonskillhdToken.java
@@ -52,7 +52,7 @@ public class MonnonskillhdToken extends AbstractNonEmptyToken<PCClass>
 		if (bon == null)
 		{
 			return new ParseResult.Fail(getTokenName()
-					+ " was given invalid bonus value: " + value, context);
+					+ " was given invalid bonus value: " + value);
 		}
 		bon.setTokenSource(getTokenName());
 		context.getObjectContext().addToList(pcc, ListKey.BONUS, bon);

--- a/code/src/java/plugin/lsttokens/pcclass/MonskillToken.java
+++ b/code/src/java/plugin/lsttokens/pcclass/MonskillToken.java
@@ -55,13 +55,13 @@ public class MonskillToken extends AbstractNonEmptyToken<PCClass> implements
 		if (bon == null)
 		{
 			return new ParseResult.Fail(getTokenName()
-					+ " was given invalid bonus value: " + value, context);
+					+ " was given invalid bonus value: " + value);
 		}
 		Prerequisite prereq = getPrerequisite("PRELEVELMAX:1");
 		if (prereq == null)
 		{
 			return new ParseResult.Fail("Internal Error: " + getTokenName()
-					+ " had invalid prerequisite", context);
+					+ " had invalid prerequisite");
 		}
 		bon.addPrerequisite(prereq);
 		bon.setTokenSource(getTokenName());

--- a/code/src/java/plugin/lsttokens/pcclass/ProhibitspellToken.java
+++ b/code/src/java/plugin/lsttokens/pcclass/ProhibitspellToken.java
@@ -1,19 +1,17 @@
 /*
  * Copyright (c) 2008 Tom Parker <thpr@users.sourceforge.net>
  * 
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free
- * Software Foundation; either version 2.1 of the License, or (at your option)
- * any later version.
+ * This program is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
  * 
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
- * details.
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
  * 
- * You should have received a copy of the GNU Lesser General Public License
- * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 51 Franklin Street,
+ * Fifth Floor, Boston, MA 02110-1301, USA
  */
 package plugin.lsttokens.pcclass;
 
@@ -36,7 +34,6 @@ import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.token.AbstractTokenWithSeparator;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import pcgen.rules.persistence.token.ParseResult;
-import pcgen.util.Logging;
 import pcgen.util.enumeration.ProhibitedSpellType;
 
 /**
@@ -59,30 +56,17 @@ public class ProhibitspellToken extends AbstractTokenWithSeparator<PCClass>
 	}
 
 	@Override
-	protected ParseResult parseTokenWithSeparator(LoadContext context,
-		PCClass pcc, String value)
-	{
-		SpellProhibitor sp = subParse(value);
-		if (sp == null)
-		{
-			return ParseResult.INTERNAL_ERROR;
-		}
-		context.getObjectContext().addToList(pcc, ListKey.SPELL_PROHIBITOR, sp);
-		return ParseResult.SUCCESS;
-	}
-
-	public SpellProhibitor subParse(String value)
+	protected ParseResult parseTokenWithSeparator(LoadContext context, PCClass pcc,
+		String value)
 	{
 		StringTokenizer tok = new StringTokenizer(value, Constants.PIPE);
-
 		String token = tok.nextToken();
 
 		int dotLoc = token.indexOf(Constants.DOT);
 		if (dotLoc == -1)
 		{
-			Logging.errorPrint(getTokenName()
-					+ " has no . separator for arguments: " + value);
-			return null;
+			return new ParseResult.Fail(
+				getTokenName() + " has no . separator for arguments: " + value);
 		}
 		String pstString = token.substring(0, dotLoc);
 		ProhibitedSpellType type;
@@ -93,81 +77,36 @@ public class ProhibitspellToken extends AbstractTokenWithSeparator<PCClass>
 		}
 		catch (IllegalArgumentException e)
 		{
-			Logging
-					.errorPrint(getTokenName()
-							+ " encountered an invalid Prohibited Spell Type: "
-							+ value);
-			Logging.errorPrint("  Legal values are: "
-					+ StringUtil.join(Arrays.asList(ProhibitedSpellType
-							.values()), ", "));
-			return null;
+			return new ParseResult.Fail(
+				getTokenName() + " encountered an invalid Prohibited Spell Type: " + value
+					+ "\n  Legal values are: "
+					+ StringUtil.join(Arrays.asList(ProhibitedSpellType.values()), ", "));
 		}
 
-		SpellProhibitor spellProb =
-				typeSafeParse(type, token.substring(dotLoc + 1));
-		if (spellProb == null)
-		{
-			Logging.errorPrint("  entire token value was: " + value);
-			return null;
-		}
-		if (!tok.hasMoreTokens())
-		{
-			// No prereqs, so we're done
-			return spellProb;
-		}
-		token = tok.nextToken();
-
-		while (true)
-		{
-			Prerequisite prereq = getPrerequisite(token);
-			if (prereq == null)
-			{
-				Logging
-						.errorPrint("   (Did you put more than one limit, or items after the "
-								+ "PRExxx tags in " + getTokenName() + ":?)");
-				return null;
-			}
-			spellProb.addPrerequisite(prereq);
-			if (!tok.hasMoreTokens())
-			{
-				break;
-			}
-			token = tok.nextToken();
-		}
-		return spellProb;
-	}
-
-	private SpellProhibitor typeSafeParse(ProhibitedSpellType type, String args)
-	{
+		String args = token.substring(dotLoc + 1);
 		SpellProhibitor spellProb = new SpellProhibitor();
 		spellProb.setType(type);
 		if (args.isEmpty())
 		{
-			Logging.errorPrint(getTokenName() + ' ' + type
-					+ " has no arguments");
-			return null;
+			return new ParseResult.Fail(
+				getTokenName() + ' ' + type + " has no arguments");
 		}
 
 		String joinChar = getJoinChar(type, new LinkedList<>());
 		if (args.indexOf(joinChar) == 0)
 		{
-			Logging.errorPrint(getTokenName()
-					+ " arguments may not start with " + joinChar);
-			return null;
+			return new ParseResult.Fail(
+				getTokenName() + " arguments may not start with " + joinChar);
 		}
 		if (args.lastIndexOf(joinChar) == args.length() - 1)
 		{
-			Logging.errorPrint(getTokenName() + " arguments may not end with "
-					+ joinChar);
-			return null;
+			return new ParseResult.Fail(
+				getTokenName() + " arguments may not end with " + joinChar);
 		}
 		if (args.indexOf(joinChar + joinChar) != -1)
 		{
-			Logging
-					.errorPrint(getTokenName()
-							+ " arguments uses double separator " + joinChar
-							+ joinChar);
-			return null;
+			return new ParseResult.Fail(getTokenName()
+				+ " arguments uses double separator " + joinChar + joinChar);
 		}
 
 		StringTokenizer elements = new StringTokenizer(args, joinChar);
@@ -175,28 +114,41 @@ public class ProhibitspellToken extends AbstractTokenWithSeparator<PCClass>
 		{
 			String aValue = elements.nextToken();
 			if (type.equals(ProhibitedSpellType.ALIGNMENT)
-					&& (!aValue.equalsIgnoreCase("GOOD"))
-					&& (!aValue.equalsIgnoreCase("EVIL"))
-					&& (!aValue.equalsIgnoreCase("LAWFUL"))
-					&& (!aValue.equalsIgnoreCase("CHAOTIC")))
+				&& (!aValue.equalsIgnoreCase("GOOD"))
+				&& (!aValue.equalsIgnoreCase("EVIL"))
+				&& (!aValue.equalsIgnoreCase("LAWFUL"))
+				&& (!aValue.equalsIgnoreCase("CHAOTIC")))
 			{
-				Logging.errorPrint("Illegal PROHIBITSPELL:ALIGNMENT subtag '"
-						+ aValue + '\'');
-				return null;
+				return new ParseResult.Fail(
+					"Illegal PROHIBITSPELL:ALIGNMENT subtag '" + aValue + '\'');
 			}
 			else
 			{
 				spellProb.addValue(aValue);
 			}
 		}
-		return spellProb;
+		while (tok.hasMoreTokens())
+		{
+			token = tok.nextToken();
+			Prerequisite prereq = getPrerequisite(token);
+			if (prereq == null)
+			{
+				return new ParseResult.Fail(
+					"   (Did you put more than one limit, or items after the "
+						+ "PRExxx tags in " + getTokenName() + ":?), value was:" + value);
+			}
+			spellProb.addPrerequisite(prereq);
+		}
+
+		context.getObjectContext().addToList(pcc, ListKey.SPELL_PROHIBITOR, spellProb);
+		return ParseResult.SUCCESS;
 	}
 
 	@Override
 	public String[] unparse(LoadContext context, PCClass pcc)
 	{
-		Changes<SpellProhibitor> changes = context.getObjectContext()
-				.getListChanges(pcc, ListKey.SPELL_PROHIBITOR);
+		Changes<SpellProhibitor> changes =
+				context.getObjectContext().getListChanges(pcc, ListKey.SPELL_PROHIBITOR);
 		Collection<SpellProhibitor> added = changes.getAdded();
 		if (added == null || added.isEmpty())
 		{
@@ -217,19 +169,16 @@ public class ProhibitspellToken extends AbstractTokenWithSeparator<PCClass>
 			if (sp.hasPrerequisites())
 			{
 				sb.append(Constants.PIPE);
-				sb.append(getPrerequisiteString(context, sp
-						.getPrerequisiteList()));
+				sb.append(getPrerequisiteString(context, sp.getPrerequisiteList()));
 			}
 			list.add(sb.toString());
 		}
 		return list.toArray(new String[list.size()]);
 	}
 
-	private <T> String getJoinChar(ProhibitedSpellType pst,
-			Collection<String> spValues)
+	private <T> String getJoinChar(ProhibitedSpellType pst, Collection<String> spValues)
 	{
-		return pst.getRequiredCount(spValues) == 1 ? Constants.COMMA
-				: Constants.DOT;
+		return pst.getRequiredCount(spValues) == 1 ? Constants.COMMA : Constants.DOT;
 	}
 
 	@Override

--- a/code/src/java/plugin/lsttokens/pcclass/ProhibitspellToken.java
+++ b/code/src/java/plugin/lsttokens/pcclass/ProhibitspellToken.java
@@ -92,24 +92,15 @@ public class ProhibitspellToken extends AbstractTokenWithSeparator<PCClass>
 				getTokenName() + ' ' + type + " has no arguments");
 		}
 
-		String joinChar = getJoinChar(type, new LinkedList<>());
-		if (args.indexOf(joinChar) == 0)
+		char joinChar = getJoinChar(type, new LinkedList<>());
+		ParseResult pr = checkForIllegalSeparator(joinChar, args);
+		if (!pr.passed())
 		{
-			return new ParseResult.Fail(
-				getTokenName() + " arguments may not start with " + joinChar);
-		}
-		if (args.lastIndexOf(joinChar) == args.length() - 1)
-		{
-			return new ParseResult.Fail(
-				getTokenName() + " arguments may not end with " + joinChar);
-		}
-		if (args.indexOf(joinChar + joinChar) != -1)
-		{
-			return new ParseResult.Fail(getTokenName()
-				+ " arguments uses double separator " + joinChar + joinChar);
+			return pr;
 		}
 
-		StringTokenizer elements = new StringTokenizer(args, joinChar);
+		StringTokenizer elements =
+				new StringTokenizer(args, Character.toString(joinChar));
 		while (elements.hasMoreTokens())
 		{
 			String aValue = elements.nextToken();
@@ -163,7 +154,7 @@ public class ProhibitspellToken extends AbstractTokenWithSeparator<PCClass>
 			sb.append(pst.toString().toUpperCase());
 			sb.append('.');
 			Collection<String> valueSet = sp.getValueList();
-			String joinChar = getJoinChar(pst, valueSet);
+			char joinChar = getJoinChar(pst, valueSet);
 			sb.append(StringUtil.join(new TreeSet<>(valueSet), joinChar));
 
 			if (sp.hasPrerequisites())
@@ -176,9 +167,9 @@ public class ProhibitspellToken extends AbstractTokenWithSeparator<PCClass>
 		return list.toArray(new String[list.size()]);
 	}
 
-	private <T> String getJoinChar(ProhibitedSpellType pst, Collection<String> spValues)
+	private <T> char getJoinChar(ProhibitedSpellType pst, Collection<String> spValues)
 	{
-		return pst.getRequiredCount(spValues) == 1 ? Constants.COMMA : Constants.DOT;
+		return pst.getRequiredCount(spValues) == 1 ? ',' : '.';
 	}
 
 	@Override

--- a/code/src/java/plugin/lsttokens/pcclass/RoleToken.java
+++ b/code/src/java/plugin/lsttokens/pcclass/RoleToken.java
@@ -67,7 +67,7 @@ public class RoleToken extends AbstractNonEmptyToken<PCClass> implements
 			else
 			{
 				return new ParseResult.Fail(getTokenName() + " '" + role
-					+ "' is not a known monster role for this game mode.", context);
+					+ "' is not a known monster role for this game mode.");
 			}
 		}
 		

--- a/code/src/java/plugin/lsttokens/pcclass/SkilllistToken.java
+++ b/code/src/java/plugin/lsttokens/pcclass/SkilllistToken.java
@@ -66,17 +66,17 @@ public class SkilllistToken extends AbstractTokenWithSeparator<PCClass>
 		if (!count.isValid())
 		{
 			return new ParseResult.Fail("Count in " + getTokenName()
-					+ " was not valid: " + count.toString(), context);
+					+ " was not valid: " + count.toString());
 		}
 		if (!count.isStatic() || count.resolveStatic().intValue() <= 0)
 		{
-			return new ParseResult.Fail("Count in " + getTokenName() + " must be > 0", context);
+			return new ParseResult.Fail("Count in " + getTokenName() + " must be > 0");
 		}
 		if (!tok.hasMoreTokens())
 		{
 			return new ParseResult.Fail(getTokenName()
 					+ " must have a | separating "
-					+ "count from the list of possible values: " + value, context);
+					+ "count from the list of possible values: " + value);
 		}
 		List<CDOMReference<ClassSkillList>> refs = new ArrayList<>();
 

--- a/code/src/java/plugin/lsttokens/pcclass/SpelllistToken.java
+++ b/code/src/java/plugin/lsttokens/pcclass/SpelllistToken.java
@@ -71,17 +71,17 @@ public class SpelllistToken extends AbstractTokenWithSeparator<PCClass>
 		if (!count.isValid())
 		{
 			return new ParseResult.Fail("Count in " + getTokenName()
-					+ " was not valid: " + count.toString(), context);
+					+ " was not valid: " + count.toString());
 		}
 		if (!count.isStatic() || count.resolveStatic().intValue() <= 0)
 		{
-			return new ParseResult.Fail("Count in " + getTokenName() + " must be > 0", context);
+			return new ParseResult.Fail("Count in " + getTokenName() + " must be > 0");
 		}
 		if (!tok.hasMoreTokens())
 		{
 			return new ParseResult.Fail(getTokenName()
 					+ " must have a | separating "
-					+ "count from the list of possible values: " + value, context);
+					+ "count from the list of possible values: " + value);
 		}
 		List<CDOMReference<? extends CDOMListObject<Spell>>> refs =
 				new ArrayList<>();
@@ -112,7 +112,7 @@ public class SpelllistToken extends AbstractTokenWithSeparator<PCClass>
 		{
 			return new ParseResult.Fail("Non-sensical "
 					+ getTokenName()
-					+ ": Contains ANY and a specific reference: " + value, context);
+					+ ": Contains ANY and a specific reference: " + value);
 		}
 
 		ChoiceSet<? extends CDOMListObject<Spell>> cs = new ChoiceSet<>(

--- a/code/src/java/plugin/lsttokens/pcclass/SpellstatToken.java
+++ b/code/src/java/plugin/lsttokens/pcclass/SpellstatToken.java
@@ -66,7 +66,7 @@ public class SpellstatToken extends AbstractNonEmptyToken<PCClass> implements
 		if (pcs == null)
 		{
 			return new ParseResult.Fail("Invalid Stat Abbreviation in " + getTokenName()
-					+ ": " + value, context);
+					+ ": " + value);
 		}
 		context.getObjectContext().put(pcc, ObjectKey.SPELL_STAT, pcs);
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/pcclass/StartskillptsToken.java
+++ b/code/src/java/plugin/lsttokens/pcclass/StartskillptsToken.java
@@ -47,7 +47,7 @@ public class StartskillptsToken extends AbstractNonEmptyToken<PCClass>
 		if (!formula.isValid())
 		{
 			return new ParseResult.Fail("Formula in " + getTokenName()
-					+ " was not valid: " + formula.toString(), context);
+					+ " was not valid: " + formula.toString());
 		}
 		context.getObjectContext().put(pcc, FormulaKey.START_SKILL_POINTS,
 				formula);

--- a/code/src/java/plugin/lsttokens/pcclass/VisibleToken.java
+++ b/code/src/java/plugin/lsttokens/pcclass/VisibleToken.java
@@ -53,7 +53,7 @@ public class VisibleToken extends AbstractNonEmptyToken<PCClass> implements
 		}
 		else
 		{
-			return new ParseResult.Fail("Can't understand Visibility: " + value, context);
+			return new ParseResult.Fail("Can't understand Visibility: " + value);
 		}
 		context.getObjectContext().put(pcc, ObjectKey.VISIBILITY, vis);
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/pcclass/WeaponbonusToken.java
+++ b/code/src/java/plugin/lsttokens/pcclass/WeaponbonusToken.java
@@ -93,7 +93,7 @@ public class WeaponbonusToken extends AbstractTokenWithSeparator<PCClass>
 				{
 					return new ParseResult.Fail(
 						"  Error was encountered while parsing "
-							+ getTokenName(), context);
+							+ getTokenName());
 				}
 				context.getObjectContext().addToList(pcc, ListKey.WEAPONBONUS, ref);
 			}
@@ -101,7 +101,7 @@ public class WeaponbonusToken extends AbstractTokenWithSeparator<PCClass>
 		if (foundAny && foundOther)
 		{
 			return new ParseResult.Fail("Non-sensical " + getTokenName()
-				+ ": Contains ANY and a specific reference: " + value, context);
+				+ ": Contains ANY and a specific reference: " + value);
 		}
 		return ParseResult.SUCCESS;
 	}

--- a/code/src/java/plugin/lsttokens/pcclass/XtrafeatsToken.java
+++ b/code/src/java/plugin/lsttokens/pcclass/XtrafeatsToken.java
@@ -56,7 +56,7 @@ public class XtrafeatsToken implements CDOMPrimaryToken<PCClass>
 			else if (featCount <= 0)
 			{
 				return new ParseResult.Fail("Number in " + getTokenName()
-						+ " must be greater than zero: " + value, context);
+						+ " must be greater than zero: " + value);
 			}
 			context.getObjectContext().put(pcc, IntegerKey.START_FEATS, featCount);
 			return ParseResult.SUCCESS;
@@ -64,7 +64,7 @@ public class XtrafeatsToken implements CDOMPrimaryToken<PCClass>
 		catch (NumberFormatException nfe)
 		{
 			return new ParseResult.Fail("Invalid Number in " + getTokenName() + ": "
-					+ value, context);
+					+ value);
 		}
 	}
 

--- a/code/src/java/plugin/lsttokens/pcclass/level/AdddomainsToken.java
+++ b/code/src/java/plugin/lsttokens/pcclass/level/AdddomainsToken.java
@@ -81,7 +81,7 @@ public class AdddomainsToken extends AbstractTokenWithSeparator<PCClassLevel> im
 				if (tokString.indexOf(']') != -1)
 				{
 					return new ParseResult.Fail("Invalid " + getTokenName()
-							+ " must have '[' if it contains a PREREQ tag", context);
+							+ " must have '[' if it contains a PREREQ tag");
 				}
 				domainKey = tokString;
 			}
@@ -90,7 +90,7 @@ public class AdddomainsToken extends AbstractTokenWithSeparator<PCClassLevel> im
 				if (tokString.indexOf(']') != tokString.length() - 1)
 				{
 					return new ParseResult.Fail("Invalid " + getTokenName()
-							+ " must end with ']' if it contains a PREREQ tag", context);
+							+ " must end with ']' if it contains a PREREQ tag");
 				}
 				domainKey = tokString.substring(0, openBracketLoc);
 				String prereqString = tokString.substring(openBracketLoc + 1,
@@ -98,13 +98,13 @@ public class AdddomainsToken extends AbstractTokenWithSeparator<PCClassLevel> im
 				if (prereqString.isEmpty())
 				{
 					return new ParseResult.Fail(getTokenName()
-							+ " cannot have empty prerequisite : " + value, context);
+							+ " cannot have empty prerequisite : " + value);
 				}
 				prereq = getPrerequisite(prereqString);
 				if (prereq == null)
 				{
 					return new ParseResult.Fail(getTokenName()
-							+ " had invalid prerequisite : " + prereqString, context);
+							+ " had invalid prerequisite : " + prereqString);
 				}
 			}
 			AssociatedPrereqObject apo = context.getListContext().addToList(

--- a/code/src/java/plugin/lsttokens/pcclass/level/CastToken.java
+++ b/code/src/java/plugin/lsttokens/pcclass/level/CastToken.java
@@ -66,7 +66,7 @@ public class CastToken extends AbstractTokenWithSeparator<PCClassLevel> implemen
 				if (Integer.parseInt(tok) < 0)
 				{
 					return new ParseResult.Fail("Invalid Spell Count: " + tok
-							+ " is less than zero", context);
+							+ " is less than zero");
 				}
 			}
 			catch (NumberFormatException e)
@@ -77,7 +77,7 @@ public class CastToken extends AbstractTokenWithSeparator<PCClassLevel> implemen
 			if (!formula.isValid())
 			{
 				return new ParseResult.Fail("Formula in " + getTokenName()
-						+ " was not valid: " + formula.toString(), context);
+						+ " was not valid: " + formula.toString());
 			}
 			context.getObjectContext().addToList(level, ListKey.CAST, formula);
 		}

--- a/code/src/java/plugin/lsttokens/pcclass/level/CcskillToken.java
+++ b/code/src/java/plugin/lsttokens/pcclass/level/CcskillToken.java
@@ -73,7 +73,7 @@ public class CcskillToken extends AbstractTokenWithSeparator<PCClassLevel>
 				{
 					return new ParseResult.Fail("  Non-sensical "
 							+ getTokenName()
-							+ ": .CLEAR was not the first list item", context);
+							+ ": .CLEAR was not the first list item");
 				}
 				context.getObjectContext().removeList(obj,
 						ListKey.LOCALCCSKILL);
@@ -95,7 +95,7 @@ public class CcskillToken extends AbstractTokenWithSeparator<PCClassLevel>
 					{
 						return new ParseResult.Fail(
 								"  Error was encountered while parsing "
-										+ getTokenName(), context);
+										+ getTokenName());
 					}
 					context.getObjectContext().removeFromList(obj,
 							ListKey.LOCALCCSKILL, ref);
@@ -125,7 +125,7 @@ public class CcskillToken extends AbstractTokenWithSeparator<PCClassLevel>
 					{
 						return new ParseResult.Fail(
 								"  Error was encountered while parsing "
-										+ getTokenName(), context);
+										+ getTokenName());
 					}
 					context.getObjectContext().addToList(obj,
 							ListKey.LOCALCCSKILL, ref);
@@ -136,7 +136,7 @@ public class CcskillToken extends AbstractTokenWithSeparator<PCClassLevel>
 		if (foundAny && foundOther)
 		{
 			return new ParseResult.Fail("Non-sensical " + getTokenName()
-					+ ": Contains ANY and a specific reference: " + value, context);
+					+ ": Contains ANY and a specific reference: " + value);
 		}
 		return ParseResult.SUCCESS;
 	}

--- a/code/src/java/plugin/lsttokens/pcclass/level/CskillToken.java
+++ b/code/src/java/plugin/lsttokens/pcclass/level/CskillToken.java
@@ -72,7 +72,7 @@ public class CskillToken extends AbstractTokenWithSeparator<PCClassLevel>
 				{
 					return new ParseResult.Fail("  Non-sensical "
 							+ getTokenName()
-							+ ": .CLEAR was not the first list item", context);
+							+ ": .CLEAR was not the first list item");
 				}
 				context.getObjectContext()
 						.removeList(obj, ListKey.LOCALCSKILL);
@@ -94,7 +94,7 @@ public class CskillToken extends AbstractTokenWithSeparator<PCClassLevel>
 					{
 						return new ParseResult.Fail(
 								"  Error was encountered while parsing "
-										+ getTokenName(), context);
+										+ getTokenName());
 					}
 					context.getObjectContext().removeFromList(obj,
 							ListKey.LOCALCSKILL, ref);
@@ -124,7 +124,7 @@ public class CskillToken extends AbstractTokenWithSeparator<PCClassLevel>
 					{
 						return new ParseResult.Fail(
 								"  Error was encountered while parsing "
-										+ getTokenName(), context);
+										+ getTokenName());
 					}
 					context.getObjectContext().addToList(obj,
 							ListKey.LOCALCSKILL, ref);
@@ -135,7 +135,7 @@ public class CskillToken extends AbstractTokenWithSeparator<PCClassLevel>
 		if (foundAny && foundOther)
 		{
 			return new ParseResult.Fail("Non-sensical " + getTokenName()
-					+ ": Contains ANY and a specific reference: " + value, context);
+					+ ": Contains ANY and a specific reference: " + value);
 		}
 		return ParseResult.SUCCESS;
 	}

--- a/code/src/java/plugin/lsttokens/pcclass/level/DomainToken.java
+++ b/code/src/java/plugin/lsttokens/pcclass/level/DomainToken.java
@@ -73,7 +73,7 @@ public class DomainToken extends AbstractTokenWithSeparator<PCClassLevel> implem
 		if (looksLikeAPrerequisite(tok))
 		{
 			return new ParseResult.Fail("Cannot have only PRExxx subtoken in "
-				+ getTokenName() + ": " + value, context);
+				+ getTokenName() + ": " + value);
 		}
 
 		List<QualifiedObject<CDOMSingleRef<Domain>>> toAdd =
@@ -86,7 +86,7 @@ public class DomainToken extends AbstractTokenWithSeparator<PCClassLevel> implem
 				if (!first)
 				{
 					return new ParseResult.Fail("  Non-sensical " + getTokenName()
-							+ ": .CLEAR was not the first list item", context);
+							+ ": .CLEAR was not the first list item");
 				}
 				context.getObjectContext().removeList(pcl, ListKey.DOMAIN);
 				foundClear = true;
@@ -116,7 +116,7 @@ public class DomainToken extends AbstractTokenWithSeparator<PCClassLevel> implem
 		{
 			return new ParseResult.Fail(
 					"Cannot use PREREQs when using .CLEAR in "
-							+ getTokenName(), context);
+							+ getTokenName());
 		}
 
 		while (true)
@@ -125,7 +125,7 @@ public class DomainToken extends AbstractTokenWithSeparator<PCClassLevel> implem
 			if (prereq == null)
 			{
 				return new ParseResult.Fail("   (Did you put feats after the "
-						+ "PRExxx tags in " + getTokenName() + ":?)", context);
+						+ "PRExxx tags in " + getTokenName() + ":?)");
 			}
 			for (PrereqObject pro : toAdd)
 			{

--- a/code/src/java/plugin/lsttokens/pcclass/level/HitdieLst.java
+++ b/code/src/java/plugin/lsttokens/pcclass/level/HitdieLst.java
@@ -56,7 +56,7 @@ public class HitdieLst extends AbstractToken implements
 			if (pipeLoc != -1)
 			{
 				return new ParseResult.Fail(getTokenName() + " is invalid has a pipe: "
-						+ value, context);
+						+ value);
 			}
 			Processor<HitDie> hdm;
 			if (lock.startsWith("%/"))
@@ -67,7 +67,7 @@ public class HitdieLst extends AbstractToken implements
 				{
 					return new ParseResult.Fail(getTokenName()
 							+ " was expecting a Positive Integer "
-							+ "for dividing Lock, was : " + lock.substring(2), context);
+							+ "for dividing Lock, was : " + lock.substring(2));
 				}
 				hdm = new HitDieFormula(new DividingFormula(denom));
 			}
@@ -80,7 +80,7 @@ public class HitdieLst extends AbstractToken implements
 					return new ParseResult.Fail(getTokenName()
 							+ " was expecting a Positive "
 							+ "Integer for multiplying Lock, was : "
-							+ lock.substring(2), context);
+							+ lock.substring(2));
 				}
 				hdm = new HitDieFormula(new MultiplyingFormula(mult));
 			}
@@ -94,7 +94,7 @@ public class HitdieLst extends AbstractToken implements
 					return new ParseResult.Fail(getTokenName()
 							+ " was expecting a Positive "
 							+ "Integer for adding Lock, was : "
-							+ lock.substring(2), context);
+							+ lock.substring(2));
 				}
 				hdm = new HitDieFormula(new AddingFormula(add));
 			}
@@ -109,7 +109,7 @@ public class HitdieLst extends AbstractToken implements
 					return new ParseResult.Fail(getTokenName()
 							+ " was expecting a Positive "
 							+ "Integer for subtracting Lock, was : "
-							+ lock.substring(2), context);
+							+ lock.substring(2));
 				}
 				hdm = new HitDieFormula(new SubtractingFormula(sub));
 			}
@@ -122,12 +122,12 @@ public class HitdieLst extends AbstractToken implements
 				if (steps <= 0)
 				{
 					return new ParseResult.Fail("Invalid Step Count: " + steps + " in "
-							+ getTokenName() + " up (must be positive)", context);
+							+ getTokenName() + " up (must be positive)");
 				}
 				if (steps >= 5)
 				{
 					return new ParseResult.Fail("Invalid Step Count: " + steps + " in "
-							+ getTokenName() + " up (too large)", context);
+							+ getTokenName() + " up (too large)");
 				}
 
 				hdm = new HitDieStep(steps, new HitDie(12));
@@ -141,7 +141,7 @@ public class HitdieLst extends AbstractToken implements
 				if (steps <= 0)
 				{
 					return new ParseResult.Fail("Invalid Step Count: " + steps + " in "
-							+ getTokenName(), context);
+							+ getTokenName());
 				}
 				hdm = new HitDieStep(steps, null);
 			}
@@ -155,12 +155,12 @@ public class HitdieLst extends AbstractToken implements
 				if (steps <= 0)
 				{
 					return new ParseResult.Fail("Invalid Step Count: " + steps + " in "
-							+ getTokenName() + " down (must be positive)", context);
+							+ getTokenName() + " down (must be positive)");
 				}
 				if (steps >= 5)
 				{
 					return new ParseResult.Fail("Invalid Step Count: " + steps + " in "
-							+ getTokenName() + " down (too large)", context);
+							+ getTokenName() + " down (too large)");
 				}
 
 				hdm = new HitDieStep(-steps, new HitDie(4));
@@ -174,7 +174,7 @@ public class HitdieLst extends AbstractToken implements
 				if (steps <= 0)
 				{
 					return new ParseResult.Fail("Invalid Step Count: " + steps + " in "
-							+ getTokenName(), context);
+							+ getTokenName());
 				}
 				hdm = new HitDieStep(-steps, null);
 			}
@@ -184,7 +184,7 @@ public class HitdieLst extends AbstractToken implements
 				if (i <= 0)
 				{
 					return new ParseResult.Fail("Invalid HitDie: " + i + " in "
-							+ getTokenName(), context);
+							+ getTokenName());
 				}
 				// HITDIE:num --- sets the hit die to num regardless of class.
 				hdm = new HitDieLock(new HitDie(i));

--- a/code/src/java/plugin/lsttokens/pcclass/level/KnownToken.java
+++ b/code/src/java/plugin/lsttokens/pcclass/level/KnownToken.java
@@ -65,7 +65,7 @@ public class KnownToken extends AbstractTokenWithSeparator<PCClassLevel> impleme
 				if (Integer.parseInt(tok) < 0)
 				{
 					return new ParseResult.Fail("Invalid Spell Count: " + tok
-							+ " is less than zero", context);
+							+ " is less than zero");
 				}
 			}
 			catch (NumberFormatException e)
@@ -76,7 +76,7 @@ public class KnownToken extends AbstractTokenWithSeparator<PCClassLevel> impleme
 			if (!formula.isValid())
 			{
 				return new ParseResult.Fail("Formula in " + getTokenName()
-						+ " was not valid: " + formula.toString(), context);
+						+ " was not valid: " + formula.toString());
 			}
 			context.getObjectContext().addToList(level, ListKey.KNOWN, formula);
 		}

--- a/code/src/java/plugin/lsttokens/pcclass/level/SpecialtyknownToken.java
+++ b/code/src/java/plugin/lsttokens/pcclass/level/SpecialtyknownToken.java
@@ -66,7 +66,7 @@ public class SpecialtyknownToken extends AbstractTokenWithSeparator<PCClassLevel
 				if (Integer.parseInt(tok) < 0)
 				{
 					return new ParseResult.Fail("Invalid Spell Count: " + tok
-							+ " is less than zero", context);
+							+ " is less than zero");
 				}
 			}
 			catch (NumberFormatException e)
@@ -77,7 +77,7 @@ public class SpecialtyknownToken extends AbstractTokenWithSeparator<PCClassLevel
 			if (!formula.isValid())
 			{
 				return new ParseResult.Fail("Formula in " + getTokenName()
-						+ " was not valid: " + formula.toString(), context);
+						+ " was not valid: " + formula.toString());
 			}
 			context.getObjectContext().addToList(level, ListKey.SPECIALTYKNOWN, formula);
 		}

--- a/code/src/java/plugin/lsttokens/pointbuy/method/BonusToken.java
+++ b/code/src/java/plugin/lsttokens/pointbuy/method/BonusToken.java
@@ -52,7 +52,7 @@ public class BonusToken extends AbstractNonEmptyToken<PointBuyMethod> implements
 		if (bon == null)
 		{
 			return new ParseResult.Fail(getTokenName()
-					+ " was given invalid bonus: " + value, context);
+					+ " was given invalid bonus: " + value);
 		}
 		bon.setTokenSource(getTokenName());
 		pbm.addBonus(bon);

--- a/code/src/java/plugin/lsttokens/pointbuy/stat/CostToken.java
+++ b/code/src/java/plugin/lsttokens/pointbuy/stat/CostToken.java
@@ -51,7 +51,7 @@ public class CostToken extends AbstractNonEmptyToken<PointBuyCost> implements
 		{
 			return new ParseResult.Fail(getTokenName()
 					+ " expected an integer.  Tag must be of the form: "
-					+ getTokenName() + ":<int>", context);
+					+ getTokenName() + ":<int>");
 		}
 	}
 

--- a/code/src/java/plugin/lsttokens/race/CrModToken.java
+++ b/code/src/java/plugin/lsttokens/race/CrModToken.java
@@ -54,24 +54,24 @@ public class CrModToken extends AbstractNonEmptyToken<Race> implements
 		if (pipeLoc == -1)
 		{
 			return new ParseResult.Fail(getTokenName() + " expecting '|', format is: "
-					+ "ClassTypes|CRMod was: " + value, context);
+					+ "ClassTypes|CRMod was: " + value);
 		}
 		if (pipeLoc != value.lastIndexOf(Constants.PIPE))
 		{
 			return new ParseResult.Fail(getTokenName() + " expecting only one '|', "
-					+ "format is: ClassTypes|CRMod was: " + value, context);
+					+ "format is: ClassTypes|CRMod was: " + value);
 		}
 		String keys = value.substring(0, pipeLoc);
 		if (keys.isEmpty())
 		{
 			return new ParseResult.Fail(getTokenName() + " expecting non-empty class type, "
-					+ "format is: ClassTypes|CRMod was: " + value, context);
+					+ "format is: ClassTypes|CRMod was: " + value);
 		}
 		String val = value.substring(pipeLoc + 1);
 		if (val.isEmpty())
 		{
 			return new ParseResult.Fail(getTokenName() + " expecting non-empty CR mod, "
-					+ "format is: ClassTypes|CRMod was: " + value, context);
+					+ "format is: ClassTypes|CRMod was: " + value);
 		}
 		try 
 		{
@@ -84,7 +84,7 @@ public class CrModToken extends AbstractNonEmptyToken<Race> implements
 		catch (NumberFormatException e)
 		{
 			return new ParseResult.Fail(getTokenName() + " expecting number CR mod, "
-					+ "format is: ClassTypes|CRMod was: " + value, context);
+					+ "format is: ClassTypes|CRMod was: " + value);
 		}
 		
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/race/CrToken.java
+++ b/code/src/java/plugin/lsttokens/race/CrToken.java
@@ -55,19 +55,19 @@ public class CrToken extends AbstractNonEmptyToken<Race> implements
 			if (intRating < 0)
 			{
 				return new ParseResult.Fail(getTokenName()
-						+ " Challenge Rating cannot be negative", context);
+						+ " Challenge Rating cannot be negative");
 			}
 		}
 		catch (NumberFormatException e)
 		{
 			return new ParseResult.Fail(getTokenName()
-					+ "Challenge Rating must be a positive integer i or 1/i", context);
+					+ "Challenge Rating must be a positive integer i or 1/i");
 		}
 		Formula formula = FormulaFactory.getFormulaFor(value);
 		if (!formula.isValid())
 		{
 			return new ParseResult.Fail("Formula in " + getTokenName()
-					+ " was not valid: " + formula.toString(), context);
+					+ " was not valid: " + formula.toString());
 		}
 		ChallengeRating cr = new ChallengeRating(formula);
 		context.getObjectContext().put(race, ObjectKey.CHALLENGE_RATING, cr);

--- a/code/src/java/plugin/lsttokens/race/FaceToken.java
+++ b/code/src/java/plugin/lsttokens/race/FaceToken.java
@@ -58,8 +58,7 @@ public class FaceToken extends AbstractNonEmptyToken<Race> implements
 		if (ControlUtilities.hasControlToken(context, CControl.FACE))
 		{
 			return new ParseResult.Fail(
-				"FACE: LST Token is disabled when FACE: control is used",
-				context);
+				"FACE: LST Token is disabled when FACE: control is used");
 		}
 		if (value.indexOf(',') == -1)
 		{
@@ -79,19 +78,19 @@ public class FaceToken extends AbstractNonEmptyToken<Race> implements
 		{
 			return new ParseResult.Fail(getTokenName() + " Modifier "
 				+ MOD_IDENTIFICATION + " had value " + value
-				+ " but it was not valid: " + iae.getMessage(), context);
+				+ " but it was not valid: " + iae.getMessage());
 		}
 		modifier.addAssociation("PRIORITY=" + MOD_PRIORITY);
 		OrderedPair pair = modifier.process(null);
 		if (pair.getPreciseX().doubleValue() < 0.0)
 		{
 			return new ParseResult.Fail(getTokenName() + " had value " + value
-				+ " but first item cannot be negative", context);
+				+ " but first item cannot be negative");
 		}
 		if (pair.getPreciseY().doubleValue() < 0.0)
 		{
 			return new ParseResult.Fail(getTokenName() + " had value " + value
-				+ " but second item cannot be negative", context);
+				+ " but second item cannot be negative");
 		}
 
 		if (!context.getVariableContext().isLegalVariableID(scope, VAR_NAME))
@@ -99,7 +98,7 @@ public class FaceToken extends AbstractNonEmptyToken<Race> implements
 			return new ParseResult.Fail(getTokenName()
 				+ " internal error: found invalid var name: " + VAR_NAME
 				+ ", Modified on " + race.getClass().getSimpleName() + ' '
-				+ race.getKeyName(), context);
+				+ race.getKeyName());
 		}
 		VarModifier<OrderedPair> vm =
 				new VarModifier<>(VAR_NAME, scope, modifier);

--- a/code/src/java/plugin/lsttokens/race/HandsToken.java
+++ b/code/src/java/plugin/lsttokens/race/HandsToken.java
@@ -63,8 +63,7 @@ public class HandsToken extends AbstractIntToken<Race> implements
 		if (ControlUtilities.hasControlToken(context, CControl.CREATUREHANDS))
 		{
 			return new ParseResult.Fail(getTokenName()
-				+ " is disabled when CREATUREHANDS control is used: " + value,
-				context);
+				+ " is disabled when CREATUREHANDS control is used: " + value);
 		}
 		return super.parseToken(context, obj, value);
 	}

--- a/code/src/java/plugin/lsttokens/race/HitdiceadvancementToken.java
+++ b/code/src/java/plugin/lsttokens/race/HitdiceadvancementToken.java
@@ -69,7 +69,7 @@ public class HitdiceadvancementToken extends AbstractTokenWithSeparator<Race>
 				if (commaTok.hasMoreTokens())
 				{
 					return new ParseResult.Fail("Found * in " + getTokenName()
-							+ " but was not at end of list", context);
+							+ " but was not at end of list");
 				}
 
 				hd = Integer.MAX_VALUE;
@@ -84,13 +84,13 @@ public class HitdiceadvancementToken extends AbstractTokenWithSeparator<Race>
 						return new ParseResult.Fail("Found " + hd + " in "
 										+ getTokenName() + " but was < 1 "
 										+ "or the previous value in the list: "
-										+ value, context);
+										+ value);
 					}
 					last = hd;
 				}
 				catch (NumberFormatException nfe)
 				{
-					return new ParseResult.Fail(nfe.getMessage(), context);
+					return new ParseResult.Fail(nfe.getMessage());
 				}
 			}
 			context.getObjectContext().addToList(race,

--- a/code/src/java/plugin/lsttokens/race/HitdieToken.java
+++ b/code/src/java/plugin/lsttokens/race/HitdieToken.java
@@ -63,7 +63,7 @@ public class HitdieToken extends AbstractNonEmptyToken<Race> implements
 			if (pipeLoc != lock.lastIndexOf(Constants.PIPE))
 			{
 				return new ParseResult.Fail(getTokenName() + " has more than one pipe, "
-						+ "is not of format: <int>[|<prereq>]", context);
+						+ "is not of format: <int>[|<prereq>]");
 			}
 			// Do not initialize, null is significant
 			CDOMReference<PCClass> owner = null;
@@ -78,7 +78,7 @@ public class HitdieToken extends AbstractNonEmptyToken<Race> implements
 					{
 						return new ParseResult.Fail(
 							"Cannot have Empty Type Limitation in " + getTokenName()
-								+ ": " + value, context);
+								+ ": " + value);
 					}
 					ParseResult pr = checkForIllegalSeparator('.', substring); 
 					if (!pr.passed())
@@ -95,7 +95,7 @@ public class HitdieToken extends AbstractNonEmptyToken<Race> implements
 					{
 						return new ParseResult.Fail(
 							"Cannot have Empty Class Limitation in " + getTokenName()
-								+ ": " + value, context);
+								+ ": " + value);
 					}
 					owner = context.getReferenceContext().getCDOMReference(PCCLASS_CLASS,
 							substring);
@@ -103,7 +103,7 @@ public class HitdieToken extends AbstractNonEmptyToken<Race> implements
 				else
 				{
 					return new ParseResult.Fail("Invalid Limitation in HITDIE: "
-							+ lockPre, context);
+							+ lockPre);
 				}
 				lock = lock.substring(0, pipeLoc);
 			}
@@ -117,7 +117,7 @@ public class HitdieToken extends AbstractNonEmptyToken<Race> implements
 				{
 					return new ParseResult.Fail(getTokenName()
 							+ " was expecting a Positive Integer "
-							+ "for dividing Lock, was : " + lock.substring(2), context);
+							+ "for dividing Lock, was : " + lock.substring(2));
 				}
 				hdm = new HitDieFormula(new DividingFormula(denom));
 			}
@@ -130,7 +130,7 @@ public class HitdieToken extends AbstractNonEmptyToken<Race> implements
 					return new ParseResult.Fail(getTokenName()
 							+ " was expecting a Positive "
 							+ "Integer for multiplying Lock, was : "
-							+ lock.substring(2), context);
+							+ lock.substring(2));
 				}
 				hdm = new HitDieFormula(new MultiplyingFormula(mult));
 			}
@@ -144,7 +144,7 @@ public class HitdieToken extends AbstractNonEmptyToken<Race> implements
 					return new ParseResult.Fail(getTokenName()
 							+ " was expecting a Positive "
 							+ "Integer for adding Lock, was : "
-							+ lock.substring(2), context);
+							+ lock.substring(2));
 				}
 				hdm = new HitDieFormula(new AddingFormula(add));
 			}
@@ -159,7 +159,7 @@ public class HitdieToken extends AbstractNonEmptyToken<Race> implements
 					return new ParseResult.Fail(getTokenName()
 							+ " was expecting a Positive "
 							+ "Integer for subtracting Lock, was : "
-							+ lock.substring(2), context);
+							+ lock.substring(2));
 				}
 				hdm = new HitDieFormula(new SubtractingFormula(sub));
 			}
@@ -172,12 +172,12 @@ public class HitdieToken extends AbstractNonEmptyToken<Race> implements
 				if (steps <= 0)
 				{
 					return new ParseResult.Fail("Invalid Step Count: " + steps + " in "
-							+ getTokenName() + " up (must be positive)", context);
+							+ getTokenName() + " up (must be positive)");
 				}
 				if (steps >= 5)
 				{
 					return new ParseResult.Fail("Invalid Step Count: " + steps + " in "
-							+ getTokenName() + " up (too large)", context);
+							+ getTokenName() + " up (too large)");
 				}
 
 				hdm = new HitDieStep(steps, new HitDie(12));
@@ -191,7 +191,7 @@ public class HitdieToken extends AbstractNonEmptyToken<Race> implements
 				if (steps <= 0)
 				{
 					return new ParseResult.Fail("Invalid Step Count: " + steps + " in "
-							+ getTokenName(), context);
+							+ getTokenName());
 				}
 				hdm = new HitDieStep(steps, null);
 			}
@@ -205,12 +205,12 @@ public class HitdieToken extends AbstractNonEmptyToken<Race> implements
 				if (steps <= 0)
 				{
 					return new ParseResult.Fail("Invalid Step Count: " + steps + " in "
-							+ getTokenName() + " down (must be positive)", context);
+							+ getTokenName() + " down (must be positive)");
 				}
 				if (steps >= 5)
 				{
 					return new ParseResult.Fail("Invalid Step Count: " + steps + " in "
-							+ getTokenName() + " down (too large)", context);
+							+ getTokenName() + " down (too large)");
 				}
 
 				hdm = new HitDieStep(-steps, new HitDie(4));
@@ -224,7 +224,7 @@ public class HitdieToken extends AbstractNonEmptyToken<Race> implements
 				if (steps <= 0)
 				{
 					return new ParseResult.Fail("Invalid Step Count: " + steps + " in "
-							+ getTokenName(), context);
+							+ getTokenName());
 				}
 				hdm = new HitDieStep(-steps, null);
 			}
@@ -234,7 +234,7 @@ public class HitdieToken extends AbstractNonEmptyToken<Race> implements
 				if (i <= 0)
 				{
 					return new ParseResult.Fail("Invalid HitDie: " + i + " in "
-							+ getTokenName(), context);
+							+ getTokenName());
 				}
 				// HITDIE:num --- sets the hit die to num regardless of class.
 				hdm = new HitDieLock(new HitDie(i));
@@ -248,7 +248,7 @@ public class HitdieToken extends AbstractNonEmptyToken<Race> implements
 		catch (NumberFormatException nfe)
 		{
 			return new ParseResult.Fail("Invalid Number (must be an Integer) in " + getTokenName() + ": "
-					+ nfe.getLocalizedMessage(), context);
+					+ nfe.getLocalizedMessage());
 		}
 	}
 

--- a/code/src/java/plugin/lsttokens/race/LangbonusToken.java
+++ b/code/src/java/plugin/lsttokens/race/LangbonusToken.java
@@ -73,7 +73,7 @@ public class LangbonusToken extends AbstractTokenWithSeparator<Race> implements
 				{
 					return new ParseResult.Fail("Non-sensical situation was "
 							+ "encountered while parsing " + getTokenName()
-							+ ": When used, .CLEAR must be the first argument", context);
+							+ ": When used, .CLEAR must be the first argument");
 				}
 				context.getListContext().removeAllFromList(getTokenName(),
 						race, Language.STARTING_LIST);
@@ -90,7 +90,7 @@ public class LangbonusToken extends AbstractTokenWithSeparator<Race> implements
 									+ ": "
 									+ value
 									+ " had an invalid .CLEAR. reference: "
-									+ clearText, context);
+									+ clearText);
 				}
 				context.getListContext().removeFromList(getTokenName(), race,
 						Language.STARTING_LIST, lang);
@@ -121,7 +121,7 @@ public class LangbonusToken extends AbstractTokenWithSeparator<Race> implements
 				{
 					return new ParseResult.Fail("  Error was encountered while parsing "
 							+ getTokenName() + ": " + value
-							+ " had an invalid reference: " + tokText, context);
+							+ " had an invalid reference: " + tokText);
 				}
 				context.getListContext().addToList(getTokenName(), race,
 						Language.STARTING_LIST, lang);
@@ -131,7 +131,7 @@ public class LangbonusToken extends AbstractTokenWithSeparator<Race> implements
 		if (foundAny && foundOther)
 		{
 			return new ParseResult.Fail("Non-sensical " + getTokenName()
-					+ ": Contains ANY and a specific reference: " + value, context);
+					+ ": Contains ANY and a specific reference: " + value);
 		}
 		return ParseResult.SUCCESS;
 	}

--- a/code/src/java/plugin/lsttokens/race/LeveladjustmentToken.java
+++ b/code/src/java/plugin/lsttokens/race/LeveladjustmentToken.java
@@ -47,7 +47,7 @@ public class LeveladjustmentToken extends AbstractNonEmptyToken<Race> implements
 		if (!formula.isValid())
 		{
 			return new ParseResult.Fail("Formula in " + getTokenName()
-					+ " was not valid: " + formula.toString(), context);
+					+ " was not valid: " + formula.toString());
 		}
 		context.getObjectContext().put(race, FormulaKey.LEVEL_ADJUSTMENT,
 				formula);

--- a/code/src/java/plugin/lsttokens/race/MonccskillToken.java
+++ b/code/src/java/plugin/lsttokens/race/MonccskillToken.java
@@ -83,7 +83,7 @@ public class MonccskillToken extends AbstractTokenWithSeparator<Race> implements
 				{
 					return new ParseResult.Fail("Non-sensical situation was "
 							+ "encountered while parsing " + getTokenName()
-							+ ": When used, .CLEAR must be the first argument", context);
+							+ ": When used, .CLEAR must be the first argument");
 				}
 				context.getListContext().removeAllFromList(getTokenName(),
 						race, monsterList);
@@ -104,7 +104,7 @@ public class MonccskillToken extends AbstractTokenWithSeparator<Race> implements
 				{
 					return new ParseResult.Fail(
 							"  Error was encountered while parsing "
-									+ getTokenName(), context);
+									+ getTokenName());
 				}
 				context.getListContext().removeFromList(getTokenName(), race,
 						monsterList, skill);
@@ -134,7 +134,7 @@ public class MonccskillToken extends AbstractTokenWithSeparator<Race> implements
 				{
 					return new ParseResult.Fail(
 							"  Error was encountered while parsing "
-									+ getTokenName(), context);
+									+ getTokenName());
 				}
 				AssociatedPrereqObject apo = context.getListContext()
 						.addToList(getTokenName(), race, monsterList, skill);
@@ -146,7 +146,7 @@ public class MonccskillToken extends AbstractTokenWithSeparator<Race> implements
 		if (foundAny && foundOther)
 		{
 			return new ParseResult.Fail("Non-sensical " + getTokenName()
-					+ ": Contains ANY and a specific reference: " + value, context);
+					+ ": Contains ANY and a specific reference: " + value);
 		}
 		return ParseResult.SUCCESS;
 	}

--- a/code/src/java/plugin/lsttokens/race/MoncskillToken.java
+++ b/code/src/java/plugin/lsttokens/race/MoncskillToken.java
@@ -90,7 +90,7 @@ public class MoncskillToken extends AbstractTokenWithSeparator<Race> implements
 				{
 					return new ParseResult.Fail("Non-sensical situation was "
 							+ "encountered while parsing " + getTokenName()
-							+ ": When used, .CLEAR must be the first argument", context);
+							+ ": When used, .CLEAR must be the first argument");
 				}
 				context.getListContext().removeAllFromList(getTokenName(),
 						race, monsterList);
@@ -117,7 +117,7 @@ public class MoncskillToken extends AbstractTokenWithSeparator<Race> implements
 						{
 							return new ParseResult.Fail(
 									"  Error was encountered while parsing "
-											+ getTokenName(), context);
+											+ getTokenName());
 						}
 					}
 				}
@@ -158,7 +158,7 @@ public class MoncskillToken extends AbstractTokenWithSeparator<Race> implements
 						{
 							return new ParseResult.Fail(
 									"  Error was encountered while parsing "
-											+ getTokenName(), context);
+											+ getTokenName());
 						}
 					}
 				}
@@ -176,7 +176,7 @@ public class MoncskillToken extends AbstractTokenWithSeparator<Race> implements
 		if (foundAny && foundOther)
 		{
 			return new ParseResult.Fail("Non-sensical " + getTokenName()
-					+ ": Contains ANY and a specific reference: " + value, context);
+					+ ": Contains ANY and a specific reference: " + value);
 		}
 		return ParseResult.SUCCESS;
 	}

--- a/code/src/java/plugin/lsttokens/race/MonsterclassToken.java
+++ b/code/src/java/plugin/lsttokens/race/MonsterclassToken.java
@@ -59,13 +59,13 @@ public class MonsterclassToken extends AbstractNonEmptyToken<Race> implements
 		if (!sep.hasNext())
 		{
 			return new ParseResult.Fail(getTokenName() + " must have a colon: "
-					+ value, context);
+					+ value);
 		}
 		String numLevels = sep.next();
 		if (sep.hasNext())
 		{
 			return new ParseResult.Fail(getTokenName() + " must have only one colon: "
-					+ value, context);
+					+ value);
 		}
 		CDOMSingleRef<PCClass> cl = context.getReferenceContext().getCDOMReference(PCCLASS_CLASS,
 				classString);
@@ -75,7 +75,7 @@ public class MonsterclassToken extends AbstractNonEmptyToken<Race> implements
 			if (lvls <= 0)
 			{
 				return new ParseResult.Fail("Number of levels in " + getTokenName()
-						+ " must be greater than zero: " + value, context);
+						+ " must be greater than zero: " + value);
 			}
 			LevelCommandFactory cf = new LevelCommandFactory(cl, FormulaFactory
 					.getFormulaFor(lvls));
@@ -85,7 +85,7 @@ public class MonsterclassToken extends AbstractNonEmptyToken<Race> implements
 		catch (NumberFormatException nfe)
 		{
 			return new ParseResult.Fail("Number of levels in " + getTokenName()
-					+ " must be an integer greater than zero: " + value, context);
+					+ " must be an integer greater than zero: " + value);
 		}
 	}
 

--- a/code/src/java/plugin/lsttokens/race/MoveToken.java
+++ b/code/src/java/plugin/lsttokens/race/MoveToken.java
@@ -105,7 +105,7 @@ public class MoveToken extends AbstractTokenWithSeparator<Race> implements
 			if (moves.countTokens() != 0)
 			{
 				return new ParseResult.Fail("Badly formed MOVE token "
-					+ "(extra value at end of list): " + value, context);
+					+ "(extra value at end of list): " + value);
 			}
 		}
 		cm.setMoveRatesFlag(0);

--- a/code/src/java/plugin/lsttokens/race/RacesubtypeToken.java
+++ b/code/src/java/plugin/lsttokens/race/RacesubtypeToken.java
@@ -67,7 +67,7 @@ public class RacesubtypeToken extends AbstractTokenWithSeparator<Race>
 				if (!first)
 				{
 					return new ParseResult.Fail("  Non-sensical " + getTokenName()
-							+ ": .CLEAR was not the first list item: " + value, context);
+							+ ": .CLEAR was not the first list item: " + value);
 				}
 				context.getObjectContext().removeList(race, ListKey.RACESUBTYPE);
 			}

--- a/code/src/java/plugin/lsttokens/race/ReachToken.java
+++ b/code/src/java/plugin/lsttokens/race/ReachToken.java
@@ -63,8 +63,7 @@ public class ReachToken extends AbstractIntToken<Race> implements
 		if (ControlUtilities.hasControlToken(context, CControl.PCREACH))
 		{
 			return new ParseResult.Fail(getTokenName()
-				+ " is disabled when CREATEUREREACH control is used: " + value,
-				context);
+				+ " is disabled when CREATEUREREACH control is used: " + value);
 		}
 		return super.parseToken(context, obj, value);
 	}

--- a/code/src/java/plugin/lsttokens/race/RoleToken.java
+++ b/code/src/java/plugin/lsttokens/race/RoleToken.java
@@ -67,7 +67,7 @@ public class RoleToken extends AbstractNonEmptyToken<Race> implements
 			else
 			{
 				return new ParseResult.Fail(getTokenName() + " '" + role
-					+ "' is not a known monster role for this game mode.", context);
+					+ "' is not a known monster role for this game mode.");
 			}
 		}
 		

--- a/code/src/java/plugin/lsttokens/race/StartfeatsToken.java
+++ b/code/src/java/plugin/lsttokens/race/StartfeatsToken.java
@@ -57,20 +57,20 @@ public class StartfeatsToken extends AbstractToken implements
 		{
 			return new ParseResult.Fail("Error encountered in "
 					+ getTokenName()
-					+ " was expecting value to be an integer, found: " + value, context);
+					+ " was expecting value to be an integer, found: " + value);
 		}
 
 		BonusObj bon = Bonus.newBonus(context, "FEAT|POOL|" + bonusValue);
 		if (bon == null)
 		{
 			return new ParseResult.Fail("Internal Error: " + getTokenName()
-					+ " had invalid bonus", context);
+					+ " had invalid bonus");
 		}
 		Prerequisite prereq = getPrerequisite("PREMULT:1,[PREHD:MIN=1],[PRELEVEL:MIN=1]");
 		if (prereq == null)
 		{
 			return new ParseResult.Fail("Internal Error: " + getTokenName()
-					+ " had invalid prerequisite", context);
+					+ " had invalid prerequisite");
 		}
 		bon.addPrerequisite(prereq);
 		bon.setTokenSource(getTokenName());

--- a/code/src/java/plugin/lsttokens/race/WeaponbonusToken.java
+++ b/code/src/java/plugin/lsttokens/race/WeaponbonusToken.java
@@ -91,7 +91,7 @@ public class WeaponbonusToken extends AbstractTokenWithSeparator<Race>
 				if (ref == null)
 				{
 					return new ParseResult.Fail("  Error was encountered while parsing "
-							+ getTokenName(), context);
+							+ getTokenName());
 				}
 				context.getObjectContext().addToList(race, ListKey.WEAPONBONUS, ref);
 			}
@@ -99,7 +99,7 @@ public class WeaponbonusToken extends AbstractTokenWithSeparator<Race>
 		if (foundAny && foundOther)
 		{
 			return new ParseResult.Fail("Non-sensical " + getTokenName()
-					+ ": Contains ANY and a specific reference: " + value, context);
+					+ ": Contains ANY and a specific reference: " + value);
 		}
 		return ParseResult.SUCCESS;
 	}

--- a/code/src/java/plugin/lsttokens/race/XtraskillptsperlvlToken.java
+++ b/code/src/java/plugin/lsttokens/race/XtraskillptsperlvlToken.java
@@ -57,7 +57,7 @@ public class XtraskillptsperlvlToken extends AbstractNonEmptyToken<Race> impleme
 		if (!formula.isValid())
 		{
 			return new ParseResult.Fail("Formula in " + getTokenName()
-					+ " was not valid: " + formula.toString(), context);
+					+ " was not valid: " + formula.toString());
 		}
 		context.getObjectContext().put(race, FormulaKey.SKILL_POINTS_PER_LEVEL, formula);
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/rules/DefaultToken.java
+++ b/code/src/java/plugin/lsttokens/rules/DefaultToken.java
@@ -47,7 +47,7 @@ public class DefaultToken extends AbstractNonEmptyToken<RuleCheck> implements
 			if (value.length() > 1 && !value.equalsIgnoreCase("YES"))
 			{
 				return new ParseResult.Fail("You should use 'YES' as the "
-						+ getTokenName() + ": " + value, context);
+						+ getTokenName() + ": " + value);
 			}
 			set = Boolean.TRUE;
 		}
@@ -57,13 +57,13 @@ public class DefaultToken extends AbstractNonEmptyToken<RuleCheck> implements
 			{
 				return new ParseResult.Fail(
 						"You should use 'YES' or 'NO' as the " + getTokenName()
-								+ ": " + value, context);
+								+ ": " + value);
 			}
 			if (value.length() > 1 && !value.equalsIgnoreCase("NO"))
 			{
 				return new ParseResult.Fail(
 						"You should use 'YES' or 'NO' as the " + getTokenName()
-								+ ": " + value, context);
+								+ ": " + value);
 			}
 			set = Boolean.FALSE;
 		}

--- a/code/src/java/plugin/lsttokens/sizeadjustment/AbbToken.java
+++ b/code/src/java/plugin/lsttokens/sizeadjustment/AbbToken.java
@@ -51,12 +51,12 @@ public class AbbToken extends AbstractNonEmptyToken<SizeAdjustment> implements
 		{
 			if (!context.processToken(size, "KEY", value))
 			{
-				return new ParseResult.Fail("Internal Error", context);
+				return new ParseResult.Fail("Internal Error");
 			}
 		}
 		catch (PersistenceLayerException e)
 		{
-			return new ParseResult.Fail(e.getLocalizedMessage(), context);
+			return new ParseResult.Fail(e.getLocalizedMessage());
 		}
 		context.getObjectContext().put(size, StringKey.ABB_KR, value);
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/skill/AcheckToken.java
+++ b/code/src/java/plugin/lsttokens/skill/AcheckToken.java
@@ -82,7 +82,7 @@ public class AcheckToken extends AbstractNonEmptyToken<Skill> implements
 			else
 			{
 				return new ParseResult.Fail("Skill "
-						+ getTokenName() + " Did not understand: " + value, context);
+						+ getTokenName() + " Did not understand: " + value);
 			}
 		}
 

--- a/code/src/java/plugin/lsttokens/skill/ClassesToken.java
+++ b/code/src/java/plugin/lsttokens/skill/ClassesToken.java
@@ -72,7 +72,7 @@ public class ClassesToken extends AbstractTokenWithSeparator<Skill> implements
 					return new ParseResult.Fail("Non-sensical Skill "
 							+ getTokenName()
 							+ ": Contains ALL after a specific reference: "
-							+ value, context);
+							+ value);
 				}
 				break;
 			}
@@ -80,7 +80,7 @@ public class ClassesToken extends AbstractTokenWithSeparator<Skill> implements
 			{
 				return new ParseResult.Fail("Non-sensical Skill "
 						+ getTokenName()
-						+ ": Contains ! without (or before) ALL: " + value, context);
+						+ ": Contains ! without (or before) ALL: " + value);
 			}
 			allow.add(context.getReferenceContext().getCDOMReference(SKILLLIST_CLASS, className));
 			added = true;
@@ -101,7 +101,7 @@ public class ClassesToken extends AbstractTokenWithSeparator<Skill> implements
 							|| Constants.LST_ANY.equals(clString))
 					{
 						return new ParseResult.Fail("Invalid " + getTokenName()
-								+ " cannot use !ALL", context);
+								+ " cannot use !ALL");
 					}
 					CDOMSingleRef<ClassSkillList> ref = context.getReferenceContext()
 							.getCDOMReference(SKILLLIST_CLASS, clString);
@@ -112,7 +112,7 @@ public class ClassesToken extends AbstractTokenWithSeparator<Skill> implements
 					return new ParseResult.Fail("Non-sensical Skill "
 							+ getTokenName()
 							+ ": Contains ALL and a specific reference: "
-							+ value, context);
+							+ value);
 				}
 			}
 			context.getListContext()

--- a/code/src/java/plugin/lsttokens/skill/KeystatToken.java
+++ b/code/src/java/plugin/lsttokens/skill/KeystatToken.java
@@ -50,7 +50,7 @@ public class KeystatToken extends AbstractNonEmptyToken<Skill> implements
 		if (pcs == null)
 		{
 			return new ParseResult.Fail("Invalid Stat Abbreviation in Token "
-					+ getTokenName() + ": " + value, context);
+					+ getTokenName() + ": " + value);
 		}
 		context.getObjectContext().put(skill, ObjectKey.KEY_STAT, pcs);
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/skill/SituationToken.java
+++ b/code/src/java/plugin/lsttokens/skill/SituationToken.java
@@ -64,8 +64,7 @@ public class SituationToken extends AbstractTokenWithSeparator<Skill> implements
 				{
 					return new ParseResult.Fail("  Non-sensical "
 						+ getTokenName()
-						+ ": .CLEARALL was not the first list item: " + value,
-						context);
+						+ ": .CLEARALL was not the first list item: " + value);
 				}
 				context.getObjectContext().removeList(skill, ListKey.SITUATION);
 			}

--- a/code/src/java/plugin/lsttokens/skill/VisibleToken.java
+++ b/code/src/java/plugin/lsttokens/skill/VisibleToken.java
@@ -56,7 +56,7 @@ public class VisibleToken extends AbstractNonEmptyToken<Skill> implements
 			else
 			{
 				return new ParseResult.Fail("Misunderstood text after pipe on Tag: "
-						+ value, context);
+						+ value);
 			}
 		}
 		Visibility vis;
@@ -104,7 +104,7 @@ public class VisibleToken extends AbstractNonEmptyToken<Skill> implements
 			if (vis.equals(Visibility.OUTPUT_ONLY))
 			{
 				return new ParseResult.Fail("|READONLY suffix not valid with "
-						+ getTokenName() + " EXPORT or CSHEET", context);
+						+ getTokenName() + " EXPORT or CSHEET");
 			}
 			context.getObjectContext().put(skill, ObjectKey.READ_ONLY,
 					Boolean.TRUE);

--- a/code/src/java/plugin/lsttokens/spell/CasttimeToken.java
+++ b/code/src/java/plugin/lsttokens/spell/CasttimeToken.java
@@ -64,7 +64,7 @@ public class CasttimeToken extends AbstractTokenWithSeparator<Spell> implements
 				if (!first)
 				{
 					return new ParseResult.Fail("Non-sensical use of .CLEAR in "
-							+ getTokenName() + ": " + value, context);
+							+ getTokenName() + ": " + value);
 				}
 				context.getObjectContext().removeList(spell, ListKey.CASTTIME);
 			}

--- a/code/src/java/plugin/lsttokens/spell/ClassesToken.java
+++ b/code/src/java/plugin/lsttokens/spell/ClassesToken.java
@@ -96,13 +96,13 @@ public class ClassesToken extends AbstractTokenWithSeparator<Spell> implements
 			if (value.lastIndexOf(']') != value.length() - 1)
 			{
 				return new ParseResult.Fail("Invalid " + getTokenName()
-						+ " must end with ']' if it contains a PREREQ tag", context);
+						+ " must end with ']' if it contains a PREREQ tag");
 			}
 			if (value.lastIndexOf('|') > openBracketLoc)
 			{
 				return new ParseResult.Fail("Invalid " + getTokenName()
 					+ ": PRExxx must be at the END of the Token. Token was "
-					+ value, context);
+					+ value);
 			}
 			classKey = value.substring(0, openBracketLoc);
 			String prereqString = value.substring(openBracketLoc + 1, value
@@ -110,13 +110,13 @@ public class ClassesToken extends AbstractTokenWithSeparator<Spell> implements
 			if (prereqString.isEmpty())
 			{
 				return new ParseResult.Fail(getTokenName()
-						+ " cannot have empty prerequisite : " + value, context);
+						+ " cannot have empty prerequisite : " + value);
 			}
 			prereq = getPrerequisite(prereqString);
 			if (prereq == null)
 			{
 				return new ParseResult.Fail(getTokenName()
-						+ " had invalid prerequisite : " + prereqString, context);
+						+ " had invalid prerequisite : " + prereqString);
 			}
 		}
 
@@ -135,12 +135,12 @@ public class ClassesToken extends AbstractTokenWithSeparator<Spell> implements
 			if (equalLoc == -1)
 			{
 				return new ParseResult.Fail("Malformed " + getTokenName()
-						+ " Token (expecting an =): " + tokString, context);
+						+ " Token (expecting an =): " + tokString);
 			}
 			if (equalLoc != tokString.lastIndexOf(Constants.EQUALS))
 			{
 				return new ParseResult.Fail("Malformed " + getTokenName()
-						+ " Token (more than one =): " + tokString, context);
+						+ " Token (more than one =): " + tokString);
 			}
 
 			String nameList = tokString.substring(0, equalLoc);
@@ -152,14 +152,14 @@ public class ClassesToken extends AbstractTokenWithSeparator<Spell> implements
 				if (level.intValue() < -1)
 				{
 					return new ParseResult.Fail(getTokenName()
-							+ " may not use a negative level: " + value, context);
+							+ " may not use a negative level: " + value);
 				}
 				else if (level.intValue() == -1)
 				{
 					if (prereq != null)
 					{
 						return new ParseResult.Fail(getTokenName()
-								+ " may not use -1 with a PREREQ: " + value, context);
+								+ " may not use -1 with a PREREQ: " + value);
 					}
 					// Logging.deprecationPrint(getTokenName()
 					// + " should not use a negative level: " + value);
@@ -168,7 +168,7 @@ public class ClassesToken extends AbstractTokenWithSeparator<Spell> implements
 			catch (NumberFormatException nfe)
 			{
 				return new ParseResult.Fail("Malformed Level in " + getTokenName()
-						+ " (expected an Integer): " + levelString, context);
+						+ " (expected an Integer): " + levelString);
 			}
 
 			ParseResult pr = checkForIllegalSeparator(',', nameList);
@@ -196,8 +196,7 @@ public class ClassesToken extends AbstractTokenWithSeparator<Spell> implements
 							SPELLLIST_CLASS, token);
 					if (ref == null)
 					{
-						return new ParseResult.Fail("  error was in " + getTokenName(),
-							context);
+						return new ParseResult.Fail("  error was in " + getTokenName());
 					}
 				}
 				if (level == -1)
@@ -223,7 +222,7 @@ public class ClassesToken extends AbstractTokenWithSeparator<Spell> implements
 		if (foundAny && foundOther)
 		{
 			return new ParseResult.Fail("Non-sensical " + getTokenName()
-					+ ": Contains ANY and a specific reference: " + value, context);
+					+ ": Contains ANY and a specific reference: " + value);
 		}
 		return ParseResult.SUCCESS;
 	}

--- a/code/src/java/plugin/lsttokens/spell/CompsToken.java
+++ b/code/src/java/plugin/lsttokens/spell/CompsToken.java
@@ -64,7 +64,7 @@ public class CompsToken extends AbstractTokenWithSeparator<Spell> implements
 				if (!first)
 				{
 					return new ParseResult.Fail("Non-sensical use of .CLEAR in "
-							+ getTokenName() + ": " + value, context);
+							+ getTokenName() + ": " + value);
 				}
 				context.getObjectContext()
 						.removeList(spell, ListKey.COMPONENTS);

--- a/code/src/java/plugin/lsttokens/spell/CostToken.java
+++ b/code/src/java/plugin/lsttokens/spell/CostToken.java
@@ -58,7 +58,7 @@ public class CostToken extends AbstractNonEmptyToken<Spell> implements
 				if (cost.compareTo(BigDecimal.ZERO) <= 0)
 				{
 					return new ParseResult.Fail(getTokenName()
-						+ " requires a positive Integer", context);
+						+ " requires a positive Integer");
 				}
 				context.getObjectContext().put(spell, ObjectKey.COST, cost);
 			}
@@ -66,7 +66,7 @@ public class CostToken extends AbstractNonEmptyToken<Spell> implements
 			{
 				return new ParseResult.Fail(getTokenName()
 					+ " expected an integer.  Tag must be of the form: "
-					+ getTokenName() + ":<int>", context);
+					+ getTokenName() + ":<int>");
 			}
 		}
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/spell/CtToken.java
+++ b/code/src/java/plugin/lsttokens/spell/CtToken.java
@@ -68,7 +68,7 @@ public class CtToken implements CDOMPrimaryToken<Spell>
 			if (ct.intValue() < 0)
 			{
 				return new ParseResult.Fail(getTokenName()
-						+ " requires a positive Integer", context);
+						+ " requires a positive Integer");
 			}
 			context.getObjectContext().put(spell, IntegerKey.CASTING_THRESHOLD, ct);
 			return ParseResult.SUCCESS;
@@ -77,7 +77,7 @@ public class CtToken implements CDOMPrimaryToken<Spell>
 		{
 			return new ParseResult.Fail(getTokenName()
 					+ " expected an integer.  Tag must be of the form: "
-					+ getTokenName() + ":<int>", context);
+					+ getTokenName() + ":<int>");
 		}
 	}
 }

--- a/code/src/java/plugin/lsttokens/spell/DescriptorToken.java
+++ b/code/src/java/plugin/lsttokens/spell/DescriptorToken.java
@@ -63,7 +63,7 @@ public class DescriptorToken extends AbstractTokenWithSeparator<Spell>
 				if (!first)
 				{
 					return new ParseResult.Fail("  Non-sensical " + getTokenName()
-							+ ": .CLEAR was not the first list item: " + value, context);
+							+ ": .CLEAR was not the first list item: " + value);
 				}
 				context.getObjectContext().removeList(spell,
 						ListKey.SPELL_DESCRIPTOR);

--- a/code/src/java/plugin/lsttokens/spell/DomainsToken.java
+++ b/code/src/java/plugin/lsttokens/spell/DomainsToken.java
@@ -95,7 +95,7 @@ public class DomainsToken extends AbstractTokenWithSeparator<Spell> implements
 			if (value.lastIndexOf(']') != value.length() - 1)
 			{
 				return new ParseResult.Fail("Invalid " + getTokenName()
-						+ " must end with ']' if it contains a PREREQ tag", context);
+						+ " must end with ']' if it contains a PREREQ tag");
 			}
 			domainKey = value.substring(0, openBracketLoc);
 			String prereqString = value.substring(openBracketLoc + 1, value
@@ -103,13 +103,13 @@ public class DomainsToken extends AbstractTokenWithSeparator<Spell> implements
 			if (prereqString.isEmpty())
 			{
 				return new ParseResult.Fail(getTokenName()
-						+ " cannot have empty prerequisite : " + value, context);
+						+ " cannot have empty prerequisite : " + value);
 			}
 			prereq = getPrerequisite(prereqString);
 			if (prereq == null)
 			{
 				return new ParseResult.Fail(getTokenName()
-						+ " had invalid prerequisite : " + prereqString, context);
+						+ " had invalid prerequisite : " + prereqString);
 			}
 		}
 
@@ -127,12 +127,12 @@ public class DomainsToken extends AbstractTokenWithSeparator<Spell> implements
 			if (equalLoc == -1)
 			{
 				return new ParseResult.Fail("Malformed " + getTokenName()
-						+ " Token (expecting an =): " + tokString, context);
+						+ " Token (expecting an =): " + tokString);
 			}
 			if (equalLoc != tokString.lastIndexOf(Constants.EQUALS))
 			{
 				return new ParseResult.Fail("Malformed " + getTokenName()
-						+ " Token (more than one =): " + tokString, context);
+						+ " Token (more than one =): " + tokString);
 			}
 
 			String nameList = tokString.substring(0, equalLoc);
@@ -144,14 +144,14 @@ public class DomainsToken extends AbstractTokenWithSeparator<Spell> implements
 				if (level.intValue() < -1)
 				{
 					return new ParseResult.Fail(getTokenName()
-							+ " may not use a negative level: " + value, context);
+							+ " may not use a negative level: " + value);
 				}
 				else if (level.intValue() == -1)
 				{
 					if (prereq != null)
 					{
 						return new ParseResult.Fail(getTokenName()
-								+ " may not use -1 with a PREREQ: " + value, context);
+								+ " may not use -1 with a PREREQ: " + value);
 					}
 					// Logging.deprecationPrint(getTokenName()
 					// + " should not use a negative level: " + value);
@@ -160,7 +160,7 @@ public class DomainsToken extends AbstractTokenWithSeparator<Spell> implements
 			catch (NumberFormatException nfe)
 			{
 				return new ParseResult.Fail("Malformed Level in " + getTokenName()
-						+ " (expected an Integer): " + levelString, context);
+						+ " (expected an Integer): " + levelString);
 			}
 
 			ParseResult pr = checkForIllegalSeparator(',', nameList);
@@ -189,7 +189,7 @@ public class DomainsToken extends AbstractTokenWithSeparator<Spell> implements
 				}
 				if (ref == null)
 				{
-					return new ParseResult.Fail("  Error was in " + getTokenName(), context);
+					return new ParseResult.Fail("  Error was in " + getTokenName());
 				}
 				if (level == -1)
 				{
@@ -214,7 +214,7 @@ public class DomainsToken extends AbstractTokenWithSeparator<Spell> implements
 		if (foundAny && foundOther)
 		{
 			return new ParseResult.Fail("Non-sensical " + getTokenName()
-					+ ": Contains ANY and a specific reference: " + value, context);
+					+ ": Contains ANY and a specific reference: " + value);
 		}
 		return ParseResult.SUCCESS;
 	}

--- a/code/src/java/plugin/lsttokens/spell/DurationToken.java
+++ b/code/src/java/plugin/lsttokens/spell/DurationToken.java
@@ -64,7 +64,7 @@ public class DurationToken extends AbstractTokenWithSeparator<Spell> implements
 				if (!first)
 				{
 					return new ParseResult.Fail("Non-sensical use of .CLEAR in "
-							+ getTokenName() + ": " + value, context);
+							+ getTokenName() + ": " + value);
 				}
 				context.getObjectContext().removeList(spell, ListKey.DURATION);
 			}
@@ -73,8 +73,7 @@ public class DurationToken extends AbstractTokenWithSeparator<Spell> implements
 				if (!StringUtil.hasBalancedParens(value))
 				{
 					return new ParseResult.Fail("Unbalanced parentheses in "
-						+ getTokenName() + " '" + value + "' used in spell " + spell,
-						context);
+						+ getTokenName() + " '" + value + "' used in spell " + spell);
 				}
 				context.getObjectContext().addToList(spell, ListKey.DURATION,
 						tok);

--- a/code/src/java/plugin/lsttokens/spell/ItemToken.java
+++ b/code/src/java/plugin/lsttokens/spell/ItemToken.java
@@ -66,14 +66,14 @@ public class ItemToken extends AbstractTokenWithSeparator<Spell> implements
 				{
 					return new ParseResult.Fail("Invalid " + getTokenName()
 							+ ": mismatched open Bracket: " + tokString
-							+ " in " + value, context);
+							+ " in " + value);
 				}
 				String substring = tokString.substring(1,
 						tokString.length() - 1);
 				if (substring.isEmpty())
 				{
 					return new ParseResult.Fail("Invalid " + getTokenName()
-							+ ": cannot be empty item in brackets []", context);
+							+ ": cannot be empty item in brackets []");
 				}
 				context.getObjectContext().addToList(spell,
 						ListKey.PROHIBITED_ITEM, Type.getConstant(substring));
@@ -84,7 +84,7 @@ public class ItemToken extends AbstractTokenWithSeparator<Spell> implements
 				{
 					return new ParseResult.Fail("Invalid " + getTokenName()
 							+ ": mismatched close Bracket: " + tokString
-							+ " in " + value, context);
+							+ " in " + value);
 				}
 				context.getObjectContext().addToList(spell, ListKey.ITEM,
 						Type.getConstant(tokString));

--- a/code/src/java/plugin/lsttokens/spell/RangeToken.java
+++ b/code/src/java/plugin/lsttokens/spell/RangeToken.java
@@ -64,7 +64,7 @@ public class RangeToken extends AbstractTokenWithSeparator<Spell> implements
 				if (!first)
 				{
 					return new ParseResult.Fail("Non-sensical use of .CLEAR in "
-							+ getTokenName() + ": " + value, context);
+							+ getTokenName() + ": " + value);
 				}
 				context.getObjectContext().removeList(spell, ListKey.RANGE);
 			}
@@ -73,8 +73,7 @@ public class RangeToken extends AbstractTokenWithSeparator<Spell> implements
 				if (!StringUtil.hasBalancedParens(value))
 				{
 					return new ParseResult.Fail("Unbalanced parentheses in "
-						+ getTokenName() + " '" + value + "' used in spell " + spell,
-						context);
+						+ getTokenName() + " '" + value + "' used in spell " + spell);
 				}
 				context.getObjectContext().addToList(spell, ListKey.RANGE, tok);
 			}

--- a/code/src/java/plugin/lsttokens/spell/SaveinfoToken.java
+++ b/code/src/java/plugin/lsttokens/spell/SaveinfoToken.java
@@ -64,7 +64,7 @@ public class SaveinfoToken extends AbstractTokenWithSeparator<Spell> implements
 				if (!first)
 				{
 					return new ParseResult.Fail("Non-sensical use of .CLEAR in "
-							+ getTokenName() + ": " + value, context);
+							+ getTokenName() + ": " + value);
 				}
 				context.getObjectContext().removeList(spell, ListKey.SAVE_INFO);
 			}

--- a/code/src/java/plugin/lsttokens/spell/SchoolToken.java
+++ b/code/src/java/plugin/lsttokens/spell/SchoolToken.java
@@ -64,7 +64,7 @@ public class SchoolToken extends AbstractTokenWithSeparator<Spell> implements
 				if (!first)
 				{
 					return new ParseResult.Fail("  Non-sensical " + getTokenName()
-							+ ": .CLEAR was not the first list item: " + value, context);
+							+ ": .CLEAR was not the first list item: " + value);
 				}
 				context.getObjectContext().removeList(spell,
 						ListKey.SPELL_SCHOOL);
@@ -72,12 +72,12 @@ public class SchoolToken extends AbstractTokenWithSeparator<Spell> implements
 			else if (Constants.LST_ALL.equals(tokString))
 			{
 				return new ParseResult.Fail(getTokenName()
-					+ "used reserved word ALL: " + value, context);
+					+ "used reserved word ALL: " + value);
 			}
 			else if (Constants.LST_ANY.equals(tokString))
 			{
 				return new ParseResult.Fail(getTokenName()
-					+ "used reserved word ANY: " + value, context);
+					+ "used reserved word ANY: " + value);
 			}
 			else
 			{

--- a/code/src/java/plugin/lsttokens/spell/SpellresToken.java
+++ b/code/src/java/plugin/lsttokens/spell/SpellresToken.java
@@ -64,7 +64,7 @@ public class SpellresToken extends AbstractTokenWithSeparator<Spell> implements
 				if (!first)
 				{
 					return new ParseResult.Fail("Non-sensical use of .CLEAR in "
-							+ getTokenName() + ": " + value, context);
+							+ getTokenName() + ": " + value);
 				}
 				context.getObjectContext().removeList(spell,
 						ListKey.SPELL_RESISTANCE);

--- a/code/src/java/plugin/lsttokens/spell/StatToken.java
+++ b/code/src/java/plugin/lsttokens/spell/StatToken.java
@@ -50,7 +50,7 @@ public class StatToken extends AbstractNonEmptyToken<Spell> implements
 		if (pcs == null)
 		{
 			return new ParseResult.Fail("Invalid Stat Abbreviation in Token "
-					+ getTokenName() + ": " + value, context);
+					+ getTokenName() + ": " + value);
 		}
 		context.getObjectContext().put(spell, ObjectKey.SPELL_STAT, pcs);
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/spell/SubschoolToken.java
+++ b/code/src/java/plugin/lsttokens/spell/SubschoolToken.java
@@ -63,7 +63,7 @@ public class SubschoolToken extends AbstractTokenWithSeparator<Spell> implements
 				if (!first)
 				{
 					return new ParseResult.Fail("  Non-sensical " + getTokenName()
-							+ ": .CLEAR was not the first list item: " + value, context);
+							+ ": .CLEAR was not the first list item: " + value);
 				}
 				context.getObjectContext().removeList(spell,
 						ListKey.SPELL_SUBSCHOOL);

--- a/code/src/java/plugin/lsttokens/spell/TargetareaToken.java
+++ b/code/src/java/plugin/lsttokens/spell/TargetareaToken.java
@@ -46,7 +46,7 @@ public class TargetareaToken implements CDOMPrimaryToken<Spell>
 		if (value == null || value.isEmpty())
 		{
 			return new ParseResult.Fail(getTokenName()
-				+ " arguments may not be empty", context);
+				+ " arguments may not be empty");
 		}
 		if (Constants.LST_DOT_CLEAR.equals(value))
 		{
@@ -58,7 +58,7 @@ public class TargetareaToken implements CDOMPrimaryToken<Spell>
 			{
 				return new ParseResult.Fail("Unbalanced parentheses in "
 					+ getTokenName() + " '" + value + "' used in spell "
-					+ spell, context);
+					+ spell);
 			}
 			context.getObjectContext().put(spell, StringKey.TARGET_AREA, value);
 		}

--- a/code/src/java/plugin/lsttokens/spell/VariantsToken.java
+++ b/code/src/java/plugin/lsttokens/spell/VariantsToken.java
@@ -64,7 +64,7 @@ public class VariantsToken extends AbstractTokenWithSeparator<Spell> implements
 				if (!first)
 				{
 					return new ParseResult.Fail("Non-sensical use of .CLEAR in "
-							+ getTokenName() + ": " + value, context);
+							+ getTokenName() + ": " + value);
 				}
 				context.getObjectContext().removeList(spell, ListKey.VARIANTS);
 			}

--- a/code/src/java/plugin/lsttokens/sponsor/ImagebannerToken.java
+++ b/code/src/java/plugin/lsttokens/sponsor/ImagebannerToken.java
@@ -54,7 +54,7 @@ public class ImagebannerToken implements CDOMPrimaryToken<Sponsor>
 		catch (MalformedURLException e)
 		{
 			return new ParseResult.Fail("Error in " + getTokenName() + ": "
-					+ e.getMessage(), context);
+					+ e.getMessage());
 		}
 	}
 

--- a/code/src/java/plugin/lsttokens/sponsor/ImagelargeToken.java
+++ b/code/src/java/plugin/lsttokens/sponsor/ImagelargeToken.java
@@ -54,7 +54,7 @@ public class ImagelargeToken implements CDOMPrimaryToken<Sponsor>
 		catch (MalformedURLException e)
 		{
 			return new ParseResult.Fail("Error in " + getTokenName() + ": "
-					+ e.getMessage(), context);
+					+ e.getMessage());
 		}
 	}
 

--- a/code/src/java/plugin/lsttokens/sponsor/ImagesmallToken.java
+++ b/code/src/java/plugin/lsttokens/sponsor/ImagesmallToken.java
@@ -54,7 +54,7 @@ public class ImagesmallToken implements CDOMPrimaryToken<Sponsor>
 		catch (MalformedURLException e)
 		{
 			return new ParseResult.Fail("Error in " + getTokenName() + ": "
-					+ e.getMessage(), context);
+					+ e.getMessage());
 		}
 	}
 

--- a/code/src/java/plugin/lsttokens/statsandchecks/alignment/AbbToken.java
+++ b/code/src/java/plugin/lsttokens/statsandchecks/alignment/AbbToken.java
@@ -51,12 +51,12 @@ public class AbbToken extends AbstractNonEmptyToken<PCAlignment> implements
 		{
 			if (!context.processToken(al, "KEY", value))
 			{
-				return new ParseResult.Fail("Internal Error", context);
+				return new ParseResult.Fail("Internal Error");
 			}
 		}
 		catch (PersistenceLayerException e)
 		{
-			return new ParseResult.Fail(e.getLocalizedMessage(), context);
+			return new ParseResult.Fail(e.getLocalizedMessage());
 		}
 		context.getObjectContext().put(al, StringKey.ABB_KR, value);
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/statsandchecks/bonusspell/BasestatscoreToken.java
+++ b/code/src/java/plugin/lsttokens/statsandchecks/bonusspell/BasestatscoreToken.java
@@ -50,7 +50,7 @@ public class BasestatscoreToken implements CDOMPrimaryToken<BonusSpellInfo>
 			if (intValue < 1)
 			{
 				return new ParseResult.Fail(getTokenName()
-						+ " must be an integer >= " + 1, context);
+						+ " must be an integer >= " + 1);
 			}
 			bsi.setStatScore(intValue);
 			return ParseResult.SUCCESS;
@@ -59,7 +59,7 @@ public class BasestatscoreToken implements CDOMPrimaryToken<BonusSpellInfo>
 		{
 			return new ParseResult.Fail(getTokenName()
 					+ " expected an integer.  Tag must be of the form: "
-					+ getTokenName() + ":<int>", context);
+					+ getTokenName() + ":<int>");
 		}
 	}
 

--- a/code/src/java/plugin/lsttokens/statsandchecks/bonusspell/StatrangeToken.java
+++ b/code/src/java/plugin/lsttokens/statsandchecks/bonusspell/StatrangeToken.java
@@ -50,7 +50,7 @@ public class StatrangeToken implements CDOMPrimaryToken<BonusSpellInfo>
 			if (intValue < 1)
 			{
 				return new ParseResult.Fail(getTokenName()
-						+ " must be an integer >= " + 1, context);
+						+ " must be an integer >= " + 1);
 			}
 			bsi.setStatRange(intValue);
 			return ParseResult.SUCCESS;
@@ -59,7 +59,7 @@ public class StatrangeToken implements CDOMPrimaryToken<BonusSpellInfo>
 		{
 			return new ParseResult.Fail(getTokenName()
 					+ " expected an integer.  Tag must be of the form: "
-					+ getTokenName() + ":<int>", context);
+					+ getTokenName() + ":<int>");
 		}
 	}
 

--- a/code/src/java/plugin/lsttokens/statsandchecks/stat/AbbToken.java
+++ b/code/src/java/plugin/lsttokens/statsandchecks/stat/AbbToken.java
@@ -49,12 +49,12 @@ public class AbbToken extends AbstractNonEmptyToken<PCStat> implements CDOMPrima
 		{
 			if (!context.processToken(stat, "KEY", value))
 			{
-				return new ParseResult.Fail("Internal Error", context);
+				return new ParseResult.Fail("Internal Error");
 			}
 		}
 		catch (PersistenceLayerException e)
 		{
-			return new ParseResult.Fail(e.getLocalizedMessage(), context);
+			return new ParseResult.Fail(e.getLocalizedMessage());
 		}
 		context.getObjectContext().put(stat, StringKey.ABB_KR, value);
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/statsandchecks/stat/StatmodToken.java
+++ b/code/src/java/plugin/lsttokens/statsandchecks/stat/StatmodToken.java
@@ -42,13 +42,13 @@ public class StatmodToken implements CDOMPrimaryToken<PCStat>
 	{
 		if (value == null || value.isEmpty())
 		{
-			return new ParseResult.Fail(getTokenName() + " arguments may not be empty", context);
+			return new ParseResult.Fail(getTokenName() + " arguments may not be empty");
 		}
 		Formula formula = FormulaFactory.getFormulaFor(value);
 		if (!formula.isValid())
 		{
 			return new ParseResult.Fail("Formula in " + getTokenName()
-					+ " was not valid: " + formula.toString(), context);
+					+ " was not valid: " + formula.toString());
 		}
 		context.getObjectContext().put(stat, FormulaKey.STAT_MOD, formula);
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/statsandchecks/stat/StatrangeToken.java
+++ b/code/src/java/plugin/lsttokens/statsandchecks/stat/StatrangeToken.java
@@ -57,14 +57,14 @@ public class StatrangeToken implements CDOMPrimaryToken<PCStat>
 			{
 				return new ParseResult.Fail("Error in specified Stat range, "
 						+ "expected two comma separated integers, found: "
-						+ value, context);
+						+ value);
 			}
 		}
 		else
 		{
 			return new ParseResult.Fail("Error in specified Stat range, "
 					+ "expected two comma separated integers, found "
-					+ aTok.countTokens() + " values in: " + value, context);
+					+ aTok.countTokens() + " values in: " + value);
 		}
 	}
 

--- a/code/src/java/plugin/lsttokens/subclass/ChoiceToken.java
+++ b/code/src/java/plugin/lsttokens/subclass/ChoiceToken.java
@@ -60,13 +60,13 @@ public class ChoiceToken extends AbstractTokenWithSeparator<SubClass> implements
 		if (pipeLoc == -1)
 		{
 			return new ParseResult.Fail(getTokenName()
-					+ " has no | separator for arguments: " + value, context);
+					+ " has no | separator for arguments: " + value);
 		}
 
 		if (value.lastIndexOf('|') != pipeLoc)
 		{
 			return new ParseResult.Fail(getTokenName()
-					+ " has more than two | separated arguments: " + value, context);
+					+ " has more than two | separated arguments: " + value);
 		}
 
 		String pstString = value.substring(0, pipeLoc);
@@ -99,7 +99,7 @@ public class ChoiceToken extends AbstractTokenWithSeparator<SubClass> implements
 		}
 
 		return new ParseResult.Fail("Invalid TYPE in " + getTokenName() + ": "
-				+ pstString, context);
+				+ pstString);
 	}
 
 	@Override

--- a/code/src/java/plugin/lsttokens/tempbonus/AnyPCToken.java
+++ b/code/src/java/plugin/lsttokens/tempbonus/AnyPCToken.java
@@ -52,7 +52,7 @@ public class AnyPCToken extends AbstractTokenWithSeparator<CDOMObject>
 		if (bon == null)
 		{
 			return new ParseResult.Fail(getFullTokenName()
-				+ " was given invalid type: " + value, context);
+				+ " was given invalid type: " + value);
 		}
 		bon.setTokenSource(getFullTokenName());
 		context.getObjectContext().addToList(obj, ListKey.BONUS_ANYPC, bon);

--- a/code/src/java/plugin/lsttokens/tempbonus/EQToken.java
+++ b/code/src/java/plugin/lsttokens/tempbonus/EQToken.java
@@ -62,7 +62,7 @@ public class EQToken extends AbstractTokenWithSeparator<CDOMObject> implements
 		if (bon == null)
 		{
 			return new ParseResult.Fail(getFullTokenName()
-				+ " was given invalid type: " + bonus, context);
+				+ " was given invalid type: " + bonus);
 		}
 		bon.setTokenSource(getFullTokenName());
 		EquipBonus eb = new EquipBonus(bon, constraints);

--- a/code/src/java/plugin/lsttokens/tempbonus/PCToken.java
+++ b/code/src/java/plugin/lsttokens/tempbonus/PCToken.java
@@ -52,7 +52,7 @@ public class PCToken extends AbstractTokenWithSeparator<CDOMObject> implements
 		if (bon == null)
 		{
 			return new ParseResult.Fail(getFullTokenName()
-				+ " was given invalid type: " + value, context);
+				+ " was given invalid type: " + value);
 		}
 		bon.setTokenSource(getFullTokenName());
 		context.getObjectContext().addToList(obj, ListKey.BONUS_PC, bon);

--- a/code/src/java/plugin/lsttokens/template/AddLevelToken.java
+++ b/code/src/java/plugin/lsttokens/template/AddLevelToken.java
@@ -101,7 +101,7 @@ public class AddLevelToken extends AbstractNonEmptyToken<PCTemplate> implements
 			if (lvls <= 0)
 			{
 				return new ParseResult.Fail("Number of Levels granted in "
-						+ getTokenName() + " must be greater than zero", context);
+						+ getTokenName() + " must be greater than zero");
 			}
 			f = FormulaFactory.getFormulaFor(lvls);
 		}
@@ -112,7 +112,7 @@ public class AddLevelToken extends AbstractNonEmptyToken<PCTemplate> implements
 		if (!f.isValid())
 		{
 			return new ParseResult.Fail("Formula in " + getTokenName()
-					+ " was not valid: " + f.toString(), context);
+					+ " was not valid: " + f.toString());
 		}
 		LevelCommandFactory cf = new LevelCommandFactory(cl, f);
 		context.getObjectContext().addToList(template, ListKey.ADD_LEVEL, cf);

--- a/code/src/java/plugin/lsttokens/template/CrToken.java
+++ b/code/src/java/plugin/lsttokens/template/CrToken.java
@@ -51,7 +51,7 @@ public class CrToken extends AbstractNonEmptyToken<PCTemplate> implements
 		}
 		catch (NumberFormatException nfe)
 		{
-			return new ParseResult.Fail("Misunderstood Double in Tag: " + value, context);
+			return new ParseResult.Fail("Misunderstood Double in Tag: " + value);
 		}
 	}
 

--- a/code/src/java/plugin/lsttokens/template/FaceToken.java
+++ b/code/src/java/plugin/lsttokens/template/FaceToken.java
@@ -64,8 +64,7 @@ public class FaceToken extends AbstractNonEmptyToken<PCTemplate> implements
 		if (ControlUtilities.hasControlToken(context, CControl.FACE))
 		{
 			return new ParseResult.Fail(
-				"FACE: LST Token is disabled when FACE: control is used",
-				context);
+				"FACE: LST Token is disabled when FACE: control is used");
 		}
 		if (value.indexOf(',') == -1)
 		{
@@ -86,19 +85,19 @@ public class FaceToken extends AbstractNonEmptyToken<PCTemplate> implements
 		{
 			return new ParseResult.Fail(getTokenName()
 				+ " Modifier SET had value " + value
-				+ " but it was not valid: " + iae.getMessage(), context);
+				+ " but it was not valid: " + iae.getMessage());
 		}
 		modifier.addAssociation("PRIORITY=" + MOD_PRIORITY);
 		OrderedPair pair = modifier.process(null);
 		if (pair.getPreciseX().doubleValue() < 0.0)
 		{
 			return new ParseResult.Fail(getTokenName() + " had value " + value
-				+ " but first item cannot be negative", context);
+				+ " but first item cannot be negative");
 		}
 		if (pair.getPreciseY().doubleValue() < 0.0)
 		{
 			return new ParseResult.Fail(getTokenName() + " had value " + value
-				+ " but second item cannot be negative", context);
+				+ " but second item cannot be negative");
 		}
 		String varName = VAR_NAME;
 		if (!context.getVariableContext().isLegalVariableID(scope, varName))
@@ -106,7 +105,7 @@ public class FaceToken extends AbstractNonEmptyToken<PCTemplate> implements
 			return new ParseResult.Fail(getTokenName()
 				+ " internal error: found invalid fact name: " + varName
 				+ ", Modified on " + fObj.getClass().getSimpleName() + ' '
-				+ fObj.getKeyName(), context);
+				+ fObj.getKeyName());
 		}
 		VarModifier<OrderedPair> vm =
 				new VarModifier<>(varName, scope, modifier);

--- a/code/src/java/plugin/lsttokens/template/FavoredclassToken.java
+++ b/code/src/java/plugin/lsttokens/template/FavoredclassToken.java
@@ -130,7 +130,7 @@ public class FavoredclassToken extends AbstractTokenWithSeparator<PCTemplate>
 		{
 			return new ParseResult.Fail("Non-sensical " + getTokenName()
 				+ ": Contains " + Constants.HIGHEST_LEVEL_CLASS
-				+ " and a specific reference: " + value, context);
+				+ " and a specific reference: " + value);
 		}
 		return ParseResult.SUCCESS;
 	}

--- a/code/src/java/plugin/lsttokens/template/GenderlockToken.java
+++ b/code/src/java/plugin/lsttokens/template/GenderlockToken.java
@@ -51,7 +51,7 @@ public class GenderlockToken extends AbstractNonEmptyToken<PCTemplate>
 		catch (IllegalArgumentException iae)
 		{
 			return new ParseResult.Fail("Invalid Gender provided in " + getTokenName()
-					+ ": " + value, context);
+					+ ": " + value);
 		}
 	}
 

--- a/code/src/java/plugin/lsttokens/template/HandsToken.java
+++ b/code/src/java/plugin/lsttokens/template/HandsToken.java
@@ -64,8 +64,7 @@ public class HandsToken extends AbstractIntToken<PCTemplate> implements
 		if (ControlUtilities.hasControlToken(context, CControl.CREATUREHANDS))
 		{
 			return new ParseResult.Fail(getTokenName()
-				+ " is disabled when CREATUREHANDS control is used: " + value,
-				context);
+				+ " is disabled when CREATUREHANDS control is used: " + value);
 		}
 		return super.parseToken(context, obj, value);
 	}

--- a/code/src/java/plugin/lsttokens/template/HdToken.java
+++ b/code/src/java/plugin/lsttokens/template/HdToken.java
@@ -85,7 +85,7 @@ public class HdToken extends AbstractTokenWithSeparator<PCTemplate> implements
 				if (plusLoc == 0)
 				{
 					return new ParseResult.Fail("Malformed " + getTokenName()
-						+ " Cannot start with +: " + hdString, context);
+						+ " Cannot start with +: " + hdString);
 				}
 				else if (plusLoc == hdString.length() - 1)
 				{
@@ -107,27 +107,27 @@ public class HdToken extends AbstractTokenWithSeparator<PCTemplate> implements
 			if (maxhd < minhd)
 			{
 				return new ParseResult.Fail("Malformed " + getTokenName()
-						+ " Token (Max < Min): " + hdString, context);
+						+ " Token (Max < Min): " + hdString);
 			}
 		}
 		catch (NumberFormatException ex)
 		{
 			return new ParseResult.Fail("Malformed " + getTokenName()
-					+ " Token (HD syntax invalid): " + hdString, context);
+					+ " Token (HD syntax invalid): " + hdString);
 		}
 
 		if (!tok.hasMoreTokens())
 		{
 			return new ParseResult.Fail("Invalid " + getTokenName()
 					+ ": requires 3 colon separated elements (has one): "
-					+ value, context);
+					+ value);
 		}
 		String typeStr = tok.nextToken();
 		if (!tok.hasMoreTokens())
 		{
 			return new ParseResult.Fail("Invalid " + getTokenName()
 					+ ": requires 3 colon separated elements (has two): "
-					+ value, context);
+					+ value);
 		}
 		String argument = tok.nextToken();
 		PCTemplate derivative = new PCTemplate();
@@ -146,7 +146,7 @@ public class HdToken extends AbstractTokenWithSeparator<PCTemplate> implements
 		}
 		catch (PersistenceLayerException e)
 		{
-			return new ParseResult.Fail(e.getMessage(), context);
+			return new ParseResult.Fail(e.getMessage());
 		}
 		return ParseResult.INTERNAL_ERROR;
 	}

--- a/code/src/java/plugin/lsttokens/template/HitdieToken.java
+++ b/code/src/java/plugin/lsttokens/template/HitdieToken.java
@@ -63,7 +63,7 @@ public class HitdieToken extends AbstractNonEmptyToken<PCTemplate> implements
 			if (pipeLoc != lock.lastIndexOf(Constants.PIPE))
 			{
 				return new ParseResult.Fail(getTokenName() + " has more than one pipe, "
-						+ "is not of format: <int>[|<prereq>]", context);
+						+ "is not of format: <int>[|<prereq>]");
 			}
 			// Do not initialize, null is significant
 			CDOMReference<PCClass> owner = null;
@@ -78,7 +78,7 @@ public class HitdieToken extends AbstractNonEmptyToken<PCTemplate> implements
 					{
 						return new ParseResult.Fail(
 							"Cannot have Empty Type Limitation in " + getTokenName()
-								+ ": " + value, context);
+								+ ": " + value);
 					}
 					ParseResult pr = checkForIllegalSeparator('.', substring);
 					if (!pr.passed())
@@ -95,7 +95,7 @@ public class HitdieToken extends AbstractNonEmptyToken<PCTemplate> implements
 					{
 						return new ParseResult.Fail(
 							"Cannot have Empty Class Limitation in " + getTokenName()
-								+ ": " + value, context);
+								+ ": " + value);
 					}
 					owner = context.getReferenceContext().getCDOMReference(PCCLASS_CLASS,
 							substring);
@@ -103,7 +103,7 @@ public class HitdieToken extends AbstractNonEmptyToken<PCTemplate> implements
 				else
 				{
 					return new ParseResult.Fail("Invalid Limitation in HITDIE: "
-							+ lockPre, context);
+							+ lockPre);
 				}
 				lock = lock.substring(0, pipeLoc);
 			}
@@ -117,7 +117,7 @@ public class HitdieToken extends AbstractNonEmptyToken<PCTemplate> implements
 				{
 					return new ParseResult.Fail(getTokenName()
 							+ " was expecting a Positive Integer "
-							+ "for dividing Lock, was : " + lock.substring(2), context);
+							+ "for dividing Lock, was : " + lock.substring(2));
 				}
 				hdm = new HitDieFormula(new DividingFormula(denom));
 			}
@@ -130,7 +130,7 @@ public class HitdieToken extends AbstractNonEmptyToken<PCTemplate> implements
 					return new ParseResult.Fail(getTokenName()
 							+ " was expecting a Positive "
 							+ "Integer for multiplying Lock, was : "
-							+ lock.substring(2), context);
+							+ lock.substring(2));
 				}
 				hdm = new HitDieFormula(new MultiplyingFormula(mult));
 			}
@@ -144,7 +144,7 @@ public class HitdieToken extends AbstractNonEmptyToken<PCTemplate> implements
 					return new ParseResult.Fail(getTokenName()
 							+ " was expecting a Positive "
 							+ "Integer for adding Lock, was : "
-							+ lock.substring(2), context);
+							+ lock.substring(2));
 				}
 				hdm = new HitDieFormula(new AddingFormula(add));
 			}
@@ -159,7 +159,7 @@ public class HitdieToken extends AbstractNonEmptyToken<PCTemplate> implements
 					return new ParseResult.Fail(getTokenName()
 							+ " was expecting a Positive "
 							+ "Integer for subtracting Lock, was : "
-							+ lock.substring(2), context);
+							+ lock.substring(2));
 				}
 				hdm = new HitDieFormula(new SubtractingFormula(sub));
 			}
@@ -172,12 +172,12 @@ public class HitdieToken extends AbstractNonEmptyToken<PCTemplate> implements
 				if (steps <= 0)
 				{
 					return new ParseResult.Fail("Invalid Step Count: " + steps + " in "
-							+ getTokenName() + " up (must be positive)", context);
+							+ getTokenName() + " up (must be positive)");
 				}
 				if (steps >= 5)
 				{
 					return new ParseResult.Fail("Invalid Step Count: " + steps + " in "
-							+ getTokenName() + " up (too large)", context);
+							+ getTokenName() + " up (too large)");
 				}
 
 				hdm = new HitDieStep(steps, new HitDie(12));
@@ -190,7 +190,7 @@ public class HitdieToken extends AbstractNonEmptyToken<PCTemplate> implements
 				if (steps <= 0)
 				{
 					return new ParseResult.Fail("Invalid Step Count: " + steps + " in "
-							+ getTokenName(), context);
+							+ getTokenName());
 				}
 				hdm = new HitDieStep(steps, null);
 			}
@@ -204,12 +204,12 @@ public class HitdieToken extends AbstractNonEmptyToken<PCTemplate> implements
 				if (steps <= 0)
 				{
 					return new ParseResult.Fail("Invalid Step Count: " + steps + " in "
-							+ getTokenName() + " down (must be positive)", context);
+							+ getTokenName() + " down (must be positive)");
 				}
 				if (steps >= 5)
 				{
 					return new ParseResult.Fail("Invalid Step Count: " + steps + " in "
-							+ getTokenName() + " down (too large)", context);
+							+ getTokenName() + " down (too large)");
 				}
 
 				hdm = new HitDieStep(-steps, new HitDie(4));
@@ -223,7 +223,7 @@ public class HitdieToken extends AbstractNonEmptyToken<PCTemplate> implements
 				if (steps <= 0)
 				{
 					return new ParseResult.Fail("Invalid Step Count: " + steps + " in "
-							+ getTokenName(), context);
+							+ getTokenName());
 				}
 				hdm = new HitDieStep(-steps, null);
 			}
@@ -233,7 +233,7 @@ public class HitdieToken extends AbstractNonEmptyToken<PCTemplate> implements
 				if (i <= 0)
 				{
 					return new ParseResult.Fail("Invalid HitDie: " + i + " in "
-							+ getTokenName(), context);
+							+ getTokenName());
 				}
 				// HITDIE:num --- sets the hit die to num regardless of class.
 				hdm = new HitDieLock(new HitDie(i));

--- a/code/src/java/plugin/lsttokens/template/LangbonusToken.java
+++ b/code/src/java/plugin/lsttokens/template/LangbonusToken.java
@@ -72,7 +72,7 @@ public class LangbonusToken extends AbstractTokenWithSeparator<PCTemplate>
 				{
 					return new ParseResult.Fail("Non-sensical situation was "
 							+ "encountered while parsing " + getTokenName()
-							+ ": When used, .CLEAR must be the first argument", context);
+							+ ": When used, .CLEAR must be the first argument");
 				}
 				context.getListContext().removeAllFromList(getTokenName(),
 						template, Language.STARTING_LIST);
@@ -89,7 +89,7 @@ public class LangbonusToken extends AbstractTokenWithSeparator<PCTemplate>
 									+ ": "
 									+ value
 									+ " had an invalid .CLEAR. reference: "
-									+ clearText, context);
+									+ clearText);
 				}
 				context.getListContext().removeFromList(getTokenName(),
 						template, Language.STARTING_LIST, lang);
@@ -120,7 +120,7 @@ public class LangbonusToken extends AbstractTokenWithSeparator<PCTemplate>
 				{
 					return new ParseResult.Fail("  Error was encountered while parsing "
 							+ getTokenName() + ": " + value
-							+ " had an invalid reference: " + tokText, context);
+							+ " had an invalid reference: " + tokText);
 				}
 				context.getListContext().addToList(getTokenName(), template,
 						Language.STARTING_LIST, lang);
@@ -130,7 +130,7 @@ public class LangbonusToken extends AbstractTokenWithSeparator<PCTemplate>
 		if (foundAny && foundOther)
 		{
 			return new ParseResult.Fail("Non-sensical " + getTokenName()
-					+ ": Contains ANY and a specific reference: " + value, context);
+					+ ": Contains ANY and a specific reference: " + value);
 		}
 		return ParseResult.SUCCESS;
 	}

--- a/code/src/java/plugin/lsttokens/template/LevelToken.java
+++ b/code/src/java/plugin/lsttokens/template/LevelToken.java
@@ -83,7 +83,7 @@ public class LevelToken extends AbstractTokenWithSeparator<PCTemplate>
 		if (plusLoc == 0)
 		{
 			return new ParseResult.Fail("Malformed " + getTokenName()
-				+ " Level cannot start with +: " + value, context);
+				+ " Level cannot start with +: " + value);
 		}
 		int lvl;
 		try
@@ -105,21 +105,21 @@ public class LevelToken extends AbstractTokenWithSeparator<PCTemplate>
 		catch (NumberFormatException ex)
 		{
 			return new ParseResult.Fail("Misunderstood Level value: " + levelStr
-					+ " in " + getTokenName(), context);
+					+ " in " + getTokenName());
 		}
 
 		if (!tok.hasMoreTokens())
 		{
 			return new ParseResult.Fail("Invalid " + getTokenName()
 					+ ": requires 3 colon separated elements (has one): "
-					+ value, context);
+					+ value);
 		}
 		String typeStr = tok.nextToken();
 		if (!tok.hasMoreTokens())
 		{
 			return new ParseResult.Fail("Invalid " + getTokenName()
 					+ ": requires 3 colon separated elements (has two): "
-					+ value, context);
+					+ value);
 		}
 		String argument = tok.nextToken();
 		PCTemplate derivative = new PCTemplate();
@@ -137,7 +137,7 @@ public class LevelToken extends AbstractTokenWithSeparator<PCTemplate>
 		}
 		catch (PersistenceLayerException e)
 		{
-			return new ParseResult.Fail(e.getMessage(), context);
+			return new ParseResult.Fail(e.getMessage());
 		}
 		return ParseResult.INTERNAL_ERROR;
 	}

--- a/code/src/java/plugin/lsttokens/template/LeveladjustmentToken.java
+++ b/code/src/java/plugin/lsttokens/template/LeveladjustmentToken.java
@@ -46,7 +46,7 @@ public class LeveladjustmentToken extends AbstractNonEmptyToken<PCTemplate>
 		if (!formula.isValid())
 		{
 			return new ParseResult.Fail("Formula in " + getTokenName()
-					+ " was not valid: " + formula.toString(), context);
+					+ " was not valid: " + formula.toString());
 		}
 		context.getObjectContext().put(template, FormulaKey.LEVEL_ADJUSTMENT,
 				formula);

--- a/code/src/java/plugin/lsttokens/template/RacesubtypeToken.java
+++ b/code/src/java/plugin/lsttokens/template/RacesubtypeToken.java
@@ -63,7 +63,7 @@ public class RacesubtypeToken extends AbstractTokenWithSeparator<PCTemplate>
 				if (substring.isEmpty())
 				{
 					return new ParseResult.Fail("Invalid .REMOVE. in " + getTokenName()
-						+ " requires an argument", context);
+						+ " requires an argument");
 				}
 				context.getObjectContext().addToList(template,
 						ListKey.REMOVED_RACESUBTYPE,

--- a/code/src/java/plugin/lsttokens/template/ReachToken.java
+++ b/code/src/java/plugin/lsttokens/template/ReachToken.java
@@ -63,8 +63,7 @@ public class ReachToken extends AbstractIntToken<PCTemplate> implements
 		if (ControlUtilities.hasControlToken(context, CControl.PCREACH))
 		{
 			return new ParseResult.Fail(getTokenName()
-				+ " is disabled when PCREACH control is used: " + value,
-				context);
+				+ " is disabled when PCREACH control is used: " + value);
 		}
 		return super.parseToken(context, obj, value);
 	}

--- a/code/src/java/plugin/lsttokens/template/RepeatlevelToken.java
+++ b/code/src/java/plugin/lsttokens/template/RepeatlevelToken.java
@@ -69,19 +69,19 @@ public class RepeatlevelToken extends AbstractTokenWithSeparator<PCTemplate>
 		if (endRepeat < 0)
 		{
 			return new ParseResult.Fail("Malformed " + getTokenName()
-					+ " Token (No Colon): " + value, context);
+					+ " Token (No Colon): " + value);
 		}
 		int endLevel = value.indexOf(Constants.COLON, endRepeat + 1);
 		if (endLevel < 0)
 		{
 			return new ParseResult.Fail("Malformed " + getTokenName()
-					+ " Token (Only One Colon): " + value, context);
+					+ " Token (Only One Colon): " + value);
 		}
 		int endAssignType = value.indexOf(Constants.COLON, endLevel + 1);
 		if (endAssignType == -1)
 		{
 			return new ParseResult.Fail("Malformed " + getTokenName()
-					+ " Token (Only Two Colons): " + value, context);
+					+ " Token (Only Two Colons): " + value);
 		}
 
 		String repeatedInfo = value.substring(0, endRepeat);
@@ -91,7 +91,7 @@ public class RepeatlevelToken extends AbstractTokenWithSeparator<PCTemplate>
 		{
 			return new ParseResult.Fail("Malformed " + getTokenName()
 					+ " Token (incorrect PIPE count in repeat): "
-					+ repeatedInfo, context);
+					+ repeatedInfo);
 		}
 
 		String levelIncrement = repeatToken.nextToken();
@@ -104,12 +104,12 @@ public class RepeatlevelToken extends AbstractTokenWithSeparator<PCTemplate>
 		{
 			return new ParseResult.Fail("Malformed " + getTokenName()
 					+ " Token (Level Increment was not an Integer): "
-					+ levelIncrement, context);
+					+ levelIncrement);
 		}
 		if (lvlIncrement <= 0)
 		{
 			return new ParseResult.Fail("Malformed " + getTokenName()
-					+ " Token (Level Increment was <= 0): " + lvlIncrement, context);
+					+ " Token (Level Increment was <= 0): " + lvlIncrement);
 		}
 
 		String consecutiveString = repeatToken.nextToken();
@@ -122,12 +122,12 @@ public class RepeatlevelToken extends AbstractTokenWithSeparator<PCTemplate>
 		{
 			return new ParseResult.Fail("Malformed " + getTokenName()
 					+ " Token (Consecutive Value was not an Integer): "
-					+ consecutiveString, context);
+					+ consecutiveString);
 		}
 		if (consecutive < 0)
 		{
 			return new ParseResult.Fail("Malformed " + getTokenName()
-					+ " Token (Consecutive String was <= 0): " + consecutive, context);
+					+ " Token (Consecutive String was <= 0): " + consecutive);
 		}
 
 		String maxLevelString = repeatToken.nextToken();
@@ -140,12 +140,12 @@ public class RepeatlevelToken extends AbstractTokenWithSeparator<PCTemplate>
 		{
 			return new ParseResult.Fail("Malformed " + getTokenName()
 					+ " Token (Max Level was not an Integer): "
-					+ maxLevelString, context);
+					+ maxLevelString);
 		}
 		if (maxLevel <= 0)
 		{
 			return new ParseResult.Fail("Malformed " + getTokenName()
-					+ " Token (Max Level was <= 0): " + maxLevel, context);
+					+ " Token (Max Level was <= 0): " + maxLevel);
 		}
 
 		String levelString = value.substring(endRepeat + 1, endLevel);
@@ -157,24 +157,23 @@ public class RepeatlevelToken extends AbstractTokenWithSeparator<PCTemplate>
 		catch (NumberFormatException nfe)
 		{
 			return new ParseResult.Fail("Malformed " + getTokenName()
-					+ " Token (Level was not a number): " + levelString, context);
+					+ " Token (Level was not a number): " + levelString);
 		}
 		if (iLevel <= 0)
 		{
 			return new ParseResult.Fail("Malformed " + getTokenName()
-					+ " Token (Level was <= 0): " + iLevel, context);
+					+ " Token (Level was <= 0): " + iLevel);
 		}
 
 		if (iLevel > maxLevel)
 		{
 			return new ParseResult.Fail("Malformed " + getTokenName()
-					+ " Token (Starting Level was > Maximum Level)", context);
+					+ " Token (Starting Level was > Maximum Level)");
 		}
 		if (iLevel + lvlIncrement > maxLevel)
 		{
 			return new ParseResult.Fail("Malformed " + getTokenName()
-				+ " Token (Does not repeat, Staring Level + Increment > Maximum Level)",
-				context);
+				+ " Token (Does not repeat, Staring Level + Increment > Maximum Level)");
 		}
 		if (consecutive != 0
 				&& ((maxLevel - iLevel) / lvlIncrement) < consecutive)
@@ -222,7 +221,7 @@ public class RepeatlevelToken extends AbstractTokenWithSeparator<PCTemplate>
 				}
 				catch (PersistenceLayerException e)
 				{
-					return new ParseResult.Fail(e.getMessage(), context);
+					return new ParseResult.Fail(e.getMessage());
 				}
 			}
 			if (consecutive != 0)

--- a/code/src/java/plugin/lsttokens/template/VisibleToken.java
+++ b/code/src/java/plugin/lsttokens/template/VisibleToken.java
@@ -61,7 +61,7 @@ public class VisibleToken extends AbstractNonEmptyToken<PCTemplate> implements
 		}
 		else
 		{
-			return new ParseResult.Fail("Can't understand Visibility: " + value, context);
+			return new ParseResult.Fail("Can't understand Visibility: " + value);
 		}
 		context.getObjectContext().put(template, ObjectKey.VISIBILITY, vis);
 		return ParseResult.SUCCESS;

--- a/code/src/java/plugin/lsttokens/template/WeaponbonusToken.java
+++ b/code/src/java/plugin/lsttokens/template/WeaponbonusToken.java
@@ -91,7 +91,7 @@ public class WeaponbonusToken extends AbstractTokenWithSeparator<PCTemplate>
 				if (ref == null)
 				{
 					return new ParseResult.Fail("  Error was encountered while parsing "
-							+ getTokenName(), context);
+							+ getTokenName());
 				}
 				context.getObjectContext().addToList(template, ListKey.WEAPONBONUS, ref);
 			}
@@ -99,7 +99,7 @@ public class WeaponbonusToken extends AbstractTokenWithSeparator<PCTemplate>
 		if (foundAny && foundOther)
 		{
 			return new ParseResult.Fail("Non-sensical " + getTokenName()
-					+ ": Contains ANY and a specific reference: " + value, context);
+					+ ": Contains ANY and a specific reference: " + value);
 		}
 		return ParseResult.SUCCESS;
 	}

--- a/code/src/java/plugin/lsttokens/variable/ChannelToken.java
+++ b/code/src/java/plugin/lsttokens/variable/ChannelToken.java
@@ -126,7 +126,7 @@ public class ChannelToken extends AbstractNonEmptyToken<DatasetVariable>
 			return new ParseResult.Fail(getTokenName()
 				+ " found a var defined in incompatible variable scopes: "
 				+ varName + " was requested in " + fullscope
-				+ " but was previously in " + sb.toString(), context);
+				+ " but was previously in " + sb.toString());
 		}
 		dv.setName(channelName);
 		dv.setFormat(format);

--- a/code/src/java/plugin/lsttokens/variable/GlobalToken.java
+++ b/code/src/java/plugin/lsttokens/variable/GlobalToken.java
@@ -97,7 +97,7 @@ public class GlobalToken extends AbstractNonEmptyToken<DatasetVariable>
 			return new ParseResult.Fail(getTokenName()
 				+ " found a var defined in incompatible variable scopes: "
 				+ value + " was requested in " + scope.getName()
-				+ " but was previously in " + sb.toString(), context);
+				+ " but was previously in " + sb.toString());
 		}
 		dv.setName(varName);
 		dv.setFormat(format);

--- a/code/src/java/plugin/lsttokens/variable/LocalToken.java
+++ b/code/src/java/plugin/lsttokens/variable/LocalToken.java
@@ -116,7 +116,7 @@ public class LocalToken extends AbstractNonEmptyToken<DatasetVariable>
 			return new ParseResult.Fail(getTokenName()
 				+ " found a var defined in incompatible variable scopes: "
 				+ varName + " was requested in " + fullscope
-				+ " but was previously in " + sb.toString(), context);
+				+ " but was previously in " + sb.toString());
 		}
 		dv.setName(varName);
 		dv.setFormat(format);

--- a/code/src/testcommon/util/TestURI.java
+++ b/code/src/testcommon/util/TestURI.java
@@ -18,10 +18,21 @@ package util;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+/**
+ * This is a URI for use across the test classes
+ */
 public final class TestURI
 {
+	/**
+	 * The (lazily instantiated) Test URI
+	 */
 	private static URI uri;
 	
+	/**
+	 * Returns the test URI.
+	 * 
+	 * @return The test URI
+	 */
 	public static URI getURI()
 	{
 		if (uri == null)

--- a/code/src/testcommon/util/TestURI.java
+++ b/code/src/testcommon/util/TestURI.java
@@ -1,0 +1,41 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+package util;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public final class TestURI
+{
+	private static URI uri;
+	
+	public static URI getURI()
+	{
+		if (uri == null)
+		{
+			try
+			{
+				uri = new URI("file:/TESTCASE");
+			}
+			catch (URISyntaxException e)
+			{
+				throw new IllegalStateException(e);
+			}
+		}
+		return uri;
+	}
+	
+}

--- a/code/src/testcommon/util/TestURI.java
+++ b/code/src/testcommon/util/TestURI.java
@@ -28,6 +28,11 @@ public final class TestURI
 	 */
 	private static URI uri;
 	
+	private TestURI()
+	{
+		//Private for Utility Class
+	}
+
 	/**
 	 * Returns the test URI.
 	 * 

--- a/code/src/utest/pcgen/rules/persistence/TableLoaderTest.java
+++ b/code/src/utest/pcgen/rules/persistence/TableLoaderTest.java
@@ -10,6 +10,7 @@ import pcgen.rules.context.ConsolidatedListCommitStrategy;
 import pcgen.rules.context.LoadContext;
 import pcgen.rules.context.RuntimeLoadContext;
 import pcgen.rules.context.RuntimeReferenceContext;
+import util.TestURI;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -25,7 +26,7 @@ public class TableLoaderTest
 	@Before
 	public void setUp() throws Exception
 	{
-		uri = new URI("file:/Test%20Case");
+		uri = TestURI.getURI();
 		context = new RuntimeLoadContext(RuntimeReferenceContext.createRuntimeReferenceContext(),
 			new ConsolidatedListCommitStrategy());
 		loader = new TableLoader();

--- a/code/src/utest/plugin/lsttokens/campaign/LicenseTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/campaign/LicenseTokenTest.java
@@ -31,6 +31,7 @@ import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.testsupport.AbstractCDOMTokenTestCase;
 import plugin.lsttokens.testsupport.CDOMTokenLoader;
 import plugin.lsttokens.testsupport.ConsolidationRule;
+import util.TestURI;
 
 public class LicenseTokenTest extends AbstractCDOMTokenTestCase<Campaign>
 {
@@ -65,7 +66,7 @@ public class LicenseTokenTest extends AbstractCDOMTokenTestCase<Campaign>
 	public void setUp() throws PersistenceLayerException, URISyntaxException
 	{
 		super.setUp();
-		URI uri = new URI("http://www.sourceforge.net");
+		URI uri = TestURI.getURI();
 		primaryContext.setSourceURI(uri);
 		secondaryContext.setSourceURI(uri);
 	}

--- a/code/src/utest/plugin/lsttokens/datacontrol/DataTypeTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/datacontrol/DataTypeTokenTest.java
@@ -38,6 +38,7 @@ import pcgen.rules.context.LoadContext;
 import pcgen.rules.context.RuntimeLoadContext;
 import pcgen.rules.context.RuntimeReferenceContext;
 import plugin.lsttokens.testsupport.TokenRegistration;
+import util.TestURI;
 
 public class DataTypeTokenTest extends TestCase
 {
@@ -54,8 +55,7 @@ public class DataTypeTokenTest extends TestCase
 	public static void classSetUp() throws URISyntaxException
 	{
 		testCampaign =
-				new CampaignSourceEntry(new Campaign(), new URI(
-					"file:/Test%20Case"));
+				new CampaignSourceEntry(new Campaign(), TestURI.getURI());
 		classSetUpFired = true;
 	}
 

--- a/code/src/utest/plugin/lsttokens/datacontrol/DisplayNameTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/datacontrol/DisplayNameTokenTest.java
@@ -36,6 +36,7 @@ import pcgen.rules.context.LoadContext;
 import pcgen.rules.context.RuntimeLoadContext;
 import pcgen.rules.context.RuntimeReferenceContext;
 import plugin.lsttokens.testsupport.TokenRegistration;
+import util.TestURI;
 
 public class DisplayNameTokenTest extends TestCase
 {
@@ -52,8 +53,7 @@ public class DisplayNameTokenTest extends TestCase
 	public static void classSetUp() throws URISyntaxException
 	{
 		testCampaign =
-				new CampaignSourceEntry(new Campaign(), new URI(
-					"file:/Test%20Case"));
+				new CampaignSourceEntry(new Campaign(), TestURI.getURI());
 		classSetUpFired = true;
 	}
 

--- a/code/src/utest/plugin/lsttokens/datacontrol/ExplanationTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/datacontrol/ExplanationTokenTest.java
@@ -36,6 +36,7 @@ import pcgen.rules.context.LoadContext;
 import pcgen.rules.context.RuntimeLoadContext;
 import pcgen.rules.context.RuntimeReferenceContext;
 import plugin.lsttokens.testsupport.TokenRegistration;
+import util.TestURI;
 
 public class ExplanationTokenTest extends TestCase
 {
@@ -52,8 +53,7 @@ public class ExplanationTokenTest extends TestCase
 	public static void classSetUp() throws URISyntaxException
 	{
 		testCampaign =
-				new CampaignSourceEntry(new Campaign(), new URI(
-					"file:/Test%20Case"));
+				new CampaignSourceEntry(new Campaign(), TestURI.getURI());
 		classSetUpFired = true;
 	}
 

--- a/code/src/utest/plugin/lsttokens/datacontrol/FactDefTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/datacontrol/FactDefTokenTest.java
@@ -37,6 +37,7 @@ import pcgen.rules.context.LoadContext;
 import pcgen.rules.context.RuntimeLoadContext;
 import pcgen.rules.context.RuntimeReferenceContext;
 import plugin.lsttokens.testsupport.TokenRegistration;
+import util.TestURI;
 
 public class FactDefTokenTest extends TestCase
 {
@@ -53,8 +54,7 @@ public class FactDefTokenTest extends TestCase
 	public static void classSetUp() throws URISyntaxException
 	{
 		testCampaign =
-				new CampaignSourceEntry(new Campaign(), new URI(
-					"file:/Test%20Case"));
+				new CampaignSourceEntry(new Campaign(), TestURI.getURI());
 		classSetUpFired = true;
 	}
 

--- a/code/src/utest/plugin/lsttokens/datacontrol/FactSetDefTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/datacontrol/FactSetDefTokenTest.java
@@ -37,6 +37,7 @@ import pcgen.rules.context.LoadContext;
 import pcgen.rules.context.RuntimeLoadContext;
 import pcgen.rules.context.RuntimeReferenceContext;
 import plugin.lsttokens.testsupport.TokenRegistration;
+import util.TestURI;
 
 public class FactSetDefTokenTest extends TestCase
 {
@@ -53,8 +54,7 @@ public class FactSetDefTokenTest extends TestCase
 	public static void classSetUp() throws URISyntaxException
 	{
 		testCampaign =
-				new CampaignSourceEntry(new Campaign(), new URI(
-					"file:/Test%20Case"));
+				new CampaignSourceEntry(new Campaign(), TestURI.getURI());
 		classSetUpFired = true;
 	}
 

--- a/code/src/utest/plugin/lsttokens/datacontrol/FunctionTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/datacontrol/FunctionTokenTest.java
@@ -35,6 +35,7 @@ import pcgen.rules.context.LoadContext;
 import pcgen.rules.context.RuntimeLoadContext;
 import pcgen.rules.context.RuntimeReferenceContext;
 import plugin.lsttokens.testsupport.TokenRegistration;
+import util.TestURI;
 
 public class FunctionTokenTest extends TestCase
 {
@@ -51,8 +52,7 @@ public class FunctionTokenTest extends TestCase
 	public static void classSetUp() throws URISyntaxException
 	{
 		testCampaign =
-				new CampaignSourceEntry(new Campaign(), new URI(
-					"file:/Test%20Case"));
+				new CampaignSourceEntry(new Campaign(), TestURI.getURI());
 		classSetUpFired = true;
 	}
 

--- a/code/src/utest/plugin/lsttokens/datacontrol/RequiredTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/datacontrol/RequiredTokenTest.java
@@ -36,6 +36,7 @@ import pcgen.rules.context.LoadContext;
 import pcgen.rules.context.RuntimeLoadContext;
 import pcgen.rules.context.RuntimeReferenceContext;
 import plugin.lsttokens.testsupport.TokenRegistration;
+import util.TestURI;
 
 public class RequiredTokenTest extends TestCase
 {
@@ -52,8 +53,7 @@ public class RequiredTokenTest extends TestCase
 	public static void classSetUp() throws URISyntaxException
 	{
 		testCampaign =
-				new CampaignSourceEntry(new Campaign(), new URI(
-					"file:/Test%20Case"));
+				new CampaignSourceEntry(new Campaign(), TestURI.getURI());
 		classSetUpFired = true;
 	}
 

--- a/code/src/utest/plugin/lsttokens/datacontrol/SelectableTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/datacontrol/SelectableTokenTest.java
@@ -36,6 +36,7 @@ import pcgen.rules.context.LoadContext;
 import pcgen.rules.context.RuntimeLoadContext;
 import pcgen.rules.context.RuntimeReferenceContext;
 import plugin.lsttokens.testsupport.TokenRegistration;
+import util.TestURI;
 
 public class SelectableTokenTest extends TestCase
 {
@@ -52,8 +53,7 @@ public class SelectableTokenTest extends TestCase
 	public static void classSetUp() throws URISyntaxException
 	{
 		testCampaign =
-				new CampaignSourceEntry(new Campaign(), new URI(
-					"file:/Test%20Case"));
+				new CampaignSourceEntry(new Campaign(), TestURI.getURI());
 		classSetUpFired = true;
 	}
 

--- a/code/src/utest/plugin/lsttokens/datacontrol/ValueTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/datacontrol/ValueTokenTest.java
@@ -35,6 +35,7 @@ import pcgen.rules.context.LoadContext;
 import pcgen.rules.context.RuntimeLoadContext;
 import pcgen.rules.context.RuntimeReferenceContext;
 import plugin.lsttokens.testsupport.TokenRegistration;
+import util.TestURI;
 
 public class ValueTokenTest extends TestCase
 {
@@ -51,8 +52,7 @@ public class ValueTokenTest extends TestCase
 	public static void classSetUp() throws URISyntaxException
 	{
 		testCampaign =
-				new CampaignSourceEntry(new Campaign(), new URI(
-					"file:/Test%20Case"));
+				new CampaignSourceEntry(new Campaign(), TestURI.getURI());
 		classSetUpFired = true;
 	}
 

--- a/code/src/utest/plugin/lsttokens/datacontrol/VisibleTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/datacontrol/VisibleTokenTest.java
@@ -37,6 +37,7 @@ import pcgen.rules.context.RuntimeLoadContext;
 import pcgen.rules.context.RuntimeReferenceContext;
 import pcgen.util.enumeration.Visibility;
 import plugin.lsttokens.testsupport.TokenRegistration;
+import util.TestURI;
 
 public class VisibleTokenTest extends TestCase
 {
@@ -53,8 +54,7 @@ public class VisibleTokenTest extends TestCase
 	public static void classSetUp() throws URISyntaxException
 	{
 		testCampaign =
-				new CampaignSourceEntry(new Campaign(), new URI(
-					"file:/Test%20Case"));
+				new CampaignSourceEntry(new Campaign(), TestURI.getURI());
 		classSetUpFired = true;
 	}
 

--- a/code/src/utest/plugin/lsttokens/pcclass/level/AbstractPCClassLevelTokenTestCase.java
+++ b/code/src/utest/plugin/lsttokens/pcclass/level/AbstractPCClassLevelTokenTestCase.java
@@ -17,15 +17,13 @@
  */
 package plugin.lsttokens.pcclass.level;
 
-import java.net.URI;
 import java.net.URISyntaxException;
-
-import junit.framework.TestCase;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import junit.framework.TestCase;
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.inst.PCClassLevel;
 import pcgen.core.Campaign;
@@ -43,6 +41,7 @@ import pcgen.util.Logging;
 import plugin.lsttokens.testsupport.CDOMTokenLoader;
 import plugin.lsttokens.testsupport.ConsolidationRule;
 import plugin.lsttokens.testsupport.TokenRegistration;
+import util.TestURI;
 
 public abstract class AbstractPCClassLevelTokenTestCase extends TestCase
 {
@@ -64,8 +63,7 @@ public abstract class AbstractPCClassLevelTokenTestCase extends TestCase
 	@BeforeClass
 	public static void classSetUp() throws URISyntaxException
 	{
-		testCampaign = new CampaignSourceEntry(new Campaign(), new URI(
-				"file:/Test%20Case"));
+		testCampaign = new CampaignSourceEntry(new Campaign(), TestURI.getURI());
 		classSetUpFired = true;
 	}
 

--- a/code/src/utest/plugin/lsttokens/testsupport/AbstractCampaignTokenTestCase.java
+++ b/code/src/utest/plugin/lsttokens/testsupport/AbstractCampaignTokenTestCase.java
@@ -26,6 +26,7 @@ import pcgen.cdom.enumeration.ListKey;
 import pcgen.core.Campaign;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.rules.persistence.CDOMLoader;
+import util.TestURI;
 
 public abstract class AbstractCampaignTokenTestCase extends
 		AbstractCDOMTokenTestCase<Campaign>
@@ -47,7 +48,7 @@ public abstract class AbstractCampaignTokenTestCase extends
 	public void setUp() throws PersistenceLayerException, URISyntaxException
 	{
 		super.setUp();
-		URI uri = new URI("http://www.sourceforge.net");
+		URI uri = TestURI.getURI();
 		primaryContext.setSourceURI(uri);
 		secondaryContext.setSourceURI(uri);
 	}

--- a/code/src/utest/plugin/lsttokens/testsupport/AbstractGlobalTokenTestCase.java
+++ b/code/src/utest/plugin/lsttokens/testsupport/AbstractGlobalTokenTestCase.java
@@ -18,16 +18,14 @@
 package plugin.lsttokens.testsupport;
 
 
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Locale;
-
-import junit.framework.TestCase;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import junit.framework.TestCase;
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.base.ConcretePrereqObject;
 import pcgen.core.AbilityCategory;
@@ -45,6 +43,7 @@ import pcgen.rules.persistence.TokenLibrary;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import pcgen.rules.persistence.token.ParseResult;
 import pcgen.util.Logging;
+import util.TestURI;
 
 public abstract class AbstractGlobalTokenTestCase extends TestCase
 {
@@ -60,8 +59,7 @@ public abstract class AbstractGlobalTokenTestCase extends TestCase
 	public static void classSetUp() throws URISyntaxException
 	{
 		Locale.setDefault(Locale.US);
-		testCampaign = new CampaignSourceEntry(new Campaign(), new URI(
-				"file:/Test%20Case"));
+		testCampaign = new CampaignSourceEntry(new Campaign(), TestURI.getURI());
 		classSetUpFired = true;
 	}
 
@@ -222,7 +220,7 @@ public abstract class AbstractGlobalTokenTestCase extends TestCase
 		}
 		else
 		{
-			pr.addMessagesToLog();
+			pr.addMessagesToLog(TestURI.getURI());
 			primaryContext.rollback();
 			Logging.rewindParseMessages();
 			Logging.replayParsedMessages();

--- a/code/src/utest/plugin/lsttokens/testsupport/AbstractKitTokenTestCase.java
+++ b/code/src/utest/plugin/lsttokens/testsupport/AbstractKitTokenTestCase.java
@@ -43,6 +43,7 @@ import pcgen.rules.persistence.TokenLibrary;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import pcgen.rules.persistence.token.ParseResult;
 import pcgen.util.Logging;
+import util.TestURI;
 
 public abstract class AbstractKitTokenTestCase<T extends Loadable> extends TestCase
 {
@@ -58,8 +59,7 @@ public abstract class AbstractKitTokenTestCase<T extends Loadable> extends TestC
 	@BeforeClass
 	public static void classSetUp() throws URISyntaxException
 	{
-		testCampaign = new CampaignSourceEntry(new Campaign(), new URI(
-				"file:/Test%20Case"));
+		testCampaign = new CampaignSourceEntry(new Campaign(), TestURI.getURI());
 		classSetUpFired = true;
 	}
 
@@ -179,7 +179,7 @@ public abstract class AbstractKitTokenTestCase<T extends Loadable> extends TestC
 		}
 		else
 		{
-			pr.addMessagesToLog();
+			pr.addMessagesToLog(TestURI.getURI());
 			primaryContext.rollback();
 			Logging.rewindParseMessages();
 			Logging.replayParsedMessages();

--- a/code/src/utest/plugin/lsttokens/testsupport/AbstractTokenTestCase.java
+++ b/code/src/utest/plugin/lsttokens/testsupport/AbstractTokenTestCase.java
@@ -43,6 +43,7 @@ import pcgen.rules.persistence.TokenLibrary;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import pcgen.rules.persistence.token.ParseResult;
 import pcgen.util.Logging;
+import util.TestURI;
 
 @SuppressWarnings("nls")
 public abstract class AbstractTokenTestCase<T extends Loadable> extends
@@ -60,8 +61,7 @@ public abstract class AbstractTokenTestCase<T extends Loadable> extends
 	@BeforeClass
 	public static void classSetUp() throws URISyntaxException
 	{
-		testCampaign = new CampaignSourceEntry(new Campaign(), new URI(
-				"file:/Test%20Case"));
+		testCampaign = new CampaignSourceEntry(new Campaign(), TestURI.getURI());
 		classSetUpFired = true;
 	}
 
@@ -259,7 +259,7 @@ public abstract class AbstractTokenTestCase<T extends Loadable> extends
 		}
 		else
 		{
-			pr.addMessagesToLog();
+			pr.addMessagesToLog(TestURI.getURI());
 			primaryContext.rollback();
 			Logging.rewindParseMessages();
 			Logging.replayParsedMessages();
@@ -277,7 +277,7 @@ public abstract class AbstractTokenTestCase<T extends Loadable> extends
 		}
 		else
 		{
-			pr.addMessagesToLog();
+			pr.addMessagesToLog(TestURI.getURI());
 			secondaryContext.rollback();
 			Logging.rewindParseMessages();
 			Logging.replayParsedMessages();


### PR DESCRIPTION
This means ParseResult.Fail will not capture the URI where the failure
occurred - rather the LoadContext (which gets back the ParseResult) will
have to pass the URI into the ParseResult reporting mechanisms.  This
corrects for many places where a context was not being passed into the
ParseResult.Fail at construction, so we may have been losing locations
where errors were occurring.
