### PR TITLE
CODE-3037 Fix: PaperInfo problem

### DIFF
--- a/code/src/java/pcgen/cdom/reference/AbstractReferenceManufacturer.java
+++ b/code/src/java/pcgen/cdom/reference/AbstractReferenceManufacturer.java
@@ -1278,12 +1278,6 @@ public abstract class AbstractReferenceManufacturer<T extends Loadable>
 	}
 
 	@Override
-	public T getItemInOrder(int index)
-	{
-		return active.getItemInOrder(index);
-	}
-
-	@Override
 	public ManufacturableFactory<T> getFactory()
 	{
 		return factory;

--- a/code/src/java/pcgen/cdom/reference/ReferenceManufacturer.java
+++ b/code/src/java/pcgen/cdom/reference/ReferenceManufacturer.java
@@ -335,10 +335,6 @@ public interface ReferenceManufacturer<T extends Loadable> extends
 	 */
 	public int getConstructedObjectCount();
 
-	public T getItemInOrder(int index);
-
-	public String getReferenceDescription();
-
 	public T buildObject(String name);
 
 	public void fireUnconstuctedEvent(CDOMReference<?> reference);

--- a/code/src/java/pcgen/cdom/util/CControl.java
+++ b/code/src/java/pcgen/cdom/util/CControl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016-18 (C) Tom Parker <thpr@sourceforge.net>
+ * 
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 59 Temple Place,
+ * Suite 330, Boston, MA 02111-1307 USA
+ */
 package pcgen.cdom.util;
 
 public final class CControl

--- a/code/src/java/pcgen/cdom/util/SortKeyComparator.java
+++ b/code/src/java/pcgen/cdom/util/SortKeyComparator.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 (C) Tom Parker <thpr@sourceforge.net>
+ * 
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 59 Temple Place,
+ * Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.cdom.util;
+
+import java.util.Comparator;
+
+/**
+ * This is a trivial sorter for objects that implement the SortKeyed interface
+ */
+public class SortKeyComparator implements Comparator<SortKeyed>
+{
+
+	@Override
+	public int compare(SortKeyed o1, SortKeyed o2)
+	{
+		return o1.getSortKey().compareTo(o1.getSortKey());
+	}
+
+}

--- a/code/src/java/pcgen/cdom/util/SortKeyed.java
+++ b/code/src/java/pcgen/cdom/util/SortKeyed.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 (C) Tom Parker <thpr@sourceforge.net>
+ * 
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 59 Temple Place,
+ * Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.cdom.util;
+
+/**
+ * A SortKeyed object is an object that implements the getSortKey method to allow those
+ * objects to be sorted.
+ */
+public interface SortKeyed
+{
+	/**
+	 * Returns the String by which the given object should be sorted.
+	 * 
+	 * @return The String by which the given object should be sorted
+	 */
+	public String getSortKey();
+}

--- a/code/src/java/pcgen/core/Globals.java
+++ b/code/src/java/pcgen/core/Globals.java
@@ -44,6 +44,7 @@ import pcgen.cdom.enumeration.RaceType;
 import pcgen.cdom.enumeration.SourceFormat;
 import pcgen.cdom.enumeration.StringKey;
 import pcgen.cdom.enumeration.Type;
+import pcgen.cdom.util.SortKeyComparator;
 import pcgen.core.character.EquipSlot;
 import pcgen.core.chooser.CDOMChooserFacadeImpl;
 import pcgen.core.utils.CoreUtility;
@@ -429,17 +430,20 @@ public final class Globals
 	 */
 	public static String getPaperInfo(final int idx, final int infoType)
 	{
-		if ((idx < 0)
-				|| (idx >= SettingsHandler.getGame().getModeContext().getReferenceContext()
-						.getConstructedObjectCount(PaperInfo.class)))
+		if ((idx < 0) || (idx >= getPaperCount()))
 		{
 			return null;
 		}
 
-		final PaperInfo pi = SettingsHandler.getGame().getModeContext().getReferenceContext()
-				.getItemInOrder(PaperInfo.class, idx);
+		return getSortedPaperInfo().get(idx).getPaperInfo(infoType);
+	}
 
-		return pi.getPaperInfo(infoType);
+	private static List<PaperInfo> getSortedPaperInfo()
+	{
+		List<PaperInfo> items = new ArrayList<>(SettingsHandler.getGame().getModeContext()
+			.getReferenceContext().getConstructedCDOMObjects(PaperInfo.class));
+		Collections.sort(items, new SortKeyComparator());
+		return items;
 	}
 
 	/**
@@ -841,11 +845,10 @@ public final class Globals
 	 */
 	public static boolean selectPaper(final String paperName)
 	{
-		for (int i = 0; i < SettingsHandler.getGame().getModeContext().getReferenceContext()
-				.getConstructedObjectCount(PaperInfo.class); ++i)
+		List<PaperInfo> paperInfoObjects = getSortedPaperInfo();
+		for (int i = 0; i < paperInfoObjects.size(); i++)
 		{
-			final PaperInfo pi = SettingsHandler.getGame().getModeContext().getReferenceContext()
-					.getItemInOrder(PaperInfo.class, i);
+			final PaperInfo pi = paperInfoObjects.get(i);
 
 			if (pi.getName().equals(paperName))
 			{

--- a/code/src/java/pcgen/core/PaperInfo.java
+++ b/code/src/java/pcgen/core/PaperInfo.java
@@ -20,15 +20,16 @@ package pcgen.core;
 
 import java.net.URI;
 
-import pcgen.cdom.base.Loadable;
-import pcgen.system.LanguageBundle;
-
 import org.apache.commons.lang3.StringUtils;
+
+import pcgen.cdom.base.Loadable;
+import pcgen.cdom.util.SortKeyed;
+import pcgen.system.LanguageBundle;
 
 /**
  * The Paper information for output sheets
  */
-public final class PaperInfo implements Loadable
+public final class PaperInfo implements Loadable, SortKeyed
 {
 	private URI sourceURI;
 	private String infoName;
@@ -155,6 +156,7 @@ public final class PaperInfo implements Loadable
 		sortKey = value;
 	}
 
+	@Override
 	public String getSortKey()
 	{
 		return sortKey;

--- a/code/src/java/pcgen/rules/context/AbstractReferenceContext.java
+++ b/code/src/java/pcgen/rules/context/AbstractReferenceContext.java
@@ -530,11 +530,6 @@ public abstract class AbstractReferenceContext
 		return getManufacturer(c).getConstructedObjectCount();
 	}
 
-	public <T extends Loadable> T getItemInOrder(Class<T> cl, int item)
-	{
-		return getManufacturer(cl).getItemInOrder(item);
-	}
-
 	/**
 	 * Returns the ReferenceManufacturer for the given ClassIdentity.
 	 * 

--- a/code/src/java/pcgen/rules/context/TrackingManufacturer.java
+++ b/code/src/java/pcgen/rules/context/TrackingManufacturer.java
@@ -126,12 +126,6 @@ class TrackingManufacturer<T extends Loadable> implements ReferenceManufacturer<
 	}
 
 	@Override
-	public T getItemInOrder(int item)
-	{
-		return rm.getItemInOrder(item);
-	}
-
-	@Override
 	public T getObject(String key)
 	{
 		return rm.getObject(key);

--- a/code/src/java/plugin/lsttokens/paper/SortKeyToken.java
+++ b/code/src/java/plugin/lsttokens/paper/SortKeyToken.java
@@ -17,9 +17,7 @@
  */
 package plugin.lsttokens.paper;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -97,18 +95,6 @@ public class SortKeyToken extends AbstractNonEmptyToken<PaperInfo> implements
 						+ keyName, context);
 				returnValue = false;
 			}
-		}
-		List<PaperInfo> coll = new ArrayList<>(keys.values());
-		List<PaperInfo> sorted =
-				context.getReferenceContext().getOrderSortedCDOMObjects(
-					PaperInfo.class);
-		//Remove this check after 6.6
-		if (!coll.equals(sorted))
-		{
-			Logging.errorPrint(
-				"SORTKEY sorting in PaperInfo did not match file order",
-				context);
-			returnValue = false;
 		}
 		return returnValue;
 	}


### PR DESCRIPTION
This implements the change "allowed" as of 6.06 release, which is to drop out of injection order to use SORTKEY for PaperInfo.

As a result, the entire context system is simplified, dropping entirely the getItemInOrder method.
