### PR TITLE
NEWTAG-619 Add SORTKEY for RollMethod objects

### DIFF
--- a/code/pluginbuild.xml
+++ b/code/pluginbuild.xml
@@ -6355,6 +6355,13 @@ jar-all-plugins - Generate the plugin jar files
 				</patternset>
 			</fileset>
 		</jar>
+		<jar jarfile="${systemlstplugins.dir}/GameMode-RollMethodToken-SORTKEY.jar" manifest="${src.java.dir}/plugin/lsttokens/manifest.mf">
+			<fileset dir="${build.classes.dir}">
+				<patternset>
+					<include name="plugin/lsttokens/gamemode/rollmethod/SortKeyToken.class" />
+				</patternset>
+			</fileset>
+		</jar>
 		<!-- GameMode: Tab tokens-->
 		<jar jarfile="${systemlstplugins.dir}/GameMode-TabToken-CONTEXT.jar" manifest="${src.java.dir}/plugin/lsttokens/manifest.mf">
 			<fileset dir="${build.classes.dir}">

--- a/code/src/java/pcgen/cdom/content/RollMethod.java
+++ b/code/src/java/pcgen/cdom/content/RollMethod.java
@@ -27,6 +27,7 @@ public class RollMethod implements Loadable
 	private URI sourceURI;
 	private String methodName;
 	private String rollMethod;
+	private String sortKey;
 
 	@Override
 	public URI getSourceURI()
@@ -78,6 +79,16 @@ public class RollMethod implements Loadable
 	public String getMethodRoll()
 	{
 		return rollMethod;
+	}
+
+	public void setSortKey(String sortKey)
+	{
+		this.sortKey = sortKey;
+	}
+
+	public String getSortKey()
+	{
+		return sortKey;
 	}
 
 }

--- a/code/src/java/plugin/lsttokens/gamemode/rollmethod/SortKeyToken.java
+++ b/code/src/java/plugin/lsttokens/gamemode/rollmethod/SortKeyToken.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2018 Tom Parker <thpr@users.sourceforge.net>
+ *
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 59 Temple Place,
+ * Suite 330, Boston, MA 02111-1307 USA
+ */
+package plugin.lsttokens.gamemode.rollmethod;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.TreeMap;
+
+import pcgen.cdom.content.RollMethod;
+import pcgen.rules.context.LoadContext;
+import pcgen.rules.persistence.token.AbstractNonEmptyToken;
+import pcgen.rules.persistence.token.CDOMPrimaryToken;
+import pcgen.rules.persistence.token.ParseResult;
+import pcgen.rules.persistence.token.PostValidationToken;
+import pcgen.util.Logging;
+
+/**
+ * Processes the SORTKEY token for RollMethod objects (Game Mode), loading it into the
+ * SortKey field of the RollMethod.
+ * 
+ * Note: While the intent is the same, this is necessary as a separate token from the
+ * "Global" SortKey since RollMethod does not extend CDOMObject.
+ */
+public class SortKeyToken extends AbstractNonEmptyToken<RollMethod>
+		implements CDOMPrimaryToken<RollMethod>, PostValidationToken<RollMethod>
+{
+
+	@Override
+	public String getTokenName()
+	{
+		return "SORTKEY";
+	}
+
+	@Override
+	protected ParseResult parseNonEmptyToken(LoadContext context, RollMethod rollMethod,
+		String value)
+	{
+		rollMethod.setSortKey(value);
+		return ParseResult.SUCCESS;
+	}
+
+	@Override
+	public String[] unparse(LoadContext context, RollMethod rollMethod)
+	{
+		String info = rollMethod.getSortKey();
+		if (info == null)
+		{
+			// Probably an error
+			return null;
+		}
+		return new String[]{info};
+	}
+
+	@Override
+	public Class<RollMethod> getTokenClass()
+	{
+		return RollMethod.class;
+	}
+
+	@Override
+	public boolean process(LoadContext context, Collection<? extends RollMethod> c)
+	{
+		boolean returnValue = true;
+		Map<String, RollMethod> keys = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+		for (RollMethod rollMethod : c)
+		{
+			String keyName = rollMethod.getKeyName();
+			if (keyName == null)
+			{
+				Logging.errorPrint("RollMethod: " + rollMethod.getDisplayName()
+					+ " requires a SortKey, but was null", context);
+				returnValue = false;
+			}
+			else if (keys.put(keyName, rollMethod) != null)
+			{
+				Logging.errorPrint(
+					"Found more than one RollMethod with (case insensitive) Sort Key: "
+						+ keyName,
+					context);
+				returnValue = false;
+			}
+		}
+		return returnValue;
+	}
+
+	@Override
+	public Class<RollMethod> getValidationTokenClass()
+	{
+		return RollMethod.class;
+	}
+
+	@Override
+	public int getPriority()
+	{
+		return 0;
+	}
+}


### PR DESCRIPTION
This forces all RollMethod objects to have a SORTKEY.

This will be the last class that is sorted internally to PCGen but does not have SORTKEY. With this completed, all of the existing "assumes things are sorted by how they appear first" will be deprecated and removable from PCGen.

This is proposed to be a non-graceful change (meaning it will complain immediately, not provide a transition between versions) as this is a game mode level item and therefore very isolated.  It will also not be catastrophic with this PR if SORTKEY doesn't exist... (the order won't actually change in the UI based on this at this time - it will occur later after the older methods are removed a few PRs from now)
