### PR TITLE
Alter tests: Categorized items must have a Category upon construction

### DIFF
--- a/code/src/itest/pcgen/io/AbilityTargetSaveRestoreTest.java
+++ b/code/src/itest/pcgen/io/AbilityTargetSaveRestoreTest.java
@@ -39,9 +39,10 @@ public class AbilityTargetSaveRestoreTest extends
 	{
 		if (cl.equals(Ability.class))
 		{
-			T ab = super.create(cl, key);
-			context.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, (Ability) ab);
-			return ab;
+			T source = (T) AbilityCategory.FEAT.newInstance();
+			source.setName(key);
+			context.getReferenceContext().importObject(source);
+			return source;
 		}
 		else
 		{

--- a/code/src/itest/pcgen/io/GeneralSaveRestoreTest.java
+++ b/code/src/itest/pcgen/io/GeneralSaveRestoreTest.java
@@ -38,8 +38,9 @@ public class GeneralSaveRestoreTest extends AbstractSaveRestoreTest
 		TokenRegistration.register(new plugin.lsttokens.ability.StackToken());
 		TokenRegistration.register(new plugin.exporttokens.deprecated.TemplateToken());
 		Language lang = context.getReferenceContext().constructCDOMObject(Language.class, "English");
-		Ability a = context.getReferenceContext().constructCDOMObject(Ability.class, "Ab");
-		context.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, a);
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName("Ab");
+		context.getReferenceContext().importObject(a);
 		PCTemplate pct = context.getReferenceContext().constructCDOMObject(PCTemplate.class, "Templ");
 		try
 		{

--- a/code/src/itest/pcgen/io/testsupport/AbstractGlobalTargetedSaveRestoreTest.java
+++ b/code/src/itest/pcgen/io/testsupport/AbstractGlobalTargetedSaveRestoreTest.java
@@ -550,8 +550,9 @@ public abstract class AbstractGlobalTargetedSaveRestoreTest<T extends CDOMObject
 	{
 		TokenRegistration.register(plugin.bonustokens.SkillRank.class);
 		T target = create(getObjectClass(), "Target");
-		Ability abil = context.getReferenceContext().constructCDOMObject(Ability.class, "GrantedAbility");
-		context.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, abil);
+		Ability abil = AbilityCategory.FEAT.newInstance();
+		abil.setName("GrantedAbility");
+		context.getReferenceContext().importObject(abil);
 		new plugin.lsttokens.add.AbilityToken().parseToken(context, target,
 				"FEAT|NORMAL|GrantedAbility");
 		Skill granted = create(Skill.class, "GrantedSkill");
@@ -580,8 +581,9 @@ public abstract class AbstractGlobalTargetedSaveRestoreTest<T extends CDOMObject
 	{
 		TokenRegistration.register(plugin.bonustokens.SkillRank.class);
 		T target = create(getObjectClass(), "Target");
-		Ability abil = context.getReferenceContext().constructCDOMObject(Ability.class, "GrantedAbility");
-		context.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, abil);
+		Ability abil = AbilityCategory.FEAT.newInstance();
+		abil.setName("GrantedAbility");
+		context.getReferenceContext().importObject(abil);
 		new plugin.lsttokens.add.AbilityToken().parseToken(context, target,
 				"FEAT|VIRTUAL|GrantedAbility");
 		Skill granted = create(Skill.class, "GrantedSkill");

--- a/code/src/itest/plugin/lsttokens/editcontext/AbilityIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/AbilityIntegrationTest.java
@@ -17,12 +17,15 @@
  */
 package plugin.lsttokens.editcontext;
 
+import java.net.URISyntaxException;
+
 import org.junit.Test;
 
 import pcgen.cdom.base.CDOMObject;
 import pcgen.core.Ability;
 import pcgen.core.AbilityCategory;
 import pcgen.persistence.PersistenceLayerException;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.AbilityLst;
@@ -35,6 +38,18 @@ public class AbilityIntegrationTest extends
 {
 	static AbilityLst token = new AbilityLst();
 	static CDOMTokenLoader<CDOMObject> loader = new CDOMTokenLoader<>();
+
+	@Override
+	public void setUp() throws PersistenceLayerException, URISyntaxException
+	{
+		super.setUp();
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName("Dummy");
+		primaryContext.getReferenceContext().importObject(a);
+		a = AbilityCategory.FEAT.newInstance();
+		a.setName("Dummy");
+		secondaryContext.getReferenceContext().importObject(a);
+	}
 
 	@Override
 	public Class<Ability> getCDOMClass()
@@ -58,15 +73,10 @@ public class AbilityIntegrationTest extends
 	public void testRoundRobinSimple() throws PersistenceLayerException
 	{
 		verifyCleanStart();
-		Ability ab = primaryContext.getReferenceContext().constructCDOMObject(Ability.class,
-				"Abil1");
-		primaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ab);
-		ab = secondaryContext.getReferenceContext().constructCDOMObject(Ability.class, "Abil1");
-		secondaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ab);
-		ab = primaryContext.getReferenceContext().constructCDOMObject(Ability.class, "Abil2");
-		primaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ab);
-		ab = secondaryContext.getReferenceContext().constructCDOMObject(Ability.class, "Abil2");
-		secondaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ab);
+		construct(primaryContext, "Abil1");
+		construct(secondaryContext, "Abil1");
+		construct(primaryContext, "Abil2");
+		construct(secondaryContext, "Abil2");
 		TestContext tc = new TestContext();
 		commit(testCampaign, tc, "FEAT|NORMAL|Abil1");
 		commit(modCampaign, tc, "FEAT|VIRTUAL|TYPE=TestType");
@@ -77,15 +87,10 @@ public class AbilityIntegrationTest extends
 	public void testRoundRobinRemove() throws PersistenceLayerException
 	{
 		verifyCleanStart();
-		Ability ab = primaryContext.getReferenceContext().constructCDOMObject(Ability.class,
-				"Abil1");
-		primaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ab);
-		ab = secondaryContext.getReferenceContext().constructCDOMObject(Ability.class, "Abil1");
-		secondaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ab);
-		ab = primaryContext.getReferenceContext().constructCDOMObject(Ability.class, "Abil2");
-		primaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ab);
-		ab = secondaryContext.getReferenceContext().constructCDOMObject(Ability.class, "Abil2");
-		secondaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ab);
+		construct(primaryContext, "Abil1");
+		construct(secondaryContext, "Abil1");
+		construct(primaryContext, "Abil2");
+		construct(secondaryContext, "Abil2");
 		TestContext tc = new TestContext();
 		commit(testCampaign, tc, "FEAT|VIRTUAL|Abil1|Abil2");
 		commit(modCampaign, tc, "FEAT|VIRTUAL|.CLEAR.Abil2");
@@ -96,15 +101,10 @@ public class AbilityIntegrationTest extends
 	public void testRoundRobinMixed() throws PersistenceLayerException
 	{
 		verifyCleanStart();
-		Ability ab = primaryContext.getReferenceContext().constructCDOMObject(Ability.class,
-				"Abil1");
-		primaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ab);
-		ab = secondaryContext.getReferenceContext().constructCDOMObject(Ability.class, "Abil1");
-		secondaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ab);
-		ab = primaryContext.getReferenceContext().constructCDOMObject(Ability.class, "Abil2");
-		primaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ab);
-		ab = secondaryContext.getReferenceContext().constructCDOMObject(Ability.class, "Abil2");
-		secondaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ab);
+		construct(primaryContext, "Abil1");
+		construct(secondaryContext, "Abil1");
+		construct(primaryContext, "Abil2");
+		construct(secondaryContext, "Abil2");
 		TestContext tc = new TestContext();
 		commit(testCampaign, tc, "FEAT|VIRTUAL|.CLEAR.Abil2|Abil1");
 		commit(modCampaign, tc, "FEAT|AUTOMATIC|.CLEAR.Abil1|Abil2");
@@ -115,15 +115,10 @@ public class AbilityIntegrationTest extends
 	public void testRoundRobinNoSet() throws PersistenceLayerException
 	{
 		verifyCleanStart();
-		Ability ab = primaryContext.getReferenceContext().constructCDOMObject(Ability.class,
-				"Abil1");
-		primaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ab);
-		ab = secondaryContext.getReferenceContext().constructCDOMObject(Ability.class, "Abil1");
-		secondaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ab);
-		ab = primaryContext.getReferenceContext().constructCDOMObject(Ability.class, "Abil2");
-		primaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ab);
-		ab = secondaryContext.getReferenceContext().constructCDOMObject(Ability.class, "Abil2");
-		secondaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ab);
+		construct(primaryContext, "Abil1");
+		construct(secondaryContext, "Abil1");
+		construct(primaryContext, "Abil2");
+		construct(secondaryContext, "Abil2");
 		TestContext tc = new TestContext();
 		emptyCommit(testCampaign, tc);
 		commit(modCampaign, tc, "FEAT|VIRTUAL|Abil1|Abil2");
@@ -134,15 +129,10 @@ public class AbilityIntegrationTest extends
 	public void testRoundRobinNoReset() throws PersistenceLayerException
 	{
 		verifyCleanStart();
-		Ability ab = primaryContext.getReferenceContext().constructCDOMObject(Ability.class,
-				"Abil1");
-		primaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ab);
-		ab = secondaryContext.getReferenceContext().constructCDOMObject(Ability.class, "Abil1");
-		secondaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ab);
-		ab = primaryContext.getReferenceContext().constructCDOMObject(Ability.class, "Abil2");
-		primaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ab);
-		ab = secondaryContext.getReferenceContext().constructCDOMObject(Ability.class, "Abil2");
-		secondaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ab);
+		construct(primaryContext, "Abil1");
+		construct(secondaryContext, "Abil1");
+		construct(primaryContext, "Abil2");
+		construct(secondaryContext, "Abil2");
 		TestContext tc = new TestContext();
 		commit(testCampaign, tc, "FEAT|VIRTUAL|Abil1|Abil2");
 		emptyCommit(modCampaign, tc);
@@ -153,11 +143,8 @@ public class AbilityIntegrationTest extends
 	public void testRoundRobinNoSetDotClear() throws PersistenceLayerException
 	{
 		verifyCleanStart();
-		Ability ab = primaryContext.getReferenceContext().constructCDOMObject(Ability.class,
-				"Abil2");
-		primaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ab);
-		ab = secondaryContext.getReferenceContext().constructCDOMObject(Ability.class, "Abil2");
-		secondaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ab);
+		construct(primaryContext, "Abil2");
+		construct(secondaryContext, "Abil2");
 		TestContext tc = new TestContext();
 		emptyCommit(testCampaign, tc);
 		commit(modCampaign, tc, "FEAT|VIRTUAL|.CLEAR.Abil2");
@@ -169,11 +156,8 @@ public class AbilityIntegrationTest extends
 			throws PersistenceLayerException
 	{
 		verifyCleanStart();
-		Ability ab = primaryContext.getReferenceContext().constructCDOMObject(Ability.class,
-				"Abil2");
-		primaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ab);
-		ab = secondaryContext.getReferenceContext().constructCDOMObject(Ability.class, "Abil2");
-		secondaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ab);
+		construct(primaryContext, "Abil2");
+		construct(secondaryContext, "Abil2");
 		TestContext tc = new TestContext();
 		commit(testCampaign, tc, "FEAT|VIRTUAL|.CLEAR.Abil2");
 		emptyCommit(modCampaign, tc);
@@ -183,11 +167,8 @@ public class AbilityIntegrationTest extends
 	public void testRoundRobinMixedClearDot() throws PersistenceLayerException
 	{
 		verifyCleanStart();
-		Ability ab = primaryContext.getReferenceContext().constructCDOMObject(Ability.class,
-				"Abil2");
-		primaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ab);
-		ab = secondaryContext.getReferenceContext().constructCDOMObject(Ability.class, "Abil2");
-		secondaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ab);
+		construct(primaryContext, "Abil2");
+		construct(secondaryContext, "Abil2");
 		TestContext tc = new TestContext();
 		commit(testCampaign, tc, "FEAT|VIRTUAL|.CLEAR");
 		commit(modCampaign, tc, "FEAT|VIRTUAL|.CLEAR.Abil2");
@@ -198,11 +179,8 @@ public class AbilityIntegrationTest extends
 	public void testRoundRobinMixedDotClear() throws PersistenceLayerException
 	{
 		verifyCleanStart();
-		Ability ab = primaryContext.getReferenceContext().constructCDOMObject(Ability.class,
-				"Abil2");
-		primaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ab);
-		ab = secondaryContext.getReferenceContext().constructCDOMObject(Ability.class, "Abil2");
-		secondaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ab);
+		construct(primaryContext, "Abil2");
+		construct(secondaryContext, "Abil2");
 		TestContext tc = new TestContext();
 		commit(testCampaign, tc, "FEAT|VIRTUAL|.CLEAR.Abil2");
 		commit(modCampaign, tc, "FEAT|VIRTUAL|.CLEAR");
@@ -233,19 +211,23 @@ public class AbilityIntegrationTest extends
 	public void testRoundRobinClearOrder() throws PersistenceLayerException
 	{
 		verifyCleanStart();
-		Ability ab = primaryContext.getReferenceContext().constructCDOMObject(Ability.class,
-				"Abil1");
-		primaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ab);
-		ab = secondaryContext.getReferenceContext().constructCDOMObject(Ability.class, "Abil1");
-		secondaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ab);
-		ab = primaryContext.getReferenceContext().constructCDOMObject(Ability.class, "Abil2");
-		primaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ab);
-		ab = secondaryContext.getReferenceContext().constructCDOMObject(Ability.class, "Abil2");
-		secondaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ab);
+		construct(primaryContext, "Abil1");
+		construct(secondaryContext, "Abil1");
+		construct(primaryContext, "Abil2");
+		construct(secondaryContext, "Abil2");
 		TestContext tc = new TestContext();
 		commit(testCampaign, tc, "FEAT|VIRTUAL|.CLEAR",
 				"FEAT|VIRTUAL|Abil1|Abil2");
 		commit(modCampaign, tc, "FEAT|VIRTUAL|.CLEAR");
 		completeRoundRobin(tc);
+	}
+
+	@Override
+	protected Ability construct(LoadContext context, String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		context.getReferenceContext().importObject(a);
+		return a;
 	}
 }

--- a/code/src/itest/plugin/lsttokens/editcontext/AddIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/AddIntegrationTest.java
@@ -24,7 +24,9 @@ import pcgen.cdom.base.Constants;
 import pcgen.cdom.enumeration.IntegerKey;
 import pcgen.cdom.inst.PCClassLevel;
 import pcgen.core.Ability;
+import pcgen.core.AbilityCategory;
 import pcgen.persistence.PersistenceLayerException;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.AddLst;
@@ -127,4 +129,12 @@ public class AddIntegrationTest extends AbstractIntegrationTestCase<CDOMObject>
 		completeRoundRobin(tc);
 	}
 
+	@Override
+	protected Ability construct(LoadContext context, String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		context.getReferenceContext().importObject(a);
+		return a;
+	}
 }

--- a/code/src/itest/plugin/lsttokens/editcontext/ChangeProfIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/ChangeProfIntegrationTest.java
@@ -21,8 +21,10 @@ import org.junit.Test;
 
 import pcgen.cdom.base.CDOMObject;
 import pcgen.core.Ability;
+import pcgen.core.AbilityCategory;
 import pcgen.core.WeaponProf;
 import pcgen.persistence.PersistenceLayerException;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.ChangeprofLst;
@@ -110,4 +112,12 @@ public class ChangeProfIntegrationTest extends
 		completeRoundRobin(tc);
 	}
 
+	@Override
+	protected Ability construct(LoadContext context, String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		context.getReferenceContext().importObject(a);
+		return a;
+	}
 }

--- a/code/src/itest/plugin/lsttokens/editcontext/DefineIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/DefineIntegrationTest.java
@@ -23,8 +23,10 @@ import org.junit.Test;
 
 import pcgen.cdom.base.CDOMObject;
 import pcgen.core.Ability;
+import pcgen.core.AbilityCategory;
 import pcgen.core.PCStat;
 import pcgen.persistence.PersistenceLayerException;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.DefineLst;
@@ -109,5 +111,14 @@ public class DefineIntegrationTest extends
 		commit(testCampaign, tc, "Follower|0");
 		emptyCommit(modCampaign, tc);
 		completeRoundRobin(tc);
+	}
+
+	@Override
+	protected Ability construct(LoadContext context, String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		context.getReferenceContext().importObject(a);
+		return a;
 	}
 }

--- a/code/src/itest/plugin/lsttokens/editcontext/DefineStatIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/DefineStatIntegrationTest.java
@@ -23,8 +23,10 @@ import org.junit.Test;
 
 import pcgen.cdom.base.CDOMObject;
 import pcgen.core.Ability;
+import pcgen.core.AbilityCategory;
 import pcgen.core.PCStat;
 import pcgen.persistence.PersistenceLayerException;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.DefineStatLst;
@@ -169,5 +171,14 @@ public class DefineStatIntegrationTest extends
 		commit(testCampaign, tc, "LOCK|STR|4");
 		commit(modCampaign, tc, "UNLOCK|STR");
 		completeRoundRobin(tc);
+	}
+
+	@Override
+	protected Ability construct(LoadContext context, String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		context.getReferenceContext().importObject(a);
+		return a;
 	}
 }

--- a/code/src/itest/plugin/lsttokens/editcontext/DescIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/DescIntegrationTest.java
@@ -19,6 +19,8 @@ package plugin.lsttokens.editcontext;
 
 import pcgen.cdom.base.CDOMObject;
 import pcgen.core.Ability;
+import pcgen.core.AbilityCategory;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.DescLst;
@@ -78,5 +80,14 @@ public class DescIntegrationTest extends
 	protected boolean requiresPreconstruction()
 	{
 		return false;
+	}
+
+	@Override
+	protected Ability construct(LoadContext context, String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		context.getReferenceContext().importObject(a);
+		return a;
 	}
 }

--- a/code/src/itest/plugin/lsttokens/editcontext/DrIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/DrIntegrationTest.java
@@ -22,7 +22,9 @@ import org.junit.Test;
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.base.Constants;
 import pcgen.core.Ability;
+import pcgen.core.AbilityCategory;
 import pcgen.persistence.PersistenceLayerException;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.DrLst;
@@ -141,5 +143,14 @@ public class DrIntegrationTest extends AbstractIntegrationTestCase<CDOMObject>
 		commit(testCampaign, tc, Constants.LST_DOT_CLEAR);
 		emptyCommit(modCampaign, tc);
 		completeRoundRobin(tc);
+	}
+
+	@Override
+	protected Ability construct(LoadContext context, String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		context.getReferenceContext().importObject(a);
+		return a;
 	}
 }

--- a/code/src/itest/plugin/lsttokens/editcontext/FollowersIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/FollowersIntegrationTest.java
@@ -22,7 +22,9 @@ import org.junit.Test;
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.list.CompanionList;
 import pcgen.core.Ability;
+import pcgen.core.AbilityCategory;
 import pcgen.persistence.PersistenceLayerException;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.FollowersLst;
@@ -108,4 +110,12 @@ public class FollowersIntegrationTest extends
 		completeRoundRobin(tc);
 	}
 
+	@Override
+	protected Ability construct(LoadContext context, String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		context.getReferenceContext().importObject(a);
+		return a;
+	}
 }

--- a/code/src/itest/plugin/lsttokens/editcontext/MoveCloneIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/MoveCloneIntegrationTest.java
@@ -21,7 +21,9 @@ import org.junit.Test;
 
 import pcgen.cdom.base.CDOMObject;
 import pcgen.core.Ability;
+import pcgen.core.AbilityCategory;
 import pcgen.persistence.PersistenceLayerException;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.MovecloneLst;
@@ -93,4 +95,12 @@ public class MoveCloneIntegrationTest extends
 		completeRoundRobin(tc);
 	}
 
+	@Override
+	protected Ability construct(LoadContext context, String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		context.getReferenceContext().importObject(a);
+		return a;
+	}
 }

--- a/code/src/itest/plugin/lsttokens/editcontext/MoveIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/MoveIntegrationTest.java
@@ -21,7 +21,9 @@ import org.junit.Test;
 
 import pcgen.cdom.base.CDOMObject;
 import pcgen.core.Ability;
+import pcgen.core.AbilityCategory;
 import pcgen.persistence.PersistenceLayerException;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.MoveLst;
@@ -93,4 +95,12 @@ public class MoveIntegrationTest extends
 		completeRoundRobin(tc);
 	}
 
+	@Override
+	protected Ability construct(LoadContext context, String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		context.getReferenceContext().importObject(a);
+		return a;
+	}
 }

--- a/code/src/itest/plugin/lsttokens/editcontext/NaturalAttacksIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/NaturalAttacksIntegrationTest.java
@@ -24,7 +24,9 @@ import org.junit.Test;
 
 import pcgen.cdom.base.CDOMObject;
 import pcgen.core.Ability;
+import pcgen.core.AbilityCategory;
 import pcgen.persistence.PersistenceLayerException;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.bonustokens.Weapon;
@@ -99,4 +101,12 @@ public class NaturalAttacksIntegrationTest extends
 		completeRoundRobin(tc);
 	}
 
+	@Override
+	protected Ability construct(LoadContext context, String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		context.getReferenceContext().importObject(a);
+		return a;
+	}
 }

--- a/code/src/itest/plugin/lsttokens/editcontext/PreIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/PreIntegrationTest.java
@@ -23,7 +23,9 @@ import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.base.ConcretePrereqObject;
 import pcgen.cdom.base.Constants;
 import pcgen.core.Ability;
+import pcgen.core.AbilityCategory;
 import pcgen.persistence.PersistenceLayerException;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.PreLst;
@@ -85,4 +87,12 @@ public class PreIntegrationTest extends
 		completeRoundRobin(tc);
 	}
 
+	@Override
+	protected Ability construct(LoadContext context, String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		context.getReferenceContext().importObject(a);
+		return a;
+	}
 }

--- a/code/src/itest/plugin/lsttokens/editcontext/QualifyIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/QualifyIntegrationTest.java
@@ -24,6 +24,7 @@ import pcgen.core.Ability;
 import pcgen.core.AbilityCategory;
 import pcgen.core.spell.Spell;
 import pcgen.persistence.PersistenceLayerException;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.QualifyToken;
@@ -59,11 +60,12 @@ public class QualifyIntegrationTest extends
 	public void testRoundRobinSimple() throws PersistenceLayerException
 	{
 		verifyCleanStart();
-		Ability a = primaryContext.getReferenceContext().constructCDOMObject(Ability.class,
-				"My Feat");
-		primaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, a);
-		a = secondaryContext.getReferenceContext().constructCDOMObject(Ability.class, "My Feat");
-		secondaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, a);
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName("My Feat");
+		primaryContext.getReferenceContext().importObject(a);
+		a = AbilityCategory.FEAT.newInstance();
+		a.setName("My Feat");
+		secondaryContext.getReferenceContext().importObject(a);
 		primaryContext.getReferenceContext().constructCDOMObject(Spell.class, "Lightning Bolt");
 		secondaryContext.getReferenceContext().constructCDOMObject(Spell.class, "Lightning Bolt");
 		TestContext tc = new TestContext();
@@ -94,11 +96,12 @@ public class QualifyIntegrationTest extends
 				AbilityCategory.class, "NEWCAT");
 		AbilityCategory sac = secondaryContext.getReferenceContext().constructCDOMObject(
 				AbilityCategory.class, "NEWCAT");
-		Ability ab = primaryContext.getReferenceContext().constructCDOMObject(Ability.class,
-				"Abil3");
-		primaryContext.getReferenceContext().reassociateCategory(pac, ab);
-		ab = secondaryContext.getReferenceContext().constructCDOMObject(Ability.class, "Abil3");
-		secondaryContext.getReferenceContext().reassociateCategory(sac, ab);
+		Ability a = pac.newInstance();
+		a.setName("Abil3");
+		primaryContext.getReferenceContext().importObject(a);
+		a = sac.newInstance();
+		a.setName("Abil3");
+		secondaryContext.getReferenceContext().importObject(a);
 		TestContext tc = new TestContext();
 		emptyCommit(testCampaign, tc);
 		commit(modCampaign, tc, "ABILITY=NEWCAT|Abil3");
@@ -113,15 +116,24 @@ public class QualifyIntegrationTest extends
 				AbilityCategory.class, "NEWCAT");
 		AbilityCategory sac = secondaryContext.getReferenceContext().constructCDOMObject(
 				AbilityCategory.class, "NEWCAT");
-		Ability ab = primaryContext.getReferenceContext().constructCDOMObject(Ability.class,
-				"Abil3");
-		primaryContext.getReferenceContext().reassociateCategory(pac, ab);
-		ab = secondaryContext.getReferenceContext().constructCDOMObject(Ability.class, "Abil3");
-		secondaryContext.getReferenceContext().reassociateCategory(sac, ab);
+		Ability a = pac.newInstance();
+		a.setName("Abil3");
+		primaryContext.getReferenceContext().importObject(a);
+		a = sac.newInstance();
+		a.setName("Abil3");
+		secondaryContext.getReferenceContext().importObject(a);
 		TestContext tc = new TestContext();
 		commit(testCampaign, tc, "ABILITY=NEWCAT|Abil3");
 		emptyCommit(modCampaign, tc);
 		completeRoundRobin(tc);
 	}
 
+	@Override
+	protected Ability construct(LoadContext context, String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		context.getReferenceContext().importObject(a);
+		return a;
+	}
 }

--- a/code/src/itest/plugin/lsttokens/editcontext/SabIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/SabIntegrationTest.java
@@ -19,7 +19,9 @@ package plugin.lsttokens.editcontext;
 
 import pcgen.cdom.base.CDOMObject;
 import pcgen.core.Ability;
+import pcgen.core.AbilityCategory;
 import pcgen.persistence.PersistenceLayerException;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.SabLst;
@@ -95,5 +97,12 @@ public class SabIntegrationTest extends
 		// TODO No action for now, since Sab doesn't join
 	}
 	
-	
+	@Override
+	protected Ability construct(LoadContext context, String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		context.getReferenceContext().importObject(a);
+		return a;
+	}
 }

--- a/code/src/itest/plugin/lsttokens/editcontext/SpellKnownIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/SpellKnownIntegrationTest.java
@@ -25,8 +25,10 @@ import org.junit.Test;
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.list.ClassSpellList;
 import pcgen.core.Ability;
+import pcgen.core.AbilityCategory;
 import pcgen.core.spell.Spell;
 import pcgen.persistence.PersistenceLayerException;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.SpellknownLst;
@@ -130,4 +132,12 @@ public class SpellKnownIntegrationTest extends
 		completeRoundRobin(tc);
 	}
 
+	@Override
+	protected CDOMObject construct(LoadContext context, String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		context.getReferenceContext().importObject(a);
+		return a;
+	}
 }

--- a/code/src/itest/plugin/lsttokens/editcontext/SpellLevelIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/SpellLevelIntegrationTest.java
@@ -26,8 +26,10 @@ import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.list.ClassSpellList;
 import pcgen.cdom.list.DomainSpellList;
 import pcgen.core.Ability;
+import pcgen.core.AbilityCategory;
 import pcgen.core.spell.Spell;
 import pcgen.persistence.PersistenceLayerException;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.SpelllevelLst;
@@ -130,4 +132,12 @@ public class SpellLevelIntegrationTest extends
 		completeRoundRobin(tc);
 	}
 
+	@Override
+	protected Ability construct(LoadContext context, String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		context.getReferenceContext().importObject(a);
+		return a;
+	}
 }

--- a/code/src/itest/plugin/lsttokens/editcontext/SpellsIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/SpellsIntegrationTest.java
@@ -25,8 +25,10 @@ import org.junit.Test;
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.base.Constants;
 import pcgen.core.Ability;
+import pcgen.core.AbilityCategory;
 import pcgen.core.spell.Spell;
 import pcgen.persistence.PersistenceLayerException;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.SpellsLst;
@@ -174,5 +176,14 @@ public class SpellsIntegrationTest extends
 		commit(testCampaign, tc, Constants.LST_DOT_CLEAR_ALL);
 		emptyCommit(modCampaign, tc);
 		completeRoundRobin(tc);
+	}
+
+	@Override
+	protected Ability construct(LoadContext context, String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		context.getReferenceContext().importObject(a);
+		return a;
 	}
 }

--- a/code/src/itest/plugin/lsttokens/editcontext/UDamIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/UDamIntegrationTest.java
@@ -22,7 +22,9 @@ import org.junit.Test;
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.base.Constants;
 import pcgen.core.Ability;
+import pcgen.core.AbilityCategory;
 import pcgen.persistence.PersistenceLayerException;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.UdamLst;
@@ -134,4 +136,12 @@ public class UDamIntegrationTest extends
 		completeRoundRobin(tc);
 	}
 
+	@Override
+	protected Ability construct(LoadContext context, String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		context.getReferenceContext().importObject(a);
+		return a;
+	}
 }

--- a/code/src/itest/plugin/lsttokens/editcontext/UmultIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/UmultIntegrationTest.java
@@ -19,6 +19,8 @@ package plugin.lsttokens.editcontext;
 
 import pcgen.cdom.base.CDOMObject;
 import pcgen.core.Ability;
+import pcgen.core.AbilityCategory;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.UmultLst;
@@ -78,5 +80,14 @@ public class UmultIntegrationTest extends
 	protected boolean isClearAllowed()
 	{
 		return true;
+	}
+
+	@Override
+	protected Ability construct(LoadContext context, String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		context.getReferenceContext().importObject(a);
+		return a;
 	}
 }

--- a/code/src/itest/plugin/lsttokens/editcontext/UnencumberedMoveIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/UnencumberedMoveIntegrationTest.java
@@ -21,7 +21,9 @@ import org.junit.Test;
 
 import pcgen.cdom.base.CDOMObject;
 import pcgen.core.Ability;
+import pcgen.core.AbilityCategory;
 import pcgen.persistence.PersistenceLayerException;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.UnencumberedmoveLst;
@@ -93,4 +95,12 @@ public class UnencumberedMoveIntegrationTest extends
 		completeRoundRobin(tc);
 	}
 
+	@Override
+	protected CDOMObject construct(LoadContext context, String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		context.getReferenceContext().importObject(a);
+		return a;
+	}
 }

--- a/code/src/itest/plugin/lsttokens/editcontext/VisionIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/VisionIntegrationTest.java
@@ -22,7 +22,9 @@ import org.junit.Test;
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.base.Constants;
 import pcgen.core.Ability;
+import pcgen.core.AbilityCategory;
 import pcgen.persistence.PersistenceLayerException;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.VisionLst;
@@ -193,5 +195,14 @@ public class VisionIntegrationTest extends
 		commit(testCampaign, tc, ".CLEAR.Normal");
 		emptyCommit(modCampaign, tc);
 		completeRoundRobin(tc);
+	}
+
+	@Override
+	protected Ability construct(LoadContext context, String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		context.getReferenceContext().importObject(a);
+		return a;
 	}
 }

--- a/code/src/itest/plugin/lsttokens/editcontext/ability/AddSpellLevelIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/ability/AddSpellLevelIntegrationTest.java
@@ -18,6 +18,8 @@
 package plugin.lsttokens.editcontext.ability;
 
 import pcgen.core.Ability;
+import pcgen.core.AbilityCategory;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.ability.AddspelllevelToken;
@@ -77,5 +79,14 @@ public class AddSpellLevelIntegrationTest extends
 	protected boolean isClearAllowed()
 	{
 		return false;
+	}
+
+	@Override
+	protected Ability construct(LoadContext context, String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		context.getReferenceContext().importObject(a);
+		return a;
 	}
 }

--- a/code/src/itest/plugin/lsttokens/editcontext/ability/AspectIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/ability/AspectIntegrationTest.java
@@ -20,7 +20,9 @@ package plugin.lsttokens.editcontext.ability;
 import org.junit.Test;
 
 import pcgen.core.Ability;
+import pcgen.core.AbilityCategory;
 import pcgen.persistence.PersistenceLayerException;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.ability.AspectToken;
@@ -92,4 +94,12 @@ public class AspectIntegrationTest extends
 		completeRoundRobin(tc);
 	}
 
+	@Override
+	protected Ability construct(LoadContext context, String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		context.getReferenceContext().importObject(a);
+		return a;
+	}
 }

--- a/code/src/itest/plugin/lsttokens/editcontext/ability/BenefitIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/ability/BenefitIntegrationTest.java
@@ -18,6 +18,8 @@
 package plugin.lsttokens.editcontext.ability;
 
 import pcgen.core.Ability;
+import pcgen.core.AbilityCategory;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.ability.BenefitToken;
@@ -77,5 +79,14 @@ public class BenefitIntegrationTest extends
 	protected boolean requiresPreconstruction()
 	{
 		return false;
+	}
+
+	@Override
+	protected Ability construct(LoadContext context, String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		context.getReferenceContext().importObject(a);
+		return a;
 	}
 }

--- a/code/src/itest/plugin/lsttokens/editcontext/ability/CostIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/ability/CostIntegrationTest.java
@@ -18,6 +18,8 @@
 package plugin.lsttokens.editcontext.ability;
 
 import pcgen.core.Ability;
+import pcgen.core.AbilityCategory;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.ability.CostToken;
@@ -65,5 +67,14 @@ public class CostIntegrationTest extends
 	public boolean isZeroAllowed()
 	{
 		return true;
+	}
+
+	@Override
+	protected Ability construct(LoadContext context, String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		context.getReferenceContext().importObject(a);
+		return a;
 	}
 }

--- a/code/src/itest/plugin/lsttokens/editcontext/ability/MultIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/ability/MultIntegrationTest.java
@@ -20,7 +20,9 @@ package plugin.lsttokens.editcontext.ability;
 import org.junit.Test;
 
 import pcgen.core.Ability;
+import pcgen.core.AbilityCategory;
 import pcgen.persistence.PersistenceLayerException;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.ability.MultToken;
@@ -111,5 +113,14 @@ public class MultIntegrationTest extends
 		commit(testCampaign, tc, "YES");
 		emptyCommit(modCampaign, tc);
 		completeRoundRobin(tc);
+	}
+
+	@Override
+	protected Ability construct(LoadContext context, String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		context.getReferenceContext().importObject(a);
+		return a;
 	}
 }

--- a/code/src/itest/plugin/lsttokens/editcontext/ability/StackIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/ability/StackIntegrationTest.java
@@ -20,7 +20,9 @@ package plugin.lsttokens.editcontext.ability;
 import org.junit.Test;
 
 import pcgen.core.Ability;
+import pcgen.core.AbilityCategory;
 import pcgen.persistence.PersistenceLayerException;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.ability.StackToken;
@@ -111,5 +113,14 @@ public class StackIntegrationTest extends
 		commit(testCampaign, tc, "YES");
 		emptyCommit(modCampaign, tc);
 		completeRoundRobin(tc);
+	}
+
+	@Override
+	protected Ability construct(LoadContext context, String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		context.getReferenceContext().importObject(a);
+		return a;
 	}
 }

--- a/code/src/itest/plugin/lsttokens/editcontext/ability/VisibleIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/ability/VisibleIntegrationTest.java
@@ -20,7 +20,9 @@ package plugin.lsttokens.editcontext.ability;
 import org.junit.Test;
 
 import pcgen.core.Ability;
+import pcgen.core.AbilityCategory;
 import pcgen.persistence.PersistenceLayerException;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.ability.VisibleToken;
@@ -81,5 +83,14 @@ public class VisibleIntegrationTest extends
 		commit(testCampaign, tc, "YES");
 		emptyCommit(modCampaign, tc);
 		completeRoundRobin(tc);
+	}
+
+	@Override
+	protected Ability construct(LoadContext context, String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		context.getReferenceContext().importObject(a);
+		return a;
 	}
 }

--- a/code/src/itest/plugin/lsttokens/editcontext/add/AbilityIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/add/AbilityIntegrationTest.java
@@ -123,10 +123,12 @@ public class AbilityIntegrationTest extends
 	}
 
 	@Override
-	protected void construct(LoadContext loadContext, String one)
+	protected Ability construct(LoadContext loadContext, String one)
 	{
-		Ability obj = loadContext.getReferenceContext().constructCDOMObject(Ability.class, one);
-		loadContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, obj);
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setKeyName(one);
+		loadContext.getReferenceContext().importObject(a);
+		return a;
 	}
 
 }

--- a/code/src/itest/plugin/lsttokens/editcontext/spell/StatIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/spell/StatIntegrationTest.java
@@ -22,7 +22,6 @@ import java.net.URISyntaxException;
 import pcgen.core.PCStat;
 import pcgen.core.spell.Spell;
 import pcgen.persistence.PersistenceLayerException;
-import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.editcontext.testsupport.AbstractItemIntegrationTestCase;
@@ -86,12 +85,4 @@ public class StatIntegrationTest extends
 	{
 		return PCStat.class;
 	}
-
-	@Override
-	protected void construct(LoadContext loadContext, String one)
-	{
-		//Ignore request
-	}
-	
-	
 }

--- a/code/src/itest/plugin/lsttokens/editcontext/subclass/ChoiceIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/subclass/ChoiceIntegrationTest.java
@@ -21,8 +21,10 @@ import java.net.URISyntaxException;
 
 import org.junit.Test;
 
+import pcgen.cdom.enumeration.SubClassCategory;
 import pcgen.core.SubClass;
 import pcgen.persistence.PersistenceLayerException;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.editcontext.testsupport.AbstractIntegrationTestCase;
@@ -92,4 +94,12 @@ public class ChoiceIntegrationTest extends
 		completeRoundRobin(tc);
 	}
 
+	@Override
+	protected SubClass construct(LoadContext context, String name)
+	{
+		SubClass a = SubClassCategory.getConstant("SCC").newInstance();
+		a.setName(name);
+		context.getReferenceContext().importObject(a);
+		return a;
+	}
 }

--- a/code/src/itest/plugin/lsttokens/editcontext/subclass/CostIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/subclass/CostIntegrationTest.java
@@ -17,7 +17,9 @@
  */
 package plugin.lsttokens.editcontext.subclass;
 
+import pcgen.cdom.enumeration.SubClassCategory;
 import pcgen.core.SubClass;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.editcontext.testsupport.AbstractIntegerIntegrationTestCase;
@@ -77,5 +79,14 @@ public class CostIntegrationTest extends
 	protected boolean isClearAllowed()
 	{
 		return false;
+	}
+
+	@Override
+	protected SubClass construct(LoadContext context, String name)
+	{
+		SubClass a = SubClassCategory.getConstant("SCC").newInstance();
+		a.setName(name);
+		context.getReferenceContext().importObject(a);
+		return a;
 	}
 }

--- a/code/src/itest/plugin/lsttokens/editcontext/subclass/ProhibitcostIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/subclass/ProhibitcostIntegrationTest.java
@@ -17,7 +17,9 @@
  */
 package plugin.lsttokens.editcontext.subclass;
 
+import pcgen.cdom.enumeration.SubClassCategory;
 import pcgen.core.SubClass;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.editcontext.testsupport.AbstractIntegerIntegrationTestCase;
@@ -77,5 +79,14 @@ public class ProhibitcostIntegrationTest extends
 	protected boolean isClearAllowed()
 	{
 		return false;
+	}
+
+	@Override
+	protected SubClass construct(LoadContext context, String name)
+	{
+		SubClass a = SubClassCategory.getConstant("SCC").newInstance();
+		a.setName(name);
+		context.getReferenceContext().importObject(a);
+		return a;
 	}
 }

--- a/code/src/itest/plugin/lsttokens/editcontext/template/FavoredClassIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/template/FavoredClassIntegrationTest.java
@@ -120,12 +120,13 @@ public class FavoredClassIntegrationTest extends
 		construct(primaryContext, "TestWP2");
 		construct(secondaryContext, "TestWP1");
 		construct(secondaryContext, "TestWP2");
-		SubClass obj = primaryContext.getReferenceContext().constructCDOMObject(SubClass.class,
-				"Sub");
 		SubClassCategory cat = SubClassCategory.getConstant("TestWP2");
-		primaryContext.getReferenceContext().reassociateCategory(cat, obj);
-		obj = secondaryContext.getReferenceContext().constructCDOMObject(SubClass.class, "Sub");
-		secondaryContext.getReferenceContext().reassociateCategory(cat, obj);
+		SubClass obj = cat.newInstance();
+		obj.setKeyName("Sub");
+		primaryContext.getReferenceContext().importObject(obj);
+		obj = cat.newInstance();
+		obj.setKeyName("Sub");
+		secondaryContext.getReferenceContext().importObject(obj);
 		TestContext tc = new TestContext();
 		commit(testCampaign, tc, "TestWP1");
 		commit(modCampaign, tc, "TestWP2.Sub");

--- a/code/src/itest/plugin/lsttokens/editcontext/testsupport/AbstractIntegrationTestCase.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/testsupport/AbstractIntegrationTestCase.java
@@ -86,10 +86,14 @@ public abstract class AbstractIntegrationTestCase<T extends ConcretePrereqObject
 		secondaryContext = new EditorLoadContext();
 		primaryContext.getReferenceContext().importObject(AbilityCategory.FEAT);
 		secondaryContext.getReferenceContext().importObject(AbilityCategory.FEAT);
-		primaryProf = primaryContext.getReferenceContext().constructCDOMObject(getCDOMClass(),
-				"TestObj");
-		secondaryProf = secondaryContext.getReferenceContext().constructCDOMObject(
-				getCDOMClass(), "TestObj");
+		primaryProf = construct(primaryContext, "TestObj");
+		secondaryProf = construct(secondaryContext, "TestObj");
+	}
+
+	protected T construct(LoadContext context, String name)
+	{
+		return context.getReferenceContext().constructCDOMObject(getCDOMClass(),
+				name);
 	}
 
 	public abstract Class<? extends T> getCDOMClass();

--- a/code/src/itest/plugin/lsttokens/editcontext/testsupport/AbstractItemIntegrationTestCase.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/testsupport/AbstractItemIntegrationTestCase.java
@@ -21,7 +21,6 @@ import org.junit.Test;
 
 import pcgen.cdom.base.CDOMObject;
 import pcgen.persistence.PersistenceLayerException;
-import pcgen.rules.context.LoadContext;
 
 public abstract class AbstractItemIntegrationTestCase<T extends CDOMObject, TC extends CDOMObject>
 		extends AbstractIntegrationTestCase<T>
@@ -101,10 +100,5 @@ public abstract class AbstractItemIntegrationTestCase<T extends CDOMObject, TC e
 		commit(testCampaign, tc, getSecondConstant());
 		emptyCommit(modCampaign, tc);
 		completeRoundRobin(tc);
-	}
-
-	protected void construct(LoadContext loadContext, String one)
-	{
-		loadContext.getReferenceContext().constructCDOMObject(getTargetClass(), one);
 	}
 }

--- a/code/src/itest/plugin/lsttokens/editcontext/testsupport/AbstractListIntegrationTestCase.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/testsupport/AbstractListIntegrationTestCase.java
@@ -26,7 +26,6 @@ import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.base.Constants;
 import pcgen.cdom.base.Loadable;
 import pcgen.persistence.PersistenceLayerException;
-import pcgen.rules.context.LoadContext;
 import plugin.lsttokens.testsupport.TokenRegistration;
 import plugin.pretokens.parser.PreClassParser;
 import plugin.pretokens.parser.PreRaceParser;
@@ -373,10 +372,5 @@ public abstract class AbstractListIntegrationTestCase<T extends CDOMObject, TC e
 			emptyCommit(modCampaign, tc);
 			completeRoundRobin(tc);
 		}
-	}
-
-	protected void construct(LoadContext loadContext, String one)
-	{
-		loadContext.getReferenceContext().constructCDOMObject(getTargetClass(), one);
 	}
 }

--- a/code/src/itest/tokencontent/GlobalQualifyTest.java
+++ b/code/src/itest/tokencontent/GlobalQualifyTest.java
@@ -20,6 +20,7 @@ package tokencontent;
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.facet.FacetLibrary;
 import pcgen.cdom.facet.analysis.QualifyFacet;
+import pcgen.cdom.list.CompanionList;
 import pcgen.core.Campaign;
 import pcgen.core.EquipmentModifier;
 import pcgen.core.PCAlignment;
@@ -115,7 +116,11 @@ public class GlobalQualifyTest extends AbstractContentTokenTest
 	@Test
 	public void testFromCompanionMod() throws PersistenceLayerException
 	{
-		CompanionMod source = create(CompanionMod.class, "Source");
+		CompanionList cat = create(CompanionList.class, "Category");
+		context.getReferenceContext().importObject(cat);
+		CompanionMod source = cat.newInstance();
+		cat.setKeyName("Source");
+		context.getReferenceContext().importObject(source);
 		ParseResult result = token.parseToken(context, source, "RACE|Dwarf");
 		assertFalse(result.passed());
 	}

--- a/code/src/itest/tokencontent/GlobalSpellKnownTest.java
+++ b/code/src/itest/tokencontent/GlobalSpellKnownTest.java
@@ -132,8 +132,9 @@ public class GlobalSpellKnownTest extends AbstractContentTokenTest
 	
 	public void testConditional()
 	{
-		Ability source = create(Ability.class, "Source");
-		context.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, source);
+		Ability source = AbilityCategory.FEAT.newInstance();
+		source.setKeyName("Source");
+		context.getReferenceContext().importObject(source);
 		ParseResult result =
 				token.parseToken(context, source, "CLASS|Wizard=2|Fireball|PREVARLTEQ:3,MyCasterLevel");
 		if (result != ParseResult.SUCCESS)

--- a/code/src/itest/tokencontent/testsupport/AbstractContentTokenTest.java
+++ b/code/src/itest/tokencontent/testsupport/AbstractContentTokenTest.java
@@ -26,6 +26,7 @@ import pcgen.cdom.enumeration.Nature;
 import pcgen.cdom.helper.CNAbilitySelection;
 import pcgen.cdom.helper.ClassSource;
 import pcgen.cdom.inst.PCClassLevel;
+import pcgen.cdom.list.CompanionList;
 import pcgen.core.Ability;
 import pcgen.core.AbilityCategory;
 import pcgen.core.Campaign;
@@ -46,8 +47,9 @@ public abstract class AbstractContentTokenTest extends AbstractTokenModelTest
 	@Test
 	public void testFromAbility() throws PersistenceLayerException
 	{
-		Ability source = create(Ability.class, "Source");
-		context.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, source);
+		Ability source = AbilityCategory.FEAT.newInstance();
+		source.setKeyName("Source");
+		context.getReferenceContext().importObject(source);
 		processToken(source);
 		assertEquals(baseCount(), targetFacetCount());
 		CNAbilitySelection cas =
@@ -126,7 +128,11 @@ public abstract class AbstractContentTokenTest extends AbstractTokenModelTest
 	@Test
 	public void testFromCompanionMod() throws PersistenceLayerException
 	{
-		CompanionMod source = create(CompanionMod.class, "Source");
+		CompanionList cat = create(CompanionList.class, "Category");
+		context.getReferenceContext().importObject(cat);
+		CompanionMod source = cat.newInstance();
+		cat.setKeyName("Source");
+		context.getReferenceContext().importObject(source);
 		processToken(source);
 		assertEquals(baseCount(), targetFacetCount());
 		companionModFacet.add(id, source);

--- a/code/src/itest/tokenmodel/AbilityDepthTest.java
+++ b/code/src/itest/tokenmodel/AbilityDepthTest.java
@@ -83,8 +83,9 @@ public class AbilityDepthTest extends AbstractTokenModelTest
 
 	private Ability createAbility(String key)
 	{
-		Ability a = context.getReferenceContext().constructCDOMObject(Ability.class, key);
-		context.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, a);
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setKeyName(key);
+		context.getReferenceContext().importObject(a);
 		return a;
 	}
 

--- a/code/src/itest/tokenmodel/AddAbilityNormalTest.java
+++ b/code/src/itest/tokenmodel/AddAbilityNormalTest.java
@@ -112,9 +112,8 @@ public class AddAbilityNormalTest extends AbstractAddListTokenTest<Ability>
 		}
 		for (CNAbility a : abilities)
 		{
-			boolean abilityExpected =
-					a.getAbility().equals(context.getReferenceContext().silentlyGetConstructedCDOMObject(
-						Ability.class, AbilityCategory.FEAT, "Granted"));
+			boolean abilityExpected = a.getAbility().equals(context.getReferenceContext()
+				.getManufacturerId(AbilityCategory.FEAT).getActiveObject("Granted"));
 			if (abilityExpected)
 			{
 				boolean c = assocCheck.check(a);
@@ -132,8 +131,9 @@ public class AddAbilityNormalTest extends AbstractAddListTokenTest<Ability>
 	@Override
 	protected Ability createGrantedObject()
 	{
-		Ability a = super.createGrantedObject();
-		context.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, a);
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setKeyName("Granted");
+		context.getReferenceContext().importObject(a);
 		return a;
 	}
 

--- a/code/src/itest/tokenmodel/AddAbilityVirtualTest.java
+++ b/code/src/itest/tokenmodel/AddAbilityVirtualTest.java
@@ -110,9 +110,8 @@ public class AddAbilityVirtualTest extends AbstractAddListTokenTest<Ability>
 				getTargetFacet().getPoolAbilities(id, AbilityCategory.FEAT, Nature.VIRTUAL);
 		for (CNAbility a : abilities)
 		{
-			boolean abilityExpected =
-					a.getAbility().equals(context.getReferenceContext().silentlyGetConstructedCDOMObject(
-						Ability.class, AbilityCategory.FEAT, "Granted"));
+			boolean abilityExpected = a.getAbility().equals(context.getReferenceContext()
+				.getManufacturerId(AbilityCategory.FEAT).getActiveObject("Granted"));
 			if (abilityExpected)
 			{
 				boolean c = assocCheck.check(a);
@@ -130,8 +129,9 @@ public class AddAbilityVirtualTest extends AbstractAddListTokenTest<Ability>
 	@Override
 	protected Ability createGrantedObject()
 	{
-		Ability a = super.createGrantedObject();
-		context.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, a);
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setKeyName("Granted");
+		context.getReferenceContext().importObject(a);
 		return a;
 	}
 

--- a/code/src/itest/tokenmodel/AddTargetedAbilityNormalTest.java
+++ b/code/src/itest/tokenmodel/AddTargetedAbilityNormalTest.java
@@ -87,9 +87,8 @@ public class AddTargetedAbilityNormalTest extends AbstractAddListTokenTest<Abili
 				getTargetFacet().getPoolAbilities(id, AbilityCategory.FEAT, Nature.NORMAL);
 		for (CNAbility a : abilities)
 		{
-			boolean abilityExpected =
-					a.getAbility().equals(context.getReferenceContext().silentlyGetConstructedCDOMObject(
-						Ability.class, AbilityCategory.FEAT, "Granted"));
+			boolean abilityExpected = a.getAbility().equals(context.getReferenceContext()
+				.getManufacturerId(AbilityCategory.FEAT).getActiveObject("Granted"));
 			if (abilityExpected)
 			{
 				if (pc.getDetailedAssociationCount(a) == 1)
@@ -123,7 +122,8 @@ public class AddTargetedAbilityNormalTest extends AbstractAddListTokenTest<Abili
 	protected Ability createGrantedObject()
 	{
 		context.getReferenceContext().constructCDOMObject(Language.class, "English");
-		Ability a = super.createGrantedObject();
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setKeyName("Granted");
 		ParseResult result = AUTO_LANG_TOKEN.parseToken(context, a, "%LIST");
 		if (result != ParseResult.SUCCESS)
 		{
@@ -142,7 +142,7 @@ public class AddTargetedAbilityNormalTest extends AbstractAddListTokenTest<Abili
 			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
-		context.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, a);
+		context.getReferenceContext().importObject(a);
 		return a;
 	}
 

--- a/code/src/itest/tokenmodel/AddTargetedAbilityVirtualTest.java
+++ b/code/src/itest/tokenmodel/AddTargetedAbilityVirtualTest.java
@@ -87,9 +87,8 @@ public class AddTargetedAbilityVirtualTest extends AbstractAddListTokenTest<Abil
 				getTargetFacet().getPoolAbilities(id, AbilityCategory.FEAT, Nature.VIRTUAL);
 		for (CNAbility a : abilities)
 		{
-			boolean abilityExpected =
-					a.getAbility().equals(context.getReferenceContext().silentlyGetConstructedCDOMObject(
-						Ability.class, AbilityCategory.FEAT, "Granted"));
+			boolean abilityExpected = a.getAbility().equals(context.getReferenceContext()
+				.getManufacturerId(AbilityCategory.FEAT).getActiveObject("Granted"));
 			if (abilityExpected)
 			{
 				if (pc.getDetailedAssociationCount(a) == 1)
@@ -123,7 +122,8 @@ public class AddTargetedAbilityVirtualTest extends AbstractAddListTokenTest<Abil
 	protected Ability createGrantedObject()
 	{
 		context.getReferenceContext().constructCDOMObject(Language.class, "English");
-		Ability a = super.createGrantedObject();
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setKeyName("Granted");
 		ParseResult result = AUTO_LANG_TOKEN.parseToken(context, a, "%LIST");
 		if (result != ParseResult.SUCCESS)
 		{
@@ -142,7 +142,7 @@ public class AddTargetedAbilityVirtualTest extends AbstractAddListTokenTest<Abil
 			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
-		context.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, a);
+		context.getReferenceContext().importObject(a);
 		return a;
 	}
 

--- a/code/src/itest/tokenmodel/AutoLangListTest.java
+++ b/code/src/itest/tokenmodel/AutoLangListTest.java
@@ -43,7 +43,8 @@ public class AutoLangListTest extends AbstractTokenModelTest
 	@Test
 	public void testFromAbility() throws PersistenceLayerException
 	{
-		Ability source = create(Ability.class, "Source");
+		Ability source = AbilityCategory.FEAT.newInstance();
+		source.setKeyName("Source");
 		ParseResult result =
 				new MultToken().parseToken(context, source, "YES");
 		if (result != ParseResult.SUCCESS)
@@ -51,7 +52,7 @@ public class AutoLangListTest extends AbstractTokenModelTest
 			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
-		context.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, source);
+		context.getReferenceContext().importObject(source);
 		Language granted = createGrantedObject();
 		processToken(source);
 		assertEquals(0, getCount());

--- a/code/src/itest/tokenmodel/AutoWeaponProfListTargetTest.java
+++ b/code/src/itest/tokenmodel/AutoWeaponProfListTargetTest.java
@@ -92,8 +92,9 @@ public class AutoWeaponProfListTargetTest extends AbstractTokenModelTest
 	@Test
 	public void testFromAbility() throws PersistenceLayerException
 	{
-		Ability source = create(Ability.class, "Source");
-		context.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, source);
+		Ability source = AbilityCategory.FEAT.newInstance();
+		source.setKeyName("Source");
+		context.getReferenceContext().importObject(source);
 		Ability granted = createGrantedObject();
 		context.getReferenceContext().constructCDOMObject(Language.class, "English");
 		ParseResult result =
@@ -154,10 +155,9 @@ public class AutoWeaponProfListTargetTest extends AbstractTokenModelTest
 			CNAbility cas = cnas.getCNAbility();
 			boolean featExpected =
 					cas.getAbilityCategory() == AbilityCategory.FEAT;
-			boolean abilityExpected =
-					cas.getAbility().equals(
-						context.getReferenceContext().silentlyGetConstructedCDOMObject(
-							Ability.class, AbilityCategory.FEAT, "Granted"));
+			boolean abilityExpected = cas.getAbility()
+				.equals(context.getReferenceContext()
+					.getManufacturerId(AbilityCategory.FEAT).getActiveObject("Granted"));
 			boolean natureExpected = cas.getNature() == Nature.AUTOMATIC;
 			boolean selectionExpected = "English".equals(cnas.getSelection());
 			if (featExpected && abilityExpected && natureExpected
@@ -185,8 +185,9 @@ public class AutoWeaponProfListTargetTest extends AbstractTokenModelTest
 
 	protected Ability createGrantedObject()
 	{
-		Ability a = create(Ability.class, "Granted");
-		context.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, a);
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setKeyName("Granted");
+		context.getReferenceContext().importObject(a);
 		return a;
 	}
 }

--- a/code/src/itest/tokenmodel/GlobalAbilityTest.java
+++ b/code/src/itest/tokenmodel/GlobalAbilityTest.java
@@ -84,10 +84,9 @@ public class GlobalAbilityTest extends AbstractGrantedListTokenTest<Ability>
 			CNAbility cas = cnas.getCNAbility();
 			boolean featExpected =
 					cas.getAbilityCategory() == AbilityCategory.FEAT;
-			boolean abilityExpected =
-					cas.getAbility().equals(
-						context.getReferenceContext().silentlyGetConstructedCDOMObject(
-							Ability.class, AbilityCategory.FEAT, "Granted"));
+			boolean abilityExpected = cas.getAbility()
+				.equals(context.getReferenceContext()
+					.getManufacturerId(AbilityCategory.FEAT).getActiveObject("Granted"));
 			boolean natureExpected = cas.getNature() == Nature.VIRTUAL;
 			boolean selectionExpected = cnas.getSelection() == null;
 			if (featExpected && abilityExpected && natureExpected
@@ -102,8 +101,9 @@ public class GlobalAbilityTest extends AbstractGrantedListTokenTest<Ability>
 	@Override
 	protected Ability createGrantedObject()
 	{
-		Ability a = super.createGrantedObject();
-		context.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, a);
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setKeyName("Granted");
+		context.getReferenceContext().importObject(a);
 		return a;
 	}
 

--- a/code/src/itest/tokenmodel/ability/AbilityVirtualAbilityTest.java
+++ b/code/src/itest/tokenmodel/ability/AbilityVirtualAbilityTest.java
@@ -23,9 +23,6 @@ import tokenmodel.testsupport.AbstractAbilityGrantCheckTest;
 
 public class AbilityVirtualAbilityTest extends AbstractAbilityGrantCheckTest
 {
-	private static final plugin.lsttokens.AbilityLst ABILITY_TOKEN =
-			new plugin.lsttokens.AbilityLst();
-
 	@Override
 	protected CDOMToken<? super Ability> getGrantToken()
 	{

--- a/code/src/itest/tokenmodel/testsupport/AbstractAbilityGrantCheckTest.java
+++ b/code/src/itest/tokenmodel/testsupport/AbstractAbilityGrantCheckTest.java
@@ -34,7 +34,7 @@ import util.TestURI;
 public abstract class AbstractAbilityGrantCheckTest extends AbstractTokenModelTest
 {
 
-	private static final plugin.lsttokens.AbilityLst ABILITY_TOKEN =
+	protected static final plugin.lsttokens.AbilityLst ABILITY_TOKEN =
 			new plugin.lsttokens.AbilityLst();
 	protected static final plugin.lsttokens.deprecated.AutoFeatToken AUTO_FEAT_TOKEN =
 			new plugin.lsttokens.deprecated.AutoFeatToken();
@@ -55,21 +55,22 @@ public abstract class AbstractAbilityGrantCheckTest extends AbstractTokenModelTe
 
 	public Ability getMultNo(String s)
 	{
-		Ability a = create(Ability.class, s);
-		context.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, a);
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(s);
 		ParseResult result = TYPE_TOKEN.parseToken(context, a, "Selectable");
 		if (result != ParseResult.SUCCESS)
 		{
 			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
+		context.getReferenceContext().importObject(a);
 		return a;
 	}
 
 	public Ability getMultYesStackNo(String s, String target)
 	{
-		Ability a = create(Ability.class, s);
-		context.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, a);
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(s);
 		ParseResult result = AUTO_FEAT_TOKEN.parseToken(context, a, "FEAT|%LIST");
 		if (result != ParseResult.SUCCESS)
 		{
@@ -88,13 +89,14 @@ public abstract class AbstractAbilityGrantCheckTest extends AbstractTokenModelTe
 			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
+		context.getReferenceContext().importObject(a);
 		return a;
 	}
 
 	public Ability getMultYesStackYes(String s, String target)
 	{
-		Ability a = create(Ability.class, s);
-		context.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, a);
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(s);
 		ParseResult result = AUTO_FEAT_TOKEN.parseToken(context, a, "FEAT|%LIST");
 		if (result != ParseResult.SUCCESS)
 		{
@@ -119,13 +121,14 @@ public abstract class AbstractAbilityGrantCheckTest extends AbstractTokenModelTe
 			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
+		context.getReferenceContext().importObject(a);
 		return a;
 	}
 
 	public Ability getMultYesStackNoChooseNoChoice(String s)
 	{
-		Ability a = create(Ability.class, s);
-		context.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, a);
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(s);
 		ParseResult result = ABILITY_MULT_TOKEN.parseToken(context, a, "YES");
 		if (result != ParseResult.SUCCESS)
 		{
@@ -138,13 +141,14 @@ public abstract class AbstractAbilityGrantCheckTest extends AbstractTokenModelTe
 			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
+		context.getReferenceContext().importObject(a);
 		return a;
 	}
 
 	public Ability getMultYesStackYesChooseNoChoice(String s)
 	{
-		Ability a = create(Ability.class, s);
-		context.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, a);
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(s);
 		ParseResult result = ABILITY_MULT_TOKEN.parseToken(context, a, "YES");
 		if (result != ParseResult.SUCCESS)
 		{
@@ -163,6 +167,7 @@ public abstract class AbstractAbilityGrantCheckTest extends AbstractTokenModelTe
 			result.printMessages(TestURI.getURI());
 			fail("Test Setup Failed");
 		}
+		context.getReferenceContext().importObject(a);
 		return a;
 	}
 

--- a/code/src/itest/tokenmodel/testsupport/AbstractAddListTokenTest.java
+++ b/code/src/itest/tokenmodel/testsupport/AbstractAddListTokenTest.java
@@ -41,8 +41,9 @@ public abstract class AbstractAddListTokenTest<T extends CDOMObject>
 	@Test
 	public void testFromAbility() throws PersistenceLayerException
 	{
-		Ability source = create(Ability.class, "Source");
-		context.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, source);
+		Ability source = AbilityCategory.FEAT.newInstance();
+		source.setName("Source");
+		context.getReferenceContext().importObject(source);
 		T granted = createGrantedObject();
 		processToken(source);
 		assertEquals(0, getCount());

--- a/code/src/itest/tokenmodel/testsupport/AbstractGrantedListTokenTest.java
+++ b/code/src/itest/tokenmodel/testsupport/AbstractGrantedListTokenTest.java
@@ -20,6 +20,7 @@ package tokenmodel.testsupport;
 import org.junit.Test;
 
 import pcgen.cdom.base.CDOMObject;
+import pcgen.cdom.list.CompanionList;
 import pcgen.core.Campaign;
 import pcgen.core.EquipmentModifier;
 import pcgen.core.PCCheck;
@@ -82,7 +83,11 @@ public abstract class AbstractGrantedListTokenTest<T extends CDOMObject>
 	@Test
 	public void testFromCompanionMod() throws PersistenceLayerException
 	{
-		CompanionMod source = create(CompanionMod.class, "Source");
+		CompanionList cat = create(CompanionList.class, "Category");
+		context.getReferenceContext().importObject(cat);
+		CompanionMod source = cat.newInstance();
+		cat.setName("Source");
+		context.getReferenceContext().importObject(source);
 		T granted = createGrantedObject();
 		processToken(source);
 		assertEquals(0, getCount());

--- a/code/src/java/pcgen/cdom/list/CompanionList.java
+++ b/code/src/java/pcgen/cdom/list/CompanionList.java
@@ -77,7 +77,6 @@ public class CompanionList extends CDOMListObject<Race> implements
 
 	@Override
 	public CompanionMod newInstance()
-		throws InstantiationException, IllegalAccessException
 	{
 		CompanionMod instance = new CompanionMod();
 		instance.setCDOMCategory(this);

--- a/code/src/java/pcgen/persistence/SourceFileLoader.java
+++ b/code/src/java/pcgen/persistence/SourceFileLoader.java
@@ -785,17 +785,15 @@ public class SourceFileLoader extends PCGenTask implements Observer
 			 * Yes, these are thrown away... just need to make sure the
 			 * manufacturer was built.
 			 */
-			context.getReferenceContext().getManufacturer(Ability.class, cat);
+			context.getReferenceContext().getManufacturerId(cat);
 		}
 	}
 
 	public static void createLangBonusObject(LoadContext context)
 	{
-		Ability a =
-				context.getReferenceContext().constructCDOMObject(
-					Ability.class, "*LANGBONUS");
-		context.getReferenceContext().reassociateCategory(
-			AbilityCategory.LANGBONUS, a);
+		Ability a = AbilityCategory.LANGBONUS.newInstance();
+		a.setKeyName("*LANGBONUS");
+		context.getReferenceContext().importObject(a);
 		a.put(ObjectKey.INTERNAL, true);
 		context.unconditionallyProcess(a, "CHOOSE", "LANG|!PC,LANGBONUS");
 		context.unconditionallyProcess(a, "VISIBLE", "NO");

--- a/code/src/test/pcgen/core/AbilityUtilitiesTest.java
+++ b/code/src/test/pcgen/core/AbilityUtilitiesTest.java
@@ -87,16 +87,16 @@ public class AbilityUtilitiesTest extends AbstractCharacterTestCase
 		Ability fencing = TestHelper.makeAbility("fencing", parent, "sport");
 		Ability reading = TestHelper.makeAbility("reading", parent, "interest");
 		//Throwaway is required to create it...
-		context.getReferenceContext().getManufacturer(Ability.class, typeChild);
+		context.getReferenceContext().getManufacturerId(typeChild);
 		context.getReferenceContext().validate(null);
 		context.getReferenceContext().resolveReferences(null);
 
-		Collection<Ability> allAbilities = context.getReferenceContext().getManufacturer(Ability.class, parent).getAllObjects();
+		Collection<Ability> allAbilities = context.getReferenceContext().getManufacturerId(parent).getAllObjects();
 		assertTrue("Parent missing ability 'fencing'", allAbilities.contains(fencing));
 		assertTrue("Parent missing ability 'reading'", allAbilities.contains(reading));
 		assertEquals("Incorrect number of abilities found for parent", 2, allAbilities.size());
 		
-		allAbilities = context.getReferenceContext().getManufacturer(Ability.class, typeChild).getAllObjects();
+		allAbilities = context.getReferenceContext().getManufacturerId(typeChild).getAllObjects();
 		assertTrue("TypeChild missing ability fencing", allAbilities.contains(fencing));
 		assertFalse("TypeChild shouldn't have ability 'reading'", allAbilities.contains(reading));
 		assertEquals("Incorrect number of abilities found for TypeChild", 1, allAbilities.size());

--- a/code/src/test/pcgen/core/PObjectTest.java
+++ b/code/src/test/pcgen/core/PObjectTest.java
@@ -255,8 +255,7 @@ public class PObjectTest extends AbstractCharacterTestCase
 				"Toughness	CATEGORY:FEAT	TYPE:General	STACK:YES	MULT:YES	CHOOSE:NOCHOICE	BONUS:HP|CURRENTMAX|3", source);
 
 		Ability pObj = Globals.getContext().getReferenceContext()
-				.silentlyGetConstructedCDOMObject(Ability.class,
-						AbilityCategory.FEAT, "Toughness");
+			.getManufacturerId(AbilityCategory.FEAT).getActiveObject("Toughness");
 		Globals.getContext().getReferenceContext().constructCDOMObject(Language.class, "Foo");
 		PlayerCharacter aPC = getCharacter();
 		int baseHP = aPC.hitPoints();
@@ -295,8 +294,7 @@ public class PObjectTest extends AbstractCharacterTestCase
 				null,
 				"Toughness	CATEGORY:FEAT	TYPE:General	STACK:YES	MULT:YES	CHOOSE:NOCHOICE	BONUS:HP|CURRENTMAX|3", source);
 		Ability pObj = Globals.getContext().getReferenceContext()
-				.silentlyGetConstructedCDOMObject(Ability.class,
-						AbilityCategory.FEAT, "Toughness");
+			.getManufacturerId(AbilityCategory.FEAT).getActiveObject("Toughness");
 		PlayerCharacter aPC = getCharacter();
 		int baseHP = aPC.hitPoints();
 		AbstractCharacterTestCase.applyAbility(aPC, AbilityCategory.FEAT, pObj, "");

--- a/code/src/test/pcgen/core/analysis/SpellLevelTest.java
+++ b/code/src/test/pcgen/core/analysis/SpellLevelTest.java
@@ -82,8 +82,7 @@ public class SpellLevelTest extends AbstractCharacterTestCase
 		AbilityLoader abilityLoader = new AbilityLoader();
 		abilityLoader.parseLine(context, null, abilityLine, source);
 		Ability ab1 = Globals.getContext().getReferenceContext()
-				.silentlyGetConstructedCDOMObject(Ability.class,
-						AbilityCategory.FEAT, "Spell bonanza");
+			.getManufacturerId(AbilityCategory.FEAT).getActiveObject("Spell bonanza");
 
 		// Do the post parsing cleanup
 		context.resolveDeferredTokens();

--- a/code/src/test/plugin/lsttokens/gamemode/abilitycategory/AbilityListTokenTest.java
+++ b/code/src/test/plugin/lsttokens/gamemode/abilitycategory/AbilityListTokenTest.java
@@ -54,8 +54,9 @@ public class AbilityListTokenTest extends TestCase
 
 	private static Ability buildFeat(RuntimeLoadContext context, String abName)
 	{
-		Ability ab = context.getReferenceContext().constructCDOMObject(Ability.class, abName);
-		context.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ab);
+		Ability ab = AbilityCategory.FEAT.newInstance();
+		ab.setName(abName);
+		context.getReferenceContext().importObject(ab);
 		return ab;
 	}
 	

--- a/code/src/utest/actor/add/AbilityTokenTest.java
+++ b/code/src/utest/actor/add/AbilityTokenTest.java
@@ -114,8 +114,9 @@ public class AbilityTokenTest extends AbstractCharacterUsingTestCase
 		AbilityCategory ff = context.getReferenceContext().constructCDOMObject(AbilityCategory.class, "Fighter Feat");
 		ff.setAbilityCategory(CDOMDirectSingleRef.getRef(AbilityCategory.FEAT));
 		AbilityCategory oc = context.getReferenceContext().constructCDOMObject(AbilityCategory.class, "Some Other Category");
-		Ability badCA = context.getReferenceContext().constructCDOMObject(Ability.class, "ChooseAbility");
-		context.getReferenceContext().reassociateCategory(oc, badCA);
+		Ability badCA = oc.newInstance();
+		badCA.setName("ChooseAbility");
+		context.getReferenceContext().importObject(badCA);
 		try {
 			assertTrue(context.processToken(item, "CHOOSE", "LANG|Foo|Bar|Goo|Wow|Rev"));
 			assertTrue(context.processToken(item, "MULT", "Yes"));
@@ -187,8 +188,9 @@ public class AbilityTokenTest extends AbstractCharacterUsingTestCase
 
 	protected Ability construct(String one)
 	{
-		Ability obj = context.getReferenceContext().constructCDOMObject(Ability.class, one);
-		context.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, obj);
-		return obj;
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(one);
+		context.getReferenceContext().importObject(a);
+		return a;
 	}
 }

--- a/code/src/utest/actor/choose/AbilitySelectionTokenTest.java
+++ b/code/src/utest/actor/choose/AbilitySelectionTokenTest.java
@@ -106,8 +106,9 @@ public class AbilitySelectionTokenTest
 
 	protected Ability construct(String one)
 	{
-		Ability obj = context.getReferenceContext().constructCDOMObject(Ability.class, one);
-		context.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, obj);
-		return obj;
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(one);
+		context.getReferenceContext().importObject(a);
+		return a;
 	}
 }

--- a/code/src/utest/actor/choose/AbilityTokenTest.java
+++ b/code/src/utest/actor/choose/AbilityTokenTest.java
@@ -55,9 +55,10 @@ public class AbilityTokenTest
 
 	private Ability getObject()
 	{
-		Ability obj = context.getReferenceContext().constructCDOMObject(Ability.class, ITEM_NAME);
-		context.getReferenceContext().reassociateCategory(CATEGORY, obj);
-		return obj;
+		Ability a = CATEGORY.newInstance();
+		a.setName(ITEM_NAME);
+		context.getReferenceContext().importObject(a);
+		return a;
 	}
 
 	@Test

--- a/code/src/utest/plugin/lsttokens/AbilityLstTest.java
+++ b/code/src/utest/plugin/lsttokens/AbilityLstTest.java
@@ -59,6 +59,9 @@ public class AbilityLstTest extends AbstractGlobalTokenTestCase
 		TokenRegistration.register(new PreLevelWriter());
 		TokenRegistration.register(new PreClassParser());
 		TokenRegistration.register(new PreClassWriter());
+		//We build dummy objects so that AbilityCategory.FEAT has been loaded properly
+		construct(primaryContext, "Dummy");
+		construct(secondaryContext, "Dummy");
 	}
 
 	@Override
@@ -257,16 +260,18 @@ public class AbilityLstTest extends AbstractGlobalTokenTestCase
 				AbilityCategory.class, "NEWCAT");
 		AbilityCategory sac = secondaryContext.getReferenceContext().constructCDOMObject(
 				AbilityCategory.class, "NEWCAT");
-		Ability ab = primaryContext.getReferenceContext().constructCDOMObject(Ability.class, "Abil3");
-		primaryContext.getReferenceContext().reassociateCategory(pac, ab);
-		ab = secondaryContext.getReferenceContext().constructCDOMObject(Ability.class,
-				"Abil3");
-		secondaryContext.getReferenceContext().reassociateCategory(sac, ab);
-		ab = primaryContext.getReferenceContext().constructCDOMObject(Ability.class, "Abil4");
-		primaryContext.getReferenceContext().reassociateCategory(pac, ab);
-		ab = secondaryContext.getReferenceContext().constructCDOMObject(Ability.class,
-				"Abil4");
-		secondaryContext.getReferenceContext().reassociateCategory(sac, ab);
+		Ability a = pac.newInstance();
+		a.setName("Abil3");
+		primaryContext.getReferenceContext().importObject(a);
+		Ability b = sac.newInstance();
+		b.setName("Abil3");
+		secondaryContext.getReferenceContext().importObject(b);
+		a = pac.newInstance();
+		a.setName("Abil4");
+		primaryContext.getReferenceContext().importObject(a);
+		b = sac.newInstance();
+		b.setName("Abil4");
+		secondaryContext.getReferenceContext().importObject(b);
 		runRoundRobin("FEAT|VIRTUAL|Abil1|Abil2", "NEWCAT|VIRTUAL|Abil3|Abil4");
 	}
 
@@ -329,12 +334,12 @@ public class AbilityLstTest extends AbstractGlobalTokenTestCase
 		runRoundRobin("FEAT|AUTOMATIC|Improved Critical(%LIST)|PRECLASS:1,Oracle=8");
 	}
 
-	//  
 	private static Ability construct(LoadContext context, String name)
 	{
-		Ability ab = context.getReferenceContext().constructCDOMObject(Ability.class, name);
-		context.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ab);
-		return ab;
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		context.getReferenceContext().importObject(a);
+		return a;
 	}
 
 	@Test

--- a/code/src/utest/plugin/lsttokens/QualifyTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/QualifyTokenTest.java
@@ -17,6 +17,8 @@
  */
 package plugin.lsttokens;
 
+import java.net.URISyntaxException;
+
 import org.junit.Test;
 
 import pcgen.cdom.base.CDOMObject;
@@ -37,6 +39,19 @@ public class QualifyTokenTest extends AbstractGlobalTokenTestCase
 
 	static CDOMPrimaryToken<CDOMObject> token = new QualifyToken();
 	static CDOMTokenLoader<PCTemplate> loader = new CDOMTokenLoader<>();
+
+	@Override
+	public void setUp() throws PersistenceLayerException, URISyntaxException
+	{
+		super.setUp();
+		//Dummy builds to ensure initialization
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName("Dummy");
+		primaryContext.getReferenceContext().importObject(a);
+		a = AbilityCategory.FEAT.newInstance();
+		a.setName("Dummy");
+		secondaryContext.getReferenceContext().importObject(a);
+	}
 
 	@Override
 	public CDOMLoader<PCTemplate> getLoader()
@@ -163,11 +178,12 @@ public class QualifyTokenTest extends AbstractGlobalTokenTestCase
 				AbilityCategory.class, "NEWCAT");
 		AbilityCategory sac = secondaryContext.getReferenceContext().constructCDOMObject(
 				AbilityCategory.class, "NEWCAT");
-		Ability ab = primaryContext.getReferenceContext().constructCDOMObject(Ability.class, "Abil3");
-		primaryContext.getReferenceContext().reassociateCategory(pac, ab);
-		ab = secondaryContext.getReferenceContext().constructCDOMObject(Ability.class,
-				"Abil3");
-		secondaryContext.getReferenceContext().reassociateCategory(sac, ab);
+		Ability a = pac.newInstance();
+		a.setName("Abil3");
+		primaryContext.getReferenceContext().importObject(a);
+		Ability b = sac.newInstance();
+		b.setName("Abil3");
+		secondaryContext.getReferenceContext().importObject(b);
 		runRoundRobin("ABILITY=NEWCAT|Abil3");
 	}
 
@@ -191,11 +207,12 @@ public class QualifyTokenTest extends AbstractGlobalTokenTestCase
 				AbilityCategory.class, "NEWCAT");
 		AbilityCategory sac = secondaryContext.getReferenceContext().constructCDOMObject(
 				AbilityCategory.class, "NEWCAT");
-		Ability ab = primaryContext.getReferenceContext().constructCDOMObject(Ability.class, "Abil3");
-		primaryContext.getReferenceContext().reassociateCategory(pac, ab);
-		ab = secondaryContext.getReferenceContext().constructCDOMObject(Ability.class,
-				"Abil3");
-		secondaryContext.getReferenceContext().reassociateCategory(sac, ab);
+		Ability a = pac.newInstance();
+		a.setName("Abil3");
+		primaryContext.getReferenceContext().importObject(a);
+		Ability b = sac.newInstance();
+		b.setName("Abil3");
+		secondaryContext.getReferenceContext().importObject(b);
 		primaryContext.getReferenceContext().constructCDOMObject(Spell.class,
 				"Lightning Bolt");
 		secondaryContext.getReferenceContext().constructCDOMObject(Spell.class,
@@ -207,12 +224,12 @@ public class QualifyTokenTest extends AbstractGlobalTokenTestCase
 	public void testRoundRobinFeatSpell()
 			throws PersistenceLayerException
 	{
-		Ability a = primaryContext.getReferenceContext().constructCDOMObject(
-				Ability.class, "My Feat");
-		primaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, a);
-		a = secondaryContext.getReferenceContext().constructCDOMObject(Ability.class,
-				"My Feat");
-		secondaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, a);
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName("My Feat");
+		primaryContext.getReferenceContext().importObject(a);
+		Ability b = AbilityCategory.FEAT.newInstance();
+		b.setName("My Feat");
+		secondaryContext.getReferenceContext().importObject(b);
 		primaryContext.getReferenceContext().constructCDOMObject(Spell.class,
 				"Lightning Bolt");
 		secondaryContext.getReferenceContext().constructCDOMObject(Spell.class,

--- a/code/src/utest/plugin/lsttokens/ServesAsTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/ServesAsTokenTest.java
@@ -171,11 +171,12 @@ public class ServesAsTokenTest extends AbstractGlobalTokenTestCase
 				AbilityCategory.class, "NEWCAT");
 		AbilityCategory sac = secondaryContext.getReferenceContext().constructCDOMObject(
 				AbilityCategory.class, "NEWCAT");
-		Ability ab = primaryContext.getReferenceContext().constructCDOMObject(Ability.class, "Abil3");
-		primaryContext.getReferenceContext().reassociateCategory(pac, ab);
-		ab = secondaryContext.getReferenceContext().constructCDOMObject(Ability.class,
-				"Abil3");
-		secondaryContext.getReferenceContext().reassociateCategory(sac, ab);
+		Ability a = pac.newInstance();
+		a.setName("Abil3");
+		primaryContext.getReferenceContext().importObject(a);
+		Ability b = sac.newInstance();
+		b.setName("Abil3");
+		secondaryContext.getReferenceContext().importObject(b);
 		runRoundRobin("ABILITY=NEWCAT|Abil3");
 	}
 

--- a/code/src/utest/plugin/lsttokens/ability/AddspelllevelTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/ability/AddspelllevelTokenTest.java
@@ -19,6 +19,7 @@ package plugin.lsttokens.ability;
 
 import pcgen.cdom.enumeration.IntegerKey;
 import pcgen.core.Ability;
+import pcgen.core.AbilityCategory;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.testsupport.AbstractIntegerTokenTestCase;
@@ -72,4 +73,21 @@ public class AddspelllevelTokenTest extends AbstractIntegerTokenTestCase<Ability
 		return true;
 	}
 
+	@Override
+	protected Ability getSecondary(String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		secondaryContext.getReferenceContext().importObject(a);
+		return a;
+	}
+
+	@Override
+	protected Ability getPrimary(String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		primaryContext.getReferenceContext().importObject(a);
+		return a;
+	}
 }

--- a/code/src/utest/plugin/lsttokens/ability/AspectTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/ability/AspectTokenTest.java
@@ -20,6 +20,7 @@ package plugin.lsttokens.ability;
 import org.junit.Test;
 
 import pcgen.core.Ability;
+import pcgen.core.AbilityCategory;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
@@ -154,5 +155,23 @@ public class AspectTokenTest extends AbstractCDOMTokenTestCase<Ability>
 	protected ConsolidationRule getConsolidationRule()
 	{
 		return ConsolidationRule.SEPARATE;
+	}
+
+	@Override
+	protected Ability getSecondary(String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		secondaryContext.getReferenceContext().importObject(a);
+		return a;
+	}
+
+	@Override
+	protected Ability getPrimary(String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		primaryContext.getReferenceContext().importObject(a);
+		return a;
 	}
 }

--- a/code/src/utest/plugin/lsttokens/ability/BenefitTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/ability/BenefitTokenTest.java
@@ -23,6 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import pcgen.core.Ability;
+import pcgen.core.AbilityCategory;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
@@ -184,5 +185,23 @@ public class BenefitTokenTest extends AbstractCDOMTokenTestCase<Ability>
 	protected ConsolidationRule getConsolidationRule()
 	{
 		return ConsolidationRule.SEPARATE;
+	}
+
+	@Override
+	protected Ability getSecondary(String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		secondaryContext.getReferenceContext().importObject(a);
+		return a;
+	}
+
+	@Override
+	protected Ability getPrimary(String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		primaryContext.getReferenceContext().importObject(a);
+		return a;
 	}
 }

--- a/code/src/utest/plugin/lsttokens/ability/CategoryTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/ability/CategoryTokenTest.java
@@ -73,13 +73,27 @@ public class CategoryTokenTest extends AbstractCDOMTokenTestCase<Ability>
 	@Test
 	public void testRoundRobinFeat() throws PersistenceLayerException
 	{
-		runRoundRobin("FEAT");
+		String str = "FEAT";
+		parse(str);
+		primaryProf.setSourceURI(testCampaign.getURI());
+		String[] unparsed = validateUnparsed(primaryContext, primaryProf, str);
+		parseSecondary(unparsed);
+		// Ensure the objects are the same
+		isCDOMEqual(primaryProf, secondaryProf);
+		validateUnparse(unparsed);
 	}
 
 	@Test
 	public void testRoundRobinMutation() throws PersistenceLayerException
 	{
-		runRoundRobin("Mutation");
+		String str = "Mutation";
+		parse(str);
+		primaryProf.setSourceURI(testCampaign.getURI());
+		String[] unparsed = validateUnparsed(primaryContext, primaryProf, str);
+		parseSecondary(unparsed);
+		// Ensure the objects are the same
+		isCDOMEqual(primaryProf, secondaryProf);
+		validateUnparse(unparsed);
 	}
 
 	@Override
@@ -98,5 +112,23 @@ public class CategoryTokenTest extends AbstractCDOMTokenTestCase<Ability>
 	protected ConsolidationRule getConsolidationRule()
 	{
 		return ConsolidationRule.OVERWRITE;
+	}
+
+	@Override
+	protected Ability getSecondary(String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		secondaryContext.getReferenceContext().importObject(a);
+		return a;
+	}
+
+	@Override
+	protected Ability getPrimary(String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		primaryContext.getReferenceContext().importObject(a);
+		return a;
 	}
 }

--- a/code/src/utest/plugin/lsttokens/ability/CostTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/ability/CostTokenTest.java
@@ -21,6 +21,7 @@ import java.math.BigDecimal;
 
 import pcgen.cdom.enumeration.ObjectKey;
 import pcgen.core.Ability;
+import pcgen.core.AbilityCategory;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.testsupport.AbstractBigDecimalTokenTestCase;
@@ -78,5 +79,23 @@ public class CostTokenTest extends AbstractBigDecimalTokenTestCase<Ability>
 	public boolean isClearLegal()
 	{
 		return false;
+	}
+
+	@Override
+	protected Ability getSecondary(String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		secondaryContext.getReferenceContext().importObject(a);
+		return a;
+	}
+
+	@Override
+	protected Ability getPrimary(String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		primaryContext.getReferenceContext().importObject(a);
+		return a;
 	}
 }

--- a/code/src/utest/plugin/lsttokens/ability/MultTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/ability/MultTokenTest.java
@@ -19,6 +19,7 @@ package plugin.lsttokens.ability;
 
 import pcgen.cdom.enumeration.ObjectKey;
 import pcgen.core.Ability;
+import pcgen.core.AbilityCategory;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.testsupport.AbstractYesNoTokenTestCase;
@@ -54,4 +55,21 @@ public class MultTokenTest extends AbstractYesNoTokenTestCase<Ability>
 		return ObjectKey.MULTIPLE_ALLOWED;
 	}
 
+	@Override
+	protected Ability getSecondary(String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		secondaryContext.getReferenceContext().importObject(a);
+		return a;
+	}
+
+	@Override
+	protected Ability getPrimary(String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		primaryContext.getReferenceContext().importObject(a);
+		return a;
+	}
 }

--- a/code/src/utest/plugin/lsttokens/ability/StackTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/ability/StackTokenTest.java
@@ -19,6 +19,7 @@ package plugin.lsttokens.ability;
 
 import pcgen.cdom.enumeration.ObjectKey;
 import pcgen.core.Ability;
+import pcgen.core.AbilityCategory;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.testsupport.AbstractYesNoTokenTestCase;
@@ -54,4 +55,21 @@ public class StackTokenTest extends AbstractYesNoTokenTestCase<Ability>
 		return ObjectKey.STACKS;
 	}
 
+	@Override
+	protected Ability getSecondary(String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		secondaryContext.getReferenceContext().importObject(a);
+		return a;
+	}
+
+	@Override
+	protected Ability getPrimary(String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		primaryContext.getReferenceContext().importObject(a);
+		return a;
+	}
 }

--- a/code/src/utest/plugin/lsttokens/ability/VisibleTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/ability/VisibleTokenTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 
 import pcgen.cdom.enumeration.ObjectKey;
 import pcgen.core.Ability;
+import pcgen.core.AbilityCategory;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
@@ -194,4 +195,24 @@ public class VisibleTokenTest extends AbstractCDOMTokenTestCase<Ability>
 			//Yep!
 		}
 	}
+
+	@Override
+	protected Ability getSecondary(String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		secondaryContext.getReferenceContext().importObject(a);
+		return a;
+	}
+
+	@Override
+	protected Ability getPrimary(String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		primaryContext.getReferenceContext().importObject(a);
+		return a;
+	}
+	
+	
 }

--- a/code/src/utest/plugin/lsttokens/add/AbilityTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/add/AbilityTokenTest.java
@@ -64,6 +64,8 @@ public class AbilityTokenTest extends AbstractCDOMTokenTestCase<CDOMObject>
 	{
 		super.setUp();
 		TokenRegistration.register(getSubToken());
+		construct(primaryContext, "Dummy");
+		construct(secondaryContext, "Dummy");
 	}
 
 	@Override
@@ -111,9 +113,10 @@ public class AbilityTokenTest extends AbstractCDOMTokenTestCase<CDOMObject>
 
 	protected CDOMObject construct(LoadContext loadContext, String one)
 	{
-		Ability obj = loadContext.getReferenceContext().constructCDOMObject(Ability.class, one);
-		loadContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, obj);
-		return obj;
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(one);
+		loadContext.getReferenceContext().importObject(a);
+		return a;
 	}
 
 	public String getSubTokenName()
@@ -828,10 +831,10 @@ public class AbilityTokenTest extends AbstractCDOMTokenTestCase<CDOMObject>
 	private List<CDOMReference<Ability>> createSingle(String name)
 	{
 		List<CDOMReference<Ability>> refs = new ArrayList<>();
-		Ability obj = primaryContext.getReferenceContext().constructCDOMObject(Ability.class,
-				name);
-		primaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, obj);
-		CDOMDirectSingleRef<Ability> ar = CDOMDirectSingleRef.getRef(obj);
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		primaryContext.getReferenceContext().importObject(a);
+		CDOMDirectSingleRef<Ability> ar = CDOMDirectSingleRef.getRef(a);
 		refs.add(ar);
 		if (name.indexOf('(') != -1)
 		{
@@ -847,8 +850,9 @@ public class AbilityTokenTest extends AbstractCDOMTokenTestCase<CDOMObject>
 	public void testUnparseType() throws PersistenceLayerException
 	{
 		List<CDOMReference<Ability>> refs = new ArrayList<>();
-		CDOMGroupRef<Ability> ref = primaryContext.getReferenceContext().getCDOMTypeReference(
-				Ability.class, AbilityCategory.FEAT, "Foo", "Bar");
+		CDOMGroupRef<Ability> ref = primaryContext.getReferenceContext()
+			.getManufacturerId(AbilityCategory.FEAT)
+			.getTypeReference(new String[]{"Foo", "Bar"});
 		refs.add(ref);
 
 		createTC(refs, FormulaFactory.ONE);
@@ -916,8 +920,8 @@ public class AbilityTokenTest extends AbstractCDOMTokenTestCase<CDOMObject>
 		if (isAllLegal())
 		{
 			List<CDOMReference<Ability>> refs = createSingle("TestWP1");
-			CDOMGroupRef<Ability> ref = primaryContext.getReferenceContext().getCDOMAllReference(
-					Ability.class, AbilityCategory.FEAT);
+			CDOMGroupRef<Ability> ref = primaryContext.getReferenceContext()
+				.getManufacturerId(AbilityCategory.FEAT).getAllReference();
 			refs.add(ref);
 			createTC(refs, FormulaFactory.ONE);
 			assertBadUnparse();
@@ -930,8 +934,8 @@ public class AbilityTokenTest extends AbstractCDOMTokenTestCase<CDOMObject>
 		if (isAllLegal())
 		{
 			List<CDOMReference<Ability>> refs = new ArrayList<>();
-			CDOMGroupRef<Ability> ref = primaryContext.getReferenceContext().getCDOMAllReference(
-					Ability.class, AbilityCategory.FEAT);
+			CDOMGroupRef<Ability> ref = primaryContext.getReferenceContext()
+				.getManufacturerId(AbilityCategory.FEAT).getAllReference();
 			refs.add(ref);
 			createTC(refs, FormulaFactory.ONE);
 			String[] unparsed = getToken().unparse(primaryContext, primaryProf);
@@ -946,11 +950,11 @@ public class AbilityTokenTest extends AbstractCDOMTokenTestCase<CDOMObject>
 		{
 			List<CDOMReference<Ability>> refs = new ArrayList<>();
 			CDOMGroupRef<Ability> ref = primaryContext.getReferenceContext()
-					.getCDOMTypeReference(Ability.class, AbilityCategory.FEAT,
-							"Foo", "Bar");
+				.getManufacturerId(AbilityCategory.FEAT)
+				.getTypeReference(new String[]{"Foo", "Bar"});
 			refs.add(ref);
-			ref = primaryContext.getReferenceContext().getCDOMAllReference(Ability.class,
-					AbilityCategory.FEAT);
+			ref = primaryContext.getReferenceContext()
+				.getManufacturerId(AbilityCategory.FEAT).getAllReference();
 			refs.add(ref);
 			createTC(refs, FormulaFactory.ONE);
 			assertBadUnparse();

--- a/code/src/utest/plugin/lsttokens/campaign/ForwardrefTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/campaign/ForwardrefTokenTest.java
@@ -17,6 +17,8 @@
  */
 package plugin.lsttokens.campaign;
 
+import java.net.URISyntaxException;
+
 import org.junit.Test;
 
 import pcgen.core.Ability;
@@ -35,6 +37,19 @@ public class ForwardrefTokenTest extends AbstractCDOMTokenTestCase<Campaign>
 
 	static CDOMPrimaryToken<Campaign> token = new ForwardRefToken();
 	static CDOMTokenLoader<Campaign> loader = new CDOMTokenLoader<>();
+
+	@Override
+	public void setUp() throws PersistenceLayerException, URISyntaxException
+	{
+		super.setUp();
+		//Dummy items to ensure Category is initialized
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName("Dummy");
+		primaryContext.getReferenceContext().importObject(a);
+		Ability b = AbilityCategory.FEAT.newInstance();
+		b.setName("Dummy");
+		secondaryContext.getReferenceContext().importObject(b);
+	}
 
 	@Override
 	public CDOMLoader<Campaign> getLoader()
@@ -159,10 +174,12 @@ public class ForwardrefTokenTest extends AbstractCDOMTokenTestCase<Campaign>
 	{
 		AbilityCategory newCatp = primaryContext.getReferenceContext().constructCDOMObject(AbilityCategory.class, "NEWCAT");
 		AbilityCategory newCats = secondaryContext.getReferenceContext().constructCDOMObject(AbilityCategory.class, "NEWCAT");
-		Ability a = primaryContext.getReferenceContext().constructCDOMObject(Ability.class, "Abil3");
-		primaryContext.getReferenceContext().reassociateCategory(newCatp, a);
-		Ability b = secondaryContext.getReferenceContext().constructCDOMObject(Ability.class, "Abil3");
-		secondaryContext.getReferenceContext().reassociateCategory(newCats, b);
+		Ability a = newCatp.newInstance();
+		a.setName("Abil3");
+		primaryContext.getReferenceContext().importObject(a);
+		Ability b = newCats.newInstance();
+		b.setName("Abil3");
+		secondaryContext.getReferenceContext().importObject(b);
 		runRoundRobin("ABILITY=NEWCAT|Abil3");
 	}
 
@@ -184,10 +201,12 @@ public class ForwardrefTokenTest extends AbstractCDOMTokenTestCase<Campaign>
 		secondaryContext.getReferenceContext().constructCDOMObject(Spell.class, "Lightning Bolt");
 		AbilityCategory newCatp = primaryContext.getReferenceContext().constructCDOMObject(AbilityCategory.class, "NEWCAT");
 		AbilityCategory newCats = secondaryContext.getReferenceContext().constructCDOMObject(AbilityCategory.class, "NEWCAT");
-		Ability a = primaryContext.getReferenceContext().constructCDOMObject(Ability.class, "Abil3");
-		primaryContext.getReferenceContext().reassociateCategory(newCatp, a);
-		Ability b = secondaryContext.getReferenceContext().constructCDOMObject(Ability.class, "Abil3");
-		secondaryContext.getReferenceContext().reassociateCategory(newCats, b);
+		Ability a = newCatp.newInstance();
+		a.setName("Abil3");
+		primaryContext.getReferenceContext().importObject(a);
+		Ability b = newCats.newInstance();
+		b.setName("Abil3");
+		secondaryContext.getReferenceContext().importObject(b);
 		runRoundRobin("ABILITY=NEWCAT|Abil3", "SPELL|Lightning Bolt");
 	}
 
@@ -197,11 +216,13 @@ public class ForwardrefTokenTest extends AbstractCDOMTokenTestCase<Campaign>
 	{
 		primaryContext.getReferenceContext().constructCDOMObject(Spell.class, "Lightning Bolt");
 		secondaryContext.getReferenceContext().constructCDOMObject(Spell.class, "Lightning Bolt");
-		Ability a = primaryContext.getReferenceContext().constructCDOMObject(Ability.class, "My Feat");
-		primaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, a);
-		Ability b = secondaryContext.getReferenceContext().constructCDOMObject(Ability.class, "My Feat");
-		secondaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, b);
-		runRoundRobin("FEAT|My Feat", "SPELL|Lightning Bolt");
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName("My Feat");
+		primaryContext.getReferenceContext().importObject(a);
+		Ability b = AbilityCategory.FEAT.newInstance();
+		b.setName("My Feat");
+		secondaryContext.getReferenceContext().importObject(b);
+		runRoundRobin("ABILITY=FEAT|My Feat", "SPELL|Lightning Bolt");
 	}
 
 	@Override

--- a/code/src/utest/plugin/lsttokens/campaign/ForwardrefTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/campaign/ForwardrefTokenTest.java
@@ -222,7 +222,7 @@ public class ForwardrefTokenTest extends AbstractCDOMTokenTestCase<Campaign>
 		Ability b = AbilityCategory.FEAT.newInstance();
 		b.setName("My Feat");
 		secondaryContext.getReferenceContext().importObject(b);
-		runRoundRobin("ABILITY=FEAT|My Feat", "SPELL|Lightning Bolt");
+		runRoundRobin("FEAT|My Feat", "SPELL|Lightning Bolt");
 	}
 
 	@Override

--- a/code/src/utest/plugin/lsttokens/choose/AbilitySelectionTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/choose/AbilitySelectionTokenTest.java
@@ -48,7 +48,9 @@ public class AbilitySelectionTokenTest extends
 			"Special Ability");
 		secondaryContext.getReferenceContext().constructCDOMObject(AbilityCategory.class,
 			"Special Ability");
-
+		//Build dummy objects so the ReferenceContext is properly initialized
+		construct(primaryContext, "Dummy");
+		construct(secondaryContext, "Dummy");
 	}
 
 	static ChooseLst token = new ChooseLst();
@@ -106,12 +108,13 @@ public class AbilitySelectionTokenTest extends
 	@Override
 	protected Loadable construct(LoadContext loadContext, String one)
 	{
-		Ability obj = loadContext.getReferenceContext().constructCDOMObject(Ability.class, one);
-		Category<Ability> cat = loadContext.getReferenceContext()
+		AbilityCategory cat = loadContext.getReferenceContext()
 				.silentlyGetConstructedCDOMObject(AbilityCategory.class,
 						"Special Ability");
-		loadContext.getReferenceContext().reassociateCategory(cat, obj);
-		return obj;
+		Ability a = cat.newInstance();
+		a.setName(one);
+		loadContext.getReferenceContext().importObject(a);
+		return a;
 	}
 
 	@Override
@@ -120,7 +123,7 @@ public class AbilitySelectionTokenTest extends
 		Category<Ability> cat = primaryContext.getReferenceContext()
 				.silentlyGetConstructedCDOMObject(AbilityCategory.class,
 						"Special Ability");
-		return primaryContext.getReferenceContext().getManufacturer(getTargetClass(), cat);
+		return primaryContext.getReferenceContext().getManufacturerId(cat);
 	}
 
 	@Override
@@ -145,5 +148,23 @@ public class AbilitySelectionTokenTest extends
 	public void testUnparseLegal() throws PersistenceLayerException
 	{
 		//Hard to get correct - doesn't assume Category :(
+	}
+
+	@Override
+	protected Ability getSecondary(String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		secondaryContext.getReferenceContext().importObject(a);
+		return a;
+	}
+
+	@Override
+	protected Ability getPrimary(String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		primaryContext.getReferenceContext().importObject(a);
+		return a;
 	}
 }

--- a/code/src/utest/plugin/lsttokens/choose/AbilityTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/choose/AbilityTokenTest.java
@@ -54,6 +54,9 @@ public class AbilityTokenTest extends
 				"Special Ability");
 		secondaryContext.getReferenceContext().constructCDOMObject(AbilityCategory.class,
 				"Special Ability");
+		//We build dummy objects so that AbilityCategory.FEAT has been loaded properly
+		construct(primaryContext, "Dummy");
+		construct(secondaryContext, "Dummy");
 	}
 
 	@Override
@@ -107,12 +110,13 @@ public class AbilityTokenTest extends
 	@Override
 	protected Loadable construct(LoadContext loadContext, String one)
 	{
-		Ability obj = loadContext.getReferenceContext().constructCDOMObject(Ability.class, one);
-		Category<Ability> cat = loadContext.getReferenceContext()
+		AbilityCategory cat = loadContext.getReferenceContext()
 				.silentlyGetConstructedCDOMObject(AbilityCategory.class,
 						"Special Ability");
-		loadContext.getReferenceContext().reassociateCategory(cat, obj);
-		return obj;
+		Ability a = cat.newInstance();
+		a.setName(one);
+		loadContext.getReferenceContext().importObject(a);
+		return a;
 	}
 
 	@Override
@@ -121,7 +125,7 @@ public class AbilityTokenTest extends
 		Category<Ability> cat = primaryContext.getReferenceContext()
 				.silentlyGetConstructedCDOMObject(AbilityCategory.class,
 						"Special Ability");
-		return primaryContext.getReferenceContext().getManufacturer(getTargetClass(), cat);
+		return primaryContext.getReferenceContext().getManufacturerId(cat);
 	}
 
 	@Override
@@ -153,6 +157,24 @@ public class AbilityTokenTest extends
 	{
 		assertFalse(parse("ABILITY|BadCat|TYPE=Foo"));
 		assertNoSideEffects();
+	}
+
+	@Override
+	protected Ability getSecondary(String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		secondaryContext.getReferenceContext().importObject(a);
+		return a;
+	}
+
+	@Override
+	protected Ability getPrimary(String name)
+	{
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(name);
+		primaryContext.getReferenceContext().importObject(a);
+		return a;
 	}
 }
 

--- a/code/src/utest/plugin/lsttokens/choose/SchoolsTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/choose/SchoolsTokenTest.java
@@ -99,14 +99,12 @@ public class SchoolsTokenTest extends AbstractChooseTokenTestCase
 	{
 		construct(primaryContext, "Abjuration");
 		construct(secondaryContext, "Abjuration");
-		Ability ss =
-				primaryContext.getReferenceContext().constructCDOMObject(Ability.class,
-					"School Stuff");
-		primaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ss);
-		ss =
-				secondaryContext.getReferenceContext().constructCDOMObject(Ability.class,
-					"School Stuff");
-		secondaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ss);
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName("School Stuff");
+		primaryContext.getReferenceContext().importObject(a);
+		Ability b = AbilityCategory.FEAT.newInstance();
+		b.setName("School Stuff");
+		secondaryContext.getReferenceContext().importObject(b);
 		runRoundRobin("SCHOOLS|ABILITY=FEAT[School Stuff]");
 	}
 

--- a/code/src/utest/plugin/lsttokens/kit/ability/AbilityTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/kit/ability/AbilityTokenTest.java
@@ -17,6 +17,8 @@
  */
 package plugin.lsttokens.kit.ability;
 
+import java.net.URISyntaxException;
+
 import org.junit.Test;
 
 import pcgen.cdom.enumeration.ListKey;
@@ -35,6 +37,18 @@ public class AbilityTokenTest extends AbstractKitTokenTestCase<KitAbilities>
 	static AbilityToken token = new AbilityToken();
 	static CDOMSubLineLoader<KitAbilities> loader = new CDOMSubLineLoader<>(
 			"SKILL", KitAbilities.class);
+
+	@Override
+	public void setUp() throws PersistenceLayerException, URISyntaxException
+	{
+		super.setUp();
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName("Dummy");
+		primaryContext.getReferenceContext().importObject(a);
+		Ability b = AbilityCategory.FEAT.newInstance();
+		b.setName("Dummy");
+		secondaryContext.getReferenceContext().importObject(b);
+	}
 
 	@Override
 	public Class<KitAbilities> getCDOMClass()
@@ -64,42 +78,44 @@ public class AbilityTokenTest extends AbstractKitTokenTestCase<KitAbilities>
 	@Test
 	public void testRoundRobinSimple() throws PersistenceLayerException
 	{
-		Ability ab = primaryContext.getReferenceContext().constructCDOMObject(Ability.class,
-				"Fireball");
-		primaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ab);
-		ab = secondaryContext.getReferenceContext()
-				.constructCDOMObject(Ability.class, "Fireball");
-		secondaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ab);
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName("Fireball");
+		primaryContext.getReferenceContext().importObject(a);
+		Ability b = AbilityCategory.FEAT.newInstance();
+		b.setName("Fireball");
+		secondaryContext.getReferenceContext().importObject(b);
 		runRoundRobin("CATEGORY=FEAT|Fireball");
 	}
 
 	@Test
 	public void testRoundRobinType() throws PersistenceLayerException
 	{
-		Ability ab = primaryContext.getReferenceContext().constructCDOMObject(Ability.class,
-				"Fireball");
-		primaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ab);
-		ab.addToListFor(ListKey.TYPE, Type.getConstant("Test"));
-		ab = secondaryContext.getReferenceContext()
-				.constructCDOMObject(Ability.class, "Fireball");
-		secondaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ab);
-		ab.addToListFor(ListKey.TYPE, Type.getConstant("Test"));
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName("Fireball");
+		a.addToListFor(ListKey.TYPE, Type.getConstant("Test"));
+		primaryContext.getReferenceContext().importObject(a);
+		Ability b = AbilityCategory.FEAT.newInstance();
+		b.setName("Fireball");
+		b.addToListFor(ListKey.TYPE, Type.getConstant("Test"));
+		secondaryContext.getReferenceContext().importObject(b);
 		runRoundRobin("CATEGORY=FEAT|TYPE=Test");
 	}
 
 	@Test
 	public void testRoundRobinTwo() throws PersistenceLayerException
 	{
-		Ability ab = primaryContext.getReferenceContext().constructCDOMObject(Ability.class,
-				"Fireball");
-		primaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ab);
-		ab = secondaryContext.getReferenceContext()
-				.constructCDOMObject(Ability.class, "Fireball");
-		secondaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ab);
-		ab = primaryContext.getReferenceContext().constructCDOMObject(Ability.class, "English");
-		primaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ab);
-		ab = secondaryContext.getReferenceContext().constructCDOMObject(Ability.class, "English");
-		secondaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ab);
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName("Fireball");
+		primaryContext.getReferenceContext().importObject(a);
+		Ability b = AbilityCategory.FEAT.newInstance();
+		b.setName("Fireball");
+		secondaryContext.getReferenceContext().importObject(b);
+		a = AbilityCategory.FEAT.newInstance();
+		a.setName("English");
+		primaryContext.getReferenceContext().importObject(a);
+		b = AbilityCategory.FEAT.newInstance();
+		b.setName("English");
+		secondaryContext.getReferenceContext().importObject(b);
 		runRoundRobin("CATEGORY=FEAT|English" + getJoinCharacter() + "Fireball");
 	}
 

--- a/code/src/utest/plugin/lsttokens/kit/clazz/SubClassTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/kit/clazz/SubClassTokenTest.java
@@ -78,14 +78,18 @@ public class SubClassTokenTest extends AbstractKitTokenTestCase<KitClass>
 	public void testInvalidInputOnlyOne() throws PersistenceLayerException
 	{
 		SubClassCategory cat = SubClassCategory.getConstant("Wizard");
-		SubClass sc = primaryContext.getReferenceContext().constructCDOMObject(SubClass.class, "Fireball");
-		primaryContext.getReferenceContext().reassociateCategory(cat, sc);
-		sc = secondaryContext.getReferenceContext().constructCDOMObject(SubClass.class, "Fireball");
-		secondaryContext.getReferenceContext().reassociateCategory(cat, sc);
-		sc = primaryContext.getReferenceContext().constructCDOMObject(SubClass.class, "English");
-		primaryContext.getReferenceContext().reassociateCategory(cat, sc);
-		sc = secondaryContext.getReferenceContext().constructCDOMObject(SubClass.class, "English");
-		secondaryContext.getReferenceContext().reassociateCategory(cat, sc);
+		SubClass obj = cat.newInstance();
+		obj.setKeyName("Fireball");
+		primaryContext.getReferenceContext().importObject(obj);
+		obj = cat.newInstance();
+		obj.setKeyName("Fireball");
+		secondaryContext.getReferenceContext().importObject(obj);
+		obj = cat.newInstance();
+		obj.setKeyName("English");
+		primaryContext.getReferenceContext().importObject(obj);
+		obj = cat.newInstance();
+		obj.setKeyName("English");
+		secondaryContext.getReferenceContext().importObject(obj);
 		assertTrue(parse("Fireball,English"));
 		assertConstructionError();
 	}
@@ -94,10 +98,12 @@ public class SubClassTokenTest extends AbstractKitTokenTestCase<KitClass>
 	public void testRoundRobinSimple() throws PersistenceLayerException
 	{
 		SubClassCategory cat = SubClassCategory.getConstant("Wizard");
-		SubClass sc = primaryContext.getReferenceContext().constructCDOMObject(SubClass.class, "Fireball");
-		primaryContext.getReferenceContext().reassociateCategory(cat, sc);
-		sc = secondaryContext.getReferenceContext().constructCDOMObject(SubClass.class, "Fireball");
-		secondaryContext.getReferenceContext().reassociateCategory(cat, sc);
+		SubClass obj = cat.newInstance();
+		obj.setKeyName("Fireball");
+		primaryContext.getReferenceContext().importObject(obj);
+		obj = cat.newInstance();
+		obj.setKeyName("Fireball");
+		secondaryContext.getReferenceContext().importObject(obj);
 		runRoundRobin("Fireball");
 	}
 }

--- a/code/src/utest/plugin/lsttokens/kit/spells/SpellsTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/kit/spells/SpellsTokenTest.java
@@ -136,10 +136,12 @@ public class SpellsTokenTest extends AbstractKitTokenTestCase<KitSpells>
 		secondaryContext.getReferenceContext().constructCDOMObject(Spell.class, "Fireball");
 		primaryContext.getReferenceContext().constructCDOMObject(PCClass.class, "Wizard");
 		secondaryContext.getReferenceContext().constructCDOMObject(PCClass.class, "Wizard");
-		Ability ab = primaryContext.getReferenceContext().constructCDOMObject(Ability.class, "EnhancedFeat");
-		primaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ab);
-		ab = secondaryContext.getReferenceContext().constructCDOMObject(Ability.class, "EnhancedFeat");
-		secondaryContext.getReferenceContext().reassociateCategory(AbilityCategory.FEAT, ab);
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName("EnhancedFeat");
+		primaryContext.getReferenceContext().importObject(a);
+		a = AbilityCategory.FEAT.newInstance();
+		a.setName("EnhancedFeat");
+		secondaryContext.getReferenceContext().importObject(a);
 		runRoundRobin("SPELLBOOK=Personal|CLASS=Wizard|Fireball[EnhancedFeat]=2");
 	}
 

--- a/code/src/utest/plugin/lsttokens/race/FavoredClassTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/race/FavoredClassTokenTest.java
@@ -139,26 +139,11 @@ public class FavoredClassTokenTest extends
 	{
 		construct(primaryContext, "TestWP1");
 		assertTrue(parse("TestWP1.Two"));
-		SubClass obj = primaryContext.getReferenceContext().constructCDOMObject(SubClass.class,
-				"Two");
 		SubClassCategory cat = SubClassCategory.getConstant("TestWP2");
-		primaryContext.getReferenceContext().reassociateCategory(cat, obj);
+		SubClass obj = cat.newInstance();
+		obj.setName("Two");
+		primaryContext.getReferenceContext().importObject(obj);
 		assertConstructionError();
-	}
-
-	@Test
-	public void testCategorizationPass() throws PersistenceLayerException
-	{
-		construct(primaryContext, "TestWP1");
-		assertTrue(parse("TestWP1.Two"));
-		SubClass obj = primaryContext.getReferenceContext().constructCDOMObject(SubClass.class,
-				"Two");
-		SubClassCategory cat = SubClassCategory.getConstant("TestWP2");
-		primaryContext.getReferenceContext().reassociateCategory(cat, obj);
-		obj = primaryContext.getReferenceContext().constructCDOMObject(SubClass.class, "Two");
-		cat = SubClassCategory.getConstant("TestWP1");
-		primaryContext.getReferenceContext().reassociateCategory(cat, obj);
-		assertCleanConstruction();
 	}
 
 	@Test
@@ -170,12 +155,13 @@ public class FavoredClassTokenTest extends
 		construct(secondaryContext, "TestWP1");
 		construct(secondaryContext, "TestWP2");
 		construct(secondaryContext, "TestWP3");
-		SubClass obj = primaryContext.getReferenceContext().constructCDOMObject(SubClass.class,
-				"Sub");
 		SubClassCategory cat = SubClassCategory.getConstant("TestWP2");
-		primaryContext.getReferenceContext().reassociateCategory(cat, obj);
-		obj = secondaryContext.getReferenceContext().constructCDOMObject(SubClass.class, "Sub");
-		secondaryContext.getReferenceContext().reassociateCategory(cat, obj);
+		SubClass obj = cat.newInstance();
+		obj.setName("Sub");
+		primaryContext.getReferenceContext().importObject(obj);
+		obj = cat.newInstance();
+		obj.setName("Sub");
+		secondaryContext.getReferenceContext().importObject(obj);
 		runRoundRobin("TestWP1" + getJoinCharacter() + "TestWP2.Sub"
 				+ getJoinCharacter() + "TestWP3");
 	}

--- a/code/src/utest/plugin/lsttokens/subclass/ChoiceTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/subclass/ChoiceTokenTest.java
@@ -20,6 +20,7 @@ package plugin.lsttokens.subclass;
 import org.junit.Test;
 
 import pcgen.cdom.enumeration.ObjectKey;
+import pcgen.cdom.enumeration.SubClassCategory;
 import pcgen.core.SpellProhibitor;
 import pcgen.core.SubClass;
 import pcgen.persistence.PersistenceLayerException;
@@ -221,5 +222,25 @@ public class ChoiceTokenTest extends AbstractCDOMTokenTestCase<SubClass>
 	protected ConsolidationRule getConsolidationRule()
 	{
 		return ConsolidationRule.OVERWRITE;
+	}
+
+	@Override
+	protected SubClass getSecondary(String name)
+	{
+		SubClassCategory scc = SubClassCategory.getConstant("SCC");
+		SubClass sc = scc.newInstance();
+		sc.setName(name);
+		secondaryContext.getReferenceContext().importObject(sc);
+		return sc;
+	}
+
+	@Override
+	protected SubClass getPrimary(String name)
+	{
+		SubClassCategory scc = SubClassCategory.getConstant("SCC");
+		SubClass sc = scc.newInstance();
+		sc.setName(name);
+		primaryContext.getReferenceContext().importObject(sc);
+		return sc;
 	}
 }

--- a/code/src/utest/plugin/lsttokens/subclass/CostTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/subclass/CostTokenTest.java
@@ -18,6 +18,7 @@
 package plugin.lsttokens.subclass;
 
 import pcgen.cdom.enumeration.IntegerKey;
+import pcgen.cdom.enumeration.SubClassCategory;
 import pcgen.core.SubClass;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
@@ -70,5 +71,25 @@ public class CostTokenTest extends AbstractIntegerTokenTestCase<SubClass>
 	public boolean isPositiveAllowed()
 	{
 		return true;
+	}
+
+	@Override
+	protected SubClass getSecondary(String name)
+	{
+		SubClassCategory scc = SubClassCategory.getConstant("SCC");
+		SubClass sc = scc.newInstance();
+		sc.setName(name);
+		secondaryContext.getReferenceContext().importObject(sc);
+		return sc;
+	}
+
+	@Override
+	protected SubClass getPrimary(String name)
+	{
+		SubClassCategory scc = SubClassCategory.getConstant("SCC");
+		SubClass sc = scc.newInstance();
+		sc.setName(name);
+		primaryContext.getReferenceContext().importObject(sc);
+		return sc;
 	}
 }

--- a/code/src/utest/plugin/lsttokens/subclass/ProhibitcostTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/subclass/ProhibitcostTokenTest.java
@@ -18,6 +18,7 @@
 package plugin.lsttokens.subclass;
 
 import pcgen.cdom.enumeration.IntegerKey;
+import pcgen.cdom.enumeration.SubClassCategory;
 import pcgen.core.SubClass;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
@@ -71,5 +72,25 @@ public class ProhibitcostTokenTest extends
 	public boolean isPositiveAllowed()
 	{
 		return true;
+	}
+
+	@Override
+	protected SubClass getSecondary(String name)
+	{
+		SubClassCategory scc = SubClassCategory.getConstant("SCC");
+		SubClass sc = scc.newInstance();
+		sc.setName(name);
+		secondaryContext.getReferenceContext().importObject(sc);
+		return sc;
+	}
+
+	@Override
+	protected SubClass getPrimary(String name)
+	{
+		SubClassCategory scc = SubClassCategory.getConstant("SCC");
+		SubClass sc = scc.newInstance();
+		sc.setName(name);
+		primaryContext.getReferenceContext().importObject(sc);
+		return sc;
 	}
 }

--- a/code/src/utest/plugin/lsttokens/template/FavoredClassTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/template/FavoredClassTokenTest.java
@@ -126,10 +126,10 @@ public class FavoredClassTokenTest extends
 	{
 		construct(primaryContext, "TestWP1");
 		assertTrue(parse("TestWP1.Two"));
-		SubClass obj = primaryContext.getReferenceContext().constructCDOMObject(SubClass.class,
-				"Two");
 		SubClassCategory cat = SubClassCategory.getConstant("TestWP2");
-		primaryContext.getReferenceContext().reassociateCategory(cat, obj);
+		SubClass obj = cat.newInstance();
+		obj.setKeyName("Two");
+		primaryContext.getReferenceContext().importObject(obj);
 		assertConstructionError();
 	}
 
@@ -138,13 +138,14 @@ public class FavoredClassTokenTest extends
 	{
 		construct(primaryContext, "TestWP1");
 		assertTrue(parse("TestWP1.Two"));
-		SubClass obj = primaryContext.getReferenceContext().constructCDOMObject(SubClass.class,
-				"Two");
 		SubClassCategory cat = SubClassCategory.getConstant("TestWP2");
-		primaryContext.getReferenceContext().reassociateCategory(cat, obj);
-		obj = primaryContext.getReferenceContext().constructCDOMObject(SubClass.class, "Two");
+		SubClass obj = cat.newInstance();
+		obj.setKeyName("Two");
+		primaryContext.getReferenceContext().importObject(obj);
 		cat = SubClassCategory.getConstant("TestWP1");
-		primaryContext.getReferenceContext().reassociateCategory(cat, obj);
+		obj = cat.newInstance();
+		obj.setKeyName("Two");
+		primaryContext.getReferenceContext().importObject(obj);
 		assertCleanConstruction();
 	}
 
@@ -157,12 +158,13 @@ public class FavoredClassTokenTest extends
 		construct(secondaryContext, "TestWP1");
 		construct(secondaryContext, "TestWP2");
 		construct(secondaryContext, "TestWP3");
-		SubClass obj = primaryContext.getReferenceContext().constructCDOMObject(SubClass.class,
-				"Sub");
 		SubClassCategory cat = SubClassCategory.getConstant("TestWP2");
-		primaryContext.getReferenceContext().reassociateCategory(cat, obj);
-		obj = secondaryContext.getReferenceContext().constructCDOMObject(SubClass.class, "Sub");
-		secondaryContext.getReferenceContext().reassociateCategory(cat, obj);
+		SubClass obj = cat.newInstance();
+		obj.setKeyName("Sub");
+		primaryContext.getReferenceContext().importObject(obj);
+		obj = cat.newInstance();
+		obj.setKeyName("Sub");
+		secondaryContext.getReferenceContext().importObject(obj);
 		runRoundRobin("TestWP1" + getJoinCharacter() + "TestWP2.Sub"
 				+ getJoinCharacter() + "TestWP3");
 	}

--- a/code/src/utest/plugin/qualifier/ability/PCQualifierTokenTest.java
+++ b/code/src/utest/plugin/qualifier/ability/PCQualifierTokenTest.java
@@ -46,6 +46,9 @@ public class PCQualifierTokenTest extends
 	{
 		super.setUp();
 		TokenRegistration.register(PC_TOKEN);
+		//Dummy to ensure initialization
+		construct(primaryContext, "Dummy");
+		construct(secondaryContext, "Dummy");
 	}
 
 	@Override
@@ -90,9 +93,9 @@ public class PCQualifierTokenTest extends
 	@Override
 	protected CDOMObject construct(LoadContext loadContext, String one)
 	{
-		Ability a = (Ability) super.construct(loadContext, one);
-		loadContext.getReferenceContext().reassociateCategory(
-			AbilityCategory.FEAT, a);
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(one);
+		loadContext.getReferenceContext().importObject(a);
 		return a;
 	}
 
@@ -100,10 +103,9 @@ public class PCQualifierTokenTest extends
 	protected CDOMObject construct(LoadContext loadContext,
 		Class<? extends CDOMObject> cl, String one)
 	{
-		Ability a = (Ability) super.construct(loadContext, cl, one);
-		loadContext.getReferenceContext().reassociateCategory(
-			AbilityCategory.FEAT, a);
+		Ability a = AbilityCategory.FEAT.newInstance();
+		a.setName(one);
+		loadContext.getReferenceContext().importObject(a);
 		return a;
 	}
-
 }


### PR DESCRIPTION
Going forward, the process for creating objects like Abilities will be changed to have a Category at construction.  (Reassociation of a category will be prohibited to help optimize how the ClassIdentity/Context system works)

In effect, that will have wide-ranging effects across the test infrastructure and test classes.  This pulls the vast majority of those test changes (and two small changes to the main files) into a separate PR.  This demonstrates that the tests haven't changed function/behavior with current code and prepares for cleaner PRs going forward that will be concentrated on the main part of the code repository and not diluted with lots of test changes.
