### PR TITLE
This fixes a problem with .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,11 +5,11 @@ batch-convert.jar
 plugins/*.jar
 plugins/*plugins/
 
-bin/
-code/bin/
-code/build/
-code/comp-manifest
-code/manifest
+/bin/
+/code/bin/
+/code/build/
+/code/comp-manifest
+/code/manifest
 
 hs_err_*.log
 checkstyle-cachefile
@@ -28,10 +28,10 @@ pcgen.log
 pcgen.log.*
 pcgen_low_mem.bat
 
-output/
-build/
-libs/
-code/testsuite/output/
+/output/
+/build/
+/libs/
+/code/testsuite/output/
 .gradle/
 pcgen-batch-convert.jar
 /.metadata
@@ -43,7 +43,7 @@ pcgen-batch-convert.jar
 
 .idea/
 
-data/customsources/*
+/data/customsources/*
 !data/customsources/readme-customsources.txt
 /.nb-gradle/
 /jre/


### PR DESCRIPTION
Ths existing incarnation uses simple words for some very specific
folders, and these pattern matches accidentally impact portions of the
code base, meaning there are places where files can be added but they
will not be detected by git as significant... that's obviously a major
problem, so the .gitignore file needs to be more specific of what it is
ignoring.