### PR TITLE
FORMAT and SCOPE Separation

### DIFF
--- a/code/src/java/pcgen/cdom/facet/ScopeFacet.java
+++ b/code/src/java/pcgen/cdom/facet/ScopeFacet.java
@@ -24,7 +24,7 @@ import pcgen.base.formula.base.VarScoped;
 import pcgen.base.formula.inst.ScopeInstanceFactory;
 import pcgen.cdom.enumeration.CharID;
 import pcgen.cdom.facet.base.AbstractItemFacet;
-import pcgen.cdom.inst.Dynamic;
+import pcgen.cdom.formula.scope.GlobalScope;
 
 /**
  * ScopeFacet stores the relationship from a Character, LegalScope, and
@@ -32,8 +32,6 @@ import pcgen.cdom.inst.Dynamic;
  */
 public class ScopeFacet extends AbstractItemFacet<CharID, ScopeInstanceFactory>
 {
-	public static final VarScoped GLOBAL_FACT = new Global();
-
 	/**
 	 * Returns the Global ScopeInstance for the PlayerCharacter represented by
 	 * the given CharID.
@@ -46,7 +44,7 @@ public class ScopeFacet extends AbstractItemFacet<CharID, ScopeInstanceFactory>
 	 */
 	public ScopeInstance getGlobalScope(CharID id)
 	{
-		return get(id).getGlobalInstance("Global");
+		return get(id).getGlobalInstance(GlobalScope.GLOBAL_SCOPE_NAME);
 	}
 
 	/**
@@ -103,13 +101,5 @@ public class ScopeFacet extends AbstractItemFacet<CharID, ScopeInstanceFactory>
 	public Collection<VarScoped> getObjectsWithVariables(CharID id)
 	{
 		return get(id).getInstancedObjects();
-	}
-
-	private static class Global extends Dynamic
-	{
-		public Global()
-		{
-			setName("Global");
-		}
 	}
 }

--- a/code/src/java/pcgen/cdom/formula/scope/GlobalScope.java
+++ b/code/src/java/pcgen/cdom/formula/scope/GlobalScope.java
@@ -25,6 +25,8 @@ import pcgen.base.formula.base.LegalScope;
 public class GlobalScope implements LegalScope
 {
 
+	public static final String GLOBAL_SCOPE_NAME = "Global";
+
 	/**
 	 * The String representation of the objects covered by this Scope
 	 * 
@@ -33,7 +35,7 @@ public class GlobalScope implements LegalScope
 	@Override
 	public String getName()
 	{
-		return "Global";
+		return GLOBAL_SCOPE_NAME;
 	}
 
 	/**

--- a/code/src/java/pcgen/core/PlayerCharacter.java
+++ b/code/src/java/pcgen/core/PlayerCharacter.java
@@ -222,6 +222,7 @@ import pcgen.cdom.facet.model.StatFacet;
 import pcgen.cdom.facet.model.TemplateFacet;
 import pcgen.cdom.facet.model.WeaponProfModelFacet;
 import pcgen.cdom.formula.MonitorableVariableStore;
+import pcgen.cdom.formula.scope.GlobalScope;
 import pcgen.cdom.helper.CNAbilitySelection;
 import pcgen.cdom.helper.ClassSource;
 import pcgen.cdom.helper.ProfProvider;
@@ -635,7 +636,8 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 		SplitFormulaSetup formulaSetup =
 				formulaSetupFacet.get(id.getDatasetID());
 		MonitorableVariableStore varStore = new MonitorableVariableStore();
-		IndividualSetup mySetup = new IndividualSetup(formulaSetup, "Global", varStore);
+		IndividualSetup mySetup = new IndividualSetup(formulaSetup,
+			GlobalScope.GLOBAL_SCOPE_NAME, varStore);
 		scopeFacet.set(id, mySetup.getInstanceFactory());
 		variableStoreFacet.set(id, varStore);
 		SolverFactory solverFactory = solverFactoryFacet.get(id.getDatasetID());

--- a/code/src/java/pcgen/persistence/SourceFileLoader.java
+++ b/code/src/java/pcgen/persistence/SourceFileLoader.java
@@ -49,6 +49,7 @@ import pcgen.cdom.enumeration.ObjectKey;
 import pcgen.cdom.enumeration.SourceFormat;
 import pcgen.cdom.enumeration.StringKey;
 import pcgen.cdom.enumeration.Type;
+import pcgen.cdom.formula.scope.GlobalScope;
 import pcgen.cdom.util.CControl;
 import pcgen.cdom.util.ControlUtilities;
 import pcgen.core.Ability;
@@ -703,7 +704,7 @@ public class SourceFileLoader extends PCGenTask implements Observer
 	private void defineVariable(VariableContext varContext,
 		FormatManager<?> formatManager, String varName)
 	{
-		LegalScope varScope = varContext.getScope("Global");
+		LegalScope varScope = varContext.getScope(GlobalScope.GLOBAL_SCOPE_NAME);
 		varContext.assertLegalVariableID(varScope, formatManager, varName);
 	}
 

--- a/code/src/java/pcgen/rules/context/LoadContextInst.java
+++ b/code/src/java/pcgen/rules/context/LoadContextInst.java
@@ -37,6 +37,7 @@ import pcgen.cdom.enumeration.DataSetID;
 import pcgen.cdom.facet.DataSetInitializationFacet;
 import pcgen.cdom.facet.FacetInitialization;
 import pcgen.cdom.facet.FacetLibrary;
+import pcgen.cdom.formula.scope.GlobalScope;
 import pcgen.cdom.inst.ObjectCache;
 import pcgen.cdom.reference.ReferenceManufacturer;
 import pcgen.cdom.reference.SelectionCreator;
@@ -533,7 +534,7 @@ abstract class LoadContextInst implements LoadContext
 	{
 		if (legalScope == null)
 		{
-			legalScope = var.getScope("Global");
+			legalScope = var.getScope(GlobalScope.GLOBAL_SCOPE_NAME);
 		}
 		return legalScope;
 	}

--- a/code/src/java/pcgen/rules/context/VariableContext.java
+++ b/code/src/java/pcgen/rules/context/VariableContext.java
@@ -32,6 +32,7 @@ import pcgen.base.solver.SplitFormulaSetup;
 import pcgen.base.util.ComplexResult;
 import pcgen.base.util.FormatManager;
 import pcgen.cdom.formula.PluginFunctionLibrary;
+import pcgen.cdom.formula.scope.GlobalScope;
 import pcgen.cdom.formula.scope.LegalScopeUtilities;
 import pcgen.rules.persistence.MasterModifierFactory;
 import pcgen.util.Logging;
@@ -67,7 +68,7 @@ public class VariableContext
 	{
 		if (dummySetup == null)
 		{
-			dummySetup = new IndividualSetup(formulaSetup, "Global",
+			dummySetup = new IndividualSetup(formulaSetup, GlobalScope.GLOBAL_SCOPE_NAME,
 				new SimpleVariableStore());
 		}
 		return dummySetup;

--- a/code/src/java/plugin/lsttokens/variable/ChannelToken.java
+++ b/code/src/java/plugin/lsttokens/variable/ChannelToken.java
@@ -23,6 +23,7 @@ import pcgen.base.formula.base.LegalScope;
 import pcgen.base.util.FormatManager;
 import pcgen.cdom.base.Constants;
 import pcgen.cdom.content.DatasetVariable;
+import pcgen.cdom.formula.scope.GlobalScope;
 import pcgen.output.channel.ChannelUtilities;
 import pcgen.rules.context.LoadContext;
 import pcgen.rules.context.VariableContext;
@@ -96,16 +97,7 @@ public class ChannelToken extends AbstractNonEmptyToken<DatasetVariable>
 				+ " does not support format " + format + ", found in " + value
 				+ " due to " + e.getMessage());
 		}
-		LegalScope lvs;
-		if ("GLOBAL".equals(fullscope))
-		{
-			lvs = context.getActiveScope();
-		}
-		else
-		{
-			lvs = varContext.getScope(fullscope);
-		}
-
+		LegalScope lvs = varContext.getScope(fullscope);
 		if (!DatasetVariable.isLegalName(varName))
 		{
 			return new ParseResult.Fail(varName
@@ -147,7 +139,7 @@ public class ChannelToken extends AbstractNonEmptyToken<DatasetVariable>
 		if (scope == null || scope.equals("Global Variables"))
 		{
 			//Global channel
-			scope = "GLOBAL";
+			scope = GlobalScope.GLOBAL_SCOPE_NAME;
 		}
 		String format = dv.getFormat();
 		if (format == null)

--- a/code/src/utest/plugin/function/AbstractFormulaTestCase.java
+++ b/code/src/utest/plugin/function/AbstractFormulaTestCase.java
@@ -45,6 +45,7 @@ import pcgen.base.solver.SplitFormulaSetup;
 import pcgen.base.util.FormatManager;
 import pcgen.cdom.formula.ManagerKey;
 import pcgen.cdom.formula.MonitorableVariableStore;
+import pcgen.cdom.formula.scope.GlobalScope;
 import pcgen.cdom.formula.scope.LegalScopeUtilities;
 import pcgen.rules.context.LoadContext;
 
@@ -65,7 +66,8 @@ public abstract class AbstractFormulaTestCase extends TestCase
 		super.setUp();
 		setup = new SplitFormulaSetup();
 		LegalScopeUtilities.loadLegalScopeLibrary(setup.getLegalScopeLibrary());
-		localSetup = new IndividualSetup(setup, "Global", new MonitorableVariableStore());
+		localSetup = new IndividualSetup(setup, GlobalScope.GLOBAL_SCOPE_NAME,
+			new MonitorableVariableStore());
 		setup.getSolverFactory().addSolverFormat(Number.class, new Modifier()
 		{
 

--- a/code/src/utest/plugin/function/DropIntoContextFunctionTest.java
+++ b/code/src/utest/plugin/function/DropIntoContextFunctionTest.java
@@ -28,6 +28,7 @@ import pcgen.base.formula.operator.number.NumberMinus;
 import pcgen.base.formula.parse.SimpleNode;
 import pcgen.base.formula.visitor.ReconstructionVisitor;
 import pcgen.base.formula.visitor.SemanticsVisitor;
+import pcgen.cdom.formula.scope.GlobalScope;
 import pcgen.core.Equipment;
 import pcgen.rules.context.ConsolidatedListCommitStrategy;
 import pcgen.rules.context.LoadContext;
@@ -133,7 +134,8 @@ public class DropIntoContextFunctionTest extends AbstractFormulaTestCase
 	{
 		VariableLibrary vl = getVariableLibrary();
 		LegalScope equipScope = getScopeLibrary().getScope("EQUIPMENT");
-		LegalScope globalScope = getScopeLibrary().getScope("Global");
+		LegalScope globalScope =
+				getScopeLibrary().getScope(GlobalScope.GLOBAL_SCOPE_NAME);
 		vl.assertLegalVariableID("LocalVar", equipScope, numberManager);
 		vl.assertLegalVariableID("EquipVar", globalScope, stringManager);
 
@@ -160,7 +162,8 @@ public class DropIntoContextFunctionTest extends AbstractFormulaTestCase
 		ScopeInstance scopeInsta = getInstanceFactory().get("EQUIPMENT", equipalt);
 		VariableID varIDa = vl.getVariableID(scopeInsta, "LocalVar");
 		getVariableStore().put(varIDa, 3);
-		ScopeInstance globalInst = getInstanceFactory().getGlobalInstance("Global");
+		ScopeInstance globalInst =
+				getInstanceFactory().getGlobalInstance(GlobalScope.GLOBAL_SCOPE_NAME);
 		VariableID varIDq = vl.getVariableID(globalInst, "EquipVar");
 		getVariableStore().put(varIDq, "EquipKey");
 		LoadContext context = new RuntimeLoadContext(RuntimeReferenceContext.createRuntimeReferenceContext(),

--- a/code/src/utest/plugin/function/GetFactFunctionTest.java
+++ b/code/src/utest/plugin/function/GetFactFunctionTest.java
@@ -37,7 +37,7 @@ import pcgen.cdom.content.fact.FactDefinition;
 import pcgen.cdom.enumeration.FactKey;
 import pcgen.cdom.formula.ManagerKey;
 import pcgen.cdom.formula.scope.GlobalScope;
-import pcgen.core.Equipment;
+import pcgen.core.Skill;
 import pcgen.rules.context.ConsolidatedListCommitStrategy;
 import pcgen.rules.context.LoadContext;
 import pcgen.rules.context.RuntimeLoadContext;
@@ -62,10 +62,10 @@ public class GetFactFunctionTest extends AbstractFormulaTestCase
 	@Test
 	public void testInvalidWrongArgCount()
 	{
-		String formula = "getFact(\"EQUIPMENT\")";
+		String formula = "getFact(\"SKILL\")";
 		SimpleNode node = TestUtilities.doParse(formula);
 		isNotValid(formula, node, numberManager, null);
-		String s = "getFact(\"EQUIPMENT\", \"Foo\", 4, 5)";
+		String s = "getFact(\"SKILL\", \"Foo\", 4, 5)";
 		SimpleNode simpleNode = TestUtilities.doParse(s);
 		isNotValid(s, simpleNode, numberManager, null);
 	}
@@ -73,17 +73,28 @@ public class GetFactFunctionTest extends AbstractFormulaTestCase
 	@Test
 	public void testInvalidWrongArgType()
 	{
-		LegalScope equipScope = getScopeLibrary().getScope("EQUIPMENT");
-		getVariableLibrary().assertLegalVariableID("LocalVar", equipScope, numberManager);
-		String s = "getFact(\"EQUIPMENT\",\"EquipKey\",LocalVar)";
+		LegalScope skillScope = getScopeLibrary().getScope("SKILL");
+		getVariableLibrary().assertLegalVariableID("LocalVar", skillScope, numberManager);
+		String s = "getFact(\"SKILL\",\"SkillKey\",LocalVar)";
 		SimpleNode simpleNode = TestUtilities.doParse(s);
-		isNotValid(s, simpleNode, numberManager, null);
+		SemanticsVisitor semanticsVisitor = new SemanticsVisitor();
+		FormulaSemantics semantics = generateFormulaSemantics(
+			getFormulaManager(), getGlobalScope(), null);
+		LoadContext context = new RuntimeLoadContext(
+			RuntimeReferenceContext.createRuntimeReferenceContext(),
+			new ConsolidatedListCommitStrategy());
+		semanticsVisitor.visit(simpleNode, semantics.getWith(ManagerKey.CONTEXT, context));
+		if (semantics.isValid())
+		{
+			TestCase.fail(
+				"Expected Invalid Formula: " + s + " but was valid");
+		}
 	}
 
 	@Test
 	public void testInvalidWrongFormat1()
 	{
-		String formula = "getFact(3,\"EquipKey\",3)";
+		String formula = "getFact(3,\"SkillKey\",3)";
 		SimpleNode node = TestUtilities.doParse(formula);
 		isNotValid(formula, node, numberManager, null);
 	}
@@ -91,7 +102,7 @@ public class GetFactFunctionTest extends AbstractFormulaTestCase
 	@Test
 	public void testInvalidWrongFormat2()
 	{
-		String formula = "getFact(\"EQUIPMENT\",3,3)";
+		String formula = "getFact(\"SKILL\",3,3)";
 		SimpleNode node = TestUtilities.doParse(formula);
 		isNotValid(formula, node, numberManager, null);
 	}
@@ -100,12 +111,13 @@ public class GetFactFunctionTest extends AbstractFormulaTestCase
 	public void testInvalidWrongFormat3()
 	{
 		String formula =
-				"getFact(\"EQUIPMENT\", \"EquipKey\",\"Stuff\")";
+				"getFact(\"SKILL\", \"SkillKey\",\"Stuff\")";
 		SimpleNode node = TestUtilities.doParse(formula);
 		SemanticsVisitor semanticsVisitor = new SemanticsVisitor();
 		FormulaSemantics semantics = generateFormulaSemantics
 			(getFormulaManager(), getGlobalScope(), null);
-		LoadContext context = new RuntimeLoadContext(RuntimeReferenceContext.createRuntimeReferenceContext(),
+		LoadContext context = new RuntimeLoadContext(
+			RuntimeReferenceContext.createRuntimeReferenceContext(),
 			new ConsolidatedListCommitStrategy());
 		Object result = semanticsVisitor.visit(node,
 			semantics.getWith(ManagerKey.CONTEXT, context));
@@ -120,17 +132,18 @@ public class GetFactFunctionTest extends AbstractFormulaTestCase
 	public void testBasic()
 	{
 		FactDefinition fd = new FactDefinition();
-		fd.setName("EQUIPMENT.Stuff");
+		fd.setName("SKILL.Stuff");
 		fd.setFactName("Stuff");
-		fd.setUsableLocation(Equipment.class);
+		fd.setUsableLocation(Skill.class);
 		fd.setFormatManager(STRING_MANAGER);
 		fd.setVisibility(Visibility.HIDDEN);
-		LoadContext context = new RuntimeLoadContext(RuntimeReferenceContext.createRuntimeReferenceContext(),
+		LoadContext context = new RuntimeLoadContext(
+			RuntimeReferenceContext.createRuntimeReferenceContext(),
 			new ConsolidatedListCommitStrategy());
 
 		context.getReferenceContext().importObject(fd);
 		String formula =
-				"getFact(\"EQUIPMENT\",\"EquipKey\",\"Stuff\")";
+				"getFact(\"SKILL\",\"SkillKey\",\"Stuff\")";
 		SimpleNode node = TestUtilities.doParse(formula);
 		SemanticsVisitor semanticsVisitor = new SemanticsVisitor();
 		FormulaSemantics semantics = generateFormulaSemantics(
@@ -142,8 +155,8 @@ public class GetFactFunctionTest extends AbstractFormulaTestCase
 				+ " but was told: " + semantics.getReport());
 		}
 		isStatic(formula, node, true);
-		Equipment equip = new Equipment();
-		equip.setName("EquipKey");
+		Skill equip = new Skill();
+		equip.setName("SkillKey");
 		FactKey<String> fk = FactKey.getConstant("Stuff", STRING_MANAGER);
 		equip.put(fk, new BasicIndirect(STRING_MANAGER, "Wow!"));
 
@@ -158,23 +171,24 @@ public class GetFactFunctionTest extends AbstractFormulaTestCase
 	public void testDynamic()
 	{
 		VariableLibrary vl = getVariableLibrary();
-		LegalScope equipScope = getScopeLibrary().getScope("EQUIPMENT");
+		LegalScope skillScope = getScopeLibrary().getScope("SKILL");
 		LegalScope globalScope =
 				getScopeLibrary().getScope(GlobalScope.GLOBAL_SCOPE_NAME);
-		vl.assertLegalVariableID("EquipVar", globalScope, stringManager);
+		vl.assertLegalVariableID("SkillVar", globalScope, stringManager);
 
 		FactDefinition fd = new FactDefinition();
-		fd.setName("EQUIPMENT.Stuff");
+		fd.setName("SKILL.Stuff");
 		fd.setFactName("Stuff");
-		fd.setUsableLocation(Equipment.class);
+		fd.setUsableLocation(Skill.class);
 		fd.setFormatManager(STRING_MANAGER);
 		fd.setVisibility(Visibility.HIDDEN);
-		LoadContext context = new RuntimeLoadContext(RuntimeReferenceContext.createRuntimeReferenceContext(),
+		LoadContext context = new RuntimeLoadContext(
+			RuntimeReferenceContext.createRuntimeReferenceContext(),
 			new ConsolidatedListCommitStrategy());
 		context.getReferenceContext().importObject(fd);
 
 		String formula =
-				"getFact(\"EQUIPMENT\",EquipVar,\"Stuff\")";
+				"getFact(\"SKILL\",SkillVar,\"Stuff\")";
 		SimpleNode node = TestUtilities.doParse(formula);
 		SemanticsVisitor semanticsVisitor = new SemanticsVisitor();
 		FormulaSemantics semantics = generateFormulaSemantics(
@@ -186,25 +200,25 @@ public class GetFactFunctionTest extends AbstractFormulaTestCase
 				+ " but was told: " + semantics.getReport());
 		}
 		isStatic(formula, node, false);
-		Equipment equip = new Equipment();
-		equip.setName("EquipKey");
-		Equipment equipalt = new Equipment();
-		equipalt.setName("EquipAlt");
+		Skill skill = new Skill();
+		skill.setName("SkillKey");
+		Skill skillalt = new Skill();
+		skillalt.setName("SkillAlt");
 		ScopeInstance globalInst =
 				getInstanceFactory().getGlobalInstance(GlobalScope.GLOBAL_SCOPE_NAME);
-		VariableID varIDq = vl.getVariableID(globalInst, "EquipVar");
-		getVariableStore().put(varIDq, "EquipKey");
-		context.getReferenceContext().importObject(equip);
-		context.getReferenceContext().importObject(equipalt);
+		VariableID varIDq = vl.getVariableID(globalInst, "SkillVar");
+		getVariableStore().put(varIDq, "SkillKey");
+		context.getReferenceContext().importObject(skill);
+		context.getReferenceContext().importObject(skillalt);
 		FactKey<String> fk = FactKey.getConstant("Stuff", STRING_MANAGER);
-		equip.put(fk, new BasicIndirect(STRING_MANAGER, "Wow!"));
-		equipalt.put(fk, new BasicIndirect(STRING_MANAGER, "Zers!"));
+		skill.put(fk, new BasicIndirect(STRING_MANAGER, "Wow!"));
+		skillalt.put(fk, new BasicIndirect(STRING_MANAGER, "Zers!"));
 
 		evaluatesTo(formula, node, "Wow!", context);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertEquals(formula, rv.toString());
-		getVariableStore().put(varIDq, "EquipAlt");
+		getVariableStore().put(varIDq, "SkillAlt");
 		evaluatesTo(formula, node, "Zers!", context);
 	}
 }

--- a/code/src/utest/plugin/function/GetFactFunctionTest.java
+++ b/code/src/utest/plugin/function/GetFactFunctionTest.java
@@ -36,6 +36,7 @@ import pcgen.base.util.BasicIndirect;
 import pcgen.cdom.content.fact.FactDefinition;
 import pcgen.cdom.enumeration.FactKey;
 import pcgen.cdom.formula.ManagerKey;
+import pcgen.cdom.formula.scope.GlobalScope;
 import pcgen.core.Equipment;
 import pcgen.rules.context.ConsolidatedListCommitStrategy;
 import pcgen.rules.context.LoadContext;
@@ -158,7 +159,8 @@ public class GetFactFunctionTest extends AbstractFormulaTestCase
 	{
 		VariableLibrary vl = getVariableLibrary();
 		LegalScope equipScope = getScopeLibrary().getScope("EQUIPMENT");
-		LegalScope globalScope = getScopeLibrary().getScope("Global");
+		LegalScope globalScope =
+				getScopeLibrary().getScope(GlobalScope.GLOBAL_SCOPE_NAME);
 		vl.assertLegalVariableID("EquipVar", globalScope, stringManager);
 
 		FactDefinition fd = new FactDefinition();
@@ -188,7 +190,8 @@ public class GetFactFunctionTest extends AbstractFormulaTestCase
 		equip.setName("EquipKey");
 		Equipment equipalt = new Equipment();
 		equipalt.setName("EquipAlt");
-		ScopeInstance globalInst = getInstanceFactory().getGlobalInstance("Global");
+		ScopeInstance globalInst =
+				getInstanceFactory().getGlobalInstance(GlobalScope.GLOBAL_SCOPE_NAME);
 		VariableID varIDq = vl.getVariableID(globalInst, "EquipVar");
 		getVariableStore().put(varIDq, "EquipKey");
 		context.getReferenceContext().importObject(equip);

--- a/code/src/utest/plugin/function/InputFunctionTest.java
+++ b/code/src/utest/plugin/function/InputFunctionTest.java
@@ -36,6 +36,7 @@ import pcgen.cdom.facet.VariableLibraryFacet;
 import pcgen.cdom.facet.VariableStoreFacet;
 import pcgen.cdom.formula.MonitorableVariableStore;
 import pcgen.cdom.formula.VariableChannel;
+import pcgen.cdom.formula.scope.GlobalScope;
 import pcgen.output.channel.ChannelUtilities;
 import plugin.function.testsupport.AbstractFormulaTestCase;
 import plugin.function.testsupport.TestUtilities;
@@ -113,7 +114,8 @@ public class InputFunctionTest extends AbstractFormulaTestCase
 	{
 		VariableLibrary varLib = variableLibraryFacet.get(id.getDatasetID());
 		ScopeInstanceFactory instFactory = scopeFacet.get(id);
-		ScopeInstance globalInstance = instFactory.getGlobalInstance("Global");
+		ScopeInstance globalInstance =
+				instFactory.getGlobalInstance(GlobalScope.GLOBAL_SCOPE_NAME);
 		varLib.assertLegalVariableID(ChannelUtilities.createVarName("STR"),
 			globalInstance.getLegalScope(), numberManager);
 		VariableChannel<Number> strChannel =

--- a/code/src/utest/plugin/function/testsupport/AbstractFormulaTestCase.java
+++ b/code/src/utest/plugin/function/testsupport/AbstractFormulaTestCase.java
@@ -47,6 +47,7 @@ import pcgen.base.solver.Modifier;
 import pcgen.base.solver.SplitFormulaSetup;
 import pcgen.base.util.FormatManager;
 import pcgen.cdom.formula.MonitorableVariableStore;
+import pcgen.cdom.formula.scope.GlobalScope;
 import pcgen.rules.context.ConsolidatedListCommitStrategy;
 import pcgen.rules.context.LoadContext;
 import pcgen.rules.context.PCGenManagerFactory;
@@ -74,7 +75,8 @@ public abstract class AbstractFormulaTestCase extends TestCase
 		setup = context.getVariableContext().getFormulaSetup();
 		setup.getSolverFactory().addSolverFormat(Number.class, getDMod(0, numberManager));
 		setup.getSolverFactory().addSolverFormat(String.class, getDMod("", stringManager));
-		localSetup = new IndividualSetup(setup, "Global", new MonitorableVariableStore());
+		localSetup = new IndividualSetup(setup, GlobalScope.GLOBAL_SCOPE_NAME,
+			new MonitorableVariableStore());
 	}
 
 	public void isValid(String formula, SimpleNode node,

--- a/code/src/utest/plugin/modifier/number/SetNumberModifierTest.java
+++ b/code/src/utest/plugin/modifier/number/SetNumberModifierTest.java
@@ -32,12 +32,14 @@ import pcgen.base.formula.inst.SimpleVariableStore;
 import pcgen.base.solver.IndividualSetup;
 import pcgen.base.solver.SplitFormulaSetup;
 import pcgen.base.util.FormatManager;
+import pcgen.cdom.formula.scope.GlobalScope;
 import plugin.modifier.testsupport.EvalManagerUtilities;
 
 public class SetNumberModifierTest
 {
 
-	private LegalScope varScope = new SimpleLegalScope(null, "Global");
+	private LegalScope varScope =
+			new SimpleLegalScope(null, GlobalScope.GLOBAL_SCOPE_NAME);
 	FormatManager<Number> numManager = new NumberManager();
 
 	@Test
@@ -213,7 +215,8 @@ public class SetNumberModifierTest
 		SplitFormulaSetup setup = new SplitFormulaSetup();
 		setup.loadBuiltIns();
 		setup.getLegalScopeLibrary().registerScope(varScope);
-		IndividualSetup iSetup = new IndividualSetup(setup, "Global", new SimpleVariableStore());
+		IndividualSetup iSetup = new IndividualSetup(setup, GlobalScope.GLOBAL_SCOPE_NAME,
+			new SimpleVariableStore());
 		SetModifierFactory factory = new SetModifierFactory();
 		FormulaModifier<Number> modifier =
 				factory.getModifier("6+5", new ManagerFactory(){}, iSetup.getFormulaManager(), varScope, numManager);


### PR DESCRIPTION
This is cleanup work that separates the concepts of FORMAT and SCOPE.

This is necessary to have certain later behaviors work correctly, as well as to generally avoid confusion (and bugs) later on.  This supports, but is not exclusively preparation for, Library version 147.  (Meaning if 147 never happens or the relevant changes are backed out, this is still a good commit and shouldn't be removed)

In particular, this (1) Shares the Global Scope name through a constant (2) clearly drives getFact and dropIntoContext to have their first argument as a FORMAT (3) Changes some tests to use SKILL rather than EQUIPMENT since EQUIPMENT can't be used as a FORMAT at this time

To consider why getFact and dropIntoContext use FORMAT, consider something like getFact("EQUIPMENT.PART","xx","FactName").  Right now both EquipmentHead and EquipmentModifier use "EQUIPMENT.PART" as their scope - so what would "xx" be?  "EQUIPMENT.PART" (a scope) were allowed, then the name is ambiguous, and the scopes start to control what object names overlap.  That would be BAD.  Therefore, getFact must use a FORMAT, where sub objects are distinguishable.  (Note for the moment that since Equipment is not necessarily unique on a PC - you can have two Longsword - it can't be used as a proper format because we can't tell which one the code is talking about...

