### PR TITLE
 Update for Formula Library version 149

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -171,7 +171,7 @@ dependencies {
         compile group: 'org.xmlunit', name: 'xmlunit-core', version:'2.5.1'
         compile group: 'org.xmlunit', name: 'xmlunit-legacy', version:'2.5.1'
         compile group: 'net.sourceforge.pcgen', name: 'PCGen-base', version:'1.0.127'
-        compile group: 'net.sourceforge.pcgen', name: 'PCGen-Formula', version:'1.0.146'
+        compile group: 'net.sourceforge.pcgen', name: 'PCGen-Formula', version:'1.0.149'
         compile group: 'xml-apis', name: 'xml-apis', version:'1.3.04'
     }
 

--- a/code/src/java/pcgen/cdom/content/VarModifier.java
+++ b/code/src/java/pcgen/cdom/content/VarModifier.java
@@ -133,4 +133,17 @@ public class VarModifier<T>
 		}
 		return false;
 	}
+
+	/**
+	 * Returns the fully qualified Legal Scope Name for the LegalScope in this
+	 * VarModifier.
+	 * 
+	 * (e.g. The LegalScope might be "SKILL" and the fully qualified name "PC.SKILL")
+	 * 
+	 * @return The fully qualified Legal Scope Name for the LegalScope in this VarModifier
+	 */
+	public String getFullLegalScopeName()
+	{
+		return LegalScope.getFullName(getLegalScope());
+	}
 }

--- a/code/src/java/pcgen/cdom/facet/SolverManagerFacet.java
+++ b/code/src/java/pcgen/cdom/facet/SolverManagerFacet.java
@@ -46,7 +46,7 @@ public class SolverManagerFacet extends
 	public <T> boolean addModifier(CharID id, VarModifier<T> vm, VarScoped target,
 		ScopeInstance source)
 	{
-		ScopeInstance scope = scopeFacet.get(id, vm.getLegalScope().getName(), target);
+		ScopeInstance scope = scopeFacet.get(id, vm.getFullLegalScopeName(), target);
 		VariableID<T> varID =
 				(VariableID<T>) variableLibraryFacet.getVariableID(
 					id.getDatasetID(), scope, vm.getVarName());
@@ -56,7 +56,7 @@ public class SolverManagerFacet extends
 	public <T> void removeModifier(CharID id, VarModifier<T> vm,
 		VarScoped target, ScopeInstance source)
 	{
-		ScopeInstance scope = scopeFacet.get(id, vm.getLegalScope().getName(), target);
+		ScopeInstance scope = scopeFacet.get(id, vm.getFullLegalScopeName(), target);
 		VariableID<T> varID =
 				(VariableID<T>) variableLibraryFacet.getVariableID(
 					id.getDatasetID(), scope, vm.getVarName());

--- a/code/src/java/pcgen/cdom/formula/scope/EquipmentPartScope.java
+++ b/code/src/java/pcgen/cdom/formula/scope/EquipmentPartScope.java
@@ -39,7 +39,7 @@ public class EquipmentPartScope implements LegalScope
 	@Override
 	public String getName()
 	{
-		return "EQUIPMENT.PART";
+		return "PART";
 	}
 
 	/**

--- a/code/src/java/pcgen/cdom/formula/scope/GlobalScope.java
+++ b/code/src/java/pcgen/cdom/formula/scope/GlobalScope.java
@@ -27,7 +27,7 @@ public class GlobalScope implements LegalScope
 	/**
 	 * The name of the Global Scope for PCGen characters, publicly available for reuse...
 	 */
-	public static final String GLOBAL_SCOPE_NAME = "Global";
+	public static final String GLOBAL_SCOPE_NAME = "PC";
 
 	/**
 	 * The String representation of the objects covered by this Scope

--- a/code/src/java/pcgen/cdom/inst/Dynamic.java
+++ b/code/src/java/pcgen/cdom/inst/Dynamic.java
@@ -87,7 +87,7 @@ public class Dynamic implements VarScoped, Categorized<Dynamic>
 	@Override
 	public String getLocalScopeName()
 	{
-		return category.getKeyName();
+		return "PC." + category.getKeyName();
 	}
 
 	@Override

--- a/code/src/java/pcgen/cdom/inst/EquipmentHead.java
+++ b/code/src/java/pcgen/cdom/inst/EquipmentHead.java
@@ -168,7 +168,7 @@ public final class EquipmentHead extends CDOMObject
 	@Override
 	public String getLocalScopeName()
 	{
-		return "EQUIPMENT.PART";
+		return "PC.EQUIPMENT.PART";
 	}
 
 	@Override

--- a/code/src/java/pcgen/core/Equipment.java
+++ b/code/src/java/pcgen/core/Equipment.java
@@ -6655,7 +6655,7 @@ public final class Equipment extends PObject implements Serializable,
 	@Override
 	public String getLocalScopeName()
 	{
-		return "EQUIPMENT";
+		return "PC.EQUIPMENT";
 	}
 
 	public Object getLocalVariable(CharID id, String varName)

--- a/code/src/java/pcgen/core/EquipmentModifier.java
+++ b/code/src/java/pcgen/core/EquipmentModifier.java
@@ -308,7 +308,7 @@ public final class EquipmentModifier extends PObject implements Comparable<Objec
 	@Override
 	public String getLocalScopeName()
 	{
-		return "EQUIPMENT.PART";
+		return "PC.EQUIPMENT.PART";
 	}
 
 	private VarScoped variableParent;

--- a/code/src/java/pcgen/core/PCCheck.java
+++ b/code/src/java/pcgen/core/PCCheck.java
@@ -28,7 +28,7 @@ public final class PCCheck extends PObject implements NonInteractive,
 	@Override
 	public String getLocalScopeName()
 	{
-		return "SAVE";
+		return "PC.SAVE";
 	}
 
 	@Override

--- a/code/src/java/pcgen/core/PCStat.java
+++ b/code/src/java/pcgen/core/PCStat.java
@@ -51,7 +51,7 @@ public final class PCStat extends PObject implements StatFacade,
 	@Override
 	public String getLocalScopeName()
 	{
-		return "STAT";
+		return "PC.STAT";
 	}
 
 	@Override

--- a/code/src/java/pcgen/core/SizeAdjustment.java
+++ b/code/src/java/pcgen/core/SizeAdjustment.java
@@ -48,6 +48,6 @@ public final class SizeAdjustment extends PObject implements
 	@Override
 	public String getLocalScopeName()
 	{
-		return "SIZE";
+		return "PC.SIZE";
 	}
 }

--- a/code/src/java/pcgen/core/Skill.java
+++ b/code/src/java/pcgen/core/Skill.java
@@ -190,6 +190,6 @@ public final class Skill extends PObject implements SkillFacade, ChooseDriver,
 	@Override
 	public String getLocalScopeName()
 	{
-		return "SKILL";
+		return "PC.SKILL";
 	}
 }

--- a/code/src/java/pcgen/persistence/SourceFileLoader.java
+++ b/code/src/java/pcgen/persistence/SourceFileLoader.java
@@ -142,19 +142,25 @@ public class SourceFileLoader extends PCGenTask implements Observer
 	private final LstObjectFileLoader abilityLoader = new AbilityLoader();
 	private final LstObjectFileLoader featLoader = new FeatLoader();
 	private final LstObjectFileLoader<PCTemplate> templateLoader = new GenericLoader<>(PCTemplate.class);
-	private final LstObjectFileLoader<Equipment> equipmentLoader = new GenericLocalVariableLoader<>(Equipment.class, "PC.EQUIPMENT");
-	private final LstObjectFileLoader<EquipmentModifier> eqModLoader = new GenericLocalVariableLoader<>(EquipmentModifier.class, "PC.EQUIPMENT.PART");
+	private final LstObjectFileLoader<Equipment> equipmentLoader =
+			new GenericLocalVariableLoader<>(Equipment.class, "PC.EQUIPMENT");
+	private final LstObjectFileLoader<EquipmentModifier> eqModLoader =
+			new GenericLocalVariableLoader<>(EquipmentModifier.class, "PC.EQUIPMENT.PART");
 	private final LstObjectFileLoader<Race> raceLoader = new GenericLoader<>(Race.class);
-	private final LstObjectFileLoader<Skill> skillLoader = new GenericLocalVariableLoader<>(Skill.class, "PC.SKILL");
+	private final LstObjectFileLoader<Skill> skillLoader =
+			new GenericLocalVariableLoader<>(Skill.class, "PC.SKILL");
 	private final LstObjectFileLoader<WeaponProf> wProfLoader = new GenericLoader<>(WeaponProf.class);
 	private final LstObjectFileLoader<ArmorProf> aProfLoader = new GenericLoader<>(ArmorProf.class);
 	private final LstObjectFileLoader<ShieldProf> sProfLoader = new GenericLoader<>(ShieldProf.class);
 	private final LstObjectFileLoader<Deity> deityLoader = new GenericLoader<>(Deity.class);
 	private final LstObjectFileLoader<Domain> domainLoader = new GenericLoader<>(Domain.class);
-	private final LstObjectFileLoader<PCCheck> savesLoader = new GenericLocalVariableLoader<>(PCCheck.class, "PC.SAVE");
+	private final LstObjectFileLoader<PCCheck> savesLoader =
+			new GenericLocalVariableLoader<>(PCCheck.class, "PC.SAVE");
 	private final LstObjectFileLoader<PCAlignment> alignmentLoader = new GenericLoader<>(PCAlignment.class);
-	private final LstObjectFileLoader<PCStat> statLoader = new GenericLocalVariableLoader<>(PCStat.class, "PC.STAT");
-	private final LstObjectFileLoader<SizeAdjustment> sizeLoader = new GenericLocalVariableLoader<>(SizeAdjustment.class, "PC.SIZE");
+	private final LstObjectFileLoader<PCStat> statLoader =
+			new GenericLocalVariableLoader<>(PCStat.class, "PC.STAT");
+	private final LstObjectFileLoader<SizeAdjustment> sizeLoader =
+			new GenericLocalVariableLoader<>(SizeAdjustment.class, "PC.SIZE");
 	private final LstObjectFileLoader<Spell> spellLoader = new GenericLoader<>(Spell.class);
 	private final LstLineFileLoader dataControlLoader = new CDOMControlLoader();
 	private final VariableLoader variableLoader = new VariableLoader();

--- a/code/src/java/pcgen/persistence/SourceFileLoader.java
+++ b/code/src/java/pcgen/persistence/SourceFileLoader.java
@@ -142,19 +142,19 @@ public class SourceFileLoader extends PCGenTask implements Observer
 	private final LstObjectFileLoader abilityLoader = new AbilityLoader();
 	private final LstObjectFileLoader featLoader = new FeatLoader();
 	private final LstObjectFileLoader<PCTemplate> templateLoader = new GenericLoader<>(PCTemplate.class);
-	private final LstObjectFileLoader<Equipment> equipmentLoader = new GenericLocalVariableLoader<>(Equipment.class, "EQUIPMENT");
-	private final LstObjectFileLoader<EquipmentModifier> eqModLoader = new GenericLocalVariableLoader<>(EquipmentModifier.class, "EQUIPMENT.PART");
+	private final LstObjectFileLoader<Equipment> equipmentLoader = new GenericLocalVariableLoader<>(Equipment.class, "PC.EQUIPMENT");
+	private final LstObjectFileLoader<EquipmentModifier> eqModLoader = new GenericLocalVariableLoader<>(EquipmentModifier.class, "PC.EQUIPMENT.PART");
 	private final LstObjectFileLoader<Race> raceLoader = new GenericLoader<>(Race.class);
-	private final LstObjectFileLoader<Skill> skillLoader = new GenericLocalVariableLoader<>(Skill.class, "SKILL");
+	private final LstObjectFileLoader<Skill> skillLoader = new GenericLocalVariableLoader<>(Skill.class, "PC.SKILL");
 	private final LstObjectFileLoader<WeaponProf> wProfLoader = new GenericLoader<>(WeaponProf.class);
 	private final LstObjectFileLoader<ArmorProf> aProfLoader = new GenericLoader<>(ArmorProf.class);
 	private final LstObjectFileLoader<ShieldProf> sProfLoader = new GenericLoader<>(ShieldProf.class);
 	private final LstObjectFileLoader<Deity> deityLoader = new GenericLoader<>(Deity.class);
 	private final LstObjectFileLoader<Domain> domainLoader = new GenericLoader<>(Domain.class);
-	private final LstObjectFileLoader<PCCheck> savesLoader = new GenericLocalVariableLoader<>(PCCheck.class, "SAVE");
+	private final LstObjectFileLoader<PCCheck> savesLoader = new GenericLocalVariableLoader<>(PCCheck.class, "PC.SAVE");
 	private final LstObjectFileLoader<PCAlignment> alignmentLoader = new GenericLoader<>(PCAlignment.class);
-	private final LstObjectFileLoader<PCStat> statLoader = new GenericLocalVariableLoader<>(PCStat.class, "STAT");
-	private final LstObjectFileLoader<SizeAdjustment> sizeLoader = new GenericLocalVariableLoader<>(SizeAdjustment.class, "SIZE");
+	private final LstObjectFileLoader<PCStat> statLoader = new GenericLocalVariableLoader<>(PCStat.class, "PC.STAT");
+	private final LstObjectFileLoader<SizeAdjustment> sizeLoader = new GenericLocalVariableLoader<>(SizeAdjustment.class, "PC.SIZE");
 	private final LstObjectFileLoader<Spell> spellLoader = new GenericLoader<>(Spell.class);
 	private final LstLineFileLoader dataControlLoader = new CDOMControlLoader();
 	private final VariableLoader variableLoader = new VariableLoader();
@@ -453,7 +453,7 @@ public class SourceFileLoader extends PCGenTask implements Observer
 		context.setSourceURI(uri);
 		SourceEntry source =
 				new CampaignSourceEntry(new Campaign(), uri);
-		LoadContext subContext = context.dropIntoContext("EQUIPMENT");
+		LoadContext subContext = context.dropIntoContext("PC.EQUIPMENT");
 		String aLine;
 		aLine =
 				"Add Type\tKEY:ADDTYPE\tTYPE:ALL\tCOST:0\tNAMEOPT:NONAME\tSOURCELONG:PCGen Internal\tCHOOSE:EQBUILDER.EQTYPE|COUNT=ALL|TITLE=desired TYPE(s)";

--- a/code/src/java/plugin/lsttokens/ModifyOtherLst.java
+++ b/code/src/java/plugin/lsttokens/ModifyOtherLst.java
@@ -94,7 +94,8 @@ public class ModifyOtherLst extends AbstractTokenWithSeparator<CDOMObject>
 			return new ParseResult.Fail(getTokenName()
 				+ " needed 2nd argument: " + value);
 		}
-		LoadContext subContext = context.dropIntoContext(lvs.getName());
+		String fullName = LegalScope.getFullName(lvs);
+		LoadContext subContext = context.dropIntoContext(fullName);
 		return continueParsing(subContext, obj, value, sep);
 	}
 
@@ -113,8 +114,8 @@ public class ModifyOtherLst extends AbstractTokenWithSeparator<CDOMObject>
 				@Override
 				public boolean contains(VarScoped item)
 				{
-					return Objects.equals(item.getLocalScopeName(), scope.getName())
-						&& (item instanceof CDOMObject)
+					return Objects.equals(item.getLocalScopeName(),
+						LegalScope.getFullName(scope)) && (item instanceof CDOMObject)
 						&& ((CDOMObject) item).containsInList(ListKey.GROUP, groupName);
 				}
 
@@ -138,7 +139,8 @@ public class ModifyOtherLst extends AbstractTokenWithSeparator<CDOMObject>
 				@Override
 				public boolean contains(VarScoped item)
 				{
-					return Objects.equals(item.getLocalScopeName(), scope.getName());
+					return Objects.equals(item.getLocalScopeName(),
+						LegalScope.getFullName(scope));
 				}
 
 				@Override
@@ -161,7 +163,8 @@ public class ModifyOtherLst extends AbstractTokenWithSeparator<CDOMObject>
 				@Override
 				public boolean contains(VarScoped item)
 				{
-					return Objects.equals(item.getLocalScopeName(), scope.getName())
+					return Objects.equals(item.getLocalScopeName(),
+						LegalScope.getFullName(scope))
 						&& item.getKeyName().equalsIgnoreCase(groupingName);
 				}
 
@@ -187,10 +190,9 @@ public class ModifyOtherLst extends AbstractTokenWithSeparator<CDOMObject>
 		String varName = sep.next();
 		if (!context.getVariableContext().isLegalVariableID(scope, varName))
 		{
-			return new ParseResult.Fail(
-				getTokenName() + " found invalid var name: " + varName
-					+ "(scope: " + scope.getName() + ") Modified on "
-					+ obj.getClass().getSimpleName() + ' ' + obj.getKeyName());
+			return new ParseResult.Fail(getTokenName() + " found invalid var name: "
+				+ varName + "(scope: " + LegalScope.getFullName(scope) + ") Modified on "
+				+ obj.getClass().getSimpleName() + ' ' + obj.getKeyName());
 		}
 		if (!sep.hasNext())
 		{
@@ -273,7 +275,7 @@ public class ModifyOtherLst extends AbstractTokenWithSeparator<CDOMObject>
 				VarModifier<?> vm = rm.getVarModifier();
 				StringBuilder sb = new StringBuilder();
 				ObjectGrouping og = rm.getGrouping();
-				sb.append(og.getScope().getName());
+				sb.append(LegalScope.getFullName(og.getScope()));
 				sb.append(Constants.PIPE);
 				sb.append(og.getIdentifier());
 				sb.append(Constants.PIPE);

--- a/code/src/utest/pcgen/base/solver/SetSolverManagerTest.java
+++ b/code/src/utest/pcgen/base/solver/SetSolverManagerTest.java
@@ -180,7 +180,7 @@ public class SetSolverManagerTest
 	@Test
 	public void testProcessDynamicSet()
 	{
-		LegalScope skillScope = vsLib.getScope("SKILL");
+		LegalScope skillScope = vsLib.getScope("PC.SKILL");
 		sl.assertLegalVariableID("LocalVar", skillScope, numberManager);
 		sl.assertLegalVariableID("ResultVar", globalScope, numberManager);
 		sl.assertLegalVariableID("SkillVar", globalScope, skillManager);
@@ -190,11 +190,11 @@ public class SetSolverManagerTest
 		Skill skillalt = new Skill();
 		skillalt.setName("SkillAlt");
 
-		ScopeInstance scopeInste = siFactory.get("SKILL", skill);
+		ScopeInstance scopeInste = siFactory.get("PC.SKILL", skill);
 		VariableID varIDe = sl.getVariableID(scopeInste, "LocalVar");
 		manager.createChannel(varIDe);
 		vc.put(varIDe, 2);
-		ScopeInstance scopeInsta = siFactory.get("SKILL", skillalt);
+		ScopeInstance scopeInsta = siFactory.get("PC.SKILL", skillalt);
 		VariableID varIDa = sl.getVariableID(scopeInsta, "LocalVar");
 		manager.createChannel(varIDa);
 		vc.put(varIDa, 3);

--- a/code/src/utest/plugin/function/DropIntoContextFunctionTest.java
+++ b/code/src/utest/plugin/function/DropIntoContextFunctionTest.java
@@ -17,6 +17,9 @@
  */
 package plugin.function;
 
+import org.junit.Test;
+
+import junit.framework.TestCase;
 import pcgen.base.formatmanager.FormatUtilities;
 import pcgen.base.formatmanager.SimpleFormatManagerLibrary;
 import pcgen.base.formula.base.FormulaSemantics;
@@ -35,9 +38,6 @@ import pcgen.rules.context.ConsolidatedListCommitStrategy;
 import pcgen.rules.context.LoadContext;
 import pcgen.rules.context.RuntimeLoadContext;
 import pcgen.rules.context.RuntimeReferenceContext;
-
-import junit.framework.TestCase;
-import org.junit.Test;
 
 public class DropIntoContextFunctionTest extends AbstractFormulaTestCase
 {
@@ -103,7 +103,7 @@ public class DropIntoContextFunctionTest extends AbstractFormulaTestCase
 	public void testBasic()
 	{
 		VariableLibrary vl = getVariableLibrary();
-		LegalScope skillScope = getScopeLibrary().getScope("SKILL");
+		LegalScope skillScope = getScopeLibrary().getScope("PC.SKILL");
 		vl.assertLegalVariableID("LocalVar", skillScope, numberManager);
 
 		String formula =
@@ -124,7 +124,7 @@ public class DropIntoContextFunctionTest extends AbstractFormulaTestCase
 		isStatic(formula, node, false);
 		Skill skill = new Skill();
 		skill.setName("SkillKey");
-		ScopeInstance scopeInst = getInstanceFactory().get("SKILL", skill);
+		ScopeInstance scopeInst = getInstanceFactory().get("PC.SKILL", skill);
 		VariableID varID = vl.getVariableID(scopeInst, "LocalVar");
 		getVariableStore().put(varID, 2);
 		context.getReferenceContext().importObject(skill);
@@ -138,7 +138,7 @@ public class DropIntoContextFunctionTest extends AbstractFormulaTestCase
 	public void testDynamic()
 	{
 		VariableLibrary vl = getVariableLibrary();
-		LegalScope skillScope = getScopeLibrary().getScope("SKILL");
+		LegalScope skillScope = getScopeLibrary().getScope("PC.SKILL");
 		LegalScope globalScope =
 				getScopeLibrary().getScope(GlobalScope.GLOBAL_SCOPE_NAME);
 		vl.assertLegalVariableID("LocalVar", skillScope, numberManager);
@@ -164,10 +164,10 @@ public class DropIntoContextFunctionTest extends AbstractFormulaTestCase
 		skill.setName("SkillKey");
 		Skill skillalt = new Skill();
 		skillalt.setName("SkillAlt");
-		ScopeInstance scopeInste = getInstanceFactory().get("SKILL", skill);
+		ScopeInstance scopeInste = getInstanceFactory().get("PC.SKILL", skill);
 		VariableID varIDe = vl.getVariableID(scopeInste, "LocalVar");
 		getVariableStore().put(varIDe, 2);
-		ScopeInstance scopeInsta = getInstanceFactory().get("SKILL", skillalt);
+		ScopeInstance scopeInsta = getInstanceFactory().get("PC.SKILL", skillalt);
 		VariableID varIDa = vl.getVariableID(scopeInsta, "LocalVar");
 		getVariableStore().put(varIDa, 3);
 		ScopeInstance globalInst =

--- a/code/src/utest/plugin/function/GetFactFunctionTest.java
+++ b/code/src/utest/plugin/function/GetFactFunctionTest.java
@@ -73,7 +73,7 @@ public class GetFactFunctionTest extends AbstractFormulaTestCase
 	@Test
 	public void testInvalidWrongArgType()
 	{
-		LegalScope skillScope = getScopeLibrary().getScope("SKILL");
+		LegalScope skillScope = getScopeLibrary().getScope("PC.SKILL");
 		getVariableLibrary().assertLegalVariableID("LocalVar", skillScope, numberManager);
 		String s = "getFact(\"SKILL\",\"SkillKey\",LocalVar)";
 		SimpleNode simpleNode = TestUtilities.doParse(s);

--- a/code/src/utest/plugin/lsttokens/ModifyOtherLstTest.java
+++ b/code/src/utest/plugin/lsttokens/ModifyOtherLstTest.java
@@ -76,7 +76,7 @@ public class ModifyOtherLstTest extends AbstractGlobalTokenTestCase
 	public void testInvalidObject() throws PersistenceLayerException
 	{
 		assertFalse(token.parseToken(primaryContext, new Campaign(),
-				"SKILL|Foo|MyVar|ADD|3").passed());
+				"PC.SKILL|Foo|MyVar|ADD|3").passed());
 	}
 
 	@Test
@@ -89,70 +89,70 @@ public class ModifyOtherLstTest extends AbstractGlobalTokenTestCase
 	@Test
 	public void testInvalidInputOneItem() throws PersistenceLayerException
 	{
-		assertFalse(parse("SKILL"));
+		assertFalse(parse("PC.SKILL"));
 		assertNoSideEffects();
 	}
 
 	@Test
 	public void testInvalidInputTwoItems() throws PersistenceLayerException
 	{
-		assertFalse(parse("SKILL|Foo"));
+		assertFalse(parse("PC.SKILL|Foo"));
 		assertNoSideEffects();
 	}
 
 	@Test
 	public void testInvalidInputThreeItems() throws PersistenceLayerException
 	{
-		assertFalse(parse("SKILL|Foo|MyVar"));
+		assertFalse(parse("PC.SKILL|Foo|MyVar"));
 		assertNoSideEffects();
 	}
 
 	@Test
 	public void testInvalidInputFourItems() throws PersistenceLayerException
 	{
-		assertFalse(parse("SKILL|Foo|MyVar|ADD"));
+		assertFalse(parse("PC.SKILL|Foo|MyVar|ADD"));
 		assertNoSideEffects();
 	}
 
 	@Test
 	public void testInvalidInputDoublePipe() throws PersistenceLayerException
 	{
-		assertFalse(parse("SKILL|Foo|MyVar||ADD|3"));
+		assertFalse(parse("PC.SKILL|Foo|MyVar||ADD|3"));
 		assertNoSideEffects();
 	}
 
 	@Test
 	public void testInvalidInputNoValue() throws PersistenceLayerException
 	{
-		assertFalse(parse("SKILL|Foo|MyVar|ADD|"));
+		assertFalse(parse("PC.SKILL|Foo|MyVar|ADD|"));
 		assertNoSideEffects();
 	}
 
 	@Test
 	public void testInvalidInputNoVar() throws PersistenceLayerException
 	{
-		assertFalse(parse("SKILL|Foo|ADD|3"));
+		assertFalse(parse("PC.SKILL|Foo|ADD|3"));
 		assertNoSideEffects();
 	}
 
 	@Test
 	public void testInvalidInputNoModifier() throws PersistenceLayerException
 	{
-		assertFalse(parse("SKILL|Foo|MyVar||3"));
+		assertFalse(parse("PC.SKILL|Foo|MyVar||3"));
 		assertNoSideEffects();
 	}
 
 	@Test
 	public void testInvalidInputInvalidVarName() throws PersistenceLayerException
 	{
-		assertFalse(parse("SKILL|Foo|IllegalVar|ADD|3"));
+		assertFalse(parse("PC.SKILL|Foo|IllegalVar|ADD|3"));
 		assertNoSideEffects();
 	}
 
 	@Test
 	public void testInvalidInputInvalidMod() throws PersistenceLayerException
 	{
-		assertFalse(parse("SKILL|Foo|MyVar|TRUFFLE|3"));
+		assertFalse(parse("PC.SKILL|Foo|MyVar|TRUFFLE|3"));
 		assertNoSideEffects();
 	}
 
@@ -166,99 +166,99 @@ public class ModifyOtherLstTest extends AbstractGlobalTokenTestCase
 	@Test
 	public void testInvalidInputInvalidNoPriority() throws PersistenceLayerException
 	{
-		assertFalse(parse("SKILL|Foo|MyVar|ADD|3|PRIORITY="));
+		assertFalse(parse("PC.SKILL|Foo|MyVar|ADD|3|PRIORITY="));
 		assertNoSideEffects();
 	}
 
 	@Test
 	public void testInvalidInputInvalidNegativePriority() throws PersistenceLayerException
 	{
-		assertFalse(parse("SKILL|Foo|MyVar|ADD|3|PRIORITY=-1000"));
+		assertFalse(parse("PC.SKILL|Foo|MyVar|ADD|3|PRIORITY=-1000"));
 		assertNoSideEffects();
 	}
 
 	@Test
 	public void testInvalidInputInvalidNonNumberPriority() throws PersistenceLayerException
 	{
-		assertFalse(parse("SKILL|Foo|MyVar|ADD|3|PRIORITY=String"));
+		assertFalse(parse("PC.SKILL|Foo|MyVar|ADD|3|PRIORITY=String"));
 		assertNoSideEffects();
 	}
 
 	@Test
 	public void testInvalidInputInvalidTooManyArgs() throws PersistenceLayerException
 	{
-		assertFalse(parse("SKILL|Foo|MyVar|ADD|3|PRIORITY=3|Yes"));
+		assertFalse(parse("PC.SKILL|Foo|MyVar|ADD|3|PRIORITY=3|Yes"));
 		assertNoSideEffects();
 	}
 
 	@Test
 	public void testInvalidInputInvalidIllegalSourceVar() throws PersistenceLayerException
 	{
-		assertFalse(parse("SKILL|Foo|MyVar|ADD|IllegalVar"));
+		assertFalse(parse("PC.SKILL|Foo|MyVar|ADD|IllegalVar"));
 		assertNoSideEffects();
 	}
 
 	@Test
 	public void testInvalidInputInvalidNotPriority1() throws PersistenceLayerException
 	{
-		assertFalse(parse("SKILL|Foo|MyVar|ADD|3|OTHER=3"));
+		assertFalse(parse("PC.SKILL|Foo|MyVar|ADD|3|OTHER=3"));
 		assertNoSideEffects();
 	}
 
 	@Test
 	public void testInvalidInputInvalidNotPriority2() throws PersistenceLayerException
 	{
-		assertFalse(parse("SKILL|Foo|MyVar|ADD|3|OTHERSTRING=3"));
+		assertFalse(parse("PC.SKILL|Foo|MyVar|ADD|3|OTHERSTRING=3"));
 		assertNoSideEffects();
 	}
 
 	@Test
 	public void testInvalidInputBadVar() throws PersistenceLayerException
 	{
-		assertFalse(parse("SKILL|Foo|4|ADD|3"));
+		assertFalse(parse("PC.SKILL|Foo|4|ADD|3"));
 		assertNoSideEffects();
 	}
 
 	@Test
 	public void testRoundRobinAdd() throws PersistenceLayerException
 	{
-		runRoundRobin("SKILL|Foo|MyVar|ADD|3");
+		runRoundRobin("PC.SKILL|Foo|MyVar|ADD|3");
 	}
 
 	@Test
 	public void testRoundRobinAddGroup() throws PersistenceLayerException
 	{
-		runRoundRobin("SKILL|GROUP=Foo|MyVar|ADD|3");
+		runRoundRobin("PC.SKILL|GROUP=Foo|MyVar|ADD|3");
 	}
 
 	@Test
 	public void testRoundRobinAddAll() throws PersistenceLayerException
 	{
-		runRoundRobin("SKILL|ALL|MyVar|ADD|3");
+		runRoundRobin("PC.SKILL|ALL|MyVar|ADD|3");
 	}
 
 	@Test
 	public void testRoundRobinMultiply() throws PersistenceLayerException
 	{
-		runRoundRobin("SKILL|Foo|MyVar|MULTIPLY|OtherVar");
+		runRoundRobin("PC.SKILL|Foo|MyVar|MULTIPLY|OtherVar");
 	}
 
 	@Test
 	public void testRoundRobinPriority() throws PersistenceLayerException
 	{
-		runRoundRobin("SKILL|Foo|MyVar|ADD|3|PRIORITY=1090");
+		runRoundRobin("PC.SKILL|Foo|MyVar|ADD|3|PRIORITY=1090");
 	}
 
 	@Override
 	protected String getLegalValue()
 	{
-		return "SKILL|Foo|MyVar|ADD|3";
+		return "PC.SKILL|Foo|MyVar|ADD|3";
 	}
 
 	@Override
 	protected String getAlternateLegalValue()
 	{
-		return "SKILL|Foo|OtherVar|MULTIPLY|3|PRIORITY=1000";
+		return "PC.SKILL|Foo|OtherVar|MULTIPLY|3|PRIORITY=1000";
 	}
 
 	@Override

--- a/code/src/utest/plugin/lsttokens/variable/LocalTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/variable/LocalTokenTest.java
@@ -81,40 +81,40 @@ public class LocalTokenTest extends AbstractTokenTestCase<DatasetVariable>
 	@Test
 	public void testValidBasic() throws PersistenceLayerException
 	{
-		assertTrue(parse("EQUIPMENT|IsANumberVar"));
+		assertTrue(parse("PC.EQUIPMENT|IsANumberVar"));
 	}
 
 	@Test
 	public void testValidFormatted() throws PersistenceLayerException
 	{
-		assertTrue(parse("EQUIPMENT|NUMBER=IsANumberVar"));
+		assertTrue(parse("PC.EQUIPMENT|NUMBER=IsANumberVar"));
 	}
 
 	@Test
 	public void testInvalidDoubleEqual() throws PersistenceLayerException
 	{
-		assertFalse(parse("EQUIPMENT|STRING==Pipe"));
+		assertFalse(parse("PC.EQUIPMENT|STRING==Pipe"));
 		assertNoSideEffects();
 	}
 
 	@Test
 	public void testInvalidDoublePipe() throws PersistenceLayerException
 	{
-		assertFalse(parse("EQUIPMENT||STRING=Pipe"));
+		assertFalse(parse("PC.EQUIPMENT||STRING=Pipe"));
 		assertNoSideEffects();
 	}
 
 	@Test
 	public void testInvalidThreeArgs() throws PersistenceLayerException
 	{
-		assertFalse(parse("EQUIPMENT|STRING|Pipe"));
+		assertFalse(parse("PC.EQUIPMENT|STRING|Pipe"));
 		assertNoSideEffects();
 	}
 
 	@Test
 	public void testInvalidThreeEqualArgs() throws PersistenceLayerException
 	{
-		assertFalse(parse("EQUIPMENT|STRING=Pipe=Too"));
+		assertFalse(parse("PC.EQUIPMENT|STRING=Pipe=Too"));
 		assertNoSideEffects();
 	}
 
@@ -128,35 +128,35 @@ public class LocalTokenTest extends AbstractTokenTestCase<DatasetVariable>
 	@Test
 	public void testInvalidOnlyEqual() throws PersistenceLayerException
 	{
-		assertFalse(parse("EQUIPMENT|="));
+		assertFalse(parse("PC.EQUIPMENT|="));
 		assertNoSideEffects();
 	}
 
 	@Test
 	public void testInvalidEmptyFormat() throws PersistenceLayerException
 	{
-		assertFalse(parse("EQUIPMENT|=Value"));
+		assertFalse(parse("PC.EQUIPMENT|=Value"));
 		assertNoSideEffects();
 	}
 
 	@Test
 	public void testInvalidEmptyVarName() throws PersistenceLayerException
 	{
-		assertFalse(parse("EQUIPMENT|NUMBER="));
+		assertFalse(parse("PC.EQUIPMENT|NUMBER="));
 		assertNoSideEffects();
 	}
 
 	@Test
 	public void testInvalidBadFormat() throws PersistenceLayerException
 	{
-		assertFalse(parse("EQUIPMENT|BADFORMAT=Illegal"));
+		assertFalse(parse("PC.EQUIPMENT|BADFORMAT=Illegal"));
 		assertNoSideEffects();
 	}
 
 	@Test
 	public void testInvalidName() throws PersistenceLayerException
 	{
-		assertFalse(parse("EQUIPMENT|NUMBER=Illegal Name!"));
+		assertFalse(parse("PC.EQUIPMENT|NUMBER=Illegal Name!"));
 		assertNoSideEffects();
 	}
 
@@ -177,25 +177,25 @@ public class LocalTokenTest extends AbstractTokenTestCase<DatasetVariable>
 	@Test
 	public void testRoundRobinDefault() throws PersistenceLayerException
 	{
-		runRoundRobin("EQUIPMENT|IsANumberVar");
+		runRoundRobin("PC.EQUIPMENT|IsANumberVar");
 	}
 
 	@Test
 	public void testRoundRobinFormatted() throws PersistenceLayerException
 	{
-		runRoundRobin("EQUIPMENT|STRING=StringVar");
+		runRoundRobin("PC.EQUIPMENT|STRING=StringVar");
 	}
 
 	@Override
 	protected String getAlternateLegalValue()
 	{
-		return "EQUIPMENT|Alt";
+		return "PC.EQUIPMENT|Alt";
 	}
 
 	@Override
 	protected String getLegalValue()
 	{
-		return "EQUIPMENT|Var";
+		return "PC.EQUIPMENT|Var";
 	}
 
 	@Test
@@ -203,9 +203,9 @@ public class LocalTokenTest extends AbstractTokenTestCase<DatasetVariable>
 	{
 		DatasetVariable dv = new DatasetVariable();
 		ParseResult pr =
-				token.parseToken(primaryContext, dv, "EQUIPMENT|MyVar");
+				token.parseToken(primaryContext, dv, "PC.EQUIPMENT|MyVar");
 		assertTrue(pr.passed());
-		assertFalse(parse("EQUIPMENT|STRING=MyVar"));
+		assertFalse(parse("PC.EQUIPMENT|STRING=MyVar"));
 		assertNoSideEffects();
 	}
 


### PR DESCRIPTION

The major change here is that local scopes are now PC.x (this impacts
what appears on MODIFYOTHER as the first argument)

The primary reason for this change is to isolate the PC as a formula scope.  Basically, there are places where we need to do calculations independent of a PC (Equipment and Spells both come to mind), so this will ease that isolation.