### PR TITLE
Fix bug: DATA-3565

### DIFF
--- a/data/pathfinder/paizo/roleplaying_game/bestiary_4/_bestiary4.pcc
+++ b/data/pathfinder/paizo/roleplaying_game/bestiary_4/_bestiary4.pcc
@@ -50,10 +50,8 @@ COPYRIGHT:PCGen dataset conversion for "Pathfinder Roleplaying Game Bestiary 4" 
 ABILITY:b4_abilities_class.lst
 ABILITY:b4_abilities_companion.lst
 ABILITY:b4_abilities_race.lst
-ABILITY:b4_abilities_race_arg.lst
 ABILITY:b4_abilities_races_ce.lst
 ABILITYCATEGORY:b4_abilitycategories.lst
-ABILITYCATEGORY:b4_abilitycategories_arg.lst
 COMPANIONMOD:b4_companionmods.lst
 DOMAIN:b4_domains.lst
 EQUIPMENT:b4_equip_arms_armor.lst
@@ -65,13 +63,15 @@ KIT:b4_kits_race.lst
 LANGUAGE:b4_languages.lst
 WEAPONPROF:b4_profs_weapon.lst
 RACE:b4_races.lst
-RACE:b4_races_arg.lst
 RACE:b4_races_companion.lst
 SKILL:b4_skills.lst
 SPELL:b4_spells_modified.lst
 TEMPLATE:b4_templates.lst
-TEMPLATE:b4_templates_arg.lst
 
+ABILITY:b4_abilities_race_arg.lst|!PRECAMPAIGN:1,Advanced Race Guide
+ABILITYCATEGORY:b4_abilitycategories_arg.lst|!PRECAMPAIGN:1,Advanced Race Guide
+RACE:b4_races_arg.lst|!PRECAMPAIGN:1,Advanced Race Guide
+TEMPLATE:b4_templates_arg.lst|!PRECAMPAIGN:1,Advanced Race Guide
 
 # Support
 ABILITY:support/b4_abilities_race_ma.lst|PRECAMPAIGN:1,Mythic Adventures


### PR DESCRIPTION
Kitsune PC race overridden by Kitsune monster race when both ARG and Bestiary 4 are loaded