### PR TITLE
Reduce direct usage of AbilityCategory.FEAT in tests

### DIFF
--- a/code/src/itest/pcgen/io/AbilityTargetSaveRestoreTest.java
+++ b/code/src/itest/pcgen/io/AbilityTargetSaveRestoreTest.java
@@ -26,9 +26,9 @@ import pcgen.cdom.enumeration.Nature;
 import pcgen.cdom.enumeration.ObjectKey;
 import pcgen.cdom.helper.CNAbilitySelection;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.core.analysis.ChooseActivation;
 import pcgen.io.testsupport.AbstractGlobalTargetedSaveRestoreTest;
+import plugin.lsttokens.testsupport.BuildUtilities;
 
 public class AbilityTargetSaveRestoreTest extends
 		AbstractGlobalTargetedSaveRestoreTest<Ability>
@@ -39,7 +39,7 @@ public class AbilityTargetSaveRestoreTest extends
 	{
 		if (cl.equals(Ability.class))
 		{
-			T source = (T) AbilityCategory.FEAT.newInstance();
+			T source = (T) BuildUtilities.getFeatCat().newInstance();
 			source.setName(key);
 			context.getReferenceContext().importObject(source);
 			return source;
@@ -64,7 +64,7 @@ public class AbilityTargetSaveRestoreTest extends
 		{
 			assoc = "Granted";
 		}
-		CNAbility cna = CNAbilityFactory.getCNAbility(AbilityCategory.FEAT, Nature.NORMAL, obj);
+		CNAbility cna = CNAbilityFactory.getCNAbility(BuildUtilities.getFeatCat(), Nature.NORMAL, obj);
 		CNAbilitySelection cnas = new CNAbilitySelection(cna, assoc);
 		pc.addAbility(cnas, UserSelection.getInstance(), UserSelection.getInstance());
 	}
@@ -79,7 +79,7 @@ public class AbilityTargetSaveRestoreTest extends
 	protected void remove(Object o)
 	{
 		Ability abil = (Ability) o;
-		CNAbility cna = CNAbilityFactory.getCNAbility(AbilityCategory.FEAT, Nature.NORMAL, abil);
+		CNAbility cna = CNAbilityFactory.getCNAbility(BuildUtilities.getFeatCat(), Nature.NORMAL, abil);
 		String assoc = null;
 		if (ChooseActivation.hasNewChooseToken(abil))
 		{

--- a/code/src/itest/pcgen/io/GeneralSaveRestoreTest.java
+++ b/code/src/itest/pcgen/io/GeneralSaveRestoreTest.java
@@ -21,7 +21,6 @@ import java.util.List;
 
 import pcgen.cdom.content.CNAbility;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.core.Language;
 import pcgen.core.PCTemplate;
 import pcgen.io.testsupport.AbstractSaveRestoreTest;
@@ -39,7 +38,7 @@ public class GeneralSaveRestoreTest extends AbstractSaveRestoreTest
 		TokenRegistration.register(new plugin.lsttokens.ability.StackToken());
 		TokenRegistration.register(new plugin.exporttokens.deprecated.TemplateToken());
 		Language lang = context.getReferenceContext().constructCDOMObject(Language.class, "English");
-		Ability a = BuildUtilities.buildAbility(context, AbilityCategory.FEAT, "Ab");
+		Ability a = BuildUtilities.buildAbility(context, BuildUtilities.getFeatCat(), "Ab");
 		PCTemplate pct = context.getReferenceContext().constructCDOMObject(PCTemplate.class, "Templ");
 		try
 		{

--- a/code/src/itest/pcgen/io/testsupport/AbstractGlobalTargetedSaveRestoreTest.java
+++ b/code/src/itest/pcgen/io/testsupport/AbstractGlobalTargetedSaveRestoreTest.java
@@ -26,7 +26,6 @@ import pcgen.cdom.enumeration.SkillCost;
 import pcgen.cdom.enumeration.Type;
 import pcgen.cdom.reference.CDOMDirectSingleRef;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.core.ArmorProf;
 import pcgen.core.Equipment;
 import pcgen.core.Language;
@@ -551,7 +550,7 @@ public abstract class AbstractGlobalTargetedSaveRestoreTest<T extends CDOMObject
 	{
 		TokenRegistration.register(plugin.bonustokens.SkillRank.class);
 		T target = create(getObjectClass(), "Target");
-		Ability abil = BuildUtilities.buildAbility(context, AbilityCategory.FEAT,
+		Ability abil = BuildUtilities.buildAbility(context, BuildUtilities.getFeatCat(),
 			"GrantedAbility");
 		new plugin.lsttokens.add.AbilityToken().parseToken(context, target,
 				"FEAT|NORMAL|GrantedAbility");
@@ -581,7 +580,7 @@ public abstract class AbstractGlobalTargetedSaveRestoreTest<T extends CDOMObject
 	{
 		TokenRegistration.register(plugin.bonustokens.SkillRank.class);
 		T target = create(getObjectClass(), "Target");
-		Ability abil = BuildUtilities.buildAbility(context, AbilityCategory.FEAT,
+		Ability abil = BuildUtilities.buildAbility(context, BuildUtilities.getFeatCat(),
 			"GrantedAbility");
 		new plugin.lsttokens.add.AbilityToken().parseToken(context, target,
 				"FEAT|VIRTUAL|GrantedAbility");

--- a/code/src/itest/pcgen/io/testsupport/AbstractSaveRestoreTest.java
+++ b/code/src/itest/pcgen/io/testsupport/AbstractSaveRestoreTest.java
@@ -61,7 +61,6 @@ import pcgen.cdom.facet.model.StatFacet;
 import pcgen.cdom.facet.model.TemplateFacet;
 import pcgen.cdom.inst.CodeControl;
 import pcgen.cdom.util.CControl;
-import pcgen.core.AbilityCategory;
 import pcgen.core.GameMode;
 import pcgen.core.Globals;
 import pcgen.core.Language;
@@ -327,7 +326,7 @@ public abstract class AbstractSaveRestoreTest extends TestCase
 		FactDefinition<?, String> fd =
 				BuildUtilities.createFact(context, "SpellType", PCClass.class);
 		fd.setSelectable(true);
-		context.getReferenceContext().importObject(AbilityCategory.FEAT);
+		context.getReferenceContext().importObject(BuildUtilities.getFeatCat());
 		SourceFileLoader.createLangBonusObject(Globals.getContext());
 		ChooserFactory.setDelegate(new MockUIDelegate());
 		FormatManager<?> fmtManager = ref.getFormatManager("ALIGNMENT");

--- a/code/src/itest/plugin/lsttokens/editcontext/AbilityIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/AbilityIntegrationTest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 
 import pcgen.cdom.base.CDOMObject;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
@@ -31,6 +30,7 @@ import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.AbilityLst;
 import plugin.lsttokens.editcontext.testsupport.AbstractIntegrationTestCase;
 import plugin.lsttokens.editcontext.testsupport.TestContext;
+import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.lsttokens.testsupport.CDOMTokenLoader;
 
 public class AbilityIntegrationTest extends
@@ -43,10 +43,10 @@ public class AbilityIntegrationTest extends
 	public void setUp() throws PersistenceLayerException, URISyntaxException
 	{
 		super.setUp();
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName("Dummy");
 		primaryContext.getReferenceContext().importObject(a);
-		a = AbilityCategory.FEAT.newInstance();
+		a = BuildUtilities.getFeatCat().newInstance();
 		a.setName("Dummy");
 		secondaryContext.getReferenceContext().importObject(a);
 	}
@@ -225,7 +225,7 @@ public class AbilityIntegrationTest extends
 	@Override
 	protected Ability construct(LoadContext context, String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		context.getReferenceContext().importObject(a);
 		return a;

--- a/code/src/itest/plugin/lsttokens/editcontext/AddIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/AddIntegrationTest.java
@@ -24,7 +24,6 @@ import pcgen.cdom.base.Constants;
 import pcgen.cdom.enumeration.IntegerKey;
 import pcgen.cdom.inst.PCClassLevel;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
@@ -32,6 +31,7 @@ import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.AddLst;
 import plugin.lsttokens.editcontext.testsupport.AbstractIntegrationTestCase;
 import plugin.lsttokens.editcontext.testsupport.TestContext;
+import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.lsttokens.testsupport.CDOMTokenLoader;
 
 public class AddIntegrationTest extends AbstractIntegrationTestCase<CDOMObject>
@@ -132,7 +132,7 @@ public class AddIntegrationTest extends AbstractIntegrationTestCase<CDOMObject>
 	@Override
 	protected Ability construct(LoadContext context, String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		context.getReferenceContext().importObject(a);
 		return a;

--- a/code/src/itest/plugin/lsttokens/editcontext/ChangeProfIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/ChangeProfIntegrationTest.java
@@ -21,7 +21,6 @@ import org.junit.Test;
 
 import pcgen.cdom.base.CDOMObject;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.core.WeaponProf;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.rules.context.LoadContext;
@@ -30,6 +29,7 @@ import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.ChangeprofLst;
 import plugin.lsttokens.editcontext.testsupport.AbstractIntegrationTestCase;
 import plugin.lsttokens.editcontext.testsupport.TestContext;
+import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.lsttokens.testsupport.CDOMTokenLoader;
 
 public class ChangeProfIntegrationTest extends
@@ -115,7 +115,7 @@ public class ChangeProfIntegrationTest extends
 	@Override
 	protected Ability construct(LoadContext context, String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		context.getReferenceContext().importObject(a);
 		return a;

--- a/code/src/itest/plugin/lsttokens/editcontext/DefineIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/DefineIntegrationTest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 
 import pcgen.cdom.base.CDOMObject;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.core.PCStat;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.rules.context.LoadContext;
@@ -116,7 +115,7 @@ public class DefineIntegrationTest extends
 	@Override
 	protected Ability construct(LoadContext context, String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		context.getReferenceContext().importObject(a);
 		return a;

--- a/code/src/itest/plugin/lsttokens/editcontext/DefineStatIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/DefineStatIntegrationTest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 
 import pcgen.cdom.base.CDOMObject;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.core.PCStat;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.rules.context.LoadContext;
@@ -176,7 +175,7 @@ public class DefineStatIntegrationTest extends
 	@Override
 	protected Ability construct(LoadContext context, String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		context.getReferenceContext().importObject(a);
 		return a;

--- a/code/src/itest/plugin/lsttokens/editcontext/DescIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/DescIntegrationTest.java
@@ -19,12 +19,12 @@ package plugin.lsttokens.editcontext;
 
 import pcgen.cdom.base.CDOMObject;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.DescLst;
 import plugin.lsttokens.editcontext.testsupport.AbstractTypeSafeListIntegrationTestCase;
+import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.lsttokens.testsupport.CDOMTokenLoader;
 
 public class DescIntegrationTest extends
@@ -85,7 +85,7 @@ public class DescIntegrationTest extends
 	@Override
 	protected Ability construct(LoadContext context, String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		context.getReferenceContext().importObject(a);
 		return a;

--- a/code/src/itest/plugin/lsttokens/editcontext/DrIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/DrIntegrationTest.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.base.Constants;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
@@ -30,6 +29,7 @@ import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.DrLst;
 import plugin.lsttokens.editcontext.testsupport.AbstractIntegrationTestCase;
 import plugin.lsttokens.editcontext.testsupport.TestContext;
+import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.lsttokens.testsupport.CDOMTokenLoader;
 
 public class DrIntegrationTest extends AbstractIntegrationTestCase<CDOMObject>
@@ -148,7 +148,7 @@ public class DrIntegrationTest extends AbstractIntegrationTestCase<CDOMObject>
 	@Override
 	protected Ability construct(LoadContext context, String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		context.getReferenceContext().importObject(a);
 		return a;

--- a/code/src/itest/plugin/lsttokens/editcontext/FollowersIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/FollowersIntegrationTest.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.list.CompanionList;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
@@ -30,6 +29,7 @@ import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.FollowersLst;
 import plugin.lsttokens.editcontext.testsupport.AbstractIntegrationTestCase;
 import plugin.lsttokens.editcontext.testsupport.TestContext;
+import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.lsttokens.testsupport.CDOMTokenLoader;
 
 public class FollowersIntegrationTest extends
@@ -113,7 +113,7 @@ public class FollowersIntegrationTest extends
 	@Override
 	protected Ability construct(LoadContext context, String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		context.getReferenceContext().importObject(a);
 		return a;

--- a/code/src/itest/plugin/lsttokens/editcontext/MoveCloneIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/MoveCloneIntegrationTest.java
@@ -21,7 +21,6 @@ import org.junit.Test;
 
 import pcgen.cdom.base.CDOMObject;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
@@ -29,6 +28,7 @@ import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.MovecloneLst;
 import plugin.lsttokens.editcontext.testsupport.AbstractIntegrationTestCase;
 import plugin.lsttokens.editcontext.testsupport.TestContext;
+import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.lsttokens.testsupport.CDOMTokenLoader;
 
 public class MoveCloneIntegrationTest extends
@@ -98,7 +98,7 @@ public class MoveCloneIntegrationTest extends
 	@Override
 	protected Ability construct(LoadContext context, String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		context.getReferenceContext().importObject(a);
 		return a;

--- a/code/src/itest/plugin/lsttokens/editcontext/MoveIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/MoveIntegrationTest.java
@@ -21,7 +21,6 @@ import org.junit.Test;
 
 import pcgen.cdom.base.CDOMObject;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
@@ -29,6 +28,7 @@ import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.MoveLst;
 import plugin.lsttokens.editcontext.testsupport.AbstractIntegrationTestCase;
 import plugin.lsttokens.editcontext.testsupport.TestContext;
+import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.lsttokens.testsupport.CDOMTokenLoader;
 
 public class MoveIntegrationTest extends
@@ -98,7 +98,7 @@ public class MoveIntegrationTest extends
 	@Override
 	protected Ability construct(LoadContext context, String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		context.getReferenceContext().importObject(a);
 		return a;

--- a/code/src/itest/plugin/lsttokens/editcontext/NaturalAttacksIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/NaturalAttacksIntegrationTest.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 
 import pcgen.cdom.base.CDOMObject;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
@@ -33,6 +32,7 @@ import plugin.bonustokens.Weapon;
 import plugin.lsttokens.NaturalattacksLst;
 import plugin.lsttokens.editcontext.testsupport.AbstractIntegrationTestCase;
 import plugin.lsttokens.editcontext.testsupport.TestContext;
+import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.lsttokens.testsupport.CDOMTokenLoader;
 
 public class NaturalAttacksIntegrationTest extends
@@ -104,7 +104,7 @@ public class NaturalAttacksIntegrationTest extends
 	@Override
 	protected Ability construct(LoadContext context, String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		context.getReferenceContext().importObject(a);
 		return a;

--- a/code/src/itest/plugin/lsttokens/editcontext/PreIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/PreIntegrationTest.java
@@ -23,7 +23,6 @@ import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.base.ConcretePrereqObject;
 import pcgen.cdom.base.Constants;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
@@ -31,6 +30,7 @@ import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.PreLst;
 import plugin.lsttokens.editcontext.testsupport.AbstractIntegrationTestCase;
 import plugin.lsttokens.editcontext.testsupport.TestContext;
+import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.lsttokens.testsupport.CDOMTokenLoader;
 
 public class PreIntegrationTest extends
@@ -90,7 +90,7 @@ public class PreIntegrationTest extends
 	@Override
 	protected Ability construct(LoadContext context, String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		context.getReferenceContext().importObject(a);
 		return a;

--- a/code/src/itest/plugin/lsttokens/editcontext/QualifyIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/QualifyIntegrationTest.java
@@ -61,8 +61,8 @@ public class QualifyIntegrationTest extends
 	public void testRoundRobinSimple() throws PersistenceLayerException
 	{
 		verifyCleanStart();
-		BuildUtilities.buildAbility(primaryContext, AbilityCategory.FEAT, "My Feat");
-		BuildUtilities.buildAbility(secondaryContext, AbilityCategory.FEAT, "My Feat");
+		BuildUtilities.buildAbility(primaryContext, BuildUtilities.getFeatCat(), "My Feat");
+		BuildUtilities.buildAbility(secondaryContext, BuildUtilities.getFeatCat(), "My Feat");
 		primaryContext.getReferenceContext().constructCDOMObject(Spell.class, "Lightning Bolt");
 		secondaryContext.getReferenceContext().constructCDOMObject(Spell.class, "Lightning Bolt");
 		TestContext tc = new TestContext();
@@ -120,7 +120,7 @@ public class QualifyIntegrationTest extends
 	@Override
 	protected Ability construct(LoadContext context, String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		context.getReferenceContext().importObject(a);
 		return a;

--- a/code/src/itest/plugin/lsttokens/editcontext/SabIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/SabIntegrationTest.java
@@ -19,13 +19,13 @@ package plugin.lsttokens.editcontext;
 
 import pcgen.cdom.base.CDOMObject;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.SabLst;
 import plugin.lsttokens.editcontext.testsupport.AbstractTypeSafeListIntegrationTestCase;
+import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.lsttokens.testsupport.CDOMTokenLoader;
 
 public class SabIntegrationTest extends
@@ -100,7 +100,7 @@ public class SabIntegrationTest extends
 	@Override
 	protected Ability construct(LoadContext context, String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		context.getReferenceContext().importObject(a);
 		return a;

--- a/code/src/itest/plugin/lsttokens/editcontext/SpellKnownIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/SpellKnownIntegrationTest.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.list.ClassSpellList;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.core.spell.Spell;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.rules.context.LoadContext;
@@ -34,6 +33,7 @@ import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.SpellknownLst;
 import plugin.lsttokens.editcontext.testsupport.AbstractIntegrationTestCase;
 import plugin.lsttokens.editcontext.testsupport.TestContext;
+import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.lsttokens.testsupport.CDOMTokenLoader;
 import plugin.lsttokens.testsupport.TokenRegistration;
 import plugin.pretokens.parser.PreClassParser;
@@ -135,7 +135,7 @@ public class SpellKnownIntegrationTest extends
 	@Override
 	protected CDOMObject construct(LoadContext context, String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		context.getReferenceContext().importObject(a);
 		return a;

--- a/code/src/itest/plugin/lsttokens/editcontext/SpellLevelIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/SpellLevelIntegrationTest.java
@@ -26,7 +26,6 @@ import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.list.ClassSpellList;
 import pcgen.cdom.list.DomainSpellList;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.core.spell.Spell;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.rules.context.LoadContext;
@@ -35,6 +34,7 @@ import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.SpelllevelLst;
 import plugin.lsttokens.editcontext.testsupport.AbstractIntegrationTestCase;
 import plugin.lsttokens.editcontext.testsupport.TestContext;
+import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.lsttokens.testsupport.CDOMTokenLoader;
 import plugin.lsttokens.testsupport.TokenRegistration;
 import plugin.pretokens.parser.PreClassParser;
@@ -135,7 +135,7 @@ public class SpellLevelIntegrationTest extends
 	@Override
 	protected Ability construct(LoadContext context, String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		context.getReferenceContext().importObject(a);
 		return a;

--- a/code/src/itest/plugin/lsttokens/editcontext/SpellsIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/SpellsIntegrationTest.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.base.Constants;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.core.spell.Spell;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.rules.context.LoadContext;
@@ -34,6 +33,7 @@ import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.SpellsLst;
 import plugin.lsttokens.editcontext.testsupport.AbstractIntegrationTestCase;
 import plugin.lsttokens.editcontext.testsupport.TestContext;
+import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.lsttokens.testsupport.CDOMTokenLoader;
 import plugin.lsttokens.testsupport.TokenRegistration;
 import plugin.pretokens.parser.PreClassParser;
@@ -181,7 +181,7 @@ public class SpellsIntegrationTest extends
 	@Override
 	protected Ability construct(LoadContext context, String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		context.getReferenceContext().importObject(a);
 		return a;

--- a/code/src/itest/plugin/lsttokens/editcontext/UDamIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/UDamIntegrationTest.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.base.Constants;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
@@ -30,6 +29,7 @@ import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.UdamLst;
 import plugin.lsttokens.editcontext.testsupport.AbstractIntegrationTestCase;
 import plugin.lsttokens.editcontext.testsupport.TestContext;
+import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.lsttokens.testsupport.CDOMTokenLoader;
 
 public class UDamIntegrationTest extends
@@ -139,7 +139,7 @@ public class UDamIntegrationTest extends
 	@Override
 	protected Ability construct(LoadContext context, String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		context.getReferenceContext().importObject(a);
 		return a;

--- a/code/src/itest/plugin/lsttokens/editcontext/UmultIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/UmultIntegrationTest.java
@@ -19,12 +19,12 @@ package plugin.lsttokens.editcontext;
 
 import pcgen.cdom.base.CDOMObject;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.UmultLst;
 import plugin.lsttokens.editcontext.testsupport.AbstractIntegerIntegrationTestCase;
+import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.lsttokens.testsupport.CDOMTokenLoader;
 
 public class UmultIntegrationTest extends
@@ -85,7 +85,7 @@ public class UmultIntegrationTest extends
 	@Override
 	protected Ability construct(LoadContext context, String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		context.getReferenceContext().importObject(a);
 		return a;

--- a/code/src/itest/plugin/lsttokens/editcontext/UnencumberedMoveIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/UnencumberedMoveIntegrationTest.java
@@ -21,7 +21,6 @@ import org.junit.Test;
 
 import pcgen.cdom.base.CDOMObject;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
@@ -29,6 +28,7 @@ import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.UnencumberedmoveLst;
 import plugin.lsttokens.editcontext.testsupport.AbstractIntegrationTestCase;
 import plugin.lsttokens.editcontext.testsupport.TestContext;
+import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.lsttokens.testsupport.CDOMTokenLoader;
 
 public class UnencumberedMoveIntegrationTest extends
@@ -98,7 +98,7 @@ public class UnencumberedMoveIntegrationTest extends
 	@Override
 	protected CDOMObject construct(LoadContext context, String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		context.getReferenceContext().importObject(a);
 		return a;

--- a/code/src/itest/plugin/lsttokens/editcontext/VisionIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/VisionIntegrationTest.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.base.Constants;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
@@ -30,6 +29,7 @@ import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.VisionLst;
 import plugin.lsttokens.editcontext.testsupport.AbstractIntegrationTestCase;
 import plugin.lsttokens.editcontext.testsupport.TestContext;
+import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.lsttokens.testsupport.CDOMTokenLoader;
 
 public class VisionIntegrationTest extends
@@ -200,7 +200,7 @@ public class VisionIntegrationTest extends
 	@Override
 	protected Ability construct(LoadContext context, String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		context.getReferenceContext().importObject(a);
 		return a;

--- a/code/src/itest/plugin/lsttokens/editcontext/ability/AddSpellLevelIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/ability/AddSpellLevelIntegrationTest.java
@@ -18,12 +18,12 @@
 package plugin.lsttokens.editcontext.ability;
 
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.ability.AddspelllevelToken;
 import plugin.lsttokens.editcontext.testsupport.AbstractIntegerIntegrationTestCase;
+import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.lsttokens.testsupport.CDOMTokenLoader;
 
 public class AddSpellLevelIntegrationTest extends
@@ -84,7 +84,7 @@ public class AddSpellLevelIntegrationTest extends
 	@Override
 	protected Ability construct(LoadContext context, String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		context.getReferenceContext().importObject(a);
 		return a;

--- a/code/src/itest/plugin/lsttokens/editcontext/ability/AspectIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/ability/AspectIntegrationTest.java
@@ -20,7 +20,6 @@ package plugin.lsttokens.editcontext.ability;
 import org.junit.Test;
 
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
@@ -28,6 +27,7 @@ import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.ability.AspectToken;
 import plugin.lsttokens.editcontext.testsupport.AbstractIntegrationTestCase;
 import plugin.lsttokens.editcontext.testsupport.TestContext;
+import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.lsttokens.testsupport.CDOMTokenLoader;
 
 public class AspectIntegrationTest extends
@@ -97,7 +97,7 @@ public class AspectIntegrationTest extends
 	@Override
 	protected Ability construct(LoadContext context, String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		context.getReferenceContext().importObject(a);
 		return a;

--- a/code/src/itest/plugin/lsttokens/editcontext/ability/BenefitIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/ability/BenefitIntegrationTest.java
@@ -18,12 +18,12 @@
 package plugin.lsttokens.editcontext.ability;
 
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.ability.BenefitToken;
 import plugin.lsttokens.editcontext.testsupport.AbstractTypeSafeListIntegrationTestCase;
+import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.lsttokens.testsupport.CDOMTokenLoader;
 
 public class BenefitIntegrationTest extends
@@ -84,7 +84,7 @@ public class BenefitIntegrationTest extends
 	@Override
 	protected Ability construct(LoadContext context, String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		context.getReferenceContext().importObject(a);
 		return a;

--- a/code/src/itest/plugin/lsttokens/editcontext/ability/CostIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/ability/CostIntegrationTest.java
@@ -18,12 +18,12 @@
 package plugin.lsttokens.editcontext.ability;
 
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.ability.CostToken;
 import plugin.lsttokens.editcontext.testsupport.AbstractBigDecimalIntegrationTestCase;
+import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.lsttokens.testsupport.CDOMTokenLoader;
 
 public class CostIntegrationTest extends
@@ -72,7 +72,7 @@ public class CostIntegrationTest extends
 	@Override
 	protected Ability construct(LoadContext context, String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		context.getReferenceContext().importObject(a);
 		return a;

--- a/code/src/itest/plugin/lsttokens/editcontext/ability/MultIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/ability/MultIntegrationTest.java
@@ -20,7 +20,6 @@ package plugin.lsttokens.editcontext.ability;
 import org.junit.Test;
 
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
@@ -28,6 +27,7 @@ import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.ability.MultToken;
 import plugin.lsttokens.editcontext.testsupport.AbstractIntegrationTestCase;
 import plugin.lsttokens.editcontext.testsupport.TestContext;
+import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.lsttokens.testsupport.CDOMTokenLoader;
 
 public class MultIntegrationTest extends
@@ -118,7 +118,7 @@ public class MultIntegrationTest extends
 	@Override
 	protected Ability construct(LoadContext context, String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		context.getReferenceContext().importObject(a);
 		return a;

--- a/code/src/itest/plugin/lsttokens/editcontext/ability/StackIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/ability/StackIntegrationTest.java
@@ -20,7 +20,6 @@ package plugin.lsttokens.editcontext.ability;
 import org.junit.Test;
 
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
@@ -28,6 +27,7 @@ import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.ability.StackToken;
 import plugin.lsttokens.editcontext.testsupport.AbstractIntegrationTestCase;
 import plugin.lsttokens.editcontext.testsupport.TestContext;
+import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.lsttokens.testsupport.CDOMTokenLoader;
 
 public class StackIntegrationTest extends
@@ -118,7 +118,7 @@ public class StackIntegrationTest extends
 	@Override
 	protected Ability construct(LoadContext context, String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		context.getReferenceContext().importObject(a);
 		return a;

--- a/code/src/itest/plugin/lsttokens/editcontext/ability/VisibleIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/ability/VisibleIntegrationTest.java
@@ -20,7 +20,6 @@ package plugin.lsttokens.editcontext.ability;
 import org.junit.Test;
 
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
@@ -28,6 +27,7 @@ import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.ability.VisibleToken;
 import plugin.lsttokens.editcontext.testsupport.AbstractIntegrationTestCase;
 import plugin.lsttokens.editcontext.testsupport.TestContext;
+import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.lsttokens.testsupport.CDOMTokenLoader;
 
 public class VisibleIntegrationTest extends
@@ -88,7 +88,7 @@ public class VisibleIntegrationTest extends
 	@Override
 	protected Ability construct(LoadContext context, String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		context.getReferenceContext().importObject(a);
 		return a;

--- a/code/src/itest/plugin/lsttokens/editcontext/add/AbilityIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/add/AbilityIntegrationTest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 
 import pcgen.cdom.base.CDOMObject;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.core.PCTemplate;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.rules.context.LoadContext;
@@ -32,6 +31,7 @@ import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.AddLst;
 import plugin.lsttokens.add.AbilityToken;
 import plugin.lsttokens.editcontext.testsupport.AbstractListIntegrationTestCase;
+import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.lsttokens.testsupport.CDOMTokenLoader;
 import plugin.lsttokens.testsupport.TokenRegistration;
 
@@ -125,7 +125,7 @@ public class AbilityIntegrationTest extends
 	@Override
 	protected Ability construct(LoadContext loadContext, String one)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setKeyName(one);
 		loadContext.getReferenceContext().importObject(a);
 		return a;

--- a/code/src/itest/plugin/lsttokens/editcontext/testsupport/AbstractIntegrationTestCase.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/testsupport/AbstractIntegrationTestCase.java
@@ -28,7 +28,6 @@ import org.junit.BeforeClass;
 import junit.framework.TestCase;
 import pcgen.cdom.base.ConcretePrereqObject;
 import pcgen.cdom.base.Loadable;
-import pcgen.core.AbilityCategory;
 import pcgen.core.Campaign;
 import pcgen.core.bonus.BonusObj;
 import pcgen.output.publish.OutputDB;
@@ -41,6 +40,7 @@ import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.TokenLibrary;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
+import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.lsttokens.testsupport.TokenRegistration;
 import util.TestURI;
 
@@ -84,8 +84,8 @@ public abstract class AbstractIntegrationTestCase<T extends ConcretePrereqObject
 		TokenRegistration.register(getToken());
 		primaryContext = new EditorLoadContext();
 		secondaryContext = new EditorLoadContext();
-		primaryContext.getReferenceContext().importObject(AbilityCategory.FEAT);
-		secondaryContext.getReferenceContext().importObject(AbilityCategory.FEAT);
+		primaryContext.getReferenceContext().importObject(BuildUtilities.getFeatCat());
+		secondaryContext.getReferenceContext().importObject(BuildUtilities.getFeatCat());
 		primaryProf = construct(primaryContext, "TestObj");
 		secondaryProf = construct(secondaryContext, "TestObj");
 	}

--- a/code/src/itest/tokencontent/GlobalSpellKnownTest.java
+++ b/code/src/itest/tokencontent/GlobalSpellKnownTest.java
@@ -142,8 +142,8 @@ public class GlobalSpellKnownTest extends AbstractContentTokenTest
 		}
 		finishLoad();
 		assertEquals(baseCount(), targetFacetCount());
-		CNAbilitySelection cas =
-				new CNAbilitySelection(CNAbilityFactory.getCNAbility(BuildUtilities.getFeatCat(), Nature.AUTOMATIC, source));
+		CNAbilitySelection cas = new CNAbilitySelection(CNAbilityFactory
+			.getCNAbility(BuildUtilities.getFeatCat(), Nature.AUTOMATIC, source));
 		directAbilityFacet.add(id, cas, UserSelection.getInstance());
 		assertFalse(containsExpected());
 		PCTemplate varsource = create(PCTemplate.class, "VarSource");

--- a/code/src/itest/tokencontent/GlobalSpellKnownTest.java
+++ b/code/src/itest/tokencontent/GlobalSpellKnownTest.java
@@ -30,7 +30,6 @@ import pcgen.cdom.facet.KnownSpellFacet;
 import pcgen.cdom.helper.CNAbilitySelection;
 import pcgen.cdom.list.ClassSpellList;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.core.PCTemplate;
 import pcgen.core.prereq.PrerequisiteTestFactory;
 import pcgen.core.spell.Spell;
@@ -144,7 +143,7 @@ public class GlobalSpellKnownTest extends AbstractContentTokenTest
 		finishLoad();
 		assertEquals(baseCount(), targetFacetCount());
 		CNAbilitySelection cas =
-				new CNAbilitySelection(CNAbilityFactory.getCNAbility(AbilityCategory.FEAT, Nature.AUTOMATIC, source));
+				new CNAbilitySelection(CNAbilityFactory.getCNAbility(BuildUtilities.getFeatCat(), Nature.AUTOMATIC, source));
 		directAbilityFacet.add(id, cas, UserSelection.getInstance());
 		assertFalse(containsExpected());
 		PCTemplate varsource = create(PCTemplate.class, "VarSource");

--- a/code/src/itest/tokencontent/testsupport/AbstractContentTokenTest.java
+++ b/code/src/itest/tokencontent/testsupport/AbstractContentTokenTest.java
@@ -52,8 +52,8 @@ public abstract class AbstractContentTokenTest extends AbstractTokenModelTest
 		Ability source = BuildUtilities.buildFeat(context, "Source");
 		processToken(source);
 		assertEquals(baseCount(), targetFacetCount());
-		CNAbilitySelection cas =
-				new CNAbilitySelection(CNAbilityFactory.getCNAbility(BuildUtilities.getFeatCat(), Nature.AUTOMATIC, source));
+		CNAbilitySelection cas = new CNAbilitySelection(CNAbilityFactory
+			.getCNAbility(BuildUtilities.getFeatCat(), Nature.AUTOMATIC, source));
 		directAbilityFacet.add(id, cas, UserSelection.getInstance());
 		assertTrue(containsExpected());
 		assertEquals(baseCount() + 1, targetFacetCount());

--- a/code/src/itest/tokencontent/testsupport/AbstractContentTokenTest.java
+++ b/code/src/itest/tokencontent/testsupport/AbstractContentTokenTest.java
@@ -29,7 +29,6 @@ import pcgen.cdom.helper.ClassSource;
 import pcgen.cdom.inst.PCClassLevel;
 import pcgen.cdom.list.CompanionList;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.core.Campaign;
 import pcgen.core.Deity;
 import pcgen.core.Domain;
@@ -54,7 +53,7 @@ public abstract class AbstractContentTokenTest extends AbstractTokenModelTest
 		processToken(source);
 		assertEquals(baseCount(), targetFacetCount());
 		CNAbilitySelection cas =
-				new CNAbilitySelection(CNAbilityFactory.getCNAbility(AbilityCategory.FEAT, Nature.AUTOMATIC, source));
+				new CNAbilitySelection(CNAbilityFactory.getCNAbility(BuildUtilities.getFeatCat(), Nature.AUTOMATIC, source));
 		directAbilityFacet.add(id, cas, UserSelection.getInstance());
 		assertTrue(containsExpected());
 		assertEquals(baseCount() + 1, targetFacetCount());

--- a/code/src/itest/tokenmodel/AbilityDepthTest.java
+++ b/code/src/itest/tokenmodel/AbilityDepthTest.java
@@ -27,13 +27,13 @@ import pcgen.cdom.facet.FacetLibrary;
 import pcgen.cdom.facet.GrantedAbilityFacet;
 import pcgen.cdom.helper.CNAbilitySelection;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.rules.persistence.token.CDOMToken;
 import pcgen.rules.persistence.token.ParseResult;
 import plugin.lsttokens.AbilityLst;
 import plugin.lsttokens.add.AbilityToken;
 import plugin.lsttokens.deprecated.VFeatLst;
+import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.lsttokens.testsupport.TokenRegistration;
 
 import junit.framework.Test;
@@ -83,7 +83,7 @@ public class AbilityDepthTest extends AbstractTokenModelTest
 
 	private Ability createAbility(String key)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(key);
 		context.getReferenceContext().importObject(a);
 		return a;
@@ -139,7 +139,7 @@ public class AbilityDepthTest extends AbstractTokenModelTest
 
 		CNAbilitySelection cas =
 				new CNAbilitySelection(CNAbilityFactory.getCNAbility(
-					AbilityCategory.FEAT, Nature.AUTOMATIC, top));
+					BuildUtilities.getFeatCat(), Nature.AUTOMATIC, top));
 
 		assertEquals(0, getCount());
 		pc.addAbility(cas, "This", "That");
@@ -155,7 +155,7 @@ public class AbilityDepthTest extends AbstractTokenModelTest
 	protected boolean containsExpected(Ability granted)
 	{
 		Collection<CNAbility> abilities =
-				grantedAbilityFacet.getPoolAbilities(id, AbilityCategory.FEAT);
+				grantedAbilityFacet.getPoolAbilities(id, BuildUtilities.getFeatCat());
 		if (abilities.isEmpty())
 		{
 			System.err.println("No Abilities");
@@ -180,7 +180,7 @@ public class AbilityDepthTest extends AbstractTokenModelTest
 
 	protected int getCount()
 	{
-		return grantedAbilityFacet.getPoolAbilities(id, AbilityCategory.FEAT)
+		return grantedAbilityFacet.getPoolAbilities(id, BuildUtilities.getFeatCat())
 			.size();
 	}
 

--- a/code/src/itest/tokenmodel/AddAbilityNormalTest.java
+++ b/code/src/itest/tokenmodel/AddAbilityNormalTest.java
@@ -26,7 +26,6 @@ import pcgen.cdom.facet.FacetLibrary;
 import pcgen.cdom.facet.GrantedAbilityFacet;
 import pcgen.cdom.helper.ClassSource;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.core.Domain;
 import pcgen.core.PCClass;
 import pcgen.persistence.PersistenceLayerException;
@@ -97,7 +96,7 @@ public class AddAbilityNormalTest extends AbstractAddListTokenTest<Ability>
 	@Override
 	protected int getCount()
 	{
-		return getTargetFacet().getPoolAbilities(id, AbilityCategory.FEAT, Nature.NORMAL)
+		return getTargetFacet().getPoolAbilities(id, BuildUtilities.getFeatCat(), Nature.NORMAL)
 			.size();
 	}
 
@@ -105,7 +104,7 @@ public class AddAbilityNormalTest extends AbstractAddListTokenTest<Ability>
 	protected boolean containsExpected(Ability granted)
 	{
 		Collection<CNAbility> abilities =
-				getTargetFacet().getPoolAbilities(id, AbilityCategory.FEAT, Nature.NORMAL);
+				getTargetFacet().getPoolAbilities(id, BuildUtilities.getFeatCat(), Nature.NORMAL);
 		if (abilities.isEmpty())
 		{
 			System.err.println("No Abilities");
@@ -114,7 +113,7 @@ public class AddAbilityNormalTest extends AbstractAddListTokenTest<Ability>
 		for (CNAbility a : abilities)
 		{
 			boolean abilityExpected = a.getAbility().equals(context.getReferenceContext()
-				.getManufacturerId(AbilityCategory.FEAT).getActiveObject("Granted"));
+				.getManufacturerId(BuildUtilities.getFeatCat()).getActiveObject("Granted"));
 			if (abilityExpected)
 			{
 				boolean c = assocCheck.check(a);

--- a/code/src/itest/tokenmodel/AddAbilityVirtualTest.java
+++ b/code/src/itest/tokenmodel/AddAbilityVirtualTest.java
@@ -26,7 +26,6 @@ import pcgen.cdom.facet.FacetLibrary;
 import pcgen.cdom.facet.GrantedAbilityFacet;
 import pcgen.cdom.helper.ClassSource;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.core.Domain;
 import pcgen.core.PCClass;
 import pcgen.persistence.PersistenceLayerException;
@@ -35,6 +34,7 @@ import pcgen.rules.persistence.token.ParseResult;
 import plugin.lsttokens.ability.StackToken;
 import plugin.lsttokens.add.AbilityToken;
 import plugin.lsttokens.choose.NoChoiceToken;
+import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.lsttokens.testsupport.TokenRegistration;
 
 import org.junit.Test;
@@ -99,7 +99,7 @@ public class AddAbilityVirtualTest extends AbstractAddListTokenTest<Ability>
 	@Override
 	protected int getCount()
 	{
-		return getTargetFacet().getPoolAbilities(id, AbilityCategory.FEAT, Nature.VIRTUAL)
+		return getTargetFacet().getPoolAbilities(id, BuildUtilities.getFeatCat(), Nature.VIRTUAL)
 			.size();
 	}
 
@@ -107,11 +107,11 @@ public class AddAbilityVirtualTest extends AbstractAddListTokenTest<Ability>
 	protected boolean containsExpected(Ability granted)
 	{
 		Collection<CNAbility> abilities =
-				getTargetFacet().getPoolAbilities(id, AbilityCategory.FEAT, Nature.VIRTUAL);
+				getTargetFacet().getPoolAbilities(id, BuildUtilities.getFeatCat(), Nature.VIRTUAL);
 		for (CNAbility a : abilities)
 		{
 			boolean abilityExpected = a.getAbility().equals(context.getReferenceContext()
-				.getManufacturerId(AbilityCategory.FEAT).getActiveObject("Granted"));
+				.getManufacturerId(BuildUtilities.getFeatCat()).getActiveObject("Granted"));
 			if (abilityExpected)
 			{
 				boolean c = assocCheck.check(a);
@@ -129,7 +129,7 @@ public class AddAbilityVirtualTest extends AbstractAddListTokenTest<Ability>
 	@Override
 	protected Ability createGrantedObject()
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName("Granted");
 		context.getReferenceContext().importObject(a);
 		return a;

--- a/code/src/itest/tokenmodel/AddTargetedAbilityNormalTest.java
+++ b/code/src/itest/tokenmodel/AddTargetedAbilityNormalTest.java
@@ -25,7 +25,6 @@ import pcgen.cdom.enumeration.Nature;
 import pcgen.cdom.facet.FacetLibrary;
 import pcgen.cdom.facet.GrantedAbilityFacet;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.core.Language;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.rules.persistence.token.CDOMToken;
@@ -76,7 +75,7 @@ public class AddTargetedAbilityNormalTest extends AbstractAddListTokenTest<Abili
 	@Override
 	protected int getCount()
 	{
-		return getTargetFacet().getPoolAbilities(id, AbilityCategory.FEAT, Nature.NORMAL)
+		return getTargetFacet().getPoolAbilities(id, BuildUtilities.getFeatCat(), Nature.NORMAL)
 			.size();
 	}
 
@@ -84,11 +83,11 @@ public class AddTargetedAbilityNormalTest extends AbstractAddListTokenTest<Abili
 	protected boolean containsExpected(Ability granted)
 	{
 		Collection<CNAbility> abilities =
-				getTargetFacet().getPoolAbilities(id, AbilityCategory.FEAT, Nature.NORMAL);
+				getTargetFacet().getPoolAbilities(id, BuildUtilities.getFeatCat(), Nature.NORMAL);
 		for (CNAbility a : abilities)
 		{
 			boolean abilityExpected = a.getAbility().equals(context.getReferenceContext()
-				.getManufacturerId(AbilityCategory.FEAT).getActiveObject("Granted"));
+				.getManufacturerId(BuildUtilities.getFeatCat()).getActiveObject("Granted"));
 			if (abilityExpected)
 			{
 				if (pc.getDetailedAssociationCount(a) == 1)

--- a/code/src/itest/tokenmodel/AddTargetedAbilityVirtualTest.java
+++ b/code/src/itest/tokenmodel/AddTargetedAbilityVirtualTest.java
@@ -25,7 +25,6 @@ import pcgen.cdom.enumeration.Nature;
 import pcgen.cdom.facet.FacetLibrary;
 import pcgen.cdom.facet.GrantedAbilityFacet;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.core.Language;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.rules.persistence.token.CDOMToken;
@@ -76,7 +75,7 @@ public class AddTargetedAbilityVirtualTest extends AbstractAddListTokenTest<Abil
 	@Override
 	protected int getCount()
 	{
-		return getTargetFacet().getPoolAbilities(id, AbilityCategory.FEAT, Nature.VIRTUAL)
+		return getTargetFacet().getPoolAbilities(id, BuildUtilities.getFeatCat(), Nature.VIRTUAL)
 			.size();
 	}
 
@@ -84,11 +83,11 @@ public class AddTargetedAbilityVirtualTest extends AbstractAddListTokenTest<Abil
 	protected boolean containsExpected(Ability granted)
 	{
 		Collection<CNAbility> abilities =
-				getTargetFacet().getPoolAbilities(id, AbilityCategory.FEAT, Nature.VIRTUAL);
+				getTargetFacet().getPoolAbilities(id, BuildUtilities.getFeatCat(), Nature.VIRTUAL);
 		for (CNAbility a : abilities)
 		{
 			boolean abilityExpected = a.getAbility().equals(context.getReferenceContext()
-				.getManufacturerId(AbilityCategory.FEAT).getActiveObject("Granted"));
+				.getManufacturerId(BuildUtilities.getFeatCat()).getActiveObject("Granted"));
 			if (abilityExpected)
 			{
 				if (pc.getDetailedAssociationCount(a) == 1)

--- a/code/src/itest/tokenmodel/AutoLangListTest.java
+++ b/code/src/itest/tokenmodel/AutoLangListTest.java
@@ -54,8 +54,8 @@ public class AutoLangListTest extends AbstractTokenModelTest
 		Language granted = createGrantedObject();
 		processToken(source);
 		assertEquals(0, getCount());
-		CNAbilitySelection cas =
-				new CNAbilitySelection(CNAbilityFactory.getCNAbility(BuildUtilities.getFeatCat(), Nature.AUTOMATIC, source), "Granted");
+		CNAbilitySelection cas = new CNAbilitySelection(CNAbilityFactory.getCNAbility(
+			BuildUtilities.getFeatCat(), Nature.AUTOMATIC, source), "Granted");
 		directAbilityFacet.add(id, cas, UserSelection.getInstance());
 		assertTrue(containsExpected(granted));
 		assertEquals(1,
@@ -151,7 +151,8 @@ public class AutoLangListTest extends AbstractTokenModelTest
 	@Override
 	protected Object getAssoc()
 	{
-		return context.getReferenceContext().silentlyGetConstructedCDOMObject(Language.class, "Granted");
+		return context.getReferenceContext()
+			.silentlyGetConstructedCDOMObject(Language.class, "Granted");
 	}
 	
 	

--- a/code/src/itest/tokenmodel/AutoLangListTest.java
+++ b/code/src/itest/tokenmodel/AutoLangListTest.java
@@ -24,7 +24,6 @@ import pcgen.cdom.enumeration.Nature;
 import pcgen.cdom.facet.model.LanguageFacet;
 import pcgen.cdom.helper.CNAbilitySelection;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.core.Language;
 import pcgen.core.PCTemplate;
 import pcgen.core.Race;
@@ -56,7 +55,7 @@ public class AutoLangListTest extends AbstractTokenModelTest
 		processToken(source);
 		assertEquals(0, getCount());
 		CNAbilitySelection cas =
-				new CNAbilitySelection(CNAbilityFactory.getCNAbility(AbilityCategory.FEAT, Nature.AUTOMATIC, source), "Granted");
+				new CNAbilitySelection(CNAbilityFactory.getCNAbility(BuildUtilities.getFeatCat(), Nature.AUTOMATIC, source), "Granted");
 		directAbilityFacet.add(id, cas, UserSelection.getInstance());
 		assertTrue(containsExpected(granted));
 		assertEquals(1,

--- a/code/src/itest/tokenmodel/AutoWeaponProfListTargetTest.java
+++ b/code/src/itest/tokenmodel/AutoWeaponProfListTargetTest.java
@@ -128,8 +128,8 @@ public class AutoWeaponProfListTargetTest extends AbstractTokenModelTest
 		}
 		finishLoad();
 		assertEquals(0, directAbilityFacet.getCount(id));
-		CNAbilitySelection cas =
-				new CNAbilitySelection(CNAbilityFactory.getCNAbility(BuildUtilities.getFeatCat(), Nature.AUTOMATIC, source), "English");
+		CNAbilitySelection cas = new CNAbilitySelection(CNAbilityFactory.getCNAbility(
+			BuildUtilities.getFeatCat(), Nature.AUTOMATIC, source), "English");
 		directAbilityFacet.add(id, cas, UserSelection.getInstance());
 		assertTrue(containsExpected());
 		assertEquals(2, directAbilityFacet.getCount(id));

--- a/code/src/itest/tokenmodel/AutoWeaponProfListTargetTest.java
+++ b/code/src/itest/tokenmodel/AutoWeaponProfListTargetTest.java
@@ -27,7 +27,6 @@ import pcgen.cdom.facet.DirectAbilityFacet;
 import pcgen.cdom.facet.FacetLibrary;
 import pcgen.cdom.helper.CNAbilitySelection;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.core.Language;
 import pcgen.core.PCTemplate;
 import pcgen.persistence.PersistenceLayerException;
@@ -130,7 +129,7 @@ public class AutoWeaponProfListTargetTest extends AbstractTokenModelTest
 		finishLoad();
 		assertEquals(0, directAbilityFacet.getCount(id));
 		CNAbilitySelection cas =
-				new CNAbilitySelection(CNAbilityFactory.getCNAbility(AbilityCategory.FEAT, Nature.AUTOMATIC, source), "English");
+				new CNAbilitySelection(CNAbilityFactory.getCNAbility(BuildUtilities.getFeatCat(), Nature.AUTOMATIC, source), "English");
 		directAbilityFacet.add(id, cas, UserSelection.getInstance());
 		assertTrue(containsExpected());
 		assertEquals(2, directAbilityFacet.getCount(id));
@@ -153,10 +152,10 @@ public class AutoWeaponProfListTargetTest extends AbstractTokenModelTest
 		{
 			CNAbility cas = cnas.getCNAbility();
 			boolean featExpected =
-					cas.getAbilityCategory() == AbilityCategory.FEAT;
+					cas.getAbilityCategory() == BuildUtilities.getFeatCat();
 			boolean abilityExpected = cas.getAbility()
 				.equals(context.getReferenceContext()
-					.getManufacturerId(AbilityCategory.FEAT).getActiveObject("Granted"));
+					.getManufacturerId(BuildUtilities.getFeatCat()).getActiveObject("Granted"));
 			boolean natureExpected = cas.getNature() == Nature.AUTOMATIC;
 			boolean selectionExpected = "English".equals(cnas.getSelection());
 			if (featExpected && abilityExpected && natureExpected
@@ -184,7 +183,7 @@ public class AutoWeaponProfListTargetTest extends AbstractTokenModelTest
 
 	protected Ability createGrantedObject()
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName("Granted");
 		context.getReferenceContext().importObject(a);
 		return a;

--- a/code/src/itest/tokenmodel/GlobalAbilityTest.java
+++ b/code/src/itest/tokenmodel/GlobalAbilityTest.java
@@ -25,11 +25,10 @@ import pcgen.cdom.enumeration.Nature;
 import pcgen.cdom.facet.DirectAbilityFacet;
 import pcgen.cdom.helper.CNAbilitySelection;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.rules.persistence.token.CDOMToken;
 import pcgen.rules.persistence.token.ParseResult;
 import plugin.lsttokens.AbilityLst;
-
+import plugin.lsttokens.testsupport.BuildUtilities;
 import tokenmodel.testsupport.AbstractGrantedListTokenTest;
 import util.TestURI;
 
@@ -83,10 +82,10 @@ public class GlobalAbilityTest extends AbstractGrantedListTokenTest<Ability>
 		{
 			CNAbility cas = cnas.getCNAbility();
 			boolean featExpected =
-					cas.getAbilityCategory() == AbilityCategory.FEAT;
+					cas.getAbilityCategory() == BuildUtilities.getFeatCat();
 			boolean abilityExpected = cas.getAbility()
 				.equals(context.getReferenceContext()
-					.getManufacturerId(AbilityCategory.FEAT).getActiveObject("Granted"));
+					.getManufacturerId(BuildUtilities.getFeatCat()).getActiveObject("Granted"));
 			boolean natureExpected = cas.getNature() == Nature.VIRTUAL;
 			boolean selectionExpected = cnas.getSelection() == null;
 			if (featExpected && abilityExpected && natureExpected
@@ -101,7 +100,7 @@ public class GlobalAbilityTest extends AbstractGrantedListTokenTest<Ability>
 	@Override
 	protected Ability createGrantedObject()
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName("Granted");
 		context.getReferenceContext().importObject(a);
 		return a;

--- a/code/src/itest/tokenmodel/testsupport/AbstractAbilityGrantCheckTest.java
+++ b/code/src/itest/tokenmodel/testsupport/AbstractAbilityGrantCheckTest.java
@@ -23,7 +23,6 @@ import pcgen.cdom.content.CNAbilityFactory;
 import pcgen.cdom.enumeration.Nature;
 import pcgen.cdom.helper.CNAbilitySelection;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.rules.persistence.token.CDOMToken;
 import pcgen.rules.persistence.token.ParseResult;
 import plugin.lsttokens.ability.StackToken;
@@ -168,9 +167,9 @@ public abstract class AbstractAbilityGrantCheckTest extends AbstractTokenModelTe
 		Ability parent = getGrantor("MultNo");
 		finishLoad();
 		applyParent(parent);
-		assertTrue(pc.hasAbilityKeyed(AbilityCategory.FEAT, "Parent"));
-		assertTrue(pc.hasAbilityKeyed(AbilityCategory.FEAT, "Grantor"));
-		assertTrue(pc.hasAbilityKeyed(AbilityCategory.FEAT, "MultNo"));
+		assertTrue(pc.hasAbilityKeyed(BuildUtilities.getFeatCat(), "Parent"));
+		assertTrue(pc.hasAbilityKeyed(BuildUtilities.getFeatCat(), "Grantor"));
+		assertTrue(pc.hasAbilityKeyed(BuildUtilities.getFeatCat(), "MultNo"));
 	}
 
 	public void testNaturalParens()
@@ -179,9 +178,9 @@ public abstract class AbstractAbilityGrantCheckTest extends AbstractTokenModelTe
 		Ability parent = getGrantor("Natural (Parens)");
 		finishLoad();
 		applyParent(parent);
-		assertTrue(pc.hasAbilityKeyed(AbilityCategory.FEAT, "Parent"));
-		assertTrue(pc.hasAbilityKeyed(AbilityCategory.FEAT, "Grantor"));
-		assertTrue(pc.hasAbilityKeyed(AbilityCategory.FEAT, "Natural (Parens)"));
+		assertTrue(pc.hasAbilityKeyed(BuildUtilities.getFeatCat(), "Parent"));
+		assertTrue(pc.hasAbilityKeyed(BuildUtilities.getFeatCat(), "Grantor"));
+		assertTrue(pc.hasAbilityKeyed(BuildUtilities.getFeatCat(), "Natural (Parens)"));
 	}
 
 	public void testMultYes()
@@ -191,10 +190,10 @@ public abstract class AbstractAbilityGrantCheckTest extends AbstractTokenModelTe
 		Ability parent = getGrantor("MultYes (Target)");
 		finishLoad();
 		applyParent(parent);
-		assertTrue(pc.hasAbilityKeyed(AbilityCategory.FEAT, "Parent"));
-		assertTrue(pc.hasAbilityKeyed(AbilityCategory.FEAT, "Grantor"));
-		assertTrue(pc.hasAbilityKeyed(AbilityCategory.FEAT, "MultYes"));
-		assertTrue(pc.hasAbilityKeyed(AbilityCategory.FEAT, "Target"));
+		assertTrue(pc.hasAbilityKeyed(BuildUtilities.getFeatCat(), "Parent"));
+		assertTrue(pc.hasAbilityKeyed(BuildUtilities.getFeatCat(), "Grantor"));
+		assertTrue(pc.hasAbilityKeyed(BuildUtilities.getFeatCat(), "MultYes"));
+		assertTrue(pc.hasAbilityKeyed(BuildUtilities.getFeatCat(), "Target"));
 	}
 
 	public void testMultYesTargetParens()
@@ -204,10 +203,10 @@ public abstract class AbstractAbilityGrantCheckTest extends AbstractTokenModelTe
 		Ability parent = getGrantor("MultYes (Target (Parens))");
 		finishLoad();
 		applyParent(parent);
-		assertTrue(pc.hasAbilityKeyed(AbilityCategory.FEAT, "Parent"));
-		assertTrue(pc.hasAbilityKeyed(AbilityCategory.FEAT, "Grantor"));
-		assertTrue(pc.hasAbilityKeyed(AbilityCategory.FEAT, "MultYes"));
-		assertTrue(pc.hasAbilityKeyed(AbilityCategory.FEAT, "Target (Parens)"));
+		assertTrue(pc.hasAbilityKeyed(BuildUtilities.getFeatCat(), "Parent"));
+		assertTrue(pc.hasAbilityKeyed(BuildUtilities.getFeatCat(), "Grantor"));
+		assertTrue(pc.hasAbilityKeyed(BuildUtilities.getFeatCat(), "MultYes"));
+		assertTrue(pc.hasAbilityKeyed(BuildUtilities.getFeatCat(), "Target (Parens)"));
 	}
 
 	public void testMultYesNC()
@@ -216,9 +215,9 @@ public abstract class AbstractAbilityGrantCheckTest extends AbstractTokenModelTe
 		Ability parent = getGrantor("MultYesNC");
 		finishLoad();
 		applyParent(parent);
-		assertTrue(pc.hasAbilityKeyed(AbilityCategory.FEAT, "Parent"));
-		assertTrue(pc.hasAbilityKeyed(AbilityCategory.FEAT, "Grantor"));
-		assertTrue(pc.hasAbilityKeyed(AbilityCategory.FEAT, "MultYesNC"));
+		assertTrue(pc.hasAbilityKeyed(BuildUtilities.getFeatCat(), "Parent"));
+		assertTrue(pc.hasAbilityKeyed(BuildUtilities.getFeatCat(), "Grantor"));
+		assertTrue(pc.hasAbilityKeyed(BuildUtilities.getFeatCat(), "MultYesNC"));
 	}
 
 	public void testStackYes()
@@ -228,10 +227,10 @@ public abstract class AbstractAbilityGrantCheckTest extends AbstractTokenModelTe
 		Ability parent = getGrantor("MultYesStackYes (Target)");
 		finishLoad();
 		applyParent(parent);
-		assertTrue(pc.hasAbilityKeyed(AbilityCategory.FEAT, "Parent"));
-		assertTrue(pc.hasAbilityKeyed(AbilityCategory.FEAT, "Grantor"));
-		assertTrue(pc.hasAbilityKeyed(AbilityCategory.FEAT, "MultYesStackYes"));
-		assertTrue(pc.hasAbilityKeyed(AbilityCategory.FEAT, "Target"));
+		assertTrue(pc.hasAbilityKeyed(BuildUtilities.getFeatCat(), "Parent"));
+		assertTrue(pc.hasAbilityKeyed(BuildUtilities.getFeatCat(), "Grantor"));
+		assertTrue(pc.hasAbilityKeyed(BuildUtilities.getFeatCat(), "MultYesStackYes"));
+		assertTrue(pc.hasAbilityKeyed(BuildUtilities.getFeatCat(), "Target"));
 	}
 
 	public void testStackYesNC()
@@ -240,14 +239,14 @@ public abstract class AbstractAbilityGrantCheckTest extends AbstractTokenModelTe
 		Ability parent = getGrantor("MultYesStackYesNC");
 		finishLoad();
 		applyParent(parent);
-		assertTrue(pc.hasAbilityKeyed(AbilityCategory.FEAT, "Parent"));
-		assertTrue(pc.hasAbilityKeyed(AbilityCategory.FEAT, "Grantor"));
-		assertTrue(pc.hasAbilityKeyed(AbilityCategory.FEAT, "MultYesStackYesNC"));
+		assertTrue(pc.hasAbilityKeyed(BuildUtilities.getFeatCat(), "Parent"));
+		assertTrue(pc.hasAbilityKeyed(BuildUtilities.getFeatCat(), "Grantor"));
+		assertTrue(pc.hasAbilityKeyed(BuildUtilities.getFeatCat(), "MultYesStackYesNC"));
 	}
 
 	private void applyParent(Ability parent)
 	{
-		CNAbility cna = CNAbilityFactory.getCNAbility(AbilityCategory.FEAT, Nature.NORMAL, parent);
+		CNAbility cna = CNAbilityFactory.getCNAbility(BuildUtilities.getFeatCat(), Nature.NORMAL, parent);
 		CNAbilitySelection cnas = new CNAbilitySelection(cna);
 		pc.addAbility(cnas, UserSelection.getInstance(), this);
 	}

--- a/code/src/itest/tokenmodel/testsupport/AbstractAddListTokenTest.java
+++ b/code/src/itest/tokenmodel/testsupport/AbstractAddListTokenTest.java
@@ -45,8 +45,8 @@ public abstract class AbstractAddListTokenTest<T extends CDOMObject>
 		T granted = createGrantedObject();
 		processToken(source);
 		assertEquals(0, getCount());
-		CNAbilitySelection cas =
-				new CNAbilitySelection(CNAbilityFactory.getCNAbility(BuildUtilities.getFeatCat(), Nature.AUTOMATIC, source));
+		CNAbilitySelection cas = new CNAbilitySelection(CNAbilityFactory
+			.getCNAbility(BuildUtilities.getFeatCat(), Nature.AUTOMATIC, source));
 		directAbilityFacet.add(id, cas, UserSelection.getInstance());
 		assertTrue(containsExpected(granted));
 		assertEquals((directAbilityFacet == getTargetFacet()) ? 2 : 1,

--- a/code/src/itest/tokenmodel/testsupport/AbstractAddListTokenTest.java
+++ b/code/src/itest/tokenmodel/testsupport/AbstractAddListTokenTest.java
@@ -27,7 +27,6 @@ import pcgen.cdom.helper.CNAbilitySelection;
 import pcgen.cdom.helper.ClassSource;
 import pcgen.cdom.inst.PCClassLevel;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.core.Deity;
 import pcgen.core.Domain;
 import pcgen.core.PCClass;
@@ -47,7 +46,7 @@ public abstract class AbstractAddListTokenTest<T extends CDOMObject>
 		processToken(source);
 		assertEquals(0, getCount());
 		CNAbilitySelection cas =
-				new CNAbilitySelection(CNAbilityFactory.getCNAbility(AbilityCategory.FEAT, Nature.AUTOMATIC, source));
+				new CNAbilitySelection(CNAbilityFactory.getCNAbility(BuildUtilities.getFeatCat(), Nature.AUTOMATIC, source));
 		directAbilityFacet.add(id, cas, UserSelection.getInstance());
 		assertTrue(containsExpected(granted));
 		assertEquals((directAbilityFacet == getTargetFacet()) ? 2 : 1,

--- a/code/src/itest/tokenmodel/testsupport/AbstractTokenModelTest.java
+++ b/code/src/itest/tokenmodel/testsupport/AbstractTokenModelTest.java
@@ -49,7 +49,6 @@ import pcgen.cdom.facet.model.WeaponProfModelFacet;
 import pcgen.cdom.inst.CodeControl;
 import pcgen.cdom.inst.GlobalModifiers;
 import pcgen.cdom.util.CControl;
-import pcgen.core.AbilityCategory;
 import pcgen.core.GameMode;
 import pcgen.core.Globals;
 import pcgen.core.Language;
@@ -304,7 +303,7 @@ public abstract class AbstractTokenModelTest extends TestCase
 		FactDefinition<?, String> fd =
 				BuildUtilities.createFact(context, "SpellType", PCClass.class);
 		fd.setSelectable(true);
-		context.getReferenceContext().importObject(AbilityCategory.FEAT);
+		context.getReferenceContext().importObject(BuildUtilities.getFeatCat());
 		SourceFileLoader.createLangBonusObject(Globals.getContext());
 		FormatManager<?> fmtManager = ref.getFormatManager("ALIGNMENT");
 		proc(fmtManager);

--- a/code/src/test/pcgen/AbstractCharacterTestCase.java
+++ b/code/src/test/pcgen/AbstractCharacterTestCase.java
@@ -180,7 +180,7 @@ public abstract class AbstractCharacterTestCase extends PCGenTestCase
 		proc(context, fmtManager);
 		GameModeFileLoader.addDefaultUnitSet(SettingsHandler.getGame());
 		SettingsHandler.getGame().selectDefaultUnitSet();
-		ref.importObject(AbilityCategory.FEAT);
+		ref.importObject(BuildUtilities.getFeatCat());
 		additionalSetUp();
 		context.getReferenceContext().buildDerivedObjects();
 		context.resolveDeferredTokens();

--- a/code/src/test/pcgen/AbstractJunit4CharacterTestCase.java
+++ b/code/src/test/pcgen/AbstractJunit4CharacterTestCase.java
@@ -217,7 +217,7 @@ abstract public class AbstractJunit4CharacterTestCase
 
 		GameModeFileLoader.addDefaultUnitSet(SettingsHandler.getGame());
 		SettingsHandler.getGame().selectDefaultUnitSet();
-		ref.importObject(AbilityCategory.FEAT);
+		ref.importObject(BuildUtilities.getFeatCat());
 		SourceFileLoader.processFactDefinitions(context);
 		additionalSetUp();
 		if (!ref.resolveReferences(null))

--- a/code/src/test/pcgen/cdom/helper/AspectTest.java
+++ b/code/src/test/pcgen/cdom/helper/AspectTest.java
@@ -34,6 +34,7 @@ import pcgen.core.Globals;
 import pcgen.core.Language;
 import pcgen.core.PlayerCharacter;
 import pcgen.util.TestHelper;
+import plugin.lsttokens.testsupport.BuildUtilities;
 
 /**
  * This class tests the handling of ASPECT fields in PCGen
@@ -51,9 +52,10 @@ public class AspectTest extends AbstractCharacterTestCase
 	public void testEmptyDesc()
 	{
 		final Ability dummy =
-				TestHelper.makeAbility("dummy", AbilityCategory.FEAT, "Foo");
+				TestHelper.makeAbility("dummy", BuildUtilities.getFeatCat(), "Foo");
 		final Aspect aspect = new Aspect(ASPECT_NAME, Constants.EMPTY_STRING);
-		assertEquals("", aspect.getAspectText(this.getCharacter(), buildMap(dummy, AbilityCategory.FEAT, Nature.NORMAL)));
+		assertEquals("", aspect.getAspectText(this.getCharacter(),
+			buildMap(dummy, BuildUtilities.getFeatCat(), Nature.NORMAL)));
 	}
 
 	public void testNull()
@@ -68,10 +70,11 @@ public class AspectTest extends AbstractCharacterTestCase
 	public void testSimpleDesc()
 	{
 		final Ability dummy =
-				TestHelper.makeAbility("dummy", AbilityCategory.FEAT, "Foo");
+				TestHelper.makeAbility("dummy", BuildUtilities.getFeatCat(), "Foo");
 		final String simpleDesc = "This is a test";
 		final Aspect aspect = new Aspect(ASPECT_NAME, simpleDesc);
-		assertEquals(simpleDesc, aspect.getAspectText(getCharacter(), buildMap(dummy, AbilityCategory.FEAT, Nature.NORMAL)));
+		assertEquals(simpleDesc, aspect.getAspectText(getCharacter(),
+			buildMap(dummy, BuildUtilities.getFeatCat(), Nature.NORMAL)));
 	}
 
 	/**
@@ -80,10 +83,11 @@ public class AspectTest extends AbstractCharacterTestCase
 	public void testSimpleReplacement()
 	{
 		final Ability dummy =
-				TestHelper.makeAbility("dummy", AbilityCategory.FEAT, "Foo");
+				TestHelper.makeAbility("dummy", BuildUtilities.getFeatCat(), "Foo");
 		final Aspect aspect = new Aspect(ASPECT_NAME, "%1");
 		aspect.addVariable("\"Variable\"");
-		assertEquals("Variable", aspect.getAspectText(getCharacter(), buildMap(dummy, AbilityCategory.FEAT, Nature.NORMAL)));
+		assertEquals("Variable", aspect.getAspectText(getCharacter(),
+			buildMap(dummy, BuildUtilities.getFeatCat(), Nature.NORMAL)));
 	}
 
 	/**
@@ -93,11 +97,12 @@ public class AspectTest extends AbstractCharacterTestCase
 	{
 		final Ability pobj = new Ability();
 		pobj.setName("PObject");
-		pobj.setCDOMCategory(AbilityCategory.FEAT);
+		pobj.setCDOMCategory(BuildUtilities.getFeatCat());
 
 		final Aspect aspect = new Aspect(ASPECT_NAME, "%1");
 		aspect.addVariable("%NAME");
-		assertEquals("PObject", aspect.getAspectText(getCharacter(), buildMap(pobj, AbilityCategory.FEAT, Nature.NORMAL)));
+		assertEquals("PObject", aspect.getAspectText(getCharacter(),
+			buildMap(pobj, BuildUtilities.getFeatCat(), Nature.NORMAL)));
 	}
 
 	/**
@@ -106,16 +111,18 @@ public class AspectTest extends AbstractCharacterTestCase
 	public void testSimpleVariableReplacement()
 	{
 		final Ability dummy =
-				TestHelper.makeAbility("dummy", AbilityCategory.FEAT, "Foo");
+				TestHelper.makeAbility("dummy", BuildUtilities.getFeatCat(), "Foo");
 		dummy.put(VariableKey.getConstant("TestVar"), FormulaFactory
 				.getFormulaFor(2));
 
 		final Aspect aspect = new Aspect(ASPECT_NAME, "%1");
 		aspect.addVariable("TestVar");
-		assertEquals("0", aspect.getAspectText(getCharacter(), buildMap(dummy, AbilityCategory.FEAT, Nature.NORMAL)));
+		assertEquals("0", aspect.getAspectText(getCharacter(),
+			buildMap(dummy, BuildUtilities.getFeatCat(), Nature.NORMAL)));
 
-		addAbility(AbilityCategory.FEAT, dummy);
-		assertEquals("2", aspect.getAspectText(getCharacter(), buildMap(dummy, AbilityCategory.FEAT, Nature.NORMAL)));
+		addAbility(BuildUtilities.getFeatCat(), dummy);
+		assertEquals("2", aspect.getAspectText(getCharacter(),
+			buildMap(dummy, BuildUtilities.getFeatCat(), Nature.NORMAL)));
 	}
 
 	/**
@@ -124,7 +131,7 @@ public class AspectTest extends AbstractCharacterTestCase
 	public void testSimpleListReplacement()
 	{
 		final Ability pobj =
-				TestHelper.makeAbility("dummy", AbilityCategory.FEAT, "Foo");
+				TestHelper.makeAbility("dummy", BuildUtilities.getFeatCat(), "Foo");
 		Globals.getContext().unconditionallyProcess(pobj, "CHOOSE", "LANG|ALL");
 		Globals.getContext().unconditionallyProcess(pobj, "MULT", "YES");
 		Globals.getContext().getReferenceContext().constructCDOMObject(Language.class, "Foo");
@@ -132,8 +139,9 @@ public class AspectTest extends AbstractCharacterTestCase
 
 		final Aspect aspect = new Aspect(ASPECT_NAME, "%1");
 		aspect.addVariable("%LIST");
-		assertEquals("", aspect.getAspectText(pc, buildMap(pobj, AbilityCategory.FEAT, Nature.NORMAL)));
-		AbilityCategory category = AbilityCategory.FEAT;
+		assertEquals("", aspect.getAspectText(pc,
+			buildMap(pobj, BuildUtilities.getFeatCat(), Nature.NORMAL)));
+		AbilityCategory category = BuildUtilities.getFeatCat();
 
 		CNAbility cna = finalizeTest(pobj, "Foo", pc, category);
 		assertEquals("Foo", aspect.getAspectText(pc, Collections.singletonList(cna)));
@@ -145,10 +153,11 @@ public class AspectTest extends AbstractCharacterTestCase
 	public void testEmptyReplacement()
 	{
 		final Ability pobj =
-				TestHelper.makeAbility("dummy", AbilityCategory.FEAT, "Foo");
+				TestHelper.makeAbility("dummy", BuildUtilities.getFeatCat(), "Foo");
 
 		final Aspect aspect = new Aspect(ASPECT_NAME, "%1");
-		assertEquals("", aspect.getAspectText(getCharacter(), buildMap(pobj, AbilityCategory.FEAT, Nature.NORMAL)));
+		assertEquals("", aspect.getAspectText(getCharacter(),
+			buildMap(pobj, BuildUtilities.getFeatCat(), Nature.NORMAL)));
 	}
 
 	/**
@@ -157,7 +166,7 @@ public class AspectTest extends AbstractCharacterTestCase
 	public void testExtraVariables()
 	{
 		final Ability pobj =
-				TestHelper.makeAbility("dummy", AbilityCategory.FEAT, "Foo");
+				TestHelper.makeAbility("dummy", BuildUtilities.getFeatCat(), "Foo");
 		Globals.getContext().unconditionallyProcess(pobj, "CHOOSE", "LANG|ALL");
 		Globals.getContext().unconditionallyProcess(pobj, "MULT", "YES");
 		Globals.getContext().getReferenceContext().constructCDOMObject(Language.class, "Foo");
@@ -165,10 +174,13 @@ public class AspectTest extends AbstractCharacterTestCase
 		final Aspect aspect = new Aspect(ASPECT_NAME, "Testing");
 		aspect.addVariable("%LIST");
 		PlayerCharacter pc = getCharacter();
-		assertEquals("Testing", aspect.getAspectText(pc, buildMap(pobj, AbilityCategory.FEAT, Nature.NORMAL)));
+		assertEquals("Testing", aspect.getAspectText(pc,
+			buildMap(pobj, BuildUtilities.getFeatCat(), Nature.NORMAL)));
 
-		AbstractCharacterTestCase.applyAbility(pc, AbilityCategory.FEAT, pobj, "Foo");
-		assertEquals("Testing", aspect.getAspectText(pc, buildMap(pobj, AbilityCategory.FEAT, Nature.NORMAL)));
+		AbstractCharacterTestCase.applyAbility(pc, BuildUtilities.getFeatCat(), pobj,
+			"Foo");
+		assertEquals("Testing", aspect.getAspectText(pc,
+			buildMap(pobj, BuildUtilities.getFeatCat(), Nature.NORMAL)));
 	}
 
 	/**
@@ -177,7 +189,7 @@ public class AspectTest extends AbstractCharacterTestCase
 	public void testComplexVariableReplacement()
 	{
 		final Ability dummy =
-			TestHelper.makeAbility("dummy", AbilityCategory.FEAT, "Foo");
+			TestHelper.makeAbility("dummy", BuildUtilities.getFeatCat(), "Foo");
 		Globals.getContext().unconditionallyProcess(dummy, "CHOOSE", "LANG|ALL");
 		Globals.getContext().unconditionallyProcess(dummy, "MULT", "YES");
 		Globals.getContext().getReferenceContext().constructCDOMObject(Language.class, "Associated 1");
@@ -189,10 +201,11 @@ public class AspectTest extends AbstractCharacterTestCase
 
 		final Aspect aspect = new Aspect(ASPECT_NAME, "%1 test %2");
 		aspect.addVariable("TestVar");
-		assertEquals("0 test ", aspect.getAspectText(pc, buildMap(dummy, AbilityCategory.FEAT, Nature.NORMAL)));
+		assertEquals("0 test ", aspect.getAspectText(pc,
+			buildMap(dummy, BuildUtilities.getFeatCat(), Nature.NORMAL)));
 
-		CNAbility cna = finalizeTest(dummy, "Associated 1", pc, AbilityCategory.FEAT);
-		finalizeTest(dummy, "Associated 2", pc, AbilityCategory.FEAT);
+		CNAbility cna = finalizeTest(dummy, "Associated 1", pc, BuildUtilities.getFeatCat());
+		finalizeTest(dummy, "Associated 2", pc, BuildUtilities.getFeatCat());
 		assertEquals("2 test ", aspect.getAspectText(pc, Collections.singletonList(cna)));
 
 		aspect.addVariable("%LIST");
@@ -200,7 +213,7 @@ public class AspectTest extends AbstractCharacterTestCase
 			"2 test Associated 1 and Associated 2", aspect
 				.getAspectText(pc, Collections.singletonList(cna)));
 
-		finalizeTest(dummy, "Associated 3", pc, AbilityCategory.FEAT);
+		finalizeTest(dummy, "Associated 3", pc, BuildUtilities.getFeatCat());
 		aspect.addVariable("%LIST");
 		assertEquals("Replacement of %LIST failed",
 			"2 test Associated 1, Associated 2, Associated 3", aspect

--- a/code/src/test/pcgen/core/DataSetTest.java
+++ b/code/src/test/pcgen/core/DataSetTest.java
@@ -27,6 +27,7 @@ import pcgen.facade.util.DefaultListFacade;
 import pcgen.facade.util.ListFacade;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.util.TestHelper;
+import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.pretokens.parser.PreAbilityParser;
 
 /**
@@ -96,10 +97,10 @@ public class DataSetTest extends TestCase
 	 */
 	public void testGetPrereqAbilities() throws Exception
 	{
-		Ability acrobatics = TestHelper.makeAbility("Acrobatics", AbilityCategory.FEAT, "general");
-		Ability dodge = TestHelper.makeAbility("Dodge", AbilityCategory.FEAT, "general");
-		Ability mobility = TestHelper.makeAbility("Mobility", AbilityCategory.FEAT, "general");
-		Ability springAttack = TestHelper.makeAbility("Spring Attack", AbilityCategory.FEAT, "general");
+		Ability acrobatics = TestHelper.makeAbility("Acrobatics", BuildUtilities.getFeatCat(), "general");
+		Ability dodge = TestHelper.makeAbility("Dodge", BuildUtilities.getFeatCat(), "general");
+		Ability mobility = TestHelper.makeAbility("Mobility", BuildUtilities.getFeatCat(), "general");
+		Ability springAttack = TestHelper.makeAbility("Spring Attack", BuildUtilities.getFeatCat(), "general");
 		PreAbilityParser parser = new PreAbilityParser();
 		Prerequisite prereq =
 				parser.parse("ability", "1,CATEGORY=FEAT,KEY_Dodge",

--- a/code/src/test/pcgen/core/DescriptionTest.java
+++ b/code/src/test/pcgen/core/DescriptionTest.java
@@ -36,6 +36,7 @@ import pcgen.core.chooser.ChooserUtilities;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.persistence.lst.prereq.PreParserFactory;
 import pcgen.util.TestHelper;
+import plugin.lsttokens.testsupport.BuildUtilities;
 
 /**
  * This class tests the handling of DESC fields in PCGen
@@ -50,9 +51,11 @@ public class DescriptionTest extends AbstractCharacterTestCase
 	public void testEmptyDesc()
 	{
 		final Ability dummy =
-				TestHelper.makeAbility("dummy", AbilityCategory.FEAT, "Foo");
+				TestHelper.makeAbility("dummy", BuildUtilities.getFeatCat(), "Foo");
 		final Description desc = new Description(Constants.EMPTY_STRING);
-		assertTrue(desc.getDescription(this.getCharacter(), Collections.singletonList(CNAbilityFactory.getCNAbility(AbilityCategory.FEAT, Nature.NORMAL, dummy))).isEmpty());
+		List<CNAbility> singletonAbility = Collections.singletonList(CNAbilityFactory
+			.getCNAbility(BuildUtilities.getFeatCat(), Nature.NORMAL, dummy));
+		assertTrue(desc.getDescription(this.getCharacter(), singletonAbility).isEmpty());
 	}
 
 	/**
@@ -61,10 +64,13 @@ public class DescriptionTest extends AbstractCharacterTestCase
 	public void testSimpleDesc()
 	{
 		final Ability dummy =
-				TestHelper.makeAbility("dummy", AbilityCategory.FEAT, "Foo");
+				TestHelper.makeAbility("dummy", BuildUtilities.getFeatCat(), "Foo");
 		final String simpleDesc = "This is a test";
 		final Description desc = new Description(simpleDesc);
-		assertTrue(desc.getDescription(getCharacter(), Collections.singletonList(CNAbilityFactory.getCNAbility(AbilityCategory.FEAT, Nature.NORMAL, dummy))).equals(simpleDesc));
+		List<CNAbility> singletonAbility = Collections.singletonList(CNAbilityFactory
+			.getCNAbility(BuildUtilities.getFeatCat(), Nature.NORMAL, dummy));
+		assertTrue(
+			desc.getDescription(getCharacter(), singletonAbility).equals(simpleDesc));
 	}
 
 	/**
@@ -74,7 +80,7 @@ public class DescriptionTest extends AbstractCharacterTestCase
 	public void testPreReqs() throws Exception
 	{
 		final Ability dummy =
-				TestHelper.makeAbility("dummy", AbilityCategory.FEAT, "Foo");
+				TestHelper.makeAbility("dummy", BuildUtilities.getFeatCat(), "Foo");
 		final String simpleDesc = "This is a test";
 		final Description desc = new Description(simpleDesc);
 
@@ -82,14 +88,16 @@ public class DescriptionTest extends AbstractCharacterTestCase
 
 		final Prerequisite prereqNE = factory.parse("PRETEMPLATE:1,KEY_Natural Lycanthrope");
 		desc.addPrerequisite(prereqNE);
-		is(desc.getDescription(getCharacter(), Collections.singletonList(CNAbilityFactory.getCNAbility(AbilityCategory.FEAT, Nature.NORMAL, dummy))), strEq(""));
+		List<CNAbility> singletonAbility = Collections.singletonList(CNAbilityFactory
+			.getCNAbility(BuildUtilities.getFeatCat(), Nature.NORMAL, dummy));
+		is(desc.getDescription(getCharacter(), singletonAbility), strEq(""));
 
 		PCTemplate template = new PCTemplate();
 		template.setName("Natural Lycanthrope");
 		template.put(StringKey.KEY_NAME, "KEY_Natural Lycanthrope");
 		Globals.getContext().getReferenceContext().importObject(template);
 		getCharacter().addTemplate(template);
-		is(desc.getDescription(getCharacter(), Collections.singletonList(CNAbilityFactory.getCNAbility(AbilityCategory.FEAT, Nature.NORMAL, dummy))), strEq(simpleDesc));
+		is(desc.getDescription(getCharacter(), singletonAbility), strEq(simpleDesc));
 	}
 
 	/**
@@ -98,10 +106,13 @@ public class DescriptionTest extends AbstractCharacterTestCase
 	public void testSimpleReplacement()
 	{
 		final Ability dummy =
-				TestHelper.makeAbility("dummy", AbilityCategory.FEAT, "Foo");
+				TestHelper.makeAbility("dummy", BuildUtilities.getFeatCat(), "Foo");
 		final Description desc = new Description("%1");
 		desc.addVariable("\"Variable\"");
-		assertTrue(desc.getDescription(getCharacter(), Collections.singletonList(CNAbilityFactory.getCNAbility(AbilityCategory.FEAT, Nature.NORMAL, dummy))).equals("Variable"));
+		List<CNAbility> singletonAbility = Collections.singletonList(CNAbilityFactory
+			.getCNAbility(BuildUtilities.getFeatCat(), Nature.NORMAL, dummy));
+		assertTrue(
+			desc.getDescription(getCharacter(), singletonAbility).equals("Variable"));
 	}
 
 	/**
@@ -210,7 +221,7 @@ public class DescriptionTest extends AbstractCharacterTestCase
 	 */
 	public void testComplexVariableReplacement()
 	{
-		final Ability dummy = AbilityCategory.FEAT.newInstance();
+		final Ability dummy = BuildUtilities.getFeatCat().newInstance();
 		dummy.setKeyName("Dummy");
 		Globals.getContext().unconditionallyProcess(dummy, "CATEGORY", "FEAT");
 		Globals.getContext().unconditionallyProcess(dummy, "CHOOSE", "LANG|ALL");
@@ -225,10 +236,11 @@ public class DescriptionTest extends AbstractCharacterTestCase
 		final Description desc = new Description("%1 test %3 %2");
 		desc.addVariable("TestVar");
 		dummy.addToListFor(ListKey.DESCRIPTION, desc);
-		List<CNAbility> wrappedDummy = Collections.singletonList(CNAbilityFactory.getCNAbility(AbilityCategory.FEAT, Nature.NORMAL, dummy));
+		List<CNAbility> wrappedDummy = Collections.singletonList(CNAbilityFactory
+			.getCNAbility(BuildUtilities.getFeatCat(), Nature.NORMAL, dummy));
 		assertEquals("0 test  ", desc.getDescription(pc, wrappedDummy));
 
-		AbilityCategory category = AbilityCategory.FEAT;
+		AbilityCategory category = BuildUtilities.getFeatCat();
 
 		CNAbility cna = finalizeTest(dummy, "Associated 1", pc, category);
 		finalizeTest(dummy, "Associated 2", pc, category);

--- a/code/src/test/pcgen/core/PCClassTest.java
+++ b/code/src/test/pcgen/core/PCClassTest.java
@@ -546,10 +546,10 @@ public class PCClassTest extends AbstractCharacterTestCase
 				Globals.getContext(),
 				casterFeat,
 				"CasterBoost	TYPE:General	BONUS:SPELLCAST|CLASS=MegaCaster;LEVEL=11|1", source);
-		casterFeat.setCDOMCategory(AbilityCategory.FEAT);
+		casterFeat.setCDOMCategory(BuildUtilities.getFeatCat());
 		context.getReferenceContext().importObject(casterFeat);
 
-		AbstractCharacterTestCase.applyAbility(character, AbilityCategory.FEAT, casterFeat, null);
+		AbstractCharacterTestCase.applyAbility(character, BuildUtilities.getFeatCat(), casterFeat, null);
 		cast =
 				character.getSpellSupport(charClass).getCastForLevel(11, sbook, true, false, character)
 					+ character.getSpellSupport(charClass).getBonusCastForLevelString(11, sbook, character);

--- a/code/src/test/pcgen/core/PCTemplateTest.java
+++ b/code/src/test/pcgen/core/PCTemplateTest.java
@@ -39,6 +39,7 @@ import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.CampaignSourceEntry;
 import pcgen.persistence.lst.GenericLoader;
 import pcgen.rules.context.LoadContext;
+import plugin.lsttokens.testsupport.BuildUtilities;
 
 /**
  * <code>PCTemplateTest</code> tests the fucntion of the PCTemplate class.
@@ -164,11 +165,11 @@ public class PCTemplateTest extends AbstractCharacterTestCase
 		// Create some abilities to be added
 		Ability ab1 = new Ability();
 		ab1.setName("Ability1");
-		ab1.setCDOMCategory(AbilityCategory.FEAT);
+		ab1.setCDOMCategory(BuildUtilities.getFeatCat());
 		context.getReferenceContext().importObject(ab1);
 		Ability ab2 = new Ability();
 		ab2.setName("Ability2");
-		ab2.setCDOMCategory(AbilityCategory.FEAT);
+		ab2.setCDOMCategory(BuildUtilities.getFeatCat());
 		context.getReferenceContext().importObject(ab2);
 
 		CampaignSourceEntry source;
@@ -210,10 +211,10 @@ public class PCTemplateTest extends AbstractCharacterTestCase
 		PlayerCharacter pc = getCharacter();
 		pc.addTemplate(template);
 		// Need to do this to populate the ability list
-		//pc.getAutomaticAbilityList(AbilityCategory.FEAT);
-		assertTrue("Character should have ability1.", hasAbility(pc, AbilityCategory.FEAT,
+		//pc.getAutomaticAbilityList(BuildUtilities.getFeatCat());
+		assertTrue("Character should have ability1.", hasAbility(pc, BuildUtilities.getFeatCat(),
 			Nature.AUTOMATIC, ab1));
-		assertTrue("Character should have ability2.", hasAbility(pc, AbilityCategory.FEAT,
+		assertTrue("Character should have ability2.", hasAbility(pc, BuildUtilities.getFeatCat(),
 			Nature.AUTOMATIC, ab2));
 	}
 
@@ -314,11 +315,11 @@ public class PCTemplateTest extends AbstractCharacterTestCase
 		LoadContext context = Globals.getContext();
 		Ability ab1 = new Ability();
 		ab1.setName("Ability1");
-		ab1.setCDOMCategory(AbilityCategory.FEAT);
+		ab1.setCDOMCategory(BuildUtilities.getFeatCat());
 		context.getReferenceContext().importObject(ab1);
 		Ability ab2 = new Ability();
 		ab2.setName("Ability2");
-		ab2.setCDOMCategory(AbilityCategory.FEAT);
+		ab2.setCDOMCategory(BuildUtilities.getFeatCat());
 		context.getReferenceContext().importObject(ab2);
 
 		CampaignSourceEntry source;
@@ -368,20 +369,20 @@ public class PCTemplateTest extends AbstractCharacterTestCase
 		// Add the template to the character
 		PlayerCharacter pc = getCharacter();
 		pc.addTemplate(template);
-		assertFalse("Character should not have ability1.", hasAbility(pc, AbilityCategory.FEAT,
+		assertFalse("Character should not have ability1.", hasAbility(pc, BuildUtilities.getFeatCat(),
 			Nature.AUTOMATIC, ab1));
-		assertTrue("Character should have ability2.", hasAbility(pc, AbilityCategory.FEAT,
+		assertTrue("Character should have ability2.", hasAbility(pc, BuildUtilities.getFeatCat(),
 			Nature.AUTOMATIC, ab2));
 		
 		// Level the character up, testing for when the level tag kicks in
 		pc.incrementClassLevel(1, testClass);
 		pc.calcActiveBonuses();
-		assertFalse("Character should not have ability1.", hasAbility(pc, AbilityCategory.FEAT,
+		assertFalse("Character should not have ability1.", hasAbility(pc, BuildUtilities.getFeatCat(),
 			Nature.AUTOMATIC, ab1));
 
 		pc.incrementClassLevel(1, testClass);
 		pc.calcActiveBonuses();
-		assertTrue("Character should have ability1.", hasAbility(pc, AbilityCategory.FEAT,
+		assertTrue("Character should have ability1.", hasAbility(pc, BuildUtilities.getFeatCat(),
 			Nature.AUTOMATIC, ab1));
 		
 	}

--- a/code/src/test/pcgen/core/PObjectTest.java
+++ b/code/src/test/pcgen/core/PObjectTest.java
@@ -210,7 +210,8 @@ public class PObjectTest extends AbstractCharacterTestCase
 		Globals.getContext().getReferenceContext().constructCDOMObject(Language.class, "TestPsion 1");
 
 		PlayerCharacter aPC = getCharacter();
-		CNAbility cna = AbstractCharacterTestCase.applyAbility(aPC, BuildUtilities.getFeatCat(), pObj, "TestPsion 1");
+		CNAbility cna = AbstractCharacterTestCase.applyAbility(aPC,
+			BuildUtilities.getFeatCat(), pObj, "TestPsion 1");
 		pObj = cna.getAbility();
 		BonusAddition.applyBonus("SPELLKNOWN|CLASS=TestPsion;LEVEL=1|1", "TestPsion 1",
 			aPC, pObj);

--- a/code/src/test/pcgen/core/PObjectTest.java
+++ b/code/src/test/pcgen/core/PObjectTest.java
@@ -49,6 +49,7 @@ import pcgen.persistence.lst.CampaignSourceEntry;
 import pcgen.persistence.lst.GenericLoader;
 import pcgen.persistence.lst.PCClassLoader;
 import pcgen.rules.context.LoadContext;
+import plugin.lsttokens.testsupport.BuildUtilities;
 
 /**
  * Test the PObject class.
@@ -200,29 +201,29 @@ public class PObjectTest extends AbstractCharacterTestCase
 	public void testAssociatedBonus()
 	{
 		Ability pObj = new Ability();
-		pObj.setCDOMCategory(AbilityCategory.FEAT);
+		pObj.setCDOMCategory(BuildUtilities.getFeatCat());
 		pObj.setName("My PObject");
-		pObj.setCDOMCategory(AbilityCategory.FEAT);
+		pObj.setCDOMCategory(BuildUtilities.getFeatCat());
 		Globals.getContext().unconditionallyProcess(pObj, "CHOOSE", "LANG|ALL");
 		Globals.getContext().unconditionallyProcess(pObj, "MULT", "YES");
 		Globals.getContext().unconditionallyProcess(pObj, "STACK", "YES");
 		Globals.getContext().getReferenceContext().constructCDOMObject(Language.class, "TestPsion 1");
 
 		PlayerCharacter aPC = getCharacter();
-		CNAbility cna = AbstractCharacterTestCase.applyAbility(aPC, AbilityCategory.FEAT, pObj, "TestPsion 1");
+		CNAbility cna = AbstractCharacterTestCase.applyAbility(aPC, BuildUtilities.getFeatCat(), pObj, "TestPsion 1");
 		pObj = cna.getAbility();
 		BonusAddition.applyBonus("SPELLKNOWN|CLASS=TestPsion;LEVEL=1|1", "TestPsion 1",
 			aPC, pObj);
 		aPC.calcActiveBonuses();
 		assertEquals("Should get 1 bonus known spells", 1, (int) aPC
 			.getTotalBonusTo("SPELLKNOWN", "CLASS.TestPsion;LEVEL.1"));
-		AbstractCharacterTestCase.applyAbility(aPC, AbilityCategory.FEAT, pObj, "TestPsion 1");
+		AbstractCharacterTestCase.applyAbility(aPC, BuildUtilities.getFeatCat(), pObj, "TestPsion 1");
 		BonusAddition.applyBonus("SPELLKNOWN|CLASS=TestPsion;LEVEL=1|1", "TestPsion 1",
 			aPC, pObj);
 		aPC.calcActiveBonuses();
 		assertEquals("Should get 4 bonus known spells", (2 * 2), (int) aPC
 			.getTotalBonusTo("SPELLKNOWN", "CLASS.TestPsion;LEVEL.1"));
-		AbstractCharacterTestCase.applyAbility(aPC, AbilityCategory.FEAT, pObj, "TestPsion 1");
+		AbstractCharacterTestCase.applyAbility(aPC, BuildUtilities.getFeatCat(), pObj, "TestPsion 1");
 		BonusAddition.applyBonus("SPELLKNOWN|CLASS=TestPsion;LEVEL=1|1", "TestPsion 1",
 			aPC, pObj);
 		aPC.calcActiveBonuses();
@@ -255,15 +256,15 @@ public class PObjectTest extends AbstractCharacterTestCase
 				"Toughness	CATEGORY:FEAT	TYPE:General	STACK:YES	MULT:YES	CHOOSE:NOCHOICE	BONUS:HP|CURRENTMAX|3", source);
 
 		Ability pObj = Globals.getContext().getReferenceContext()
-			.getManufacturerId(AbilityCategory.FEAT).getActiveObject("Toughness");
+			.getManufacturerId(BuildUtilities.getFeatCat()).getActiveObject("Toughness");
 		Globals.getContext().getReferenceContext().constructCDOMObject(Language.class, "Foo");
 		PlayerCharacter aPC = getCharacter();
 		int baseHP = aPC.hitPoints();
-		AbstractCharacterTestCase.applyAbility(aPC, AbilityCategory.FEAT, pObj, "");
+		AbstractCharacterTestCase.applyAbility(aPC, BuildUtilities.getFeatCat(), pObj, "");
 		aPC.calcActiveBonuses();
 		assertEquals("Should have added 3 HPs", baseHP + 3, aPC.hitPoints());
 
-		AbstractCharacterTestCase.applyAbility(aPC, AbilityCategory.FEAT, pObj, "");
+		AbstractCharacterTestCase.applyAbility(aPC, BuildUtilities.getFeatCat(), pObj, "");
 		aPC.calcActiveBonuses();
 		assertEquals("2 instances should have added 6 HPs", baseHP + 6, aPC
 			.hitPoints());
@@ -294,14 +295,14 @@ public class PObjectTest extends AbstractCharacterTestCase
 				null,
 				"Toughness	CATEGORY:FEAT	TYPE:General	STACK:YES	MULT:YES	CHOOSE:NOCHOICE	BONUS:HP|CURRENTMAX|3", source);
 		Ability pObj = Globals.getContext().getReferenceContext()
-			.getManufacturerId(AbilityCategory.FEAT).getActiveObject("Toughness");
+			.getManufacturerId(BuildUtilities.getFeatCat()).getActiveObject("Toughness");
 		PlayerCharacter aPC = getCharacter();
 		int baseHP = aPC.hitPoints();
-		AbstractCharacterTestCase.applyAbility(aPC, AbilityCategory.FEAT, pObj, "");
+		AbstractCharacterTestCase.applyAbility(aPC, BuildUtilities.getFeatCat(), pObj, "");
 		aPC.calcActiveBonuses();
 		assertEquals("Should have added 3 HPs", baseHP + 3, aPC.hitPoints());
 
-		AbstractCharacterTestCase.applyAbility(aPC, AbilityCategory.FEAT, pObj, "");
+		AbstractCharacterTestCase.applyAbility(aPC, BuildUtilities.getFeatCat(), pObj, "");
 		aPC.calcActiveBonuses();
 		assertEquals("2 instances should have added 6 HPs", baseHP + 6, aPC
 			.hitPoints());

--- a/code/src/test/pcgen/core/PlayerCharacterTest.java
+++ b/code/src/test/pcgen/core/PlayerCharacterTest.java
@@ -192,7 +192,7 @@ public class PlayerCharacterTest extends AbstractCharacterTestCase
 		toughness.put(ObjectKey.MULTIPLE_ALLOWED, Boolean.TRUE);
 		toughness.put(ObjectKey.STACKS, Boolean.TRUE);
 		context.unconditionallyProcess(toughness, "CHOOSE", "NOCHOICE");
-		toughness.setCDOMCategory(AbilityCategory.FEAT);
+		toughness.setCDOMCategory(BuildUtilities.getFeatCat());
 		final BonusObj aBonus = Bonus.newBonus(context, "HP|CURRENTMAX|3");
 		
 		if (aBonus != null)
@@ -202,7 +202,7 @@ public class PlayerCharacterTest extends AbstractCharacterTestCase
 		context.getReferenceContext().importObject(toughness);
 	
 		Ability exoticWpnProf =
-				TestHelper.makeAbility("Exotic Weapon Proficiency", AbilityCategory.FEAT,
+				TestHelper.makeAbility("Exotic Weapon Proficiency", BuildUtilities.getFeatCat(),
 					"General.Fighter");
 		exoticWpnProf.put(ObjectKey.MULTIPLE_ALLOWED, Boolean.TRUE);
 		context.unconditionallyProcess(exoticWpnProf, "CHOOSE", "WEAPONPROFICIENCY|!PC[TYPE.Exotic]");
@@ -238,7 +238,7 @@ public class PlayerCharacterTest extends AbstractCharacterTestCase
 		
 		specialFeatCat = Globals.getContext().getReferenceContext()
 				.constructNowIfNecessary(AbilityCategory.class, "Special Feat");
-		specialFeatCat.setAbilityCategory(CDOMDirectSingleRef.getRef(AbilityCategory.FEAT));
+		specialFeatCat.setAbilityCategory(CDOMDirectSingleRef.getRef(BuildUtilities.getFeatCat()));
 		specialAbilityCat = Globals.getContext().getReferenceContext()
 				.constructNowIfNecessary(AbilityCategory.class, "Special Ability");
 		
@@ -490,7 +490,7 @@ public class PlayerCharacterTest extends AbstractCharacterTestCase
 		is((int) character.getRemainingFeatPoints(true), eq(2), "Start with 2 feats");
 		try
 		{
-			AbstractCharacterTestCase.applyAbility(character, AbilityCategory.FEAT, toughness, "");
+			AbstractCharacterTestCase.applyAbility(character, BuildUtilities.getFeatCat(), toughness, "");
 			is((int) character.getRemainingFeatPoints(true), eq(1), "Only 1 feat used");
 		}
 		catch (HeadlessException e)
@@ -939,11 +939,11 @@ public class PlayerCharacterTest extends AbstractCharacterTestCase
 		
 		try
 		{
-			AbstractCharacterTestCase.applyAbility(pc, AbilityCategory.FEAT, toughness, "");
+			AbstractCharacterTestCase.applyAbility(pc, BuildUtilities.getFeatCat(), toughness, "");
 			//pc.calcActiveBonuses();
 			assertEquals("Check application of single bonus", base+3, pc.getTotalBonusTo(
 				"HP", "CURRENTMAX"));
-			AbstractCharacterTestCase.applyAbility(pc, AbilityCategory.FEAT, toughness, "");
+			AbstractCharacterTestCase.applyAbility(pc, BuildUtilities.getFeatCat(), toughness, "");
 			pc.calcActiveBonuses();
 			assertEquals("Check application of second bonus", base+6, pc.getTotalBonusTo(
 				"HP", "CURRENTMAX"));
@@ -1006,7 +1006,7 @@ public class PlayerCharacterTest extends AbstractCharacterTestCase
 		setPCStat(pc, str, 14);
 
 		Ability strBonusAbility =
-				TestHelper.makeAbility("Strength power up", AbilityCategory.FEAT,
+				TestHelper.makeAbility("Strength power up", BuildUtilities.getFeatCat(),
 					"General.Fighter");
 		final BonusObj strBonus = Bonus.newBonus(context, "STAT|STR|2");
 		strBonusAbility.addToListFor(ListKey.BONUS, strBonus);
@@ -1014,7 +1014,7 @@ public class PlayerCharacterTest extends AbstractCharacterTestCase
 		assertEquals("Before bonus, no temp no equip", 14, pc.getPartialStatFor(str, false, false));
 		assertEquals("Before bonus, temp no equip", 14, pc.getPartialStatFor(str, true, false));
 
-		AbstractCharacterTestCase.applyAbility(pc, AbilityCategory.FEAT, strBonusAbility, null);
+		AbstractCharacterTestCase.applyAbility(pc, BuildUtilities.getFeatCat(), strBonusAbility, null);
 		pc.calcActiveBonuses();
 
 		assertEquals("After bonus, no temp no equip", 16, pc.getPartialStatFor(str, false, false));
@@ -1037,13 +1037,13 @@ public class PlayerCharacterTest extends AbstractCharacterTestCase
 	public void testGetAvailableFollowers()
 	{
 		readyToRun();
-		Ability ab = TestHelper.makeAbility("Tester1", AbilityCategory.FEAT, "Empty Container");
-		Ability mab = TestHelper.makeAbility("Tester2", AbilityCategory.FEAT, "Mount Container");
-		Ability fab = TestHelper.makeAbility("Tester3", AbilityCategory.FEAT, "Familiar Container");
+		Ability ab = TestHelper.makeAbility("Tester1", BuildUtilities.getFeatCat(), "Empty Container");
+		Ability mab = TestHelper.makeAbility("Tester2", BuildUtilities.getFeatCat(), "Mount Container");
+		Ability fab = TestHelper.makeAbility("Tester3", BuildUtilities.getFeatCat(), "Familiar Container");
 		PlayerCharacter pc = getCharacter();
 		CharacterDisplay display = pc.getDisplay();
 		
-		addAbility(AbilityCategory.FEAT, ab);
+		addAbility(BuildUtilities.getFeatCat(), ab);
 		CDOMSingleRef<CompanionList> ref = new CDOMSimpleSingleRef<>(
 				BasicClassIdentity.getIdentity(CompanionList.class), "Mount");
 		CDOMReference<Race> race  = new CDOMDirectSingleRef<>(giantRace);
@@ -1060,7 +1060,7 @@ public class PlayerCharacterTest extends AbstractCharacterTestCase
 		fo = display.getAvailableFollowers("MOUNT", null).keySet();
 		assertTrue("Initially mount list should be empty", fo.isEmpty());
 		
-		addAbility(AbilityCategory.FEAT, mab);
+		addAbility(BuildUtilities.getFeatCat(), mab);
 		fo = display.getAvailableFollowers("Familiar", null).keySet();
 		assertTrue("Familiar list should still be empty", fo.isEmpty());
 		fo = display.getAvailableFollowers("MOUNT", null).keySet();
@@ -1068,7 +1068,7 @@ public class PlayerCharacterTest extends AbstractCharacterTestCase
 		assertEquals("Mount should be the giant race", giantRace.getKeyName(), fo.iterator().next().getRace().getKeyName());
 		assertEquals("Mount list should only have one entry", 1, fo.size());
 		
-		addAbility(AbilityCategory.FEAT, fab);
+		addAbility(BuildUtilities.getFeatCat(), fab);
 		fo = display.getAvailableFollowers("Familiar", null).keySet();
 		assertFalse("Familiar list should not be empty anymore", fo.isEmpty());
 		assertEquals("Familiar should be the human race", human.getKeyName(), fo.iterator().next().getRace().getKeyName());
@@ -1083,7 +1083,7 @@ public class PlayerCharacterTest extends AbstractCharacterTestCase
 	{
 		Ability resToAcid =
 				TestHelper.makeAbility("Swelter",
-					AbilityCategory.FEAT.getKeyName(), "Foo");
+					BuildUtilities.getFeatCat().getKeyName(), "Foo");
 		LoadContext context = Globals.getContext();
 		context.unconditionallyProcess(resToAcid, "MULT", "YES");
 		context.unconditionallyProcess(resToAcid, "STACK", "YES");
@@ -1097,19 +1097,19 @@ public class PlayerCharacterTest extends AbstractCharacterTestCase
 		readyToRun();
 		PlayerCharacter pc = getCharacter();
 		
-		List<Ability> abList = pc.getAggregateAbilityListNoDuplicates(AbilityCategory.FEAT);
+		List<Ability> abList = pc.getAggregateAbilityListNoDuplicates(BuildUtilities.getFeatCat());
 		assertEquals(0, abList.size());
 
 		pc.setRace(human);
-		abList = pc.getAggregateAbilityListNoDuplicates(AbilityCategory.FEAT);
+		abList = pc.getAggregateAbilityListNoDuplicates(BuildUtilities.getFeatCat());
 		assertEquals(1, abList.size());
 		
 		pc.addTemplate(template);
-		abList = pc.getAggregateAbilityListNoDuplicates(AbilityCategory.FEAT);
+		abList = pc.getAggregateAbilityListNoDuplicates(BuildUtilities.getFeatCat());
 		assertEquals(1, abList.size());
 		
 		pc.addTemplate(templateNorm);
-		abList = pc.getAggregateAbilityListNoDuplicates(AbilityCategory.FEAT);
+		abList = pc.getAggregateAbilityListNoDuplicates(BuildUtilities.getFeatCat());
 		assertEquals(1, abList.size());
 	}
 
@@ -1119,7 +1119,7 @@ public class PlayerCharacterTest extends AbstractCharacterTestCase
 	public void testAdjustMoveRates()
 	{
 		Ability quickFlySlowSwim =
-				TestHelper.makeAbility("quickFlySlowSwim", AbilityCategory.FEAT
+				TestHelper.makeAbility("quickFlySlowSwim", BuildUtilities.getFeatCat()
 					.getKeyName(), "Foo");
 		PCTemplate template = TestHelper.makeTemplate("slowFlyQuickSwim");
 		PCTemplate template2 = TestHelper.makeTemplate("dig");
@@ -1152,7 +1152,7 @@ public class PlayerCharacterTest extends AbstractCharacterTestCase
 		assertEquals(0.0, display.movementOfType("Swim"), 0.1);
 		assertEquals(0.0, display.movementOfType("Fly"), 0.1);
 
-		addAbility(AbilityCategory.FEAT, quickFlySlowSwim);
+		addAbility(BuildUtilities.getFeatCat(), quickFlySlowSwim);
 		pc.calcActiveBonuses();
 		pc.adjustMoveRates();
 		assertEquals(10.0, display.movementOfType("Swim"), 0.1);

--- a/code/src/test/pcgen/core/PrereqHandlerTest.java
+++ b/code/src/test/pcgen/core/PrereqHandlerTest.java
@@ -7,6 +7,7 @@ import pcgen.core.prereq.Prerequisite;
 import pcgen.output.channel.ChannelCompatibility;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.prereq.PreParserFactory;
+import plugin.lsttokens.testsupport.BuildUtilities;
 
 /**
  * <code>PrereqHandlerTest</code> tests the operation of the
@@ -73,9 +74,9 @@ public class PrereqHandlerTest extends AbstractCharacterTestCase
 
 		final Ability ud = new Ability();
 		ud.setName("Uncanny Dodge");
-		ud.setCDOMCategory(AbilityCategory.FEAT);
+		ud.setCDOMCategory(BuildUtilities.getFeatCat());
 		ud.put(StringKey.KEY_NAME, "Uncanny Dodge");
-		addAbility(AbilityCategory.FEAT, ud);
+		addAbility(BuildUtilities.getFeatCat(), ud);
 		assertFalse("Feat should return false", PrereqHandler.passes(prereq,
 			pc, null));
 	}

--- a/code/src/test/pcgen/core/StatListTest.java
+++ b/code/src/test/pcgen/core/StatListTest.java
@@ -29,6 +29,7 @@ import pcgen.core.bonus.Bonus;
 import pcgen.core.bonus.BonusObj;
 import pcgen.rules.context.LoadContext;
 import pcgen.util.TestHelper;
+import plugin.lsttokens.testsupport.BuildUtilities;
 
 /**
  * <code>StatListTest</code> checks the function of the 
@@ -58,13 +59,13 @@ public class StatListTest extends AbstractCharacterTestCase
 		unlocker = new PCTemplate();
 		unlocker.setName("unlocker");
 		unlocker.addToListFor(ListKey.UNLOCKED_STATS, strRef);
-		bonus = TestHelper.makeAbility("Bonus", AbilityCategory.FEAT, "General.Fighter");
+		bonus = TestHelper.makeAbility("Bonus", BuildUtilities.getFeatCat(), "General.Fighter");
 		BonusObj aBonus = Bonus.newBonus(context, "STAT|STR|7|TYPE=Enhancement");
 		if (aBonus != null)
 		{
 			bonus.addToListFor(ListKey.BONUS, aBonus);
 		}
-		lockedBonus = TestHelper.makeAbility("LockedBonus", AbilityCategory.FEAT, "General.Fighter");
+		lockedBonus = TestHelper.makeAbility("LockedBonus", BuildUtilities.getFeatCat(), "General.Fighter");
 		aBonus = Bonus.newBonus(context, "LOCKEDSTAT|STR|3|TYPE=Morale");
 		if (aBonus != null)
 		{
@@ -84,14 +85,14 @@ public class StatListTest extends AbstractCharacterTestCase
 		assertEquals("Starting STR should be 6", 6, pc.getBaseStatFor(str));
 
 		// Bonus should not affect base stat
-		addAbility(AbilityCategory.FEAT, bonus);
+		addAbility(BuildUtilities.getFeatCat(), bonus);
 		pc.calcActiveBonuses();
 		assertEquals("Stat should still be base", 6, pc.getBaseStatFor(str));
 		
 		pc.addTemplate(locker);
 		assertEquals("Stat should now be locked", 12, pc.getBaseStatFor(str));
 
-		addAbility(AbilityCategory.FEAT, lockedBonus);
+		addAbility(BuildUtilities.getFeatCat(), lockedBonus);
 		pc.calcActiveBonuses();
 		assertEquals("Stat should still be locked", 12, pc.getBaseStatFor(str));
 		
@@ -109,14 +110,14 @@ public class StatListTest extends AbstractCharacterTestCase
 		assertEquals("Starting STR should be 6", 6, pc.getTotalStatFor(str));
 
 		// Bonus should affect total stat
-		addAbility(AbilityCategory.FEAT, bonus);
+		addAbility(BuildUtilities.getFeatCat(), bonus);
 		pc.calcActiveBonuses();
 		assertEquals("Stat should have bonus", 13, pc.getTotalStatFor(str));
 		
 		pc.addTemplate(locker);
 		assertEquals("Stat should now be locked", 12, pc.getTotalStatFor(str));
 
-		addAbility(AbilityCategory.FEAT, lockedBonus);
+		addAbility(BuildUtilities.getFeatCat(), lockedBonus);
 		pc.calcActiveBonuses();
 		assertEquals("Stat should be locked but bonused", 15, pc.getTotalStatFor(str));
 

--- a/code/src/test/pcgen/core/analysis/SpellLevelTest.java
+++ b/code/src/test/pcgen/core/analysis/SpellLevelTest.java
@@ -28,7 +28,6 @@ import pcgen.cdom.enumeration.ObjectKey;
 import pcgen.cdom.facet.FacetLibrary;
 import pcgen.cdom.facet.KnownSpellFacet;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.core.Campaign;
 import pcgen.core.Globals;
 import pcgen.core.PCClass;
@@ -39,6 +38,7 @@ import pcgen.persistence.lst.CampaignSourceEntry;
 import pcgen.persistence.lst.PCClassLoader;
 import pcgen.rules.context.LoadContext;
 import pcgen.util.TestHelper;
+import plugin.lsttokens.testsupport.BuildUtilities;
 
 /**
  * The Class <code>SpellLevelTest</code> checks the SpellLevel class.
@@ -82,7 +82,7 @@ public class SpellLevelTest extends AbstractCharacterTestCase
 		AbilityLoader abilityLoader = new AbilityLoader();
 		abilityLoader.parseLine(context, null, abilityLine, source);
 		Ability ab1 = Globals.getContext().getReferenceContext()
-			.getManufacturerId(AbilityCategory.FEAT).getActiveObject("Spell bonanza");
+			.getManufacturerId(BuildUtilities.getFeatCat()).getActiveObject("Spell bonanza");
 
 		// Do the post parsing cleanup
 		context.resolveDeferredTokens();
@@ -96,7 +96,7 @@ public class SpellLevelTest extends AbstractCharacterTestCase
 		Collection<Integer> levels = listManagerFacet.getScopes2(aPC.getCharID(), pcc.get(ObjectKey.CLASS_SPELLLIST));
 		assertEquals("Initial number of spell levels incorrect", 0, levels.size());
 		
-		addAbility(AbilityCategory.FEAT, ab1);
+		addAbility(BuildUtilities.getFeatCat(), ab1);
 
 		// Now for the tests
 		levels = listManagerFacet.getScopes2(aPC.getCharID(), pcc.get(ObjectKey.CLASS_SPELLLIST));

--- a/code/src/test/pcgen/core/bonus/BonusTest.java
+++ b/code/src/test/pcgen/core/bonus/BonusTest.java
@@ -28,7 +28,6 @@ import pcgen.cdom.enumeration.StringKey;
 import pcgen.cdom.enumeration.Type;
 import pcgen.cdom.enumeration.VariableKey;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.core.Equipment;
 import pcgen.core.Globals;
 import pcgen.core.PCClass;
@@ -38,6 +37,7 @@ import pcgen.core.analysis.BonusActivation;
 import pcgen.core.character.EquipSet;
 import pcgen.rules.context.LoadContext;
 import plugin.bonustokens.Var;
+import plugin.lsttokens.testsupport.BuildUtilities;
 
 /**
  * <code>BonusTest</code> test that the Bonus class is functioning
@@ -110,7 +110,7 @@ public class BonusTest extends AbstractCharacterTestCase
 
 		Ability dummyFeat = new Ability();
 		dummyFeat.setName("DummyFeat");
-		dummyFeat.setCDOMCategory(AbilityCategory.FEAT);
+		dummyFeat.setCDOMCategory(BuildUtilities.getFeatCat());
 		final PlayerCharacter pc = getCharacter();
 
 		// Create a variable
@@ -119,7 +119,7 @@ public class BonusTest extends AbstractCharacterTestCase
 		// Create a bonus to it
 		Ability dummyFeat2 = new Ability();
 		dummyFeat2.setName("DummyFeat2");
-		dummyFeat2.setCDOMCategory(AbilityCategory.FEAT);
+		dummyFeat2.setCDOMCategory(BuildUtilities.getFeatCat());
 		BonusObj aBonus = Bonus.newBonus(context, "VAR|NegLevels|7");
 		
 		if (aBonus != null)
@@ -138,14 +138,14 @@ public class BonusTest extends AbstractCharacterTestCase
 
 		assertEquals("Variable value", 0.0, pc
 			.getVariableValue("NegLevels", "").doubleValue(), 0.05);
-		addAbility(AbilityCategory.FEAT, dummyFeat);
+		addAbility(BuildUtilities.getFeatCat(), dummyFeat);
 		assertEquals("Variable value", 0.0, pc
 			.getVariableValue("NegLevels", "").doubleValue(), 0.05);
 		assertEquals("Variable value", -0.0, pc.getVariableValue(
 			"-1*NegLevels", "").doubleValue(), 0.05);
 
 		// Add a bonus to it
-		addAbility(AbilityCategory.FEAT, dummyFeat2);
+		addAbility(BuildUtilities.getFeatCat(), dummyFeat2);
 		assertEquals("Variable value", 7.0, pc
 			.getVariableValue("NegLevels", "").doubleValue(), 0.05);
 		assertEquals("Variable value", -7.0, pc.getVariableValue(
@@ -218,11 +218,12 @@ public class BonusTest extends AbstractCharacterTestCase
 		bonusList.add(bonus);
 		Ability testBonus = new Ability();
 		testBonus.setName("TB1Assoc");
-		testBonus.setCDOMCategory(AbilityCategory.FEAT);
+		testBonus.setCDOMCategory(BuildUtilities.getFeatCat());
 		testBonus.addToListFor(ListKey.BONUS, bonus);
 		Globals.getContext().unconditionallyProcess(testBonus, "CHOOSE", "PCSTAT|ALL");
 		Globals.getContext().unconditionallyProcess(testBonus, "MULT", "YES");
-		CNAbility cna = AbstractCharacterTestCase.applyAbility(character, AbilityCategory.FEAT, testBonus, "INT");
+		CNAbility cna = AbstractCharacterTestCase.applyAbility(character,
+			BuildUtilities.getFeatCat(), testBonus, "INT");
 		testBonus = cna.getAbility();
 		character.calcActiveBonuses();
 		bonus = testBonus.getSafeListFor(ListKey.BONUS).get(0);
@@ -246,13 +247,15 @@ public class BonusTest extends AbstractCharacterTestCase
 		bonusList.add(bonus);
 		Ability testBonus = new Ability();
 		testBonus.setName("TB2Assoc");
-		testBonus.setCDOMCategory(AbilityCategory.FEAT);
+		testBonus.setCDOMCategory(BuildUtilities.getFeatCat());
 		testBonus.addToListFor(ListKey.BONUS, bonus);
 		Globals.getContext().unconditionallyProcess(testBonus, "CHOOSE", "PCSTAT|ALL");
 		Globals.getContext().unconditionallyProcess(testBonus, "MULT", "YES");
-		CNAbility cna = AbstractCharacterTestCase.applyAbility(character, AbilityCategory.FEAT, testBonus, "INT");
+		CNAbility cna = AbstractCharacterTestCase.applyAbility(character,
+			BuildUtilities.getFeatCat(), testBonus, "INT");
 		testBonus = cna.getAbility();
-		AbstractCharacterTestCase.applyAbility(character, AbilityCategory.FEAT, testBonus, "STR");
+		AbstractCharacterTestCase.applyAbility(character, BuildUtilities.getFeatCat(),
+			testBonus, "STR");
 		character.calcActiveBonuses();
 		bonus = testBonus.getSafeListFor(ListKey.BONUS).get(0);
 
@@ -280,13 +283,15 @@ public class BonusTest extends AbstractCharacterTestCase
 		bonusList.add(bonus);
 		Ability testBonus = new Ability();
 		testBonus.setName("TB2AssocList");
-		testBonus.setCDOMCategory(AbilityCategory.FEAT);
+		testBonus.setCDOMCategory(BuildUtilities.getFeatCat());
 		Globals.getContext().unconditionallyProcess(testBonus, "CHOOSE", "PCSTAT|ALL");
 		Globals.getContext().unconditionallyProcess(testBonus, "MULT", "YES");
 		testBonus.addToListFor(ListKey.BONUS, bonus);
-		CNAbility cna = AbstractCharacterTestCase.applyAbility(character, AbilityCategory.FEAT, testBonus, "INT");
+		CNAbility cna = AbstractCharacterTestCase.applyAbility(character,
+			BuildUtilities.getFeatCat(), testBonus, "INT");
 		testBonus = cna.getAbility();
-		AbstractCharacterTestCase.applyAbility(character, AbilityCategory.FEAT, testBonus, "STR");
+		AbstractCharacterTestCase.applyAbility(character, BuildUtilities.getFeatCat(),
+			testBonus, "STR");
 		character.calcActiveBonuses();
 		bonus = testBonus.getSafeListFor(ListKey.BONUS).get(0);
 
@@ -320,11 +325,12 @@ public class BonusTest extends AbstractCharacterTestCase
 		bonusList.add(bonus);
 		Ability testBonus = new Ability();
 		testBonus.setName("TB1Assoc");
-		testBonus.setCDOMCategory(AbilityCategory.FEAT);
+		testBonus.setCDOMCategory(BuildUtilities.getFeatCat());
 		testBonus.addToListFor(ListKey.BONUS, bonus);
 		Globals.getContext().unconditionallyProcess(testBonus, "CHOOSE", "SPELLLEVEL|Wizard|1|5");
 		Globals.getContext().unconditionallyProcess(testBonus, "MULT", "YES");
-		CNAbility cna = AbstractCharacterTestCase.applyAbility(character, AbilityCategory.FEAT, testBonus, "CLASS.Wizard;LEVEL.1");
+		CNAbility cna = AbstractCharacterTestCase.applyAbility(character,
+			BuildUtilities.getFeatCat(), testBonus, "CLASS.Wizard;LEVEL.1");
 		testBonus = cna.getAbility();
 		character.calcActiveBonuses();
 		bonus = testBonus.getSafeListFor(ListKey.BONUS).get(0);

--- a/code/src/test/pcgen/core/display/SkillCostDisplayTest.java
+++ b/code/src/test/pcgen/core/display/SkillCostDisplayTest.java
@@ -24,7 +24,6 @@ import pcgen.cdom.enumeration.ListKey;
 import pcgen.cdom.enumeration.ObjectKey;
 import pcgen.cdom.enumeration.SkillArmorCheck;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.core.Globals;
 import pcgen.core.PCClass;
 import pcgen.core.PlayerCharacter;
@@ -34,6 +33,7 @@ import pcgen.core.bonus.Bonus;
 import pcgen.core.bonus.BonusObj;
 import pcgen.rules.context.LoadContext;
 import pcgen.util.TestHelper;
+import plugin.lsttokens.testsupport.BuildUtilities;
 
 /**
  * The Class <code>SkillModifierTest</code> is responsible for checking that the 
@@ -72,7 +72,7 @@ public class SkillCostDisplayTest extends AbstractCharacterTestCase
 				SkillArmorCheck.NONE);
 
 			skillFocus =
-					TestHelper.makeAbility("Skill Focus", AbilityCategory.FEAT, "General");
+					TestHelper.makeAbility("Skill Focus", BuildUtilities.getFeatCat(), "General");
 			BonusObj aBonus = Bonus.newBonus(context, "SKILL|LIST|3");
 			
 			if (aBonus != null)
@@ -88,7 +88,7 @@ public class SkillCostDisplayTest extends AbstractCharacterTestCase
 					"SKILL|TYPE.Strength|TYPE.Dexterity|TYPE.Constitution|TYPE.Intelligence|TYPE.Wisdom|TYPE.Charisma");
 
 			persuasive =
-					TestHelper.makeAbility("Persuasive", AbilityCategory.FEAT, "General");
+					TestHelper.makeAbility("Persuasive", BuildUtilities.getFeatCat(), "General");
 			aBonus = Bonus.newBonus(context, "SKILL|KEY_Bluff,KEY_Listen|2");
 			
 			if (aBonus != null)
@@ -129,12 +129,12 @@ public class SkillCostDisplayTest extends AbstractCharacterTestCase
 		assertEquals("Initial state", "", SkillCostDisplay.getModifierExplanation(
 			bluff, pc, false));
 
-		AbstractCharacterTestCase.applyAbility(pc, AbilityCategory.FEAT, skillFocus, "KEY_Bluff");
+		AbstractCharacterTestCase.applyAbility(pc, BuildUtilities.getFeatCat(), skillFocus, "KEY_Bluff");
 		pc.calcActiveBonuses();
 		assertEquals("Bonus after skill focus", "+3[Skill Focus]",
 			SkillCostDisplay.getModifierExplanation(bluff, pc, false));
 
-		addAbility(AbilityCategory.FEAT, persuasive);
+		addAbility(BuildUtilities.getFeatCat(), persuasive);
 		String modifierExplanation = SkillCostDisplay
 			.getModifierExplanation(bluff, pc, false);
 		// Have to account for random order of the bonuses. 

--- a/code/src/test/pcgen/core/prereq/PreAbilityTest.java
+++ b/code/src/test/pcgen/core/prereq/PreAbilityTest.java
@@ -25,10 +25,10 @@ import pcgen.cdom.enumeration.ListKey;
 import pcgen.cdom.enumeration.ObjectKey;
 import pcgen.cdom.reference.CDOMDirectSingleRef;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.core.PlayerCharacter;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.util.TestHelper;
+import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.pretokens.parser.PreAbilityParser;
 
 /**
@@ -188,7 +188,7 @@ public class PreAbilityTest extends AbstractCharacterTestCase
 	 */
 	public void testKeyMatchWithServesAs() throws PersistenceLayerException
 	{
-		Ability fd = TestHelper.makeAbility("Dancer", AbilityCategory.FEAT, "General");
+		Ability fd = TestHelper.makeAbility("Dancer", BuildUtilities.getFeatCat(), "General");
 		Ability ab2 =
 				TestHelper.makeAbility("Dancer", "BARDIC",
 						"General.Bardic");
@@ -234,7 +234,7 @@ public class PreAbilityTest extends AbstractCharacterTestCase
 	 */
 	public void testTypeMatchWithServesAs() throws PersistenceLayerException
 	{
-		Ability pa = TestHelper.makeAbility("Power Attack", AbilityCategory.FEAT, "Fighter");
+		Ability pa = TestHelper.makeAbility("Power Attack", BuildUtilities.getFeatCat(), "Fighter");
 		Ability ab2 =
 				TestHelper.makeAbility("Dancer", "BARDIC", "General.Bardic");
 		ab2.put(ObjectKey.MULTIPLE_ALLOWED, Boolean.FALSE);
@@ -275,7 +275,7 @@ public class PreAbilityTest extends AbstractCharacterTestCase
 	{
 		Ability fas = TestHelper.makeAbility("Fascinate", "BARDIC", "Normal");
 		Ability ab2 =
-				TestHelper.makeAbility("Dancer", AbilityCategory.FEAT,
+				TestHelper.makeAbility("Dancer", BuildUtilities.getFeatCat(),
 						"General.Bardic");
 		ab2.addToListFor(ListKey.SERVES_AS_ABILITY, CDOMDirectSingleRef.getRef(fas));
 		ab2.put(ObjectKey.MULTIPLE_ALLOWED, Boolean.FALSE);

--- a/code/src/test/pcgen/core/prereq/PreArmorProfTest.java
+++ b/code/src/test/pcgen/core/prereq/PreArmorProfTest.java
@@ -29,7 +29,6 @@ import pcgen.base.lang.UnreachableError;
 import pcgen.cdom.enumeration.ListKey;
 import pcgen.cdom.enumeration.Type;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.core.ArmorProf;
 import pcgen.core.Campaign;
 import pcgen.core.Equipment;
@@ -39,6 +38,7 @@ import pcgen.persistence.lst.CampaignSourceEntry;
 import pcgen.persistence.lst.FeatLoader;
 import pcgen.persistence.lst.prereq.PreParserFactory;
 import pcgen.util.TestHelper;
+import plugin.lsttokens.testsupport.BuildUtilities;
 
 /**
  * <code>PreArmorProfTest</code> tests that the PREARMORPROF tag is
@@ -91,7 +91,7 @@ public class PreArmorProfTest extends AbstractCharacterTestCase
 		Globals.getContext().unconditionallyProcess(martialProf, "AUTO", "ARMORPROF|Full Plate");
 		assertTrue(Globals.getContext().getReferenceContext().resolveReferences(null));
 
-		AbstractCharacterTestCase.applyAbility(character, AbilityCategory.FEAT, martialProf, null);
+		AbstractCharacterTestCase.applyAbility(character, BuildUtilities.getFeatCat(), martialProf, null);
 
 		assertTrue("Character has the Chainmail proficiency.", 
 					PrereqHandler.passes(prereq, character, null));
@@ -131,7 +131,7 @@ public class PreArmorProfTest extends AbstractCharacterTestCase
 		Globals.getContext().unconditionallyProcess(martialProf, "AUTO", "ARMORPROF|Full Plate");
 		assertTrue(Globals.getContext().getReferenceContext().resolveReferences(null));
 		
-		AbstractCharacterTestCase.applyAbility(character, AbilityCategory.FEAT, martialProf, null);
+		AbstractCharacterTestCase.applyAbility(character, BuildUtilities.getFeatCat(), martialProf, null);
 
 		assertTrue("Character has one of Chainmail or Full Plate proficiency", 
 			PrereqHandler.passes(prereq, character, null));
@@ -169,7 +169,7 @@ public class PreArmorProfTest extends AbstractCharacterTestCase
 			TestHelper.makeAbility("Shield Proficiency (Single)", "FEAT", "General");
 		Globals.getContext().unconditionallyProcess(martialProf, "AUTO", "ARMORPROF|ARMORTYPE=Medium");
 		
-		AbstractCharacterTestCase.applyAbility(character, AbilityCategory.FEAT, martialProf, null);
+		AbstractCharacterTestCase.applyAbility(character, BuildUtilities.getFeatCat(), martialProf, null);
 		
 		assertTrue("Character has Medium Armor Proficiency", 
 				PrereqHandler.passes(prereq, character, null));
@@ -199,7 +199,7 @@ public class PreArmorProfTest extends AbstractCharacterTestCase
 		Globals.getContext().unconditionallyProcess(martialProf, "AUTO", "ARMORPROF|Breastplate");
 		assertTrue(Globals.getContext().getReferenceContext().resolveReferences(null));
 		
-		AbstractCharacterTestCase.applyAbility(character, AbilityCategory.FEAT, martialProf, null);
+		AbstractCharacterTestCase.applyAbility(character, BuildUtilities.getFeatCat(), martialProf, null);
 
 		assertFalse("Character has the Breastplate proficiency.", 
 					PrereqHandler.passes(prereq, character, null));
@@ -235,11 +235,11 @@ public class PreArmorProfTest extends AbstractCharacterTestCase
 			prereq, character, null));
 		
 		final Ability martialProf = 
-			TestHelper.makeAbility("Armor Proficiency (Single)", AbilityCategory.FEAT, "General");
+			TestHelper.makeAbility("Armor Proficiency (Single)", BuildUtilities.getFeatCat(), "General");
 		Globals.getContext().unconditionallyProcess(martialProf, "AUTO", "ARMORPROF|ARMORTYPE=Medium");
 		assertTrue(Globals.getContext().getReferenceContext().resolveReferences(null));
 
-		AbstractCharacterTestCase.applyAbility(character, AbilityCategory.FEAT, martialProf, null);
+		AbstractCharacterTestCase.applyAbility(character, BuildUtilities.getFeatCat(), martialProf, null);
 
 		assertTrue("Character has the Breastplate proficiency.", 
 					PrereqHandler.passes(prereq, character, null));
@@ -287,7 +287,7 @@ public class PreArmorProfTest extends AbstractCharacterTestCase
 		final String barStr =
 			"Bar	TYPE:General	DESC:See Text	BONUS:HP|CURRENTMAX|50";
 		featLoader.parseLine(Globals.getContext(), bar, barStr, cse);
-		addAbility(AbilityCategory.FEAT, bar);
+		addAbility(BuildUtilities.getFeatCat(), bar);
 		
 		assertEquals("Character should have 50 bonus hp added.",
 					baseHp+50,
@@ -299,13 +299,13 @@ public class PreArmorProfTest extends AbstractCharacterTestCase
 		Globals.getContext().unconditionallyProcess(martialProf, "AUTO", "ARMORPROF|Full Plate");
 		assertTrue(Globals.getContext().getReferenceContext().resolveReferences(null));
 		
-		AbstractCharacterTestCase.applyAbility(character, AbilityCategory.FEAT, martialProf, null);
+		AbstractCharacterTestCase.applyAbility(character, BuildUtilities.getFeatCat(), martialProf, null);
 		
 		Ability foo = new Ability();
 		final String fooStr =
 			"Foo	TYPE:General	DESC:See Text	BONUS:HP|CURRENTMAX|50|PREPROFWITHARMOR:1,Full Plate";
 		featLoader.parseLine(Globals.getContext(), foo, fooStr, cse);
-		addAbility(AbilityCategory.FEAT, foo);
+		addAbility(BuildUtilities.getFeatCat(), foo);
 		
 		assertEquals("Character has the Full Plate proficiency so the bonus should be added",
 					baseHp+50+50,

--- a/code/src/test/pcgen/core/prereq/PreArmorTypeTest.java
+++ b/code/src/test/pcgen/core/prereq/PreArmorTypeTest.java
@@ -21,12 +21,12 @@ import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.enumeration.ListKey;
 import pcgen.cdom.enumeration.Type;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.core.Equipment;
 import pcgen.core.Globals;
 import pcgen.core.PlayerCharacter;
 import pcgen.persistence.lst.prereq.PreParserFactory;
 import pcgen.util.TestHelper;
+import plugin.lsttokens.testsupport.BuildUtilities;
 
 /**
  * <code>PreArmorTypeTest</code> tests that the PREARMORTYPE tag is
@@ -133,11 +133,11 @@ public class PreArmorTypeTest extends AbstractCharacterTestCase
 		final PlayerCharacter character = getCharacter();
 
 		final Ability mediumProf =
-				TestHelper.makeAbility("Armor Proficiency (Medium)", AbilityCategory.FEAT,
+				TestHelper.makeAbility("Armor Proficiency (Medium)", BuildUtilities.getFeatCat(),
 					"General");
 		Globals.getContext().unconditionallyProcess(mediumProf, "AUTO",
 				"ARMORPROF|ARMORTYPE.Medium");
-		AbstractCharacterTestCase.applyAbility(character, AbilityCategory.FEAT, mediumProf, null);
+		AbstractCharacterTestCase.applyAbility(character, BuildUtilities.getFeatCat(), mediumProf, null);
 
 		final Equipment chainmail = new Equipment();
 		chainmail.addToListFor(ListKey.TYPE, Type.getConstant("ARMOR"));

--- a/code/src/test/pcgen/core/prereq/PreMultTest.java
+++ b/code/src/test/pcgen/core/prereq/PreMultTest.java
@@ -25,7 +25,6 @@ import pcgen.cdom.enumeration.ListKey;
 import pcgen.cdom.enumeration.StringKey;
 import pcgen.cdom.enumeration.Type;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.core.Globals;
 import pcgen.core.PCClass;
 import pcgen.core.PlayerCharacter;
@@ -144,37 +143,37 @@ public class PreMultTest extends AbstractCharacterTestCase
 		metamagic1.addToListFor(ListKey.TYPE, Type.getConstant("METAMAGIC"));
 		metamagic1.setName("MM1");
 		metamagic1.put(StringKey.KEY_NAME, "MM1");
-		metamagic1.setCDOMCategory(AbilityCategory.FEAT);
+		metamagic1.setCDOMCategory(BuildUtilities.getFeatCat());
 
 		final Ability metamagic2 = new Ability();
 		metamagic2.addToListFor(ListKey.TYPE, Type.getConstant("METAMAGIC"));
 		metamagic2.setName("MM2");
 		metamagic2.put(StringKey.KEY_NAME, "MM2");
-		metamagic2.setCDOMCategory(AbilityCategory.FEAT);
+		metamagic2.setCDOMCategory(BuildUtilities.getFeatCat());
 
 		final Ability metamagic3 = new Ability();
 		metamagic3.addToListFor(ListKey.TYPE, Type.getConstant("METAMAGIC"));
 		metamagic3.setName("MM3");
 		metamagic3.put(StringKey.KEY_NAME, "MM3");
-		metamagic3.setCDOMCategory(AbilityCategory.FEAT);
+		metamagic3.setCDOMCategory(BuildUtilities.getFeatCat());
 
 		final Ability item1 = new Ability();
 		item1.addToListFor(ListKey.TYPE, Type.getConstant("ItemCreation"));
 		item1.setName("IC1");
 		item1.put(StringKey.KEY_NAME, "IC1");
-		item1.setCDOMCategory(AbilityCategory.FEAT);
+		item1.setCDOMCategory(BuildUtilities.getFeatCat());
 
 		final Ability item2 = new Ability();
 		item2.addToListFor(ListKey.TYPE, Type.getConstant("ItemCreation"));
 		item2.setName("IC2");
 		item2.put(StringKey.KEY_NAME, "IC2");
-		item2.setCDOMCategory(AbilityCategory.FEAT);
+		item2.setCDOMCategory(BuildUtilities.getFeatCat());
 
 		final Ability item3 = new Ability();
 		item3.addToListFor(ListKey.TYPE, Type.getConstant("ItemCreation"));
 		item3.setName("IC3");
 		item3.put(StringKey.KEY_NAME, "IC3");
-		item3.setCDOMCategory(AbilityCategory.FEAT);
+		item3.setCDOMCategory(BuildUtilities.getFeatCat());
 
 		final PlayerCharacter character = getCharacter();
 
@@ -188,35 +187,35 @@ public class PreMultTest extends AbstractCharacterTestCase
 		int passes = test.passes(prereq, character, null);
 		assertEquals("No feats should not pass", 0, passes);
 
-		addAbility(AbilityCategory.FEAT, metamagic1);
+		addAbility(BuildUtilities.getFeatCat(), metamagic1);
 		passes = test.passes(prereq, character, null);
 		assertEquals("One feat should not pass", 0, passes);
 
-		addAbility(AbilityCategory.FEAT, metamagic2);
+		addAbility(BuildUtilities.getFeatCat(), metamagic2);
 		passes = test.passes(prereq, character, null);
 		assertEquals("Two feats should not pass", 0, passes);
 
-		addAbility(AbilityCategory.FEAT, metamagic3);
+		addAbility(BuildUtilities.getFeatCat(), metamagic3);
 		passes = test.passes(prereq, character, null);
 		assertEquals("Three feats should pass", 1, passes);
 
-		removeAbility(AbilityCategory.FEAT, metamagic3);
-		addAbility(AbilityCategory.FEAT, item1);
+		removeAbility(BuildUtilities.getFeatCat(), metamagic3);
+		addAbility(BuildUtilities.getFeatCat(), item1);
 		passes = test.passes(prereq, character, null);
 		assertEquals("Three feats should pass", 1, passes);
 
-		addAbility(AbilityCategory.FEAT, item2);
-		addAbility(AbilityCategory.FEAT, item3);
-		addAbility(AbilityCategory.FEAT, metamagic3);
+		addAbility(BuildUtilities.getFeatCat(), item2);
+		addAbility(BuildUtilities.getFeatCat(), item3);
+		addAbility(BuildUtilities.getFeatCat(), metamagic3);
 		passes = test.passes(prereq, character, null);
 		assertEquals("Six feats should pass", 1, passes);
 
-		removeAbility(AbilityCategory.FEAT, metamagic3);
-		removeAbility(AbilityCategory.FEAT, item3);
-		removeAbility(AbilityCategory.FEAT, item2);
-		removeAbility(AbilityCategory.FEAT, item1);
-		removeAbility(AbilityCategory.FEAT, metamagic2);
-		removeAbility(AbilityCategory.FEAT, metamagic1);
+		removeAbility(BuildUtilities.getFeatCat(), metamagic3);
+		removeAbility(BuildUtilities.getFeatCat(), item3);
+		removeAbility(BuildUtilities.getFeatCat(), item2);
+		removeAbility(BuildUtilities.getFeatCat(), item1);
+		removeAbility(BuildUtilities.getFeatCat(), metamagic2);
+		removeAbility(BuildUtilities.getFeatCat(), metamagic1);
 	}
 
 	/**

--- a/code/src/test/pcgen/core/prereq/PreShieldProfTest.java
+++ b/code/src/test/pcgen/core/prereq/PreShieldProfTest.java
@@ -29,7 +29,6 @@ import pcgen.base.lang.UnreachableError;
 import pcgen.cdom.enumeration.ListKey;
 import pcgen.cdom.enumeration.Type;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.core.Campaign;
 import pcgen.core.Equipment;
 import pcgen.core.Globals;
@@ -39,6 +38,7 @@ import pcgen.persistence.lst.CampaignSourceEntry;
 import pcgen.persistence.lst.FeatLoader;
 import pcgen.persistence.lst.prereq.PreParserFactory;
 import pcgen.util.TestHelper;
+import plugin.lsttokens.testsupport.BuildUtilities;
 
 /**
  * <code>PreShieldProfTest</code> tests that the PREPROFWITHSHIELD tag is
@@ -89,7 +89,7 @@ public class PreShieldProfTest extends AbstractCharacterTestCase
 		Globals.getContext().unconditionallyProcess(martialProf, "AUTO", "SHIELDPROF|Heavy Steel Shield");
 		assertTrue(Globals.getContext().getReferenceContext().resolveReferences(null));
 		
-		AbstractCharacterTestCase.applyAbility(character, AbilityCategory.FEAT, martialProf, null);
+		AbstractCharacterTestCase.applyAbility(character, BuildUtilities.getFeatCat(), martialProf, null);
 
 		assertTrue("Character has the Heavy Wooden Shield proficiency.", 
 					PrereqHandler.passes(prereq, character, null));
@@ -129,7 +129,7 @@ public class PreShieldProfTest extends AbstractCharacterTestCase
 		Globals.getContext().unconditionallyProcess(martialProf, "AUTO", "SHIELDPROF|Full Plate");
 		assertTrue(Globals.getContext().getReferenceContext().resolveReferences(null));
 		
-		AbstractCharacterTestCase.applyAbility(character, AbilityCategory.FEAT, martialProf, null);
+		AbstractCharacterTestCase.applyAbility(character, BuildUtilities.getFeatCat(), martialProf, null);
 
 		assertTrue("Character has one of Heavy Wooden Shield or Full Plate proficiency", 
 			PrereqHandler.passes(prereq, character, null));
@@ -169,7 +169,7 @@ public class PreShieldProfTest extends AbstractCharacterTestCase
 		Globals.getContext().unconditionallyProcess(martialProf, "AUTO", "SHIELDPROF|SHIELDTYPE=Medium");
 		Globals.getContext().getReferenceContext().resolveReferences(null);
 		
-		AbstractCharacterTestCase.applyAbility(character, AbilityCategory.FEAT, martialProf, null);
+		AbstractCharacterTestCase.applyAbility(character, BuildUtilities.getFeatCat(), martialProf, null);
 		
 		assertTrue("Character has Medium Shield Proficiency", 
 				PrereqHandler.passes(prereq, character, null));
@@ -198,7 +198,7 @@ public class PreShieldProfTest extends AbstractCharacterTestCase
 		Globals.getContext().unconditionallyProcess(martialProf, "AUTO", "SHIELDPROF|Heavy Steel Shield");
 		assertTrue(Globals.getContext().getReferenceContext().resolveReferences(null));
 		
-		AbstractCharacterTestCase.applyAbility(character, AbilityCategory.FEAT, martialProf, null);
+		AbstractCharacterTestCase.applyAbility(character, BuildUtilities.getFeatCat(), martialProf, null);
 
 		assertFalse("Character has the Heavy Steel Shield proficiency.", 
 					PrereqHandler.passes(prereq, character, null));
@@ -234,10 +234,10 @@ public class PreShieldProfTest extends AbstractCharacterTestCase
 			prereq, character, null));
 		
 		final Ability martialProf = 
-			TestHelper.makeAbility("Shield Proficiency (Single)", AbilityCategory.FEAT, "General");
+			TestHelper.makeAbility("Shield Proficiency (Single)", BuildUtilities.getFeatCat(), "General");
 		Globals.getContext().unconditionallyProcess(martialProf, "AUTO", "SHIELDPROF|SHIELDTYPE.Heavy");
 		
-		AbstractCharacterTestCase.applyAbility(character, AbilityCategory.FEAT, martialProf, null);
+		AbstractCharacterTestCase.applyAbility(character, BuildUtilities.getFeatCat(), martialProf, null);
 
 		assertTrue("Character has the Heavy Steel Shield proficiency.", 
 					PrereqHandler.passes(prereq, character, null));
@@ -284,7 +284,7 @@ public class PreShieldProfTest extends AbstractCharacterTestCase
 		final String barStr =
 			"Bar	TYPE:General	DESC:See Text	BONUS:HP|CURRENTMAX|50";
 		featLoader.parseLine(Globals.getContext(), bar, barStr, cse);
-		addAbility(AbilityCategory.FEAT, bar);
+		addAbility(BuildUtilities.getFeatCat(), bar);
 		
 		assertEquals("Character should have 50 bonus hp added.",
 					baseHp+50,
@@ -296,13 +296,13 @@ public class PreShieldProfTest extends AbstractCharacterTestCase
 		Globals.getContext().unconditionallyProcess(martialProf, "AUTO", "SHIELDPROF|Full Plate");
 		assertTrue(Globals.getContext().getReferenceContext().resolveReferences(null));
 		
-		AbstractCharacterTestCase.applyAbility(character, AbilityCategory.FEAT, martialProf, null);
+		AbstractCharacterTestCase.applyAbility(character, BuildUtilities.getFeatCat(), martialProf, null);
 		
 		Ability foo = new Ability();
 		final String fooStr =
 			"Foo	TYPE:General	DESC:See Text	BONUS:HP|CURRENTMAX|50|PREPROFWITHSHIELD:1,Full Plate";
 		featLoader.parseLine(Globals.getContext(), foo, fooStr, cse);
-		addAbility(AbilityCategory.FEAT, foo);
+		addAbility(BuildUtilities.getFeatCat(), foo);
 		
 		assertEquals("Character has the Full Plate proficiency so the bonus should be added",
 					baseHp+50+50,

--- a/code/src/test/pcgen/core/prereq/PreWeaponProfTest.java
+++ b/code/src/test/pcgen/core/prereq/PreWeaponProfTest.java
@@ -29,7 +29,6 @@ import pcgen.base.lang.UnreachableError;
 import pcgen.cdom.enumeration.ListKey;
 import pcgen.cdom.enumeration.Type;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.core.Campaign;
 import pcgen.core.Globals;
 import pcgen.core.PCTemplate;
@@ -40,6 +39,7 @@ import pcgen.persistence.lst.FeatLoader;
 import pcgen.persistence.lst.prereq.PreParserFactory;
 import pcgen.rules.context.LoadContext;
 import pcgen.util.TestHelper;
+import plugin.lsttokens.testsupport.BuildUtilities;
 
 /**
  * <code>PreWeaponProfTest</code> tests that the PREWEAPONPROF tag is
@@ -231,12 +231,12 @@ public class PreWeaponProfTest extends AbstractCharacterTestCase
 			prereq, character, null));
 		
 		final Ability martialProf = 
-			TestHelper.makeAbility("Weapon Proficiency (Martial)", AbilityCategory.FEAT, "General");
+			TestHelper.makeAbility("Weapon Proficiency (Martial)", BuildUtilities.getFeatCat(), "General");
 		Globals.getContext().unconditionallyProcess(martialProf, "AUTO",
 				"WEAPONPROF|TYPE.Martial");
 		assertTrue(Globals.getContext().getReferenceContext().resolveReferences(null));
 		
-		AbstractCharacterTestCase.applyAbility(character, AbilityCategory.FEAT, martialProf, null);
+		AbstractCharacterTestCase.applyAbility(character, BuildUtilities.getFeatCat(), martialProf, null);
 
 		assertTrue("Character has the Longsword proficiency.", 
 					PrereqHandler.passes(prereq, character, null));
@@ -287,7 +287,7 @@ public class PreWeaponProfTest extends AbstractCharacterTestCase
 		final String barStr =
 			"Bar	TYPE:General	DESC:See Text	BONUS:HP|CURRENTMAX|50";
 		featLoader.parseLine(Globals.getContext(), bar, barStr, cse);
-		addAbility(AbilityCategory.FEAT, bar);
+		addAbility(BuildUtilities.getFeatCat(), bar);
 		
 		assertEquals("Character should have 50 bonus hp added.",
 					baseHp+50,
@@ -300,7 +300,7 @@ public class PreWeaponProfTest extends AbstractCharacterTestCase
 		final String fooStr =
 			"Foo	TYPE:General	DESC:See Text	BONUS:HP|CURRENTMAX|50|PREWEAPONPROF:1,Longsword";
 		featLoader.parseLine(Globals.getContext(), foo, fooStr, cse);
-		addAbility(AbilityCategory.FEAT, foo);
+		addAbility(BuildUtilities.getFeatCat(), foo);
 		
 		assertEquals("Character has the longsword proficiency so the bonus should be added",
 					baseHp+50+50,

--- a/code/src/test/pcgen/gui2/facade/CharacterAbilitiesTest.java
+++ b/code/src/test/pcgen/gui2/facade/CharacterAbilitiesTest.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.enumeration.ObjectKey;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.core.Globals;
 import pcgen.core.PlayerCharacter;
 import pcgen.core.SettingsHandler;
@@ -32,6 +31,7 @@ import pcgen.facade.util.ListFacade;
 import pcgen.rules.persistence.token.ParseResult;
 import pcgen.util.TestHelper;
 import plugin.lsttokens.choose.StringToken;
+import plugin.lsttokens.testsupport.BuildUtilities;
 
 /**
  * The Class <code>CharacterAbilitiesTest</code> verifies the operation of the 
@@ -58,15 +58,15 @@ public class CharacterAbilitiesTest extends AbstractCharacterTestCase
 		ca.rebuildAbilityLists();
 		ListFacade<AbilityCategoryFacade> categories = ca.getActiveAbilityCategories();
 		assertNotNull("Categories should not be null", categories);
-		assertTrue("Feat should be active", categories.containsElement(AbilityCategory.FEAT));
-		ListFacade<AbilityFacade> abilities = ca.getAbilities(AbilityCategory.FEAT);
+		assertTrue("Feat should be active", categories.containsElement(BuildUtilities.getFeatCat()));
+		ListFacade<AbilityFacade> abilities = ca.getAbilities(BuildUtilities.getFeatCat());
 		assertNotNull("Feat list should not be null", abilities);
 		assertTrue("Feat list should be empty", abilities.isEmpty());
 		
 		// Add an entry - note rebuild is implicit
-		Ability fencing = TestHelper.makeAbility("fencing", AbilityCategory.FEAT, "sport");
-		addAbility(AbilityCategory.FEAT, fencing);
-		abilities = ca.getAbilities(AbilityCategory.FEAT);
+		Ability fencing = TestHelper.makeAbility("fencing", BuildUtilities.getFeatCat(), "sport");
+		addAbility(BuildUtilities.getFeatCat(), fencing);
+		abilities = ca.getAbilities(BuildUtilities.getFeatCat());
 		assertEquals("Feat list should have one entry", 1, abilities.getSize());
 		Ability abilityFromList = (Ability) abilities.getElementAt(0);
 		assertEquals("Should have found fencing", fencing, abilityFromList);
@@ -83,29 +83,29 @@ public class CharacterAbilitiesTest extends AbstractCharacterTestCase
 		ca.rebuildAbilityLists();
 		ListFacade<AbilityCategoryFacade> categories = ca.getActiveAbilityCategories();
 		assertNotNull("Categories should not be null", categories);
-		assertTrue("Feat should be active", categories.containsElement(AbilityCategory.FEAT));
-		ListFacade<AbilityFacade> abilities = ca.getAbilities(AbilityCategory.FEAT);
+		assertTrue("Feat should be active", categories.containsElement(BuildUtilities.getFeatCat()));
+		ListFacade<AbilityFacade> abilities = ca.getAbilities(BuildUtilities.getFeatCat());
 		assertNotNull("Feat list should not be null", abilities);
 		assertTrue("Feat list should be empty", abilities.isEmpty());
 		
 		// Add an entry - note rebuild is implicit
-		Ability reading = TestHelper.makeAbility("reading", AbilityCategory.FEAT, "interest");
+		Ability reading = TestHelper.makeAbility("reading", BuildUtilities.getFeatCat(), "interest");
 		reading.put(ObjectKey.MULTIPLE_ALLOWED, Boolean.TRUE);
 		StringToken st = new plugin.lsttokens.choose.StringToken();
 		ParseResult pr = st.parseToken(Globals.getContext(), reading, "STRING|Magazines|Books");
 		assertTrue(pr.passed());
 		Globals.getContext().commit();
-		applyAbility(pc, AbilityCategory.FEAT, reading, "Books");
-		abilities = ca.getAbilities(AbilityCategory.FEAT);
+		applyAbility(pc, BuildUtilities.getFeatCat(), reading, "Books");
+		abilities = ca.getAbilities(BuildUtilities.getFeatCat());
 		assertFalse("Feat list should not be empty", abilities.isEmpty());
 		Ability abilityFromList = (Ability) abilities.getElementAt(0);
 		assertEquals("Should have found reading", reading, abilityFromList);
 		assertEquals("Feat list should have one entry", 1, abilities.getSize());
 
 		// Now add the choice
-		finalizeTest(abilityFromList, "Magazines", pc, AbilityCategory.FEAT);
+		finalizeTest(abilityFromList, "Magazines", pc, BuildUtilities.getFeatCat());
 		ca.rebuildAbilityLists();
-		abilities = ca.getAbilities(AbilityCategory.FEAT);
+		abilities = ca.getAbilities(BuildUtilities.getFeatCat());
 		assertEquals("Feat list should have one entry", 1, abilities.getSize());
 		abilityFromList = (Ability) abilities.getElementAt(0);
 		assertEquals("Should have found reading", reading, abilityFromList);
@@ -120,7 +120,7 @@ public class CharacterAbilitiesTest extends AbstractCharacterTestCase
 	{
 		super.setUp();
 		dataset = new MockDataSetFacade(SettingsHandler.getGame());
-		dataset.addAbilityCategory(AbilityCategory.FEAT);
+		dataset.addAbilityCategory(BuildUtilities.getFeatCat());
 		uiDelegate = new MockUIDelegate();
 		todoManager = new TodoManager();
 	}

--- a/code/src/test/pcgen/gui2/facade/CharacterFacadeImplTest.java
+++ b/code/src/test/pcgen/gui2/facade/CharacterFacadeImplTest.java
@@ -21,10 +21,10 @@ import org.junit.Before;
 import org.junit.Test;
 
 import pcgen.AbstractCharacterTestCase;
-import pcgen.core.AbilityCategory;
 import pcgen.core.PlayerCharacter;
 import pcgen.core.SettingsHandler;
 import pcgen.core.character.EquipSet;
+import plugin.lsttokens.testsupport.BuildUtilities;
 
 /**
  * The Class <code>CharacterFacadeImplTest</code> verifies the behaviour of 
@@ -66,7 +66,7 @@ public class CharacterFacadeImplTest extends AbstractCharacterTestCase
 	{
 		super.setUp();
 		dataset = new MockDataSetFacade(SettingsHandler.getGame());
-		dataset.addAbilityCategory(AbilityCategory.FEAT);
+		dataset.addAbilityCategory(BuildUtilities.getFeatCat());
 		uiDelegate = new MockUIDelegate();
 	}
 

--- a/code/src/test/pcgen/gui2/facade/Gui2InfoFactoryTest.java
+++ b/code/src/test/pcgen/gui2/facade/Gui2InfoFactoryTest.java
@@ -21,7 +21,6 @@ import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.enumeration.ListKey;
 import pcgen.cdom.enumeration.ObjectKey;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.core.Description;
 import pcgen.core.Globals;
 import pcgen.core.PlayerCharacter;
@@ -29,6 +28,7 @@ import pcgen.core.SettingsHandler;
 import pcgen.rules.persistence.token.ParseResult;
 import pcgen.util.TestHelper;
 import plugin.lsttokens.choose.StringToken;
+import plugin.lsttokens.testsupport.BuildUtilities;
 
 /**
  * The Class <code>Gui2InfoFactoryTest</code> verifies the operation of the 
@@ -51,7 +51,7 @@ public class Gui2InfoFactoryTest extends AbstractCharacterTestCase
 		Gui2InfoFactory ca = new Gui2InfoFactory(pc);
 
 		Ability choiceAbility =
-				TestHelper.makeAbility("Skill Focus", AbilityCategory.FEAT,
+				TestHelper.makeAbility("Skill Focus", BuildUtilities.getFeatCat(),
 					"General");
 		choiceAbility.put(ObjectKey.MULTIPLE_ALLOWED, Boolean.TRUE);
 		StringToken st = new plugin.lsttokens.choose.StringToken();
@@ -59,12 +59,12 @@ public class Gui2InfoFactoryTest extends AbstractCharacterTestCase
 		assertTrue(pr.passed());
 		Globals.getContext().commit();
 		finalizeTest(choiceAbility, "Perception", pc,
-			AbilityCategory.FEAT);
+			BuildUtilities.getFeatCat());
 		assertEquals("Incorrect single choice", "Perception",
 			ca.getChoices(choiceAbility));
 
 		finalizeTest(choiceAbility, "Acrobatics", pc,
-			AbilityCategory.FEAT);
+			BuildUtilities.getFeatCat());
 		assertEquals("Incorrect multiple choice", "Acrobatics, Perception",
 			ca.getChoices(choiceAbility));
 	}
@@ -79,12 +79,12 @@ public class Gui2InfoFactoryTest extends AbstractCharacterTestCase
 
 		Ability tbAbility =
 				TestHelper.makeAbility("Combat expertise",
-					AbilityCategory.FEAT, "General");
+					BuildUtilities.getFeatCat(), "General");
 		tbAbility.put(ObjectKey.MULTIPLE_ALLOWED, Boolean.FALSE);
 		final Description desc = new Description("CE Desc");
 		tbAbility.addToListFor(ListKey.DESCRIPTION, desc);
 		Globals.getContext().commit();
-		addAbility(AbilityCategory.FEAT, tbAbility);
+		addAbility(BuildUtilities.getFeatCat(), tbAbility);
 
 		TempBonusFacadeImpl tbf = new TempBonusFacadeImpl(tbAbility);
 
@@ -102,7 +102,7 @@ public class Gui2InfoFactoryTest extends AbstractCharacterTestCase
 	{
 		super.setUp();
 		dataset = new MockDataSetFacade(SettingsHandler.getGame());
-		dataset.addAbilityCategory(AbilityCategory.FEAT);
+		dataset.addAbilityCategory(BuildUtilities.getFeatCat());
 	}
 
 }

--- a/code/src/test/pcgen/gui2/facade/SpellBuilderFacadeImplTest.java
+++ b/code/src/test/pcgen/gui2/facade/SpellBuilderFacadeImplTest.java
@@ -24,7 +24,6 @@ import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.enumeration.ObjectKey;
 import pcgen.cdom.facet.FacetLibrary;
 import pcgen.cdom.facet.MasterAvailableSpellFacet;
-import pcgen.core.AbilityCategory;
 import pcgen.core.Globals;
 import pcgen.core.PCClass;
 import pcgen.core.PlayerCharacter;
@@ -81,7 +80,7 @@ public class SpellBuilderFacadeImplTest extends AbstractCharacterTestCase
 		fighterCls = TestHelper.makeClass("Fighter");
 		
 		dataset = new MockDataSetFacade(SettingsHandler.getGame());
-		dataset.addAbilityCategory(AbilityCategory.FEAT);
+		dataset.addAbilityCategory(BuildUtilities.getFeatCat());
 		dataset.addClass(wizardCls);
 		dataset.addClass(divineCls);
 		dataset.addClass(fighterCls);

--- a/code/src/test/pcgen/io/ExportHandlerTest.java
+++ b/code/src/test/pcgen/io/ExportHandlerTest.java
@@ -53,6 +53,7 @@ import pcgen.core.bonus.BonusObj;
 import pcgen.core.character.EquipSet;
 import pcgen.rules.context.LoadContext;
 import pcgen.util.TestHelper;
+import plugin.lsttokens.testsupport.BuildUtilities;
 
 /**
  * <code>SkillTokenTest</code> contains tests to verify that the
@@ -263,39 +264,39 @@ public class ExportHandlerTest extends AbstractCharacterTestCase
 		PlayerCharacter pc = getCharacter();
 		Ability dummyFeat1 = new Ability();
 		dummyFeat1.setName("1");
-		dummyFeat1.setCDOMCategory(AbilityCategory.FEAT);
+		dummyFeat1.setCDOMCategory(BuildUtilities.getFeatCat());
 		
 		Ability dummyFeat2 = new Ability();
 		dummyFeat2.setName("2");
-		dummyFeat2.setCDOMCategory(AbilityCategory.FEAT);
+		dummyFeat2.setCDOMCategory(BuildUtilities.getFeatCat());
 		
 		Ability dummyFeat3 = new Ability();
 		dummyFeat3.setName("3");
-		dummyFeat3.setCDOMCategory(AbilityCategory.FEAT);
+		dummyFeat3.setCDOMCategory(BuildUtilities.getFeatCat());
 		
 		Ability dummyFeat4 = new Ability();
 		dummyFeat4.setName("4");
-		dummyFeat4.setCDOMCategory(AbilityCategory.FEAT);
+		dummyFeat4.setCDOMCategory(BuildUtilities.getFeatCat());
 		
 		Ability dummyFeat5 = new Ability();
 		dummyFeat5.setName("5");
-		dummyFeat5.setCDOMCategory(AbilityCategory.FEAT);
+		dummyFeat5.setCDOMCategory(BuildUtilities.getFeatCat());
 		
 		Ability dummyFeat6 = new Ability();
 		dummyFeat6.setName("6");
-		dummyFeat6.setCDOMCategory(AbilityCategory.FEAT);
+		dummyFeat6.setCDOMCategory(BuildUtilities.getFeatCat());
 		
 		Ability dummyFeat7 = new Ability();
 		dummyFeat7.setName("7");
-		dummyFeat7.setCDOMCategory(AbilityCategory.FEAT);	
+		dummyFeat7.setCDOMCategory(BuildUtilities.getFeatCat());	
 		
-		addAbility(AbilityCategory.FEAT, dummyFeat1);
-		addAbility(AbilityCategory.FEAT, dummyFeat2);
-		addAbility(AbilityCategory.FEAT, dummyFeat3);
-		addAbility(AbilityCategory.FEAT, dummyFeat4);
-		addAbility(AbilityCategory.FEAT, dummyFeat5);
-		addAbility(AbilityCategory.FEAT, dummyFeat6);
-		addAbility(AbilityCategory.FEAT, dummyFeat7);
+		addAbility(BuildUtilities.getFeatCat(), dummyFeat1);
+		addAbility(BuildUtilities.getFeatCat(), dummyFeat2);
+		addAbility(BuildUtilities.getFeatCat(), dummyFeat3);
+		addAbility(BuildUtilities.getFeatCat(), dummyFeat4);
+		addAbility(BuildUtilities.getFeatCat(), dummyFeat5);
+		addAbility(BuildUtilities.getFeatCat(), dummyFeat6);
+		addAbility(BuildUtilities.getFeatCat(), dummyFeat7);
 		
 		assertEquals("Test for evaluates correctly", "----------------",
 			evaluateToken(
@@ -351,7 +352,7 @@ public class ExportHandlerTest extends AbstractCharacterTestCase
 		LoadContext context = Globals.getContext();
 		Ability dummyFeat = new Ability();
 		dummyFeat.setName("DummyFeat");
-		dummyFeat.setCDOMCategory(AbilityCategory.FEAT);
+		dummyFeat.setCDOMCategory(BuildUtilities.getFeatCat());
 		final PlayerCharacter pc = getCharacter();
 
 		// Create a variable
@@ -361,7 +362,7 @@ public class ExportHandlerTest extends AbstractCharacterTestCase
 		// Create a bonus to it
 		Ability dummyFeat2 = new Ability();
 		dummyFeat2.setName("DummyFeat2");
-		dummyFeat2.setCDOMCategory(AbilityCategory.FEAT);
+		dummyFeat2.setCDOMCategory(BuildUtilities.getFeatCat());
 		final BonusObj aBonus = Bonus.newBonus(context, "VAR|NegLevels|7");
 		
 		if (aBonus != null)
@@ -381,8 +382,8 @@ public class ExportHandlerTest extends AbstractCharacterTestCase
 		dummyFeat4.setName("DummyFeat4");
 		dummyFeat4.setCDOMCategory(cat2);
 		
-		addAbility(AbilityCategory.FEAT, dummyFeat);
-		addAbility(AbilityCategory.FEAT, dummyFeat2);
+		addAbility(BuildUtilities.getFeatCat(), dummyFeat);
+		addAbility(BuildUtilities.getFeatCat(), dummyFeat2);
 		addAbility(cat, dummyFeat3);
 		addAbility(cat2, dummyFeat4);
 		

--- a/code/src/test/pcgen/io/exporttoken/AbilityListTokenTest.java
+++ b/code/src/test/pcgen/io/exporttoken/AbilityListTokenTest.java
@@ -30,6 +30,7 @@ import pcgen.core.SettingsHandler;
 import pcgen.io.ExportHandler;
 import pcgen.util.TestHelper;
 import pcgen.util.enumeration.Visibility;
+import plugin.lsttokens.testsupport.BuildUtilities;
 
 /**
  * <code>AbilityListTokenTest</code> tests the functioning of the ABILITYLIST 
@@ -58,22 +59,22 @@ public class AbilityListTokenTest extends AbstractCharacterTestCase
 		AbilityCategory bardCategory = Globals.getContext().getReferenceContext()
 				.constructNowIfNecessary(AbilityCategory.class, "BARDIC");
 
-		Ability ab1 = TestHelper.makeAbility("Perform (Dance)", AbilityCategory.FEAT, "General.Fighter");
+		Ability ab1 = TestHelper.makeAbility("Perform (Dance)", BuildUtilities.getFeatCat(), "General.Fighter");
 		ab1.put(ObjectKey.MULTIPLE_ALLOWED, Boolean.FALSE);
 		ab1.put(ObjectKey.VISIBILITY, Visibility.DEFAULT);
-		addAbility(AbilityCategory.FEAT, ab1);
+		addAbility(BuildUtilities.getFeatCat(), ab1);
 
 		Ability ab2 = TestHelper.makeAbility("Perform (Dance)", "BARDIC", "General.Bardic");
 		ab2.put(ObjectKey.MULTIPLE_ALLOWED, Boolean.FALSE);
 		addAbility(bardCategory, ab2);
 
-		Ability ab3 = TestHelper.makeAbility("Perform (Oratory)", AbilityCategory.FEAT, "General.Fighter");
+		Ability ab3 = TestHelper.makeAbility("Perform (Oratory)", BuildUtilities.getFeatCat(), "General.Fighter");
 		ab3.put(ObjectKey.MULTIPLE_ALLOWED, Boolean.FALSE);
-		addAbility(AbilityCategory.FEAT, ab3);
+		addAbility(BuildUtilities.getFeatCat(), ab3);
 
-		Ability ab4 = TestHelper.makeAbility("Silent Step", AbilityCategory.FEAT, "General");
+		Ability ab4 = TestHelper.makeAbility("Silent Step", BuildUtilities.getFeatCat(), "General");
 		ab4.put(ObjectKey.MULTIPLE_ALLOWED, Boolean.FALSE);
-		addAbility(AbilityCategory.FEAT, ab4);
+		addAbility(BuildUtilities.getFeatCat(), ab4);
 	}
 
 	/**
@@ -120,12 +121,12 @@ public class AbilityListTokenTest extends AbstractCharacterTestCase
 		AbilityCategory featCategory = 
 			SettingsHandler.getGame().getAbilityCategory("Feat");
 
-		Ability ab5 = TestHelper.makeAbility("Silent Step (Greater)", AbilityCategory.FEAT, "General");
+		Ability ab5 = TestHelper.makeAbility("Silent Step (Greater)", BuildUtilities.getFeatCat(), "General");
 		ab5.put(ObjectKey.MULTIPLE_ALLOWED, Boolean.FALSE);
 		ab5.put(ObjectKey.VISIBILITY, Visibility.OUTPUT_ONLY);
 		addAbility(featCategory, ab5);
 
-        Ability ab6 = TestHelper.makeAbility("Perform (Fiddle)", AbilityCategory.FEAT, "Bardic");
+        Ability ab6 = TestHelper.makeAbility("Perform (Fiddle)", BuildUtilities.getFeatCat(), "Bardic");
         ab6.put(ObjectKey.MULTIPLE_ALLOWED, Boolean.FALSE);
         addAbility(featCategory, ab6);
 

--- a/code/src/test/pcgen/io/exporttoken/AbilityListTokenTest.java
+++ b/code/src/test/pcgen/io/exporttoken/AbilityListTokenTest.java
@@ -59,7 +59,8 @@ public class AbilityListTokenTest extends AbstractCharacterTestCase
 		AbilityCategory bardCategory = Globals.getContext().getReferenceContext()
 				.constructNowIfNecessary(AbilityCategory.class, "BARDIC");
 
-		Ability ab1 = TestHelper.makeAbility("Perform (Dance)", BuildUtilities.getFeatCat(), "General.Fighter");
+		Ability ab1 = TestHelper.makeAbility("Perform (Dance)",
+			BuildUtilities.getFeatCat(), "General.Fighter");
 		ab1.put(ObjectKey.MULTIPLE_ALLOWED, Boolean.FALSE);
 		ab1.put(ObjectKey.VISIBILITY, Visibility.DEFAULT);
 		addAbility(BuildUtilities.getFeatCat(), ab1);
@@ -68,11 +69,13 @@ public class AbilityListTokenTest extends AbstractCharacterTestCase
 		ab2.put(ObjectKey.MULTIPLE_ALLOWED, Boolean.FALSE);
 		addAbility(bardCategory, ab2);
 
-		Ability ab3 = TestHelper.makeAbility("Perform (Oratory)", BuildUtilities.getFeatCat(), "General.Fighter");
+		Ability ab3 = TestHelper.makeAbility("Perform (Oratory)",
+			BuildUtilities.getFeatCat(), "General.Fighter");
 		ab3.put(ObjectKey.MULTIPLE_ALLOWED, Boolean.FALSE);
 		addAbility(BuildUtilities.getFeatCat(), ab3);
 
-		Ability ab4 = TestHelper.makeAbility("Silent Step", BuildUtilities.getFeatCat(), "General");
+		Ability ab4 = TestHelper.makeAbility("Silent Step", BuildUtilities.getFeatCat(),
+			"General");
 		ab4.put(ObjectKey.MULTIPLE_ALLOWED, Boolean.FALSE);
 		addAbility(BuildUtilities.getFeatCat(), ab4);
 	}
@@ -121,12 +124,14 @@ public class AbilityListTokenTest extends AbstractCharacterTestCase
 		AbilityCategory featCategory = 
 			SettingsHandler.getGame().getAbilityCategory("Feat");
 
-		Ability ab5 = TestHelper.makeAbility("Silent Step (Greater)", BuildUtilities.getFeatCat(), "General");
+		Ability ab5 = TestHelper.makeAbility("Silent Step (Greater)",
+			BuildUtilities.getFeatCat(), "General");
 		ab5.put(ObjectKey.MULTIPLE_ALLOWED, Boolean.FALSE);
 		ab5.put(ObjectKey.VISIBILITY, Visibility.OUTPUT_ONLY);
 		addAbility(featCategory, ab5);
 
-        Ability ab6 = TestHelper.makeAbility("Perform (Fiddle)", BuildUtilities.getFeatCat(), "Bardic");
+		Ability ab6 = TestHelper.makeAbility("Perform (Fiddle)",
+			BuildUtilities.getFeatCat(), "Bardic");
         ab6.put(ObjectKey.MULTIPLE_ALLOWED, Boolean.FALSE);
         addAbility(featCategory, ab6);
 

--- a/code/src/test/pcgen/io/exporttoken/AbilityTokenTest.java
+++ b/code/src/test/pcgen/io/exporttoken/AbilityTokenTest.java
@@ -69,7 +69,8 @@ public class AbilityTokenTest extends AbstractCharacterTestCase
 		PlayerCharacter character = getCharacter();
 
 		// Make some ability categories and add them to the game mode
-		Ability ab1 = TestHelper.makeAbility("Perform (Dance)", BuildUtilities.getFeatCat(), "General.Fighter");
+		Ability ab1 = TestHelper.makeAbility("Perform (Dance)",
+			BuildUtilities.getFeatCat(), "General.Fighter");
 		ab1.put(ObjectKey.MULTIPLE_ALLOWED, Boolean.FALSE);
 		ab1.put(ObjectKey.VISIBILITY, Visibility.DEFAULT);
 		List<Aspect> colourList = new ArrayList<>();
@@ -110,8 +111,10 @@ public class AbilityTokenTest extends AbstractCharacterTestCase
 		}
 		skillFocus.put(ObjectKey.MULTIPLE_ALLOWED, true);
 		Globals.getContext().unconditionallyProcess(skillFocus, "CHOOSE", "SKILL|ALL");
-		AbstractCharacterTestCase.applyAbility(character, BuildUtilities.getFeatCat(), skillFocus, "KEY_Bluff");
-		AbstractCharacterTestCase.applyAbility(character, BuildUtilities.getFeatCat(), skillFocus, "KEY_Listen");
+		AbstractCharacterTestCase.applyAbility(character, BuildUtilities.getFeatCat(),
+			skillFocus, "KEY_Bluff");
+		AbstractCharacterTestCase.applyAbility(character, BuildUtilities.getFeatCat(),
+			skillFocus, "KEY_Listen");
 		character.calcActiveBonuses();
 	}
 

--- a/code/src/test/pcgen/io/exporttoken/AbilityTokenTest.java
+++ b/code/src/test/pcgen/io/exporttoken/AbilityTokenTest.java
@@ -30,7 +30,6 @@ import pcgen.cdom.enumeration.ObjectKey;
 import pcgen.cdom.enumeration.SkillArmorCheck;
 import pcgen.cdom.helper.Aspect;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.core.Globals;
 import pcgen.core.PlayerCharacter;
 import pcgen.core.bonus.Bonus;
@@ -40,6 +39,7 @@ import pcgen.core.prereq.PrerequisiteOperator;
 import pcgen.io.ExportHandler;
 import pcgen.util.TestHelper;
 import pcgen.util.enumeration.Visibility;
+import plugin.lsttokens.testsupport.BuildUtilities;
 
 /**
  * <code>AbilityTokenTest</code> tests the functioning of the ABILITY 
@@ -69,7 +69,7 @@ public class AbilityTokenTest extends AbstractCharacterTestCase
 		PlayerCharacter character = getCharacter();
 
 		// Make some ability categories and add them to the game mode
-		Ability ab1 = TestHelper.makeAbility("Perform (Dance)", AbilityCategory.FEAT, "General.Fighter");
+		Ability ab1 = TestHelper.makeAbility("Perform (Dance)", BuildUtilities.getFeatCat(), "General.Fighter");
 		ab1.put(ObjectKey.MULTIPLE_ALLOWED, Boolean.FALSE);
 		ab1.put(ObjectKey.VISIBILITY, Visibility.DEFAULT);
 		List<Aspect> colourList = new ArrayList<>();
@@ -94,7 +94,7 @@ public class AbilityTokenTest extends AbstractCharacterTestCase
 		List<Aspect> ageList = new ArrayList<>();
 		ageList.add(new Aspect("Age In Years", "2000"));
 		ab1.addToMapFor(MapKey.ASPECT, AspectName.getConstant("Age In Years"), ageList);
-		addAbility(AbilityCategory.FEAT, ab1);
+		addAbility(BuildUtilities.getFeatCat(), ab1);
 
 		TestHelper.makeSkill("Bluff", "Charisma", cha, true,
 			SkillArmorCheck.NONE);
@@ -102,7 +102,7 @@ public class AbilityTokenTest extends AbstractCharacterTestCase
 			SkillArmorCheck.NONE);
 
 		skillFocus =
-				TestHelper.makeAbility("Skill Focus", AbilityCategory.FEAT, "General");
+				TestHelper.makeAbility("Skill Focus", BuildUtilities.getFeatCat(), "General");
 		BonusObj aBonus = Bonus.newBonus(Globals.getContext(), "SKILL|LIST|3");
 		if (aBonus != null)
 		{
@@ -110,8 +110,8 @@ public class AbilityTokenTest extends AbstractCharacterTestCase
 		}
 		skillFocus.put(ObjectKey.MULTIPLE_ALLOWED, true);
 		Globals.getContext().unconditionallyProcess(skillFocus, "CHOOSE", "SKILL|ALL");
-		AbstractCharacterTestCase.applyAbility(character, AbilityCategory.FEAT, skillFocus, "KEY_Bluff");
-		AbstractCharacterTestCase.applyAbility(character, AbilityCategory.FEAT, skillFocus, "KEY_Listen");
+		AbstractCharacterTestCase.applyAbility(character, BuildUtilities.getFeatCat(), skillFocus, "KEY_Bluff");
+		AbstractCharacterTestCase.applyAbility(character, BuildUtilities.getFeatCat(), skillFocus, "KEY_Listen");
 		character.calcActiveBonuses();
 	}
 

--- a/code/src/test/pcgen/io/exporttoken/WeaponTokenTest.java
+++ b/code/src/test/pcgen/io/exporttoken/WeaponTokenTest.java
@@ -38,7 +38,6 @@ import pcgen.cdom.formula.FixedSizeFormula;
 import pcgen.cdom.helper.Capacity;
 import pcgen.cdom.reference.CDOMDirectSingleRef;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.core.Equipment;
 import pcgen.core.EquipmentModifier;
 import pcgen.core.GameMode;
@@ -58,6 +57,7 @@ import pcgen.core.character.WieldCategory;
 import pcgen.core.spell.Spell;
 import pcgen.rules.context.LoadContext;
 import pcgen.util.TestHelper;
+import plugin.lsttokens.testsupport.BuildUtilities;
 
 /**
  * <code>WeaponTokenTest</code> contains tests to verify that the
@@ -386,7 +386,7 @@ public class WeaponTokenTest extends AbstractCharacterTestCase
 		context.unconditionallyProcess(wpnBonusPct, "BONUS",
 				"WEAPONPROF=DoubleWpn|TOHIT|4");
 		
-		wpnBonusAbility = TestHelper.makeAbility("FEAT_BONUS", AbilityCategory.FEAT, "General");
+		wpnBonusAbility = TestHelper.makeAbility("FEAT_BONUS", BuildUtilities.getFeatCat(), "General");
 		context.unconditionallyProcess(wpnBonusAbility, "BONUS",
 				"WEAPONPROF=DoubleWpn|DAMAGE|1");
 		context.unconditionallyProcess(wpnBonusAbility, "BONUS",
@@ -713,13 +713,13 @@ public class WeaponTokenTest extends AbstractCharacterTestCase
 		// Now apply weapon finess and check dex is used rather than str
 		Ability wpnFinesse = new Ability();
 		wpnFinesse.setName("Weapon Finesse");
-		wpnFinesse.setCDOMCategory(AbilityCategory.FEAT);
+		wpnFinesse.setCDOMCategory(BuildUtilities.getFeatCat());
 		wpnFinesse.put(StringKey.KEY_NAME, "Weapon Finesse");
 		final BonusObj wfBonus =
 				Bonus
 					.newBonus(context, "COMBAT|TOHIT.Finesseable|((max(STR,DEX)-STR)+SHIELDACCHECK)|TYPE=NotRanged");
 		wpnFinesse.addToListFor(ListKey.BONUS, wfBonus);
-		addAbility(AbilityCategory.FEAT, wpnFinesse);
+		addAbility(BuildUtilities.getFeatCat(), wpnFinesse);
 		assertEquals("Fine sword", "+19/+14/+9/+4", token.getToken(
 			"WEAPON.3.BASEHIT", character, null));
 
@@ -899,7 +899,7 @@ public class WeaponTokenTest extends AbstractCharacterTestCase
 		assertEquals("feat damage bonus, before adding", "+0",
 			token.getToken("WEAPON.0.FEATDAMAGE", character, null));
 		
-		addAbility(AbilityCategory.FEAT, wpnBonusAbility);
+		addAbility(BuildUtilities.getFeatCat(), wpnBonusAbility);
 		character.calcActiveBonuses();
 		assertEquals("feat tohit bonus, after adding", "+2",
 			token.getToken("WEAPON.0.FEATHIT", character, null));

--- a/code/src/test/pcgen/io/freemarker/PCBooleanFunctionTest.java
+++ b/code/src/test/pcgen/io/freemarker/PCBooleanFunctionTest.java
@@ -28,13 +28,13 @@ import org.junit.Test;
 
 import pcgen.AbstractJunit4CharacterTestCase;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.core.Campaign;
 import pcgen.core.Globals;
 import pcgen.core.PlayerCharacter;
 import pcgen.io.ExportHandler;
 import pcgen.persistence.lst.CampaignSourceEntry;
 import pcgen.persistence.lst.FeatLoader;
+import plugin.lsttokens.testsupport.BuildUtilities;
 
 /**
  * The Class <code></code> ...
@@ -77,7 +77,7 @@ public class PCBooleanFunctionTest extends AbstractJunit4CharacterTestCase
 		Boolean result = (Boolean) pcbf.exec(Collections.singletonList("VAR.VARDEFINED:FooV"));
 		assertFalse("Should not have var", result);
 
-		addAbility(AbilityCategory.FEAT, fooFeat);
+		addAbility(BuildUtilities.getFeatCat(), fooFeat);
 		pc.calcActiveBonuses();
 		assertTrue("Should have var FooV", pc.hasVariable("FooV"));
 		result = (Boolean) pcbf.exec(Collections.singletonList("VAR.VARDEFINED:FooV"));

--- a/code/src/test/pcgen/io/freemarker/PCHasVarFunctionTest.java
+++ b/code/src/test/pcgen/io/freemarker/PCHasVarFunctionTest.java
@@ -28,13 +28,13 @@ import org.junit.Test;
 
 import pcgen.AbstractJunit4CharacterTestCase;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.core.Campaign;
 import pcgen.core.Globals;
 import pcgen.core.PlayerCharacter;
 import pcgen.io.ExportHandler;
 import pcgen.persistence.lst.CampaignSourceEntry;
 import pcgen.persistence.lst.FeatLoader;
+import plugin.lsttokens.testsupport.BuildUtilities;
 
 /**
  * The Class <code>PCHasVarFunctionTest</code> verifies the correctness of 
@@ -78,7 +78,7 @@ public class PCHasVarFunctionTest extends AbstractJunit4CharacterTestCase
 		Boolean result = (Boolean) pchv.exec(Collections.singletonList("FooV"));
 		assertFalse("Should not have var", result);
 
-		addAbility(AbilityCategory.FEAT, fooFeat);
+		addAbility(BuildUtilities.getFeatCat(), fooFeat);
 		pc.calcActiveBonuses();
 		assertTrue("Should have var FooV", pc.hasVariable("FooV"));
 		result = (Boolean) pchv.exec(Collections.singletonList("FooV"));

--- a/code/src/test/plugin/exporttokens/VAbilityTokenTest.java
+++ b/code/src/test/plugin/exporttokens/VAbilityTokenTest.java
@@ -35,7 +35,6 @@ import pcgen.cdom.enumeration.SkillArmorCheck;
 import pcgen.cdom.helper.Aspect;
 import pcgen.cdom.helper.CNAbilitySelection;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.core.Globals;
 import pcgen.core.PlayerCharacter;
 import pcgen.core.bonus.Bonus;
@@ -45,6 +44,7 @@ import pcgen.core.prereq.PrerequisiteOperator;
 import pcgen.io.ExportHandler;
 import pcgen.util.TestHelper;
 import pcgen.util.enumeration.Visibility;
+import plugin.lsttokens.testsupport.BuildUtilities;
 
 /**
  * <code>VAbilityTokenTest</code> tests the functioning of the VABILITY 
@@ -74,7 +74,7 @@ public class VAbilityTokenTest extends AbstractCharacterTestCase
 		PlayerCharacter character = getCharacter();
 
 		// Make some ability categories and add them to the game mode
-		Ability ab1 = TestHelper.makeAbility("Perform (Dance)", AbilityCategory.FEAT, "General.Fighter");
+		Ability ab1 = TestHelper.makeAbility("Perform (Dance)", BuildUtilities.getFeatCat(), "General.Fighter");
 		ab1.put(ObjectKey.MULTIPLE_ALLOWED, Boolean.FALSE);
 		ab1.put(ObjectKey.VISIBILITY, Visibility.DEFAULT);
 		List<Aspect> colourList = new ArrayList<>();
@@ -99,7 +99,7 @@ public class VAbilityTokenTest extends AbstractCharacterTestCase
 		List<Aspect> ageList = new ArrayList<>();
 		ageList.add(new Aspect("Age In Years", "2000"));
 		ab1.addToMapFor(MapKey.ASPECT, AspectName.getConstant("Age In Years"), ageList);
-		CNAbility cna = CNAbilityFactory.getCNAbility(AbilityCategory.FEAT, Nature.VIRTUAL, ab1);
+		CNAbility cna = CNAbilityFactory.getCNAbility(BuildUtilities.getFeatCat(), Nature.VIRTUAL, ab1);
 		character.addAbility(new CNAbilitySelection(cna),
 			UserSelection.getInstance(), UserSelection.getInstance());
 
@@ -109,7 +109,7 @@ public class VAbilityTokenTest extends AbstractCharacterTestCase
 			SkillArmorCheck.NONE);
 
 		skillFocus =
-				TestHelper.makeAbility("Skill Focus", AbilityCategory.FEAT, "General");
+				TestHelper.makeAbility("Skill Focus", BuildUtilities.getFeatCat(), "General");
 		BonusObj aBonus = Bonus.newBonus(Globals.getContext(), "SKILL|LIST|3");
 		if (aBonus != null)
 		{
@@ -117,7 +117,7 @@ public class VAbilityTokenTest extends AbstractCharacterTestCase
 		}
 		skillFocus.put(ObjectKey.MULTIPLE_ALLOWED, true);
 		Globals.getContext().unconditionallyProcess(skillFocus, "CHOOSE", "SKILL|ALL");
-		cna = CNAbilityFactory.getCNAbility(AbilityCategory.FEAT, Nature.VIRTUAL, skillFocus);
+		cna = CNAbilityFactory.getCNAbility(BuildUtilities.getFeatCat(), Nature.VIRTUAL, skillFocus);
 		character.addAbility(new CNAbilitySelection(cna, "KEY_Bluff"),
 			UserSelection.getInstance(), UserSelection.getInstance());
 		character.addAbility(new CNAbilitySelection(cna, "KEY_Listen"),

--- a/code/src/test/plugin/jepcommands/CountCommandTest.java
+++ b/code/src/test/plugin/jepcommands/CountCommandTest.java
@@ -28,6 +28,7 @@ import pcgen.core.Globals;
 import pcgen.core.PlayerCharacter;
 import pcgen.util.TestHelper;
 import pcgen.util.enumeration.Visibility;
+import plugin.lsttokens.testsupport.BuildUtilities;
 
 /**
  * <code>CountCommandTest</code> tests the functioning of the jep count plugin
@@ -61,13 +62,13 @@ public class CountCommandTest extends AbstractCharacterTestCase
 
         final Ability[] abArray = new Ability[14];
 
-        abArray[0]  = TestHelper.makeAbility("Quick Draw",               AbilityCategory.FEAT,   "General.Fighter");
-        abArray[1]  = TestHelper.makeAbility("Improved Initiative",      AbilityCategory.FEAT,   "General.Fighter");
-        abArray[2]  = TestHelper.makeAbility("Silent Step",              AbilityCategory.FEAT,   "General.Fighter.Rogue");
-        abArray[3]  = TestHelper.makeAbility("Silent Step (Greater)",    AbilityCategory.FEAT,   "General.Fighter.Rogue");
+        abArray[0]  = TestHelper.makeAbility("Quick Draw",               BuildUtilities.getFeatCat(),   "General.Fighter");
+        abArray[1]  = TestHelper.makeAbility("Improved Initiative",      BuildUtilities.getFeatCat(),   "General.Fighter");
+        abArray[2]  = TestHelper.makeAbility("Silent Step",              BuildUtilities.getFeatCat(),   "General.Fighter.Rogue");
+        abArray[3]  = TestHelper.makeAbility("Silent Step (Greater)",    BuildUtilities.getFeatCat(),   "General.Fighter.Rogue");
 
-        abArray[4]  = TestHelper.makeAbility("Hidden 01",                AbilityCategory.FEAT,   "ClassAbility");
-        abArray[5]  = TestHelper.makeAbility("Perform (Dance)",          AbilityCategory.FEAT,   "ClassAbility");
+        abArray[4]  = TestHelper.makeAbility("Hidden 01",                BuildUtilities.getFeatCat(),   "ClassAbility");
+        abArray[5]  = TestHelper.makeAbility("Perform (Dance)",          BuildUtilities.getFeatCat(),   "ClassAbility");
 
         abArray[6]  = TestHelper.makeAbility("Perform (Dance)",          "BARDIC", "Performance.SpecialAbility");
         abArray[7]  = TestHelper.makeAbility("Perform (Oratory)",        "BARDIC", "Performance.SpecialAbility");
@@ -95,13 +96,13 @@ public class CountCommandTest extends AbstractCharacterTestCase
 
         abArray[1].put(ObjectKey.MULTIPLE_ALLOWED, Boolean.TRUE);
 		Globals.getContext().unconditionallyProcess(abArray[1], "CHOOSE", "STRING|one|two|three");
-        AbstractCharacterTestCase.applyAbility(character, AbilityCategory.FEAT, abArray[1], "one");
-        AbstractCharacterTestCase.applyAbility(character, AbilityCategory.FEAT, abArray[1], "two");
+        AbstractCharacterTestCase.applyAbility(character, BuildUtilities.getFeatCat(), abArray[1], "one");
+        AbstractCharacterTestCase.applyAbility(character, BuildUtilities.getFeatCat(), abArray[1], "two");
 
-        addAbility(AbilityCategory.FEAT, abArray[0]);
+        addAbility(BuildUtilities.getFeatCat(), abArray[0]);
 		for (int i = 2;6 > i;i++) {
             Ability anAbility = abArray[i];
-            addAbility(AbilityCategory.FEAT, anAbility);
+            addAbility(BuildUtilities.getFeatCat(), anAbility);
         }
 
         for (int i = 6;12 > i;i++) {

--- a/code/src/test/plugin/jepcommands/CountDistinctCommandTest.java
+++ b/code/src/test/plugin/jepcommands/CountDistinctCommandTest.java
@@ -63,13 +63,13 @@ public class CountDistinctCommandTest extends AbstractCharacterTestCase
 
         final Ability[] abArray = new Ability[14];
 
-        abArray[0]  = TestHelper.makeAbility("Quick Draw",               AbilityCategory.FEAT,   "General.Fighter");
-        abArray[1]  = TestHelper.makeAbility("Improved Initiative",      AbilityCategory.FEAT,   "General.Fighter");
-        abArray[2]  = TestHelper.makeAbility("Silent Step",              AbilityCategory.FEAT,   "General.Fighter.Rogue");
-        abArray[3]  = TestHelper.makeAbility("Silent Step (Greater)",    AbilityCategory.FEAT,   "General.Fighter.Rogue");
+        abArray[0]  = TestHelper.makeAbility("Quick Draw",               BuildUtilities.getFeatCat(),   "General.Fighter");
+        abArray[1]  = TestHelper.makeAbility("Improved Initiative",      BuildUtilities.getFeatCat(),   "General.Fighter");
+        abArray[2]  = TestHelper.makeAbility("Silent Step",              BuildUtilities.getFeatCat(),   "General.Fighter.Rogue");
+        abArray[3]  = TestHelper.makeAbility("Silent Step (Greater)",    BuildUtilities.getFeatCat(),   "General.Fighter.Rogue");
 
-        abArray[4]  = TestHelper.makeAbility("Hidden 01",                AbilityCategory.FEAT,   "ClassAbility");
-        abArray[5]  = TestHelper.makeAbility("Perform (Dance)",          AbilityCategory.FEAT,   "ClassAbility");
+        abArray[4]  = TestHelper.makeAbility("Hidden 01",                BuildUtilities.getFeatCat(),   "ClassAbility");
+        abArray[5]  = TestHelper.makeAbility("Perform (Dance)",          BuildUtilities.getFeatCat(),   "ClassAbility");
 
         abArray[6]  = TestHelper.makeAbility("Perform (Dance)",          "BARDIC", "Performance.SpecialAbility");
         abArray[7]  = TestHelper.makeAbility("Perform (Oratory)",        "BARDIC", "Performance.SpecialAbility");
@@ -97,13 +97,13 @@ public class CountDistinctCommandTest extends AbstractCharacterTestCase
 
         abArray[1].put(ObjectKey.MULTIPLE_ALLOWED, Boolean.TRUE);
         Globals.getContext().unconditionallyProcess(abArray[1], "CHOOSE", "STRING|one|two|three");
-        AbstractCharacterTestCase.applyAbility(character, AbilityCategory.FEAT, abArray[1], "one");
-        AbstractCharacterTestCase.applyAbility(character, AbilityCategory.FEAT, abArray[1], "two");
+        AbstractCharacterTestCase.applyAbility(character, BuildUtilities.getFeatCat(), abArray[1], "one");
+        AbstractCharacterTestCase.applyAbility(character, BuildUtilities.getFeatCat(), abArray[1], "two");
 
-        addAbility(AbilityCategory.FEAT, abArray[0]);
+        addAbility(BuildUtilities.getFeatCat(), abArray[0]);
 		for (int i = 2;6 > i;i++) {
             Ability anAbility = abArray[i];
-            addAbility(AbilityCategory.FEAT, anAbility);
+            addAbility(BuildUtilities.getFeatCat(), anAbility);
         }
 
         for (int i = 6;12 > i;i++) {

--- a/code/src/test/plugin/lsttokens/gamemode/abilitycategory/AbilityListTokenTest.java
+++ b/code/src/test/plugin/lsttokens/gamemode/abilitycategory/AbilityListTokenTest.java
@@ -50,7 +50,7 @@ public class AbilityListTokenTest extends TestCase
 		super.setUp();
 		context = new RuntimeLoadContext(RuntimeReferenceContext.createRuntimeReferenceContext(),
 				new ConsolidatedListCommitStrategy());
-		context.getReferenceContext().importObject(AbilityCategory.FEAT);
+		context.getReferenceContext().importObject(BuildUtilities.getFeatCat());
 	}
 
 	private void assertContains(AbilityCategory cat, Ability ab, boolean expected)
@@ -73,7 +73,7 @@ public class AbilityListTokenTest extends TestCase
 	{
 		AbilityCategory aCat = context.getReferenceContext().constructCDOMObject(
 				AbilityCategory.class, "TestCat");
-		aCat.setAbilityCategory(CDOMDirectSingleRef.getRef(AbilityCategory.FEAT));
+		aCat.setAbilityCategory(CDOMDirectSingleRef.getRef(BuildUtilities.getFeatCat()));
 		assertFalse("Test category should start with an empty list of keys",
 			aCat.hasDirectReferences());
 		assertEquals("Test category should start with an empty list of keys",
@@ -94,7 +94,7 @@ public class AbilityListTokenTest extends TestCase
 	{
 		AbilityCategory aCat = context.getReferenceContext().constructCDOMObject(
 				AbilityCategory.class, "TestCat");
-		aCat.setAbilityCategory(CDOMDirectSingleRef.getRef(AbilityCategory.FEAT));
+		aCat.setAbilityCategory(CDOMDirectSingleRef.getRef(BuildUtilities.getFeatCat()));
 		assertFalse("Test category should start with an empty list of keys",
 			aCat.hasDirectReferences());
 		assertEquals("Test category should start with an empty list of keys",
@@ -119,7 +119,7 @@ public class AbilityListTokenTest extends TestCase
 	{
 		AbilityCategory aCat = context.getReferenceContext().constructCDOMObject(
 				AbilityCategory.class, "TestCat");
-		aCat.setAbilityCategory(CDOMDirectSingleRef.getRef(AbilityCategory.FEAT));
+		aCat.setAbilityCategory(CDOMDirectSingleRef.getRef(BuildUtilities.getFeatCat()));
 		assertFalse("Test category should start with an empty list of keys",
 			aCat.hasDirectReferences());
 		assertEquals("Test category should start with an empty list of keys",

--- a/code/src/testcommon/plugin/lsttokens/testsupport/BuildUtilities.java
+++ b/code/src/testcommon/plugin/lsttokens/testsupport/BuildUtilities.java
@@ -159,7 +159,7 @@ public final class BuildUtilities
 	 */
 	public static Ability buildFeat(LoadContext context, String name)
 	{
-		return buildAbility(context, AbilityCategory.FEAT, name);
+		return buildAbility(context, BuildUtilities.getFeatCat(), name);
 	}
 
 	/**
@@ -192,5 +192,13 @@ public final class BuildUtilities
 		Race r = context.getReferenceContext().constructCDOMObject(Race.class, "Unselected");
 		r.addToListFor(ListKey.GROUP, "UNSELECTED");
 		r.addToListFor(ListKey.TYPE, Type.valueOf("Humanoid"));
+	}
+	
+	/**
+	 * Get the FEAT AbilityCategory
+	 */
+	public static AbilityCategory getFeatCat()
+	{
+		return AbilityCategory.FEAT;
 	}
 }

--- a/code/src/utest/actor/add/AbilityTokenTest.java
+++ b/code/src/utest/actor/add/AbilityTokenTest.java
@@ -64,8 +64,8 @@ public class AbilityTokenTest extends AbstractCharacterUsingTestCase
 	public void testEncodeChoice()
 	{
 		Ability item = construct("ItemName");
-		CNAbilitySelection as =
-				new CNAbilitySelection(CNAbilityFactory.getCNAbility(BuildUtilities.getFeatCat(), Nature.NORMAL, item));
+		CNAbilitySelection as = new CNAbilitySelection(CNAbilityFactory
+			.getCNAbility(BuildUtilities.getFeatCat(), Nature.NORMAL, item));
 		assertEquals("CATEGORY=FEAT|NATURE=NORMAL|ItemName", pca
 			.encodeChoice(as));
 	}
@@ -83,8 +83,8 @@ public class AbilityTokenTest extends AbstractCharacterUsingTestCase
 			// OK
 		}
 		Ability item = construct("ItemName");
-		CNAbilitySelection as =
-				new CNAbilitySelection(CNAbilityFactory.getCNAbility(BuildUtilities.getFeatCat(), Nature.NORMAL, item));
+		CNAbilitySelection as = new CNAbilitySelection(CNAbilityFactory
+			.getCNAbility(BuildUtilities.getFeatCat(), Nature.NORMAL, item));
 		assertEquals(as, pca
 			.decodeChoice(context, "CATEGORY=FEAT|NATURE=NORMAL|ItemName"));
 	}
@@ -110,9 +110,11 @@ public class AbilityTokenTest extends AbstractCharacterUsingTestCase
 		context.getReferenceContext().constructCDOMObject(Language.class, "Goo");
 		context.getReferenceContext().constructCDOMObject(Language.class, "Wow");
 		context.getReferenceContext().constructCDOMObject(Language.class, "Rev");
-		AbilityCategory ff = context.getReferenceContext().constructCDOMObject(AbilityCategory.class, "Fighter Feat");
+		AbilityCategory ff = context.getReferenceContext()
+			.constructCDOMObject(AbilityCategory.class, "Fighter Feat");
 		ff.setAbilityCategory(CDOMDirectSingleRef.getRef(BuildUtilities.getFeatCat()));
-		AbilityCategory oc = context.getReferenceContext().constructCDOMObject(AbilityCategory.class, "Some Other Category");
+		AbilityCategory oc = context.getReferenceContext()
+			.constructCDOMObject(AbilityCategory.class, "Some Other Category");
 		Ability badCA = oc.newInstance();
 		badCA.setName("ChooseAbility");
 		context.getReferenceContext().importObject(badCA);
@@ -130,16 +132,22 @@ public class AbilityTokenTest extends AbstractCharacterUsingTestCase
 		PlayerCharacter pc = new PlayerCharacter();
 		Object source = UserSelection.getInstance();
 		
-		CNAbilitySelection badCACAS = new CNAbilitySelection(CNAbilityFactory.getCNAbility(oc, Nature.AUTOMATIC, badCA), "Foo");
-		CNAbilitySelection fooCAS = new CNAbilitySelection(CNAbilityFactory.getCNAbility(BuildUtilities.getFeatCat(), Nature.AUTOMATIC, item), "Foo");
-		CNAbilitySelection barCAS = new CNAbilitySelection(CNAbilityFactory.getCNAbility(BuildUtilities.getFeatCat(), Nature.VIRTUAL, item), "Bar");
-		CNAbilitySelection gooCAS = new CNAbilitySelection(CNAbilityFactory.getCNAbility(BuildUtilities.getFeatCat(), Nature.NORMAL, item), "Goo");
-		CNAbilitySelection wowCAS =
-				new CNAbilitySelection(CNAbilityFactory.getCNAbility(BuildUtilities.getFeatCat(), Nature.NORMAL, item), "Wow");
-		CNAbilitySelection wowFFCAS = new CNAbilitySelection(CNAbilityFactory.getCNAbility(ff, Nature.NORMAL, item), "Wow");
-		CNAbilitySelection revCAS =
-				new CNAbilitySelection(CNAbilityFactory.getCNAbility(BuildUtilities.getFeatCat(), Nature.NORMAL, item), "Rev");
-		CNAbilitySelection revFFCAS = new CNAbilitySelection(CNAbilityFactory.getCNAbility(ff, Nature.NORMAL, item), "Rev");
+		CNAbilitySelection badCACAS = new CNAbilitySelection(
+			CNAbilityFactory.getCNAbility(oc, Nature.AUTOMATIC, badCA), "Foo");
+		CNAbilitySelection fooCAS = new CNAbilitySelection(CNAbilityFactory
+			.getCNAbility(BuildUtilities.getFeatCat(), Nature.AUTOMATIC, item), "Foo");
+		CNAbilitySelection barCAS = new CNAbilitySelection(CNAbilityFactory
+			.getCNAbility(BuildUtilities.getFeatCat(), Nature.VIRTUAL, item), "Bar");
+		CNAbilitySelection gooCAS = new CNAbilitySelection(CNAbilityFactory
+			.getCNAbility(BuildUtilities.getFeatCat(), Nature.NORMAL, item), "Goo");
+		CNAbilitySelection wowCAS = new CNAbilitySelection(CNAbilityFactory
+			.getCNAbility(BuildUtilities.getFeatCat(), Nature.NORMAL, item), "Wow");
+		CNAbilitySelection wowFFCAS = new CNAbilitySelection(
+			CNAbilityFactory.getCNAbility(ff, Nature.NORMAL, item), "Wow");
+		CNAbilitySelection revCAS = new CNAbilitySelection(CNAbilityFactory
+			.getCNAbility(BuildUtilities.getFeatCat(), Nature.NORMAL, item), "Rev");
+		CNAbilitySelection revFFCAS = new CNAbilitySelection(
+			CNAbilityFactory.getCNAbility(ff, Nature.NORMAL, item), "Rev");
 		
 		assertTrue(pca.allow(fooCAS, pc, false));
 		assertTrue(pca.allow(barCAS, pc, false));

--- a/code/src/utest/actor/add/AbilityTokenTest.java
+++ b/code/src/utest/actor/add/AbilityTokenTest.java
@@ -17,6 +17,9 @@
  */
 package actor.add;
 
+import org.junit.Before;
+import org.junit.Test;
+
 import pcgen.cdom.base.UserSelection;
 import pcgen.cdom.content.CNAbilityFactory;
 import pcgen.cdom.enumeration.Nature;
@@ -32,11 +35,9 @@ import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.LstToken;
 import pcgen.rules.context.LoadContext;
 import pcgen.testsupport.AbstractCharacterUsingTestCase;
-
-import org.junit.Before;
-import org.junit.Test;
 import plugin.lsttokens.AddLst;
 import plugin.lsttokens.add.AbilityToken;
+import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.lsttokens.testsupport.TokenRegistration;
 
 public class AbilityTokenTest extends AbstractCharacterUsingTestCase
@@ -56,9 +57,7 @@ public class AbilityTokenTest extends AbstractCharacterUsingTestCase
 		super.setUp();
 		SettingsHandler.getGame().clearLoadContext();
 		context = Globals.getContext();
-		context.getReferenceContext().importObject(AbilityCategory.FEAT);
-		// new RuntimeLoadContext(new RuntimeReferenceContext(),
-		// new ConsolidatedListCommitStrategy());
+		context.getReferenceContext().importObject(BuildUtilities.getFeatCat());
 	}
 
 	@Test
@@ -66,7 +65,7 @@ public class AbilityTokenTest extends AbstractCharacterUsingTestCase
 	{
 		Ability item = construct("ItemName");
 		CNAbilitySelection as =
-				new CNAbilitySelection(CNAbilityFactory.getCNAbility(AbilityCategory.FEAT, Nature.NORMAL, item));
+				new CNAbilitySelection(CNAbilityFactory.getCNAbility(BuildUtilities.getFeatCat(), Nature.NORMAL, item));
 		assertEquals("CATEGORY=FEAT|NATURE=NORMAL|ItemName", pca
 			.encodeChoice(as));
 	}
@@ -85,7 +84,7 @@ public class AbilityTokenTest extends AbstractCharacterUsingTestCase
 		}
 		Ability item = construct("ItemName");
 		CNAbilitySelection as =
-				new CNAbilitySelection(CNAbilityFactory.getCNAbility(AbilityCategory.FEAT, Nature.NORMAL, item));
+				new CNAbilitySelection(CNAbilityFactory.getCNAbility(BuildUtilities.getFeatCat(), Nature.NORMAL, item));
 		assertEquals(as, pca
 			.decodeChoice(context, "CATEGORY=FEAT|NATURE=NORMAL|ItemName"));
 	}
@@ -98,7 +97,7 @@ public class AbilityTokenTest extends AbstractCharacterUsingTestCase
 			setUpPC();
 			//Need to make sure we use the character related context
 			context = Globals.getContext();
-			context.getReferenceContext().importObject(AbilityCategory.FEAT);
+			context.getReferenceContext().importObject(BuildUtilities.getFeatCat());
 			TokenRegistration.register(ADD_TOKEN);
 			TokenRegistration.register(ADD_ABILITY_TOKEN);
 		} catch (PersistenceLayerException e1) {
@@ -112,7 +111,7 @@ public class AbilityTokenTest extends AbstractCharacterUsingTestCase
 		context.getReferenceContext().constructCDOMObject(Language.class, "Wow");
 		context.getReferenceContext().constructCDOMObject(Language.class, "Rev");
 		AbilityCategory ff = context.getReferenceContext().constructCDOMObject(AbilityCategory.class, "Fighter Feat");
-		ff.setAbilityCategory(CDOMDirectSingleRef.getRef(AbilityCategory.FEAT));
+		ff.setAbilityCategory(CDOMDirectSingleRef.getRef(BuildUtilities.getFeatCat()));
 		AbilityCategory oc = context.getReferenceContext().constructCDOMObject(AbilityCategory.class, "Some Other Category");
 		Ability badCA = oc.newInstance();
 		badCA.setName("ChooseAbility");
@@ -132,14 +131,14 @@ public class AbilityTokenTest extends AbstractCharacterUsingTestCase
 		Object source = UserSelection.getInstance();
 		
 		CNAbilitySelection badCACAS = new CNAbilitySelection(CNAbilityFactory.getCNAbility(oc, Nature.AUTOMATIC, badCA), "Foo");
-		CNAbilitySelection fooCAS = new CNAbilitySelection(CNAbilityFactory.getCNAbility(AbilityCategory.FEAT, Nature.AUTOMATIC, item), "Foo");
-		CNAbilitySelection barCAS = new CNAbilitySelection(CNAbilityFactory.getCNAbility(AbilityCategory.FEAT, Nature.VIRTUAL, item), "Bar");
-		CNAbilitySelection gooCAS = new CNAbilitySelection(CNAbilityFactory.getCNAbility(AbilityCategory.FEAT, Nature.NORMAL, item), "Goo");
+		CNAbilitySelection fooCAS = new CNAbilitySelection(CNAbilityFactory.getCNAbility(BuildUtilities.getFeatCat(), Nature.AUTOMATIC, item), "Foo");
+		CNAbilitySelection barCAS = new CNAbilitySelection(CNAbilityFactory.getCNAbility(BuildUtilities.getFeatCat(), Nature.VIRTUAL, item), "Bar");
+		CNAbilitySelection gooCAS = new CNAbilitySelection(CNAbilityFactory.getCNAbility(BuildUtilities.getFeatCat(), Nature.NORMAL, item), "Goo");
 		CNAbilitySelection wowCAS =
-				new CNAbilitySelection(CNAbilityFactory.getCNAbility(AbilityCategory.FEAT, Nature.NORMAL, item), "Wow");
+				new CNAbilitySelection(CNAbilityFactory.getCNAbility(BuildUtilities.getFeatCat(), Nature.NORMAL, item), "Wow");
 		CNAbilitySelection wowFFCAS = new CNAbilitySelection(CNAbilityFactory.getCNAbility(ff, Nature.NORMAL, item), "Wow");
 		CNAbilitySelection revCAS =
-				new CNAbilitySelection(CNAbilityFactory.getCNAbility(AbilityCategory.FEAT, Nature.NORMAL, item), "Rev");
+				new CNAbilitySelection(CNAbilityFactory.getCNAbility(BuildUtilities.getFeatCat(), Nature.NORMAL, item), "Rev");
 		CNAbilitySelection revFFCAS = new CNAbilitySelection(CNAbilityFactory.getCNAbility(ff, Nature.NORMAL, item), "Rev");
 		
 		assertTrue(pca.allow(fooCAS, pc, false));
@@ -188,7 +187,7 @@ public class AbilityTokenTest extends AbstractCharacterUsingTestCase
 
 	protected Ability construct(String one)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(one);
 		context.getReferenceContext().importObject(a);
 		return a;

--- a/code/src/utest/actor/choose/AbilitySelectionTokenTest.java
+++ b/code/src/utest/actor/choose/AbilitySelectionTokenTest.java
@@ -22,7 +22,6 @@ import java.net.URISyntaxException;
 import pcgen.cdom.content.AbilitySelection;
 import pcgen.cdom.enumeration.ObjectKey;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.core.Globals;
 import pcgen.core.SettingsHandler;
 import pcgen.persistence.PersistenceLayerException;
@@ -33,6 +32,8 @@ import org.junit.Before;
 import org.junit.Test;
 import plugin.lsttokens.choose.AbilitySelectionToken;
 import plugin.lsttokens.choose.StringToken;
+import plugin.lsttokens.testsupport.BuildUtilities;
+
 import static org.junit.Assert.*;
 
 /**
@@ -54,7 +55,7 @@ public class AbilitySelectionTokenTest
 		SettingsHandler.getGame().clearLoadContext();
 		context = Globals.getContext();
 		
-		context.getReferenceContext().importObject(AbilityCategory.FEAT);
+		context.getReferenceContext().importObject(BuildUtilities.getFeatCat());
 	}
 
 	@Test
@@ -106,7 +107,7 @@ public class AbilitySelectionTokenTest
 
 	protected Ability construct(String one)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(one);
 		context.getReferenceContext().importObject(a);
 		return a;

--- a/code/src/utest/actor/choose/AbilityTokenTest.java
+++ b/code/src/utest/actor/choose/AbilityTokenTest.java
@@ -21,7 +21,6 @@ import java.net.URISyntaxException;
 
 import pcgen.cdom.base.CategorizedChooser;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.core.Globals;
 import pcgen.core.SettingsHandler;
 import pcgen.persistence.PersistenceLayerException;
@@ -30,6 +29,8 @@ import pcgen.rules.context.LoadContext;
 import org.junit.Before;
 import org.junit.Test;
 import plugin.lsttokens.choose.AbilityToken;
+import plugin.lsttokens.testsupport.BuildUtilities;
+
 import static org.junit.Assert.*;
 
 /**
@@ -39,7 +40,6 @@ import static org.junit.Assert.*;
 public class AbilityTokenTest
 {
 
-	private static final AbilityCategory CATEGORY = AbilityCategory.FEAT;
 	private static final CategorizedChooser<Ability> pca = new AbilityToken();
 	private static final String ITEM_NAME = "ItemName";
 
@@ -50,12 +50,12 @@ public class AbilityTokenTest
 	{
 		SettingsHandler.getGame().clearLoadContext();
 		context = Globals.getContext();
-		context.getReferenceContext().importObject(CATEGORY);
+		context.getReferenceContext().importObject(BuildUtilities.getFeatCat());
 	}
 
 	private Ability getObject()
 	{
-		Ability a = CATEGORY.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(ITEM_NAME);
 		context.getReferenceContext().importObject(a);
 		return a;
@@ -75,13 +75,15 @@ public class AbilityTokenTest
 	@Test
 	public void testDecodeChoice()
 	{
-		assertEquals(getObject(), pca.decodeChoice(context, getExpected(), CATEGORY));
+		assertEquals(getObject(),
+			pca.decodeChoice(context, getExpected(), BuildUtilities.getFeatCat()));
 	}
 
 	@Test
 	public void testLegacyDecodeChoice()
 	{
-		assertEquals(getObject(), pca.decodeChoice(context, "CATEGORY=FEAT|" +ITEM_NAME, CATEGORY));
+		assertEquals(getObject(), pca.decodeChoice(context, "CATEGORY=FEAT|" + ITEM_NAME,
+			BuildUtilities.getFeatCat()));
 	}
 
 }

--- a/code/src/utest/actor/testsupport/AbstractPersistentChoiceActorTestCase.java
+++ b/code/src/utest/actor/testsupport/AbstractPersistentChoiceActorTestCase.java
@@ -20,11 +20,11 @@ package actor.testsupport;
 import java.net.URISyntaxException;
 
 import pcgen.cdom.base.Persistent;
-import pcgen.core.AbilityCategory;
 import pcgen.core.Globals;
 import pcgen.core.SettingsHandler;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.rules.context.LoadContext;
+import plugin.lsttokens.testsupport.BuildUtilities;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -40,7 +40,7 @@ public abstract class AbstractPersistentChoiceActorTestCase<T>
 	{
 		SettingsHandler.getGame().clearLoadContext();
 		context = Globals.getContext();
-		context.getReferenceContext().importObject(AbilityCategory.FEAT);
+		context.getReferenceContext().importObject(BuildUtilities.getFeatCat());
 //				new RuntimeLoadContext(new RuntimeReferenceContext(),
 //					new ConsolidatedListCommitStrategy());
 	}

--- a/code/src/utest/pcgen/cdom/testsupport/AbstractCNASEnforcingFacetTest.java
+++ b/code/src/utest/pcgen/cdom/testsupport/AbstractCNASEnforcingFacetTest.java
@@ -22,6 +22,7 @@ import pcgen.cdom.helper.CNAbilitySelectionUtilities;
 import pcgen.cdom.reference.CDOMDirectSingleRef;
 import pcgen.core.Ability;
 import pcgen.core.AbilityCategory;
+import plugin.lsttokens.testsupport.BuildUtilities;
 
 public abstract class AbstractCNASEnforcingFacetTest extends TestCase
 {
@@ -882,17 +883,17 @@ public abstract class AbstractCNASEnforcingFacetTest extends TestCase
 	{
 		Ability a1 = new Ability();
 		a1.setName("Abil");
-		a1.setCDOMCategory(AbilityCategory.FEAT);
-		return new CNAbilitySelection(CNAbilityFactory.getCNAbility(AbilityCategory.FEAT, Nature.VIRTUAL, a1));
+		a1.setCDOMCategory(BuildUtilities.getFeatCat());
+		return new CNAbilitySelection(CNAbilityFactory.getCNAbility(BuildUtilities.getFeatCat(), Nature.VIRTUAL, a1));
 	}
 
 	protected CNAbilitySelection getMultObject(String tgt)
 	{
 		Ability a1 = new Ability();
 		a1.setName("Abil");
-		a1.setCDOMCategory(AbilityCategory.FEAT);
+		a1.setCDOMCategory(BuildUtilities.getFeatCat());
 		a1.put(ObjectKey.MULTIPLE_ALLOWED, true);
-		return new CNAbilitySelection(CNAbilityFactory.getCNAbility(AbilityCategory.FEAT, Nature.VIRTUAL, a1), tgt);
+		return new CNAbilitySelection(CNAbilityFactory.getCNAbility(BuildUtilities.getFeatCat(), Nature.VIRTUAL, a1), tgt);
 	}
 
 	//TODO Need to test events :/

--- a/code/src/utest/pcgen/cdom/testsupport/AbstractCNASEnforcingFacetTest.java
+++ b/code/src/utest/pcgen/cdom/testsupport/AbstractCNASEnforcingFacetTest.java
@@ -884,7 +884,8 @@ public abstract class AbstractCNASEnforcingFacetTest extends TestCase
 		Ability a1 = new Ability();
 		a1.setName("Abil");
 		a1.setCDOMCategory(BuildUtilities.getFeatCat());
-		return new CNAbilitySelection(CNAbilityFactory.getCNAbility(BuildUtilities.getFeatCat(), Nature.VIRTUAL, a1));
+		return new CNAbilitySelection(CNAbilityFactory
+			.getCNAbility(BuildUtilities.getFeatCat(), Nature.VIRTUAL, a1));
 	}
 
 	protected CNAbilitySelection getMultObject(String tgt)
@@ -893,7 +894,8 @@ public abstract class AbstractCNASEnforcingFacetTest extends TestCase
 		a1.setName("Abil");
 		a1.setCDOMCategory(BuildUtilities.getFeatCat());
 		a1.put(ObjectKey.MULTIPLE_ALLOWED, true);
-		return new CNAbilitySelection(CNAbilityFactory.getCNAbility(BuildUtilities.getFeatCat(), Nature.VIRTUAL, a1), tgt);
+		return new CNAbilitySelection(CNAbilityFactory
+			.getCNAbility(BuildUtilities.getFeatCat(), Nature.VIRTUAL, a1), tgt);
 	}
 
 	//TODO Need to test events :/

--- a/code/src/utest/plugin/lsttokens/AbilityLstTest.java
+++ b/code/src/utest/plugin/lsttokens/AbilityLstTest.java
@@ -60,7 +60,7 @@ public class AbilityLstTest extends AbstractGlobalTokenTestCase
 		TokenRegistration.register(new PreLevelWriter());
 		TokenRegistration.register(new PreClassParser());
 		TokenRegistration.register(new PreClassWriter());
-		//We build dummy objects so that AbilityCategory.FEAT has been loaded properly
+		//We build dummy objects so that BuildUtilities.getFeatCat() has been loaded properly
 		construct(primaryContext, "Dummy");
 		construct(secondaryContext, "Dummy");
 	}
@@ -329,7 +329,7 @@ public class AbilityLstTest extends AbstractGlobalTokenTestCase
 
 	private static Ability construct(LoadContext context, String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		context.getReferenceContext().importObject(a);
 		return a;

--- a/code/src/utest/plugin/lsttokens/QualifyTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/QualifyTokenTest.java
@@ -46,10 +46,10 @@ public class QualifyTokenTest extends AbstractGlobalTokenTestCase
 	{
 		super.setUp();
 		//Dummy builds to ensure initialization
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName("Dummy");
 		primaryContext.getReferenceContext().importObject(a);
-		a = AbilityCategory.FEAT.newInstance();
+		a = BuildUtilities.getFeatCat().newInstance();
 		a.setName("Dummy");
 		secondaryContext.getReferenceContext().importObject(a);
 	}
@@ -217,8 +217,8 @@ public class QualifyTokenTest extends AbstractGlobalTokenTestCase
 	public void testRoundRobinFeatSpell()
 			throws PersistenceLayerException
 	{
-		BuildUtilities.buildAbility(primaryContext, AbilityCategory.FEAT, "My Feat");
-		BuildUtilities.buildAbility(secondaryContext, AbilityCategory.FEAT, "My Feat");
+		BuildUtilities.buildAbility(primaryContext, BuildUtilities.getFeatCat(), "My Feat");
+		BuildUtilities.buildAbility(secondaryContext, BuildUtilities.getFeatCat(), "My Feat");
 		primaryContext.getReferenceContext().constructCDOMObject(Spell.class,
 				"Lightning Bolt");
 		secondaryContext.getReferenceContext().constructCDOMObject(Spell.class,

--- a/code/src/utest/plugin/lsttokens/ability/AddspelllevelTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/ability/AddspelllevelTokenTest.java
@@ -19,10 +19,10 @@ package plugin.lsttokens.ability;
 
 import pcgen.cdom.enumeration.IntegerKey;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.testsupport.AbstractIntegerTokenTestCase;
+import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.lsttokens.testsupport.CDOMTokenLoader;
 
 public class AddspelllevelTokenTest extends AbstractIntegerTokenTestCase<Ability>
@@ -76,7 +76,7 @@ public class AddspelllevelTokenTest extends AbstractIntegerTokenTestCase<Ability
 	@Override
 	protected Ability getSecondary(String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		secondaryContext.getReferenceContext().importObject(a);
 		return a;
@@ -85,7 +85,7 @@ public class AddspelllevelTokenTest extends AbstractIntegerTokenTestCase<Ability
 	@Override
 	protected Ability getPrimary(String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		primaryContext.getReferenceContext().importObject(a);
 		return a;

--- a/code/src/utest/plugin/lsttokens/ability/AspectTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/ability/AspectTokenTest.java
@@ -20,11 +20,11 @@ package plugin.lsttokens.ability;
 import org.junit.Test;
 
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.testsupport.AbstractCDOMTokenTestCase;
+import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.lsttokens.testsupport.CDOMTokenLoader;
 import plugin.lsttokens.testsupport.ConsolidationRule;
 
@@ -160,7 +160,7 @@ public class AspectTokenTest extends AbstractCDOMTokenTestCase<Ability>
 	@Override
 	protected Ability getSecondary(String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		secondaryContext.getReferenceContext().importObject(a);
 		return a;
@@ -169,7 +169,7 @@ public class AspectTokenTest extends AbstractCDOMTokenTestCase<Ability>
 	@Override
 	protected Ability getPrimary(String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		primaryContext.getReferenceContext().importObject(a);
 		return a;

--- a/code/src/utest/plugin/lsttokens/ability/BenefitTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/ability/BenefitTokenTest.java
@@ -23,11 +23,11 @@ import org.junit.Before;
 import org.junit.Test;
 
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.testsupport.AbstractCDOMTokenTestCase;
+import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.lsttokens.testsupport.CDOMTokenLoader;
 import plugin.lsttokens.testsupport.ConsolidationRule;
 import plugin.lsttokens.testsupport.TokenRegistration;
@@ -190,7 +190,7 @@ public class BenefitTokenTest extends AbstractCDOMTokenTestCase<Ability>
 	@Override
 	protected Ability getSecondary(String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		secondaryContext.getReferenceContext().importObject(a);
 		return a;
@@ -199,7 +199,7 @@ public class BenefitTokenTest extends AbstractCDOMTokenTestCase<Ability>
 	@Override
 	protected Ability getPrimary(String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		primaryContext.getReferenceContext().importObject(a);
 		return a;

--- a/code/src/utest/plugin/lsttokens/ability/CostTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/ability/CostTokenTest.java
@@ -21,10 +21,10 @@ import java.math.BigDecimal;
 
 import pcgen.cdom.enumeration.ObjectKey;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.testsupport.AbstractBigDecimalTokenTestCase;
+import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.lsttokens.testsupport.CDOMTokenLoader;
 
 public class CostTokenTest extends AbstractBigDecimalTokenTestCase<Ability>
@@ -84,7 +84,7 @@ public class CostTokenTest extends AbstractBigDecimalTokenTestCase<Ability>
 	@Override
 	protected Ability getSecondary(String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		secondaryContext.getReferenceContext().importObject(a);
 		return a;
@@ -93,7 +93,7 @@ public class CostTokenTest extends AbstractBigDecimalTokenTestCase<Ability>
 	@Override
 	protected Ability getPrimary(String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		primaryContext.getReferenceContext().importObject(a);
 		return a;

--- a/code/src/utest/plugin/lsttokens/ability/MultTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/ability/MultTokenTest.java
@@ -19,10 +19,10 @@ package plugin.lsttokens.ability;
 
 import pcgen.cdom.enumeration.ObjectKey;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.testsupport.AbstractYesNoTokenTestCase;
+import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.lsttokens.testsupport.CDOMTokenLoader;
 
 public class MultTokenTest extends AbstractYesNoTokenTestCase<Ability>
@@ -58,7 +58,7 @@ public class MultTokenTest extends AbstractYesNoTokenTestCase<Ability>
 	@Override
 	protected Ability getSecondary(String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		secondaryContext.getReferenceContext().importObject(a);
 		return a;
@@ -67,7 +67,7 @@ public class MultTokenTest extends AbstractYesNoTokenTestCase<Ability>
 	@Override
 	protected Ability getPrimary(String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		primaryContext.getReferenceContext().importObject(a);
 		return a;

--- a/code/src/utest/plugin/lsttokens/ability/StackTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/ability/StackTokenTest.java
@@ -19,10 +19,10 @@ package plugin.lsttokens.ability;
 
 import pcgen.cdom.enumeration.ObjectKey;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.testsupport.AbstractYesNoTokenTestCase;
+import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.lsttokens.testsupport.CDOMTokenLoader;
 
 public class StackTokenTest extends AbstractYesNoTokenTestCase<Ability>
@@ -58,7 +58,7 @@ public class StackTokenTest extends AbstractYesNoTokenTestCase<Ability>
 	@Override
 	protected Ability getSecondary(String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		secondaryContext.getReferenceContext().importObject(a);
 		return a;
@@ -67,7 +67,7 @@ public class StackTokenTest extends AbstractYesNoTokenTestCase<Ability>
 	@Override
 	protected Ability getPrimary(String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		primaryContext.getReferenceContext().importObject(a);
 		return a;

--- a/code/src/utest/plugin/lsttokens/ability/VisibleTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/ability/VisibleTokenTest.java
@@ -21,12 +21,12 @@ import org.junit.Test;
 
 import pcgen.cdom.enumeration.ObjectKey;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import pcgen.util.enumeration.Visibility;
 import plugin.lsttokens.testsupport.AbstractCDOMTokenTestCase;
+import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.lsttokens.testsupport.CDOMTokenLoader;
 import plugin.lsttokens.testsupport.ConsolidationRule;
 
@@ -199,7 +199,7 @@ public class VisibleTokenTest extends AbstractCDOMTokenTestCase<Ability>
 	@Override
 	protected Ability getSecondary(String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		secondaryContext.getReferenceContext().importObject(a);
 		return a;
@@ -208,7 +208,7 @@ public class VisibleTokenTest extends AbstractCDOMTokenTestCase<Ability>
 	@Override
 	protected Ability getPrimary(String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		primaryContext.getReferenceContext().importObject(a);
 		return a;

--- a/code/src/utest/plugin/lsttokens/add/AbilityTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/add/AbilityTokenTest.java
@@ -38,7 +38,6 @@ import pcgen.cdom.helper.CNAbilitySelection;
 import pcgen.cdom.reference.CDOMDirectSingleRef;
 import pcgen.cdom.reference.CDOMGroupRef;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.core.AbilityUtilities;
 import pcgen.core.PCTemplate;
 import pcgen.persistence.PersistenceLayerException;
@@ -48,6 +47,7 @@ import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import pcgen.rules.persistence.token.CDOMSecondaryToken;
 import plugin.lsttokens.AddLst;
 import plugin.lsttokens.testsupport.AbstractCDOMTokenTestCase;
+import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.lsttokens.testsupport.CDOMTokenLoader;
 import plugin.lsttokens.testsupport.ConsolidationRule;
 import plugin.lsttokens.testsupport.TokenRegistration;
@@ -113,7 +113,7 @@ public class AbilityTokenTest extends AbstractCDOMTokenTestCase<CDOMObject>
 
 	protected Ability construct(LoadContext loadContext, String one)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(one);
 		loadContext.getReferenceContext().importObject(a);
 		return a;
@@ -849,7 +849,7 @@ public class AbilityTokenTest extends AbstractCDOMTokenTestCase<CDOMObject>
 	{
 		List<CDOMReference<Ability>> refs = new ArrayList<>();
 		CDOMGroupRef<Ability> ref = primaryContext.getReferenceContext()
-			.getManufacturerId(AbilityCategory.FEAT)
+			.getManufacturerId(BuildUtilities.getFeatCat())
 			.getTypeReference(new String[]{"Foo", "Bar"});
 		refs.add(ref);
 
@@ -860,7 +860,7 @@ public class AbilityTokenTest extends AbstractCDOMTokenTestCase<CDOMObject>
 
 	private void createTC(List<CDOMReference<Ability>> refs, Formula count)
 	{
-		AbilityRefChoiceSet rcs = new AbilityRefChoiceSet(CDOMDirectSingleRef.getRef(AbilityCategory.FEAT),
+		AbilityRefChoiceSet rcs = new AbilityRefChoiceSet(CDOMDirectSingleRef.getRef(BuildUtilities.getFeatCat()),
 				refs, Nature.NORMAL);
 		// TODO: Should this be present for the unit tests?
 		//assertTrue("Invalid grouping state " + rcs.getGroupingState(), rcs.getGroupingState().isValid());
@@ -919,7 +919,7 @@ public class AbilityTokenTest extends AbstractCDOMTokenTestCase<CDOMObject>
 		{
 			List<CDOMReference<Ability>> refs = createSingle("TestWP1");
 			CDOMGroupRef<Ability> ref = primaryContext.getReferenceContext()
-				.getManufacturerId(AbilityCategory.FEAT).getAllReference();
+				.getManufacturerId(BuildUtilities.getFeatCat()).getAllReference();
 			refs.add(ref);
 			createTC(refs, FormulaFactory.ONE);
 			assertBadUnparse();
@@ -933,7 +933,7 @@ public class AbilityTokenTest extends AbstractCDOMTokenTestCase<CDOMObject>
 		{
 			List<CDOMReference<Ability>> refs = new ArrayList<>();
 			CDOMGroupRef<Ability> ref = primaryContext.getReferenceContext()
-				.getManufacturerId(AbilityCategory.FEAT).getAllReference();
+				.getManufacturerId(BuildUtilities.getFeatCat()).getAllReference();
 			refs.add(ref);
 			createTC(refs, FormulaFactory.ONE);
 			String[] unparsed = getToken().unparse(primaryContext, primaryProf);
@@ -948,11 +948,11 @@ public class AbilityTokenTest extends AbstractCDOMTokenTestCase<CDOMObject>
 		{
 			List<CDOMReference<Ability>> refs = new ArrayList<>();
 			CDOMGroupRef<Ability> ref = primaryContext.getReferenceContext()
-				.getManufacturerId(AbilityCategory.FEAT)
+				.getManufacturerId(BuildUtilities.getFeatCat())
 				.getTypeReference(new String[]{"Foo", "Bar"});
 			refs.add(ref);
 			ref = primaryContext.getReferenceContext()
-				.getManufacturerId(AbilityCategory.FEAT).getAllReference();
+				.getManufacturerId(BuildUtilities.getFeatCat()).getAllReference();
 			refs.add(ref);
 			createTC(refs, FormulaFactory.ONE);
 			assertBadUnparse();
@@ -963,7 +963,7 @@ public class AbilityTokenTest extends AbstractCDOMTokenTestCase<CDOMObject>
 	public void testUnparseComplex() throws PersistenceLayerException
 	{
 		List<CDOMReference<Ability>> refs = createSingle("TestWP1");
-		AbilityRefChoiceSet rcs = new AbilityRefChoiceSet(CDOMDirectSingleRef.getRef(AbilityCategory.FEAT),
+		AbilityRefChoiceSet rcs = new AbilityRefChoiceSet(CDOMDirectSingleRef.getRef(BuildUtilities.getFeatCat()),
 				refs, Nature.VIRTUAL);
 		assert (rcs.getGroupingState().isValid());
 		AbilityChoiceSet cs = new AbilityChoiceSet(

--- a/code/src/utest/plugin/lsttokens/campaign/ForwardrefTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/campaign/ForwardrefTokenTest.java
@@ -30,6 +30,7 @@ import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.testsupport.AbstractCDOMTokenTestCase;
+import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.lsttokens.testsupport.CDOMTokenLoader;
 import plugin.lsttokens.testsupport.ConsolidationRule;
 
@@ -44,10 +45,10 @@ public class ForwardrefTokenTest extends AbstractCDOMTokenTestCase<Campaign>
 	{
 		super.setUp();
 		//Dummy items to ensure Category is initialized
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName("Dummy");
 		primaryContext.getReferenceContext().importObject(a);
-		Ability b = AbilityCategory.FEAT.newInstance();
+		Ability b = BuildUtilities.getFeatCat().newInstance();
 		b.setName("Dummy");
 		secondaryContext.getReferenceContext().importObject(b);
 	}
@@ -209,8 +210,8 @@ public class ForwardrefTokenTest extends AbstractCDOMTokenTestCase<Campaign>
 	{
 		primaryContext.getReferenceContext().constructCDOMObject(Spell.class, "Lightning Bolt");
 		secondaryContext.getReferenceContext().constructCDOMObject(Spell.class, "Lightning Bolt");
-		constructAbility(primaryContext, AbilityCategory.FEAT, "My Feat");
-		constructAbility(secondaryContext, AbilityCategory.FEAT, "My Feat");
+		constructAbility(primaryContext, BuildUtilities.getFeatCat(), "My Feat");
+		constructAbility(secondaryContext, BuildUtilities.getFeatCat(), "My Feat");
 		runRoundRobin("ABILITY=FEAT|My Feat", "SPELL|Lightning Bolt");
 	}
 

--- a/code/src/utest/plugin/lsttokens/choose/AbilitySelectionTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/choose/AbilitySelectionTokenTest.java
@@ -33,6 +33,7 @@ import pcgen.rules.persistence.token.CDOMSecondaryToken;
 import pcgen.rules.persistence.token.QualifierToken;
 import plugin.lsttokens.ChooseLst;
 import plugin.lsttokens.testsupport.AbstractChooseTokenTestCase;
+import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.lsttokens.testsupport.CDOMTokenLoader;
 import plugin.qualifier.ability.PCToken;
 
@@ -153,7 +154,7 @@ public class AbilitySelectionTokenTest extends
 	@Override
 	protected Ability getSecondary(String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		secondaryContext.getReferenceContext().importObject(a);
 		return a;
@@ -162,7 +163,7 @@ public class AbilitySelectionTokenTest extends
 	@Override
 	protected Ability getPrimary(String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		primaryContext.getReferenceContext().importObject(a);
 		return a;

--- a/code/src/utest/plugin/lsttokens/choose/AbilityTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/choose/AbilityTokenTest.java
@@ -55,7 +55,7 @@ public class AbilityTokenTest extends
 				"Special Ability");
 		secondaryContext.getReferenceContext().constructCDOMObject(AbilityCategory.class,
 				"Special Ability");
-		//We build dummy objects so that AbilityCategory.FEAT has been loaded properly
+		//We build dummy objects so that BuildUtilities.getFeatCat() has been loaded properly
 		construct(primaryContext, "Dummy");
 		construct(secondaryContext, "Dummy");
 	}
@@ -160,7 +160,7 @@ public class AbilityTokenTest extends
 	@Override
 	protected Ability getSecondary(String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		secondaryContext.getReferenceContext().importObject(a);
 		return a;
@@ -169,7 +169,7 @@ public class AbilityTokenTest extends
 	@Override
 	protected Ability getPrimary(String name)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
 		primaryContext.getReferenceContext().importObject(a);
 		return a;

--- a/code/src/utest/plugin/lsttokens/choose/SchoolsTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/choose/SchoolsTokenTest.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.base.Loadable;
 import pcgen.cdom.identifier.SpellSchool;
-import pcgen.core.AbilityCategory;
 import pcgen.core.PCTemplate;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.rules.context.LoadContext;
@@ -99,8 +98,8 @@ public class SchoolsTokenTest extends AbstractChooseTokenTestCase
 	{
 		construct(primaryContext, "Abjuration");
 		construct(secondaryContext, "Abjuration");
-		BuildUtilities.buildAbility(primaryContext, AbilityCategory.FEAT, "School Stuff");
-		BuildUtilities.buildAbility(secondaryContext, AbilityCategory.FEAT, "School Stuff");
+		BuildUtilities.buildAbility(primaryContext, BuildUtilities.getFeatCat(), "School Stuff");
+		BuildUtilities.buildAbility(secondaryContext, BuildUtilities.getFeatCat(), "School Stuff");
 		runRoundRobin("SCHOOLS|ABILITY=FEAT[School Stuff]");
 	}
 

--- a/code/src/utest/plugin/lsttokens/kit/ability/AbilityTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/kit/ability/AbilityTokenTest.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 import pcgen.cdom.enumeration.ListKey;
 import pcgen.cdom.enumeration.Type;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.core.kit.KitAbilities;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.rules.persistence.CDOMSubLineLoader;
@@ -43,10 +42,10 @@ public class AbilityTokenTest extends AbstractKitTokenTestCase<KitAbilities>
 	public void setUp() throws PersistenceLayerException, URISyntaxException
 	{
 		super.setUp();
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName("Dummy");
 		primaryContext.getReferenceContext().importObject(a);
-		Ability b = AbilityCategory.FEAT.newInstance();
+		Ability b = BuildUtilities.getFeatCat().newInstance();
 		b.setName("Dummy");
 		secondaryContext.getReferenceContext().importObject(b);
 	}

--- a/code/src/utest/plugin/lsttokens/kit/spells/SpellsTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/kit/spells/SpellsTokenTest.java
@@ -21,7 +21,6 @@ import org.junit.Test;
 
 import pcgen.cdom.enumeration.ListKey;
 import pcgen.cdom.enumeration.Type;
-import pcgen.core.AbilityCategory;
 import pcgen.core.PCClass;
 import pcgen.core.kit.KitSpells;
 import pcgen.core.spell.Spell;
@@ -29,6 +28,7 @@ import pcgen.persistence.PersistenceLayerException;
 import pcgen.rules.persistence.CDOMSubLineLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.testsupport.AbstractKitTokenTestCase;
+import plugin.lsttokens.testsupport.BuildUtilities;
 
 public class SpellsTokenTest extends AbstractKitTokenTestCase<KitSpells>
 {
@@ -135,8 +135,8 @@ public class SpellsTokenTest extends AbstractKitTokenTestCase<KitSpells>
 		secondaryContext.getReferenceContext().constructCDOMObject(Spell.class, "Fireball");
 		primaryContext.getReferenceContext().constructCDOMObject(PCClass.class, "Wizard");
 		secondaryContext.getReferenceContext().constructCDOMObject(PCClass.class, "Wizard");
-		constructCategorized(primaryContext, AbilityCategory.FEAT, "EnhancedFeat");
-		constructCategorized(secondaryContext, AbilityCategory.FEAT, "EnhancedFeat");
+		constructCategorized(primaryContext, BuildUtilities.getFeatCat(), "EnhancedFeat");
+		constructCategorized(secondaryContext, BuildUtilities.getFeatCat(), "EnhancedFeat");
 		runRoundRobin("SPELLBOOK=Personal|CLASS=Wizard|Fireball[EnhancedFeat]=2");
 	}
 

--- a/code/src/utest/plugin/lsttokens/testsupport/AbstractGlobalTokenTestCase.java
+++ b/code/src/utest/plugin/lsttokens/testsupport/AbstractGlobalTokenTestCase.java
@@ -28,7 +28,6 @@ import org.junit.Test;
 import junit.framework.TestCase;
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.base.ConcretePrereqObject;
-import pcgen.core.AbilityCategory;
 import pcgen.core.Campaign;
 import pcgen.core.bonus.BonusObj;
 import pcgen.persistence.PersistenceLayerException;
@@ -78,8 +77,8 @@ public abstract class AbstractGlobalTokenTestCase extends TestCase
 				"TestObj");
 		secondaryProf = secondaryContext.getReferenceContext().constructCDOMObject(
 				getCDOMClass(), "TestObj");
-		primaryContext.getReferenceContext().importObject(AbilityCategory.FEAT);
-		secondaryContext.getReferenceContext().importObject(AbilityCategory.FEAT);
+		primaryContext.getReferenceContext().importObject(BuildUtilities.getFeatCat());
+		secondaryContext.getReferenceContext().importObject(BuildUtilities.getFeatCat());
 	}
 
 	public abstract <T extends CDOMObject> Class<T> getCDOMClass();

--- a/code/src/utest/plugin/lsttokens/testsupport/AbstractKitTokenTestCase.java
+++ b/code/src/utest/plugin/lsttokens/testsupport/AbstractKitTokenTestCase.java
@@ -29,7 +29,6 @@ import junit.framework.TestCase;
 import pcgen.cdom.base.Categorized;
 import pcgen.cdom.base.Category;
 import pcgen.cdom.base.Loadable;
-import pcgen.core.AbilityCategory;
 import pcgen.core.Campaign;
 import pcgen.core.bonus.BonusObj;
 import pcgen.persistence.PersistenceLayerException;
@@ -83,8 +82,8 @@ public abstract class AbstractKitTokenTestCase<T extends Loadable> extends TestC
 		primaryContext.setExtractURI(testURI);
 		secondaryContext.setSourceURI(testURI);
 		secondaryContext.setExtractURI(testURI);
-		primaryContext.getReferenceContext().importObject(AbilityCategory.FEAT);
-		secondaryContext.getReferenceContext().importObject(AbilityCategory.FEAT);
+		primaryContext.getReferenceContext().importObject(BuildUtilities.getFeatCat());
+		secondaryContext.getReferenceContext().importObject(BuildUtilities.getFeatCat());
 		primaryProf = getSubInstance();
 		secondaryProf = getSubInstance();
 		expectedPrimaryMessageCount = 0;

--- a/code/src/utest/plugin/lsttokens/testsupport/AbstractTokenTestCase.java
+++ b/code/src/utest/plugin/lsttokens/testsupport/AbstractTokenTestCase.java
@@ -29,7 +29,6 @@ import junit.framework.TestCase;
 import pcgen.cdom.base.Categorized;
 import pcgen.cdom.base.Category;
 import pcgen.cdom.base.Loadable;
-import pcgen.core.AbilityCategory;
 import pcgen.core.Campaign;
 import pcgen.core.bonus.BonusObj;
 import pcgen.persistence.PersistenceLayerException;
@@ -91,8 +90,8 @@ public abstract class AbstractTokenTestCase<T extends Loadable> extends
 		primaryContext.setExtractURI(testURI);
 		secondaryContext.setSourceURI(testURI);
 		secondaryContext.setExtractURI(testURI);
-		primaryContext.getReferenceContext().importObject(AbilityCategory.FEAT);
-		secondaryContext.getReferenceContext().importObject(AbilityCategory.FEAT);
+		primaryContext.getReferenceContext().importObject(BuildUtilities.getFeatCat());
+		secondaryContext.getReferenceContext().importObject(BuildUtilities.getFeatCat());
 		primaryProf = getPrimary("TestObj");
 		primaryProf.setSourceURI(testCampaign.getURI());
 		secondaryProf = getSecondary("TestObj");

--- a/code/src/utest/plugin/qualifier/ability/PCQualifierTokenTest.java
+++ b/code/src/utest/plugin/qualifier/ability/PCQualifierTokenTest.java
@@ -22,13 +22,13 @@ import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.content.CNAbilityFactory;
 import pcgen.cdom.enumeration.Nature;
 import pcgen.core.Ability;
-import pcgen.core.AbilityCategory;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.token.CDOMSecondaryToken;
 import pcgen.rules.persistence.token.QualifierToken;
 import plugin.lsttokens.choose.AbilityToken;
 import plugin.lsttokens.testsupport.AbstractPCQualifierTokenTestCase;
+import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.lsttokens.testsupport.TokenRegistration;
 import plugin.lsttokens.testsupport.TransparentPlayerCharacter;
 
@@ -66,7 +66,7 @@ public class PCQualifierTokenTest extends
 	@Override
 	protected void addToPCSet(TransparentPlayerCharacter pc, Ability item)
 	{
-		pc.abilitySet.add(CNAbilityFactory.getCNAbility(AbilityCategory.FEAT,
+		pc.abilitySet.add(CNAbilityFactory.getCNAbility(BuildUtilities.getFeatCat(),
 			Nature.NORMAL, item));
 	}
 
@@ -93,7 +93,7 @@ public class PCQualifierTokenTest extends
 	@Override
 	protected CDOMObject construct(LoadContext loadContext, String one)
 	{
-		Ability a = AbilityCategory.FEAT.newInstance();
+		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(one);
 		loadContext.getReferenceContext().importObject(a);
 		return a;


### PR DESCRIPTION
This prepares for removal of the internal constant