### PR TITLE
Add tests to ensure tokens don't accidentally capture the full file

### DIFF
--- a/code/src/java/pcgen/rules/persistence/TokenUtilities.java
+++ b/code/src/java/pcgen/rules/persistence/TokenUtilities.java
@@ -63,7 +63,7 @@ public final class TokenUtilities
 		}
 		else
 		{
-			return rm.getReference(s);
+			return rm.getReference(new String(s));
 		}
 	}
 

--- a/code/src/java/plugin/lsttokens/spell/TargetareaToken.java
+++ b/code/src/java/plugin/lsttokens/spell/TargetareaToken.java
@@ -25,15 +25,16 @@ import pcgen.cdom.base.Constants;
 import pcgen.cdom.enumeration.StringKey;
 import pcgen.core.spell.Spell;
 import pcgen.rules.context.LoadContext;
+import pcgen.rules.persistence.token.AbstractNonEmptyToken;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import pcgen.rules.persistence.token.ParseResult;
 
 /**
  * Class deals with TARGETAREA Token
  */
-public class TargetareaToken implements CDOMPrimaryToken<Spell>
+public class TargetareaToken extends AbstractNonEmptyToken<Spell>
+		implements CDOMPrimaryToken<Spell>
 {
-
 	@Override
 	public String getTokenName()
 	{
@@ -41,13 +42,8 @@ public class TargetareaToken implements CDOMPrimaryToken<Spell>
 	}
 
 	@Override
-	public ParseResult parseToken(LoadContext context, Spell spell, String value)
+	public ParseResult parseNonEmptyToken(LoadContext context, Spell spell, String value)
 	{
-		if (value == null || value.isEmpty())
-		{
-			return new ParseResult.Fail(getTokenName()
-				+ " arguments may not be empty");
-		}
 		if (Constants.LST_DOT_CLEAR.equals(value))
 		{
 			context.getObjectContext().remove(spell, StringKey.TARGET_AREA);

--- a/code/src/utest/plugin/lsttokens/AddTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/AddTokenTest.java
@@ -139,7 +139,7 @@ public class AddTokenTest extends AbstractGlobalTokenTestCase
 	protected String getLegalValue()
 	{
 		// Not worth it, nothing ever unparses
-		return null;
+		return Constants.LST_DOT_CLEAR;
 	}
 
 	@Override

--- a/code/src/utest/plugin/lsttokens/PreTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/PreTokenTest.java
@@ -91,7 +91,7 @@ public class PreTokenTest extends AbstractGlobalTokenTestCase
 	protected String getLegalValue()
 	{
 		//Not worth it, nothing ever unparses
-		return null;
+		return Constants.LST_DOT_CLEAR;
 	}
 
 	@Override

--- a/code/src/utest/plugin/lsttokens/testsupport/AbstractGlobalTokenTestCase.java
+++ b/code/src/utest/plugin/lsttokens/testsupport/AbstractGlobalTokenTestCase.java
@@ -18,6 +18,7 @@
 package plugin.lsttokens.testsupport;
 
 
+import java.lang.ref.WeakReference;
 import java.net.URISyntaxException;
 import java.util.Locale;
 
@@ -304,6 +305,20 @@ public abstract class AbstractGlobalTokenTestCase extends TestCase
 	{
 		assertTrue(primaryContext.getReferenceContext().validate(null));
 		assertTrue(primaryContext.getReferenceContext().resolveReferences(null));
+	}
+
+	@Test
+	public void testCleanup() throws PersistenceLayerException
+	{
+		String s = new String(getLegalValue());
+		WeakReference<String> wr = new WeakReference<>(s);
+		assertTrue(parse(s));
+		s = null;
+		System.gc();
+		if (wr.get() != null)
+		{
+			fail("retained");
+		}
 	}
 
 }

--- a/code/src/utest/plugin/lsttokens/testsupport/AbstractTokenTestCase.java
+++ b/code/src/utest/plugin/lsttokens/testsupport/AbstractTokenTestCase.java
@@ -18,6 +18,7 @@
 package plugin.lsttokens.testsupport;
 
 
+import java.lang.ref.WeakReference;
 import java.net.URI;
 import java.net.URISyntaxException;
 
@@ -312,6 +313,20 @@ public abstract class AbstractTokenTestCase<T extends Loadable> extends
 		assertTrue(parse(getAlternateLegalValue()));
 		validateUnparsed(primaryContext, primaryProf, getConsolidationRule()
 				.getAnswer(getLegalValue(), getAlternateLegalValue()));
+	}
+
+	@Test
+	public void testCleanup() throws PersistenceLayerException
+	{
+		String s = new String(getLegalValue());
+		WeakReference<String> wr = new WeakReference<>(s);
+		assertTrue(parse(s));
+		s = null;
+		System.gc();
+		if (wr.get() != null)
+		{
+			fail("retained");
+		}
 	}
 
 	protected abstract String getLegalValue();


### PR DESCRIPTION
Unfortunately, the way we break up LST files uses StringTokenizer, which doesn't create new Strings.  Therefore, one accidental move by a token can ingest the full file stored on disk into memory - "permanently".  These additional tests (and one fix in TokenUtilities) are designed to detect that accidental capture (at least in some circumstances) to reduce the probability of it occurring.

Note this does rely on certain behavior by System.gc() that is not guaranteed, but we have nothing better in Java.
