### PR TITLE
Additional Testing for memory leaks

### DIFF
--- a/code/src/utest/plugin/lsttokens/AbilityLstTest.java
+++ b/code/src/utest/plugin/lsttokens/AbilityLstTest.java
@@ -60,9 +60,6 @@ public class AbilityLstTest extends AbstractGlobalTokenTestCase
 		TokenRegistration.register(new PreLevelWriter());
 		TokenRegistration.register(new PreClassParser());
 		TokenRegistration.register(new PreClassWriter());
-		//We build dummy objects so that BuildUtilities.getFeatCat() has been loaded properly
-		construct(primaryContext, "Dummy");
-		construct(secondaryContext, "Dummy");
 	}
 
 	@Override
@@ -567,4 +564,14 @@ public class AbilityLstTest extends AbstractGlobalTokenTestCase
 	{
 		return Constants.LST_DOT_CLEAR;
 	}
+
+	@Override
+	protected void additionalSetup(LoadContext context)
+	{
+		super.additionalSetup(context);
+		//We build dummy objects so that AbilityCategory.FEAT has been loaded properly
+		construct(context, "Dummy");
+	}
+
+	
 }

--- a/code/src/utest/plugin/lsttokens/FactLstTest.java
+++ b/code/src/utest/plugin/lsttokens/FactLstTest.java
@@ -47,16 +47,6 @@ public class FactLstTest extends AbstractGlobalTokenTestCase
 	{
 		TokenRegistration.clearTokens();
 		super.setUp();
-		FactDefinition fd = new FactDefinition();
-		fd.setName("DOMAIN.Possibility");
-		fd.setFactName("Possibility");
-		fd.setUsableLocation(Domain.class);
-		fd.setFormatManager(new StringManager());
-		fd.setVisibility(Visibility.HIDDEN);
-		primaryContext.getReferenceContext().importObject(fd);
-		secondaryContext.getReferenceContext().importObject(fd);
-		SourceFileLoader.processFactDefinitions(primaryContext);
-		SourceFileLoader.processFactDefinitions(secondaryContext);
 	}
 
 	@Override
@@ -187,4 +177,20 @@ public class FactLstTest extends AbstractGlobalTokenTestCase
 	{
 		return ConsolidationRule.OVERWRITE;
 	}
+
+	@Override
+	protected void additionalSetup(LoadContext context)
+	{
+		super.additionalSetup(context);
+		FactDefinition fd = new FactDefinition();
+		fd.setName("DOMAIN.Possibility");
+		fd.setFactName("Possibility");
+		fd.setUsableLocation(Domain.class);
+		fd.setFormatManager(new StringManager());
+		fd.setVisibility(Visibility.HIDDEN);
+		context.getReferenceContext().importObject(fd);
+		SourceFileLoader.processFactDefinitions(context);
+	}
+	
+	
 }

--- a/code/src/utest/plugin/lsttokens/FactSetLstTest.java
+++ b/code/src/utest/plugin/lsttokens/FactSetLstTest.java
@@ -47,16 +47,6 @@ public class FactSetLstTest extends AbstractGlobalTokenTestCase
 	{
 		TokenRegistration.clearTokens();
 		super.setUp();
-		FactSetDefinition fd = new FactSetDefinition();
-		fd.setName("DEITY.Possibility");
-		fd.setFactSetName("Possibility");
-		fd.setUsableLocation(Domain.class);
-		fd.setFormatManager(new StringManager());
-		fd.setVisibility(Visibility.HIDDEN);
-		primaryContext.getReferenceContext().importObject(fd);
-		secondaryContext.getReferenceContext().importObject(fd);
-		SourceFileLoader.processFactDefinitions(primaryContext);
-		SourceFileLoader.processFactDefinitions(secondaryContext);
 	}
 
 	@Override
@@ -181,4 +171,20 @@ public class FactSetLstTest extends AbstractGlobalTokenTestCase
 	{
 		return strings -> new String[] { "Possibility|TestWP1|TestWP2" };
 	}
+
+	@Override
+	protected void additionalSetup(LoadContext context)
+	{
+		super.additionalSetup(context);
+		FactSetDefinition fd = new FactSetDefinition();
+		fd.setName("DEITY.Possibility");
+		fd.setFactSetName("Possibility");
+		fd.setUsableLocation(Domain.class);
+		fd.setFormatManager(new StringManager());
+		fd.setVisibility(Visibility.HIDDEN);
+		context.getReferenceContext().importObject(fd);
+		SourceFileLoader.processFactDefinitions(context);
+	}
+	
+	
 }

--- a/code/src/utest/plugin/lsttokens/ModifyLstTest.java
+++ b/code/src/utest/plugin/lsttokens/ModifyLstTest.java
@@ -27,6 +27,7 @@ import pcgen.cdom.base.CDOMObject;
 import pcgen.core.Campaign;
 import pcgen.core.PCTemplate;
 import pcgen.persistence.PersistenceLayerException;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.testsupport.AbstractGlobalTokenTestCase;
@@ -45,13 +46,6 @@ public class ModifyLstTest extends AbstractGlobalTokenTestCase
 		super.setUp();
 		TokenRegistration.register(new plugin.modifier.number.AddModifierFactory());
 		TokenRegistration.register(new plugin.modifier.number.MultiplyModifierFactory());
-		FormatManager<?> formatManager = primaryContext.getReferenceContext().getFormatManager("NUMBER");
-		LegalScope pscope = primaryContext.getActiveScope();
-		LegalScope sscope = primaryContext.getActiveScope();
-		primaryContext.getVariableContext().assertLegalVariableID(pscope, formatManager, "MyVar");
-		secondaryContext.getVariableContext().assertLegalVariableID(sscope, formatManager, "MyVar");
-		primaryContext.getVariableContext().assertLegalVariableID(pscope, formatManager, "OtherVar");
-		secondaryContext.getVariableContext().assertLegalVariableID(sscope, formatManager, "OtherVar");
 	}
 
 	@Override
@@ -233,4 +227,15 @@ public class ModifyLstTest extends AbstractGlobalTokenTestCase
 	{
 		return ConsolidationRule.SEPARATE;
 	}
+
+	@Override
+	protected void additionalSetup(LoadContext context)
+	{
+		super.additionalSetup(context);
+		FormatManager<?> formatManager = context.getReferenceContext().getFormatManager("NUMBER");
+		LegalScope scope = context.getActiveScope();
+		context.getVariableContext().assertLegalVariableID(scope, formatManager, "MyVar");
+		context.getVariableContext().assertLegalVariableID(scope, formatManager, "OtherVar");
+	}
+
 }

--- a/code/src/utest/plugin/lsttokens/ModifyOtherLstTest.java
+++ b/code/src/utest/plugin/lsttokens/ModifyOtherLstTest.java
@@ -27,6 +27,7 @@ import pcgen.cdom.base.CDOMObject;
 import pcgen.core.Campaign;
 import pcgen.core.PCTemplate;
 import pcgen.persistence.PersistenceLayerException;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.testsupport.AbstractGlobalTokenTestCase;
@@ -45,13 +46,6 @@ public class ModifyOtherLstTest extends AbstractGlobalTokenTestCase
 		super.setUp();
 		TokenRegistration.register(new plugin.modifier.number.AddModifierFactory());
 		TokenRegistration.register(new plugin.modifier.number.MultiplyModifierFactory());
-		FormatManager<?> formatManager = primaryContext.getReferenceContext().getFormatManager("NUMBER");
-		LegalScope pscope = primaryContext.getActiveScope();
-		LegalScope sscope = primaryContext.getActiveScope();
-		primaryContext.getVariableContext().assertLegalVariableID(pscope, formatManager, "MyVar");
-		secondaryContext.getVariableContext().assertLegalVariableID(sscope, formatManager, "MyVar");
-		primaryContext.getVariableContext().assertLegalVariableID(pscope, formatManager, "OtherVar");
-		secondaryContext.getVariableContext().assertLegalVariableID(sscope, formatManager, "OtherVar");
 	}
 
 	@Override
@@ -265,5 +259,15 @@ public class ModifyOtherLstTest extends AbstractGlobalTokenTestCase
 	protected ConsolidationRule getConsolidationRule()
 	{
 		return ConsolidationRule.SEPARATE;
+	}
+
+	@Override
+	protected void additionalSetup(LoadContext context)
+	{
+		super.additionalSetup(context);
+		FormatManager<?> formatManager = context.getReferenceContext().getFormatManager("NUMBER");
+		LegalScope scope = context.getActiveScope();
+		context.getVariableContext().assertLegalVariableID(scope, formatManager, "MyVar");
+		context.getVariableContext().assertLegalVariableID(scope, formatManager, "OtherVar");
 	}
 }

--- a/code/src/utest/plugin/lsttokens/QualifyTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/QualifyTokenTest.java
@@ -17,8 +17,6 @@
  */
 package plugin.lsttokens;
 
-import java.net.URISyntaxException;
-
 import org.junit.Test;
 
 import pcgen.cdom.base.CDOMObject;
@@ -28,6 +26,7 @@ import pcgen.core.EquipmentModifier;
 import pcgen.core.PCTemplate;
 import pcgen.core.spell.Spell;
 import pcgen.persistence.PersistenceLayerException;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.testsupport.AbstractGlobalTokenTestCase;
@@ -40,19 +39,6 @@ public class QualifyTokenTest extends AbstractGlobalTokenTestCase
 
 	static CDOMPrimaryToken<CDOMObject> token = new QualifyToken();
 	static CDOMTokenLoader<PCTemplate> loader = new CDOMTokenLoader<>();
-
-	@Override
-	public void setUp() throws PersistenceLayerException, URISyntaxException
-	{
-		super.setUp();
-		//Dummy builds to ensure initialization
-		Ability a = BuildUtilities.getFeatCat().newInstance();
-		a.setName("Dummy");
-		primaryContext.getReferenceContext().importObject(a);
-		a = BuildUtilities.getFeatCat().newInstance();
-		a.setName("Dummy");
-		secondaryContext.getReferenceContext().importObject(a);
-	}
 
 	@Override
 	public CDOMLoader<PCTemplate> getLoader()
@@ -243,4 +229,15 @@ public class QualifyTokenTest extends AbstractGlobalTokenTestCase
 	{
 		return ConsolidationRule.SEPARATE;
 	}
+
+	@Override
+	protected void additionalSetup(LoadContext context)
+	{
+		super.additionalSetup(context);
+		Ability a = BuildUtilities.getFeatCat().newInstance();
+		a.setName("Dummy");
+		context.getReferenceContext().importObject(a);
+	}
+	
+	
 }

--- a/code/src/utest/plugin/lsttokens/ability/AddspelllevelTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/ability/AddspelllevelTokenTest.java
@@ -19,6 +19,7 @@ package plugin.lsttokens.ability;
 
 import pcgen.cdom.enumeration.IntegerKey;
 import pcgen.core.Ability;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.testsupport.AbstractIntegerTokenTestCase;
@@ -74,20 +75,11 @@ public class AddspelllevelTokenTest extends AbstractIntegerTokenTestCase<Ability
 	}
 
 	@Override
-	protected Ability getSecondary(String name)
+	protected Ability get(LoadContext context, String name)
 	{
 		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
-		secondaryContext.getReferenceContext().importObject(a);
-		return a;
-	}
-
-	@Override
-	protected Ability getPrimary(String name)
-	{
-		Ability a = BuildUtilities.getFeatCat().newInstance();
-		a.setName(name);
-		primaryContext.getReferenceContext().importObject(a);
+		context.getReferenceContext().importObject(a);
 		return a;
 	}
 }

--- a/code/src/utest/plugin/lsttokens/ability/AspectTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/ability/AspectTokenTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 
 import pcgen.core.Ability;
 import pcgen.persistence.PersistenceLayerException;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.testsupport.AbstractCDOMTokenTestCase;
@@ -158,20 +159,11 @@ public class AspectTokenTest extends AbstractCDOMTokenTestCase<Ability>
 	}
 
 	@Override
-	protected Ability getSecondary(String name)
+	protected Ability get(LoadContext context, String name)
 	{
 		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
-		secondaryContext.getReferenceContext().importObject(a);
-		return a;
-	}
-
-	@Override
-	protected Ability getPrimary(String name)
-	{
-		Ability a = BuildUtilities.getFeatCat().newInstance();
-		a.setName(name);
-		primaryContext.getReferenceContext().importObject(a);
+		context.getReferenceContext().importObject(a);
 		return a;
 	}
 }

--- a/code/src/utest/plugin/lsttokens/ability/BenefitTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/ability/BenefitTokenTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import pcgen.core.Ability;
 import pcgen.persistence.PersistenceLayerException;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.testsupport.AbstractCDOMTokenTestCase;
@@ -188,20 +189,11 @@ public class BenefitTokenTest extends AbstractCDOMTokenTestCase<Ability>
 	}
 
 	@Override
-	protected Ability getSecondary(String name)
+	protected Ability get(LoadContext context, String name)
 	{
 		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
-		secondaryContext.getReferenceContext().importObject(a);
-		return a;
-	}
-
-	@Override
-	protected Ability getPrimary(String name)
-	{
-		Ability a = BuildUtilities.getFeatCat().newInstance();
-		a.setName(name);
-		primaryContext.getReferenceContext().importObject(a);
+		context.getReferenceContext().importObject(a);
 		return a;
 	}
 }

--- a/code/src/utest/plugin/lsttokens/ability/CostTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/ability/CostTokenTest.java
@@ -21,6 +21,7 @@ import java.math.BigDecimal;
 
 import pcgen.cdom.enumeration.ObjectKey;
 import pcgen.core.Ability;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.testsupport.AbstractBigDecimalTokenTestCase;
@@ -82,20 +83,11 @@ public class CostTokenTest extends AbstractBigDecimalTokenTestCase<Ability>
 	}
 
 	@Override
-	protected Ability getSecondary(String name)
+	protected Ability get(LoadContext context, String name)
 	{
 		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
-		secondaryContext.getReferenceContext().importObject(a);
-		return a;
-	}
-
-	@Override
-	protected Ability getPrimary(String name)
-	{
-		Ability a = BuildUtilities.getFeatCat().newInstance();
-		a.setName(name);
-		primaryContext.getReferenceContext().importObject(a);
+		context.getReferenceContext().importObject(a);
 		return a;
 	}
 }

--- a/code/src/utest/plugin/lsttokens/ability/MultTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/ability/MultTokenTest.java
@@ -19,6 +19,7 @@ package plugin.lsttokens.ability;
 
 import pcgen.cdom.enumeration.ObjectKey;
 import pcgen.core.Ability;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.testsupport.AbstractYesNoTokenTestCase;
@@ -56,20 +57,11 @@ public class MultTokenTest extends AbstractYesNoTokenTestCase<Ability>
 	}
 
 	@Override
-	protected Ability getSecondary(String name)
+	protected Ability get(LoadContext context, String name)
 	{
 		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
-		secondaryContext.getReferenceContext().importObject(a);
-		return a;
-	}
-
-	@Override
-	protected Ability getPrimary(String name)
-	{
-		Ability a = BuildUtilities.getFeatCat().newInstance();
-		a.setName(name);
-		primaryContext.getReferenceContext().importObject(a);
+		context.getReferenceContext().importObject(a);
 		return a;
 	}
 }

--- a/code/src/utest/plugin/lsttokens/ability/StackTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/ability/StackTokenTest.java
@@ -19,6 +19,7 @@ package plugin.lsttokens.ability;
 
 import pcgen.cdom.enumeration.ObjectKey;
 import pcgen.core.Ability;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.testsupport.AbstractYesNoTokenTestCase;
@@ -56,20 +57,11 @@ public class StackTokenTest extends AbstractYesNoTokenTestCase<Ability>
 	}
 
 	@Override
-	protected Ability getSecondary(String name)
+	protected Ability get(LoadContext context, String name)
 	{
 		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
-		secondaryContext.getReferenceContext().importObject(a);
-		return a;
-	}
-
-	@Override
-	protected Ability getPrimary(String name)
-	{
-		Ability a = BuildUtilities.getFeatCat().newInstance();
-		a.setName(name);
-		primaryContext.getReferenceContext().importObject(a);
+		context.getReferenceContext().importObject(a);
 		return a;
 	}
 }

--- a/code/src/utest/plugin/lsttokens/ability/VisibleTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/ability/VisibleTokenTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import pcgen.cdom.enumeration.ObjectKey;
 import pcgen.core.Ability;
 import pcgen.persistence.PersistenceLayerException;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import pcgen.util.enumeration.Visibility;
@@ -197,22 +198,11 @@ public class VisibleTokenTest extends AbstractCDOMTokenTestCase<Ability>
 	}
 
 	@Override
-	protected Ability getSecondary(String name)
+	protected Ability get(LoadContext context, String name)
 	{
 		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
-		secondaryContext.getReferenceContext().importObject(a);
+		context.getReferenceContext().importObject(a);
 		return a;
 	}
-
-	@Override
-	protected Ability getPrimary(String name)
-	{
-		Ability a = BuildUtilities.getFeatCat().newInstance();
-		a.setName(name);
-		primaryContext.getReferenceContext().importObject(a);
-		return a;
-	}
-	
-	
 }

--- a/code/src/utest/plugin/lsttokens/add/AbilityTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/add/AbilityTokenTest.java
@@ -64,8 +64,6 @@ public class AbilityTokenTest extends AbstractCDOMTokenTestCase<CDOMObject>
 	{
 		super.setUp();
 		TokenRegistration.register(getSubToken());
-		construct(primaryContext, "Dummy");
-		construct(secondaryContext, "Dummy");
 	}
 
 	@Override
@@ -977,5 +975,12 @@ public class AbilityTokenTest extends AbstractCDOMTokenTestCase<CDOMObject>
 		primaryProf.addToListFor(ListKey.ADD, tc);
 		String[] unparsed = getToken().unparse(primaryContext, primaryProf);
 		expectSingle(unparsed, getSubTokenName() + '|' + "3|FEAT|VIRTUAL|STACKS=2,TestWP1");
+	}
+
+	@Override
+	protected void additionalSetup(LoadContext context)
+	{
+		super.additionalSetup(context);
+		construct(context, "Dummy");
 	}
 }

--- a/code/src/utest/plugin/lsttokens/campaign/ForwardrefTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/campaign/ForwardrefTokenTest.java
@@ -17,8 +17,6 @@
  */
 package plugin.lsttokens.campaign;
 
-import java.net.URISyntaxException;
-
 import org.junit.Test;
 
 import pcgen.core.Ability;
@@ -39,19 +37,6 @@ public class ForwardrefTokenTest extends AbstractCDOMTokenTestCase<Campaign>
 
 	static CDOMPrimaryToken<Campaign> token = new ForwardRefToken();
 	static CDOMTokenLoader<Campaign> loader = new CDOMTokenLoader<>();
-
-	@Override
-	public void setUp() throws PersistenceLayerException, URISyntaxException
-	{
-		super.setUp();
-		//Dummy items to ensure Category is initialized
-		Ability a = BuildUtilities.getFeatCat().newInstance();
-		a.setName("Dummy");
-		primaryContext.getReferenceContext().importObject(a);
-		Ability b = BuildUtilities.getFeatCat().newInstance();
-		b.setName("Dummy");
-		secondaryContext.getReferenceContext().importObject(b);
-	}
 
 	@Override
 	public CDOMLoader<Campaign> getLoader()
@@ -241,4 +226,13 @@ public class ForwardrefTokenTest extends AbstractCDOMTokenTestCase<Campaign>
 		context.getReferenceContext().importObject(a);
 	}
 
+	@Override
+	protected void additionalSetup(LoadContext context)
+	{
+		super.additionalSetup(context);
+		//Dummy items to ensure Category is initialized
+		Ability a = BuildUtilities.getFeatCat().newInstance();
+		a.setName("Dummy");
+		context.getReferenceContext().importObject(a);
+	}
 }

--- a/code/src/utest/plugin/lsttokens/campaign/LicenseTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/campaign/LicenseTokenTest.java
@@ -18,7 +18,6 @@
 package plugin.lsttokens.campaign;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.List;
 
 import org.junit.Test;
@@ -26,6 +25,7 @@ import org.junit.Test;
 import pcgen.cdom.enumeration.ListKey;
 import pcgen.core.Campaign;
 import pcgen.persistence.PersistenceLayerException;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.testsupport.AbstractCDOMTokenTestCase;
@@ -60,15 +60,6 @@ public class LicenseTokenTest extends AbstractCDOMTokenTestCase<Campaign>
 	public static ListKey<?> getListKey()
 	{
 		return ListKey.LICENSE;
-	}
-
-	@Override
-	public void setUp() throws PersistenceLayerException, URISyntaxException
-	{
-		super.setUp();
-		URI uri = TestURI.getURI();
-		primaryContext.setSourceURI(uri);
-		secondaryContext.setSourceURI(uri);
 	}
 
 	@Test
@@ -327,5 +318,13 @@ public class LicenseTokenTest extends AbstractCDOMTokenTestCase<Campaign>
 	protected ConsolidationRule getConsolidationRule()
 	{
 		return ConsolidationRule.SEPARATE;
+	}
+
+	@Override
+	protected void additionalSetup(LoadContext context)
+	{
+		super.additionalSetup(context);
+		URI uri = TestURI.getURI();
+		context.setSourceURI(uri);
 	}
 }

--- a/code/src/utest/plugin/lsttokens/choose/AbilitySelectionTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/choose/AbilitySelectionTokenTest.java
@@ -17,8 +17,6 @@
  */
 package plugin.lsttokens.choose;
 
-import java.net.URISyntaxException;
-
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.base.Category;
 import pcgen.cdom.base.Loadable;
@@ -40,19 +38,6 @@ import plugin.qualifier.ability.PCToken;
 public class AbilitySelectionTokenTest extends
 		AbstractChooseTokenTestCase<CDOMObject, Ability>
 {
-
-	@Override
-	public void setUp() throws PersistenceLayerException, URISyntaxException
-	{
-		super.setUp();
-		primaryContext.getReferenceContext().constructCDOMObject(AbilityCategory.class,
-			"Special Ability");
-		secondaryContext.getReferenceContext().constructCDOMObject(AbilityCategory.class,
-			"Special Ability");
-		//Build dummy objects so the ReferenceContext is properly initialized
-		construct(primaryContext, "Dummy");
-		construct(secondaryContext, "Dummy");
-	}
 
 	static ChooseLst token = new ChooseLst();
 	static AbilitySelectionToken subtoken = new AbilitySelectionToken();
@@ -152,20 +137,23 @@ public class AbilitySelectionTokenTest extends
 	}
 
 	@Override
-	protected Ability getSecondary(String name)
+	protected Ability get(LoadContext context, String name)
 	{
 		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
-		secondaryContext.getReferenceContext().importObject(a);
+		context.getReferenceContext().importObject(a);
 		return a;
 	}
 
 	@Override
-	protected Ability getPrimary(String name)
+	protected void additionalSetup(LoadContext context)
 	{
-		Ability a = BuildUtilities.getFeatCat().newInstance();
-		a.setName(name);
-		primaryContext.getReferenceContext().importObject(a);
-		return a;
+		super.additionalSetup(context);
+		context.getReferenceContext().constructCDOMObject(AbilityCategory.class,
+			"Special Ability");
+		//Build dummy objects so the ReferenceContext is properly initialized
+		construct(context, "Dummy");
 	}
+	
+	
 }

--- a/code/src/utest/plugin/lsttokens/choose/AbilityTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/choose/AbilityTokenTest.java
@@ -17,8 +17,6 @@
  */
 package plugin.lsttokens.choose;
 
-import java.net.URISyntaxException;
-
 import org.junit.Test;
 
 import pcgen.cdom.base.CDOMObject;
@@ -46,19 +44,6 @@ public class AbilityTokenTest extends
 	static ChooseLst token = new ChooseLst();
 	static AbilityToken subtoken = new AbilityToken();
 	static CDOMTokenLoader<CDOMObject> loader = new CDOMTokenLoader<>();
-
-	@Override
-	public void setUp() throws PersistenceLayerException, URISyntaxException
-	{
-		super.setUp();
-		primaryContext.getReferenceContext().constructCDOMObject(AbilityCategory.class,
-				"Special Ability");
-		secondaryContext.getReferenceContext().constructCDOMObject(AbilityCategory.class,
-				"Special Ability");
-		//We build dummy objects so that BuildUtilities.getFeatCat() has been loaded properly
-		construct(primaryContext, "Dummy");
-		construct(secondaryContext, "Dummy");
-	}
 
 	@Override
 	public Class<Ability> getCDOMClass()
@@ -158,21 +143,22 @@ public class AbilityTokenTest extends
 	}
 
 	@Override
-	protected Ability getSecondary(String name)
+	protected Ability get(LoadContext context, String name)
 	{
 		Ability a = BuildUtilities.getFeatCat().newInstance();
 		a.setName(name);
-		secondaryContext.getReferenceContext().importObject(a);
+		context.getReferenceContext().importObject(a);
 		return a;
 	}
 
 	@Override
-	protected Ability getPrimary(String name)
+	protected void additionalSetup(LoadContext context)
 	{
-		Ability a = BuildUtilities.getFeatCat().newInstance();
-		a.setName(name);
-		primaryContext.getReferenceContext().importObject(a);
-		return a;
+		super.additionalSetup(context);
+		context.getReferenceContext().constructCDOMObject(AbilityCategory.class,
+			"Special Ability");
+		//Build dummy objects so the ReferenceContext is properly initialized
+		construct(context, "Dummy");
 	}
 }
 

--- a/code/src/utest/plugin/lsttokens/equipment/IconTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/equipment/IconTokenTest.java
@@ -17,12 +17,16 @@
  */
 package plugin.lsttokens.equipment;
 
+import java.net.URI;
+
 import pcgen.cdom.enumeration.StringKey;
 import pcgen.core.Equipment;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.testsupport.AbstractStringTokenTestCase;
 import plugin.lsttokens.testsupport.CDOMTokenLoader;
+import util.TestURI;
 
 /**
  * The Class {@code IconTokenTest} tests the equipment ICON token.
@@ -62,4 +66,11 @@ public class IconTokenTest extends AbstractStringTokenTestCase<Equipment>
 		return false;
 	}
 
+	@Override
+	protected void additionalSetup(LoadContext context)
+	{
+		super.additionalSetup(context);
+		URI uri = TestURI.getURI();
+		context.setSourceURI(uri);
+	}
 }

--- a/code/src/utest/plugin/lsttokens/equipment/WieldTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/equipment/WieldTokenTest.java
@@ -17,8 +17,6 @@
  */
 package plugin.lsttokens.equipment;
 
-import java.net.URISyntaxException;
-
 import org.junit.Test;
 
 import pcgen.cdom.enumeration.ObjectKey;
@@ -26,6 +24,7 @@ import pcgen.core.Equipment;
 import pcgen.core.character.WieldCategory;
 import pcgen.persistence.GameModeFileLoader;
 import pcgen.persistence.PersistenceLayerException;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.testsupport.AbstractCDOMTokenTestCase;
@@ -41,13 +40,18 @@ public class WieldTokenTest extends AbstractCDOMTokenTestCase<Equipment>
 	static CDOMTokenLoader<Equipment> loader = new CDOMTokenLoader<>();
 
 	@Override
-	public void setUp() throws PersistenceLayerException, URISyntaxException
+	protected void resetContext()
 	{
-		super.setUp();
-		TokenRegistration.register(new PreVariableParser());
-		TokenRegistration.register(new PreVariableWriter());
-		GameModeFileLoader.addDefaultWieldCategories(primaryContext);
-		GameModeFileLoader.addDefaultWieldCategories(secondaryContext);
+		try
+		{
+			TokenRegistration.register(new PreVariableParser());
+			TokenRegistration.register(new PreVariableWriter());
+		}
+		catch (PersistenceLayerException e)
+		{
+			fail(e.getLocalizedMessage());
+		}
+		super.resetContext();
 	}
 
 	@Override
@@ -161,6 +165,20 @@ public class WieldTokenTest extends AbstractCDOMTokenTestCase<Equipment>
 		catch (ClassCastException e)
 		{
 			// Yep!
+		}
+	}
+
+	@Override
+	protected void additionalSetup(LoadContext context)
+	{
+		super.additionalSetup(context);
+		try
+		{
+			GameModeFileLoader.addDefaultWieldCategories(context);
+		}
+		catch (PersistenceLayerException e)
+		{
+			fail(e.getLocalizedMessage());
 		}
 	}
 }

--- a/code/src/utest/plugin/lsttokens/pcclass/level/AddDomainsTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/pcclass/level/AddDomainsTokenTest.java
@@ -28,6 +28,7 @@ import pcgen.cdom.inst.PCClassLevel;
 import pcgen.core.Domain;
 import pcgen.core.PCClass;
 import pcgen.persistence.PersistenceLayerException;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.testsupport.AbstractListContextTokenTestCase;
@@ -54,19 +55,12 @@ public class AddDomainsTokenTest extends
 		TokenRegistration.register(preracewriter);
 	}
 
-	private final PCClass primClass = new PCClass();
-	private final PCClass secClass = new PCClass();
-
 	@Override
-	protected PCClassLevel getPrimary(String name)
+	protected PCClassLevel get(LoadContext context, String name)
 	{
-		return primClass.getOriginalClassLevel(1);
-	}
-
-	@Override
-	protected PCClassLevel getSecondary(String name)
-	{
-		return secClass.getOriginalClassLevel(1);
+		PCClass pcc = context.getReferenceContext().constructNowIfNecessary(PCClass.class,
+			"Cl");
+		return pcc.getOriginalClassLevel(1);
 	}
 
 	@Override

--- a/code/src/utest/plugin/lsttokens/pcclass/level/DomainTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/pcclass/level/DomainTokenTest.java
@@ -32,6 +32,7 @@ import pcgen.core.QualifiedObject;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.prereq.PreParserFactory;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.testsupport.AbstractListTokenTestCase;
@@ -58,19 +59,12 @@ public class DomainTokenTest extends AbstractListTokenTestCase<PCClassLevel, Dom
 		TokenRegistration.register(preracewriter);
 	}
 
-	private final PCClass primClass = new PCClass();
-	private final PCClass secClass = new PCClass();
-	
 	@Override
-	protected PCClassLevel getPrimary(String name)
+	protected PCClassLevel get(LoadContext context, String name)
 	{
-		return primClass.getOriginalClassLevel(1);
-	}
-
-	@Override
-	protected PCClassLevel getSecondary(String name)
-	{
-		return secClass.getOriginalClassLevel(1);
+		PCClass pcc = context.getReferenceContext().constructNowIfNecessary(PCClass.class,
+			"Cl");
+		return pcc.getOriginalClassLevel(1);
 	}
 
 	@Override

--- a/code/src/utest/plugin/lsttokens/race/FaceTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/race/FaceTokenTest.java
@@ -27,6 +27,7 @@ import pcgen.base.util.FormatManager;
 import pcgen.cdom.enumeration.ListKey;
 import pcgen.core.Race;
 import pcgen.persistence.PersistenceLayerException;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import pcgen.rules.persistence.token.ModifierFactory;
@@ -49,10 +50,6 @@ public class FaceTokenTest extends AbstractCDOMTokenTestCase<Race>
 	{
 		super.setUp();
 		TokenRegistration.register(m);
-		primaryContext.getVariableContext().assertLegalVariableID(
-			primaryContext.getActiveScope(), opManager, "Face");
-		secondaryContext.getVariableContext().assertLegalVariableID(
-			secondaryContext.getActiveScope(), opManager, "Face");
 	}
 
 	@Override
@@ -177,4 +174,14 @@ public class FaceTokenTest extends AbstractCDOMTokenTestCase<Race>
 	{
 		return ConsolidationRule.OVERWRITE;
 	}
+
+	@Override
+	protected void additionalSetup(LoadContext context)
+	{
+		super.additionalSetup(context);
+		context.getVariableContext().assertLegalVariableID(
+			context.getActiveScope(), opManager, "Face");
+	}
+	
+	
 }

--- a/code/src/utest/plugin/lsttokens/subclass/ChoiceTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/subclass/ChoiceTokenTest.java
@@ -24,6 +24,7 @@ import pcgen.cdom.enumeration.SubClassCategory;
 import pcgen.core.SpellProhibitor;
 import pcgen.core.SubClass;
 import pcgen.persistence.PersistenceLayerException;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import pcgen.util.enumeration.ProhibitedSpellType;
@@ -225,22 +226,12 @@ public class ChoiceTokenTest extends AbstractCDOMTokenTestCase<SubClass>
 	}
 
 	@Override
-	protected SubClass getSecondary(String name)
+	protected SubClass get(LoadContext context, String name)
 	{
 		SubClassCategory scc = SubClassCategory.getConstant("SCC");
 		SubClass sc = scc.newInstance();
 		sc.setName(name);
-		secondaryContext.getReferenceContext().importObject(sc);
-		return sc;
-	}
-
-	@Override
-	protected SubClass getPrimary(String name)
-	{
-		SubClassCategory scc = SubClassCategory.getConstant("SCC");
-		SubClass sc = scc.newInstance();
-		sc.setName(name);
-		primaryContext.getReferenceContext().importObject(sc);
+		context.getReferenceContext().importObject(sc);
 		return sc;
 	}
 }

--- a/code/src/utest/plugin/lsttokens/subclass/CostTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/subclass/CostTokenTest.java
@@ -20,6 +20,7 @@ package plugin.lsttokens.subclass;
 import pcgen.cdom.enumeration.IntegerKey;
 import pcgen.cdom.enumeration.SubClassCategory;
 import pcgen.core.SubClass;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.testsupport.AbstractIntegerTokenTestCase;
@@ -74,22 +75,12 @@ public class CostTokenTest extends AbstractIntegerTokenTestCase<SubClass>
 	}
 
 	@Override
-	protected SubClass getSecondary(String name)
+	protected SubClass get(LoadContext context, String name)
 	{
 		SubClassCategory scc = SubClassCategory.getConstant("SCC");
 		SubClass sc = scc.newInstance();
 		sc.setName(name);
-		secondaryContext.getReferenceContext().importObject(sc);
-		return sc;
-	}
-
-	@Override
-	protected SubClass getPrimary(String name)
-	{
-		SubClassCategory scc = SubClassCategory.getConstant("SCC");
-		SubClass sc = scc.newInstance();
-		sc.setName(name);
-		primaryContext.getReferenceContext().importObject(sc);
+		context.getReferenceContext().importObject(sc);
 		return sc;
 	}
 }

--- a/code/src/utest/plugin/lsttokens/subclass/ProhibitcostTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/subclass/ProhibitcostTokenTest.java
@@ -20,6 +20,7 @@ package plugin.lsttokens.subclass;
 import pcgen.cdom.enumeration.IntegerKey;
 import pcgen.cdom.enumeration.SubClassCategory;
 import pcgen.core.SubClass;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.testsupport.AbstractIntegerTokenTestCase;
@@ -75,22 +76,12 @@ public class ProhibitcostTokenTest extends
 	}
 
 	@Override
-	protected SubClass getSecondary(String name)
+	protected SubClass get(LoadContext context, String name)
 	{
 		SubClassCategory scc = SubClassCategory.getConstant("SCC");
 		SubClass sc = scc.newInstance();
 		sc.setName(name);
-		secondaryContext.getReferenceContext().importObject(sc);
-		return sc;
-	}
-
-	@Override
-	protected SubClass getPrimary(String name)
-	{
-		SubClassCategory scc = SubClassCategory.getConstant("SCC");
-		SubClass sc = scc.newInstance();
-		sc.setName(name);
-		primaryContext.getReferenceContext().importObject(sc);
+		context.getReferenceContext().importObject(sc);
 		return sc;
 	}
 }

--- a/code/src/utest/plugin/lsttokens/template/FaceTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/template/FaceTokenTest.java
@@ -27,6 +27,7 @@ import pcgen.base.util.FormatManager;
 import pcgen.cdom.enumeration.ListKey;
 import pcgen.core.PCTemplate;
 import pcgen.persistence.PersistenceLayerException;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import pcgen.rules.persistence.token.ModifierFactory;
@@ -49,10 +50,6 @@ public class FaceTokenTest extends AbstractCDOMTokenTestCase<PCTemplate>
 	{
 		super.setUp();
 		TokenRegistration.register(m);
-		primaryContext.getVariableContext().assertLegalVariableID(
-			primaryContext.getActiveScope(), opManager, "Face");
-		secondaryContext.getVariableContext().assertLegalVariableID(
-			secondaryContext.getActiveScope(), opManager, "Face");
 	}
 
 	@Override
@@ -175,5 +172,13 @@ public class FaceTokenTest extends AbstractCDOMTokenTestCase<PCTemplate>
 	protected ConsolidationRule getConsolidationRule()
 	{
 		return ConsolidationRule.OVERWRITE;
+	}
+
+	@Override
+	protected void additionalSetup(LoadContext context)
+	{
+		super.additionalSetup(context);
+		context.getVariableContext().assertLegalVariableID(
+			context.getActiveScope(), opManager, "Face");
 	}
 }

--- a/code/src/utest/plugin/lsttokens/testsupport/AbstractCampaignTokenTestCase.java
+++ b/code/src/utest/plugin/lsttokens/testsupport/AbstractCampaignTokenTestCase.java
@@ -18,13 +18,13 @@
 package plugin.lsttokens.testsupport;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 
 import org.junit.Test;
 
 import pcgen.cdom.enumeration.ListKey;
 import pcgen.core.Campaign;
 import pcgen.persistence.PersistenceLayerException;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import util.TestURI;
 
@@ -42,15 +42,6 @@ public abstract class AbstractCampaignTokenTestCase extends
 	public Character getSeparator()
 	{
 		return null;
-	}
-
-	@Override
-	public void setUp() throws PersistenceLayerException, URISyntaxException
-	{
-		super.setUp();
-		URI uri = TestURI.getURI();
-		primaryContext.setSourceURI(uri);
-		secondaryContext.setSourceURI(uri);
 	}
 
 	@Test
@@ -280,5 +271,13 @@ public abstract class AbstractCampaignTokenTestCase extends
 	protected ConsolidationRule getConsolidationRule()
 	{
 		return ConsolidationRule.SEPARATE;
+	}
+
+	@Override
+	protected void additionalSetup(LoadContext context)
+	{
+		super.additionalSetup(context);
+		URI uri = TestURI.getURI();
+		context.setSourceURI(uri);
 	}
 }

--- a/code/src/utest/plugin/lsttokens/variable/GlobalTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/variable/GlobalTokenTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 
 import pcgen.cdom.content.DatasetVariable;
 import pcgen.persistence.PersistenceLayerException;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import pcgen.rules.persistence.token.ParseResult;
@@ -191,13 +192,7 @@ public class GlobalTokenTest extends AbstractTokenTestCase<DatasetVariable>
 	}
 
 	@Override
-	protected DatasetVariable getPrimary(String name)
-	{
-		return new DatasetVariable();
-	}
-
-	@Override
-	protected DatasetVariable getSecondary(String name)
+	protected DatasetVariable get(LoadContext context, String name)
 	{
 		return new DatasetVariable();
 	}

--- a/code/src/utest/plugin/lsttokens/variable/LocalTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/variable/LocalTokenTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 
 import pcgen.cdom.content.DatasetVariable;
 import pcgen.persistence.PersistenceLayerException;
+import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import pcgen.rules.persistence.token.ParseResult;
@@ -227,13 +228,7 @@ public class LocalTokenTest extends AbstractTokenTestCase<DatasetVariable>
 	}
 
 	@Override
-	protected DatasetVariable getPrimary(String name)
-	{
-		return new DatasetVariable();
-	}
-
-	@Override
-	protected DatasetVariable getSecondary(String name)
+	protected DatasetVariable get(LoadContext context, String name)
 	{
 		return new DatasetVariable();
 	}

--- a/code/src/utest/plugin/qualifier/ability/PCQualifierTokenTest.java
+++ b/code/src/utest/plugin/qualifier/ability/PCQualifierTokenTest.java
@@ -46,9 +46,6 @@ public class PCQualifierTokenTest extends
 	{
 		super.setUp();
 		TokenRegistration.register(PC_TOKEN);
-		//Dummy to ensure initialization
-		construct(primaryContext, "Dummy");
-		construct(secondaryContext, "Dummy");
 	}
 
 	@Override
@@ -105,4 +102,14 @@ public class PCQualifierTokenTest extends
 	{
 		return construct(loadContext, name);
 	}
+
+	@Override
+	protected void additionalSetup(LoadContext context)
+	{
+		super.additionalSetup(context);
+		//Dummy to ensure initialization
+		construct(context, "Dummy");
+	}
+	
+	
 }


### PR DESCRIPTION
This is an additional "memory leak check" set of forcing on tokens to ensure they are not capturing the LoadContext (since that is "inappropriate")
