### PR TITLE
Reduce usage of hard-coded AbilityCategory.FEAT

### DIFF
--- a/code/src/java/pcgen/cdom/content/AbilitySelection.java
+++ b/code/src/java/pcgen/cdom/content/AbilitySelection.java
@@ -25,10 +25,12 @@ import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.base.Constants;
 import pcgen.cdom.base.Reducible;
 import pcgen.cdom.enumeration.ObjectKey;
+import pcgen.cdom.reference.ReferenceManufacturer;
 import pcgen.core.Ability;
 import pcgen.core.AbilityCategory;
 import pcgen.core.AbilityUtilities;
 import pcgen.core.SettingsHandler;
+import pcgen.rules.context.AbstractReferenceContext;
 import pcgen.rules.context.LoadContext;
 
 public class AbilitySelection extends Selection<Ability, String> implements
@@ -129,8 +131,12 @@ public class AbilitySelection extends Selection<Ability, String> implements
 	private static AbilitySelection decodeFeatSelectionChoice(
 		LoadContext context, String persistentFormat)
 	{
-		Ability ability = context.getReferenceContext()
-			.getManufacturerId(AbilityCategory.FEAT).getActiveObject(persistentFormat);
+		AbstractReferenceContext referenceContext = context.getReferenceContext();
+		AbilityCategory featCategory =
+				referenceContext.get(AbilityCategory.class, "FEAT");
+		ReferenceManufacturer<Ability> featManufacturer =
+				referenceContext.getManufacturerId(featCategory);
+		Ability ability = featManufacturer.getActiveObject(persistentFormat);
 
 		if (ability == null)
 		{
@@ -138,8 +144,7 @@ public class AbilitySelection extends Selection<Ability, String> implements
 			String baseKey =
 					AbilityUtilities.getUndecoratedName(persistentFormat,
 						choices);
-			ability = context.getReferenceContext()
-				.getManufacturerId(AbilityCategory.FEAT).getActiveObject(baseKey);
+			ability = featManufacturer.getActiveObject(baseKey);
 			if (ability == null)
 			{
 				throw new IllegalArgumentException("String in decodeChoice "

--- a/code/src/java/pcgen/core/Globals.java
+++ b/code/src/java/pcgen/core/Globals.java
@@ -681,17 +681,20 @@ public final class Globals
 		{
 			Logging.log(logLevel, "Number of objects loaded. The following should "
 				+ "all be greater than 0:");
-			Logging.log(logLevel, "Races=" + getContext().getReferenceContext().getConstructedCDOMObjects(Race.class).size());
-			Logging.log(logLevel, "Classes=" + getContext().getReferenceContext().getConstructedCDOMObjects(PCClass.class).size());
-			Logging.log(logLevel, "Skills=" + getContext().getReferenceContext().getConstructedCDOMObjects(Skill.class).size());
-			Logging.log(logLevel, "Feats=" + getContext().getReferenceContext()
-				.getManufacturerId(AbilityCategory.FEAT).getConstructedObjectCount());
-			Logging.log(logLevel, "Equipment=" + getContext().getReferenceContext().getConstructedCDOMObjects(Equipment.class).size());
-			Logging.log(logLevel, "ArmorProfs=" + getContext().getReferenceContext().getConstructedCDOMObjects(ArmorProf.class).size());
-			Logging.log(logLevel, "ShieldProfs=" + getContext().getReferenceContext().getConstructedCDOMObjects(ShieldProf.class).size());
-			Logging.log(logLevel, "WeaponProfs=" + getContext().getReferenceContext().getConstructedCDOMObjects(WeaponProf.class).size());
-			Logging.log(logLevel, "Kits=" + getContext().getReferenceContext().getConstructedCDOMObjects(Kit.class).size());
-			Logging.log(logLevel, "Templates=" + getContext().getReferenceContext().getConstructedCDOMObjects(PCTemplate.class).size());
+			AbstractReferenceContext referenceContext = getContext().getReferenceContext();
+			Logging.log(logLevel, "Races=" + referenceContext.getConstructedCDOMObjects(Race.class).size());
+			Logging.log(logLevel, "Classes=" + referenceContext.getConstructedCDOMObjects(PCClass.class).size());
+			Logging.log(logLevel, "Skills=" + referenceContext.getConstructedCDOMObjects(Skill.class).size());
+			AbilityCategory featCategory =
+					referenceContext.get(AbilityCategory.class, "FEAT");
+			Logging.log(logLevel, "Feats=" + referenceContext
+				.getManufacturerId(featCategory).getConstructedObjectCount());
+			Logging.log(logLevel, "Equipment=" + referenceContext.getConstructedCDOMObjects(Equipment.class).size());
+			Logging.log(logLevel, "ArmorProfs=" + referenceContext.getConstructedCDOMObjects(ArmorProf.class).size());
+			Logging.log(logLevel, "ShieldProfs=" + referenceContext.getConstructedCDOMObjects(ShieldProf.class).size());
+			Logging.log(logLevel, "WeaponProfs=" + referenceContext.getConstructedCDOMObjects(WeaponProf.class).size());
+			Logging.log(logLevel, "Kits=" + referenceContext.getConstructedCDOMObjects(Kit.class).size());
+			Logging.log(logLevel, "Templates=" + referenceContext.getConstructedCDOMObjects(PCTemplate.class).size());
 		}
 		return listsHappy;
 	}

--- a/code/src/java/pcgen/core/Globals.java
+++ b/code/src/java/pcgen/core/Globals.java
@@ -682,19 +682,28 @@ public final class Globals
 			Logging.log(logLevel, "Number of objects loaded. The following should "
 				+ "all be greater than 0:");
 			AbstractReferenceContext referenceContext = getContext().getReferenceContext();
-			Logging.log(logLevel, "Races=" + referenceContext.getConstructedCDOMObjects(Race.class).size());
-			Logging.log(logLevel, "Classes=" + referenceContext.getConstructedCDOMObjects(PCClass.class).size());
-			Logging.log(logLevel, "Skills=" + referenceContext.getConstructedCDOMObjects(Skill.class).size());
+			Logging.log(logLevel,
+				"Races=" + referenceContext.getConstructedCDOMObjects(Race.class).size());
+			Logging.log(logLevel, "Classes="
+				+ referenceContext.getConstructedCDOMObjects(PCClass.class).size());
+			Logging.log(logLevel, "Skills="
+				+ referenceContext.getConstructedCDOMObjects(Skill.class).size());
 			AbilityCategory featCategory =
 					referenceContext.get(AbilityCategory.class, "FEAT");
 			Logging.log(logLevel, "Feats=" + referenceContext
 				.getManufacturerId(featCategory).getConstructedObjectCount());
-			Logging.log(logLevel, "Equipment=" + referenceContext.getConstructedCDOMObjects(Equipment.class).size());
-			Logging.log(logLevel, "ArmorProfs=" + referenceContext.getConstructedCDOMObjects(ArmorProf.class).size());
-			Logging.log(logLevel, "ShieldProfs=" + referenceContext.getConstructedCDOMObjects(ShieldProf.class).size());
-			Logging.log(logLevel, "WeaponProfs=" + referenceContext.getConstructedCDOMObjects(WeaponProf.class).size());
-			Logging.log(logLevel, "Kits=" + referenceContext.getConstructedCDOMObjects(Kit.class).size());
-			Logging.log(logLevel, "Templates=" + referenceContext.getConstructedCDOMObjects(PCTemplate.class).size());
+			Logging.log(logLevel, "Equipment="
+				+ referenceContext.getConstructedCDOMObjects(Equipment.class).size());
+			Logging.log(logLevel, "ArmorProfs="
+				+ referenceContext.getConstructedCDOMObjects(ArmorProf.class).size());
+			Logging.log(logLevel, "ShieldProfs="
+				+ referenceContext.getConstructedCDOMObjects(ShieldProf.class).size());
+			Logging.log(logLevel, "WeaponProfs="
+				+ referenceContext.getConstructedCDOMObjects(WeaponProf.class).size());
+			Logging.log(logLevel,
+				"Kits=" + referenceContext.getConstructedCDOMObjects(Kit.class).size());
+			Logging.log(logLevel, "Templates="
+				+ referenceContext.getConstructedCDOMObjects(PCTemplate.class).size());
 		}
 		return listsHappy;
 	}

--- a/code/src/java/pcgen/core/term/PCCountAbilitiesTypeNatureVirtualTermEvaluator.java
+++ b/code/src/java/pcgen/core/term/PCCountAbilitiesTypeNatureVirtualTermEvaluator.java
@@ -47,7 +47,7 @@ public class PCCountAbilitiesTypeNatureVirtualTermEvaluator
 	@Override
 	Collection<CNAbility> getAbilities(PlayerCharacter pc)
 	{
-		return pc.getPoolAbilities(AbilityCategory.FEAT, Nature.VIRTUAL);
+		return pc.getPoolAbilities(abCat, Nature.VIRTUAL);
 	}
 
 	@Override

--- a/code/src/java/pcgen/persistence/lst/FeatLoader.java
+++ b/code/src/java/pcgen/persistence/lst/FeatLoader.java
@@ -26,6 +26,7 @@ import pcgen.core.Ability;
 import pcgen.core.AbilityCategory;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.SystemLoader;
+import pcgen.rules.context.AbstractReferenceContext;
 import pcgen.rules.context.LoadContext;
 import pcgen.util.Logging;
 
@@ -43,13 +44,16 @@ public final class FeatLoader extends AbilityLoader
 	{
 		Ability feat = aFeat;
 
+		AbstractReferenceContext referenceContext = context.getReferenceContext();
+		AbilityCategory featCategory =
+				referenceContext.get(AbilityCategory.class, "FEAT");
 		if (feat == null)
 		{
 			feat = new Ability();
 			int tabLoc = lstLine.indexOf(SystemLoader.TAB_DELIM);
 			String name = tabLoc == -1 ? lstLine : lstLine.substring(0, tabLoc);
 			feat.setName(name.intern());
-			feat.setCDOMCategory(AbilityCategory.FEAT);
+			feat.setCDOMCategory(featCategory);
 			context.addStatefulInformation(feat);
 			context.getReferenceContext().importObject(feat);
 		}
@@ -82,9 +86,11 @@ public final class FeatLoader extends AbilityLoader
 	 */
 	private void loadDefaultFeats(LoadContext context, CampaignSourceEntry firstSource)
 	{
-		Ability wpFeat =
-				context.getReferenceContext().getManufacturerId(AbilityCategory.FEAT)
-					.getActiveObject(Constants.INTERNAL_WEAPON_PROF);
+		AbstractReferenceContext referenceContext = context.getReferenceContext();
+		AbilityCategory featCategory =
+				referenceContext.get(AbilityCategory.class, "FEAT");
+		Ability wpFeat = referenceContext.getManufacturerId(featCategory)
+			.getActiveObject(Constants.INTERNAL_WEAPON_PROF);
 		if (wpFeat == null)
 		{
 
@@ -120,8 +126,10 @@ public final class FeatLoader extends AbilityLoader
 	@Override
 	protected Ability getObjectKeyed(LoadContext context, final String aKey)
 	{
-		return context.getReferenceContext().getManufacturerId(AbilityCategory.FEAT)
-			.getActiveObject(aKey);
+		AbstractReferenceContext referenceContext = context.getReferenceContext();
+		AbilityCategory featCategory =
+				referenceContext.get(AbilityCategory.class, "FEAT");
+		return referenceContext.getManufacturerId(featCategory).getActiveObject(aKey);
 	}
 	
 	@Override

--- a/code/src/java/plugin/lsttokens/kit/spells/SpellsToken.java
+++ b/code/src/java/plugin/lsttokens/kit/spells/SpellsToken.java
@@ -50,7 +50,6 @@ public class SpellsToken extends AbstractNonEmptyToken<KitSpells> implements
 		CDOMPrimaryToken<KitSpells>
 {
 	private static final Class<Spell> SPELL_CLASS = Spell.class;
-	private static final Class<Ability> ABILITY_CLASS = Ability.class;
 
 	/**
 	 * Gets the name of the tag this class will parse.
@@ -111,7 +110,7 @@ public class SpellsToken extends AbstractNonEmptyToken<KitSpells> implements
 					else if (className.equalsIgnoreCase("Default"))
 					{
 						pr.addWarningMessage("Use of Default for CLASS= in KIT "
-										+ "SPELLS line is unnecessary: Ignoring");
+							+ "SPELLS line is unnecessary: Ignoring");
 					}
 					else
 					{

--- a/code/src/java/plugin/lsttokens/kit/spells/SpellsToken.java
+++ b/code/src/java/plugin/lsttokens/kit/spells/SpellsToken.java
@@ -35,6 +35,7 @@ import pcgen.core.Globals;
 import pcgen.core.PCClass;
 import pcgen.core.kit.KitSpells;
 import pcgen.core.spell.Spell;
+import pcgen.rules.context.AbstractReferenceContext;
 import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.TokenUtilities;
 import pcgen.rules.persistence.token.AbstractNonEmptyToken;
@@ -91,78 +92,84 @@ public class SpellsToken extends AbstractNonEmptyToken<KitSpells> implements
 				}
 				kitSpell.setSpellBook(spellBook);
 			}
-			else if (field.startsWith(Constants.LST_CLASS_EQUAL))
+			else
 			{
-				if (kitSpell.getCastingClass() != null)
+				AbstractReferenceContext refContext = context.getReferenceContext();
+				if (field.startsWith(Constants.LST_CLASS_EQUAL))
 				{
-					return new ParseResult.Fail("Cannot reset CLASS" + " in SPELLS: "
-							+ value);
-				}
-				String className = field.substring(6);
-				if (className.isEmpty())
-				{
-					return new ParseResult.Fail("Cannot set CLASS "
-							+ "to empty value in SPELLS: " + value);
-				}
-				else if (className.equalsIgnoreCase("Default"))
-				{
-					pr.addWarningMessage("Use of Default for CLASS= in KIT "
-									+ "SPELLS line is unnecessary: Ignoring");
+					if (kitSpell.getCastingClass() != null)
+					{
+						return new ParseResult.Fail("Cannot reset CLASS" + " in SPELLS: "
+								+ value);
+					}
+					String className = field.substring(6);
+					if (className.isEmpty())
+					{
+						return new ParseResult.Fail("Cannot set CLASS "
+								+ "to empty value in SPELLS: " + value);
+					}
+					else if (className.equalsIgnoreCase("Default"))
+					{
+						pr.addWarningMessage("Use of Default for CLASS= in KIT "
+										+ "SPELLS line is unnecessary: Ignoring");
+					}
+					else
+					{
+						kitSpell.setCastingClass(
+							refContext.getCDOMReference(PCClass.class, className));
+					}
 				}
 				else
 				{
-					kitSpell.setCastingClass(context.getReferenceContext().getCDOMReference(
-							PCClass.class, className));
-				}
-			}
-			else
-			{
-				int count = 1;
-				int equalLoc = field.indexOf(Constants.EQUALS);
-				if (equalLoc != -1)
-				{
-					String countStr = field.substring(equalLoc + 1);
-					try
+					int count = 1;
+					int equalLoc = field.indexOf(Constants.EQUALS);
+					if (equalLoc != -1)
 					{
-						count = Integer.parseInt(countStr);
+						String countStr = field.substring(equalLoc + 1);
+						try
+						{
+							count = Integer.parseInt(countStr);
+						}
+						catch (NumberFormatException e)
+						{
+							return new ParseResult.Fail("Expected an Integer COUNT,"
+									+ " but found: " + countStr + " in " + value);
+						}
+						field = field.substring(0, equalLoc);
 					}
-					catch (NumberFormatException e)
+					if (field.isEmpty())
 					{
-						return new ParseResult.Fail("Expected an Integer COUNT,"
-								+ " but found: " + countStr + " in " + value);
+						return new ParseResult.Fail("Expected an Spell in SPELLS"
+								+ " but found: " + value);
 					}
-					field = field.substring(0, equalLoc);
-				}
-				if (field.isEmpty())
-				{
-					return new ParseResult.Fail("Expected an Spell in SPELLS"
-							+ " but found: " + value);
-				}
-				StringTokenizer subTok = new StringTokenizer(field, "[]");
-				String filterString = subTok.nextToken();
+					StringTokenizer subTok = new StringTokenizer(field, "[]");
+					String filterString = subTok.nextToken();
 
-				// must satisfy all elements in a comma delimited list
-				CDOMReference<Spell> sp = null;
+					// must satisfy all elements in a comma delimited list
+					CDOMReference<Spell> sp = null;
 
-				sp = TokenUtilities.getTypeOrPrimitive(context, SPELL_CLASS,
-						filterString);
-				if (sp == null)
-				{
-					return new ParseResult.Fail("  encountered Invalid limit in "
-							+ getTokenName() + ": " + value);
+					sp = TokenUtilities.getTypeOrPrimitive(context, SPELL_CLASS,
+							filterString);
+					if (sp == null)
+					{
+						return new ParseResult.Fail("  encountered Invalid limit in "
+								+ getTokenName() + ": " + value);
+					}
+
+					KnownSpellIdentifier ksi = new KnownSpellIdentifier(sp, null);
+
+					ArrayList<CDOMSingleRef<Ability>> featList = new ArrayList<>();
+					while (subTok.hasMoreTokens())
+					{
+						String featName = subTok.nextToken();
+						AbilityCategory featCategory =
+								refContext.get(AbilityCategory.class, "FEAT");
+						CDOMSingleRef<Ability> feat = refContext
+							.getManufacturerId(featCategory).getReference(featName);
+						featList.add(feat);
+					}
+					kitSpell.addSpell(ksi, featList, count);
 				}
-
-				KnownSpellIdentifier ksi = new KnownSpellIdentifier(sp, null);
-
-				ArrayList<CDOMSingleRef<Ability>> featList = new ArrayList<>();
-				while (subTok.hasMoreTokens())
-				{
-					String featName = subTok.nextToken();
-					CDOMSingleRef<Ability> feat = context.getReferenceContext()
-						.getManufacturerId(AbilityCategory.FEAT).getReference(featName);
-					featList.add(feat);
-				}
-				kitSpell.addSpell(ksi, featList, count);
 			}
 		}
 		if (kitSpell.getSpellBook() == null)


### PR DESCRIPTION
In non-deprecated places where LoadContext is already available, use it
to indirectly look up the FEAT AbilityCategory.

Fixes one item in a term as well where the AbilityCategory is available
and it was incorrectly hardcoded to FEAT.