### PR TITLE
Interface Tokens

### DIFF
--- a/code/src/itest/tokencontent/testsupport/AbstractContentTokenTest.java
+++ b/code/src/itest/tokencontent/testsupport/AbstractContentTokenTest.java
@@ -32,6 +32,7 @@ import pcgen.core.Ability;
 import pcgen.core.Campaign;
 import pcgen.core.Deity;
 import pcgen.core.Domain;
+import pcgen.core.Equipment;
 import pcgen.core.EquipmentModifier;
 import pcgen.core.PCCheck;
 import pcgen.core.PCClass;
@@ -174,6 +175,8 @@ public abstract class AbstractContentTokenTest extends AbstractTokenModelTest
 	public void testFromEqMod() throws PersistenceLayerException
 	{
 		EquipmentModifier source = create(EquipmentModifier.class, "Source");
+		Equipment e = create(Equipment.class, "Parent");
+		source.setVariableParent(e);
 		processToken(source);
 		assertEquals(baseCount(), targetFacetCount());
 		activeEqModFacet.add(id, source, this);

--- a/code/src/itest/tokencontent/testsupport/AbstractContentTokenTest.java
+++ b/code/src/itest/tokencontent/testsupport/AbstractContentTokenTest.java
@@ -175,8 +175,8 @@ public abstract class AbstractContentTokenTest extends AbstractTokenModelTest
 	public void testFromEqMod() throws PersistenceLayerException
 	{
 		EquipmentModifier source = create(EquipmentModifier.class, "Source");
-		Equipment e = create(Equipment.class, "Parent");
-		source.setVariableParent(e);
+		Equipment equipment = create(Equipment.class, "Parent");
+		source.setVariableParent(equipment);
 		processToken(source);
 		assertEquals(baseCount(), targetFacetCount());
 		activeEqModFacet.add(id, source, this);

--- a/code/src/itest/tokenmodel/testsupport/AbstractGrantedListTokenTest.java
+++ b/code/src/itest/tokenmodel/testsupport/AbstractGrantedListTokenTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.list.CompanionList;
 import pcgen.core.Campaign;
+import pcgen.core.Equipment;
 import pcgen.core.EquipmentModifier;
 import pcgen.core.PCCheck;
 import pcgen.core.PCStat;
@@ -104,6 +105,8 @@ public abstract class AbstractGrantedListTokenTest<T extends CDOMObject>
 	public void testFromEqMod() throws PersistenceLayerException
 	{
 		EquipmentModifier source = create(EquipmentModifier.class, "Source");
+		Equipment e = create(Equipment.class, "Parent");
+		source.setVariableParent(e);
 		T granted = createGrantedObject();
 		processToken(source);
 		assertEquals(0, getCount());

--- a/code/src/itest/tokenmodel/testsupport/AbstractTokenModelTest.java
+++ b/code/src/itest/tokenmodel/testsupport/AbstractTokenModelTest.java
@@ -24,7 +24,6 @@ import pcgen.cdom.base.FormulaFactory;
 import pcgen.cdom.base.Loadable;
 import pcgen.cdom.content.fact.FactDefinition;
 import pcgen.cdom.enumeration.CharID;
-import pcgen.cdom.enumeration.ListKey;
 import pcgen.cdom.enumeration.ObjectKey;
 import pcgen.cdom.enumeration.VariableKey;
 import pcgen.cdom.facet.DirectAbilityFacet;
@@ -254,7 +253,7 @@ public abstract class AbstractTokenModelTest extends TestCase
 		AbstractReferenceContext ref = Globals.getContext().getReferenceContext();
 		GlobalModifiers mods = ref.constructNowIfNecessary(GlobalModifiers.class,
 			GlobalModifierLoader.GLOBAL_MODIFIERS);
-		mods.addToListFor(ListKey.GRANTEDVARS, ChannelUtilities.createVarName("AlignmentInput"));
+		mods.addGrantedVariable(ChannelUtilities.createVarName("AlignmentInput"));
 		lg = BuildUtilities.createAlignment("Lawful Good", "LG");
 		ref.importObject(lg);
 		ln = BuildUtilities.createAlignment("Lawful Neutral", "LN");

--- a/code/src/java/pcgen/cdom/base/CDOMObject.java
+++ b/code/src/java/pcgen/cdom/base/CDOMObject.java
@@ -37,6 +37,8 @@ import pcgen.base.util.DoubleKeyMapToList;
 import pcgen.base.util.Indirect;
 import pcgen.base.util.MapToList;
 import pcgen.base.util.ObjectContainer;
+import pcgen.cdom.content.RemoteModifier;
+import pcgen.cdom.content.VarModifier;
 import pcgen.cdom.enumeration.FactKey;
 import pcgen.cdom.enumeration.FactSetKey;
 import pcgen.cdom.enumeration.FormulaKey;
@@ -56,8 +58,13 @@ import pcgen.core.analysis.BonusActivation;
 import pcgen.core.bonus.BonusObj;
 
 public abstract class CDOMObject extends ConcretePrereqObject implements
-		Cloneable, BonusContainer, Loadable, Reducible, VarScoped
+		Cloneable, BonusContainer, Loadable, Reducible, VarScoped, VarHolder
 {
+
+	/**
+	 * An Empty String array to support VarHolder
+	 */
+	private static final String[] EMPTY_STRING_ARRAY = new String[0];
 
 	private URI sourceURI = null;
 	
@@ -1260,4 +1267,52 @@ public abstract class CDOMObject extends ConcretePrereqObject implements
 		}
 		return false;
 	}
+
+	/*
+	 * Begin implementation of methods for VarHolder interface
+	 */
+	@Override
+	public void addModifier(VarModifier<?> vm)
+	{
+		addToListFor(ListKey.MODIFY, vm);
+	}
+
+	@Override
+	public VarModifier<?>[] getModifierArray()
+	{
+		List<VarModifier<?>> list = getListFor(ListKey.MODIFY);
+		return (list == null) ? VarModifier.EMPTY_VARMODIFIER
+			: list.toArray(new VarModifier[list.size()]);
+	}
+
+	@Override
+	public void addRemoteModifier(RemoteModifier<?> vm)
+	{
+		addToListFor(ListKey.REMOTE_MODIFIER, vm);
+	}
+
+	@Override
+	public RemoteModifier<?>[] getRemoteModifierArray()
+	{
+		List<RemoteModifier<?>> list = getListFor(ListKey.REMOTE_MODIFIER);
+		return (list == null) ? RemoteModifier.EMPTY_REMOTEMODIFIER
+			: list.toArray(new RemoteModifier[list.size()]);
+	}
+
+	@Override
+	public void addGrantedVariable(String variableName)
+	{
+		addToListFor(ListKey.GRANTEDVARS, variableName);
+	}
+
+	@Override
+	public String[] getGrantedVariableArray()
+	{
+		List<String> list = getListFor(ListKey.GRANTEDVARS);
+		return (list == null) ? EMPTY_STRING_ARRAY
+			: list.toArray(new String[list.size()]);
+	}
+	/*
+	 * End implementation of methods supporting VarHolder.
+	 */
 }

--- a/code/src/java/pcgen/cdom/base/VarContainer.java
+++ b/code/src/java/pcgen/cdom/base/VarContainer.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Thomas Parker, 2018.
+ * 
+ * This program is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 51 Franklin Street,
+ * Fifth Floor, Boston, MA 02110-1301, USA
+ */
+package pcgen.cdom.base;
+
+import pcgen.cdom.content.RemoteModifier;
+import pcgen.cdom.content.VarModifier;
+
+/**
+ * A VarContainer is an object that can contain Modifiers.
+ */
+public interface VarContainer
+{
+	/**
+	 * Returns an array of the local VarModifiers in this VarContainer.
+	 * 
+	 * @return An array of the local VarModifiers in this VarContainer
+	 */
+	public VarModifier<?>[] getModifierArray();
+
+	/**
+	 * Returns an array of the remote RemoteModifiers in this VarContainer.
+	 * 
+	 * @return An array of the remote RemoteModifiers in this VarContainer
+	 */
+	public RemoteModifier<?>[] getRemoteModifierArray();
+
+	/**
+	 * Returns an array of the granted (Global) variables in this VarContainer.
+	 * 
+	 * @return An array of the granted (Global) variables in this VarContainer
+	 */
+	public String[] getGrantedVariableArray();
+}

--- a/code/src/java/pcgen/cdom/base/VarHolder.java
+++ b/code/src/java/pcgen/cdom/base/VarHolder.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Thomas Parker, 2018.
+ * 
+ * This program is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 51 Franklin Street,
+ * Fifth Floor, Boston, MA 02110-1301, USA
+ */
+package pcgen.cdom.base;
+
+import pcgen.cdom.content.RemoteModifier;
+import pcgen.cdom.content.VarModifier;
+
+/**
+ * A VarHolder is a (writeable) object that holds Modifiers.
+ */
+public interface VarHolder extends VarContainer
+{
+	/**
+	 * Adds a new local Modifier to this VarContainer.
+	 * 
+	 * @param varModifier
+	 *            The VarModifier to be added to this VarContainer.
+	 */
+	public void addModifier(VarModifier<?> varModifier);
+
+	/**
+	 * Adds a new RemoteModifier to this VarContainer.
+	 * 
+	 * @param remoteModifier
+	 *            The RemoteModifier to be added to this VarContainer.
+	 */
+	public void addRemoteModifier(RemoteModifier<?> remoteModifier);
+
+	/**
+	 * Adds a new variable that will grant objects.
+	 * 
+	 * @param variableName
+	 *            The (Global) variable name that will indicate granted objects
+	 */
+	public void addGrantedVariable(String variableName);
+
+}

--- a/code/src/java/pcgen/cdom/content/RemoteModifier.java
+++ b/code/src/java/pcgen/cdom/content/RemoteModifier.java
@@ -38,6 +38,12 @@ public class RemoteModifier<MT>
 {
 
 	/**
+	 * This is an empty array of RemoteModifier objects, available for use by a
+	 * VarContainer.
+	 */
+	public static final RemoteModifier<?>[] EMPTY_REMOTEMODIFIER = new RemoteModifier[0];
+
+	/**
 	 * The VarModifier indicating the variable to which the Modifier should be
 	 * applied.
 	 */

--- a/code/src/java/pcgen/cdom/content/VarModifier.java
+++ b/code/src/java/pcgen/cdom/content/VarModifier.java
@@ -33,6 +33,11 @@ import pcgen.cdom.formula.scope.PCGenScope;
  */
 public class VarModifier<T>
 {
+	/**
+	 * This is an empty array of VarModifier objects, available for use by a
+	 * VarContainer.
+	 */
+	public static final VarModifier<?>[] EMPTY_VARMODIFIER = new VarModifier[0];
 
 	/**
 	 * The name of the Variable to be modified when this VarModifier is applied.

--- a/code/src/java/pcgen/cdom/facet/GrantedVarFacet.java
+++ b/code/src/java/pcgen/cdom/facet/GrantedVarFacet.java
@@ -56,18 +56,18 @@ public class GrantedVarFacet extends AbstractSourcedListFacet<CharID, CDOMObject
 	public void dataAdded(DataFacetChangeEvent<CharID, CDOMObject> dfce)
 	{
 		CDOMObject cdo = dfce.getCDOMObject();
-		String[] list = cdo.getGrantedVariableArray();
-		if (list.length == 0)
+		String[] grantedVariables = cdo.getGrantedVariableArray();
+		if (grantedVariables.length == 0)
 		{
 			return;
 		}
 		Object source = dfce.getSource();
 		CharID id = dfce.getCharID();
 		ScopeInstance inst = scopeFacet.get(id, cdo);
-		for (String s : list)
+		for (String VariableName : grantedVariables)
 		{
 			VariableID<?> varID = loadContextFacet.get(id.getDatasetID()).get()
-				.getVariableContext().getVariableID(inst, s);
+				.getVariableContext().getVariableID(inst, VariableName);
 			processAdd(id, varID, source);
 		}
 	}

--- a/code/src/java/pcgen/cdom/facet/GrantedVarFacet.java
+++ b/code/src/java/pcgen/cdom/facet/GrantedVarFacet.java
@@ -15,13 +15,10 @@
  */
 package pcgen.cdom.facet;
 
-import java.util.Collection;
-
 import pcgen.base.formula.base.ScopeInstance;
 import pcgen.base.formula.base.VariableID;
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.enumeration.CharID;
-import pcgen.cdom.enumeration.ListKey;
 import pcgen.cdom.facet.base.AbstractSourcedListFacet;
 import pcgen.cdom.facet.event.DataFacetChangeEvent;
 import pcgen.cdom.facet.event.DataFacetChangeListener;
@@ -59,18 +56,19 @@ public class GrantedVarFacet extends AbstractSourcedListFacet<CharID, CDOMObject
 	public void dataAdded(DataFacetChangeEvent<CharID, CDOMObject> dfce)
 	{
 		CDOMObject cdo = dfce.getCDOMObject();
-		Collection<String> list = cdo.getListFor(ListKey.GRANTEDVARS);
-		Object source = dfce.getSource();
-		if (list != null)
+		String[] list = cdo.getGrantedVariableArray();
+		if (list.length == 0)
 		{
-			CharID id = dfce.getCharID();
-			ScopeInstance inst = scopeFacet.get(id, cdo);
-			for (String s : list)
-			{
-				VariableID<?> varID = loadContextFacet.get(id.getDatasetID()).get()
-						.getVariableContext().getVariableID(inst, s);
-				processAdd(id, varID, source);
-			}
+			return;
+		}
+		Object source = dfce.getSource();
+		CharID id = dfce.getCharID();
+		ScopeInstance inst = scopeFacet.get(id, cdo);
+		for (String s : list)
+		{
+			VariableID<?> varID = loadContextFacet.get(id.getDatasetID()).get()
+				.getVariableContext().getVariableID(inst, s);
+			processAdd(id, varID, source);
 		}
 	}
 
@@ -102,18 +100,15 @@ public class GrantedVarFacet extends AbstractSourcedListFacet<CharID, CDOMObject
 	public void dataRemoved(DataFacetChangeEvent<CharID, CDOMObject> dfce)
 	{
 		CDOMObject cdo = dfce.getCDOMObject();
-		Collection<String> list = cdo.getListFor(ListKey.GRANTEDVARS);
+		String[] list = cdo.getGrantedVariableArray();
 		Object source = dfce.getSource();
-		if (list != null)
+		CharID id = dfce.getCharID();
+		ScopeInstance inst = scopeFacet.get(id, cdo);
+		for (String s : list)
 		{
-			CharID id = dfce.getCharID();
-			ScopeInstance inst = scopeFacet.get(id, cdo);
-			for (String s : list)
-			{
-				VariableID<?> varID = loadContextFacet.get(id.getDatasetID()).get()
-						.getVariableContext().getVariableID(inst, s);
-				processRemove(id, varID, source);
-			}
+			VariableID<?> varID = loadContextFacet.get(id.getDatasetID()).get()
+				.getVariableContext().getVariableID(inst, s);
+			processRemove(id, varID, source);
 		}
 	}
 

--- a/code/src/java/pcgen/cdom/inst/GlobalModifiers.java
+++ b/code/src/java/pcgen/cdom/inst/GlobalModifiers.java
@@ -39,9 +39,9 @@ public class GlobalModifiers extends CDOMObject
 	public boolean equals(Object o)
 	{
 		if (o instanceof GlobalModifiers)
-		{
+	{
 			return isCDOMEqual((CDOMObject) o);
-		}
+	}
 		return false;
 	}
 

--- a/code/src/java/pcgen/core/Equipment.java
+++ b/code/src/java/pcgen/core/Equipment.java
@@ -40,6 +40,8 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import org.apache.commons.lang3.StringUtils;
+
 import pcgen.base.formula.Formula;
 import pcgen.base.formula.base.VarScoped;
 import pcgen.base.lang.StringUtil;
@@ -95,10 +97,8 @@ import pcgen.util.enumeration.Load;
 import pcgen.util.enumeration.View;
 import pcgen.util.enumeration.Visibility;
 
-import org.apache.commons.lang3.StringUtils;
-
-public final class Equipment extends PObject implements Serializable,
-		Comparable<Object>, VariableContainer, EquipmentFacade, VarScoped
+public final class Equipment extends PObject implements Serializable, Comparable<Object>,
+		VariableContainer, EquipmentFacade, VarScoped
 {
 
 	private static final long serialVersionUID = 1;

--- a/code/src/java/pcgen/core/EquipmentModifier.java
+++ b/code/src/java/pcgen/core/EquipmentModifier.java
@@ -44,7 +44,8 @@ import pcgen.util.Delta;
 /**
  * Definition and games rules for an equipment modifier.
  */
-public final class EquipmentModifier extends PObject implements Comparable<Object>, EquipModFacade, Cloneable
+public final class EquipmentModifier extends PObject
+		implements Comparable<Object>, EquipModFacade, Cloneable
 {
 	private static final String PERCENT_CHOICE_PATTERN = Pattern
 								.quote(Constants.LST_PERCENT_CHOICE);

--- a/code/src/java/pcgen/persistence/SourceFileLoader.java
+++ b/code/src/java/pcgen/persistence/SourceFileLoader.java
@@ -731,7 +731,7 @@ public class SourceFileLoader extends PCGenTask implements Observer
 				GlobalModifiers modifiers =
 						context.getReferenceContext().constructNowIfNecessary(
 							GlobalModifiers.class, GlobalModifierLoader.GLOBAL_MODIFIERS);
-				modifiers.addToListFor(ListKey.GRANTEDVARS, varName);
+				modifiers.addGrantedVariable(varName);
 			}
 		}
 	}

--- a/code/src/java/pcgen/rules/context/LoadContext.java
+++ b/code/src/java/pcgen/rules/context/LoadContext.java
@@ -209,7 +209,7 @@ public interface LoadContext
 	 * will be run if commit() is called or forgotten with no action if rollback() is
 	 * called.
 	 * 
-	 * @param commitTask
+	 * @param controller
 	 *            The DeferredMethodController to be added to this LoadContext
 	 */
 	public void addDeferredMethodController(DeferredMethodController<?> controller);

--- a/code/src/java/pcgen/rules/context/LoadContext.java
+++ b/code/src/java/pcgen/rules/context/LoadContext.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.List;
 
 import pcgen.base.formula.inst.NEPFormula;
+import pcgen.base.proxy.DeferredMethodController;
 import pcgen.base.util.FormatManager;
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.base.CDOMReference;
@@ -129,7 +130,17 @@ public interface LoadContext
 
 	public <T> String[] unparseSubtoken(T cdo, String tokenName);
 
-	public <T> Collection<String> unparse(T cdo);
+	/**
+	 * Unparses the given Object into a Collection of String objects, for each token that
+	 * would be on the object.
+	 * 
+	 * @param loadable
+	 *            The loadable object to be unparsed into the tokens used to persist the
+	 *            object
+	 * @return A Collection of Strings representing the tokens that are part of the
+	 *         persistent format of the given Loadable
+	 */
+	public <T extends Loadable> Collection<String> unparse(T loadable);
 
 	/*
 	 * Output Messages
@@ -192,4 +203,14 @@ public interface LoadContext
 	 */
 	public <T> NEPFormula<T> getValidFormula(FormatManager<T> formatManager,
 		String instructions);
+
+	/**
+	 * Adds a DeferredMethodController to this LoadContext. This DeferredMethodController
+	 * will be run if commit() is called or forgotten with no action if rollback() is
+	 * called.
+	 * 
+	 * @param commitTask
+	 *            The DeferredMethodController to be added to this LoadContext
+	 */
+	public void addDeferredMethodController(DeferredMethodController<?> controller);
 }

--- a/code/src/java/pcgen/rules/persistence/TokenLibrary.java
+++ b/code/src/java/pcgen/rules/persistence/TokenLibrary.java
@@ -627,8 +627,8 @@ public final class TokenLibrary implements PluginLoader
 	 * Returns the CDOMInterfaceToken of the given name. null is returned if there is no
 	 * CDOMInterfaceToken of the given name.
 	 * 
-	 * @param The
-	 *            name of the CDOMInterfaceToken to be returned
+	 * @param name
+	 *            The name of the CDOMInterfaceToken to be returned
 	 * @return The CDOMInterfaceToken of the given name
 	 */
 	public static CDOMInterfaceToken<?, ?> getInterfaceToken(String name)

--- a/code/src/java/pcgen/rules/persistence/TokenLibrary.java
+++ b/code/src/java/pcgen/rules/persistence/TokenLibrary.java
@@ -19,8 +19,11 @@ package pcgen.rules.persistence;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.TreeSet;
@@ -38,6 +41,7 @@ import pcgen.persistence.lst.LstToken;
 import pcgen.persistence.lst.prereq.PreMultParser;
 import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 import pcgen.rules.persistence.token.CDOMCompatibilityToken;
+import pcgen.rules.persistence.token.CDOMInterfaceToken;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import pcgen.rules.persistence.token.CDOMSecondaryToken;
 import pcgen.rules.persistence.token.CDOMSubToken;
@@ -69,6 +73,12 @@ public final class TokenLibrary implements PluginLoader
             new DoubleKeyMap<>();
 	private static final DoubleKeyMap<Class<?>, String, ModifierFactory<?>> modifierMap =
             new DoubleKeyMap<>();
+	
+	/**
+	 * Contains the interface tokens mapped by the token name.
+	 */
+	private static final Map<String, CDOMInterfaceToken<?, ?>> IF_TOKEN_MAP =
+			new HashMap<>();
 	private static final Set<TokenFamily> TOKEN_FAMILIES = new TreeSet<>();
 	private static final CaseInsensitiveMap<Class<? extends BonusObj>> BONUS_TAG_MAP =
             new CaseInsensitiveMap<>();
@@ -217,6 +227,20 @@ public final class TokenLibrary implements PluginLoader
 				CDOMCompatibilityToken<PCClass> clTok =
 						(CDOMCompatibilityToken<PCClass>) tok;
 				addToTokenMap(new ClassWrappedToken(clTok));
+			}
+		}
+		if (newToken instanceof CDOMInterfaceToken)
+		{
+			CDOMInterfaceToken<?, ?> tok = (CDOMInterfaceToken<?, ?>) newToken;
+			CDOMInterfaceToken<?, ?> existingToken =
+					IF_TOKEN_MAP.put(tok.getTokenName(), tok);
+			if (existingToken != null)
+			{
+				Logging.errorPrint("Duplicate "
+						+ tok.getTokenClass().getSimpleName()
+						+ " Token found for interface token " + tok.getTokenName()
+						+ ". Classes were " + existingToken.getClass().getName()
+						+ " and " + newToken.getClass().getName());
 			}
 		}
 		loadFamily(TokenFamily.CURRENT, newToken);
@@ -597,5 +621,28 @@ public final class TokenLibrary implements PluginLoader
 	public static Class<? extends BonusObj> getBonus(String bonusName)
 	{
 		return BONUS_TAG_MAP.get(bonusName);
+	}
+
+	/**
+	 * Returns the CDOMInterfaceToken of the given name. null is returned if there is no
+	 * CDOMInterfaceToken of the given name.
+	 * 
+	 * @param The
+	 *            name of the CDOMInterfaceToken to be returned
+	 * @return The CDOMInterfaceToken of the given name
+	 */
+	public static CDOMInterfaceToken<?, ?> getInterfaceToken(String name)
+	{
+		return IF_TOKEN_MAP.get(name);
+	}
+
+	/**
+	 * Returns a Collection of the CDOMInterfaceToken objects in this TokenLibrary.
+	 * 
+	 * @return A Collection of the CDOMInterfaceToken objects in this TokenLibrary
+	 */
+	public static Collection<CDOMInterfaceToken<?, ?>> getInterfaceTokens()
+	{
+		return Collections.unmodifiableCollection(IF_TOKEN_MAP.values());
 	}
 }

--- a/code/src/java/pcgen/rules/persistence/TokenSupport.java
+++ b/code/src/java/pcgen/rules/persistence/TokenSupport.java
@@ -98,15 +98,18 @@ public class TokenSupport
 		throws PersistenceLayerException
 	{
 		//Interface tokens override everything else... even if NOT VALID!
-		CDOMInterfaceToken<?, ?> ifToken = TokenLibrary.getInterfaceToken(tokenName);
-		if (ifToken != null)
+		CDOMInterfaceToken<?, ?> interfaceToken =
+				TokenLibrary.getInterfaceToken(tokenName);
+		if (interfaceToken != null)
 		{
-			if (ifToken.getTokenClass().isAssignableFrom(target.getClass()))
+			if (interfaceToken.getTokenClass().isAssignableFrom(target.getClass()))
 			{
 				//Must be true to be consistent with if above
 				@SuppressWarnings("unchecked")
-				CDOMInterfaceToken<?, T> token = (CDOMInterfaceToken<?, T>) ifToken;
-				return processInterfaceToken(context, target, tokenName, tokenValue, token);
+				CDOMInterfaceToken<?, T> token =
+						(CDOMInterfaceToken<?, T>) interfaceToken;
+				return processInterfaceToken(context, target, tokenName, tokenValue,
+					token);
 			}
 			else
 			{
@@ -174,14 +177,14 @@ public class TokenSupport
 	}
 
 	private <R, W> boolean processInterfaceToken(LoadContext context, W target,
-		String tokenName, String tokenValue, CDOMInterfaceToken<R, W> ifToken)
+		String tokenName, String tokenValue, CDOMInterfaceToken<R, W> interfaceToken)
 	{
-		StagingInfo<R, W> info = stagingFactory.produceStaging(ifToken.getReadInterface(),
-			ifToken.getTokenClass());
+		StagingInfo<R, W> info = stagingFactory.produceStaging(
+			interfaceToken.getReadInterface(), interfaceToken.getTokenClass());
 		ParseResult parse;
 		try
 		{
-			parse = ifToken.parseToken(context, info.getWriteProxy(), tokenValue);
+			parse = interfaceToken.parseToken(context, info.getWriteProxy(), tokenValue);
 		}
 		catch (IllegalArgumentException e)
 		{
@@ -334,12 +337,13 @@ public class TokenSupport
                 String.CASE_INSENSITIVE_ORDER);
 		@SuppressWarnings("unchecked")
 		Class<T> cl = (Class<T>) loadable.getClass();
-		for (CDOMInterfaceToken<?, ?> ifToken : TokenLibrary.getInterfaceTokens())
+		for (CDOMInterfaceToken<?, ?> interfaceToken : TokenLibrary.getInterfaceTokens())
 		{
-			if (ifToken.getClass().isAssignableFrom(cl))
+			if (interfaceToken.getClass().isAssignableFrom(cl))
 			{
 				@SuppressWarnings("unchecked")
-				CDOMInterfaceToken<?, T> token = (CDOMInterfaceToken<?, T>) ifToken;
+				CDOMInterfaceToken<?, T> token =
+						(CDOMInterfaceToken<?, T>) interfaceToken;
 				String[] s = token.unparse(context, loadable);
 				if (s != null)
 				{

--- a/code/src/java/pcgen/rules/persistence/TokenSupport.java
+++ b/code/src/java/pcgen/rules/persistence/TokenSupport.java
@@ -24,6 +24,12 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import pcgen.base.proxy.DeferredMethodController;
+import pcgen.base.proxy.ItemProcessor;
+import pcgen.base.proxy.ListProcessor;
+import pcgen.base.proxy.MapProcessor;
+import pcgen.base.proxy.StagingInfo;
+import pcgen.base.proxy.StagingInfoFactory;
 import pcgen.base.util.CaseInsensitiveMap;
 import pcgen.base.util.DoubleKeyMapToList;
 import pcgen.base.util.TripleKeyMapToList;
@@ -34,6 +40,7 @@ import pcgen.persistence.PersistenceLayerException;
 import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.TokenLibrary.SubTokenIterator;
 import pcgen.rules.persistence.TokenLibrary.TokenIterator;
+import pcgen.rules.persistence.token.CDOMInterfaceToken;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import pcgen.rules.persistence.token.CDOMSecondaryToken;
 import pcgen.rules.persistence.token.CDOMSubToken;
@@ -57,12 +64,69 @@ public class TokenSupport
 	private final TripleKeyMapToList<Class<?>, String, String, CDOMToken<?>> subTokenCache =
             new TripleKeyMapToList<>(HashMap.class, CaseInsensitiveMap.class, CaseInsensitiveMap.class);
 
-	public <T extends Loadable> boolean processToken(LoadContext context,
-		T derivative, String typeStr, String argument)
+	/**
+	 * The StagingInfoFactory used to as a Proxy factory for Interface tokens.
+	 */
+	private final StagingInfoFactory stagingFactory = new StagingInfoFactory();
+
+	/**
+	 * Constructs a new TokenSupport object.
+	 */
+	public TokenSupport()
+	{
+		stagingFactory.addProcessor(new ItemProcessor());
+		stagingFactory.addProcessor(new ListProcessor());
+		stagingFactory.addProcessor(new MapProcessor());
+	}
+
+	/**
+	 * Processes the given token information in the scope of the given LoadContext and
+	 * object.
+	 * 
+	 * @param context
+	 *            The LoadContext to support how the token is processed
+	 * @param target
+	 *            The object on which the token will be processed
+	 * @param tokenName
+	 *            The name of the token to be processed
+	 * @param tokenValue
+	 *            The value of the token to be processed
+	 * @return true if the parsing was successful; false otherwise
+	 */
+	public <T extends Loadable> boolean processToken(
+		LoadContext context, T target, String tokenName, String tokenValue)
 		throws PersistenceLayerException
 	{
-		Class<T> cl = (Class<T>) derivative.getClass();
-		List<? extends CDOMToken<T>> tokenList = getTokens(cl, typeStr);
+		//Interface tokens override everything else... even if NOT VALID!
+		CDOMInterfaceToken<?, ?> ifToken = TokenLibrary.getInterfaceToken(tokenName);
+		if (ifToken != null)
+		{
+			if (ifToken.getTokenClass().isAssignableFrom(target.getClass()))
+			{
+				//Must be true to be consistent with if above
+				@SuppressWarnings("unchecked")
+				CDOMInterfaceToken<?, T> token = (CDOMInterfaceToken<?, T>) ifToken;
+				return processInterfaceToken(context, target, tokenName, tokenValue, token);
+			}
+			else
+			{
+				Logging.addParseMessage(Logging.LST_ERROR,
+					"Interface Token '" + tokenName + "' '" + tokenValue
+						+ "' not compatible with Object " + target.getClass().getName()
+						+ ' ' + target + " in " + context.getSourceURI());
+				return false;
+			}
+		}
+		return processClassTokens(context, target, tokenName, tokenValue);
+	}
+
+	private <T extends Loadable> boolean processClassTokens(LoadContext context,
+		T target, String tokenName, String tokenValue)
+	{
+		//Must be true
+		@SuppressWarnings("unchecked")
+		Class<T> cl = (Class<T>) target.getClass();
+		List<? extends CDOMToken<T>> tokenList = getTokens(cl, tokenName);
 		if (tokenList != null)
 		{
 			for (CDOMToken<T> token : tokenList)
@@ -70,7 +134,7 @@ public class TokenSupport
 				ParseResult parse;
 				try
 				{
-					parse = token.parseToken(context, derivative, argument);
+					parse = token.parseToken(context, target, tokenValue);
 				}
 				catch (IllegalArgumentException e)
 				{
@@ -90,21 +154,55 @@ public class TokenSupport
 				if (Logging.isLoggable(Logging.LST_INFO))
 				{
 					Logging.addParseMessage(Logging.LST_INFO,
-						"Failed in parsing typeStr: " + typeStr + ' ' + argument);
+						"Failed in parsing typeStr: " + tokenName + ' ' + tokenValue);
 				}
 			}
 		}
-		if (typeStr.startsWith(" "))
+		if (tokenName.startsWith(" "))
 		{
-			Logging.addParseMessage(Logging.LST_ERROR, "Illegal whitespace at start of token '" + typeStr
-				+ "' '" + argument + "' for " + cl.getName() + ' '
-				+ derivative.getDisplayName() + " in " + context.getSourceURI());
+			Logging.addParseMessage(Logging.LST_ERROR, "Illegal whitespace at start of token '" + tokenName
+				+ "' '" + tokenValue + "' for " + cl.getName() + ' '
+				+ target.getDisplayName() + " in " + context.getSourceURI());
 		}
 		else
 		{
-			Logging.addParseMessage(Logging.LST_ERROR, "Illegal Token '" + typeStr
-				+ "' '" + argument + "' for " + cl.getName() + ' '
-				+ derivative.getDisplayName() + " in " + context.getSourceURI());
+			Logging.addParseMessage(Logging.LST_ERROR, "Illegal Token '" + tokenName
+				+ "' '" + tokenValue + "' for " + cl.getName() + ' '
+				+ target.getDisplayName() + " in " + context.getSourceURI());
+		}
+		return false;
+	}
+
+	private <R, W> boolean processInterfaceToken(LoadContext context, W target,
+		String tokenName, String tokenValue, CDOMInterfaceToken<R, W> ifToken)
+	{
+		StagingInfo<R, W> info = stagingFactory.produceStaging(ifToken.getReadInterface(),
+			ifToken.getTokenClass());
+		ParseResult parse;
+		try
+		{
+			parse = ifToken.parseToken(context, info.getWriteProxy(), tokenValue);
+		}
+		catch (IllegalArgumentException e)
+		{
+			e.printStackTrace();
+			Logging.addParseMessage(Logging.LST_ERROR,
+				"Token generated an IllegalArgumentException: "
+					+ e.getLocalizedMessage());
+			parse = new ParseResult.Fail("Token processing failed");
+		}
+		// Need to add messages as there may be warnings.
+		parse.addMessagesToLog(context.getSourceURI());
+		if (parse.passed())
+		{
+			context.addDeferredMethodController(
+				new DeferredMethodController<>(info.getStagingObject(), target));
+			return true;
+		}
+		if (Logging.isLoggable(Logging.LST_INFO))
+		{
+			Logging.addParseMessage(Logging.LST_INFO,
+				"Failed in parsing token: " + tokenName + ' ' + tokenValue);
 		}
 		return false;
 	}
@@ -220,11 +318,29 @@ public class TokenSupport
 		return set.toArray(new String[set.size()]);
 	}
 
-	public <T> Collection<String> unparse(LoadContext context, T cdo)
+	public <T extends Loadable, R extends Loadable> Collection<String> unparse(
+		LoadContext context, T cdo)
 	{
 		Collection<String> set = new WeightedCollection<>(
                 String.CASE_INSENSITIVE_ORDER);
+		@SuppressWarnings("unchecked")
 		Class<T> cl = (Class<T>) cdo.getClass();
+		for (CDOMInterfaceToken<?, ?> ifToken : TokenLibrary.getInterfaceTokens())
+		{
+			if (ifToken.getClass().isAssignableFrom(cl))
+			{
+				@SuppressWarnings("unchecked")
+				CDOMInterfaceToken<?, T> token = (CDOMInterfaceToken<?, T>) ifToken;
+				String[] s = token.unparse(context, cdo);
+				if (s != null)
+				{
+					for (String aString : s)
+					{
+						set.add(token.getTokenName() + ':' + aString);
+					}
+				}
+			}
+		}
 		TokenFamilyIterator<T> it = new TokenFamilyIterator<>(cl);
 		while (it.hasNext())
 		{
@@ -243,66 +359,6 @@ public class TokenSupport
 			return null;
 		}
 		return set;
-	}
-
-	/**
-	 * Produce the LST code for any occurrences of the token. An attempt to 
-	 * unparse an invalid or non-existent token will result in an 
-	 * IllegalArgumentError.
-	 *  
-	 * @param loadContext The load context to be used
-	 * @param cdo The object to be partially unparsed
-	 * @param tokenName The name of the token to be extracted, must be a primary token.
-	 * @param <T> The type of object to be processed, generally a CDOMObject.
-	 * @return An array of LST code 'fields' being each occurrence of the token for the target object.
-	 */
-	public <T> String[] unparseToken(LoadContext loadContext, T cdo, String tokenName)
-	{
-		Class<? super T> cl = (Class<T>) cdo.getClass();
-		CDOMToken<?> token = null;
-		while (token == null)
-		{
-			token = TokenFamily.CURRENT.getToken(cl, tokenName);
-			if (token == null)
-			{
-				if (Object.class.equals(cl))
-				{
-					return null;
-				}
-				cl = cl.getSuperclass();
-			}
-
-		}
-		List<String> result = new ArrayList<>();
-		if (CDOMPrimaryToken.class.isAssignableFrom(token.getClass()))
-		{
-			@SuppressWarnings("unchecked")
-			CDOMPrimaryToken<? super T> primaryToken =
-					(CDOMPrimaryToken<? super T>) token;
-			String[] s = primaryToken.unparse(loadContext, cdo);
-			if (s != null)
-			{
-				for (String aString : s)
-				{
-					result.add(token.getTokenName() + ':' + aString);
-				}
-			}
-		}
-		else
-		{
-			/*
-			 * This is catching any compatibility tokens that were (incorrectly)
-			 * placed into CURRENT
-			 */
-			throw new IllegalArgumentException(
-				"Expected a primary token in unparseToken, but " + tokenName
-					+ " - " + token.getClass().getName() + " is not a CDOMPrimaryToken.");
-		}
-		if (result.isEmpty())
-		{
-			return null;
-		}
-		return result.toArray(new String[result.size()]);
 	}
 
 	public Collection<DeferredToken<? extends Loadable>> getDeferredTokens()

--- a/code/src/java/pcgen/rules/persistence/TokenSupport.java
+++ b/code/src/java/pcgen/rules/persistence/TokenSupport.java
@@ -318,20 +318,29 @@ public class TokenSupport
 		return set.toArray(new String[set.size()]);
 	}
 
+	/**
+	 * Unparses an object into the LST tokens that would build the object.
+	 * 
+	 * @param context
+	 *            The LoadContext used to interpret the contents of the object
+	 * @param loadable
+	 *            The Loadable object to be unparsed
+	 * @return A Collection of Strings indicating the tokens that would build the object
+	 */
 	public <T extends Loadable, R extends Loadable> Collection<String> unparse(
-		LoadContext context, T cdo)
+		LoadContext context, T loadable)
 	{
 		Collection<String> set = new WeightedCollection<>(
                 String.CASE_INSENSITIVE_ORDER);
 		@SuppressWarnings("unchecked")
-		Class<T> cl = (Class<T>) cdo.getClass();
+		Class<T> cl = (Class<T>) loadable.getClass();
 		for (CDOMInterfaceToken<?, ?> ifToken : TokenLibrary.getInterfaceTokens())
 		{
 			if (ifToken.getClass().isAssignableFrom(cl))
 			{
 				@SuppressWarnings("unchecked")
 				CDOMInterfaceToken<?, T> token = (CDOMInterfaceToken<?, T>) ifToken;
-				String[] s = token.unparse(context, cdo);
+				String[] s = token.unparse(context, loadable);
 				if (s != null)
 				{
 					for (String aString : s)
@@ -345,7 +354,7 @@ public class TokenSupport
 		while (it.hasNext())
 		{
 			CDOMPrimaryToken<? super T> token = it.next();
-			String[] s = token.unparse(context, cdo);
+			String[] s = token.unparse(context, loadable);
 			if (s != null)
 			{
 				for (String aString : s)

--- a/code/src/java/pcgen/rules/persistence/token/CDOMInterfaceToken.java
+++ b/code/src/java/pcgen/rules/persistence/token/CDOMInterfaceToken.java
@@ -26,8 +26,10 @@ import pcgen.rules.context.LoadContext;
  * Note: While the interface of this class only enforces T, it should be expected that the
  * objects processed by this CDOMInterfaceToken also extend Loadable.
  * 
- * @param <T>
- *            The Interface being used for purposes of this CDOMInterfaceToken.
+ * @param <R>
+ *            The read Interface being used for purposes of this CDOMInterfaceToken.
+ * @param <W>
+ *            The write Interface being used for purposes of this CDOMInterfaceToken.
  */
 public interface CDOMInterfaceToken<R, W> extends CDOMToken<W>
 {

--- a/code/src/java/pcgen/rules/persistence/token/CDOMInterfaceToken.java
+++ b/code/src/java/pcgen/rules/persistence/token/CDOMInterfaceToken.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018 (C) Tom Parker <thpr@users.sourceforge.net>
+ * 
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 59 Temple Place,
+ * Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.rules.persistence.token;
+
+import pcgen.rules.context.LoadContext;
+
+/**
+ * A CDOMInterfaceToken is a token designed to run on an Interface of an object rather
+ * than the direct class hierarchy. (CDOMPrimaryToken et al all operate assuming their
+ * arguments are full classes that are exactly equal to or ancestors of the object being
+ * processed).
+ * 
+ * Note: While the interface of this class only enforces T, it should be expected that the
+ * objects processed by this CDOMInterfaceToken also extend Loadable.
+ * 
+ * @param <T>
+ *            The Interface being used for purposes of this CDOMInterfaceToken.
+ */
+public interface CDOMInterfaceToken<R, W> extends CDOMToken<W>
+{
+	/**
+	 * Unparses the given Object into an array of String objects, for each individual
+	 * entry that would be on the object for this token. This will return null if no
+	 * information in the given Loadable has any content related to this
+	 * CDOMInterfaceToken.
+	 * 
+	 * @param context
+	 *            The LoadContext in which the loadable exists, and which is available for
+	 *            necessary processing
+	 * @param loadable
+	 *            The loadable object to be unparsed into the entries for this
+	 *            CDOMInterfaceToken used to persist the object
+	 * @return An array of Strings representing the entries that are part of the
+	 *         persistent format of the given Loadable for this CDOMInterfaceToken.
+	 */
+	public String[] unparse(LoadContext context, W loadable);
+	
+	/**
+	 * Returns the Read Interface for this CDOMInterfaceToken.
+	 * 
+	 * Note: The write interface should be returned by the getTokenClass() method.
+	 * 
+	 * @return The Read Interface for this CDOMInterfaceToken
+	 */
+	public Class<R> getReadInterface();
+
+}

--- a/code/src/java/plugin/lsttokens/ModifyOtherLst.java
+++ b/code/src/java/plugin/lsttokens/ModifyOtherLst.java
@@ -48,6 +48,10 @@ import pcgen.rules.persistence.token.CDOMInterfaceToken;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import pcgen.rules.persistence.token.ParseResult;
 
+/**
+ * Implements the MODIFYOTHER token for remotely modifying variables in the new variable
+ * system.
+ */
 public class ModifyOtherLst extends AbstractTokenWithSeparator<VarHolder> implements
 		CDOMInterfaceToken<VarContainer, VarHolder>, CDOMPrimaryToken<VarHolder>
 {

--- a/code/src/java/plugin/lsttokens/ModifyOtherLst.java
+++ b/code/src/java/plugin/lsttokens/ModifyOtherLst.java
@@ -34,20 +34,22 @@ import pcgen.base.util.FormatManager;
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.base.Constants;
 import pcgen.cdom.base.ObjectGrouping;
+import pcgen.cdom.base.Ungranted;
+import pcgen.cdom.base.VarContainer;
+import pcgen.cdom.base.VarHolder;
 import pcgen.cdom.content.RemoteModifier;
 import pcgen.cdom.content.VarModifier;
 import pcgen.cdom.enumeration.ListKey;
 import pcgen.cdom.formula.scope.PCGenScope;
 import pcgen.core.Campaign;
-import pcgen.rules.context.Changes;
 import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.token.AbstractTokenWithSeparator;
+import pcgen.rules.persistence.token.CDOMInterfaceToken;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import pcgen.rules.persistence.token.ParseResult;
-import pcgen.util.Logging;
 
-public class ModifyOtherLst extends AbstractTokenWithSeparator<CDOMObject>
-		implements CDOMPrimaryToken<CDOMObject>
+public class ModifyOtherLst extends AbstractTokenWithSeparator<VarHolder> implements
+		CDOMInterfaceToken<VarContainer, VarHolder>, CDOMPrimaryToken<VarHolder>
 {
 
 	@Override
@@ -65,8 +67,13 @@ public class ModifyOtherLst extends AbstractTokenWithSeparator<CDOMObject>
 	//MODIFYOTHER:EQUIPMENT|GROUP=Martial|EqCritRange|ADD|1
 	@Override
 	protected ParseResult parseTokenWithSeparator(LoadContext context,
-		CDOMObject obj, String value)
+		VarHolder obj, String value)
 	{
+		if (obj instanceof Ungranted)
+		{
+			return new ParseResult.Fail(getTokenName()
+				+ " may not be used in Ungranted objects.");
+		}
 		if (obj instanceof Campaign)
 		{
 			return new ParseResult.Fail(getTokenName()
@@ -101,7 +108,7 @@ public class ModifyOtherLst extends AbstractTokenWithSeparator<CDOMObject>
 	}
 
 	private <GT extends VarScoped> ParseResult continueParsing(
-		LoadContext context, CDOMObject obj, String value, ParsingSeparator sep)
+		LoadContext context, VarHolder obj, String value, ParsingSeparator sep)
 	{
 		PCGenScope scope = context.getActiveScope();
 		final String groupingName = sep.next();
@@ -193,7 +200,7 @@ public class ModifyOtherLst extends AbstractTokenWithSeparator<CDOMObject>
 		{
 			return new ParseResult.Fail(getTokenName() + " found invalid var name: "
 				+ varName + "(scope: " + LegalScope.getFullName(scope) + ") Modified on "
-				+ obj.getClass().getSimpleName() + ' ' + obj.getKeyName());
+				+ obj.getClass().getSimpleName() + ' ' + obj);
 		}
 		if (!sep.hasNext())
 		{
@@ -246,45 +253,28 @@ public class ModifyOtherLst extends AbstractTokenWithSeparator<CDOMObject>
 		}
 		VarModifier<?> vm = new VarModifier<>(varName, scope, modifier);
 		RemoteModifier<?> rm = new RemoteModifier<>(group, vm);
-		context.getObjectContext().addToList(obj, ListKey.REMOTE_MODIFIER, rm);
+		obj.addRemoteModifier(rm);
 		return ParseResult.SUCCESS;
 	}
 
 	@Override
-	public String[] unparse(LoadContext context, CDOMObject obj)
+	public String[] unparse(LoadContext context, VarHolder obj)
 	{
-		Changes<RemoteModifier<?>> changes =
-				context.getObjectContext().getListChanges(obj,
-					ListKey.REMOTE_MODIFIER);
-		if (changes.hasRemovedItems())
-		{
-			Logging.errorPrint(getTokenName()
-				+ " does not support removed items");
-			return null;
-		}
-		if (changes.includesGlobalClear())
-		{
-			Logging.errorPrint(getTokenName() + " does not support .CLEAR");
-			return null;
-		}
-		Collection<RemoteModifier<?>> added = changes.getAdded();
+		RemoteModifier<?>[] added = obj.getRemoteModifierArray();
 		List<String> modifiers = new ArrayList<>();
-		if (added != null && !added.isEmpty())
+		for (RemoteModifier<?> rm : added)
 		{
-			for (RemoteModifier<?> rm : added)
-			{
-				VarModifier<?> vm = rm.getVarModifier();
-				StringBuilder sb = new StringBuilder();
-				ObjectGrouping og = rm.getGrouping();
-				sb.append(LegalScope.getFullName(og.getScope()));
-				sb.append(Constants.PIPE);
-				sb.append(og.getIdentifier());
-				sb.append(Constants.PIPE);
-				sb.append(vm.getVarName());
-				sb.append(Constants.PIPE);
-				sb.append(unparseModifier(vm));
-				modifiers.add(sb.toString());
-			}
+			VarModifier<?> vm = rm.getVarModifier();
+			StringBuilder sb = new StringBuilder();
+			ObjectGrouping og = rm.getGrouping();
+			sb.append(LegalScope.getFullName(og.getScope()));
+			sb.append(Constants.PIPE);
+			sb.append(og.getIdentifier());
+			sb.append(Constants.PIPE);
+			sb.append(vm.getVarName());
+			sb.append(Constants.PIPE);
+			sb.append(unparseModifier(vm));
+			modifiers.add(sb.toString());
 		}
 		if (modifiers.isEmpty())
 		{
@@ -312,8 +302,14 @@ public class ModifyOtherLst extends AbstractTokenWithSeparator<CDOMObject>
 	}
 
 	@Override
-	public Class<CDOMObject> getTokenClass()
+	public Class<VarHolder> getTokenClass()
 	{
-		return CDOMObject.class;
+		return VarHolder.class;
+	}
+
+	@Override
+	public Class<VarContainer> getReadInterface()
+	{
+		return VarContainer.class;
 	}
 }

--- a/code/src/utest/plugin/lsttokens/ModifyLstTest.java
+++ b/code/src/utest/plugin/lsttokens/ModifyLstTest.java
@@ -36,8 +36,8 @@ import plugin.lsttokens.testsupport.TokenRegistration;
 
 public class ModifyLstTest extends AbstractGlobalTokenTestCase
 {
-	static ModifyLst token = new ModifyLst();
-	static CDOMTokenLoader<Skill> loader = new CDOMTokenLoader<>();
+	private static ModifyLst token = new ModifyLst();
+	private static CDOMTokenLoader<Skill> loader = new CDOMTokenLoader<>();
 
 	@Override
 	public void setUp() throws PersistenceLayerException, URISyntaxException

--- a/code/src/utest/plugin/lsttokens/ModifyLstTest.java
+++ b/code/src/utest/plugin/lsttokens/ModifyLstTest.java
@@ -23,9 +23,8 @@ import org.junit.Test;
 
 import pcgen.base.formula.base.LegalScope;
 import pcgen.base.util.FormatManager;
-import pcgen.cdom.base.CDOMObject;
-import pcgen.core.Campaign;
-import pcgen.core.PCTemplate;
+import pcgen.cdom.base.VarHolder;
+import pcgen.core.Skill;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.CDOMLoader;
@@ -37,8 +36,8 @@ import plugin.lsttokens.testsupport.TokenRegistration;
 
 public class ModifyLstTest extends AbstractGlobalTokenTestCase
 {
-	static CDOMPrimaryToken<CDOMObject> token = new ModifyLst();
-	static CDOMTokenLoader<PCTemplate> loader = new CDOMTokenLoader<>();
+	static ModifyLst token = new ModifyLst();
+	static CDOMTokenLoader<Skill> loader = new CDOMTokenLoader<>();
 
 	@Override
 	public void setUp() throws PersistenceLayerException, URISyntaxException
@@ -49,29 +48,29 @@ public class ModifyLstTest extends AbstractGlobalTokenTestCase
 	}
 
 	@Override
-	public CDOMLoader<PCTemplate> getLoader()
+	public CDOMLoader<Skill> getLoader()
 	{
 		return loader;
 	}
 
 	@Override
-	public Class<PCTemplate> getCDOMClass()
+	public Class<Skill> getCDOMClass()
 	{
-		return PCTemplate.class;
+		return Skill.class;
 	}
 
 	@Override
-	public CDOMPrimaryToken<CDOMObject> getToken()
+	public CDOMPrimaryToken<VarHolder> getToken()
 	{
 		return token;
 	}
 
-	@Test
-	public void testInvalidObject() throws PersistenceLayerException
-	{
-		assertFalse(token.parseToken(primaryContext, new Campaign(),
-				"MyVar|ADD|3").passed());
-	}
+//	@Test
+//	public void testInvalidObject() throws PersistenceLayerException
+//	{
+//		assertFalse(token.parseToken(primaryContext, new PCTemplate(),
+//				"MyVar|ADD|3").passed());
+//	}
 
 	@Test
 	public void testInvalidInputEmpty() throws PersistenceLayerException

--- a/code/src/utest/plugin/lsttokens/ModifyLstTest.java
+++ b/code/src/utest/plugin/lsttokens/ModifyLstTest.java
@@ -65,13 +65,6 @@ public class ModifyLstTest extends AbstractGlobalTokenTestCase
 		return token;
 	}
 
-//	@Test
-//	public void testInvalidObject() throws PersistenceLayerException
-//	{
-//		assertFalse(token.parseToken(primaryContext, new PCTemplate(),
-//				"MyVar|ADD|3").passed());
-//	}
-
 	@Test
 	public void testInvalidInputEmpty() throws PersistenceLayerException
 	{

--- a/code/src/utest/plugin/lsttokens/ModifyOtherLstTest.java
+++ b/code/src/utest/plugin/lsttokens/ModifyOtherLstTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 
 import pcgen.base.formula.base.LegalScope;
 import pcgen.base.util.FormatManager;
-import pcgen.cdom.base.CDOMObject;
+import pcgen.cdom.base.VarHolder;
 import pcgen.core.Campaign;
 import pcgen.core.PCTemplate;
 import pcgen.persistence.PersistenceLayerException;
@@ -37,7 +37,7 @@ import plugin.lsttokens.testsupport.TokenRegistration;
 
 public class ModifyOtherLstTest extends AbstractGlobalTokenTestCase
 {
-	static CDOMPrimaryToken<CDOMObject> token = new ModifyOtherLst();
+	static CDOMPrimaryToken<VarHolder> token = new ModifyOtherLst();
 	static CDOMTokenLoader<PCTemplate> loader = new CDOMTokenLoader<>();
 
 	@Override
@@ -61,7 +61,7 @@ public class ModifyOtherLstTest extends AbstractGlobalTokenTestCase
 	}
 
 	@Override
-	public CDOMPrimaryToken<CDOMObject> getToken()
+	public CDOMPrimaryToken<VarHolder> getToken()
 	{
 		return token;
 	}


### PR DESCRIPTION
Leverages the Proxy system from -base

This system allows a load token to use an interface rather than the
object class (or ancestor class).  This allows multiple different,
otherwise unrelated objects to use the same load token.

This sets up for allowing Dynamic (which is not - and shouldn't be - a
CDOMObject) to handle variables.

This sets up a simplification of GlobalModifiers as well.

Overall, this also sets up the ability to do a simplification of the
token system - allowing them to ignore the context in many cases and act
directly on an interface (thus making the code clearer)