### PR TITLE
Correct Equipment Part Scoping

### DIFF
--- a/code/src/java/pcgen/cdom/facet/RemoteModifierFacet.java
+++ b/code/src/java/pcgen/cdom/facet/RemoteModifierFacet.java
@@ -213,10 +213,10 @@ public class RemoteModifierFacet extends
 	}
 
 	/*
-	 * In Ability: MODIFYOTHER:EQUIPMENT|GROUP=Martial|EqCritRange|ADD|1
+	 * In Ability: MODIFYOTHER:PC.EQUIPMENT|GROUP=Martial|EqCritRange|ADD|1
 	 * 
 	 * In Global:
-	 * MODIFYOTHER:EQUIPMENT.PART|ALL|CritRange|SOLVE|value()+EqCritRange
+	 * MODIFYOTHER:PC.EQUIPMENT.PART|ALL|CritRange|SOLVE|value()+EqCritRange
 	 * |PRIORITY=10000
 	 * 
 	 * effectively we are solving APPLYTO:EQUIPMENT|PC[GROUP=Martial]|...

--- a/code/src/java/pcgen/cdom/formula/scope/EquipmentPartScope.java
+++ b/code/src/java/pcgen/cdom/formula/scope/EquipmentPartScope.java
@@ -30,6 +30,11 @@ import pcgen.rules.context.LoadContext;
 public class EquipmentPartScope implements PCGenScope
 {
 	/**
+	 * Full scope name as used in PCGen.
+	 */
+	public static final String PC_EQUIPMENT_PART = "PC.EQUIPMENT.PART";
+
+	/**
 	 * The parent of this scope (once loaded)
 	 */
 	private Optional<PCGenScope> parent;

--- a/code/src/java/pcgen/cdom/inst/EquipmentHead.java
+++ b/code/src/java/pcgen/cdom/inst/EquipmentHead.java
@@ -22,6 +22,7 @@ import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.enumeration.CharID;
 import pcgen.cdom.facet.FacetLibrary;
 import pcgen.cdom.facet.analysis.ResultFacet;
+import pcgen.cdom.formula.scope.EquipmentPartScope;
 
 /**
  * An EquipmentHead is a CDOMObject that represents characteristics of a single
@@ -131,7 +132,7 @@ public final class EquipmentHead extends CDOMObject
 	@Override
 	public String getLocalScopeName()
 	{
-		return "PC.EQUIPMENT.PART";
+		return EquipmentPartScope.PC_EQUIPMENT_PART;
 	}
 
 	@Override

--- a/code/src/java/pcgen/core/EquipmentModifier.java
+++ b/code/src/java/pcgen/core/EquipmentModifier.java
@@ -31,6 +31,7 @@ import pcgen.cdom.content.SpellResistance;
 import pcgen.cdom.enumeration.ListKey;
 import pcgen.cdom.enumeration.ObjectKey;
 import pcgen.cdom.enumeration.Type;
+import pcgen.cdom.formula.scope.EquipmentPartScope;
 import pcgen.core.analysis.BonusCalc;
 import pcgen.core.bonus.Bonus;
 import pcgen.core.bonus.BonusObj;
@@ -309,7 +310,7 @@ public final class EquipmentModifier extends PObject
 	@Override
 	public String getLocalScopeName()
 	{
-		return "PC.EQUIPMENT.PART";
+		return EquipmentPartScope.PC_EQUIPMENT_PART;
 	}
 
 	private VarScoped variableParent;

--- a/code/src/java/pcgen/persistence/SourceFileLoader.java
+++ b/code/src/java/pcgen/persistence/SourceFileLoader.java
@@ -50,6 +50,7 @@ import pcgen.cdom.enumeration.ObjectKey;
 import pcgen.cdom.enumeration.SourceFormat;
 import pcgen.cdom.enumeration.StringKey;
 import pcgen.cdom.enumeration.Type;
+import pcgen.cdom.formula.scope.EquipmentPartScope;
 import pcgen.cdom.formula.scope.GlobalScope;
 import pcgen.cdom.inst.GlobalModifiers;
 import pcgen.cdom.util.CControl;
@@ -148,7 +149,8 @@ public class SourceFileLoader extends PCGenTask implements Observer
 	private final LstObjectFileLoader<Equipment> equipmentLoader =
 			new GenericLocalVariableLoader<>(Equipment.class, "PC.EQUIPMENT");
 	private final LstObjectFileLoader<EquipmentModifier> eqModLoader =
-			new GenericLocalVariableLoader<>(EquipmentModifier.class, "PC.EQUIPMENT.PART");
+			new GenericLocalVariableLoader<>(EquipmentModifier.class,
+				EquipmentPartScope.PC_EQUIPMENT_PART);
 	private final LstObjectFileLoader<Race> raceLoader = new GenericLoader<>(Race.class);
 	private final LstObjectFileLoader<Skill> skillLoader =
 			new GenericLocalVariableLoader<>(Skill.class, "PC.SKILL");

--- a/code/src/java/plugin/lsttokens/equipment/PartToken.java
+++ b/code/src/java/plugin/lsttokens/equipment/PartToken.java
@@ -17,6 +17,7 @@
  */
 package plugin.lsttokens.equipment;
 
+import pcgen.cdom.formula.scope.EquipmentPartScope;
 import pcgen.cdom.inst.EquipmentHead;
 import pcgen.core.Equipment;
 import pcgen.persistence.PersistenceLayerException;
@@ -80,7 +81,8 @@ public class PartToken extends AbstractNonEmptyToken<Equipment> implements
 		String tokenName = partToken.substring(0, colonLoc);
 		String tokenValue = partToken.substring(colonLoc + 1);
 
-		LoadContext subContext = context.dropIntoContext("EQUIPMENT.PART");
+		LoadContext subContext =
+				context.dropIntoContext(EquipmentPartScope.PC_EQUIPMENT_PART);
 
 		boolean processToken;
 		try


### PR DESCRIPTION
Two changes: Extracts the frequent use of constants to one location
Corrects the PartToken of Equipment to use the "PC." prefix (side
effect)