### PR TITLE
Set toolVersion for pmd and checkstyle in one place.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,14 +31,6 @@ plugins {
     id "com.dorongold.task-tree" version '1.3'
 }
 
-checkstyle {
-    toolVersion = '8.9'
-}
-
-pmd {
-    toolVersion = '6.2.0'
-}
-
 group = 'net.sourceforge.pcgen'
 
 description = """PCGen"""

--- a/code/gradle/reporting.gradle
+++ b/code/gradle/reporting.gradle
@@ -14,7 +14,7 @@ checkstyle {
 	configFile = new File('code/standards/checkstyle.xml')
 	ignoreFailures = true
 	showViolations = false
-	toolVersion = '8.7'
+	toolVersion = '8.9'
 	sourceSets = []
 }
 
@@ -24,7 +24,7 @@ pmd {
 	ruleSetFiles = files('code/standards/ruleset.xml')
 	consoleOutput = true
 	sourceSets = []
-	toolVersion = "6.0.0"
+	toolVersion = "6.2.0"
 }
 
 findbugs {


### PR DESCRIPTION
Gradle 4.4.1 had an issue (gradle/gradle#3908) where the toolVersion settings for code quality plugins could be ignored. I suspect in order to get the reports to work someone placed them near the beginning of build.gradle as well as leaving the values in code/gradle/reporting.gradle. The issue was resolved in gradle 4.6 so now you have moved to that version the recent changes to toolVersion in build.gradle are being overridden by the old values still present in reporting.gradle. So to avoid confusion this change reverts to the old setup  where you only set the toolVersion in one location (reporting.gradle).