### PR TITLE
CODE-3257: fix pcgen.sh a bit

### DIFF
--- a/code/pcgen.sh
+++ b/code/pcgen.sh
@@ -4,7 +4,7 @@ if command git rev-parse >/dev/null 2>&1
 then
   cd "$(git rev-parse --show-toplevel)/output"
 else
-  cd "$(dirname $0)"
+  cd "$(dirname "$0")"
 fi
 
 available_memory="unknown"
@@ -31,7 +31,7 @@ else
 fi
 
 # Test if the value is numeric before performing arithmetic on it
-if [ $available_memory -eq $available_memory 2> /dev/null ]; then
+if [ $available_memory -eq $available_memory ]; then
 
 	# We go with the defaults if memory is too low
 	if [ $available_memory -gt 1048576 ]; then
@@ -82,5 +82,5 @@ done
 #     -Dpcgen.filter=/path/to/filter.ini
 #     -Dpcgen.options=/path/to/options.ini
 
-cd $(dirname $(readlink -f $0))
+# shellcheck disable=SC2086
 exec java $javaargs -jar ./pcgen.jar -- "$@"


### PR DESCRIPTION
- We already cd to correct directory at the top of the file. This one is
extraneous and has incorrect quoting
- remove broken '2> /dev/null' in conditional
- add quotes