### PR TITLE
gradlew with JDK10 has issues with spotbug version '1.6.1'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ plugins {
     id 'application'
     id 'build-dashboard'
     id 'checkstyle'
-    id "com.github.spotbugs" version '1.6.1'
+    id "com.github.spotbugs" version '1.6.2'
     id 'java'
     id 'maven'
     id 'pmd'
@@ -40,7 +40,7 @@ pmd {
 }
 
 spotbugs {
-	toolVersion = '3.1.2'
+	toolVersion = '3.1.3'
 }
 
 group = 'net.sourceforge.pcgen'
@@ -203,7 +203,7 @@ dependencies {
 
     slowtestRuntime configurations.testRuntime
    
-	spotbugs 'com.github.spotbugs:spotbugs:3.1.1'
+	spotbugs 'com.github.spotbugs:spotbugs:3.1.3'
 	spotbugsPlugins 'com.h3xstream.findsecbugs:findsecbugs-plugin:1.7.1'
 }
 


### PR DESCRIPTION
, update to '1.6.2'

JDK9 is end of life. Building with gradle and Java10 had issues with spotbug version 1.6.1
Also adjusted toolVersion from 3.1.2 to 3.1.3 in two places as this seems to be current version.

Build with ./gradlew fullZip produced usable build.