### PR TITLE
Fix bug: CODE-3259

### DIFF
--- a/code/src/java/pcgen/core/analysis/SpellLevel.java
+++ b/code/src/java/pcgen/core/analysis/SpellLevel.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.Collections;
 import pcgen.base.util.HashMapToList;
 import pcgen.cdom.base.AssociatedPrereqObject;
 import pcgen.cdom.base.CDOMList;
@@ -101,16 +102,7 @@ public final class SpellLevel
 			if (levelList != null)
 			{
 				// In specific situations, this list may not be sorted, so we won't assume it is
-				int lowestLevel = levelList.get(0);
-				for (int i = 1; i < levelList.size(); i++)
-				{
-					int level = levelList.get(i);
-					if (level < lowestLevel)
-					{
-						lowestLevel = level;
-					}
-				}
-				return lowestLevel;
+				return Collections.min(levelList);
 			}
 		}
 		return -1;

--- a/code/src/java/pcgen/core/analysis/SpellLevel.java
+++ b/code/src/java/pcgen/core/analysis/SpellLevel.java
@@ -100,8 +100,17 @@ public final class SpellLevel
 			List<Integer> levelList = wLevelInfo.getListFor(list);
 			if (levelList != null)
 			{
-				// We assume those calling this method know what they are doing!
-				return levelList.get(0);
+				// In specific situations, this list may not be sorted, so we won't assume it is
+				int lowestLevel = levelList.get(0);
+				for (int i = 1; i < levelList.size(); i++)
+				{
+					int level = levelList.get(i);
+					if (level < lowestLevel)
+					{
+						lowestLevel = level;
+					}
+				}
+				return lowestLevel;
 			}
 		}
 		return -1;


### PR DESCRIPTION
This is a proposed fix to the abovementioned JIRA issue. It appears that sometimes the spell level list in question is not sorted. 

I'd like review from those more familiar with this class to ensure the assumption that the spell list is sorted is not relied upon elsewhere, which would indicate the bug comes from a different source.