### PR TITLE
CODE-3274: Fix PCGen hanging on the splash screen on MacOS with Java 10

### DIFF
--- a/code/src/java/pcgen/gui2/PCGenUIManager.java
+++ b/code/src/java/pcgen/gui2/PCGenUIManager.java
@@ -47,7 +47,7 @@ public final class PCGenUIManager
 	public static void initializeGUI()
 	{
 		// Don't start macOS GUI if we're on Java 9 since it doesn't work.
-		if (SystemUtils.IS_OS_MAC_OSX && (System.getProperty("java.runtime.version").charAt(0) != '9'))
+		if (SystemUtils.IS_OS_MAC_OSX && (Integer.parseInt(System.getProperty("java.specification.version")) <= 8))
 		{
 			MacGUIHandler.initialize();
 		}


### PR DESCRIPTION
PCGen only tests for Java version 9 to skip the non-functioning MacGUIHandler.initialize(). Changed this to be future-proof for higher versions than 9..