### PR TITLE
CODE-3274: Fix the MacGUIHandler to run with Java 9+

### DIFF
--- a/code/src/java/pcgen/gui2/PCGenUIManager.java
+++ b/code/src/java/pcgen/gui2/PCGenUIManager.java
@@ -46,8 +46,7 @@ public final class PCGenUIManager
 
 	public static void initializeGUI()
 	{
-		// Don't start macOS GUI if we're on Java 9 since it doesn't work.
-		if (SystemUtils.IS_OS_MAC_OSX && (System.getProperty("java.runtime.version").charAt(0) != '9'))
+		if (SystemUtils.IS_OS_MAC_OSX)
 		{
 			MacGUIHandler.initialize();
 		}

--- a/code/src/java/pcgen/gui2/plaf/MacGUIHandler.java
+++ b/code/src/java/pcgen/gui2/plaf/MacGUIHandler.java
@@ -32,7 +32,6 @@ import pcgen.gui2.PCGenUIManager;
 public final class MacGUIHandler
 {
 	private static MacGUIHandler theAdapter;
-	private static Desktop theDesktop;
 
 	private MacGUIHandler()
 	{
@@ -52,7 +51,7 @@ public final class MacGUIHandler
 
 		// set up the Application menu
 		theAdapter = new MacGUIHandler();
-		theDesktop = Desktop.getDesktop();
+		Desktop theDesktop = Desktop.getDesktop();
 		theDesktop.setAboutHandler(new OSXAboutHandler());
 		theDesktop.setPreferencesHandler(new OSXPreferencesHandler());
 		theDesktop.setQuitHandler(new OSXQuitHandler());

--- a/code/src/java/pcgen/gui2/plaf/MacGUIHandler.java
+++ b/code/src/java/pcgen/gui2/plaf/MacGUIHandler.java
@@ -15,12 +15,14 @@
  */
 package pcgen.gui2.plaf;
 
-import com.apple.eawt.AboutHandler;
-import com.apple.eawt.AppEvent;
-import com.apple.eawt.Application;
-import com.apple.eawt.PreferencesHandler;
-import com.apple.eawt.QuitHandler;
-import com.apple.eawt.QuitResponse;
+import java.awt.Desktop;
+import java.awt.desktop.AboutEvent;
+import java.awt.desktop.AboutHandler;
+import java.awt.desktop.PreferencesEvent;
+import java.awt.desktop.PreferencesHandler;
+import java.awt.desktop.QuitEvent;
+import java.awt.desktop.QuitHandler;
+import java.awt.desktop.QuitResponse;
 
 import pcgen.gui2.PCGenUIManager;
 
@@ -30,7 +32,7 @@ import pcgen.gui2.PCGenUIManager;
 public final class MacGUIHandler
 {
 	private static MacGUIHandler theAdapter;
-	private static Application theApp;
+	private static Desktop theDesktop;
 
 	private MacGUIHandler()
 	{
@@ -50,16 +52,16 @@ public final class MacGUIHandler
 
 		// set up the Application menu
 		theAdapter = new MacGUIHandler();
-		theApp = Application.getApplication();
-		theApp.setAboutHandler(new OSXAboutHandler());
-		theApp.setPreferencesHandler(new OSXPreferencesHandler());
-		theApp.setQuitHandler(new OSXQuitHandler());
+		theDesktop = Desktop.getDesktop();
+		theDesktop.setAboutHandler(new OSXAboutHandler());
+		theDesktop.setPreferencesHandler(new OSXPreferencesHandler());
+		theDesktop.setQuitHandler(new OSXQuitHandler());
 	}
 
 	private static class OSXAboutHandler implements AboutHandler
 	{
 		@Override
-		public void handleAbout(final AppEvent.AboutEvent aboutEvent)
+		public void handleAbout(final AboutEvent aboutEvent)
 		{
 			PCGenUIManager.displayAboutDialog();
 		}
@@ -68,7 +70,7 @@ public final class MacGUIHandler
 	private static class OSXPreferencesHandler implements PreferencesHandler
 	{
 		@Override
-		public void handlePreferences(final AppEvent.PreferencesEvent preferencesEvent)
+		public void handlePreferences(final PreferencesEvent preferencesEvent)
 		{
 			PCGenUIManager.displayPreferencesDialog();
 		}
@@ -77,7 +79,7 @@ public final class MacGUIHandler
 	private static class OSXQuitHandler implements QuitHandler
 	{
 		@Override
-		public void handleQuitRequestWith(final AppEvent.QuitEvent quitEvent, final QuitResponse quitResponse)
+		public void handleQuitRequestWith(final QuitEvent quitEvent, final QuitResponse quitResponse)
 		{
 			PCGenUIManager.closePCGen();
 		}


### PR DESCRIPTION
MacGUIHandler was no longer usable with Java 9, but was skipped for exactly Java version 9 only. Rewrote MacGUIHandler class to work with Java 9+, so it can be used again.