### PR TITLE
[test] Enable using junit 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -182,10 +182,17 @@ dependencies {
     compileOnly group: 'org.jetbrains', name: 'annotations', version:'16.0.2'
     compileOnly group: 'com.yuvimasory', name: 'orange-extensions', version: '1.3.0'
 
-    testCompile group: 'junit', name: 'junit', version:'4.12'
+    testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-api', version:'5.3.1'
     testCompile group: 'org.hamcrest', name: 'hamcrest-core', version: '1.3'
     testCompile group: 'org.hamcrest', name: 'hamcrest-library', version: '1.3'
     testCompile group: 'org.xmlunit', name: 'xmlunit-matchers', version:'2.6.0'
+
+    testCompileOnly group: 'junit', name: 'junit', version:'4.12'
+
+    testRuntime group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version:'5.3.1'
+    testRuntime group: 'org.junit.vintage', name: 'junit-vintage-engine', version:'5.3.1'
+
+
 
     itestCompile sourceSets.main.output
     itestCompile configurations.testCompile


### PR DESCRIPTION
This runs all existing tests with vintage junit 3/4 runners but new
tests should be junit 5.