### PR TITLE
Remove gradle lint again.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,6 @@ plugins {
     id "de.undercouch.download" version '3.4.3'
     id 'edu.sc.seis.launch4j' version '2.4.4'
     id 'com.github.ben-manes.versions' version '0.20.0'
-    id 'nebula.lint' version '10.1.0'
     id "com.dorongold.task-tree" version '1.3'
 }
 


### PR DESCRIPTION
Originally removed by PR #4220 but then put back by PR #4108.

Maybe using the "Rebase and merge" option for the "Merge pull request" would of caught it. May have also removed the need for PR #4247 because PR #4015 undid PR #4043.