### PR TITLE
Fix pcgen.sh so it works inside a git environment

### DIFF
--- a/code/pcgen.sh
+++ b/code/pcgen.sh
@@ -1,11 +1,5 @@
 #!/bin/sh
 set -e
-if command git rev-parse >/dev/null 2>&1
-then
-  cd "$(git rev-parse --show-toplevel)/output"
-else
-  cd "$(dirname "$0")"
-fi
 
 available_memory="unknown"
 default_min_memory=256


### PR DESCRIPTION
Currently the shell script pcgen.sh tests if it is started from inside a git repository environment. If so, it changes directory to the output directory where the build process creates the shell file and the jars. However there is no access to the libraries directory from there, and PCGen fails to run. removing this code allows the script to run from inside a git repository environment as well as when run from a normal installation or an extracted zip archive .