### PR TITLE
Fix Introspection depreciation with Java 10+ by removing some obsolete code

### DIFF
--- a/code/src/java/pcgen/gui2/tools/Utility.java
+++ b/code/src/java/pcgen/gui2/tools/Utility.java
@@ -340,20 +340,6 @@ public final class Utility
 		// macOS
 		System.setProperty("com.apple.mrj.application.apple.menu.about.name", title);
 		System.setProperty("apple.awt.application.name", title);
-
-		// X11
-		Toolkit xToolkit = Toolkit.getDefaultToolkit();
-		try
-		{
-			Field awtAppClassNameField = xToolkit.getClass().getDeclaredField("awtAppClassName"); //$NON-NLS-1$
-			awtAppClassNameField.setAccessible(true);
-			awtAppClassNameField.set(xToolkit, title);
-		}
-		catch (NoSuchFieldException | IllegalAccessException e)
-		{
-			// Rather than do a OS system condition, just ignore this expected exception
-			//Logging.log(Level.FINEST, "Can not set name of application for window manager", e);
-		}
 	}
 
 	public static void configurePlatformUI()


### PR DESCRIPTION
A block of code once used to set the application title on X11 systems is obsolete and causes a "Illegal reflective access" warning on JDK 9+ and is likely to fail in upcoming Java releases. The code also serves no purpose, and so I have removed it.