### PR TITLE
Add a gradle task to create a development environment where you can easily run PCGen from the command line

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -261,6 +261,22 @@ task syncLibsToRoot(type: Sync, dependsOn: [copyToLibs, jar, converterJar]) {
     exclude "pcgen-*.jar"
 }
 
+task installToRoot(type: Copy, dependsOn: [syncLibsToRoot, createExe, jar,
+                                           converterJar]) {
+    description="Copy the executable file into the root to create a working environment"
+    from "$buildDir/libs/pcgen-${version}.jar"
+    from "$buildDir/libs/pcgen-${version}-batch-convert.jar"
+    from "$buildDir/launch4j/pcgen.exe"
+    from("$projectDir/code/pcgen.sh") {
+        filter(FixCrLfFilter, eol:FixCrLfFilter.CrLf.newInstance("lf"))
+        fileMode 0755
+    }
+    into projectDir
+
+    rename "(.+)-$version(.+)", '$1$2'
+    mustRunAfter clean
+}
+
 task cleanOutput(type: Delete) {
     description="Clean up things copied to the output folder by the build"
     delete outputDir


### PR DESCRIPTION
Currently building PCGen from the command line with gradle does not create an environment where PCGen can easily be stared without having to copy some files after every build (also the pcgen.sh script is broken inside a development environment – see PR #4316). I have created a new task "installToRoot" that builds the executables and copies them to the root directory so PCGen can be started by running the pcgen.sh or pcgen.bat script without needing any further operations after each build.