### PR TITLE
CODE-3287: Custom magic weapons break the OS

### DIFF
--- a/code/src/java/pcgen/core/Equipment.java
+++ b/code/src/java/pcgen/core/Equipment.java
@@ -2405,15 +2405,7 @@ public final class Equipment extends PObject
 				}
 			}
 
-			head.addToListFor(ListKey.EQMOD, aMod);
-			if (bPrimary)
-			{
-				usePrimaryCache = false;
-			}
-			else
-			{
-				useSecondaryCache = false;
-			}
+			addToEqModifierList(aMod, bPrimary);
 		}
 
 		//

--- a/code/src/java/pcgen/core/Equipment.java
+++ b/code/src/java/pcgen/core/Equipment.java
@@ -976,8 +976,14 @@ public final class Equipment extends PObject
 	 */
 	public void addToEqModifierList(final EquipmentModifier eqMod, final boolean bPrimary)
 	{
-
-		usePrimaryCache = false;
+		if (bPrimary)
+		{
+			usePrimaryCache = false;
+		}
+		else
+		{
+			useSecondaryCache = false;
+		}
 		eqMod.setVariableParent(this);
 		getEquipmentHead(bPrimary ? 1 : 2).addToListFor(ListKey.EQMOD, eqMod);
 		setDirty(true);

--- a/code/src/test/pcgen/core/EquipmentTest.java
+++ b/code/src/test/pcgen/core/EquipmentTest.java
@@ -638,7 +638,8 @@ assertNotNull("Eqmod should be present", eqMod);
 	 */
 	public void testAddEqModifierSetsEquipmentAsParentOfTheModifier()
 	{
-		EquipmentModifier eqMod = Globals.getContext().getReferenceContext().silentlyGetConstructedCDOMObject(EquipmentModifier.class, "PLUS1W");
+		EquipmentModifier eqMod = Globals.getContext().getReferenceContext().silentlyGetConstructedCDOMObject(
+				EquipmentModifier.class, "PLUS1W");
 		assertNotNull("Eqmod should be present", eqMod);
 		assertNull("Eqmod parent should be null at beginning", eqMod.getVariableParent());
 

--- a/code/src/test/pcgen/core/EquipmentTest.java
+++ b/code/src/test/pcgen/core/EquipmentTest.java
@@ -632,4 +632,18 @@ assertNotNull("Eqmod should be present", eqMod);
 		assertFalse("Should not have choice Bad", aEquip.isPreType("EQMOD=PLUS1W(Bad)"));
 		
 	}
+
+	/**
+	 * EquipmentModifiers must have a parent in order to be rendered to an output sheet
+	 */
+	public void testAddEqModifierSetsEquipmentAsParentOfTheModifier()
+	{
+		EquipmentModifier eqMod = Globals.getContext().getReferenceContext().silentlyGetConstructedCDOMObject(EquipmentModifier.class, "PLUS1W");
+		assertNotNull("Eqmod should be present", eqMod);
+		assertNull("Eqmod parent should be null at beginning", eqMod.getVariableParent());
+
+		Equipment aEquip = eq.clone();
+		aEquip.addEqModifier(eqMod, true, null);
+		assertSame("Eqmod parent should be the equipment", aEquip, eqMod.getVariableParent());
+	}
 }


### PR DESCRIPTION
The issue seems to be that previously unused `EquipmentMods` don't get included in the scope tree when they are added to a piece of `Equipment`. 

`EquipmentMod`s are added to `Equipment`s in different ways:
* Via `#addToEqModifierList`, which sets the `variableParent` of the `EquipmentModifier` (thus adding it to the scope tree)
* Via `#load`, which transitively calls the private `#addEqModifier`, which makes use of `#addToEqModifierList` above
* Via the package-private `#addEqModifier`, which does *not* use `#addToEqModifierList` and does not set the `variableParent`.

The equipment editor in the inventory/purchase tab makes use of the latter option, which can lead to a case where the character has a piece of equipment with a modifier, but it's not possible to look upwards from the modifier. This causes sheet generation to fail - in some cases the user gets an error message, mostly the piece of equipment is simply skipped.

I have made a simple change to `Equipment`'s package-private `#addEqModifier` so that it makes use of `#addToEqModifierList` and so updates the `variableParent` of the `EquipmentModifier`.

I added a test to `EquipmentTest` which checks that `EquipmentModifier`s added to a piece of `Equipment` get the `variableParent` changed. I'm not fully happy with this (`EquipmentTest` is assuming too much about `EquipmentModifier`) but am not familiar enough with the code to do better. Suggestions welcome.

While making this change, I noticed that `#addToEqModifierList` was always invalidating the cache of the primary weapon head, while other methods were first checking which head was being modified. I updated `#addToEqModifierList` in a separate commit in case this change should be split up, or is in error.