### PR TITLE
CODE-3293 Don't enforce traditional separators on MODIFY

### DIFF
--- a/code/src/java/plugin/lsttokens/ModifyLst.java
+++ b/code/src/java/plugin/lsttokens/ModifyLst.java
@@ -36,7 +36,7 @@ import pcgen.cdom.content.VarModifier;
 import pcgen.cdom.formula.scope.PCGenScope;
 import pcgen.core.Campaign;
 import pcgen.rules.context.LoadContext;
-import pcgen.rules.persistence.token.AbstractTokenWithSeparator;
+import pcgen.rules.persistence.token.AbstractNonEmptyToken;
 import pcgen.rules.persistence.token.CDOMInterfaceToken;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import pcgen.rules.persistence.token.ParseResult;
@@ -45,7 +45,7 @@ import pcgen.rules.persistence.token.ParseResult;
  * The MODIFY token defined by ModifyLst defines a calculation to be performed in the
  * (new) formula system.
  */
-public class ModifyLst extends AbstractTokenWithSeparator<VarHolder>
+public class ModifyLst extends AbstractNonEmptyToken<VarHolder>
 		implements CDOMInterfaceToken<VarContainer, VarHolder>, CDOMPrimaryToken<VarHolder>
 {
 
@@ -56,13 +56,7 @@ public class ModifyLst extends AbstractTokenWithSeparator<VarHolder>
 	}
 
 	@Override
-	protected char separator()
-	{
-		return '|';
-	}
-
-	@Override
-	protected ParseResult parseTokenWithSeparator(LoadContext context, VarHolder obj, String value)
+	public ParseResult parseNonEmptyToken(LoadContext context, VarHolder obj, String value)
 	{
 		//TODO These instanceof checks will fail - the VarHolder is a proxy :(
 		if (obj instanceof Ungranted)

--- a/code/src/java/plugin/lsttokens/ModifyOtherLst.java
+++ b/code/src/java/plugin/lsttokens/ModifyOtherLst.java
@@ -41,7 +41,7 @@ import pcgen.cdom.formula.scope.PCGenScope;
 import pcgen.cdom.grouping.GroupingCollection;
 import pcgen.core.Campaign;
 import pcgen.rules.context.LoadContext;
-import pcgen.rules.persistence.token.AbstractTokenWithSeparator;
+import pcgen.rules.persistence.token.AbstractNonEmptyToken;
 import pcgen.rules.persistence.token.CDOMInterfaceToken;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import pcgen.rules.persistence.token.ParseResult;
@@ -50,7 +50,7 @@ import pcgen.rules.persistence.token.ParseResult;
  * Implements the MODIFYOTHER token for remotely modifying variables in the new variable
  * system.
  */
-public class ModifyOtherLst extends AbstractTokenWithSeparator<VarHolder>
+public class ModifyOtherLst extends AbstractNonEmptyToken<VarHolder>
 		implements CDOMInterfaceToken<VarContainer, VarHolder>, CDOMPrimaryToken<VarHolder>
 {
 
@@ -60,15 +60,9 @@ public class ModifyOtherLst extends AbstractTokenWithSeparator<VarHolder>
 		return "MODIFYOTHER";
 	}
 
-	@Override
-	protected char separator()
-	{
-		return '|';
-	}
-
 	//MODIFYOTHER:EQUIPMENT|GROUP=Martial|EqCritRange|ADD|1
 	@Override
-	protected ParseResult parseTokenWithSeparator(LoadContext context, VarHolder obj, String value)
+	public ParseResult parseNonEmptyToken(LoadContext context, VarHolder obj, String value)
 	{
 		//TODO These instanceof checks will fail - the VarHolder is a proxy :(
 		if (obj instanceof Ungranted)


### PR DESCRIPTION
Necessary because logical items like || trigger a false positive
Note: If a var is a boolean and the formula is A || B that will fail.
It will need to be written as (A || B) ... with the parenthesis
In that way, ParsingSeparator will detect the || as logical OR