### PR TITLE
Fix how FormatManager is established for variables

### DIFF
--- a/code/src/java/pcgen/cdom/content/fact/FactGroupDefinition.java
+++ b/code/src/java/pcgen/cdom/content/fact/FactGroupDefinition.java
@@ -21,7 +21,6 @@ import pcgen.base.util.FormatManager;
 import pcgen.base.util.ObjectContainer;
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.base.GroupDefinition;
-import pcgen.cdom.base.Loadable;
 import pcgen.cdom.enumeration.GroupingState;
 import pcgen.cdom.grouping.GroupingCollection;
 import pcgen.cdom.grouping.GroupingDefinition;
@@ -116,7 +115,7 @@ public class FactGroupDefinition<T extends CDOMObject, F> implements GroupDefini
 		FactGrouping<T, F> groupGrouping = new FactGrouping<>(def, info);
 		if (info.hasChild())
 		{
-			GroupingCollection<? extends Loadable> childCollection =
+			GroupingCollection<?> childCollection =
 					ChoiceSetLoadUtilities.getDynamicGroup(context, info.getChild());
 			groupGrouping.setChild(childCollection);
 		}

--- a/code/src/java/pcgen/cdom/content/fact/FactGrouping.java
+++ b/code/src/java/pcgen/cdom/content/fact/FactGrouping.java
@@ -19,7 +19,6 @@ import java.util.function.Consumer;
 
 import pcgen.base.util.Indirect;
 import pcgen.cdom.base.CDOMObject;
-import pcgen.cdom.base.Loadable;
 import pcgen.cdom.enumeration.FactKey;
 import pcgen.cdom.formula.PCGenScoped;
 import pcgen.cdom.grouping.GroupingCollection;
@@ -105,7 +104,7 @@ public class FactGrouping<T extends CDOMObject, F> implements GroupingCollection
 	 * @param childCollection
 	 *            The child GroupingCollection for this FactGrouping
 	 */
-	public void setChild(GroupingCollection<? extends Loadable> childCollection)
+	public void setChild(GroupingCollection<?> childCollection)
 	{
 		childGrouping = childCollection;
 	}

--- a/code/src/java/pcgen/cdom/grouping/GroupingDefinition.java
+++ b/code/src/java/pcgen/cdom/grouping/GroupingDefinition.java
@@ -15,7 +15,6 @@
  */
 package pcgen.cdom.grouping;
 
-import pcgen.cdom.base.Loadable;
 import pcgen.rules.context.LoadContext;
 
 /**
@@ -25,7 +24,7 @@ import pcgen.rules.context.LoadContext;
  * @param <T>
  *            The format of the object that this GroupingDefinition can process.
  */
-public interface GroupingDefinition<T extends Loadable>
+public interface GroupingDefinition<T>
 {
 
 	/**

--- a/code/src/java/pcgen/cdom/grouping/GroupingInfo.java
+++ b/code/src/java/pcgen/cdom/grouping/GroupingInfo.java
@@ -17,8 +17,8 @@ package pcgen.cdom.grouping;
 
 import java.util.Objects;
 
-import pcgen.cdom.base.ClassIdentity;
-import pcgen.cdom.base.Loadable;
+import pcgen.cdom.formula.scope.PCGenScope;
+import pcgen.rules.context.LoadContext;
 
 /**
  * GroupingInfo contains the (hierarchical) information about how items are grouped in the
@@ -28,7 +28,7 @@ import pcgen.cdom.base.Loadable;
  *            The Format (class) of the type of object which this GroupingInfo is
  *            identifying
  */
-public class GroupingInfo<T extends Loadable>
+public class GroupingInfo<T>
 {
 	/*
 	 * Note that the constructor and all set methods are package since field are set
@@ -66,9 +66,9 @@ public class GroupingInfo<T extends Loadable>
 	private GroupingInfo<?> child;
 
 	/**
-	 * The ClassIdentity of items identified by this GroupingInfo.
+	 * The PGenScope of objects that this GroupingInfo should identify.
 	 */
-	private ClassIdentity<T> identity;
+	private PCGenScope scope;
 
 	/**
 	 * Constructs a new GroupingInfo.
@@ -206,24 +206,35 @@ public class GroupingInfo<T extends Loadable>
 	}
 
 	/**
-	 * Sets the ClassIdentity of the objects this GroupingInfo is identifying.
+	 * Sets the Scope of the objects this GroupingInfo is identifying.
 	 * 
-	 * @param identity
-	 *            The ClassIdentity of the objects this GroupingInfo is identifying
+	 * @param scope
+	 *            The Scope of the objects this GroupingInfo is identifying
 	 */
-	public void setIdentity(ClassIdentity<T> identity)
+	public void setScope(PCGenScope scope)
 	{
-		this.identity = identity;
+		this.scope = scope;
 	}
 
 	/**
-	 * Returns the ClassIdentity of the objects this GroupingInfo is identifying.
+	 * Returns the Scope of the objects this GroupingInfo is identifying.
 	 * 
-	 * @return The ClassIdentity of the objects this GroupingInfo is identifying
+	 * @return The Scope of the objects this GroupingInfo is identifying
 	 */
-	public ClassIdentity<T> getIdentity()
+	public PCGenScope getScope()
 	{
-		return identity;
+		return scope;
+	}
+
+	/**
+	 * Returns the Class of objects managed by this GroupingInfo.
+	 * 
+	 * @return The Class of objects managed by this GroupingInfo
+	 */
+	@SuppressWarnings("unchecked")
+	public Class<T> getManagedClass(LoadContext context)
+	{
+		return (Class<T>) scope.getFormatManager(context).getManagedClass();
 	}
 
 }

--- a/code/src/java/pcgen/cdom/grouping/GroupingInfoFactory.java
+++ b/code/src/java/pcgen/cdom/grouping/GroupingInfoFactory.java
@@ -20,10 +20,8 @@ import java.util.Objects;
 import java.util.Stack;
 
 import pcgen.base.formula.base.LegalScope;
-import pcgen.cdom.base.ClassIdentity;
-import pcgen.cdom.base.Loadable;
+import pcgen.base.util.FormatManager;
 import pcgen.cdom.formula.scope.PCGenScope;
-import pcgen.cdom.reference.ReferenceManufacturer;
 import pcgen.rules.context.LoadContext;
 
 /**
@@ -96,21 +94,15 @@ public class GroupingInfoFactory
 		depth = 0;
 		expected.clear();
 		fullTokenizer = new GroupingTokenizer(instructions);
-		ReferenceManufacturer<? extends Loadable> formatManager =
-				context.getReferenceContext().getManufacturerByFormatName(scopeName[1]);
-		if (formatManager == null)
-		{
-			throw new GroupingStateException("Unable to determine FormatManager for Scope: " + fullScopeName);
-		}
-		return continueTypeSafeProcessing(formatManager);
+		FormatManager<?> formatManager = scope.getFormatManager(context);
+		return continueTypeSafeProcessing(scope, formatManager);
 	}
 
-	private <T extends Loadable> GroupingInfo<T> continueTypeSafeProcessing(ReferenceManufacturer<T> formatManager)
-		throws GroupingStateException
+	private <T> GroupingInfo<T> continueTypeSafeProcessing(
+		PCGenScope scope, FormatManager<T> formatManager) throws GroupingStateException
 	{
 		GroupingInfo<T> topInfo = new GroupingInfo<>();
-		ClassIdentity<T> refId = formatManager.getReferenceIdentity();
-		topInfo.setIdentity(refId);
+		topInfo.setScope(scope);
 		activeInfo = topInfo;
 		consumeGrouping();
 		if (fullTokenizer.hasNext())

--- a/code/src/java/pcgen/cdom/grouping/GroupingScopeFilter.java
+++ b/code/src/java/pcgen/cdom/grouping/GroupingScopeFilter.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 (C) Tom Parker <thpr@users.sourceforge.net>
+ * 
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 59 Temple Place,
+ * Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.cdom.grouping;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+
+import pcgen.base.formula.base.LegalScope;
+import pcgen.cdom.formula.PCGenScoped;
+import pcgen.cdom.formula.scope.PCGenScope;
+
+public class GroupingScopeFilter<T> implements GroupingCollection<T>
+{
+	/**
+	 * The underlying GroupingCollection that is responsible for filtering based on the
+	 * group instructions.
+	 */
+	private final GroupingCollection<T> underlying;
+
+	/**
+	 * The scope name of objects that this GroupingScopeFilter should be allowed to
+	 * impact; Any items in this scope will be passed to the underlying GroupingCollection
+	 * for processing.
+	 */
+	private final String scopeName;
+
+	/**
+	 * Constructs a new GroupingScopeFilter for the given scope and underlying
+	 * GroupingCollection.
+	 * 
+	 * @param scope
+	 *            The PCGenScope of objects that this GroupingCollection should process
+	 * @param grouping
+	 *            The underlying GroupingCollection to process objects that are in the
+	 *            given PCGenScope
+	 */
+	public GroupingScopeFilter(PCGenScope scope, GroupingCollection<T> grouping)
+	{
+		this.scopeName = LegalScope.getFullName(scope);
+		this.underlying = Objects.requireNonNull(grouping);
+	}
+
+	@Override
+	public String getInstructions()
+	{
+		return underlying.getInstructions();
+	}
+
+	@Override
+	public void process(PCGenScoped owner, Consumer<PCGenScoped> consumer)
+	{
+		if (owner.getLocalScopeName().equalsIgnoreCase(scopeName))
+		{
+			underlying.process(owner, consumer);
+		}
+	}
+
+}

--- a/code/src/java/pcgen/cdom/grouping/GroupingScopeFilter.java
+++ b/code/src/java/pcgen/cdom/grouping/GroupingScopeFilter.java
@@ -22,6 +22,23 @@ import pcgen.base.formula.base.LegalScope;
 import pcgen.cdom.formula.PCGenScoped;
 import pcgen.cdom.formula.scope.PCGenScope;
 
+/**
+ * A GroupingScopeFilter decorates a GroupingCollection in order to filter out objects
+ * based on their scope.
+ * 
+ * As context: In general, the grouping objects returned when analyzing something like
+ * GROUP=x are naive to their surroundings. They simply check for a GROUP= or a key, they
+ * do not check that that actual object they are checking is the correct type of object
+ * (Race, Skill, whatever). This could, of course, produce some nasty false positives.
+ * This filter enforces that larger contract (ensuring the appropriate scope) so that
+ * combined with the underlying GroupingCollection, one has both objects limited to a
+ * specific scope (the first argument of MODIFYOTHER, as enforced by this filter) as well
+ * as those that meet the appropriate grouping (the second argument of MODIFYOTHER, as
+ * enforced by the underlying GroupingCollection).
+ *
+ * @param <T>
+ *            The class of the object being stored in this GroupingScopeFilter
+ */
 public class GroupingScopeFilter<T> implements GroupingCollection<T>
 {
 	/**

--- a/code/src/java/pcgen/rules/context/AbstractReferenceContext.java
+++ b/code/src/java/pcgen/rules/context/AbstractReferenceContext.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import pcgen.base.format.dice.DiceFormat;
+import pcgen.base.formatmanager.ArrayFormatFactory;
 import pcgen.base.formatmanager.FormatUtilities;
 import pcgen.base.formatmanager.SimpleFormatManagerLibrary;
 import pcgen.base.util.DoubleKeyMap;
@@ -112,6 +113,7 @@ public abstract class AbstractReferenceContext
 	public void initialize()
 	{
 		FormatUtilities.loadDefaultFormats(fmtLibrary);
+		fmtLibrary.addFormatManagerBuilder(new ArrayFormatFactory('\n', ','));
 		fmtLibrary.addFormatManager(new DiceFormat());
 		fmtLibrary.addFormatManagerBuilder(
 			new ColumnFormatFactory(this.getManufacturer(AbstractReferenceContext.TABLE_COLUMN_CLASS)));
@@ -546,14 +548,4 @@ public abstract class AbstractReferenceContext
 	 */
 	public abstract <T extends Loadable> ReferenceManufacturer<T> getManufacturerByFormatName(String formatName,
 		Class<T> cl);
-
-	/**
-	 * Returns the ReferenceManufacturer for a given Format name and class.
-	 * 
-	 * @param formatName
-	 *            The (persistent) name of the format for which the ReferenceManufacturer
-	 *            should be returned
-	 * @return The ReferenceManufacturer for a given Format name and class
-	 */
-	public abstract ReferenceManufacturer<?> getManufacturerByFormatName(String formatName);
 }

--- a/code/src/java/pcgen/rules/context/GameReferenceContext.java
+++ b/code/src/java/pcgen/rules/context/GameReferenceContext.java
@@ -138,11 +138,4 @@ public final class GameReferenceContext extends AbstractReferenceContext
 		}
 		return mfg;
 	}
-
-	@Override
-	public ReferenceManufacturer<?> getManufacturerByFormatName(String formatName)
-	{
-		throw new UnsupportedOperationException(
-			"GameReferenceContext cannot get Format by name without knowing underlying class");
-	}
 }

--- a/code/src/java/pcgen/rules/context/LoadContext.java
+++ b/code/src/java/pcgen/rules/context/LoadContext.java
@@ -220,5 +220,5 @@ public interface LoadContext
 	 * @return A GroupingCollection<T> based on the given scope name and Group
 	 *         instructions
 	 */
-	public <T> GroupingCollection<? extends Loadable> getGrouping(PCGenScope scope, String instructions);
+	public <T> GroupingCollection<?> getGrouping(PCGenScope scope, String instructions);
 }

--- a/code/src/java/pcgen/rules/context/LoadContextInst.java
+++ b/code/src/java/pcgen/rules/context/LoadContextInst.java
@@ -579,7 +579,7 @@ abstract class LoadContextInst implements LoadContext
 	}
 
 	@Override
-	public <T> GroupingCollection<? extends Loadable> getGrouping(PCGenScope scope, String groupingName)
+	public <T> GroupingCollection<?> getGrouping(PCGenScope scope, String groupingName)
 	{
 		try
 		{
@@ -888,7 +888,7 @@ abstract class LoadContextInst implements LoadContext
 		}
 
 		@Override
-		public <T> GroupingCollection<? extends Loadable> getGrouping(PCGenScope scope, String groupingName)
+		public <T> GroupingCollection<?> getGrouping(PCGenScope scope, String groupingName)
 		{
 			return parent.getGrouping(scope, groupingName);
 		}

--- a/code/src/java/pcgen/rules/context/RuntimeReferenceContext.java
+++ b/code/src/java/pcgen/rules/context/RuntimeReferenceContext.java
@@ -188,12 +188,6 @@ public class RuntimeReferenceContext extends AbstractReferenceContext
 		Class<T> refClass)
 	{
 		Objects.requireNonNull(refClass);
-		return (ReferenceManufacturer<T>) getManufacturerByFormatName(formatName);
-	}
-
-	@Override
-	public ReferenceManufacturer<?> getManufacturerByFormatName(String formatName)
-	{
 		Objects.requireNonNull(formatName);
 		ClassIdentity<?> identity = nameMap.get(formatName);
 		if (identity == null)
@@ -210,6 +204,6 @@ public class RuntimeReferenceContext extends AbstractReferenceContext
 			 */
 			return null;
 		}
-		return map.get(identity);
+		return (ReferenceManufacturer<T>) map.get(identity);
 	}
 }

--- a/code/src/java/pcgen/rules/persistence/ChoiceSetLoadUtilities.java
+++ b/code/src/java/pcgen/rules/persistence/ChoiceSetLoadUtilities.java
@@ -31,6 +31,7 @@ import pcgen.cdom.base.PrimitiveCollection;
 import pcgen.cdom.grouping.GroupingCollection;
 import pcgen.cdom.grouping.GroupingDefinition;
 import pcgen.cdom.grouping.GroupingInfo;
+import pcgen.cdom.grouping.GroupingScopeFilter;
 import pcgen.cdom.primitive.CompoundAndPrimitive;
 import pcgen.cdom.primitive.CompoundOrPrimitive;
 import pcgen.cdom.primitive.NegatingPrimitive;
@@ -465,11 +466,12 @@ public final class ChoiceSetLoadUtilities
 	 * @return A GroupingCollection based on the given GroupingInfo interpreted within the
 	 *         given LoadContext
 	 */
-	public static <T, G extends Loadable> GroupingCollection<? extends Loadable> getDynamicGroup(LoadContext context,
+	public static <T, G> GroupingCollection<?> getDynamicGroup(LoadContext context,
 		GroupingInfo<G> info)
 	{
+		Class<G> groupingClass = info.getManagedClass(context);
 		GroupingDefinition<G> groupingDefinition =
-				TokenLibrary.getGrouping(info.getIdentity(), info.getCharacteristic());
+				TokenLibrary.getGrouping(groupingClass, info.getCharacteristic());
 		if (groupingDefinition == null)
 		{
 			/*
@@ -477,9 +479,10 @@ public final class ChoiceSetLoadUtilities
 			 * is a key, since object names should be usable directly. Therefore, try
 			 * processing it as a Key.
 			 */
-			groupingDefinition = TokenLibrary.getGrouping(info.getIdentity(), "KEY");
+			groupingDefinition = TokenLibrary.getGrouping(groupingClass, "KEY");
 		}
-		return groupingDefinition.process(context, info);
+		GroupingCollection<G> collection = groupingDefinition.process(context, info);
+		return new GroupingScopeFilter<>(info.getScope(), collection);
 	}
 
 }

--- a/code/src/java/pcgen/rules/persistence/TokenLibrary.java
+++ b/code/src/java/pcgen/rules/persistence/TokenLibrary.java
@@ -33,7 +33,6 @@ import pcgen.base.util.CaseInsensitiveMap;
 import pcgen.base.util.DoubleKeyMap;
 import pcgen.base.util.TreeMapToList;
 import pcgen.cdom.base.CDOMObject;
-import pcgen.cdom.base.ClassIdentity;
 import pcgen.cdom.base.GroupDefinition;
 import pcgen.cdom.base.Loadable;
 import pcgen.cdom.grouping.GroupingDefinition;
@@ -128,11 +127,11 @@ public final class TokenLibrary implements PluginLoader
 	 * 
 	 * @return The GroupingDefinition available with the given Format and grouping key.
 	 */
-	public static <T extends Loadable> GroupingDefinition<T> getGrouping(ClassIdentity<T> classIdentity,
+	public static <T> GroupingDefinition<T> getGrouping(Class<T> inputClass,
 		String tokenKey)
 	{
 		boolean isDirect = true;
-		Class<?> actingClass = classIdentity.getReferenceClass();
+		Class<? super T> actingClass = inputClass;
 		while (actingClass != null)
 		{
 			GroupingDefinition token = GROUPING_MAP.get(actingClass, tokenKey);

--- a/code/src/java/plugin/grouping/AllGroupingToken.java
+++ b/code/src/java/plugin/grouping/AllGroupingToken.java
@@ -59,7 +59,7 @@ public class AllGroupingToken<T extends Loadable> implements GroupingDefinition<
 		AllGrouping<T> allGrouping = new AllGrouping<>(info);
 		if (info.hasChild())
 		{
-			GroupingCollection<? extends Loadable> childCollection =
+			GroupingCollection<?> childCollection =
 					ChoiceSetLoadUtilities.getDynamicGroup(context, info.getChild());
 			allGrouping.setChild(childCollection);
 		}
@@ -104,7 +104,7 @@ public class AllGroupingToken<T extends Loadable> implements GroupingDefinition<
 			this.groupingInfo = Objects.requireNonNull(groupingInfo);
 		}
 
-		public void setChild(GroupingCollection<? extends Loadable> childCollection)
+		public void setChild(GroupingCollection<?> childCollection)
 		{
 			childGrouping = childCollection;
 		}

--- a/code/src/java/plugin/grouping/GroupGroupingToken.java
+++ b/code/src/java/plugin/grouping/GroupGroupingToken.java
@@ -57,7 +57,7 @@ public class GroupGroupingToken<T extends Loadable> implements GroupingDefinitio
 		GroupGrouping<T> groupGrouping = new GroupGrouping<>(info);
 		if (info.hasChild())
 		{
-			GroupingCollection<? extends Loadable> childCollection =
+			GroupingCollection<?> childCollection =
 					ChoiceSetLoadUtilities.getDynamicGroup(context, info.getChild());
 			groupGrouping.setChild(childCollection);
 		}
@@ -107,7 +107,7 @@ public class GroupGroupingToken<T extends Loadable> implements GroupingDefinitio
 			}
 		}
 
-		public void setChild(GroupingCollection<? extends Loadable> childCollection)
+		public void setChild(GroupingCollection<?> childCollection)
 		{
 			childGrouping = childCollection;
 		}

--- a/code/src/java/plugin/grouping/KeyGroupingToken.java
+++ b/code/src/java/plugin/grouping/KeyGroupingToken.java
@@ -55,7 +55,7 @@ public class KeyGroupingToken<T extends Loadable & PCGenScoped> implements Group
 		KeyGrouping<T> keyGrouping = new KeyGrouping<>(info);
 		if (info.hasChild())
 		{
-			GroupingCollection<? extends Loadable> childCollection =
+			GroupingCollection<?> childCollection =
 					ChoiceSetLoadUtilities.getDynamicGroup(context, info.getChild());
 			keyGrouping.setChild(childCollection);
 		}
@@ -76,9 +76,6 @@ public class KeyGroupingToken<T extends Loadable & PCGenScoped> implements Group
 	 */
 	private static class KeyGrouping<T extends Loadable> implements GroupingCollection<T>
 	{
-
-		private static final Class<PCGenScoped> PCGENSCOPED_CLASS = PCGenScoped.class;
-
 		/**
 		 * The GroupingInfo used to determine the format and GROUP: of objects contained
 		 * by this KeyGrouping.
@@ -105,14 +102,9 @@ public class KeyGroupingToken<T extends Loadable & PCGenScoped> implements Group
 				throw new IllegalArgumentException("KEY must have value following =");
 			}
 			this.groupingInfo = Objects.requireNonNull(info);
-			if (groupingInfo.hasChild() && !PCGENSCOPED_CLASS.isAssignableFrom(info.getIdentity().getReferenceClass()))
-			{
-				throw new IllegalArgumentException(
-					"KEY grouping had children but FORMAT: " + info.getIdentity().getName() + " is not a PCGenScoped");
-			}
 		}
 
-		public void setChild(GroupingCollection<? extends Loadable> childCollection)
+		public void setChild(GroupingCollection<?> childCollection)
 		{
 			childGrouping = childCollection;
 		}

--- a/code/src/java/plugin/lsttokens/ModifyOtherLst.java
+++ b/code/src/java/plugin/lsttokens/ModifyOtherLst.java
@@ -31,7 +31,6 @@ import pcgen.base.text.ParsingSeparator;
 import pcgen.base.util.CaseInsensitiveMap;
 import pcgen.base.util.FormatManager;
 import pcgen.cdom.base.Constants;
-import pcgen.cdom.base.Loadable;
 import pcgen.cdom.base.Ungranted;
 import pcgen.cdom.base.VarContainer;
 import pcgen.cdom.base.VarHolder;
@@ -105,7 +104,7 @@ public class ModifyOtherLst extends AbstractNonEmptyToken<VarHolder>
 		PCGenScope scope = context.getActiveScope();
 		String groupingName = sep.next();
 
-		GroupingCollection<? extends Loadable> group = context.getGrouping(lvs, groupingName);
+		GroupingCollection<?> group = context.getGrouping(lvs, groupingName);
 		if (group == null)
 		{
 			return new ParseResult.Fail(getTokenName() + " unable to build group from: " + groupingName);


### PR DESCRIPTION
Fixes an issue Andrew found in the new formula system
Stabilizes how certain objects work, allows many formats more easily
Grouping doesn't need to be Loadable
Include ARRAY[] format