### PR TITLE
[tests] halve the time it takes to run unit tests

### DIFF
--- a/code/src/utest/plugin/lsttokens/testsupport/AbstractTokenTestCase.java
+++ b/code/src/utest/plugin/lsttokens/testsupport/AbstractTokenTestCase.java
@@ -18,15 +18,9 @@
 package plugin.lsttokens.testsupport;
 
 
-import java.lang.ref.WeakReference;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
-import junit.framework.TestCase;
 import pcgen.cdom.base.Categorized;
 import pcgen.cdom.base.Category;
 import pcgen.cdom.base.Loadable;
@@ -44,6 +38,11 @@ import pcgen.rules.persistence.TokenLibrary;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import pcgen.rules.persistence.token.ParseResult;
 import pcgen.util.Logging;
+
+import junit.framework.TestCase;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
 import util.TestURI;
 
 @SuppressWarnings("nls")
@@ -304,20 +303,6 @@ public abstract class AbstractTokenTestCase<T extends Loadable> extends
 				.getAnswer(getLegalValue(), getAlternateLegalValue()));
 	}
 
-	@Test
-	public void testCleanup()
-	{
-		String s = new String(getLegalValue());
-		WeakReference<String> wr = new WeakReference<>(s);
-		assertTrue(parse(s));
-		s = null;
-		System.gc();
-		if (wr.get() != null)
-		{
-			fail("retained");
-		}
-	}
-
 	protected abstract String getLegalValue();
 
 	protected abstract String getAlternateLegalValue();
@@ -358,30 +343,6 @@ public abstract class AbstractTokenTestCase<T extends Loadable> extends
 		obj.setName(name);
 		context.getReferenceContext().importObject(obj);
 		return obj;
-	}
-
-	@Test
-	public void testAvoidContext()
-	{
-		RuntimeLoadContext context = new RuntimeLoadContext(
-			RuntimeReferenceContext.createRuntimeReferenceContext(),
-			new ConsolidatedListCommitStrategy());
-		additionalSetup(context);
-		WeakReference<LoadContext> wr = new WeakReference<>(context);
-		T item = this.get(context, "TestObj");
-		ParseResult pr = getToken().parseToken(context, item, getLegalValue());
-		if (!pr.passed())
-		{
-			fail();
-		}
-		context.commit();
-		assertTrue(pr.passed());
-		context = null;
-		System.gc();
-		if (wr.get() != null)
-		{
-			fail("retained");
-		}
 	}
 
 	protected void additionalSetup(LoadContext context)


### PR DESCRIPTION
These two tests take the running time of tests on my computer 5m18s to
about 12m.

In addition the tests don't quite work as expected. Java implementations
don't have do anything on a gc, and WeakReference isn't guaranteed to be
null even post gc.