### PR TITLE
[build] avoid configuration leakage in build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@
  */
 
 // import Ant helper static values to differ system families
-import static org.apache.tools.ant.taskdefs.condition.Os.*
+import org.apache.tools.ant.filters.FixCrLfFilter
 
 plugins {
     id 'com.gradle.build-scan' version '2.0.2'
@@ -24,6 +24,7 @@ plugins {
     id 'java'
     id 'maven'
     id 'pmd'
+    id 'idea'
     id "de.undercouch.download" version '3.4.3'
     id 'edu.sc.seis.launch4j' version '2.4.4'
     id 'com.github.ben-manes.versions' version '0.20.0'
@@ -100,7 +101,7 @@ sourceSets {
             srcDirs 'code/src/java'
         }
         resources {
-            srcDirs = ['code/src/java', 'code/resources' ]
+            srcDirs = ['code/src/java', 'code/resources']
             include '**/*.properties'
             include '**/*.xml'
             include '**/*.gif'
@@ -112,16 +113,28 @@ sourceSets {
         java {
             srcDirs = ['code/src/utest', 'code/src/testcommon']
         }
+        compileClasspath += sourceSets.main.output
+        runtimeClasspath += sourceSets.main.output
     }
     itest {
         java {
             srcDirs = ['code/src/itest', 'code/src/testcommon']
         }
+        compileClasspath += sourceSets.main.output
+        runtimeClasspath += sourceSets.main.output
+        compileClasspath += sourceSets.test.compileClasspath
+        runtimeClasspath += sourceSets.test.runtimeClasspath
+
     }
     slowtest {
         java {
             srcDirs = ['code/src/test', 'code/src/testcommon']
         }
+        compileClasspath += sourceSets.main.output
+        runtimeClasspath += sourceSets.main.output
+        compileClasspath += sourceSets.test.compileClasspath
+        runtimeClasspath += sourceSets.test.runtimeClasspath
+
     }
 }
 
@@ -179,18 +192,6 @@ dependencies {
     testCompile group: 'org.hamcrest', name: 'hamcrest-library', version: '1.3'
     testCompile group: 'org.xmlunit', name: 'xmlunit-matchers', version:'2.6.2'
 
-    itestCompile sourceSets.main.output
-    itestCompile configurations.testCompile
-    itestCompile sourceSets.test.output
-
-    itestRuntime configurations.testRuntime
-
-    slowtestCompile sourceSets.main.output
-    slowtestCompile configurations.testCompile
-    slowtestCompile sourceSets.test.output
-
-    slowtestRuntime configurations.testRuntime
-   
     spotbugs 'com.github.spotbugs:spotbugs:3.1.8'
     spotbugsPlugins 'com.h3xstream.findsecbugs:findsecbugs-plugin:1.8.0'
 }
@@ -237,9 +238,8 @@ task copyToLibs(type: Copy) {
     from configurations.runtime
 }
 
-import org.apache.tools.ant.filters.FixCrLfFilter;
-task copyToOutput(type: Copy, dependsOn: [createExe, copyToLibs, jar, 
-        converterJar]) {
+task copyToOutput(type: Copy, dependsOn: [createExe, copyToLibs, jar,
+                                          converterJar]) {
     from "$buildDir/libs/pcgen-${version}.jar"
     from "$buildDir/libs/pcgen-${version}-batch-convert.jar"
     from "$buildDir/launch4j/pcgen.exe"
@@ -386,6 +386,14 @@ dependencyUpdates.resolutionStrategy = {
                 selection.reject('older than current')
             }
         }
+    }
+}
+
+idea {
+    module {
+        testSourceDirs += project.sourceSets.itest.java.srcDirs
+        testSourceDirs += project.sourceSets.slowtest.java.srcDirs
+        testSourceDirs += project.sourceSets.test.java.srcDirs
     }
 }
 


### PR DESCRIPTION
New Gradle versions issue warnings if configuration is read at a "bad"
time. Reorganize in accordance with modern docs in order to avoid this
warning.

Further, teach IntelliJ that "slowtest" is a test directory.