### PR TITLE
[spotbugs] reduce log spam

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -185,7 +185,6 @@ dependencies {
     testCompile group: 'org.xmlunit', name: 'xmlunit-matchers', version:'2.6.2'
 
     spotbugs 'com.github.spotbugs:spotbugs:3.1.8'
-    spotbugsPlugins 'com.h3xstream.findsecbugs:findsecbugs-plugin:1.8.0'
 }
 
 ant.importBuild 'build-gradle.xml'

--- a/code/gradle/reporting.gradle
+++ b/code/gradle/reporting.gradle
@@ -37,7 +37,7 @@ spotbugs {
 }
 
 //Unable to determine how to do this with SpotBugs - this is consistent with their docs, but dumps stack
-//tasks.withType(com.github.spotbugs.SpotBugs) {
+//tasks.withType(com.github.spotbugs.SpotBugsTask) {
 //	reports {
 //		xml.enabled = false
 //		html.enabled = true

--- a/code/standards/spotbugs_ignore.xml
+++ b/code/standards/spotbugs_ignore.xml
@@ -1,28 +1,48 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FindBugsFilter>
-   <Match>
-        <!-- high number of false positive -->
-        <Bug pattern="PSC_PRESIZE_COLLECTIONS" />
-   </Match>
-   <Match>
-        <!-- not relevent to pcgen -->
-        <Bug pattern="IJU_SETUP_NO_SUPER,DP_DO_INSIDE_DO_PRIVILEGED,DM_EXIT" />
-    </Match>
-    <Match>
-        <!-- we have other tools for code style -->
-        <!--NM_CLASS_NAMING_CONVENTION,MS_SHOULD_BE_FINAL,NM_METHOD_NAMING_CONVENTION,-->
-            <Bug pattern="DM_BOXED_PRIMITIVE_FOR_PARSING,SIC_INNER_SHOULD_BE_STATIC,ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD,ITC_INHERITANCE_TYPE_CHECKING" />
-    </Match>
-    <Match>
-            <!-- visibility concerns: we should eventually turn these on -->
-            <Bug pattern="MS_PKGPROTECT,OPM_OVERLY_PERMISSIVE_METHOD" />
-    </Match>
-    <Match>
-        <Class name="~.*\.*Test" />
+<FindBugsFilter
+    xmlns="https://github.com/spotbugs/filter/3.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
 
-        <Not>
-            <!-- 'IJU' is the code for Bugs related to JUnit test code -->
-            <Bug code="IJU" />
-        </Not>
-    </Match>
+  <!-- We have many problems in older code, so avoid checking them for now.
+    As we improve code quality expand this exclusion-->
+  <Match>
+    <Not>
+      <Or>
+        <Package name="~pcgen\.base\..*"/>
+        <Package name="~pcgen\.cdom\..*"/>
+        <Package name="~pcgen\.output\..*"/>
+      </Or>
+    </Not>
+  </Match>
+  <Match>
+    <!-- high number of false positive -->
+    <Bug pattern="PSC_PRESIZE_COLLECTIONS,DM_CONVERT_CASE"/>
+  </Match>
+  <Match>
+    <!-- not relevent to pcgen -->
+    <Bug pattern="IJU_SETUP_NO_SUPER,DP_DO_INSIDE_DO_PRIVILEGED,DM_EXIT,SE_NO_SERIALVERSIONID"/>
+  </Match>
+  <Match>
+    <!-- we have other tools for code style -->
+    <!--NM_CLASS_NAMING_CONVENTION,MS_SHOULD_BE_FINAL,NM_METHOD_NAMING_CONVENTION,-->
+    <Bug
+        pattern="DM_BOXED_PRIMITIVE_FOR_PARSING,SIC_INNER_SHOULD_BE_STATIC,ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD,ITC_INHERITANCE_TYPE_CHECKING,RI_REDUNDANT_INTERFACES"/>
+  </Match>
+  <Match>
+    <!-- visibility concerns: we should eventually turn these on -->
+    <Bug pattern="MS_PKGPROTECT,OPM_OVERLY_PERMISSIVE_METHOD"/>
+  </Match>
+  <Match>
+    <!-- we use null too much for now -->
+    <Bug pattern="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR" />
+  </Match>
+  <Match>
+    <Class name="~.*\.*Test"/>
+
+    <Not>
+      <!-- 'IJU' is the code for Bugs related to JUnit test code -->
+      <Bug code="IJU"/>
+    </Not>
+  </Match>
 </FindBugsFilter>


### PR DESCRIPTION
We have many spotbugs reported problems. Lets focus on solving them only
in new code in order to make the logs more useful.

Further, remove com.h3xstream.findsecbugs since it doesn't report
anything for us, slows down spotbugs, and is primarily designed for web
applications (or applications with untrusted output).

Further add more bug exclusions for types we don't yet care about.