### PR TITLE
RuleConstants: make a class

### DIFF
--- a/code/src/java/pcgen/core/RuleConstants.java
+++ b/code/src/java/pcgen/core/RuleConstants.java
@@ -22,33 +22,34 @@ package pcgen.core;
 
 /**
  * {@code RuleConstants}
- * This interface holds all rules VAR names used in the code.
- *
- * (The reason for an interface rather than a class
- * is that an interface uses a little less memory.)
- *
+ * This class holds all rules VAR names used in the code.
  */
-public interface RuleConstants
+@SuppressWarnings("WeakerAccess")
+public final class RuleConstants
 {
-	String ABILRANGE = "ABILRANGE"; // Allow any range for ability scores
-	String AMMOSTACKSWITHWEAPON = "AMMOSTACKSWITHWEAPON"; // Do ammo enhancement bonus stack with those of the weapon
-	String BONUSSPELLKNOWN = "BONUSSPELLKNOWN"; // Add stat bonus to Spells Known
-	String CLASSPRE = "CLASSPRE"; // Bypass Class Prerequisites
-	String EQUIPATTACK = "EQUIPATTACK"; // Treat Weapons In Hand As Equipped For Attacks
-	String FEATPRE = "FEATPRE"; // Bypass Feat Prerequisites
-	String FREECLOTHES = "FREECLOTHES"; // Ask For Free Clothing at First Level
-	String CLOTHINGENCUMBRANCE = "CLOTHINGENCUMBRANCE"; // First set of equipped clothing counts towards encumbrance 
-	String INTBEFORE = "INTBEFORE"; // Increment STAT before calculating skill points when leveling
-	String RETROSKILL = "RETROSKILL"; // Changes to bonus skill points are retroactive
-	String INTBONUSLANG = "INTBONUSLANG"; // Allow Selection of Int bonus Languages after 1st level
-	String LEVELCAP = "LEVELCAP"; // Ignore Level Cap
-	String PROHIBITSPELLS = "PROHIBITSPELLS"; // Restrict Cleric/Druid spells based on alignment
-	String SIZECAT = "SIZECAT"; // Use 3.5 Weapon Categories
-	String SIZEOBJ = "SIZEOBJ"; // Use 3.0 Weapon Size
-	String SKILLMAX = "SKILLMAX"; // Bypass Max Skill Ranks
-	String SYS_35WP = "SYS_35WP"; // Apply 3.5 Size Category Penalty to Attacks
+	public static final String ABILRANGE = "ABILRANGE"; // Allow any range for ability scores
+	public static final String AMMOSTACKSWITHWEAPON = "AMMOSTACKSWITHWEAPON"; // Do ammo enhancement bonus stack with those of the weapon
+	public static final String BONUSSPELLKNOWN = "BONUSSPELLKNOWN"; // Add stat bonus to Spells Known
+	public static final String CLASSPRE = "CLASSPRE"; // Bypass Class Prerequisites
+	public static final String EQUIPATTACK = "EQUIPATTACK"; // Treat Weapons In Hand As Equipped For Attacks
+	public static final String FEATPRE = "FEATPRE"; // Bypass Feat Prerequisites
+	public static final String FREECLOTHES = "FREECLOTHES"; // Ask For Free Clothing at First Level
+	public static final String CLOTHINGENCUMBRANCE = "CLOTHINGENCUMBRANCE"; // First set of equipped clothing counts towards encumbrance
+	public static final String INTBEFORE = "INTBEFORE"; // Increment STAT before calculating skill points when leveling
+	public static final String RETROSKILL = "RETROSKILL"; // Changes to bonus skill points are retroactive
+	public static final String INTBONUSLANG = "INTBONUSLANG"; // Allow Selection of Int bonus Languages after 1st level
+	public static final String LEVELCAP = "LEVELCAP"; // Ignore Level Cap
+	public static final String PROHIBITSPELLS = "PROHIBITSPELLS"; // Restrict Cleric/Druid spells based on alignment
+	public static final String SIZECAT = "SIZECAT"; // Use 3.5 Weapon Categories
+	public static final String SIZEOBJ = "SIZEOBJ"; // Use 3.0 Weapon Size
+	public static final String SKILLMAX = "SKILLMAX"; // Bypass Max Skill Ranks
+	public static final String SYS_35WP = "SYS_35WP"; // Apply 3.5 Size Category Penalty to Attacks
 	//	String SYS_CIP				= "SYS_CIP";					// Improper tools incurs a -2 circumstance penalty
 	//	String SYS_DOMAIN			= "SYS_DOMAIN";					// Apply Casterlevel Bonuses from Domains to Spells
-	String SYS_LDPACSK = "SYS_LDPACSK"; // Apply Load Penalty to AC and Skills
-	String SYS_WTPSK = "SYS_WTPSK"; // Apply Weight Penalty to Skills
+	public static final String SYS_LDPACSK = "SYS_LDPACSK"; // Apply Load Penalty to AC and Skills
+	public static final String SYS_WTPSK = "SYS_WTPSK"; // Apply Weight Penalty to Skills
+
+	private RuleConstants()
+	{
+	}
 }

--- a/code/src/test/pcgen/io/exporttoken/WeaponTokenTest.java
+++ b/code/src/test/pcgen/io/exporttoken/WeaponTokenTest.java
@@ -47,6 +47,7 @@ import pcgen.core.PCTemplate;
 import pcgen.core.PlayerCharacter;
 import pcgen.core.Race;
 import pcgen.core.RuleCheck;
+import pcgen.core.RuleConstants;
 import pcgen.core.SettingsHandler;
 import pcgen.core.SizeAdjustment;
 import pcgen.core.WeaponProf;
@@ -270,9 +271,9 @@ public class WeaponTokenTest extends AbstractCharacterTestCase
 
 		GameMode gm = SettingsHandler.getGame();
 		RuleCheck rc = new RuleCheck();
-		rc.setName("SIZECAT");
+		rc.setName(RuleConstants.SIZECAT);
 		gm.getModeContext().getReferenceContext().importObject(rc);
-		SettingsHandler.setRuleCheck("SIZECAT", true);
+		SettingsHandler.setRuleCheck(RuleConstants.SIZECAT, true);
 		gm.setWCStepsFormula("EQUIP.SIZE.INT-PC.SIZE.INT");
 		gm.setWeaponReachFormula("(RACEREACH+(max(0,REACH-5)))*REACHMULT");
 


### PR DESCRIPTION
While an interface for a holder isn't inherently a problem, it leads to
confusion and encourages users to _implement_ the iface rather than
statically access the values.  Change RuleConstants to a class.