### PR TITLE
Revert "Simplify AbstractReferenceContext.resolveReferences"

### DIFF
--- a/code/src/java/pcgen/rules/context/AbstractReferenceContext.java
+++ b/code/src/java/pcgen/rules/context/AbstractReferenceContext.java
@@ -63,6 +63,7 @@ import pcgen.cdom.reference.ReferenceManufacturer;
 import pcgen.cdom.reference.UnconstructedValidator;
 import pcgen.cdom.util.IntegerKeyComparator;
 import pcgen.core.Domain;
+import pcgen.core.Globals;
 import pcgen.core.PCClass;
 import pcgen.core.SubClass;
 import pcgen.util.Logging;
@@ -98,7 +99,7 @@ public abstract class AbstractReferenceContext
 	private static final Class<DataTable> DATA_TABLE_CLASS = DataTable.class;
 	private static final Class<TableColumn> TABLE_COLUMN_CLASS = TableColumn.class;
 
-	private final DoubleKeyMap<Class<?>, Object, WeakReference<List<?>>> sortedMap = new DoubleKeyMap<>();
+	private DoubleKeyMap<Class<?>, Object, WeakReference<List<?>>> sortedMap = new DoubleKeyMap<>();
 
 	private final Map<CDOMObject, CDOMSingleRef<?>> directRefCache = new HashMap<>();
 
@@ -147,8 +148,12 @@ public abstract class AbstractReferenceContext
 
 	public boolean validate(UnconstructedValidator validator)
 	{
-		return getAllManufacturers().stream()
-                            .allMatch(ref -> ref.validate(validator));
+		boolean returnGood = true;
+		for (ReferenceManufacturer<?> ref : getAllManufacturers())
+		{
+			returnGood &= ref.validate(validator);
+		}
+		return returnGood;
 	}
 
 	public <T extends Loadable> CDOMGroupRef<T> getCDOMAllReference(Class<T> c)
@@ -252,9 +257,10 @@ public abstract class AbstractReferenceContext
 	public Set<Object> getAllConstructedObjects()
 	{
 		Set<Object> set = new HashSet<>();
-		getAllManufacturers().stream()
-		                     .map(ReferenceManufacturer::getAllObjects).
-				                     forEach(set::addAll);
+		for (ReferenceManufacturer<?> ref : getAllManufacturers())
+		{
+			set.addAll(ref.getAllObjects());
+		}
 		// Collection otherSet = categorized.getAllConstructedCDOMObjects();
 		// set.addAll(otherSet);
 		return set;
@@ -268,11 +274,12 @@ public abstract class AbstractReferenceContext
 	public void buildDerivedObjects()
 	{
 		Collection<Domain> domains = getConstructedCDOMObjects(Domain.class);
-		domains.forEach(d -> {
+		for (Domain d : domains)
+		{
 			DomainSpellList dsl = constructCDOMObject(DOMAINSPELLLIST_CLASS, d.getKeyName());
 			dsl.addType(Type.DIVINE);
 			d.put(ObjectKey.DOMAIN_SPELLLIST, dsl);
-		});
+		}
 		Collection<PCClass> classes = getConstructedCDOMObjects(PCClass.class);
 		for (PCClass pcc : classes)
 		{
@@ -392,8 +399,12 @@ public abstract class AbstractReferenceContext
 
 	public boolean resolveReferences(UnconstructedValidator validator)
 	{
-		return getAllManufacturers().stream()
-		                            .allMatch(rs -> processResolution(validator, rs));
+		boolean returnGood = true;
+		for (ReferenceManufacturer<?> rs : getAllManufacturers())
+		{
+			returnGood &= processResolution(validator, rs);
+		}
+		return returnGood;
 	}
 
 	private <T extends Loadable> boolean processResolution(UnconstructedValidator validator,
@@ -407,7 +418,10 @@ public abstract class AbstractReferenceContext
 
 	public void buildDeferredObjects()
 	{
-		getAllManufacturers().forEach(ReferenceManufacturer::buildDeferredObjects);
+		for (ReferenceManufacturer<?> rs : getAllManufacturers())
+		{
+			rs.buildDeferredObjects();
+		}
 	}
 
 	public <T extends Loadable> T constructNowIfNecessary(Class<T> cl, String name)
@@ -437,6 +451,20 @@ public abstract class AbstractReferenceContext
 		{
 			returnList = generateList(cl, new IntegerKeyComparator(key));
 			sortedMap.put(cl, key, new WeakReference<>(returnList));
+		}
+		return Collections.unmodifiableList(returnList);
+	}
+
+	public <T extends CDOMObject> List<T> getSortOrderedList(Class<T> cl)
+	{
+		List<T> returnList;
+		Comparator<CDOMObject> comp = Globals.P_OBJECT_NAME_COMP;
+		//We arbitrarily use the sort order comparator as the second key
+		WeakReference<List<?>> wr = sortedMap.get(cl, comp);
+		if ((wr == null) || ((returnList = (List<T>) wr.get()) == null))
+		{
+			returnList = generateList(cl, comp);
+			sortedMap.put(cl, comp, new WeakReference<>(returnList));
 		}
 		return Collections.unmodifiableList(returnList);
 	}

--- a/code/src/java/pcgen/rules/context/LoadContextInst.java
+++ b/code/src/java/pcgen/rules/context/LoadContextInst.java
@@ -285,19 +285,24 @@ abstract class LoadContextInst implements LoadContext
 	public void resolvePostValidationTokens()
 	{
 		Collection<? extends ReferenceManufacturer<?>> mfgs = getReferenceContext().getAllManufacturers();
-		TokenLibrary.getPostValidationTokens().forEach(token -> processPostVal(token, mfgs));
+		for (PostValidationToken<? extends Loadable> token : TokenLibrary.getPostValidationTokens())
+		{
+			processPostVal(token, mfgs);
+		}
 	}
 
 	private <T extends Loadable> void processPostVal(PostValidationToken<T> token,
 		Collection<? extends ReferenceManufacturer> mfgs)
 	{
 		Class<T> cl = token.getValidationTokenClass();
-		mfgs.stream()
-		    .filter(rm -> cl.isAssignableFrom(rm.getReferenceClass()))
-		    .forEach(rm -> {
-			setSourceURI(null);
-			token.process(this, rm.getAllObjects());
-		});
+		for (ReferenceManufacturer<? extends T> rm : mfgs)
+		{
+			if (cl.isAssignableFrom(rm.getReferenceClass()))
+			{
+				setSourceURI(null);
+				token.process(this, rm.getAllObjects());
+			}
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Reverts PCGen/pcgen#4553

This patch causes build failures - it is not logically correct
