### PR TITLE
Cleaned up until RegionFacet

### DIFF
--- a/code/src/java/pcgen/cdom/facet/analysis/AgeSetFacet.java
+++ b/code/src/java/pcgen/cdom/facet/analysis/AgeSetFacet.java
@@ -18,6 +18,7 @@
 package pcgen.cdom.facet.analysis;
 
 import java.util.List;
+import java.util.Optional;
 
 import pcgen.cdom.base.ItemFacet;
 import pcgen.cdom.enumeration.CharID;
@@ -87,7 +88,7 @@ public class AgeSetFacet extends AbstractItemFacet<CharID, AgeSet>
 	 */
 	private void update(CharID id)
 	{
-		Region region = Region.getConstant(regionFacet.getRegionString(id));
+		Optional<Region> region = regionFacet.getRegion(id);
 		AgeSet ageSet = bioSetFacet.get(id).getAgeSet(region, getAgeSetIndex(id));
 		if (ageSet == null)
 		{
@@ -133,7 +134,7 @@ public class AgeSetFacet extends AbstractItemFacet<CharID, AgeSet>
 	public int getAgeSetIndex(CharID id)
 	{
 		BioSet bioSet = bioSetFacet.get(id);
-		String region = regionFacet.getRegionString(id);
+		Optional<Region> region = regionFacet.getRegion(id);
 		Race race = raceFacet.get(id);
 		String raceName = race == null ? "" : race.getKeyName().trim();
 		List<String> values = bioSet.getValueInMaps(region, raceName, "BASEAGE");

--- a/code/src/java/pcgen/core/CustomData.java
+++ b/code/src/java/pcgen/core/CustomData.java
@@ -478,9 +478,8 @@ public final class CustomData
 			{
 				if (race.isType(Constants.TYPE_CUSTOM))
 				{
-					String region = Constants.NONE;
 					final String key = race.getKeyName();
-					bw.write(SettingsHandler.getGame().getBioSet().getRacePCCText(region, key));
+					bw.write(SettingsHandler.getGame().getBioSet().getBaseRegionPCCText(key));
 					bw.newLine();
 				}
 			}

--- a/code/src/java/pcgen/core/display/CharacterDisplay.java
+++ b/code/src/java/pcgen/core/display/CharacterDisplay.java
@@ -25,6 +25,7 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -46,6 +47,7 @@ import pcgen.cdom.enumeration.ObjectKey;
 import pcgen.cdom.enumeration.PCStringKey;
 import pcgen.cdom.enumeration.RaceSubType;
 import pcgen.cdom.enumeration.RaceType;
+import pcgen.cdom.enumeration.Region;
 import pcgen.cdom.enumeration.SkillFilter;
 import pcgen.cdom.facet.ActiveSpellsFacet;
 import pcgen.cdom.facet.AutoLanguageGrantedFacet;
@@ -495,6 +497,16 @@ public class CharacterDisplay
 	public String getRegionString()
 	{
 		return regionFacet.getRegionString(id);
+	}
+
+	/**
+	 * Get the Character's Region
+	 * 
+	 * @return character region
+	 */
+	public Optional<Region> getRegion()
+	{
+		return regionFacet.getRegion(id);
 	}
 
 	/**

--- a/code/src/java/pcgen/io/ExportHandler.java
+++ b/code/src/java/pcgen/io/ExportHandler.java
@@ -2137,7 +2137,7 @@ public final class ExportHandler
 		CharacterDisplay display = aPC.getDisplay();
 		if ("REGION".equals(aString.substring(1)))
 		{
-			if (display.getRegionString().equals(Constants.NONE))
+			if (display.getRegion().equals(Constants.NONE))
 			{
 				canWrite = false;
 			}

--- a/code/src/java/pcgen/persistence/lst/BioSetLoader.java
+++ b/code/src/java/pcgen/persistence/lst/BioSetLoader.java
@@ -20,11 +20,12 @@ package pcgen.persistence.lst;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.StringTokenizer;
 
-import pcgen.cdom.base.Constants;
 import pcgen.cdom.base.TransitionChoice;
 import pcgen.cdom.enumeration.ListKey;
+import pcgen.cdom.enumeration.Region;
 import pcgen.core.AgeSet;
 import pcgen.core.BioSet;
 import pcgen.core.GameMode;
@@ -40,7 +41,11 @@ import pcgen.util.Logging;
 
 public final class BioSetLoader extends LstLineFileLoader
 {
-	private static String regionName = Constants.NONE;
+	/**
+	 * The current Region being processed
+	 */
+	private static Optional<Region> region = Optional.empty();
+
 	BioSet bioSet = new BioSet();
 	/**
 	 * The age set (bracket) currently being processed. Used by the parseLine
@@ -49,11 +54,11 @@ public final class BioSetLoader extends LstLineFileLoader
 	int currentAgeSetIndex = 0;
 
 	/**
-	 * clear the regionName
+	 * Clear the Region.
 	 */
 	public static void clear()
 	{
-		regionName = Constants.NONE;
+		region = Optional.empty();
 	}
 
 	@Override
@@ -90,7 +95,7 @@ public final class BioSetLoader extends LstLineFileLoader
 					parseTokens(context, ageSet, colToken);
 				}
 
-				ageSet = bioSet.addToAgeMap(regionName, ageSet, sourceURI);
+				ageSet = bioSet.addToAgeMap(region, ageSet, sourceURI);
 				Integer oldIndex = bioSet.addToNameMap(ageSet);
 				if (oldIndex != null && oldIndex != currentAgeSetIndex)
 				{
@@ -122,7 +127,7 @@ public final class BioSetLoader extends LstLineFileLoader
 				}
 				else if (colString.startsWith("REGION:"))
 				{
-					regionName = colString.substring(7).intern();
+					region = Optional.of(Region.getConstant(colString.substring(7).intern()));
 				}
 				else if (PreParserFactory.isPreReqString(colString))
 				{
@@ -150,7 +155,7 @@ public final class BioSetLoader extends LstLineFileLoader
 						aString = sBuf.toString();
 					}
 
-					bioSet.addToUserMap(regionName, raceName.intern(), aString.intern(), currentAgeSetIndex);
+					bioSet.addToUserMap(region, raceName.intern(), aString.intern(), currentAgeSetIndex);
 				}
 			}
 		}

--- a/code/src/test/pcgen/core/BioSetTest.java
+++ b/code/src/test/pcgen/core/BioSetTest.java
@@ -19,6 +19,7 @@
 package pcgen.core;
 
 import java.util.Locale;
+import java.util.Optional;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.LocaleDependentTestCase;
@@ -149,7 +150,8 @@ public class BioSetTest extends AbstractCharacterTestCase
 		idx = display.getAgeSetIndex();
 		assertEquals("Ageset for " + display.getAge() + ".", 3, idx);
 
-		SettingsHandler.getGame().getBioSet().getAgeSet(Region.getConstant(pc.getDisplay().getRegionString()), idx);
+		Optional<Region> region = pc.getDisplay().getRegion();
+		SettingsHandler.getGame().getBioSet().getAgeSet(region, idx);
 
 	}
 }

--- a/code/src/test/pcgen/persistence/lst/BioSetLoaderTest.java
+++ b/code/src/test/pcgen/persistence/lst/BioSetLoaderTest.java
@@ -20,14 +20,13 @@ package pcgen.persistence.lst;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Optional;
 
-import pcgen.cdom.base.Constants;
+import junit.framework.TestCase;
 import pcgen.core.BioSet;
 import pcgen.core.Globals;
 import pcgen.core.SettingsHandler;
 import pcgen.rules.context.LoadContext;
-
-import junit.framework.TestCase;
 
 /**
  * A collection of tests to validate the functioning of the BioSetLoader class.
@@ -183,7 +182,7 @@ public final class BioSetLoaderTest extends TestCase
 			{
 				final String testArg = TEST_TAGS[j];
 				baseRaceTag =
-						currBioSet.getTagForRace(Constants.NONE, raceName,
+						currBioSet.getValueInMaps(Optional.empty(), raceName,
 							testArg);
 				//				System.out.println(
 				//					"Got '"
@@ -207,7 +206,7 @@ public final class BioSetLoaderTest extends TestCase
 	public void testParseSecondBioSetGood() throws Exception
 	{
 		assertEquals("No ogre bio details expected before load", "REGION:None\n\n", SettingsHandler
-			.getGame().getBioSet().getRacePCCText("None", "Ogre"));
+			.getGame().getBioSet().getBaseRegionPCCText("Ogre"));
 		String[] bioData2 = new String[]{
 			"AGESET:0|Adulthood",
 			"RACENAME:Ogre		CLASS:Barbarian,Rogue,Sorcerer[BASEAGEADD:1d4]|Bard,Fighter,Paladin,Ranger[BASEAGEADD:1d6]|Cleric,Druid,Monk,Wizard[BASEAGEADD:2d6]",
@@ -224,7 +223,7 @@ public final class BioSetLoaderTest extends TestCase
 
 		String racePCCText =
 				SettingsHandler.getGame().getBioSet()
-					.getRacePCCText("None", "Ogre");
+					.getBaseRegionPCCText("Ogre");
 		assertFalse("Ogre bio details expected after load but was "
 			+ racePCCText, "REGION:None\n\n".equals(racePCCText));
 		
@@ -239,7 +238,7 @@ public final class BioSetLoaderTest extends TestCase
 	public void testParseSecondBioSetBadName() throws Exception
 	{
 		assertEquals("No ogre bio details expected before load", "REGION:None\n\n", SettingsHandler
-			.getGame().getBioSet().getRacePCCText("None", "Ogre"));
+			.getGame().getBioSet().getBaseRegionPCCText("Ogre"));
 		String[] bioData2 = new String[]{
 			"AGESET:0|Bad",
 			"RACENAME:Ogre		CLASS:Barbarian,Rogue,Sorcerer[BASEAGEADD:1d4]|Bard,Fighter,Paladin,Ranger[BASEAGEADD:1d6]|Cleric,Druid,Monk,Wizard[BASEAGEADD:2d6]",
@@ -256,7 +255,7 @@ public final class BioSetLoaderTest extends TestCase
 		
 		String racePCCText =
 				SettingsHandler.getGame().getBioSet()
-					.getRacePCCText("None", "Ogre");
+					.getBaseRegionPCCText("Ogre");
 		assertTrue(
 			"Expected details to be against original ageset name but was "
 				+ racePCCText,


### PR DESCRIPTION
First step in a multi-step set of PRs

This changes the initial interface in BioSet/BioSetLoader to not use strings/null for Region.  It becomes an Optional<Region> and is thus fully type safe.

Note there is still some magic around the "None" region, which makes sense as non-defined is "None", so we still have to fall back and apply that in certain cases when the optional is empty, etc.
