### PR TITLE
[build] bump spotbugs plugin+tool version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ plugins {
     id 'application'
     id 'build-dashboard'
     id 'checkstyle'
-    id "com.github.spotbugs" version '1.6.5'
+    id "com.github.spotbugs" version '1.6.6'
     id 'java'
     id 'maven'
     id 'pmd'
@@ -183,8 +183,6 @@ dependencies {
     testCompile group: 'org.hamcrest', name: 'hamcrest-core', version: '1.3'
     testCompile group: 'org.hamcrest', name: 'hamcrest-library', version: '1.3'
     testCompile group: 'org.xmlunit', name: 'xmlunit-matchers', version:'2.6.2'
-
-    spotbugs 'com.github.spotbugs:spotbugs:3.1.8'
 }
 
 ant.importBuild 'build-gradle.xml'


### PR DESCRIPTION
We have duplicate spotbug versions: in dependencies and in toolVersion.
remove the in deps (which is older and not commonly used in gradle
files)