### PR TITLE
Remove forRemoval from @deprecated

### DIFF
--- a/code/src/java/pcgen/util/chooser/ChoiceHandler.java
+++ b/code/src/java/pcgen/util/chooser/ChoiceHandler.java
@@ -23,7 +23,7 @@ import pcgen.facade.core.ChooserFacade;
  * This interface indicates that the class can handle making a decision 
  * on a choice request.
  */
-@Deprecated(forRemoval = true)
+@Deprecated()
 @FunctionalInterface
 public interface ChoiceHandler
 {

--- a/code/src/java/pcgen/util/chooser/ChooserFactory.java
+++ b/code/src/java/pcgen/util/chooser/ChooserFactory.java
@@ -26,7 +26,7 @@ import pcgen.facade.core.UIDelegate;
  * to reduce the core/gui interdependence. Much more work is needed on this...
  * Currently only a SwingChooser has been implemented.
  */
-@Deprecated(forRemoval = true)
+@Deprecated()
 public final class ChooserFactory
 {
 	private static UIDelegate delegate;

--- a/code/src/java/pcgen/util/chooser/RandomChooser.java
+++ b/code/src/java/pcgen/util/chooser/RandomChooser.java
@@ -26,7 +26,7 @@ import pcgen.facade.util.ListFacade;
  * An implementation of the Chooser Interface that does not display a GUI but
  * simply selects a random choice from the available list of options.
  */
-@Deprecated(forRemoval = true)
+@Deprecated()
 public final class RandomChooser implements ChoiceHandler
 {
 	@Override


### PR DESCRIPTION
This makes more sense in library code than in application code and just
causes warning. Remove.