### PR TITLE
Sprinkle Optional in places

### DIFF
--- a/code/src/java/pcgen/cdom/facet/LevelInfoFacet.java
+++ b/code/src/java/pcgen/cdom/facet/LevelInfoFacet.java
@@ -20,6 +20,7 @@ package pcgen.cdom.facet;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 import pcgen.cdom.enumeration.CharID;
 import pcgen.cdom.facet.base.AbstractListFacet;
@@ -58,14 +59,14 @@ public class LevelInfoFacet extends AbstractListFacet<CharID, PCLevelInfo>
 	 * @return The object in this LevelInfoFacet for the Player Character
 	 *         represented by the given CharID and location.
 	 */
-	public PCLevelInfo get(CharID id, int location)
+	public Optional<PCLevelInfo> get(CharID id, int location)
 	{
 		List<PCLevelInfo> componentSet = (List<PCLevelInfo>) getCachedSet(id);
 		if (componentSet == null || location < 0 || location >= componentSet.size())
 		{
-			return null;
+			return Optional.empty();
 		}
-		return componentSet.get(location);
+		return Optional.of(componentSet.get(location));
 	}
 
 }

--- a/code/src/java/pcgen/cdom/facet/MonsterClassFacet.java
+++ b/code/src/java/pcgen/cdom/facet/MonsterClassFacet.java
@@ -82,7 +82,7 @@ public class MonsterClassFacet implements DataFacetChangeListener<CharID, CDOMOb
 		//
 		for (int i = levelInfoFacet.getCount(id) - 1; i >= 0; --i)
 		{
-			PCLevelInfo pli = levelInfoFacet.get(id, i);
+			PCLevelInfo pli = levelInfoFacet.get(id, i).get();
 			final String classKeyName = pli.getClassKeyName();
 			final PCClass aClass = Globals.getContext().getReferenceContext()
 				.silentlyGetConstructedCDOMObject(PCClass.class, classKeyName);

--- a/code/src/java/pcgen/core/PlayerCharacter.java
+++ b/code/src/java/pcgen/core/PlayerCharacter.java
@@ -3269,14 +3269,14 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 
 	public PCLevelInfo getLevelInfo(int index)
 	{
-		return levelInfoFacet.get(id, index);
+		return levelInfoFacet.get(id, index).get();
 	}
 
 	public String getLevelInfoClassKeyName(final int idx)
 	{
 		if ((idx >= 0) && (idx < getLevelInfoSize()))
 		{
-			return levelInfoFacet.get(id, idx).getClassKeyName();
+			return levelInfoFacet.get(id, idx).get().getClassKeyName();
 		}
 
 		return Constants.EMPTY_STRING;
@@ -3815,15 +3815,15 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 		int curStat = this.getTotalStatFor(stat);
 		for (int idx = getLevelInfoSize() - 1; idx >= level; --idx)
 		{
-			final int statLvlAdjust = levelInfoFacet.get(id, idx).getTotalStatMod(stat, true);
+			final int statLvlAdjust = levelInfoFacet.get(id, idx).get().getTotalStatMod(stat, true);
 			curStat -= statLvlAdjust;
 		}
 		// If the user doesn't want POST changes, we remove any made in the
 		// target level only
 		if (!includePost && level > 0)
 		{
-			int statLvlAdjust = levelInfoFacet.get(id, level - 1).getTotalStatMod(stat, true);
-			statLvlAdjust -= levelInfoFacet.get(id, level - 1).getTotalStatMod(stat, false);
+			int statLvlAdjust = levelInfoFacet.get(id, level - 1).get().getTotalStatMod(stat, true);
+			statLvlAdjust -= levelInfoFacet.get(id, level - 1).get().getTotalStatMod(stat, false);
 			curStat -= statLvlAdjust;
 
 		}
@@ -5575,7 +5575,7 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 			//
 			for (int idx = getLevelInfoSize() - 1; idx >= 0; --idx)
 			{
-				final PCLevelInfo li = levelInfoFacet.get(id, idx);
+				final PCLevelInfo li = levelInfoFacet.get(id, idx).get();
 
 				if (li.getClassKeyName().equals(fromClass.getKeyName()))
 				{
@@ -5861,7 +5861,7 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 
 		if (idx >= 0)
 		{
-			levelInfoFacet.get(id, idx).addModifiedStat(stat, mod, isPreMod);
+			levelInfoFacet.get(id, idx).get().addModifiedStat(stat, mod, isPreMod);
 		}
 
 		setDirty(true);
@@ -5873,7 +5873,7 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 
 		if (idx >= 0)
 		{
-			return levelInfoFacet.get(id, idx).getTotalStatMod(stat, includePost);
+			return levelInfoFacet.get(id, idx).get().getTotalStatMod(stat, includePost);
 		}
 		return 0;
 	}
@@ -6886,7 +6886,7 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 	{
 		for (int idx = getLevelInfoSize() - 1; idx >= 0; --idx)
 		{
-			final PCLevelInfo li = levelInfoFacet.get(id, idx);
+			final PCLevelInfo li = levelInfoFacet.get(id, idx).get();
 
 			if (li.getClassKeyName().equals(classKeyName))
 			{
@@ -7177,7 +7177,7 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 		int curStat = StatAnalysis.getPartialStatFor(this, stat, useTemp, useEquip);
 		for (int idx = getLevelInfoSize() - 1; idx >= level; --idx)
 		{
-			final int statLvlAdjust = levelInfoFacet.get(id, idx).getTotalStatMod(stat, usePost);
+			final int statLvlAdjust = levelInfoFacet.get(id, idx).get().getTotalStatMod(stat, usePost);
 			curStat -= statLvlAdjust;
 		}
 

--- a/code/src/java/pcgen/core/display/CharacterDisplay.java
+++ b/code/src/java/pcgen/core/display/CharacterDisplay.java
@@ -1045,7 +1045,7 @@ public class CharacterDisplay
 
 	public PCLevelInfo getLevelInfo(int index)
 	{
-		return levelInfoFacet.get(id, index);
+		return levelInfoFacet.get(id, index).get();
 	}
 
 	public int getLevelInfoSize()
@@ -1057,7 +1057,7 @@ public class CharacterDisplay
 	{
 		if ((idx >= 0) && (idx < getLevelInfoSize()))
 		{
-			return levelInfoFacet.get(id, idx).getClassKeyName();
+			return levelInfoFacet.get(id, idx).get().getClassKeyName();
 		}
 
 		return Constants.EMPTY_STRING;
@@ -1067,7 +1067,7 @@ public class CharacterDisplay
 	{
 		if ((idx >= 0) && (idx < getLevelInfoSize()))
 		{
-			return levelInfoFacet.get(id, idx).getClassLevel();
+			return levelInfoFacet.get(id, idx).get().getClassLevel();
 		}
 
 		return 0;


### PR DESCRIPTION
I found some null pointer exceptions in skill editing code. Sprinkle
Optional around to try and get the error to happen a bit earlier (and
more obviously).