### PR TITLE
PCGenAction: remove always false check

### DIFF
--- a/code/src/java/pcgen/gui2/tools/PCGenAction.java
+++ b/code/src/java/pcgen/gui2/tools/PCGenAction.java
@@ -81,14 +81,7 @@ public class PCGenAction extends AbstractAction
 			}
 			else if (aString.equalsIgnoreCase("alt"))
 			{
-				if (System.getProperty("mrj.version") != null)
-				{
-					iShortCut = menuShortcutKeyMask | InputEvent.ALT_MASK;
-				}
-				else
-				{
-					iShortCut = InputEvent.ALT_MASK;
-				}
+				iShortCut = InputEvent.ALT_MASK;
 			}
 			else if (aString.equalsIgnoreCase("shift-shortcut"))
 			{


### PR DESCRIPTION
We no longer use mrj, so this is always false.