### PR TITLE
[build] begin the conversion to newer API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -290,11 +290,13 @@ task cleanRoot(type: Delete) {
 }
 
 // Alias tasks
-task buildonly(dependsOn: ['installToRoot']) {
+tasks.register("buildonly") {
+    dependsOn 'installToRoot'
+}
+tasks.register("quickbuild") {
+    dependsOn 'installToRoot', 'test'
 }
 
-task quickbuild(dependsOn: ['installToRoot', 'test']) {
-}
 
 build {
     it.dependsOn 'copyToOutput', 'syncLibsToRoot'


### PR DESCRIPTION
See
https://docs.gradle.org/5.1-rc-1/userguide/task_configuration_avoidance.html
for configuration avoidance documentation. This begins with the simple
	ones.