### PR TITLE
Remove dead code in TaskStrategyListener

### DIFF
--- a/code/src/java/pcgen/gui2/converter/ConvertPanel.java
+++ b/code/src/java/pcgen/gui2/converter/ConvertPanel.java
@@ -73,36 +73,7 @@ public class ConvertPanel extends JPanel
 	{
 		super(new BorderLayout());
 		statusLabel = new JLabel();
-		TaskStrategyListener tsl = new TaskStrategyListener()
-		{
-			private String status;
-
-			private long time;
-
-			@Override
-			public void processMessage(Object owner, String string)
-			{
-				JOptionPane.showMessageDialog(null, string);
-			}
-
-			@Override
-			public void processStatus(Object source, String string)
-			{
-				status = string;
-				statusLabel.setText(string);
-			}
-
-			@Override
-			public void processActiveItem(Object source, String string)
-			{
-				long currentTime = System.currentTimeMillis();
-				if ((currentTime - time) > 100)
-				{
-					statusLabel.setText(status + " [" + string + "]");
-					time = currentTime;
-				}
-			}
-		};
+		TaskStrategyListener tsl = (source, string) -> statusLabel.setText(string);
 		TaskStrategyMessage.addTaskStrategyListener(tsl);
 
 		properties = new ObjectCache();

--- a/code/src/java/pcgen/gui2/converter/event/TaskStrategyListener.java
+++ b/code/src/java/pcgen/gui2/converter/event/TaskStrategyListener.java
@@ -20,13 +20,8 @@ package pcgen.gui2.converter.event;
 
 import java.util.EventListener;
 
+@FunctionalInterface
 public interface TaskStrategyListener extends EventListener
 {
-
-	void processMessage(Object owner, String string);
-
 	void processStatus(Object source, String string);
-
-	void processActiveItem(Object source, String string);
-
 }

--- a/code/src/java/pcgen/gui2/converter/event/TaskStrategyMessage.java
+++ b/code/src/java/pcgen/gui2/converter/event/TaskStrategyMessage.java
@@ -24,7 +24,6 @@ import javax.swing.event.EventListenerList;
 
 public final class TaskStrategyMessage
 {
-
 	private TaskStrategyMessage()
 	{
 	}


### PR DESCRIPTION
These methods are never called and the contents of the methods don't
matter. Just remove them.