### PR TITLE
ItemFacet: return an Optional from `get`

### DIFF
--- a/code/src/java/pcgen/cdom/base/ItemFacet.java
+++ b/code/src/java/pcgen/cdom/base/ItemFacet.java
@@ -17,6 +17,8 @@
  */
 package pcgen.cdom.base;
 
+import java.util.Optional;
+
 /**
  * An ItemFacet is a Facet that stores a single item per identifier.
  * 
@@ -32,13 +34,10 @@ public interface ItemFacet<IDT, T>
 	/**
 	 * Returns the object stored in the ItemFacet for the given Identifier.
 	 * 
-	 * It is expected that null is a legal response from an ItemFacet, as there
-	 * is no guarantee an item has been set for the given Identifier.
-	 * 
 	 * @param id
 	 *            The identifier used to identify the object to be returned by
 	 *            the ItemFacet
 	 * @return the object stored in the ItemFacet for the given Identifier
 	 */
-	public T get(IDT id);
+	public Optional<T> get(IDT id);
 }

--- a/code/src/java/pcgen/cdom/facet/ActiveSpellsFacet.java
+++ b/code/src/java/pcgen/cdom/facet/ActiveSpellsFacet.java
@@ -114,7 +114,7 @@ public class ActiveSpellsFacet extends AbstractSourcedListFacet<CharID, Characte
 	 */
 	public void process(CharID id)
 	{
-		Race race = raceFacet.get(id);
+		Race race = raceFacet.get(id).orElse(null);
 		removeAll(id, race);
 		PlayerCharacter pc = trackingFacet.getPC(id);
 		for (SpellLikeAbility sla : spellsFacet.getQualifiedSet(id))

--- a/code/src/java/pcgen/cdom/facet/AgeSetKitFacet.java
+++ b/code/src/java/pcgen/cdom/facet/AgeSetKitFacet.java
@@ -65,10 +65,10 @@ public class AgeSetKitFacet extends AbstractStorageFacet<CharID> implements Data
 	public void dataAdded(DataFacetChangeEvent<CharID, Integer> dfce)
 	{
 		CharID id = dfce.getCharID();
-		AgeSet ageSet = ageSetFacet.get(id);
 		PlayerCharacter pc = trackingFacet.getPC(id);
 		// TODO Is ageSet null check necessary?
-		if (ageSet == null || pc.isImporting())
+		AgeSet ageSet = ageSetFacet.get(id).orElse(null);
+		if ((ageSet == null) || pc.isImporting())
 		{
 			return;
 		}
@@ -90,7 +90,7 @@ public class AgeSetKitFacet extends AbstractStorageFacet<CharID> implements Data
 			if (kits != null)
 			{
 				// Need to do selection
-				BioSet bioSet = bioSetFacet.get(id);
+				BioSet bioSet = bioSetFacet.get(id).orElse(null);
 				for (TransitionChoice<Kit> kit : ageSet.getKits())
 				{
 					Collection<? extends Kit> choice = kit.driveChoice(pc);

--- a/code/src/java/pcgen/cdom/facet/BioSetTrackingFacet.java
+++ b/code/src/java/pcgen/cdom/facet/BioSetTrackingFacet.java
@@ -60,7 +60,7 @@ public class BioSetTrackingFacet extends AbstractItemFacet<CharID, BioSet>
 
 		if (!pc.isImporting())
 		{
-			bioSetFacet.get(id).randomize("AGE.HT.WT", pc);
+			bioSetFacet.get(id).get().randomize("AGE.HT.WT", pc);
 		}
 
 	}

--- a/code/src/java/pcgen/cdom/facet/GrantedVarFacet.java
+++ b/code/src/java/pcgen/cdom/facet/GrantedVarFacet.java
@@ -64,7 +64,7 @@ public class GrantedVarFacet extends AbstractSourcedListFacet<CharID, PCGenScope
 	private <T> void processAdd(CharID id, VariableID<T> varID, Object source)
 	{
 		T value = variableStoreFacet.getValue(id, varID);
-		variableStoreFacet.get(id).addVariableListener(varID, new BridgeListener(id, this));
+		variableStoreFacet.get(id).get().addVariableListener(varID, new BridgeListener(id, this));
 		/*
 		 * CONSIDER This is a hard-coding based on array - the format manager, which is
 		 * available from the VariableID, might want to provide more insight. Currently,
@@ -100,7 +100,7 @@ public class GrantedVarFacet extends AbstractSourcedListFacet<CharID, PCGenScope
 
 	private <T> void processRemove(CharID id, VariableID<T> varID, Object source)
 	{
-		variableStoreFacet.get(id).removeVariableListener(varID, new BridgeListener(id, this));
+		variableStoreFacet.get(id).get().removeVariableListener(varID, new BridgeListener(id, this));
 		T value = variableStoreFacet.getValue(id, varID);
 		if (value.getClass().isArray())
 		{

--- a/code/src/java/pcgen/cdom/facet/HitPointFacet.java
+++ b/code/src/java/pcgen/cdom/facet/HitPointFacet.java
@@ -200,7 +200,7 @@ public class HitPointFacet extends AbstractAssociationFacet<CharID, PCClassLevel
 	{
 		// Class Base Hit Die
 		HitDie currDie = pcClass.getSafe(ObjectKey.LEVEL_HITDIE);
-		Processor<HitDie> dieLock = raceFacet.get(id).get(ObjectKey.HITDIE);
+		Processor<HitDie> dieLock = raceFacet.get(id).get().get(ObjectKey.HITDIE);
 		if (dieLock != null)
 		{
 			currDie = dieLock.applyProcessor(currDie, pcClass);
@@ -289,7 +289,7 @@ public class HitPointFacet extends AbstractAssociationFacet<CharID, PCClassLevel
 		set(id, classLevel, roll);
 	}
 
-	private boolean maximizeHPatFirstLevel(PCClass pcc, int level)
+	private static boolean maximizeHPatFirstLevel(PCClass pcc, int level)
 	{
 		boolean classAllowsMaxHP = !SettingsHandler.isHPMaxAtFirstPCClassLevelOnly() || pcc.isType("PC");
 		return (level == 1) && SettingsHandler.isHPMaxAtFirstLevel() && classAllowsMaxHP;

--- a/code/src/java/pcgen/cdom/facet/MasterFacet.java
+++ b/code/src/java/pcgen/cdom/facet/MasterFacet.java
@@ -17,13 +17,14 @@
  */
 package pcgen.cdom.facet;
 
+import java.util.Objects;
+
 import pcgen.cdom.base.Constants;
 import pcgen.cdom.enumeration.CharID;
 import pcgen.cdom.enumeration.ObjectKey;
 import pcgen.cdom.enumeration.StringKey;
 import pcgen.cdom.facet.base.AbstractItemFacet;
 import pcgen.cdom.facet.model.CompanionModFacet;
-import pcgen.core.character.CompanionMod;
 import pcgen.core.character.Follower;
 
 /**
@@ -47,18 +48,14 @@ public class MasterFacet extends AbstractItemFacet<CharID, Follower>
 	 */
 	public String getCopyMasterCheck(CharID id)
 	{
-		for (CompanionMod cMod : companionModFacet.getSet(id))
-		{
-			if (cMod.getType().equalsIgnoreCase(get(id).getType().getKeyName()))
-			{
-				if (cMod.get(StringKey.MASTER_CHECK_FORMULA) != null)
-				{
-					return cMod.get(StringKey.MASTER_CHECK_FORMULA);
-				}
-			}
-		}
+		return companionModFacet.getSet(id)
+		                        .stream()
+		                        .filter(cMod -> cMod.getType().equalsIgnoreCase(get(id).get().getType().getKeyName()))
+		                        .filter(cMod -> cMod.get(StringKey.MASTER_CHECK_FORMULA) != null)
+		                        .findFirst()
+		                        .map(cMod -> cMod.get(StringKey.MASTER_CHECK_FORMULA))
+		                        .orElse(Constants.EMPTY_STRING);
 
-		return Constants.EMPTY_STRING;
 	}
 
 	/**
@@ -74,18 +71,14 @@ public class MasterFacet extends AbstractItemFacet<CharID, Follower>
 	 */
 	public String getCopyMasterHP(CharID id)
 	{
-		for (CompanionMod cMod : companionModFacet.getSet(id))
-		{
-			if (cMod.getType().equalsIgnoreCase(get(id).getType().getKeyName()))
-			{
-				if (cMod.get(StringKey.MASTER_HP_FORMULA) != null)
-				{
-					return cMod.get(StringKey.MASTER_HP_FORMULA);
-				}
-			}
-		}
+		return companionModFacet.getSet(id)
+		                        .stream()
+		                        .filter(cMod -> cMod.getType().equalsIgnoreCase(get(id).get().getType().getKeyName()))
+		                        .filter(cMod -> cMod.get(StringKey.MASTER_HP_FORMULA) != null)
+		                        .findFirst()
+		                        .map(cMod -> cMod.get(StringKey.MASTER_HP_FORMULA))
+		                        .orElse(Constants.EMPTY_STRING);
 
-		return Constants.EMPTY_STRING;
 	}
 
 	/**
@@ -101,24 +94,19 @@ public class MasterFacet extends AbstractItemFacet<CharID, Follower>
 	 */
 	public String getCopyMasterBAB(CharID id)
 	{
-		for (CompanionMod cMod : companionModFacet.getSet(id))
-		{
-			/*
-			 * TODO This is the "slow" method - proper solution here is to get
-			 * TYPE in CompanionMod to be "special" and actually store a
-			 * CompanionList object, not a String
-			 */
-			if (cMod.getType().equalsIgnoreCase(get(id).getType().getKeyName()))
-			{
-				String copyMasterBAB = cMod.get(StringKey.MASTER_BAB_FORMULA);
-				if (copyMasterBAB != null)
-				{
-					return copyMasterBAB;
-				}
-			}
-		}
+		/*
+		 * TODO This is the "slow" method - proper solution here is to get
+		 * TYPE in CompanionMod to be "special" and actually store a
+		 * CompanionList object, not a String
+		 */
+		return companionModFacet.getSet(id)
+		                        .stream()
+		                        .filter(cMod -> cMod.getType().equalsIgnoreCase(get(id).get().getType().getKeyName()))
+		                        .map(cMod -> cMod.get(StringKey.MASTER_BAB_FORMULA))
+		                        .filter(Objects::nonNull)
+		                        .findFirst()
+		                        .orElse(Constants.EMPTY_STRING);
 
-		return Constants.EMPTY_STRING;
 	}
 
 	/**
@@ -134,18 +122,11 @@ public class MasterFacet extends AbstractItemFacet<CharID, Follower>
 	 */
 	public boolean getUseMasterSkill(CharID id)
 	{
-		for (CompanionMod cMod : companionModFacet.getSet(id))
-		{
-			if (cMod.getType().equalsIgnoreCase(get(id).getType().getKeyName()))
-			{
-				if (cMod.getSafe(ObjectKey.USE_MASTER_SKILL))
-				{
-					return true;
-				}
-			}
-		}
 
-		return false;
+		return companionModFacet.getSet(id)
+		                        .stream()
+		                        .filter(cMod -> cMod.getType().equalsIgnoreCase(get(id).get().getType().getKeyName()))
+		                        .anyMatch(cMod -> cMod.getSafe(ObjectKey.USE_MASTER_SKILL));
 	}
 
 	public void setCompanionModFacet(CompanionModFacet companionModFacet)

--- a/code/src/java/pcgen/cdom/facet/ModifierFacet.java
+++ b/code/src/java/pcgen/cdom/facet/ModifierFacet.java
@@ -72,7 +72,7 @@ public class ModifierFacet implements DataFacetChangeListener<CharID, PCGenScope
 		VarScoped thisValue)
 	{
 		PCGenScope legalScope = (PCGenScope) source.getLegalScope();
-		LoadContext context = loadContextFacet.get(id.getDatasetID()).get();
+		LoadContext context = loadContextFacet.get(id.getDatasetID()).get().get();
 		Modifier<T> returnValue;
 		try
 		{

--- a/code/src/java/pcgen/cdom/facet/RemoteModifierFacet.java
+++ b/code/src/java/pcgen/cdom/facet/RemoteModifierFacet.java
@@ -105,7 +105,7 @@ public class RemoteModifierFacet extends AbstractAssociationFacet<CharID, Remote
 		ScopeInstance sourceInstance, VarScoped target, ScopeInstance targetInstance)
 	{
 		PCGenScope sourceScope = (PCGenScope) sourceInstance.getLegalScope();
-		LoadContext context = loadContextFacet.get(id.getDatasetID()).get();
+		LoadContext context = loadContextFacet.get(id.getDatasetID()).get().get();
 		Modifier<T> returnValue;
 		try
 		{

--- a/code/src/java/pcgen/cdom/facet/ScopeFacet.java
+++ b/code/src/java/pcgen/cdom/facet/ScopeFacet.java
@@ -44,7 +44,7 @@ public class ScopeFacet extends AbstractItemFacet<CharID, ScopeInstanceFactory>
 	 */
 	public ScopeInstance getGlobalScope(CharID id)
 	{
-		return get(id).getGlobalInstance(GlobalScope.GLOBAL_SCOPE_NAME);
+		return get(id).get().getGlobalInstance(GlobalScope.GLOBAL_SCOPE_NAME);
 	}
 
 	/**
@@ -66,7 +66,7 @@ public class ScopeFacet extends AbstractItemFacet<CharID, ScopeInstanceFactory>
 	 */
 	public ScopeInstance get(CharID id, String legalScopeName, VarScoped scopedObject)
 	{
-		return get(id).get(legalScopeName, Optional.of(scopedObject));
+		return get(id).get().get(legalScopeName, Optional.of(scopedObject));
 	}
 
 	public ScopeInstance get(CharID id, VarScoped vs)

--- a/code/src/java/pcgen/cdom/facet/SolverManagerFacet.java
+++ b/code/src/java/pcgen/cdom/facet/SolverManagerFacet.java
@@ -43,16 +43,16 @@ public class SolverManagerFacet extends AbstractItemFacet<CharID, SolverManager>
 
 	public <T> List<ProcessStep<T>> diagnose(CharID id, VariableID<T> varID)
 	{
-		return get(id).diagnose(varID);
+		return get(id).get().diagnose(varID);
 	}
 
 	public <T> boolean addModifier(CharID id, VarModifier<T> vm, VarScoped thisValue, Modifier<T> modifier,
 		ScopeInstance source)
 	{
 		ScopeInstance scope = scopeFacet.get(id, vm.getFullLegalScopeName(), thisValue);
-		VariableID<T> varID = (VariableID<T>) loadContextFacet.get(id.getDatasetID()).get().getVariableContext()
+		VariableID<T> varID = (VariableID<T>) loadContextFacet.get(id.getDatasetID()).get().get().getVariableContext()
 			.getVariableID(scope, vm.getVarName());
-		return get(id).addModifierAndSolve(varID, modifier, source);
+		return get(id).get().addModifierAndSolve(varID, modifier, source);
 	}
 
 	/**
@@ -62,9 +62,9 @@ public class SolverManagerFacet extends AbstractItemFacet<CharID, SolverManager>
 		ScopeInstance source)
 	{
 		ScopeInstance scope = scopeFacet.get(id, vm.getFullLegalScopeName(), thisValue);
-		VariableID<T> varID = (VariableID<T>) loadContextFacet.get(id.getDatasetID()).get().getVariableContext()
+		VariableID<T> varID = (VariableID<T>) loadContextFacet.get(id.getDatasetID()).get().get().getVariableContext()
 			.getVariableID(scope, vm.getVarName());
-		get(id).removeModifier(varID, modifier, source);
+		get(id).get().removeModifier(varID, modifier, source);
 	}
 
 	public void setScopeFacet(ScopeFacet scopeFacet)

--- a/code/src/java/pcgen/cdom/facet/StatValueFacet.java
+++ b/code/src/java/pcgen/cdom/facet/StatValueFacet.java
@@ -19,6 +19,7 @@ package pcgen.cdom.facet;
 
 import java.util.IdentityHashMap;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -79,7 +80,7 @@ public class StatValueFacet extends AbstractScopeFacet<CharID, PCStat, Number>
 		else
 		{
 			VariableID<Number> varID = getVarID(id, stat, channelName);
-			MonitorableVariableStore varStore = RESULT_FACET.get(id);
+			MonitorableVariableStore varStore = RESULT_FACET.get(id).orElse(null);
 			return varStore.get(varID);
 		}
 	}
@@ -109,7 +110,7 @@ public class StatValueFacet extends AbstractScopeFacet<CharID, PCStat, Number>
 		else
 		{
 			VariableID<Number> varID = getVarID(id, stat, channelName);
-			MonitorableVariableStore varStore = RESULT_FACET.get(id);
+			MonitorableVariableStore varStore = RESULT_FACET.get(id).orElse(null);
 			old = varStore.get(varID);
 			varStore.put(varID, value);
 		}
@@ -204,19 +205,19 @@ public class StatValueFacet extends AbstractScopeFacet<CharID, PCStat, Number>
 	private VariableID<Number> getVarID(CharID id, PCStat stat, String channelName)
 	{
 		String varName = ChannelUtilities.createVarName(channelName);
-		ScopeInstanceFactory instFactory = SCOPE_FACET.get(id);
+		ScopeInstanceFactory instFactory = SCOPE_FACET.get(id).orElse(null);
 		Optional<String> localScopeName = stat.getLocalScopeName();
 		ScopeInstance scopeInst = instFactory.get(localScopeName.get(), Optional.of(stat));
 		try
 		{
-			VariableID<Number> varID = (VariableID<Number>) loadContextFacet.get(id.getDatasetID()).get()
+			VariableID<Number> varID = (VariableID<Number>) loadContextFacet.get(id.getDatasetID()).get().get()
 				.getVariableContext().getVariableID(scopeInst, varName);
 			return varID;
 		}
-		catch (NullPointerException e)
+		catch (NoSuchElementException e)
 		{
 			throw new IllegalArgumentException("Attempt to get channel " + channelName
-				+ " for a STAT was unsuccessful. Was a CHANNEL defined in the Variable file?");
+				+ " for a STAT was unsuccessful. Was a CHANNEL defined in the Variable file?", e);
 		}
 	}
 

--- a/code/src/java/pcgen/cdom/facet/VariableStoreFacet.java
+++ b/code/src/java/pcgen/cdom/facet/VariableStoreFacet.java
@@ -18,6 +18,7 @@
 package pcgen.cdom.facet;
 
 import pcgen.base.formula.base.VariableID;
+import pcgen.base.formula.base.WriteableVariableStore;
 import pcgen.cdom.enumeration.CharID;
 import pcgen.cdom.facet.base.AbstractItemFacet;
 import pcgen.cdom.formula.MonitorableVariableStore;
@@ -29,7 +30,6 @@ import pcgen.cdom.formula.MonitorableVariableStore;
  */
 public class VariableStoreFacet extends AbstractItemFacet<CharID, MonitorableVariableStore>
 {
-
 	/**
 	 * The global LoadContextFacet used to get VariableIDs
 	 */
@@ -37,10 +37,10 @@ public class VariableStoreFacet extends AbstractItemFacet<CharID, MonitorableVar
 
 	public <T> T getValue(CharID id, VariableID<T> varID)
 	{
-		T value = get(id).get(varID);
+		T value = get(id).get().get(varID);
 		if (value == null)
 		{
-			return loadContextFacet.get(id.getDatasetID()).get().getVariableContext()
+			return loadContextFacet.get(id.getDatasetID()).get().get().getVariableContext()
 				.getDefaultValue(varID.getVariableFormat());
 		}
 		return value;
@@ -49,12 +49,10 @@ public class VariableStoreFacet extends AbstractItemFacet<CharID, MonitorableVar
 	@Override
 	public void copyContents(CharID source, CharID copy)
 	{
-		MonitorableVariableStore obj = get(source);
-		if (obj != null)
-		{
-			MonitorableVariableStore replacement = new MonitorableVariableStore();
-			replacement.importFrom(get(source));
+		get(source).ifPresent(obj -> {
+			WriteableVariableStore replacement = new MonitorableVariableStore();
+			replacement.importFrom(obj);
 			setCache(copy, replacement);
-		}
+		});
 	}
 }

--- a/code/src/java/pcgen/cdom/facet/XPTableFacet.java
+++ b/code/src/java/pcgen/cdom/facet/XPTableFacet.java
@@ -22,6 +22,8 @@ import pcgen.cdom.facet.base.AbstractItemFacet;
 import pcgen.core.LevelInfo;
 import pcgen.core.XPTable;
 
+import org.jetbrains.annotations.Nullable;
+
 /**
  * XPTableFacet is a Facet that tracks the XP table assigned to a Player
  * Character.
@@ -36,24 +38,22 @@ public class XPTableFacet extends AbstractItemFacet<CharID, XPTable>
 	 *            the level for which Level Info should be returned
 	 * @return The LevelInfo for the given level
 	 */
+	@Nullable
 	public LevelInfo getLevelInfo(CharID id, int level)
 	{
 		if (level < 1)
 		{
 			return null;
 		}
-		XPTable table = get(id);
 
-		if (table == null)
-		{
-			return null;
-		}
-		LevelInfo lInfo = table.getLevelInfo(String.valueOf(level));
+		return get(id).map(table -> {
+			LevelInfo lInfo = table.getLevelInfo(String.valueOf(level));
+			if (lInfo == null)
+			{
+				lInfo = table.getLevelInfo("LEVEL");
+			}
+			return lInfo;
 
-		if (lInfo == null)
-		{
-			lInfo = table.getLevelInfo("LEVEL");
-		}
-		return lInfo;
+		}).orElse(null);
 	}
 }

--- a/code/src/java/pcgen/cdom/facet/analysis/ChallengeRatingFacet.java
+++ b/code/src/java/pcgen/cdom/facet/analysis/ChallengeRatingFacet.java
@@ -117,7 +117,7 @@ public class ChallengeRatingFacet
 	public Integer calcRaceCR(CharID id)
 	{
 		// Calculate and add the CR from race
-		ChallengeRating cr = raceFacet.get(id).getSafe(ObjectKey.CHALLENGE_RATING);
+		ChallengeRating cr = raceFacet.get(id).get().getSafe(ObjectKey.CHALLENGE_RATING);
 		return cr.toInteger();
 	}
 
@@ -132,7 +132,7 @@ public class ChallengeRatingFacet
 	 */
 	public int getBaseHD(CharID id)
 	{
-		final LevelCommandFactory lcf = raceFacet.get(id).getSafe(ObjectKey.MONSTER_CLASS);
+		final LevelCommandFactory lcf = raceFacet.get(id).get().getSafe(ObjectKey.MONSTER_CLASS);
 		/*
 		 * BUG This converts a formula to a String?  What if it's a formula, NFE?
 		 */
@@ -206,8 +206,10 @@ public class ChallengeRatingFacet
 		int levelsConverted = 0;
 		int threshold = 0;
 
-		List<String> raceRoleList = raceFacet.get(id).getListFor(ListKey.MONSTER_ROLES);
-		if ((raceRoleList == null) || raceRoleList.isEmpty())
+
+		List<String> raceRoleList = raceFacet.get(id).get().getListFor(ListKey.MONSTER_ROLES);
+		if (raceRoleList == null || raceRoleList.isEmpty()
+		)
 		{
 			raceRoleList = SettingsHandler.getGame().getMonsterRoleDefaultList();
 		}
@@ -275,7 +277,7 @@ public class ChallengeRatingFacet
 		{
 			if (SettingsHandler.getGame().getClassTypeByName(classType) != null)
 			{
-				Integer crMod = raceFacet.get(id).get(MapKey.CRMOD, classType);
+				Integer crMod = raceFacet.get(id).get().get(MapKey.CRMOD, classType);
 				if (crMod != null)
 				{
 					return crMod;
@@ -291,7 +293,7 @@ public class ChallengeRatingFacet
 				classType = type.toString();
 				if (SettingsHandler.getGame().getClassTypeByName(classType) != null)
 				{
-					Integer crMod = raceFacet.get(id).get(MapKey.CRMOD, classType);
+					Integer crMod = raceFacet.get(id).get().get(MapKey.CRMOD, classType);
 					if (crMod != null)
 					{
 						return crMod;

--- a/code/src/java/pcgen/cdom/facet/analysis/HandsFacet.java
+++ b/code/src/java/pcgen/cdom/facet/analysis/HandsFacet.java
@@ -49,7 +49,7 @@ public class HandsFacet
 	 */
 	public int getHands(CharID id)
 	{
-		final Race aRace = raceFacet.get(id);
+		final Race aRace = raceFacet.get(id).orElse(null);
 		int hands = 0;
 		if (aRace != null)
 		{

--- a/code/src/java/pcgen/cdom/facet/analysis/HasAnyFavoredClassFacet.java
+++ b/code/src/java/pcgen/cdom/facet/analysis/HasAnyFavoredClassFacet.java
@@ -17,6 +17,8 @@
  */
 package pcgen.cdom.facet.analysis;
 
+import java.util.Optional;
+
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.base.ItemFacet;
 import pcgen.cdom.enumeration.CharID;
@@ -106,9 +108,9 @@ public class HasAnyFavoredClassFacet extends AbstractSourcedListFacet<CharID, Bo
 	}
 
 	@Override
-	public Boolean get(CharID id)
+	public Optional<Boolean> get(CharID id)
 	{
-		return contains(id, Boolean.TRUE);
+		return Optional.of(contains(id, Boolean.TRUE));
 	}
 
 }

--- a/code/src/java/pcgen/cdom/facet/analysis/LegsFacet.java
+++ b/code/src/java/pcgen/cdom/facet/analysis/LegsFacet.java
@@ -22,7 +22,6 @@ import pcgen.cdom.enumeration.IntegerKey;
 import pcgen.cdom.facet.model.RaceFacet;
 import pcgen.cdom.facet.model.TemplateFacet;
 import pcgen.core.PCTemplate;
-import pcgen.core.Race;
 
 /**
  * LegsFacet is a Facet that tracks the number of Legs possessed by a Player
@@ -46,12 +45,10 @@ public class LegsFacet
 	 */
 	public int getLegs(CharID id)
 	{
-		final Race aRace = raceFacet.get(id);
 		int legs = 0;
-		if (aRace != null)
-		{
-			legs = aRace.getSafe(IntegerKey.LEGS);
-		}
+
+		raceFacet.get(id)
+		         .ifPresent(aRace -> aRace.getSafe(IntegerKey.LEGS));
 
 		// Scan templates for any overrides
 		for (PCTemplate template : templateFacet.getSet(id))

--- a/code/src/java/pcgen/cdom/facet/analysis/LegsFacet.java
+++ b/code/src/java/pcgen/cdom/facet/analysis/LegsFacet.java
@@ -22,6 +22,7 @@ import pcgen.cdom.enumeration.IntegerKey;
 import pcgen.cdom.facet.model.RaceFacet;
 import pcgen.cdom.facet.model.TemplateFacet;
 import pcgen.core.PCTemplate;
+import pcgen.core.Race;
 
 /**
  * LegsFacet is a Facet that tracks the number of Legs possessed by a Player
@@ -46,9 +47,11 @@ public class LegsFacet
 	public int getLegs(CharID id)
 	{
 		int legs = 0;
-
-		raceFacet.get(id)
-		         .ifPresent(aRace -> aRace.getSafe(IntegerKey.LEGS));
+		final Race aRace = raceFacet.get(id).orElse(null);
+		if (aRace != null)
+		{
+			legs = aRace.getSafe(IntegerKey.LEGS);
+		}
 
 		// Scan templates for any overrides
 		for (PCTemplate template : templateFacet.getSet(id))

--- a/code/src/java/pcgen/cdom/facet/analysis/MovementResultFacet.java
+++ b/code/src/java/pcgen/cdom/facet/analysis/MovementResultFacet.java
@@ -190,7 +190,7 @@ public class MovementResultFacet extends AbstractStorageFacet<CharID>
 			movementTypes = Globals.EMPTY_STRING_ARRAY;
 			movements = EMPTY_DOUBLE_ARRAY;
 
-			Race race = raceFacet.get(id);
+			Race race = raceFacet.get(id).orElse(null);
 			if (race == null)
 			{
 				return;

--- a/code/src/java/pcgen/cdom/facet/analysis/RaceTypeFacet.java
+++ b/code/src/java/pcgen/cdom/facet/analysis/RaceTypeFacet.java
@@ -50,7 +50,7 @@ public class RaceTypeFacet
 	public RaceType getRaceType(CharID id)
 	{
 		RaceType raceType = null;
-		Race race = raceFacet.get(id);
+		Race race = raceFacet.get(id).orElse(null);
 		if (race != null)
 		{
 			RaceType rt = race.get(ObjectKey.RACETYPE);

--- a/code/src/java/pcgen/cdom/facet/analysis/RacialSubTypesFacet.java
+++ b/code/src/java/pcgen/cdom/facet/analysis/RacialSubTypesFacet.java
@@ -28,7 +28,6 @@ import pcgen.cdom.enumeration.RaceSubType;
 import pcgen.cdom.facet.model.RaceFacet;
 import pcgen.cdom.facet.model.TemplateFacet;
 import pcgen.core.PCTemplate;
-import pcgen.core.Race;
 
 /**
  * RacialSubTypesFacet is a Facet that tracks the Racial Sub Types of a
@@ -61,11 +60,8 @@ public class RacialSubTypesFacet
 	public Collection<RaceSubType> getRacialSubTypes(CharID id)
 	{
 		List<RaceSubType> racialSubTypes = new ArrayList<>();
-		Race race = raceFacet.get(id);
-		if (race != null)
-		{
-			racialSubTypes.addAll(race.getSafeListFor(ListKey.RACESUBTYPE));
-		}
+		raceFacet.get(id)
+		         .ifPresent(race -> racialSubTypes.addAll(race.getSafeListFor(ListKey.RACESUBTYPE)));
 		Collection<PCTemplate> templates = templateFacet.getSet(id);
 		if (!templates.isEmpty())
 		{

--- a/code/src/java/pcgen/cdom/facet/analysis/ReachFacet.java
+++ b/code/src/java/pcgen/cdom/facet/analysis/ReachFacet.java
@@ -17,6 +17,8 @@
  */
 package pcgen.cdom.facet.analysis;
 
+import java.util.Optional;
+
 import pcgen.cdom.base.ItemFacet;
 import pcgen.cdom.enumeration.CharID;
 import pcgen.cdom.enumeration.IntegerKey;
@@ -48,7 +50,7 @@ public class ReachFacet implements ItemFacet<CharID, Integer>
 	 */
 	public int getReach(CharID id)
 	{
-		final Race aRace = raceFacet.get(id);
+		final Race aRace = raceFacet.get(id).orElse(null);
 		int reach = 0;
 		if (aRace != null)
 		{
@@ -78,9 +80,9 @@ public class ReachFacet implements ItemFacet<CharID, Integer>
 	 *         CharID
 	 */
 	@Override
-	public Integer get(CharID id)
+	public Optional<Integer> get(CharID id)
 	{
-		return getReach(id);
+		return Optional.of(getReach(id));
 	}
 
 	public void setTemplateFacet(TemplateFacet templateFacet)

--- a/code/src/java/pcgen/cdom/facet/analysis/UnarmedDamageFacet.java
+++ b/code/src/java/pcgen/cdom/facet/analysis/UnarmedDamageFacet.java
@@ -110,7 +110,7 @@ public class UnarmedDamageFacet extends AbstractSourcedListFacet<CharID, List<St
 	 */
 	public String getUDamForRace(CharID id)
 	{
-		Race race = raceFacet.get(id);
+		Race race = raceFacet.get(id).orElse(null);
 		int iSize = formulaResolvingFacet.resolve(id, race.getSafe(FormulaKey.SIZE), race.getQualifiedKey()).intValue();
 		SizeAdjustment defAdj = SizeUtilities.getDefaultSizeAdjustment();
 		SizeAdjustment sizAdj = Globals.getContext().getReferenceContext()

--- a/code/src/java/pcgen/cdom/facet/base/AbstractItemFacet.java
+++ b/code/src/java/pcgen/cdom/facet/base/AbstractItemFacet.java
@@ -17,6 +17,9 @@
  */
 package pcgen.cdom.facet.base;
 
+import java.util.Objects;
+import java.util.Optional;
+
 import pcgen.cdom.base.PCGenIdentifier;
 import pcgen.cdom.facet.event.DataFacetChangeEvent;
 import pcgen.util.Logging;
@@ -60,7 +63,7 @@ public abstract class AbstractItemFacet<IDT extends PCGenIdentifier, T> extends 
 			Logging.errorPrint(getClass() + " received null item: ignoring");
 			return false;
 		}
-		T old = get(id);
+		T old = get(id).orElse(null);
 		if (old == obj)
 		{
 			return false;
@@ -109,10 +112,9 @@ public abstract class AbstractItemFacet<IDT extends PCGenIdentifier, T> extends 
 	 * @return the item value for this AbstractItemFacet and the Player
 	 *         Character represented by the given PCGenIdentifier.
 	 */
-	@SuppressWarnings("unchecked")
-	public T get(IDT id)
+	public Optional<T> get(IDT id)
 	{
-		return (T) getCache(id);
+		return Optional.ofNullable((T)getCache(id));
 	}
 
 	/**
@@ -135,8 +137,8 @@ public abstract class AbstractItemFacet<IDT extends PCGenIdentifier, T> extends 
 	 */
 	public boolean matches(IDT id, T obj)
 	{
-		T current = get(id);
-		return ((obj == null) && (current == null)) || ((obj != null) && obj.equals(current));
+		T current = get(id).orElse(null);
+		return Objects.equals(obj, current);
 	}
 
 	/**
@@ -165,10 +167,8 @@ public abstract class AbstractItemFacet<IDT extends PCGenIdentifier, T> extends 
 	@Override
 	public void copyContents(IDT source, IDT copy)
 	{
-		T obj = get(source);
-		if (obj != null)
-		{
-			setCache(copy, obj);
-		}
+		get(source).ifPresent(obj ->
+				setCache(copy, obj)
+		);
 	}
 }

--- a/code/src/java/pcgen/cdom/facet/base/AbstractSourcedListFacet.java
+++ b/code/src/java/pcgen/cdom/facet/base/AbstractSourcedListFacet.java
@@ -79,6 +79,7 @@ public abstract class AbstractSourcedListFacet<IDT extends PCGenIdentifier, T> e
 	 */
 	public void add(IDT id, T obj, Object source)
 	{
+
 		Objects.requireNonNull(obj, "Object to add may not be null");
 		Map<T, Set<Object>> map = getConstructingCachedMap(id);
 		Set<Object> set = map.get(obj);

--- a/code/src/java/pcgen/cdom/facet/fact/AgeFacet.java
+++ b/code/src/java/pcgen/cdom/facet/fact/AgeFacet.java
@@ -44,8 +44,7 @@ public class AgeFacet extends AbstractItemFacet<CharID, Integer> implements Item
 	 */
 	public int getAge(CharID id)
 	{
-		Integer age = get(id);
-		return age == null ? 0 : age;
+		return get(id).orElse(0);
 	}
 
 	public void init()

--- a/code/src/java/pcgen/cdom/facet/fact/GenderFacet.java
+++ b/code/src/java/pcgen/cdom/facet/fact/GenderFacet.java
@@ -89,9 +89,9 @@ public class GenderFacet extends AbstractItemFacet<CharID, Gender> implements It
 		Gender g = findTemplateGender(id);
 		if (g == null)
 		{
-			g = get(id);
+			g = get(id).orElseGet(Gender::getDefaultValue);
 		}
-		return g == null ? Gender.getDefaultValue() : g;
+		return (g == null) ? Gender.getDefaultValue() : g;
 	}
 
 	/**

--- a/code/src/java/pcgen/cdom/facet/fact/GoldFacet.java
+++ b/code/src/java/pcgen/cdom/facet/fact/GoldFacet.java
@@ -47,11 +47,7 @@ public class GoldFacet extends AbstractItemFacet<CharID, BigDecimal> implements 
 	 */
 	public void adjustGold(CharID id, double delta)
 	{
-		BigDecimal old = get(id);
-		if (old == null)
-		{
-			old = BigDecimal.ZERO;
-		}
+		BigDecimal old = get(id).orElse(BigDecimal.ZERO);
 		// I don't really like this hack, but setScale just won't work right...
 		BigDecimal newGold =
 				new BigDecimal(old.doubleValue() + delta).divide(BigDecimal.ONE, 2, RoundingMode.HALF_EVEN);

--- a/code/src/java/pcgen/cdom/facet/fact/HandedFacet.java
+++ b/code/src/java/pcgen/cdom/facet/fact/HandedFacet.java
@@ -17,6 +17,8 @@
  */
 package pcgen.cdom.facet.fact;
 
+import java.util.Optional;
+
 import pcgen.cdom.enumeration.CharID;
 import pcgen.cdom.enumeration.Handed;
 import pcgen.cdom.facet.base.AbstractItemFacet;
@@ -77,11 +79,11 @@ public class HandedFacet extends AbstractItemFacet<CharID, Handed>
 	 */
 	public Handed getHanded(CharID id)
 	{
-		Handed g = get(id);
+		Optional<Handed> g = get(id);
 		if (Logging.isDebugMode())
 		{
 			Logging.debugPrint("HandedFacet handed value " + g);
 		}
-		return g == null ? HandedCompat.getDefaultHanded() : g;
+		return g.orElseGet(HandedCompat::getDefaultHanded);
 	}
 }

--- a/code/src/java/pcgen/cdom/facet/fact/HeightFacet.java
+++ b/code/src/java/pcgen/cdom/facet/fact/HeightFacet.java
@@ -72,8 +72,7 @@ public class HeightFacet extends AbstractItemFacet<CharID, Integer> implements I
 	 */
 	public int getHeight(CharID id)
 	{
-		Integer height = get(id);
-		return (height == null) ? 0 : height;
+		return get(id).orElse(0);
 	}
 
 	/**

--- a/code/src/java/pcgen/cdom/facet/fact/WeightFacet.java
+++ b/code/src/java/pcgen/cdom/facet/fact/WeightFacet.java
@@ -78,7 +78,6 @@ public class WeightFacet extends AbstractItemFacet<CharID, Integer>
 	 */
 	public int getWeight(CharID id)
 	{
-		Integer weight = get(id);
-		return weight == null ? 0 : weight;
+		return get(id).orElse(0);
 	}
 }

--- a/code/src/java/pcgen/cdom/facet/input/RaceInputFacet.java
+++ b/code/src/java/pcgen/cdom/facet/input/RaceInputFacet.java
@@ -106,7 +106,7 @@ public class RaceInputFacet
 
 	public <T> boolean directSet(CharID id, Race race, T sel)
 	{
-		Race old = raceFacet.get(id);
+		Race old = raceFacet.get(id).orElse(null);
 		if (raceFacet.set(id, race) && (old != null))
 		{
 			PlayerCharacter pc = trackingFacet.getPC(id);

--- a/code/src/java/pcgen/cdom/formula/VariableChannelFactoryInst.java
+++ b/code/src/java/pcgen/cdom/formula/VariableChannelFactoryInst.java
@@ -59,7 +59,7 @@ public class VariableChannelFactoryInst implements VariableChannelFactory
 	@Override
 	public VariableChannel<?> getChannel(CharID id, VarScoped owner, String name)
 	{
-		ScopeInstanceFactory instFactory = SCOPE_FACET.get(id);
+		ScopeInstanceFactory instFactory = SCOPE_FACET.get(id).orElse(null);
 		Optional<String> localScopeName = owner.getLocalScopeName();
 		ScopeInstance scopeInst = instFactory.get(localScopeName.get(), Optional.of(owner));
 		return getChannel(id, scopeInst, name);
@@ -111,8 +111,8 @@ public class VariableChannelFactoryInst implements VariableChannelFactory
 		VariableChannel<T> ref = (VariableChannel<T>) channels.get(varID);
 		if (ref == null)
 		{
-			MonitorableVariableStore varStore = RESULT_FACET.get(id);
-			ref = VariableChannel.construct(MGR_FACET.get(id), varStore, varID);
+			MonitorableVariableStore varStore = RESULT_FACET.get(id).orElse(null);
+			ref = VariableChannel.construct(MGR_FACET.get(id).orElse(null), varStore, varID);
 			channels.put(varID, ref);
 			varStore.addVariableListener(varID, ref);
 		}

--- a/code/src/java/pcgen/cdom/formula/VariableUtilities.java
+++ b/code/src/java/pcgen/cdom/formula/VariableUtilities.java
@@ -66,7 +66,7 @@ public class VariableUtilities
 	{
 		ScopeInstance globalInstance = SCOPE_FACET.getGlobalScope(id);
 		VariableContext varContext =
-				LOAD_CONTEXT_FACET.get(id.getDatasetID()).get().getVariableContext();
+				LOAD_CONTEXT_FACET.get(id.getDatasetID()).get().get().getVariableContext();
 		VariableID<T> varID =
 				(VariableID<T>) varContext.getVariableID(globalInstance, variableName);
 		return varID;
@@ -86,7 +86,7 @@ public class VariableUtilities
 		VariableListener<T> listener)
 	{
 		VariableID<T> varID = VariableUtilities.getGlobalVariableID(id, variableName);
-		RESULT_FACET.get(id).addVariableListener(0, varID, listener);
+		RESULT_FACET.get(id).get().addVariableListener(0, varID, listener);
 	}
 
 	/**
@@ -104,7 +104,7 @@ public class VariableUtilities
 		VariableListener<T> listener, String variableName)
 	{
 		VariableID<T> varID = VariableUtilities.getGlobalVariableID(id, variableName);
-		RESULT_FACET.get(id).removeVariableListener(0, varID, listener);
+		RESULT_FACET.get(id).get().removeVariableListener(0, varID, listener);
 	}
 
 	/**

--- a/code/src/java/pcgen/core/PlayerCharacter.java
+++ b/code/src/java/pcgen/core/PlayerCharacter.java
@@ -979,7 +979,7 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 	 */
 	public Deity getDeity()
 	{
-		return deityFacet.get(id);
+		return deityFacet.get(id).orElse(null);
 	}
 
 	/**
@@ -1371,7 +1371,7 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 		}
 
 		// The equality comparison in AbstractItemFacet doesn't work on BigDecimal, need to use compareTo
-		BigDecimal oldAmt = goldFacet.get(id);
+		BigDecimal oldAmt = goldFacet.get(id).orElse(null);
 		if (oldAmt == null || amt.compareTo(oldAmt) != 0)
 		{
 			goldFacet.set(id, amt);
@@ -1388,7 +1388,7 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 	 */
 	public BigDecimal getGold()
 	{
-		BigDecimal g = goldFacet.get(id);
+		BigDecimal g = goldFacet.get(id).orElse(null);
 		return (g == null) ? BigDecimal.ZERO : g;
 	}
 
@@ -1777,7 +1777,7 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 	 */
 	public PlayerCharacter getMasterPC()
 	{
-		Follower followerMaster = masterFacet.get(id);
+		Follower followerMaster = masterFacet.get(id).orElse(null);
 		if (followerMaster == null)
 		{
 			return null;
@@ -1892,7 +1892,7 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 	 */
 	public Race getRace()
 	{
-		return raceFacet.get(id);
+		return raceFacet.get(id).orElse(null);
 	}
 
 	/**
@@ -3577,7 +3577,7 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 	 */
 	public SkillFilter getSkillFilter()
 	{
-		SkillFilter filter = skillFilterFacet.get(id);
+		SkillFilter filter = skillFilterFacet.get(id).orElse(null);
 		if (filter == null)
 		{
 			filter = SkillFilter.getByValue(PCGenSettings.OPTIONS_CONTEXT.initInt(PCGenSettings.OPTION_SKILL_FILTER,
@@ -6282,7 +6282,7 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 		}
 
 		// BioSet
-		list.add(bioSetFacet.get(id));
+		list.add(bioSetFacet.get(id).get());
 
 		list.addAll(checkFacet.getSet(id));
 
@@ -6293,11 +6293,8 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 		list.addAll(companionModFacet.getSet(id));
 
 		// Deity
-		Deity deity = deityFacet.get(id);
-		if (deity != null)
-		{
-			list.add(deity);
-		}
+		deityFacet.get(id)
+		          .ifPresent(list::add);
 
 		// Domain
 		list.addAll(domainFacet.getSet(id));
@@ -6319,11 +6316,7 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 		}
 
 		// Race
-		Race race = raceFacet.get(id);
-		if (race != null)
-		{
-			list.add(race);
-		}
+		raceFacet.get(id).ifPresent(list::add);
 
 		// SizeAdjustment
 		SizeAdjustment sa = getSizeAdjustment();
@@ -6716,7 +6709,7 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 		}
 		else
 		{
-			return sizeFacet.get(id);
+			return sizeFacet.get(id).orElse(null);
 		}
 	}
 
@@ -7259,10 +7252,10 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 		{
 			bean.copyContents(id, aClone.id);
 		}
-		SolverManager sm = solverManagerFacet.get(id);
+		SolverManager sm = solverManagerFacet.get(id).orElse(null);
 		if (sm != null)
 		{
-			SolverManager replacement = sm.createReplacement(variableStoreFacet.get(aClone.id));
+			SolverManager replacement = sm.createReplacement(variableStoreFacet.get(aClone.id).orElse(null));
 			solverManagerFacet.set(aClone.id, replacement);
 		}
 		aClone.bonusManager = bonusManager.buildDeepClone(aClone);
@@ -7271,7 +7264,7 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 		{
 			cloneClass.addFeatPoolBonus(aClone);
 		}
-		Follower followerMaster = masterFacet.get(id);
+		Follower followerMaster = masterFacet.get(id).orElse(null);
 		if (followerMaster != null)
 		{
 			aClone.masterFacet.set(id, followerMaster.clone());
@@ -9353,7 +9346,7 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 	public Collection<BonusContainer> getBonusContainerList()
 	{
 		List<BonusContainer> list = new ArrayList<>(getCDOMObjectList());
-		list.add(ageSetFacet.get(id));
+		list.add(ageSetFacet.get(id).orElse(null));
 		GameMode gm = SettingsHandler.getGame();
 		if (gm.isPurchaseStatMode())
 		{
@@ -9462,7 +9455,7 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 
 	public BioSet getBioSet()
 	{
-		return bioSetFacet.get(id);
+		return bioSetFacet.get(id).orElse(null);
 	}
 
 	public HitDie getLevelHitDie(PCClass pcClass, final int classLevel)
@@ -9685,7 +9678,7 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 			if (ageFacet.getAge(id) <= 0)
 			{
 				// Only generate a random age if the user hasn't set one!
-				bioSetFacet.get(id).randomize("AGE", this);
+				bioSetFacet.get(id).get().randomize("AGE", this);
 			}
 		}
 		else
@@ -9718,10 +9711,9 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 		spMod = Math.max(skillMin, spMod); // Minimum 1, not sure if bonus
 
 		// level can be < 1, better safe than sorry
-		for (PCTemplate template : getTemplateSet())
-		{
-			spMod += template.getSafe(IntegerKey.BONUS_CLASS_SKILL_POINTS);
-		}
+		spMod += getTemplateSet().stream()
+		                         .mapToInt(template -> template.getSafe(IntegerKey.BONUS_CLASS_SKILL_POINTS))
+		                         .sum();
 
 		return spMod;
 	}
@@ -9833,8 +9825,8 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 	 */
 	public boolean isAllowDebt()
 	{
-		Boolean ad = allowDebtFacet.get(id);
-		return (ad == null) ? SettingsHandler.getGearTab_AllowDebt() : ad;
+		return allowDebtFacet.get(id)
+		                     .orElseGet(SettingsHandler::getGearTab_AllowDebt);
 	}
 
 	/**
@@ -9842,8 +9834,8 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 	 */
 	public boolean isIgnoreCost()
 	{
-		Boolean ic = ignoreCostFacet.get(id);
-		return (ic == null) ? SettingsHandler.getGearTab_IgnoreCost() : ic;
+		return ignoreCostFacet.get(id)
+		                      .orElseGet(SettingsHandler::getGearTab_IgnoreCost);
 	}
 
 	public Double getSkillRankForClass(Skill sk, PCClass pcc)
@@ -10225,7 +10217,7 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 	 */
 	public <T> T solve(NEPFormula<T> formula)
 	{
-		return solverManagerFacet.get(id).solve(formula);
+		return solverManagerFacet.get(id).get().solve(formula);
 	}
 
 	/**

--- a/code/src/java/pcgen/core/analysis/SizeUtilities.java
+++ b/code/src/java/pcgen/core/analysis/SizeUtilities.java
@@ -33,15 +33,13 @@ public final class SizeUtilities
 	 */
 	public static SizeAdjustment getDefaultSizeAdjustment()
 	{
-		for (SizeAdjustment s : Globals.getContext().getReferenceContext()
-			.getConstructedCDOMObjects(SizeAdjustment.class))
-		{
-			if (s.getSafe(ObjectKey.IS_DEFAULT_SIZE))
-			{
-				return s;
-			}
-		}
+		return Globals.getContext()
+		              .getReferenceContext()
+		              .getConstructedCDOMObjects(SizeAdjustment.class)
+		              .stream()
+		              .filter(s -> s.getSafe(ObjectKey.IS_DEFAULT_SIZE))
+		              .findFirst()
+		              .orElse(null);
 
-		return null;
 	}
 }

--- a/code/src/java/pcgen/core/display/CharacterDisplay.java
+++ b/code/src/java/pcgen/core/display/CharacterDisplay.java
@@ -578,22 +578,22 @@ public class CharacterDisplay
 
 	public Race getRace()
 	{
-		return raceFacet.get(id);
+		return raceFacet.get(id).orElse(null);
 	}
 
 	public String getCharacterType()
 	{
-		return characterTypeFacet.get(id);
+		return characterTypeFacet.get(id).orElse(null);
 	}
 
 	public String getPreviewSheet()
 	{
-		return previewSheetFacet.get(id);
+		return previewSheetFacet.get(id).orElse(null);
 	}
 
 	public SkillFilter getSkillFilter()
 	{
-		return skillFilterFacet.get(id);
+		return skillFilterFacet.get(id).orElse(null);
 	}
 
 	/**
@@ -677,7 +677,7 @@ public class CharacterDisplay
 
 	public Rectangle getPortraitThumbnailRect()
 	{
-		Rectangle rect = portraitThumbnailRectFacet.get(id);
+		Rectangle rect = portraitThumbnailRectFacet.get(id).orElse(null);
 		return (rect == null) ? null : (Rectangle) rect.clone();
 	}
 
@@ -802,7 +802,7 @@ public class CharacterDisplay
 	 */
 	public Deity getDeity()
 	{
-		return deityFacet.get(id);
+		return deityFacet.get(id).orElse(null);
 	}
 
 	/**
@@ -878,7 +878,7 @@ public class CharacterDisplay
 	 */
 	public Follower getMaster()
 	{
-		return masterFacet.get(id);
+		return masterFacet.get(id).orElse(null);
 	}
 
 	/**
@@ -992,7 +992,7 @@ public class CharacterDisplay
 
 	public String getXPTableName()
 	{
-		return xpTableFacet.get(id).getName();
+		return xpTableFacet.get(id).get().getName();
 	}
 
 	/**
@@ -1271,7 +1271,7 @@ public class CharacterDisplay
 
 	public AgeSet getAgeSet()
 	{
-		return ageSetFacet.get(id);
+		return ageSetFacet.get(id).orElse(null);
 	}
 
 	/**
@@ -1543,7 +1543,7 @@ public class CharacterDisplay
 
 	public BioSet getBioSet()
 	{
-		return bioSetFacet.get(id);
+		return bioSetFacet.get(id).orElse(null);
 	}
 
 	public int getAgeSetIndex()

--- a/code/src/java/pcgen/gui2/solverview/SolverViewFrame.java
+++ b/code/src/java/pcgen/gui2/solverview/SolverViewFrame.java
@@ -118,7 +118,7 @@ public class SolverViewFrame extends JFrame
 			return;
 		}
 		ScopeInstance scope = scopeFacet.get(activeIdentifier, LegalScope.getFullName(selectedScope), activeObject);
-		if (loadContextFacet.get(activeIdentifier.getDatasetID()).get().getVariableContext()
+		if (loadContextFacet.get(activeIdentifier.getDatasetID()).get().get().getVariableContext()
 			.isLegalVariableID(scope.getLegalScope(), varNameText))
 		{
 			displayInfo(scope);
@@ -132,7 +132,7 @@ public class SolverViewFrame extends JFrame
 
 	private void displayInfo(ScopeInstance scope)
 	{
-		VariableID<?> varID = loadContextFacet.get(activeIdentifier.getDatasetID()).get().getVariableContext()
+		VariableID<?> varID = loadContextFacet.get(activeIdentifier.getDatasetID()).get().get().getVariableContext()
 			.getVariableID(scope, varNameText);
 		setSteps(varID);
 	}
@@ -211,11 +211,12 @@ public class SolverViewFrame extends JFrame
 		{
 			Object item = identifierChooser.getSelectedItem();
 			activeIdentifier = ((PCRef) item).id;
-			LoadContext loadContext = loadContextFacet.get(activeIdentifier.getDatasetID()).get();
-			for (LegalScope lvs : loadContext.getVariableContext().getScopes())
-			{
-				scopeChooser.addItem(new LegalScopeWrapper(lvs));
-			}
+			LoadContext loadContext = loadContextFacet.get(activeIdentifier.getDatasetID()).get().get();
+			loadContext.getVariableContext()
+			           .getScopes()
+			           .stream()
+			           .map(LegalScopeWrapper::new)
+			           .forEach(scopeChooser::addItem);
 			update();
 		}
 

--- a/code/src/java/pcgen/output/actor/VariableActor.java
+++ b/code/src/java/pcgen/output/actor/VariableActor.java
@@ -17,10 +17,9 @@
  */
 package pcgen.output.actor;
 
+
 import java.util.Objects;
 
-import freemarker.template.TemplateModel;
-import freemarker.template.TemplateModelException;
 import pcgen.base.formula.base.VariableID;
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.enumeration.CharID;
@@ -29,6 +28,9 @@ import pcgen.cdom.facet.ObjectWrapperFacet;
 import pcgen.cdom.facet.VariableStoreFacet;
 import pcgen.cdom.formula.VariableUtilities;
 import pcgen.output.base.OutputActor;
+
+import freemarker.template.TemplateModel;
+import freemarker.template.TemplateModelException;
 
 /**
  * A VariableActor is designed to process an interpolation and convert that into

--- a/code/src/java/pcgen/output/channel/ChannelUtilities.java
+++ b/code/src/java/pcgen/output/channel/ChannelUtilities.java
@@ -99,8 +99,8 @@ public final class ChannelUtilities
 	public static void setGlobalChannel(CharID id, String channelName, Object value)
 	{
 		VariableID<Object> varID = getChannelVariableID(id, channelName);
-		RESULT_FACET.get(id).put(varID, value);
-		SOLVER_MANAGER_FACET.get(id).solveChildren(varID);
+		RESULT_FACET.get(id).get().put(varID, value);
+		SOLVER_MANAGER_FACET.get(id).get().solveChildren(varID);
 	}
 
 	/**
@@ -228,14 +228,14 @@ public final class ChannelUtilities
 	{
 		VariableID<T> varID =
 				getChannelVariableID(id, channelName);
-		RESULT_FACET.get(id).addVariableListener(priority, varID,
+		RESULT_FACET.get(id).get().addVariableListener(priority, varID,
 			e -> VariableUtilities.forwardVariableChangeToDFCL(id, e, listener));
 	}
 
 	/**
 	 * Sets up the given Code Control so that if the value on the channel changes, the PC
 	 * is categorized as Dirty.
-	 * 
+	 *
 	 * @param pc
 	 *            The PlayerCharacter on which the channel should be watched
 	 * @param codeControl
@@ -249,7 +249,7 @@ public final class ChannelUtilities
 
 	/**
 	 * Adds a listener to the channel on the given PlayerCharacter.
-	 * 
+	 *
 	 * @param pc
 	 *            The PlayerCharacter on which the listener will be added
 	 * @param control

--- a/code/src/java/pcgen/output/model/GlobalVarModel.java
+++ b/code/src/java/pcgen/output/model/GlobalVarModel.java
@@ -19,15 +19,16 @@ package pcgen.output.model;
 
 import java.util.Objects;
 
-import freemarker.template.TemplateHashModel;
-import freemarker.template.TemplateModel;
-import freemarker.template.TemplateModelException;
 import pcgen.base.formula.base.VariableID;
 import pcgen.cdom.enumeration.CharID;
 import pcgen.cdom.facet.FacetLibrary;
 import pcgen.cdom.facet.ObjectWrapperFacet;
 import pcgen.cdom.facet.VariableStoreFacet;
 import pcgen.cdom.formula.VariableUtilities;
+
+import freemarker.template.TemplateHashModel;
+import freemarker.template.TemplateModel;
+import freemarker.template.TemplateModelException;
 
 /**
  * GlobalVarModel provides the services to expose global variables for a Player
@@ -60,8 +61,7 @@ public class GlobalVarModel implements TemplateHashModel
 	 */
 	public GlobalVarModel(CharID id)
 	{
-		Objects.requireNonNull(id, "CharID cannot be null");
-		this.id = id;
+		this.id = Objects.requireNonNull(id, "CharID cannot be null");
 	}
 
 	/**

--- a/code/src/java/pcgen/output/model/ItemFacetModel.java
+++ b/code/src/java/pcgen/output/model/ItemFacetModel.java
@@ -21,16 +21,17 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.Objects;
 
-import freemarker.template.TemplateHashModel;
-import freemarker.template.TemplateModel;
-import freemarker.template.TemplateModelException;
-import freemarker.template.TemplateScalarModel;
 import pcgen.cdom.base.CDOMObject;
-import pcgen.cdom.base.Constants;
+import pcgen.cdom.base.Identified;
 import pcgen.cdom.base.ItemFacet;
 import pcgen.cdom.enumeration.CharID;
 import pcgen.cdom.facet.FacetLibrary;
 import pcgen.cdom.facet.ObjectWrapperFacet;
+
+import freemarker.template.TemplateHashModel;
+import freemarker.template.TemplateModel;
+import freemarker.template.TemplateModelException;
+import freemarker.template.TemplateScalarModel;
 
 /**
  * An ItemFacetModel wraps a ItemFacet and serves as a TemplateHashModel for
@@ -60,12 +61,12 @@ public class ItemFacetModel<T> implements TemplateHashModel, TemplateScalarModel
 	/**
 	 * A cache of the TemplateHashModel of the underlying object, if any
 	 */
-	private transient TemplateHashModel cache;
+	private TemplateHashModel cache;
 
 	/**
 	 * Whether the cache variable has been set (required because null is legal)
 	 */
-	private transient boolean cacheSet = false;
+	private boolean cacheSet = false;
 
 	/**
 	 * Constructs a new ItemFacetModel from the given CharID and SetFacet.
@@ -79,10 +80,8 @@ public class ItemFacetModel<T> implements TemplateHashModel, TemplateScalarModel
 	 */
 	public ItemFacetModel(CharID id, ItemFacet<CharID, T> facet)
 	{
-		Objects.requireNonNull(id, "CharID may not be null");
-		Objects.requireNonNull(facet, "SetFacet may not be null");
-		this.id = id;
-		this.facet = facet;
+		this.id = Objects.requireNonNull(id, "CharID may not be null");
+		this.facet = Objects.requireNonNull(facet, "SetFacet may not be null");
 	}
 
 	@Override
@@ -100,7 +99,7 @@ public class ItemFacetModel<T> implements TemplateHashModel, TemplateScalarModel
 	{
 		if (!cacheSet)
 		{
-			T obj = facet.get(id);
+			T obj = facet.get(id).get();
 			TemplateModel wrapped = WRAPPER_FACET.wrap(id, obj);
 			if (wrapped instanceof TemplateHashModel)
 			{
@@ -114,28 +113,25 @@ public class ItemFacetModel<T> implements TemplateHashModel, TemplateScalarModel
 	@Override
 	public boolean isEmpty() throws TemplateModelException
 	{
-		return (facet.get(id) == null) || getInternalHashModel().isEmpty();
+		return (facet.get(id).isEmpty()) || getInternalHashModel().isEmpty();
 	}
 
 	@Override
-	public String getAsString() throws TemplateModelException
+	public String getAsString()
 	{
-		T obj = facet.get(id);
-		if (obj == null)
-		{
-			return Constants.EMPTY_STRING;
-		}
-		if (obj instanceof CDOMObject)
-		{
-			return ((CDOMObject) obj).getDisplayName();
-		}
-		return obj.toString();
+		return facet.get(id).map(obj -> {
+			if (obj instanceof CDOMObject)
+			{
+				return ((Identified) obj).getDisplayName();
+			}
+			return obj.toString();
+		}).orElse("");
 	}
 
 	@Override
 	public Iterator<T> iterator()
 	{
-		return Collections.singleton(facet.get(id)).iterator();
+		return Collections.singleton(facet.get(id).get()).iterator();
 	}
 
 }

--- a/code/src/utest/pcgen/cdom/facet/SkillRankFacetTest.java
+++ b/code/src/utest/pcgen/cdom/facet/SkillRankFacetTest.java
@@ -17,6 +17,10 @@
  */
 package pcgen.cdom.facet;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
 import pcgen.cdom.enumeration.CharID;
 import pcgen.cdom.enumeration.DataSetID;
 import pcgen.cdom.facet.SkillRankFacet.SkillRankChangeEvent;
@@ -26,10 +30,6 @@ import pcgen.core.Skill;
 
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
 public class SkillRankFacetTest
 {
 	private CharID id;

--- a/code/src/utest/pcgen/cdom/facet/input/GlobalAddedSkillCostFacetTest.java
+++ b/code/src/utest/pcgen/cdom/facet/input/GlobalAddedSkillCostFacetTest.java
@@ -33,6 +33,7 @@ import pcgen.rules.persistence.TokenLibrary;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+
 public class GlobalAddedSkillCostFacetTest
 {
 	protected CharID id;

--- a/code/src/utest/pcgen/cdom/facet/input/LocalAddedSkillCostFacetTest.java
+++ b/code/src/utest/pcgen/cdom/facet/input/LocalAddedSkillCostFacetTest.java
@@ -30,8 +30,8 @@ import pcgen.core.Skill;
 import pcgen.core.bonus.BonusObj;
 import pcgen.rules.persistence.TokenLibrary;
 
+import org.junit.Test;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
 public class LocalAddedSkillCostFacetTest
 {
@@ -247,32 +247,16 @@ public class LocalAddedSkillCostFacetTest
 		}
 	}
 
-	@Test
+	@Test(expected = NullPointerException.class)
 	public void testRemoveNullSkill()
 	{
-		try
-		{
-			getFacet().remove(id, class1, SkillCost.CLASS, null, source1);
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			// Yep!
-		}
+		getFacet().remove(id, class1, SkillCost.CLASS, null, source1);
 	}
 
-	@Test
+	@Test(expected = NullPointerException.class)
 	public void testRemoveNullCost()
 	{
-		try
-		{
-			getFacet().remove(id, class1, null, getObject(), source1);
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			// Yep!
-		}
+		getFacet().remove(id, class1, null, getObject(), source1);
 	}
 
 	@Test

--- a/code/src/utest/pcgen/cdom/facet/model/SizeFacetTest.java
+++ b/code/src/utest/pcgen/cdom/facet/model/SizeFacetTest.java
@@ -21,9 +21,6 @@ import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
-
-import junit.framework.TestCase;
 import pcgen.cdom.base.FormulaFactory;
 import pcgen.cdom.enumeration.CharID;
 import pcgen.cdom.enumeration.DataSetID;
@@ -41,6 +38,9 @@ import pcgen.core.SettingsHandler;
 import pcgen.core.SizeAdjustment;
 import pcgen.rules.context.AbstractReferenceContext;
 import plugin.lsttokens.testsupport.BuildUtilities;
+
+import junit.framework.TestCase;
+import org.junit.Test;
 
 public class SizeFacetTest extends TestCase
 {
@@ -100,7 +100,7 @@ public class SizeFacetTest extends TestCase
 	@Test
 	public void testReachUnsetDefault()
 	{
-		assertEquals(2, facet.get(id).get(IntegerKey.SIZEORDER).intValue());
+		assertEquals(2, facet.get(id).get().get(IntegerKey.SIZEORDER).intValue());
 		assertEquals(2, facet.racialSizeInt(id));
 	}
 
@@ -109,11 +109,11 @@ public class SizeFacetTest extends TestCase
 	{
 		rfacet.set(id, new Race());
 		facet.update(id);
-		assertEquals(2, facet.get(id).get(IntegerKey.SIZEORDER).intValue());
+		assertEquals(2, facet.get(id).get().get(IntegerKey.SIZEORDER).intValue());
 		assertEquals(2, facet.racialSizeInt(id));
 		rfacet.remove(id);
 		facet.update(id);
-		assertEquals(2, facet.get(id).get(IntegerKey.SIZEORDER).intValue());
+		assertEquals(2, facet.get(id).get().get(IntegerKey.SIZEORDER).intValue());
 		assertEquals(2, facet.racialSizeInt(id));
 	}
 
@@ -124,7 +124,7 @@ public class SizeFacetTest extends TestCase
 		r.put(FormulaKey.SIZE, FormulaFactory.getFormulaFor(3));
 		rfacet.set(id, r);
 		facet.update(id);
-		assertEquals(2, facet.get(altid).get(IntegerKey.SIZEORDER).intValue());
+		assertEquals(2, facet.get(altid).get().get(IntegerKey.SIZEORDER).intValue());
 		assertEquals(2, facet.racialSizeInt(altid));
 	}
 
@@ -135,7 +135,7 @@ public class SizeFacetTest extends TestCase
 		r.put(FormulaKey.SIZE, FormulaFactory.getFormulaFor(3));
 		rfacet.set(id, r);
 		facet.update(id);
-		assertEquals(3, facet.get(id).get(IntegerKey.SIZEORDER).intValue());
+		assertEquals(3, facet.get(id).get().get(IntegerKey.SIZEORDER).intValue());
 	}
 
 	@Test
@@ -146,10 +146,10 @@ public class SizeFacetTest extends TestCase
 		t1.put(FormulaKey.SIZE, FormulaFactory.getFormulaFor(1));
 		tfacet.add(id, t1, this);
 		facet.update(id);
-		assertEquals(1, facet.get(id).get(IntegerKey.SIZEORDER).intValue());
+		assertEquals(1, facet.get(id).get().get(IntegerKey.SIZEORDER).intValue());
 		tfacet.remove(id, t1, this);
 		facet.update(id);
-		assertEquals(2, facet.get(id).get(IntegerKey.SIZEORDER).intValue());
+		assertEquals(2, facet.get(id).get().get(IntegerKey.SIZEORDER).intValue());
 	}
 
 	@Test
@@ -160,10 +160,10 @@ public class SizeFacetTest extends TestCase
 		t1.put(FormulaKey.SIZE, FormulaFactory.getFormulaFor(3));
 		tfacet.add(id, t1, this);
 		facet.update(id);
-		assertEquals(3, facet.get(id).get(IntegerKey.SIZEORDER).intValue());
+		assertEquals(3, facet.get(id).get().get(IntegerKey.SIZEORDER).intValue());
 		tfacet.remove(id, t1, this);
 		facet.update(id);
-		assertEquals(2, facet.get(id).get(IntegerKey.SIZEORDER).intValue());
+		assertEquals(2, facet.get(id).get().get(IntegerKey.SIZEORDER).intValue());
 	}
 
 	@Test
@@ -176,10 +176,10 @@ public class SizeFacetTest extends TestCase
 		t1.put(FormulaKey.SIZE, FormulaFactory.getFormulaFor(1));
 		tfacet.add(id, t1, this);
 		facet.update(id);
-		assertEquals(1, facet.get(id).get(IntegerKey.SIZEORDER).intValue());
+		assertEquals(1, facet.get(id).get().get(IntegerKey.SIZEORDER).intValue());
 		tfacet.remove(id, t1, this);
 		facet.update(id);
-		assertEquals(3, facet.get(id).get(IntegerKey.SIZEORDER).intValue());
+		assertEquals(3, facet.get(id).get().get(IntegerKey.SIZEORDER).intValue());
 	}
 
 	@Test
@@ -192,10 +192,10 @@ public class SizeFacetTest extends TestCase
 		t1.put(FormulaKey.SIZE, FormulaFactory.getFormulaFor(4));
 		tfacet.add(id, t1, this);
 		facet.update(id);
-		assertEquals(4, facet.get(id).get(IntegerKey.SIZEORDER).intValue());
+		assertEquals(4, facet.get(id).get().get(IntegerKey.SIZEORDER).intValue());
 		tfacet.remove(id, t1, this);
 		facet.update(id);
-		assertEquals(3, facet.get(id).get(IntegerKey.SIZEORDER).intValue());
+		assertEquals(3, facet.get(id).get().get(IntegerKey.SIZEORDER).intValue());
 	}
 
 	@Test
@@ -213,13 +213,13 @@ public class SizeFacetTest extends TestCase
 		t2.put(FormulaKey.SIZE, FormulaFactory.getFormulaFor(4));
 		tfacet.add(id, t2, this);
 		facet.update(id);
-		assertEquals(4, facet.get(id).get(IntegerKey.SIZEORDER).intValue());
+		assertEquals(4, facet.get(id).get().get(IntegerKey.SIZEORDER).intValue());
 		tfacet.remove(id, t2, this);
 		facet.update(id);
-		assertEquals(3, facet.get(id).get(IntegerKey.SIZEORDER).intValue());
+		assertEquals(3, facet.get(id).get().get(IntegerKey.SIZEORDER).intValue());
 		tfacet.remove(id, t1, this);
 		facet.update(id);
-		assertEquals(1, facet.get(id).get(IntegerKey.SIZEORDER).intValue());
+		assertEquals(1, facet.get(id).get().get(IntegerKey.SIZEORDER).intValue());
 	}
 
 	@Test
@@ -229,32 +229,32 @@ public class SizeFacetTest extends TestCase
 		r.put(FormulaKey.SIZE, FormulaFactory.getFormulaFor(1));
 		rfacet.set(id, r);
 		facet.update(id);
-		assertEquals(1, facet.get(id).get(IntegerKey.SIZEORDER).intValue());
+		assertEquals(1, facet.get(id).get().get(IntegerKey.SIZEORDER).intValue());
 		bonusInfo.put(altid, 2.0);
 		// No pollution
 		facet.update(id);
-		assertEquals(1, facet.get(id).get(IntegerKey.SIZEORDER).intValue());
+		assertEquals(1, facet.get(id).get().get(IntegerKey.SIZEORDER).intValue());
 		bonusInfo.put(id, 2.0);
 		facet.update(id);
-		assertEquals(3, facet.get(id).get(IntegerKey.SIZEORDER).intValue());
+		assertEquals(3, facet.get(id).get().get(IntegerKey.SIZEORDER).intValue());
 		PCTemplate t1 = new PCTemplate();
 		t1.setName("PCT");
 		t1.put(FormulaKey.SIZE, FormulaFactory.getFormulaFor(0));
 		tfacet.add(id, t1, this);
 		facet.update(id);
-		assertEquals(2, facet.get(id).get(IntegerKey.SIZEORDER).intValue());
+		assertEquals(2, facet.get(id).get().get(IntegerKey.SIZEORDER).intValue());
 		PCTemplate t2 = new PCTemplate();
 		t2.setName("Other");
 		t2.put(FormulaKey.SIZE, FormulaFactory.getFormulaFor(3));
 		tfacet.add(id, t2, this);
 		facet.update(id);
-		assertEquals(4, facet.get(id).get(IntegerKey.SIZEORDER).intValue());
+		assertEquals(4, facet.get(id).get().get(IntegerKey.SIZEORDER).intValue());
 		tfacet.remove(id, t2, this);
 		facet.update(id);
-		assertEquals(2, facet.get(id).get(IntegerKey.SIZEORDER).intValue());
+		assertEquals(2, facet.get(id).get().get(IntegerKey.SIZEORDER).intValue());
 		bonusInfo.clear();
 		facet.update(id);
-		assertEquals(0, facet.get(id).get(IntegerKey.SIZEORDER).intValue());
+		assertEquals(0, facet.get(id).get().get(IntegerKey.SIZEORDER).intValue());
 	}
 
 	@Test
@@ -264,89 +264,89 @@ public class SizeFacetTest extends TestCase
 		r.put(FormulaKey.SIZE, FormulaFactory.getFormulaFor(1));
 		rfacet.set(id, r);
 		facet.update(id);
-		assertEquals(1, facet.get(id).get(IntegerKey.SIZEORDER).intValue());
+		assertEquals(1, facet.get(id).get().get(IntegerKey.SIZEORDER).intValue());
 		fakeLevels = 6;
 		facet.update(id);
-		assertEquals(1, facet.get(id).get(IntegerKey.SIZEORDER).intValue());
+		assertEquals(1, facet.get(id).get().get(IntegerKey.SIZEORDER).intValue());
 		r.addToListFor(ListKey.HITDICE_ADVANCEMENT, 2);
 		facet.update(id);
-		assertEquals(1, facet.get(id).get(IntegerKey.SIZEORDER).intValue());
+		assertEquals(1, facet.get(id).get().get(IntegerKey.SIZEORDER).intValue());
 		r.addToListFor(ListKey.HITDICE_ADVANCEMENT, Integer.MAX_VALUE);
 		facet.update(id);
-		assertEquals(2, facet.get(id).get(IntegerKey.SIZEORDER).intValue());
+		assertEquals(2, facet.get(id).get().get(IntegerKey.SIZEORDER).intValue());
 		r.removeListFor(ListKey.HITDICE_ADVANCEMENT);
 		r.addToListFor(ListKey.HITDICE_ADVANCEMENT, 2);
 		r.addToListFor(ListKey.HITDICE_ADVANCEMENT, 5);
 		r.addToListFor(ListKey.HITDICE_ADVANCEMENT, 6);
 		facet.update(id);
-		assertEquals(3, facet.get(id).get(IntegerKey.SIZEORDER).intValue());
+		assertEquals(3, facet.get(id).get().get(IntegerKey.SIZEORDER).intValue());
 		PCTemplate t1 = new PCTemplate();
 		t1.setName("PCT");
 		t1.put(FormulaKey.SIZE, FormulaFactory.getFormulaFor(0));
 		tfacet.add(id, t1, this);
 		facet.update(id);
-		assertEquals(2, facet.get(id).get(IntegerKey.SIZEORDER).intValue());
+		assertEquals(2, facet.get(id).get().get(IntegerKey.SIZEORDER).intValue());
 		PCTemplate t2 = new PCTemplate();
 		t2.setName("Other");
 		t2.put(FormulaKey.SIZE, FormulaFactory.getFormulaFor(3));
 		tfacet.add(id, t2, this);
 		facet.update(id);
-		assertEquals(4, facet.get(id).get(IntegerKey.SIZEORDER).intValue());
+		assertEquals(4, facet.get(id).get().get(IntegerKey.SIZEORDER).intValue());
 		tfacet.remove(id, t2, this);
 		facet.update(id);
-		assertEquals(2, facet.get(id).get(IntegerKey.SIZEORDER).intValue());
+		assertEquals(2, facet.get(id).get().get(IntegerKey.SIZEORDER).intValue());
 		r.removeListFor(ListKey.HITDICE_ADVANCEMENT);
 		facet.update(id);
-		assertEquals(0, facet.get(id).get(IntegerKey.SIZEORDER).intValue());
+		assertEquals(0, facet.get(id).get().get(IntegerKey.SIZEORDER).intValue());
 	}
 
 	@Test
 	public void testGetObjectWithBonus()
 	{
-		assertEquals(m, facet.get(id));
+		assertEquals(m, facet.get(id).get());
 		facet.update(id);
-		assertEquals(m, facet.get(id));
+		assertEquals(m, facet.get(id).get());
 		Race r = new Race();
 		r.put(FormulaKey.SIZE, FormulaFactory.getFormulaFor(1));
 		rfacet.set(id, r);
 		facet.update(id);
-		assertEquals(s, facet.get(id));
+		assertEquals(s, facet.get(id).get());
 		bonusInfo.put(altid, 2.0);
 		// No pollution
 		facet.update(id);
-		assertEquals(s, facet.get(id));
+		assertEquals(s, facet.get(id).get());
 		bonusInfo.put(id, 2.0);
 		facet.update(id);
-		assertEquals(l, facet.get(id));
+		assertEquals(l, facet.get(id).get());
 		PCTemplate t1 = new PCTemplate();
 		t1.setName("PCT");
 		t1.put(FormulaKey.SIZE, FormulaFactory.getFormulaFor(0));
 		tfacet.add(id, t1, this);
 		facet.update(id);
-		assertEquals(m, facet.get(id));
+		assertEquals(m, facet.get(id).get());
 		PCTemplate t2 = new PCTemplate();
 		t2.setName("Other");
 		t2.put(FormulaKey.SIZE, FormulaFactory.getFormulaFor(3));
 		tfacet.add(id, t2, this);
 		facet.update(id);
-		assertEquals(h, facet.get(id));
+		assertEquals(h, facet.get(id).get());
 		tfacet.remove(id, t2, this);
 		facet.update(id);
-		assertEquals(m, facet.get(id));
+		assertEquals(m, facet.get(id).get());
 		bonusInfo.put(id, -2.0);
 		t1.put(FormulaKey.SIZE, FormulaFactory.getFormulaFor(1));
 		facet.update(id);
-		assertEquals(t, facet.get(id));
+		assertEquals(t, facet.get(id).get());
 		t2.put(FormulaKey.SIZE, FormulaFactory.getFormulaFor(4));
 		tfacet.add(id, t2, this);
 		facet.update(id);
-		assertEquals(m, facet.get(id));
+		assertEquals(m, facet.get(id).get());
 		tfacet.remove(id, t2, this);
 		facet.update(id);
-		assertEquals(t, facet.get(id));
+		assertEquals(t, facet.get(id).get());
 		bonusInfo.clear();
 		facet.update(id);
-		assertEquals(s, facet.get(id));
+		assertEquals(s, facet.get(id).get());
 	}
 
 	@Test
@@ -405,40 +405,40 @@ public class SizeFacetTest extends TestCase
 		r.put(FormulaKey.SIZE, FormulaFactory.getFormulaFor(1));
 		rfacet.set(id, r);
 		facet.update(id);
-		assertEquals(s, facet.get(id));
+		assertEquals(s, facet.get(id).get());
 		fakeLevels = 6;
 		facet.update(id);
-		assertEquals(s, facet.get(id));
+		assertEquals(s, facet.get(id).get());
 		r.addToListFor(ListKey.HITDICE_ADVANCEMENT, 2);
 		facet.update(id);
-		assertEquals(s, facet.get(id));
+		assertEquals(s, facet.get(id).get());
 		r.addToListFor(ListKey.HITDICE_ADVANCEMENT, Integer.MAX_VALUE);
 		facet.update(id);
-		assertEquals(m, facet.get(id));
+		assertEquals(m, facet.get(id).get());
 		r.removeListFor(ListKey.HITDICE_ADVANCEMENT);
 		r.addToListFor(ListKey.HITDICE_ADVANCEMENT, 2);
 		r.addToListFor(ListKey.HITDICE_ADVANCEMENT, 5);
 		r.addToListFor(ListKey.HITDICE_ADVANCEMENT, 6);
 		facet.update(id);
-		assertEquals(l, facet.get(id));
+		assertEquals(l, facet.get(id).get());
 		PCTemplate t1 = new PCTemplate();
 		t1.setName("PCT");
 		t1.put(FormulaKey.SIZE, FormulaFactory.getFormulaFor(0));
 		tfacet.add(id, t1, this);
 		facet.update(id);
-		assertEquals(m, facet.get(id));
+		assertEquals(m, facet.get(id).get());
 		PCTemplate t2 = new PCTemplate();
 		t2.setName("Other");
 		t2.put(FormulaKey.SIZE, FormulaFactory.getFormulaFor(3));
 		tfacet.add(id, t2, this);
 		facet.update(id);
-		assertEquals(h, facet.get(id));
+		assertEquals(h, facet.get(id).get());
 		tfacet.remove(id, t2, this);
 		facet.update(id);
-		assertEquals(m, facet.get(id));
+		assertEquals(m, facet.get(id).get());
 		r.removeListFor(ListKey.HITDICE_ADVANCEMENT);
 		facet.update(id);
-		assertEquals(t, facet.get(id));
+		assertEquals(t, facet.get(id).get());
 	}
 
 	@Test
@@ -487,44 +487,44 @@ public class SizeFacetTest extends TestCase
 	@Test
 	public void testGetWithNegativeBonus()
 	{
-		assertEquals(2, facet.get(id).get(IntegerKey.SIZEORDER).intValue());
+		assertEquals(2, facet.get(id).get().get(IntegerKey.SIZEORDER).intValue());
 		assertEquals(2, facet.racialSizeInt(id));
 		Race r = new Race();
 		r.put(FormulaKey.SIZE, FormulaFactory.getFormulaFor(3));
 		rfacet.set(id, r);
 		facet.update(id);
-		assertEquals(3, facet.get(id).get(IntegerKey.SIZEORDER).intValue());
+		assertEquals(3, facet.get(id).get().get(IntegerKey.SIZEORDER).intValue());
 		assertEquals(3, facet.racialSizeInt(id));
 		bonusInfo.put(altid, -2.0);
 		// No pollution
 		facet.update(id);
-		assertEquals(3, facet.get(id).get(IntegerKey.SIZEORDER).intValue());
+		assertEquals(3, facet.get(id).get().get(IntegerKey.SIZEORDER).intValue());
 		assertEquals(3, facet.racialSizeInt(id));
 		bonusInfo.put(id, -2.0);
 		facet.update(id);
-		assertEquals(1, facet.get(id).get(IntegerKey.SIZEORDER).intValue());
+		assertEquals(1, facet.get(id).get().get(IntegerKey.SIZEORDER).intValue());
 		assertEquals(3, facet.racialSizeInt(id));
 		PCTemplate t1 = new PCTemplate();
 		t1.setName("PCT");
 		t1.put(FormulaKey.SIZE, FormulaFactory.getFormulaFor(1));
 		tfacet.add(id, t1, this);
 		facet.update(id);
-		assertEquals(0, facet.get(id).get(IntegerKey.SIZEORDER).intValue());
+		assertEquals(0, facet.get(id).get().get(IntegerKey.SIZEORDER).intValue());
 		assertEquals(1, facet.racialSizeInt(id));
 		PCTemplate t2 = new PCTemplate();
 		t2.setName("Other");
 		t2.put(FormulaKey.SIZE, FormulaFactory.getFormulaFor(4));
 		tfacet.add(id, t2, this);
 		facet.update(id);
-		assertEquals(2, facet.get(id).get(IntegerKey.SIZEORDER).intValue());
+		assertEquals(2, facet.get(id).get().get(IntegerKey.SIZEORDER).intValue());
 		assertEquals(4, facet.racialSizeInt(id));
 		tfacet.remove(id, t2, this);
 		facet.update(id);
-		assertEquals(0, facet.get(id).get(IntegerKey.SIZEORDER).intValue());
+		assertEquals(0, facet.get(id).get().get(IntegerKey.SIZEORDER).intValue());
 		assertEquals(1, facet.racialSizeInt(id));
 		bonusInfo.clear();
 		facet.update(id);
-		assertEquals(1, facet.get(id).get(IntegerKey.SIZEORDER).intValue());
+		assertEquals(1, facet.get(id).get().get(IntegerKey.SIZEORDER).intValue());
 		assertEquals(1, facet.racialSizeInt(id));
 	}
 	

--- a/code/src/utest/pcgen/cdom/testsupport/AbstractCNASEnforcingFacetTest.java
+++ b/code/src/utest/pcgen/cdom/testsupport/AbstractCNASEnforcingFacetTest.java
@@ -4,10 +4,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import junit.framework.TestCase;
-
-import org.junit.Test;
-
 import pcgen.cdom.content.CNAbility;
 import pcgen.cdom.content.CNAbilityFactory;
 import pcgen.cdom.enumeration.CharID;
@@ -23,6 +19,9 @@ import pcgen.cdom.reference.CDOMDirectSingleRef;
 import pcgen.core.Ability;
 import pcgen.core.AbilityCategory;
 import plugin.lsttokens.testsupport.BuildUtilities;
+
+import junit.framework.TestCase;
+import org.junit.Test;
 
 public abstract class AbstractCNASEnforcingFacetTest extends TestCase
 {

--- a/code/src/utest/pcgen/cdom/testsupport/AbstractItemFacetTest.java
+++ b/code/src/utest/pcgen/cdom/testsupport/AbstractItemFacetTest.java
@@ -17,11 +17,6 @@
  */
 package pcgen.cdom.testsupport;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import pcgen.cdom.enumeration.CharID;
 import pcgen.cdom.enumeration.DataSetID;
@@ -29,10 +24,11 @@ import pcgen.cdom.facet.base.AbstractItemFacet;
 import pcgen.cdom.facet.event.DataFacetChangeEvent;
 import pcgen.cdom.facet.event.DataFacetChangeListener;
 
+import junit.framework.TestCase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public abstract class AbstractItemFacetTest<T>
+public abstract class AbstractItemFacetTest<T> extends TestCase
 {
 	private CharID id;
 	private CharID altid;
@@ -77,7 +73,7 @@ public abstract class AbstractItemFacetTest<T>
 	@Test
 	public void testItemUnsetEmpty()
 	{
-		assertNull(getFacet().get(id));
+		assertTrue(getFacet().get(id).isEmpty());
 		assertTrue(getFacet().matches(id, null));
 	}
 
@@ -186,10 +182,10 @@ public abstract class AbstractItemFacetTest<T>
 	{
 		T t1 = getItem();
 		getFacet().set(id, t1);
-		assertEquals(t1, getFacet().get(id));
+		assertEquals(t1, getFacet().get(id).get());
 		assertEventCount(1, 0);
 		// No cross-pollution
-		assertNull(getFacet().get(altid));
+		assertThat(getFacet().get(altid).isEmpty(), is(true));
 	}
 
 	@Test
@@ -197,11 +193,11 @@ public abstract class AbstractItemFacetTest<T>
 	{
 		T t1 = getItem();
 		getFacet().set(id, t1);
-		assertEquals(t1, getFacet().get(id));
+		assertEquals(t1, getFacet().get(id).get());
 		assertEventCount(1, 0);
 		// Set same, still only set (and only one event)
 		getFacet().set(id, t1);
-		assertEquals(t1, getFacet().get(id));
+		assertEquals(t1, getFacet().get(id).get());
 		assertEventCount(1, 0);
 	}
 
@@ -210,19 +206,19 @@ public abstract class AbstractItemFacetTest<T>
 	{
 		T t1 = getItem();
 		getFacet().set(id, t1);
-		assertEquals(t1, getFacet().get(id));
+		assertEquals(t1, getFacet().get(id).get());
 		assertEventCount(1, 0);
 		T t2 = getItem();
 		getFacet().set(id, t2);
-		assertEquals(t2, getFacet().get(id));
+		assertEquals(t2, getFacet().get(id).get());
 		assertEventCount(2, 1);
 		// Remove
 		getFacet().remove(id);
-		assertNull(getFacet().get(id));
+		assertTrue(getFacet().get(id).isEmpty());
 		assertEventCount(2, 2);
 		// But only one remove event
 		getFacet().remove(id);
-		assertNull(getFacet().get(id));
+		assertTrue(getFacet().get(id).isEmpty());
 		assertEventCount(2, 2);
 	}
 
@@ -235,7 +231,7 @@ public abstract class AbstractItemFacetTest<T>
 		assertTrue(getFacet().matches(id, t1));
 		getFacet().remove(id);
 		assertFalse(getFacet().matches(id, t1));
-		assertNull(getFacet().get(id));
+		assertTrue(getFacet().get(id).isEmpty());
 		assertTrue(getFacet().matches(id, null));
 	}
 
@@ -243,7 +239,7 @@ public abstract class AbstractItemFacetTest<T>
 	public void testCopyContentsNone()
 	{
 		getFacet().copyContents(altid, id);
-		assertNull(getFacet().get(id));
+		assertNull(getFacet().get(id).orElse(null));
 		assertTrue(getFacet().matches(id, null));
 	}
 
@@ -254,10 +250,10 @@ public abstract class AbstractItemFacetTest<T>
 		T t2 = getItem();
 		getFacet().set(id, t1);
 		getFacet().copyContents(id, altid);
-		assertEquals(t1, getFacet().get(altid));
+		assertEquals(t1, getFacet().get(altid).get());
 		// Prove independence (remove from id)
 		getFacet().set(id, t2);
-		assertEquals(t1, getFacet().get(altid));
+		assertEquals(t1, getFacet().get(altid).get());
 	}
 
 	@Test
@@ -266,11 +262,11 @@ public abstract class AbstractItemFacetTest<T>
 		T t1 = getItem();
 		getFacet().set(id, t1);
 		getFacet().copyContents(id, altid);
-		assertEquals(t1, getFacet().get(altid));
+		assertEquals(t1, getFacet().get(altid).get());
 		// Prove Independence (remove from altid)
 		getFacet().remove(altid);
-		assertEquals(t1, getFacet().get(id));
-		assertNull(getFacet().get(altid));
+		assertEquals(t1, getFacet().get(id).get());
+		assertNull(getFacet().get(altid).orElse(null));
 		assertTrue(getFacet().matches(altid, null));
 	}
 

--- a/code/src/utest/pcgen/cdom/testsupport/AbstractQualifiedListFacetTest.java
+++ b/code/src/utest/pcgen/cdom/testsupport/AbstractQualifiedListFacetTest.java
@@ -23,10 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import junit.framework.TestCase;
-
-import org.junit.Test;
-
 import pcgen.cdom.base.QualifiedActor;
 import pcgen.cdom.base.QualifyingObject;
 import pcgen.cdom.enumeration.CharID;
@@ -36,6 +32,9 @@ import pcgen.cdom.facet.event.DataFacetChangeEvent;
 import pcgen.cdom.facet.event.DataFacetChangeListener;
 import pcgen.core.bonus.BonusObj;
 import pcgen.rules.persistence.TokenLibrary;
+
+import junit.framework.TestCase;
+import org.junit.Test;
 
 public abstract class AbstractQualifiedListFacetTest<T extends QualifyingObject>
 		extends TestCase

--- a/code/src/utest/plugin/function/InputFunctionTest.java
+++ b/code/src/utest/plugin/function/InputFunctionTest.java
@@ -17,8 +17,6 @@
  */
 package plugin.function;
 
-import org.junit.Test;
-
 import pcgen.base.formula.base.ScopeInstance;
 import pcgen.base.formula.base.ScopeInstanceFactory;
 import pcgen.base.formula.parse.SimpleNode;
@@ -34,6 +32,8 @@ import pcgen.cdom.formula.scope.GlobalScope;
 import pcgen.output.channel.ChannelUtilities;
 import plugin.function.testsupport.AbstractFormulaTestCase;
 import plugin.function.testsupport.TestUtilities;
+
+import org.junit.Test;
 
 public class InputFunctionTest extends AbstractFormulaTestCase
 {
@@ -95,7 +95,7 @@ public class InputFunctionTest extends AbstractFormulaTestCase
 	@Test
 	public void testGlobalChannelStrength()
 	{
-		ScopeInstanceFactory instFactory = scopeFacet.get(id);
+		ScopeInstanceFactory instFactory = scopeFacet.get(id).get();
 		ScopeInstance globalInstance =
 				instFactory.getGlobalInstance(GlobalScope.GLOBAL_SCOPE_NAME);
 		context.getVariableContext().assertLegalVariableID(ChannelUtilities.createVarName("STR"),


### PR DESCRIPTION
This makes it clear whether or not we're handling `null` properly. There 
are several cases here that look like bugs. I've attempted to change
nothing about the semantics. If you find bugs of the sort "we should add a
check there", but there wasn't one before, please comment, but I'll fix
them in a followup.

In a couple of cases we have some odd APIs (e.g., `.get().get()`) but IMHO
the tradeoffs are worth it.