### PR TITLE
Settings: remove 'rog' setting

### DIFF
--- a/code/src/java/pcgen/core/SettingsHandler.java
+++ b/code/src/java/pcgen/core/SettingsHandler.java
@@ -113,7 +113,6 @@ public final class SettingsHandler
 	private static boolean gearTab_AllowDebt = false;
 	private static int gearTab_SellRate = Constants.DEFAULT_GEAR_TAB_SELL_RATE;
 	private static int gearTab_BuyRate = Constants.DEFAULT_GEAR_TAB_BUY_RATE;
-	private static boolean isROG = false;
 	private static Point leftUpperCorner = null;
 	private static int windowState = Frame.NORMAL;
 	private static int looknFeel = 1; // default to Java L&F
@@ -913,7 +912,6 @@ public final class SettingsHandler
 		setPrereqFailColor(getPCGenOption("prereqFailColor", Color.red.getRGB())); //$NON-NLS-1$
 		setPrereqQualifyColor(getPCGenOption("prereqQualifyColor", SystemColor.text.getRGB())); //$NON-NLS-1$
 		setPreviewTabShown(getPCGenOption("previewTabShown", true)); //$NON-NLS-1$
-		setROG(getPCGenOption("isROG", false)); //$NON-NLS-1$
 		setSaveCustomInLst(getPCGenOption("saveCustomInLst", false)); //$NON-NLS-1$
 		setSaveOutputSheetWithPC(getPCGenOption("saveOutputSheetWithPC", false)); //$NON-NLS-1$
 		setPrintSpellsWithPC(getPCGenOption("printSpellsWithPC", true)); //$NON-NLS-1$
@@ -1369,15 +1367,6 @@ public final class SettingsHandler
 	public static boolean getPrintSpellsWithPC()
 	{
 		return printSpellsWithPC;
-	}
-
-	/**
-	 * I guess only ROG can document this?
-	 * @return TRUR if ROG, else FALSE
-	 */
-	public static boolean isROG()
-	{
-		return isROG;
 	}
 
 	/**
@@ -2147,15 +2136,6 @@ public final class SettingsHandler
 	private static Double getPCGenOption(final String optionName, final double defaultValue)
 	{
 		return Double.valueOf(getPCGenOption(optionName, Double.toString(defaultValue)));
-	}
-
-	/**
-	 * What does this do???
-	 * @param ROG
-	 */
-	private static void setROG(final boolean ROG)
-	{
-		isROG = ROG;
 	}
 
 	/**

--- a/code/src/java/plugin/exporttokens/SpecialAbilityToken.java
+++ b/code/src/java/plugin/exporttokens/SpecialAbilityToken.java
@@ -20,9 +20,7 @@ package plugin.exporttokens;
 
 import java.util.StringTokenizer;
 
-import pcgen.cdom.base.Constants;
 import pcgen.core.PlayerCharacter;
-import pcgen.core.SettingsHandler;
 import pcgen.io.ExportHandler;
 import pcgen.io.exporttoken.Token;
 
@@ -56,13 +54,13 @@ public class SpecialAbilityToken extends Token
 
 			if ("DESCRIPTION".equals(subToken))
 			{
-				return getDescriptionToken(pc, i);
+				return "";
 			}
 		}
 		return getSpecialAbilityToken(pc, i);
 	}
 
-	public static String getSpecialAbilityToken(PlayerCharacter pc, int specialIndex)
+	private static String getSpecialAbilityToken(PlayerCharacter pc, int specialIndex)
 	{
 		if (specialIndex >= 0 && specialIndex < pc.getSpecialAbilityTimesList().size())
 		{
@@ -71,31 +69,4 @@ public class SpecialAbilityToken extends Token
 		return "";
 	}
 
-	public static String getDescriptionToken(PlayerCharacter pc, int specialIndex)
-	{
-		if (specialIndex >= 0 && specialIndex < pc.getSpecialAbilityTimesList().size())
-		{
-			if (SettingsHandler.isROG())
-			{
-				if ("EMPTY".equals(pc.getDescriptionLst()))
-				{
-					pc.loadDescriptionFilesInDirectory("descriptions");
-				}
-
-				String description = "";
-				String search =
-						"SA" + ':' + pc.getSpecialAbilityTimesList().get(specialIndex) + Constants.LINE_SEPARATOR;
-				int pos = pc.getDescriptionLst().indexOf(search);
-
-				if (pos >= 0)
-				{
-					description = pc.getDescriptionLst().substring(pos + search.length());
-					description = description.substring(0, description.indexOf("####") - 1).trim();
-				}
-
-				return description;
-			}
-		}
-		return "";
-	}
 }

--- a/code/src/java/plugin/exporttokens/SpellMemToken.java
+++ b/code/src/java/plugin/exporttokens/SpellMemToken.java
@@ -27,7 +27,6 @@ import java.util.TreeSet;
 
 import pcgen.base.util.HashMapToList;
 import pcgen.cdom.base.CDOMList;
-import pcgen.cdom.base.Constants;
 import pcgen.cdom.enumeration.FactKey;
 import pcgen.cdom.enumeration.IntegerKey;
 import pcgen.cdom.enumeration.ListKey;
@@ -390,16 +389,15 @@ public class SpellMemToken extends Token
 						}
 						else if (aLabel.startsWith("DESCRIPTION"))
 						{
-							final String sString =
-									getItemDescription("SPELL", aSpell.getKeyName(), aPC.getDescription(aSpell), aPC);
+							final String sString = aPC.getDescription(aSpell);
 
-							if (!altLabel.isEmpty())
+							if (altLabel.isEmpty())
 							{
-								retValue.append(sString.replaceAll("\r?\n", altLabel));
+								retValue.append(sString);
 							}
 							else
 							{
-								retValue.append(sString);
+								retValue.append(sString.replaceAll("\r?\n", altLabel));
 							}
 						}
 						else if (aLabel.startsWith("BONUSSPELL"))
@@ -544,38 +542,6 @@ public class SpellMemToken extends Token
 		}
 
 		return tempSource.toString();
-	}
-
-	/**
-	 * Get the item description
-	 * @param sType
-	 * @param sKey
-	 * @param sAlt
-	 * @param aPC
-	 * @return item description
-	 */
-	public static String getItemDescription(String sType, String sKey, String sAlt, PlayerCharacter aPC)
-	{
-		if (SettingsHandler.isROG())
-		{
-			if ("EMPTY".equals(aPC.getDescriptionLst()))
-			{
-				aPC.loadDescriptionFilesInDirectory("descriptions");
-			}
-
-			String aDescription = sAlt;
-			final String aSearch = sType.toUpperCase() + ':' + sKey + Constants.LINE_SEPARATOR;
-			final int pos = aPC.getDescriptionLst().indexOf(aSearch);
-
-			if (pos >= 0)
-			{
-				aDescription = aPC.getDescriptionLst().substring(pos + aSearch.length());
-				aDescription = aDescription.substring(0, aDescription.indexOf("####") - 1).trim();
-			}
-
-			return aDescription;
-		}
-		return sAlt;
 	}
 
 }


### PR DESCRIPTION
This setting was initially added CVS in 1.175 of SettingsHandler.java.
At present there is no UI to modifying the setting, though in theory
it is honored if it was set in the past.

It doesn't seem useful to keep it around, is undocumented, and adds a
mild amount of complexity to some tokens.