### PR TITLE
Move Granted Vars to any PCGenScoped object

### DIFF
--- a/code/src/java/applicationContext.xml
+++ b/code/src/java/applicationContext.xml
@@ -292,7 +292,7 @@
 	<bean id="goldFacet" class="pcgen.cdom.facet.fact.GoldFacet"/>
 	<bean id="grantedAbilityFacet" class="pcgen.cdom.facet.GrantedAbilityFacet"/>
 	<bean id="grantedVarFacet" class="pcgen.cdom.facet.GrantedVarFacet">
-		<property name="cdomSourceFacet" ref="cdomSourceFacet"/>
+		<property name="varScopedFacet" ref="varScopedFacet"/>
 		<property name="variableStoreFacet" ref="variableStoreFacet"/>
 	</bean>
 	<!-- H -->

--- a/code/src/java/pcgen/cdom/facet/FacetInitialization.java
+++ b/code/src/java/pcgen/cdom/facet/FacetInitialization.java
@@ -150,8 +150,6 @@ public final class FacetInitialization
 
 		bonusChangeFacet.addBonusChangeListener(sizeFacet, "SIZEMOD", "NUMBER");
 
-		grantedVarFacet.addDataFacetChangeListener(charObjectFacet); //model done
-
 		expandedCampaignFacet.addDataFacetChangeListener(charObjectFacet); //model done
 		globalModifierFacet.addDataFacetChangeListener(charObjectFacet); //model done
 		bioSetFacet.addDataFacetChangeListener(charObjectFacet); //model done
@@ -182,6 +180,7 @@ public final class FacetInitialization
 		cdomSourceFacet.addDataFacetChangeListener(autoLangFacet);
 		cdomSourceFacet.addDataFacetChangeListener(dynamicWatchingFacet);
 
+		grantedVarFacet.addDataFacetChangeListener(varScopedFacet);
 		charObjectFacet.addDataFacetChangeListener(varScopedFacet);
 		dynamicConsolidationFacet.addDataFacetChangeListener(varScopedFacet); //model done
 	}

--- a/code/src/java/pcgen/cdom/facet/GrantedVarFacet.java
+++ b/code/src/java/pcgen/cdom/facet/GrantedVarFacet.java
@@ -21,20 +21,22 @@ import pcgen.cdom.enumeration.CharID;
 import pcgen.cdom.facet.base.AbstractSourcedListFacet;
 import pcgen.cdom.facet.event.DataFacetChangeEvent;
 import pcgen.cdom.facet.event.DataFacetChangeListener;
+import pcgen.cdom.facet.model.VarScopedFacet;
+import pcgen.cdom.formula.PCGenScoped;
 import pcgen.cdom.formula.VariableUtilities;
 import pcgen.cdom.helper.BridgeListener;
 
 /**
  * This Facet controls items granted from variables
  */
-public class GrantedVarFacet extends AbstractSourcedListFacet<CharID, CDOMObject>
-		implements DataFacetChangeListener<CharID, CDOMObject>
+public class GrantedVarFacet extends AbstractSourcedListFacet<CharID, PCGenScoped>
+		implements DataFacetChangeListener<CharID, PCGenScoped>
 {
 
 	/**
 	 * The source facet to watch for the addition of new objects
 	 */
-	private CDOMObjectSourceFacet cdomSourceFacet;
+	private VarScopedFacet varScopedFacet;
 
 	/**
 	 * The VariableStore Facet
@@ -42,9 +44,9 @@ public class GrantedVarFacet extends AbstractSourcedListFacet<CharID, CDOMObject
 	private VariableStoreFacet variableStoreFacet;
 
 	@Override
-	public void dataAdded(DataFacetChangeEvent<CharID, CDOMObject> dfce)
+	public void dataAdded(DataFacetChangeEvent<CharID, PCGenScoped> dfce)
 	{
-		CDOMObject cdo = dfce.getCDOMObject();
+		PCGenScoped cdo = dfce.getCDOMObject();
 		String[] grantedVariables = cdo.getGrantedVariableArray();
 		if (grantedVariables.length == 0)
 		{
@@ -84,9 +86,9 @@ public class GrantedVarFacet extends AbstractSourcedListFacet<CharID, CDOMObject
 	}
 
 	@Override
-	public void dataRemoved(DataFacetChangeEvent<CharID, CDOMObject> dfce)
+	public void dataRemoved(DataFacetChangeEvent<CharID, PCGenScoped> dfce)
 	{
-		CDOMObject cdo = dfce.getCDOMObject();
+		PCGenScoped cdo = dfce.getCDOMObject();
 		String[] list = cdo.getGrantedVariableArray();
 		Object source = dfce.getSource();
 		CharID id = dfce.getCharID();
@@ -114,9 +116,9 @@ public class GrantedVarFacet extends AbstractSourcedListFacet<CharID, CDOMObject
 		}
 	}
 
-	public void setCdomSourceFacet(CDOMObjectSourceFacet cdomSourceFacet)
+	public void setVarScopedFacet(VarScopedFacet varScopedFacet)
 	{
-		this.cdomSourceFacet = cdomSourceFacet;
+		this.varScopedFacet = varScopedFacet;
 	}
 
 	public void setVariableStoreFacet(VariableStoreFacet variableStoreFacet)
@@ -132,6 +134,6 @@ public class GrantedVarFacet extends AbstractSourcedListFacet<CharID, CDOMObject
 	 */
 	public void init()
 	{
-		cdomSourceFacet.addDataFacetChangeListener(this);
+		varScopedFacet.addDataFacetChangeListener(this);
 	}
 }

--- a/code/src/java/pcgen/cdom/helper/BridgeListener.java
+++ b/code/src/java/pcgen/cdom/helper/BridgeListener.java
@@ -20,13 +20,14 @@ import java.util.IdentityHashMap;
 import java.util.Objects;
 import java.util.Set;
 
-import org.apache.commons.lang3.tuple.ImmutablePair;
-
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.enumeration.CharID;
 import pcgen.cdom.facet.base.AbstractSourcedListFacet;
+import pcgen.cdom.formula.PCGenScoped;
 import pcgen.cdom.formula.VariableChangeEvent;
 import pcgen.cdom.formula.VariableListener;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
 
 /**
  * A BridgeListener converts from a VariableListener to then inject items into an
@@ -37,7 +38,7 @@ public class BridgeListener implements VariableListener<Object>
 	/**
 	 * The AbstractSourcedListFacet to which objects will be forwarded
 	 */
-	private final AbstractSourcedListFacet<CharID, CDOMObject> variableBridgeFacet;
+	private final AbstractSourcedListFacet<CharID, PCGenScoped> variableBridgeFacet;
 
 	/**
 	 * The CharID that this BridgeListener is serving
@@ -54,7 +55,7 @@ public class BridgeListener implements VariableListener<Object>
 	 *            The AbstractSourcedListFacet to be used as a bridge to the traditional
 	 *            Facet events
 	 */
-	public BridgeListener(CharID id, AbstractSourcedListFacet<CharID, CDOMObject> variableBridgeFacet)
+	public BridgeListener(CharID id, AbstractSourcedListFacet<CharID, PCGenScoped> variableBridgeFacet)
 	{
 		this.variableBridgeFacet = Objects.requireNonNull(variableBridgeFacet);
 		this.id = Objects.requireNonNull(id);


### PR DESCRIPTION
Today, GRANT of a variable can only be used on CDOMObjects (e.g. SKILL), but that is too limited.  It should work on any object that allows new-style variables (e.g. DYNAMIC objects should work too)
