### PR TITLE
This fixes a race condition on creation of formats for CDOM classes

### DIFF
--- a/code/src/java/pcgen/rules/context/AbstractReferenceContext.java
+++ b/code/src/java/pcgen/rules/context/AbstractReferenceContext.java
@@ -66,7 +66,6 @@ import pcgen.core.Globals;
 import pcgen.core.PCClass;
 import pcgen.core.SubClass;
 import pcgen.util.Logging;
-import pcgen.util.StringPClassUtil;
 
 /**
  * An AbstractReferenceContext is responsible for dealing with References during load of a
@@ -496,27 +495,12 @@ public abstract class AbstractReferenceContext
 
 	public FormatManager<?> getFormatManager(String clName)
 	{
-		if ((!fmtLibrary.hasFormatManager(clName)) && (StringPClassUtil.getClassForBasic(clName) != null))
-		{
-			importCDOMToFormat(clName);
-		}
 		return fmtLibrary.getFormatManager(clName);
 	}
 
-	private void importCDOMToFormat(String name)
+	void importCDOMToFormat(Class<? extends Loadable> cl)
 	{
-		Class<? extends Loadable> cl = StringPClassUtil.getClassForBasic(name);
-		if (cl == null)
-		{
-			throw new IllegalArgumentException("Invalid Data Definition Location (no class): " + name);
-		}
-		ReferenceManufacturer<? extends Loadable> mgr = getManufacturer(cl);
-		if (!name.equalsIgnoreCase(mgr.getIdentifierType()))
-		{
-			throw new IllegalArgumentException(
-				"Invalid Data: " + name + " did not return a matching manufacturer: " + mgr.getIdentifierType());
-		}
-		fmtLibrary.addFormatManager(mgr);
+		fmtLibrary.addFormatManager(getManufacturer(cl));
 	}
 
 	/**

--- a/code/src/java/pcgen/rules/context/RuntimeReferenceContext.java
+++ b/code/src/java/pcgen/rules/context/RuntimeReferenceContext.java
@@ -57,7 +57,8 @@ public class RuntimeReferenceContext extends AbstractReferenceContext
 	public void initialize()
 	{
 		super.initialize();
-		StringPClassUtil.getBaseClasses().forEach(c -> importCDOMToFormat(c));
+		StringPClassUtil.getBaseClasses()
+			.forEach(baseClass -> importCDOMToFormat(baseClass));
 	}
 
 	@Override

--- a/code/src/java/pcgen/rules/context/RuntimeReferenceContext.java
+++ b/code/src/java/pcgen/rules/context/RuntimeReferenceContext.java
@@ -38,6 +38,7 @@ import pcgen.cdom.reference.ReferenceManufacturer;
 import pcgen.cdom.reference.SimpleReferenceManufacturer;
 import pcgen.system.LanguageBundle;
 import pcgen.util.Logging;
+import pcgen.util.StringPClassUtil;
 
 public class RuntimeReferenceContext extends AbstractReferenceContext
 {
@@ -50,6 +51,13 @@ public class RuntimeReferenceContext extends AbstractReferenceContext
 
 	protected RuntimeReferenceContext()
 	{
+	}
+
+	@Override
+	public void initialize()
+	{
+		super.initialize();
+		StringPClassUtil.getBaseClasses().forEach(c -> importCDOMToFormat(c));
 	}
 
 	@Override

--- a/code/src/java/pcgen/util/StringPClassUtil.java
+++ b/code/src/java/pcgen/util/StringPClassUtil.java
@@ -18,6 +18,8 @@
 
 package pcgen.util;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -150,5 +152,18 @@ public final class StringPClassUtil
 	public static Class<? extends Category<?>> getCategoryClassFor(String className)
 	{
 		return catClassMap.get(className);
+	}
+
+	/**
+	 * Returns a Collection of the "Base" Classes in StringPClassUtil. These are the
+	 * "basic" CDOMObject classes that are simple to convert/unconvert and not
+	 * significantly dependent on other items (e.g. no Ability, no EquipmentModifier,
+	 * etc.)
+	 * 
+	 * @return A Collection of the "Base" Classes in StringPClassUtil.
+	 */
+	public static Collection<Class<? extends Loadable>> getBaseClasses()
+	{
+		return Collections.unmodifiableCollection(baseMap.values());
 	}
 }


### PR DESCRIPTION
This fixes - in hopefully a brute-force enough fashion that it's "final" - the problem of how we access a format like "SKILL".  The historical problem has been "SKILL" as a format isn't defined until the first skill is loaded, which is very late.  A previous system had tried to hack through that and say "if you requested something we recognize as a CDOM format, we'll just create it on the fly", but it has a bit of a loophole that will fail.  Asking for an Array of a format before the base format will cause the logic to fail.  This forces a pre-build of all of the "known basic formats" so that this shouldn't occur (for at least those base formats - which is most of what we will use in the formula system to start)
