### PR TITLE
Reduce Parallelism to try to reduce unexplained Travis errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -395,7 +395,7 @@ allprojects {
     }
     tasks.withType(Test) {
         maxHeapSize = "512m"
-        maxParallelForks = Runtime.runtime.availableProcessors()
+        maxParallelForks = Runtime.runtime.availableProcessors() - 2
         testLogging {
             exceptionFormat = 'full'
             events 'failed', 'skipped'


### PR DESCRIPTION
We are experiencing a 33%+ failure rate on Travis runs due to an explained issue with test threads.  This seems to have appeared about the time that the change was made to the max # of parallel threads for testing.  This reduces that number to see if it can eliminate the unexplained Travis errors
