### PR TITLE
[FOR FREEZE] Cleanup in test to reduce memory strain

### DIFF
--- a/code/src/utest/plugin/lsttokens/testsupport/AbstractTokenTestCase.java
+++ b/code/src/utest/plugin/lsttokens/testsupport/AbstractTokenTestCase.java
@@ -40,6 +40,7 @@ import pcgen.rules.persistence.token.ParseResult;
 import pcgen.util.Logging;
 
 import junit.framework.TestCase;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -77,6 +78,16 @@ public abstract class AbstractTokenTestCase<T extends Loadable> extends
 		TokenRegistration.register(getToken());
 		resetContext();
 		expectedPrimaryMessageCount = 0;
+	}
+
+	@Override
+	@After
+	public void tearDown() throws Exception
+	{
+		primaryContext = null;
+		secondaryContext = null;
+		primaryProf = null;
+		secondaryProf = null;
 	}
 
 	protected void resetContext()


### PR DESCRIPTION
This is another part of fixing the issues we currently have in master.  There is good evidence we are suffering from a memory leak of some sort, and probably not by us (but from JUnit, Gradle, etc.).  This has certain tests clean up their variables, meaning their objects will be garbage collected after the test is run.  This significantly reduces memory strain (even though one could assert it shouldn't since the objects should be destroyed when the test exits)
