### PR TITLE
[FOR FREEZE] Finish load character test

### DIFF
--- a/code/src/test/pcgen/AbstractCharacterTestCase.java
+++ b/code/src/test/pcgen/AbstractCharacterTestCase.java
@@ -221,11 +221,10 @@ public abstract class AbstractCharacterTestCase extends TestCase
 		context.resolveDeferredTokens();
 		ref.buildDeferredObjects();
 		ref.buildDerivedObjects();
-		context.resolveDeferredTokens();
-//		Assert.assertTrue(ref.validate(null));
+		Assert.assertTrue(ref.validate(null));
 		Assert.assertTrue(ref.resolveReferences(null));
+		context.resolvePostDeferredTokens();
 		context.loadCampaignFacets();
-		Globals.getContext().loadCampaignFacets();
 		character = new PlayerCharacter();
 	}
 

--- a/code/src/test/pcgen/AbstractCharacterTestCase.java
+++ b/code/src/test/pcgen/AbstractCharacterTestCase.java
@@ -78,6 +78,7 @@ public abstract class AbstractCharacterTestCase extends TestCase
 	protected SizeAdjustment tiny;
 	protected SizeAdjustment diminutive;
 	protected SizeAdjustment fine;
+	private LoadContext context;
 
 	/**
 	 * Sets up the absolute minimum amount of data to create a PlayerCharacter
@@ -107,7 +108,7 @@ public abstract class AbstractCharacterTestCase extends TestCase
 		Globals.setUseGUI(false);
 		Globals.emptyLists();
 
-		LoadContext context = Globals.getContext();
+		context = Globals.getContext();
 		BuildUtilities.buildUnselectedRace(context);
 		
 		SourceFileLoader.defineBuiltinVariables(context);
@@ -204,12 +205,27 @@ public abstract class AbstractCharacterTestCase extends TestCase
 		GameModeFileLoader.addDefaultUnitSet(SettingsHandler.getGame());
 		SettingsHandler.getGame().selectDefaultUnitSet();
 		ref.importObject(BuildUtilities.getFeatCat());
-		additionalSetUp();
-		context.getReferenceContext().buildDerivedObjects();
+		defaultSetupEnd();
+	}
+
+	protected void defaultSetupEnd()
+	{
+		finishLoad();
+	}
+
+	protected void finishLoad()
+	{
+		context.commit();
+		AbstractReferenceContext ref = context.getReferenceContext();
+		SourceFileLoader.processFactDefinitions(context);
 		context.resolveDeferredTokens();
+		ref.buildDeferredObjects();
+		ref.buildDerivedObjects();
+		context.resolveDeferredTokens();
+//		Assert.assertTrue(ref.validate(null));
 		Assert.assertTrue(ref.resolveReferences(null));
 		context.loadCampaignFacets();
-
+		Globals.getContext().loadCampaignFacets();
 		character = new PlayerCharacter();
 	}
 
@@ -220,11 +236,6 @@ public abstract class AbstractCharacterTestCase extends TestCase
 		FormulaModifier<T> defaultModifier = m.getFixedModifier(fmtManager, "NONE");
 		context.getVariableContext().addDefault(cl,
 			new ModifierDecoration<>(defaultModifier));
-	}
-
-	protected void additionalSetUp() throws Exception
-	{
-		//override to provide info
 	}
 
 	/**

--- a/code/src/test/pcgen/core/BioSetTest.java
+++ b/code/src/test/pcgen/core/BioSetTest.java
@@ -63,10 +63,12 @@ public class BioSetTest extends AbstractCharacterTestCase
 	}
 
     @Override
-	protected void additionalSetUp() throws Exception
+	public void setUp() throws Exception
 	{
+		super.setUp();
 		BioSetLoaderTest.loadBioSet(Globals.getContext(), BIO_SET_DATA,
 			new BioSetLoader());
+		finishLoad();
 	}
 
 	@Override
@@ -153,5 +155,11 @@ public class BioSetTest extends AbstractCharacterTestCase
 		Optional<Region> region = pc.getDisplay().getRegion();
 		SettingsHandler.getGame().getBioSet().getAgeSet(region, idx);
 
+	}
+
+	@Override
+	protected void defaultSetupEnd()
+	{
+		//Nothing, we will trigger ourselves
 	}
 }

--- a/code/src/test/pcgen/core/ChallengeRatingPathfinderTest.java
+++ b/code/src/test/pcgen/core/ChallengeRatingPathfinderTest.java
@@ -63,8 +63,9 @@ public class ChallengeRatingPathfinderTest extends AbstractCharacterTestCase
 	private PCClass companionClass;
 
 	@Override
-	protected void additionalSetUp() throws Exception
+	public void setUp() throws Exception
 	{
+		super.setUp();
 		GameMode gameMode = SettingsHandler.getGame();
 		gameMode.addCRstep(0, "1/2");
 		gameMode.addCRstep(-1, "1/3");
@@ -163,15 +164,12 @@ public class ChallengeRatingPathfinderTest extends AbstractCharacterTestCase
 		companionClass = classLoader.parseLine(context, null, companionClassLine, source);
 		context.getReferenceContext().importObject(companionClass);
 
-		context.commit();
 		BuildUtilities.createFact(context, "ClassType", PCClass.class);
 		FactDefinition<?, String> fd =
 				BuildUtilities.createFact(context, "SpellType", PCClass.class);
 		fd.setSelectable(true);
 
-		SourceFileLoader.processFactDefinitions(context);
-		context.getReferenceContext().buildDerivedObjects();
-		context.resolveDeferredTokens();
+		finishLoad();
 	}
 
 	/**
@@ -479,5 +477,11 @@ public class ChallengeRatingPathfinderTest extends AbstractCharacterTestCase
 		PlayerCharacter pc = getCharacter();
 		pc.setRace(centipedeRace);
 		assertEquals(SettingsHandler.getGame().getCRInteger("1/8"), pc.getDisplay().calcCR(), 0.0);
+	}
+
+	@Override
+	protected void defaultSetupEnd()
+	{
+		//Nothing, we will trigger ourselves
 	}
 }

--- a/code/src/test/pcgen/core/EquipmentTest.java
+++ b/code/src/test/pcgen/core/EquipmentTest.java
@@ -55,8 +55,9 @@ public class EquipmentTest extends AbstractCharacterTestCase
 	private CampaignSourceEntry source;
 
 	@Override
-	public void additionalSetUp() throws PersistenceLayerException
+	public void setUp() throws Exception
 	{
+		super.setUp();
 		try
 		{
 			source = new CampaignSourceEntry(new Campaign(),
@@ -102,7 +103,8 @@ public class EquipmentTest extends AbstractCharacterTestCase
 
 		SettingsHandler.getGame().addPlusCalculation(
 			"WEAPON|(2000*PLUS*PLUS)+(2000*ALTPLUS*ALTPLUS)");
-
+		
+		finishLoad();
 	}
 
 	/*****************************************************************************
@@ -609,5 +611,11 @@ assertNotNull("Eqmod should be present", eqMod);
 		Equipment aEquip = eq.clone();
 		aEquip.addEqModifier(eqMod, true, null);
 		assertSame("Eqmod parent should be the equipment", aEquip, eqMod.getVariableParent().get());
+	}
+
+	@Override
+	protected void defaultSetupEnd()
+	{
+		//Nothing, we will trigger ourselves
 	}
 }

--- a/code/src/test/pcgen/core/PCClassTest.java
+++ b/code/src/test/pcgen/core/PCClassTest.java
@@ -84,6 +84,7 @@ public class PCClassTest extends AbstractCharacterTestCase
 	 */
 	public void testFireNameChangedVariable()
 	{
+		finishLoad();
 		final PCClass myClass = new PCClass();
 		myClass.setName("myClass");
 		myClass.put(StringKey.KEY_NAME, "KEY_myClass");
@@ -123,6 +124,7 @@ public class PCClassTest extends AbstractCharacterTestCase
 	 */
 	public void testMonsterSkillPoints()
 	{
+		finishLoad();
 		// Create a medium bugbear first level
 		PlayerCharacter bugbear = new PlayerCharacter();
 		bugbear.setRace(bugbearRace);
@@ -230,6 +232,8 @@ public class PCClassTest extends AbstractCharacterTestCase
 		aNqClass.getOriginalClassLevel(2).put(VariableKey.getConstant("Foo"),
 				FormulaFactory.getFormulaFor(2));
 
+		finishLoad();
+
 		// Setup character without prereqs
 		final PlayerCharacter character = getCharacter();
 
@@ -315,6 +319,8 @@ public class PCClassTest extends AbstractCharacterTestCase
 		aNqClass.getOriginalClassLevel(2).put(VariableKey.getConstant("Foo"),
 				FormulaFactory.getFormulaFor(2));
 
+		finishLoad();
+
 		// Setup character without prereqs
 		final PlayerCharacter character = getCharacter();
 
@@ -358,6 +364,7 @@ public class PCClassTest extends AbstractCharacterTestCase
 	 */
 	public void testQualifies()
 	{
+		finishLoad();
 		// Setup character without prereqs
 		final PlayerCharacter character = getCharacter();
 
@@ -471,6 +478,8 @@ public class PCClassTest extends AbstractCharacterTestCase
 		context.unconditionallyProcess(megaCasterClass.getOriginalClassLevel(2), "CAST", "3,1,2,3,4,5,6,7,8,9,10");
 		Globals.getContext().getReferenceContext().importObject(megaCasterClass);
 
+		finishLoad();
+
 		final PlayerCharacter character = getCharacter();
 		assertEquals("Highest spell level for class", 10,
 			character.getSpellSupport(megaCasterClass).getHighestLevelSpell());
@@ -539,8 +548,8 @@ public class PCClassTest extends AbstractCharacterTestCase
 		context.unconditionallyProcess(megaCasterClass.getOriginalClassLevel(2), "KNOWN", "4,2,2,3,4,5,6,7,8,9,10");
 		context.unconditionallyProcess(megaCasterClass.getOriginalClassLevel(2), "CAST", "3,1,2,3,4,5,6,7,8,9,10");
 		Globals.getContext().getReferenceContext().importObject(megaCasterClass);
-		context.getReferenceContext().buildDerivedObjects();
-		context.loadCampaignFacets();
+
+		finishLoad();
 
 		final PlayerCharacter character = getCharacter();
 
@@ -625,8 +634,8 @@ public class PCClassTest extends AbstractCharacterTestCase
 		context.unconditionallyProcess(megaCasterClass.getOriginalClassLevel(2), "KNOWN", "4,2,2,3,4,5,6,7,8,9,10");
 		context.unconditionallyProcess(megaCasterClass.getOriginalClassLevel(2), "CAST", "3,1,2,3,4,5,6,7,8,9,10");
 		Globals.getContext().getReferenceContext().importObject(megaCasterClass);
-		context.getReferenceContext().buildDerivedObjects();
-		context.loadCampaignFacets();
+
+		finishLoad();
 
 		final PlayerCharacter character = getCharacter();
 
@@ -732,7 +741,9 @@ public class PCClassTest extends AbstractCharacterTestCase
 		CDOMSingleRef<AbilityCategory> acRef =
 				context.getReferenceContext().getCDOMReference(
 					AbilityCategory.class, "TestCat");
-		assertTrue(context.getReferenceContext().resolveReferences(null));
+
+		finishLoad();
+
 		CDOMReference<AbilityList> autoList = AbilityList.getAbilityListReference(acRef, Nature.AUTOMATIC);
 		Collection<CDOMReference<Ability>> mods = pcclass.getListMods(autoList);
 		assertEquals(1, mods.size());
@@ -774,6 +785,7 @@ public class PCClassTest extends AbstractCharacterTestCase
 	 */
 	public void testDefaultLevelsPerFeatMonster()
 	{
+		finishLoad();
 		PlayerCharacter pc = getCharacter();
 		pc.setRace(nymphRace);
 		List<BonusObj> bonusList = nymphClass.getRawBonusList(pc);
@@ -791,6 +803,7 @@ public class PCClassTest extends AbstractCharacterTestCase
 	 */
 	public void testLevelsPerFeatMonster()
 	{
+		finishLoad();
 		PlayerCharacter pc = getCharacter();
 		nymphClass.put(IntegerKey.LEVELS_PER_FEAT, 4);
 		List<BonusObj> bonusList = nymphClass.getRawBonusList(pc);
@@ -810,6 +823,7 @@ public class PCClassTest extends AbstractCharacterTestCase
 	 */
 	public void testDefaultLevelsPerFeatNonMonster()
 	{
+		finishLoad();
 		PlayerCharacter pc = getCharacter();
 		pc.setRace(nymphRace);
 		List<BonusObj> bonusList = humanoidClass.getRawBonusList(pc);
@@ -827,6 +841,7 @@ public class PCClassTest extends AbstractCharacterTestCase
 	 */
 	public void testLevelsPerFeatNonMonster()
 	{
+		finishLoad();
 		PlayerCharacter pc = getCharacter();
 		pc.setRace(nymphRace);
 		humanoidClass.put(IntegerKey.LEVELS_PER_FEAT, 4);
@@ -970,5 +985,11 @@ public class PCClassTest extends AbstractCharacterTestCase
 		nqClass.put(VariableKey.getConstant("Foo"), FormulaFactory.ONE);
 		nqClass.getOriginalClassLevel(2).put(VariableKey.getConstant("Foo"),
 				FormulaFactory.getFormulaFor(2));
+	}
+	
+	@Override
+	protected void defaultSetupEnd()
+	{
+		//Nothing, we will trigger ourselves
 	}
 }

--- a/code/src/test/pcgen/core/PlayerCharacterSpellTest.java
+++ b/code/src/test/pcgen/core/PlayerCharacterSpellTest.java
@@ -55,12 +55,6 @@ public class PlayerCharacterSpellTest extends AbstractCharacterTestCase
 	protected void setUp() throws Exception
 	{
 		super.setUp();
-		Globals.getContext().loadCampaignFacets();
-	}
-
-	@Override
-	protected void additionalSetUp() throws Exception
-	{
 		LoadContext context = Globals.getContext();
 		CampaignSourceEntry source = TestHelper.createSource(getClass());
 
@@ -92,7 +86,8 @@ public class PlayerCharacterSpellTest extends AbstractCharacterTestCase
 				context.getListContext().addToMasterList("CLASSES", classSpell,
 					ref, classSpell);
 		edge.setAssociation(AssociationKey.SPELL_LEVEL, 1);
-		context.commit();
+
+		finishLoad();
 	}
 
 	/**
@@ -127,5 +122,11 @@ public class PlayerCharacterSpellTest extends AbstractCharacterTestCase
 		assertEquals("Incorrect number of spell lists in class list", 1, spellLists.size());
 		int level = SpellLevel.getFirstLevelForKey(classSpell, spellLists, pc);
 		assertEquals("Incorrect spell level in class list", 1, level);
+	}
+
+	@Override
+	protected void defaultSetupEnd()
+	{
+		//Nothing, we will trigger ourselves
 	}
 }

--- a/code/src/test/pcgen/core/analysis/SpellLevelTest.java
+++ b/code/src/test/pcgen/core/analysis/SpellLevelTest.java
@@ -85,11 +85,7 @@ public class SpellLevelTest extends AbstractCharacterTestCase
 			.getManufacturerId(BuildUtilities.getFeatCat()).getActiveObject("Spell bonanza");
 
 		// Do the post parsing cleanup
-		context.resolveDeferredTokens();
-		context.getReferenceContext().buildDeferredObjects();
-		context.getReferenceContext().buildDerivedObjects();
-		context.getReferenceContext().validate(null);
-		assertTrue(context.getReferenceContext().resolveReferences(null));
+		finishLoad();
 
 		PlayerCharacter aPC = getCharacter();
 
@@ -108,4 +104,9 @@ public class SpellLevelTest extends AbstractCharacterTestCase
 		
 	}
 
+	@Override
+	protected void defaultSetupEnd()
+	{
+		//Nothing, we will trigger ourselves
+	}
 }

--- a/code/src/test/pcgen/core/bonus/BonusTest.java
+++ b/code/src/test/pcgen/core/bonus/BonusTest.java
@@ -91,7 +91,9 @@ public class BonusTest extends AbstractCharacterTestCase
 		BonusActivation.activateBonuses(rideSkill, pc);
 		double iBonus = saddleBonus.resolve(pc, "").doubleValue();
 		assertEquals("Bonus value", -5.0, iBonus, 0.05);
-		assertTrue("No saddle, should have a penalty", pc.isApplied(saddleBonus));
+		BonusObj appliedBonus = rideSkill.getListFor(ListKey.BONUS).get(0);
+		assertTrue("No saddle, should have a penalty", pc.isApplied(appliedBonus));
+		assertEquals(appliedBonus.toString(), saddleBonus.toString());
 
 		pc.addEquipment(saddle);
 		final EquipSet eqSet = new EquipSet("Test", "Test", "", saddle);

--- a/code/src/test/pcgen/core/bonus/BonusTest.java
+++ b/code/src/test/pcgen/core/bonus/BonusTest.java
@@ -72,6 +72,7 @@ public class BonusTest extends AbstractCharacterTestCase
 		rideSkill.setName("Ride");
 		rideSkill.put(StringKey.KEY_NAME, "Ride");
 		rideSkill.addToListFor(ListKey.TYPE, Type.getConstant("DEX"));
+		context.getReferenceContext().importObject(rideSkill);
 		final Ability skillFocus = new Ability();
 		skillFocus.setName("Skill Focus");
 		skillFocus.put(StringKey.KEY_NAME, "Skill Focus");
@@ -83,6 +84,8 @@ public class BonusTest extends AbstractCharacterTestCase
 		final Equipment saddle = new Equipment();
 		saddle.setName("Saddle, Test");
 		saddle.addToListFor(ListKey.TYPE, Type.getConstant("SADDLE"));
+
+		finishLoad();
 
 		final PlayerCharacter pc = getCharacter();
 		BonusActivation.activateBonuses(rideSkill, pc);
@@ -110,7 +113,6 @@ public class BonusTest extends AbstractCharacterTestCase
 		Ability dummyFeat = new Ability();
 		dummyFeat.setName("DummyFeat");
 		dummyFeat.setCDOMCategory(BuildUtilities.getFeatCat());
-		final PlayerCharacter pc = getCharacter();
 
 		// Create a variable
 		dummyFeat.put(VariableKey.getConstant("NegLevels"), FormulaFactory.ZERO);
@@ -135,6 +137,9 @@ public class BonusTest extends AbstractCharacterTestCase
 			equip.addToListFor(ListKey.BONUS, aBonus);
 		}
 
+		finishLoad();
+
+		final PlayerCharacter pc = getCharacter();
 		assertEquals("Variable value", 0.0, pc
 			.getVariableValue("NegLevels", "").doubleValue(), 0.05);
 		addAbility(BuildUtilities.getFeatCat(), dummyFeat);
@@ -207,6 +212,7 @@ public class BonusTest extends AbstractCharacterTestCase
 	 */
 	public void testBonuswithLISTValue()
 	{
+		finishLoad();
 		final PlayerCharacter character = getCharacter();
 		LoadContext context = Globals.getContext();
 
@@ -235,6 +241,7 @@ public class BonusTest extends AbstractCharacterTestCase
 
 	public void testBonuswithLISTValueTwoAssoc()
 	{
+		finishLoad();
 		final PlayerCharacter character = getCharacter();
 		LoadContext context = Globals.getContext();
 
@@ -272,6 +279,7 @@ public class BonusTest extends AbstractCharacterTestCase
 
 	public void testBonuswithLISTValueTwoAssocInfoList()
 	{
+		finishLoad();
 		final PlayerCharacter character = getCharacter();
 		LoadContext context = Globals.getContext();
 
@@ -315,9 +323,10 @@ public class BonusTest extends AbstractCharacterTestCase
 	 */
 	public void testSpellKnownBonusWithLISTValue()
 	{
-		final PlayerCharacter character = getCharacter();
 		LoadContext context = Globals.getContext();
 		context.getReferenceContext().constructNowIfNecessary(PCClass.class, "Wizard");
+		finishLoad();
+		final PlayerCharacter character = getCharacter();
 
 		BonusObj bonus = Bonus.newBonus(context, "SPELLKNOWN|%LIST|1");
 		List<BonusObj> bonusList = new ArrayList<>();
@@ -337,5 +346,11 @@ public class BonusTest extends AbstractCharacterTestCase
 		assertEquals(1, bonusPairs.size());
 		BonusPair bp = bonusPairs.get(0);
 		assertEquals("SPELLKNOWN.CLASS.Wizard;LEVEL.1", bp.fullyQualifiedBonusType);
+	}
+
+	@Override
+	protected void defaultSetupEnd()
+	{
+		//Nothing, we will trigger ourselves
 	}
 }

--- a/code/src/test/pcgen/core/prereq/PreFactSetTest.java
+++ b/code/src/test/pcgen/core/prereq/PreFactSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright James Dempsey, 2015
+* Copyright James Dempsey, 2015
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -34,11 +34,12 @@ public class PreFactSetTest extends AbstractCharacterTestCase
 {
 
 	@Override
-	protected void additionalSetUp() throws Exception
+	public void setUp() throws Exception
 	{
+		super.setUp();
 		LoadContext context = Globals.getContext();
 		BuildUtilities.createFactSet(context, "PANTHEON", Deity.class);
-		super.additionalSetUp();
+		finishLoad();
 	}
 
 	/**
@@ -73,5 +74,11 @@ public class PreFactSetTest extends AbstractCharacterTestCase
 
 		assertTrue("Character's deity should match pantheon", PrereqHandler.passes(prereq,
 			character, null));
+	}
+
+	@Override
+	protected void defaultSetupEnd()
+	{
+		//Nothing, we will trigger ourselves
 	}
 }

--- a/code/src/test/pcgen/core/prereq/PreFactTest.java
+++ b/code/src/test/pcgen/core/prereq/PreFactTest.java
@@ -34,12 +34,12 @@ public class PreFactTest extends AbstractCharacterTestCase
 {
 
 	@Override
-	protected void additionalSetUp() throws Exception
+	public void setUp() throws Exception
 	{
+		super.setUp();
 		LoadContext context = Globals.getContext();
 		BuildUtilities.createFact(context, "Abb", Race.class);
-		
-		super.additionalSetUp();
+		finishLoad();
 	}
 
 	/**
@@ -68,5 +68,11 @@ public class PreFactTest extends AbstractCharacterTestCase
 
 		assertTrue("Character should be a matching race", PrereqHandler.passes(prereq,
 			character, null));
+	}
+
+	@Override
+	protected void defaultSetupEnd()
+	{
+		//Nothing, we will trigger ourselves
 	}
 }

--- a/code/src/test/pcgen/core/prereq/PreSpellDescriptorTest.java
+++ b/code/src/test/pcgen/core/prereq/PreSpellDescriptorTest.java
@@ -36,12 +36,6 @@ public class PreSpellDescriptorTest extends AbstractCharacterTestCase
 	protected void setUp() throws Exception
 	{
 		super.setUp();
-		Globals.getContext().loadCampaignFacets();
-	}
-
-	@Override
-	protected void additionalSetUp() throws Exception
-	{
 		LoadContext context = Globals.getContext();
 		wiz = context.getReferenceContext().constructCDOMObject(PCClass.class, "Wizard");
 		BuildUtilities.setFact(wiz, "SpellType", "Arcane");
@@ -83,6 +77,8 @@ public class PreSpellDescriptorTest extends AbstractCharacterTestCase
 		context.getReferenceContext().importObject(cure);
 		context.unconditionallyProcess(cure, "CLASSES", "Cleric=1");
 		context.unconditionallyProcess(cure, "DESCRIPTOR", "Useful");
+		
+		finishLoad();
 	}
 
 	public void testSimpleDescriptor() throws Exception
@@ -169,4 +165,9 @@ public class PreSpellDescriptorTest extends AbstractCharacterTestCase
 		assertFalse(passes);
 	}
 
+	@Override
+	protected void defaultSetupEnd()
+	{
+		//Nothing, we will trigger ourselves
+	}
 }

--- a/code/src/test/pcgen/core/prereq/PreSpellSchoolTest.java
+++ b/code/src/test/pcgen/core/prereq/PreSpellSchoolTest.java
@@ -36,12 +36,6 @@ public class PreSpellSchoolTest extends AbstractCharacterTestCase
 	protected void setUp() throws Exception
 	{
 		super.setUp();
-		Globals.getContext().loadCampaignFacets();
-	}
-
-	@Override
-	protected void additionalSetUp() throws Exception
-	{
 		LoadContext context = Globals.getContext();
 		wiz = context.getReferenceContext().constructCDOMObject(PCClass.class, "Wizard");
 		BuildUtilities.setFact(wiz, "SpellType", "Arcane");
@@ -83,6 +77,8 @@ public class PreSpellSchoolTest extends AbstractCharacterTestCase
 		context.getReferenceContext().importObject(cure);
 		context.unconditionallyProcess(cure, "CLASSES", "Cleric=1");
 		context.unconditionallyProcess(cure, "SCHOOL", "Useful");
+		
+		finishLoad();
 	}
 
 	public void testSimpleSchool() throws Exception
@@ -168,5 +164,11 @@ public class PreSpellSchoolTest extends AbstractCharacterTestCase
 		character.incrementClassLevel(1, cle);
 		passes = PrereqHandler.passes(prereq, character, null);
 		assertFalse(passes);
+	}
+
+	@Override
+	protected void defaultSetupEnd()
+	{
+		//Nothing, we will trigger ourselves
 	}
 }

--- a/code/src/test/pcgen/core/prereq/PreSpellSubSchoolTest.java
+++ b/code/src/test/pcgen/core/prereq/PreSpellSubSchoolTest.java
@@ -36,12 +36,6 @@ public class PreSpellSubSchoolTest extends AbstractCharacterTestCase
 	protected void setUp() throws Exception
 	{
 		super.setUp();
-		Globals.getContext().loadCampaignFacets();
-	}
-
-	@Override
-	protected void additionalSetUp() throws Exception
-	{
 		LoadContext context = Globals.getContext();
 		wiz = context.getReferenceContext().constructCDOMObject(PCClass.class, "Wizard");
 		BuildUtilities.setFact(wiz, "SpellType", "Arcane");
@@ -83,6 +77,8 @@ public class PreSpellSubSchoolTest extends AbstractCharacterTestCase
 		context.getReferenceContext().importObject(cure);
 		context.unconditionallyProcess(cure, "CLASSES", "Cleric=1");
 		context.unconditionallyProcess(cure, "SUBSCHOOL", "Useful");
+		
+		finishLoad();
 	}
 
 	public void testSimpleSUBSCHOOL() throws Exception
@@ -168,5 +164,11 @@ public class PreSpellSubSchoolTest extends AbstractCharacterTestCase
 		character.incrementClassLevel(1, cle);
 		passes = PrereqHandler.passes(prereq, character, null);
 		assertFalse(passes);
+	}
+
+	@Override
+	protected void defaultSetupEnd()
+	{
+		//Nothing, we will trigger ourselves
 	}
 }

--- a/code/src/test/pcgen/core/prereq/PreSpellTypeTest.java
+++ b/code/src/test/pcgen/core/prereq/PreSpellTypeTest.java
@@ -33,8 +33,9 @@ public class PreSpellTypeTest extends AbstractCharacterTestCase
 	private PCClass cle;
 
 	@Override
-	protected void additionalSetUp() throws Exception
+	public void setUp() throws Exception
 	{
+		super.setUp();
 		LoadContext context = Globals.getContext();
 		wiz = context.getReferenceContext().constructCDOMObject(PCClass.class, "Wizard");
 		BuildUtilities.setFact(wiz, "SpellType", "Arcane");
@@ -76,6 +77,8 @@ public class PreSpellTypeTest extends AbstractCharacterTestCase
 		context.getReferenceContext().importObject(cure);
 		context.unconditionallyProcess(cure, "CLASSES", "Cleric=1");
 		context.unconditionallyProcess(cure, "TYPE", "Divine");
+
+		finishLoad();
 	}
 
 	public void testSimpleType() throws Exception
@@ -188,5 +191,11 @@ public class PreSpellTypeTest extends AbstractCharacterTestCase
 		character.incrementClassLevel(1, cle);
 		passes = PrereqHandler.passes(prereq, character, null);
 		assertFalse(passes);
+	}
+
+	@Override
+	protected void defaultSetupEnd()
+	{
+		//Nothing, we will trigger ourselves
 	}
 }

--- a/code/src/test/pcgen/gui2/facade/CompanionSupportFacadeImplTest.java
+++ b/code/src/test/pcgen/gui2/facade/CompanionSupportFacadeImplTest.java
@@ -56,6 +56,8 @@ public class CompanionSupportFacadeImplTest extends AbstractCharacterTestCase
 	{
 		super.setUp();
 		
+		companionList = Globals.getContext().getReferenceContext().constructNowIfNecessary(CompanionList.class,
+				"Familiar");
 		uiDelegate = new MockUIDelegate();
 		todoManager = new TodoManager();
 		ListFacade<CampaignFacade> campaigns = new DefaultListFacade<>();
@@ -69,6 +71,7 @@ public class CompanionSupportFacadeImplTest extends AbstractCharacterTestCase
 			companionList.getKeyName());
 		FollowerOption option = new FollowerOption(race, ref);
 		masterRace.addToListFor(ListKey.COMPANIONLIST, option);
+		finishLoad();
 	}
 
 	/**
@@ -106,10 +109,8 @@ public class CompanionSupportFacadeImplTest extends AbstractCharacterTestCase
 	}
 
 	@Override
-	protected void additionalSetUp() throws Exception
+	protected void defaultSetupEnd()
 	{
-		companionList = Globals.getContext().getReferenceContext().constructNowIfNecessary(CompanionList.class,
-			"Familiar");
+		//Nothing, we will trigger ourselves
 	}
-
 }

--- a/code/src/test/pcgen/io/PCGVer2ParserCharacterTest.java
+++ b/code/src/test/pcgen/io/PCGVer2ParserCharacterTest.java
@@ -38,15 +38,16 @@ public class PCGVer2ParserCharacterTest extends AbstractCharacterTestCase
 {
 
 	@Override
-	protected void additionalSetUp() throws Exception
+	protected void setUp() throws Exception
 	{
-		super.additionalSetUp();
+		super.setUp();
 		LoadContext context = Globals.getContext();
 		Race rakshasha =
 				context.getReferenceContext().constructCDOMObject(Race.class, "Rakshasa");
 		context
 			.unconditionallyProcess(rakshasha, "ADD", "SPELLCASTER|Sorcerer");
 		context.getReferenceContext().constructCDOMObject(PCClass.class, "Sorcerer");
+		finishLoad();
 	}
 
 	/**
@@ -72,5 +73,11 @@ public class PCGVer2ParserCharacterTest extends AbstractCharacterTestCase
 		PersistentTransitionChoice<?> tc = rakshasha.getListFor(ListKey.ADD).get(0);
 		List<Object> assocList = pc.getAssocList(tc, AssociationListKey.ADD);
 		assertEquals("Number of associations for ADD " + assocList, 1, assocList.size());
+	}
+
+	@Override
+	protected void defaultSetupEnd()
+	{
+		//Nothing, we will trigger ourselves
 	}
 }

--- a/code/src/test/pcgen/io/exporttoken/SpellMemTokenTest.java
+++ b/code/src/test/pcgen/io/exporttoken/SpellMemTokenTest.java
@@ -73,12 +73,6 @@ public class SpellMemTokenTest extends AbstractCharacterTestCase
 	protected void setUp() throws Exception
 	{
 		super.setUp();
-		Globals.getContext().loadCampaignFacets();
-	}
-
-    @Override
-	protected void additionalSetUp() throws Exception
-	{
 		LoadContext context = Globals.getContext();
 
 		// Human
@@ -116,6 +110,7 @@ public class SpellMemTokenTest extends AbstractCharacterTestCase
 		context.getReferenceContext().constructCDOMObject(Domain.class, "Fire");
 		
 		context.getReferenceContext().importObject(divineClass);
+		finishLoad();
 	}
 
     @Override
@@ -211,5 +206,11 @@ public class SpellMemTokenTest extends AbstractCharacterTestCase
 		assertEquals("Retrieve spell from prepared list of divine caster.",
 			"Test Spell", token.getToken("SPELLMEM.0.2.1.0.NAME", character,
 				null));
+	}
+
+	@Override
+	protected void defaultSetupEnd()
+	{
+		//Nothing, we will trigger ourselves
 	}
 }


### PR DESCRIPTION
This is another portion of fixing the problems we have in master and eventually lifting the code freeze.

This changes how certain tests behave.  Due to some enhancements deployed over the last few days, a number of features have interacted, causing a few badly behaved unit tests to be exposed in their less than stellar behavior.  Some of these unit tests required additional setup for a test before they "finish the load" and resolve references.  In order to accommodate that, a fairly significant change to AbstractCharacterTestCase was required.  This will fix a number of unit tests that are currently failing (3 ish?)