### PR TITLE
[FOR FREEZE] Move around to have finishLoad() in CharacterTestCase

### DIFF
--- a/code/src/test/pcgen/AbstractCharacterTestCase.java
+++ b/code/src/test/pcgen/AbstractCharacterTestCase.java
@@ -42,11 +42,11 @@ import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.TokenLibrary;
 import pcgen.rules.persistence.token.ModifierFactory;
 import pcgen.util.TestHelper;
+
 import plugin.lsttokens.testsupport.BuildUtilities;
 
-import org.junit.Assert;
-
 import junit.framework.TestCase;
+import org.junit.Assert;
 /**
  * This is an abstract TestClass designed to be able to create a PlayerCharacter
  * Object.
@@ -78,6 +78,7 @@ public abstract class AbstractCharacterTestCase extends TestCase
 	protected SizeAdjustment tiny;
 	protected SizeAdjustment diminutive;
 	protected SizeAdjustment fine;
+	private LoadContext context;
 
 	/**
 	 * Sets up the absolute minimum amount of data to create a PlayerCharacter
@@ -107,7 +108,7 @@ public abstract class AbstractCharacterTestCase extends TestCase
 		Globals.setUseGUI(false);
 		Globals.emptyLists();
 
-		LoadContext context = Globals.getContext();
+		context = Globals.getContext();
 		BuildUtilities.buildUnselectedRace(context);
 		
 		SourceFileLoader.defineBuiltinVariables(context);
@@ -204,12 +205,26 @@ public abstract class AbstractCharacterTestCase extends TestCase
 		GameModeFileLoader.addDefaultUnitSet(SettingsHandler.getGame());
 		SettingsHandler.getGame().selectDefaultUnitSet();
 		ref.importObject(BuildUtilities.getFeatCat());
-		additionalSetUp();
-		context.getReferenceContext().buildDerivedObjects();
-		context.resolveDeferredTokens();
-		Assert.assertTrue(ref.resolveReferences(null));
-		context.loadCampaignFacets();
+		defaultSetupEnd();
+	}
 
+	protected void defaultSetupEnd()
+	{
+		finishLoad();
+	}
+
+	protected void finishLoad()
+	{
+		context.commit();
+		AbstractReferenceContext ref = context.getReferenceContext();
+		SourceFileLoader.processFactDefinitions(context);
+		context.resolveDeferredTokens();
+		ref.buildDeferredObjects();
+		ref.buildDerivedObjects();
+		Assert.assertTrue(ref.validate(null));
+		Assert.assertTrue(ref.resolveReferences(null));
+		context.resolvePostDeferredTokens();
+		context.loadCampaignFacets();
 		character = new PlayerCharacter();
 	}
 
@@ -220,11 +235,6 @@ public abstract class AbstractCharacterTestCase extends TestCase
 		FormulaModifier<T> defaultModifier = m.getFixedModifier(fmtManager, "NONE");
 		context.getVariableContext().addDefault(cl,
 			new ModifierDecoration<>(defaultModifier));
-	}
-
-	protected void additionalSetUp() throws Exception
-	{
-		//override to provide info
 	}
 
 	/**
@@ -249,6 +259,8 @@ public abstract class AbstractCharacterTestCase extends TestCase
 	protected void tearDown() throws Exception
 	{
 		character = null;
+		context = null;
+		SystemCollections.clearGameModeList();
 		super.tearDown();
 	}
 

--- a/code/src/test/pcgen/core/BioSetTest.java
+++ b/code/src/test/pcgen/core/BioSetTest.java
@@ -63,10 +63,12 @@ public class BioSetTest extends AbstractCharacterTestCase
 	}
 
     @Override
-	protected void additionalSetUp() throws Exception
+	public void setUp() throws Exception
 	{
+		super.setUp();
 		BioSetLoaderTest.loadBioSet(Globals.getContext(), BIO_SET_DATA,
 			new BioSetLoader());
+		finishLoad();
 	}
 
 	@Override
@@ -153,5 +155,11 @@ public class BioSetTest extends AbstractCharacterTestCase
 		Optional<Region> region = pc.getDisplay().getRegion();
 		SettingsHandler.getGame().getBioSet().getAgeSet(region, idx);
 
+	}
+
+	@Override
+	protected void defaultSetupEnd()
+	{
+		//Nothing, we will trigger ourselves
 	}
 }

--- a/code/src/test/pcgen/core/ChallengeRatingPathfinderTest.java
+++ b/code/src/test/pcgen/core/ChallengeRatingPathfinderTest.java
@@ -21,15 +21,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 
 import pcgen.AbstractCharacterTestCase;
-import pcgen.cdom.content.fact.FactDefinition;
-import pcgen.persistence.SourceFileLoader;
 import pcgen.persistence.lst.CampaignSourceEntry;
 import pcgen.persistence.lst.GenericLoader;
 import pcgen.persistence.lst.PCClassLoader;
 import pcgen.persistence.lst.SimpleLoader;
 import pcgen.rules.context.LoadContext;
 import pcgen.util.TestHelper;
-import plugin.lsttokens.testsupport.BuildUtilities;
 
 import util.TestURI;
 
@@ -59,12 +56,12 @@ public class ChallengeRatingPathfinderTest extends AbstractCharacterTestCase
 	private PCClass pcClass2;
 	private PCClass npcClass;
 	private PCClass npcClass2;
-	private PCClass monsterClass;
 	private PCClass companionClass;
 
 	@Override
-	protected void additionalSetUp() throws Exception
+	public void setUp() throws Exception
 	{
+		super.setUp();
 		GameMode gameMode = SettingsHandler.getGame();
 		gameMode.addCRstep(0, "1/2");
 		gameMode.addCRstep(-1, "1/3");
@@ -87,9 +84,6 @@ public class ChallengeRatingPathfinderTest extends AbstractCharacterTestCase
 			TestURI.getURI());
 		
 		LoadContext context = Globals.getContext();
-
-		BuildUtilities.createFact(context, "ClassType", PCClass.class);
-		SourceFileLoader.processFactDefinitions(context);
 
 		CampaignSourceEntry source = TestHelper.createSource(getClass());
 		GenericLoader<Race> raceLoader = new GenericLoader<>(Race.class);
@@ -115,7 +109,7 @@ public class ChallengeRatingPathfinderTest extends AbstractCharacterTestCase
 		raceLoader.parseLine(context, null, dryadLine, source);
 		dryadRace = context.getReferenceContext().silentlyGetConstructedCDOMObject(Race.class, "Dryad");
 
-		final String companionLine = "TestCompanion MONSTERCLASS:TestCompanionClass:4";
+		final String companionLine = "TestCompanion	MONSTERCLASS:TestCompanionClass:4";
 		raceLoader.parseLine(context, null, companionLine, source);
 		companionRace = context.getReferenceContext().silentlyGetConstructedCDOMObject(Race.class, "TestCompanion");
 
@@ -141,37 +135,23 @@ public class ChallengeRatingPathfinderTest extends AbstractCharacterTestCase
 		
 		final String pcClassLine = "CLASS:TestPCClass	TYPE:PC		ROLE:Combat";
 		pcClass = classLoader.parseLine(context, null, pcClassLine, source);
-		context.getReferenceContext().importObject(pcClass);
 		
 		final String pcClassLine2 = "CLASS:TestPCClass2	TYPE:PC		ROLE:Druid";
 		pcClass2 = classLoader.parseLine(context, null, pcClassLine2, source);
-		context.getReferenceContext().importObject(pcClass2);
 		
-		final String npcClassLine = "CLASS:TestNPCClass2	TYPE:NPC";
+		final String npcClassLine = "CLASS:TestNPCClass	TYPE:NPC";
 		npcClass = classLoader.parseLine(context, null, npcClassLine, source);
-		context.getReferenceContext().importObject(npcClass);
 
 		final String npcClassLine2 = "CLASS:TestNPCClass2	TYPE:NPC";
 		npcClass2 = classLoader.parseLine(context, null, npcClassLine2, source);
-		context.getReferenceContext().importObject(npcClass2);
 
 		final String monsterClassLine = "CLASS:TestMonsterClass	HD:8	CLASSTYPE:Monster";
-		monsterClass = classLoader.parseLine(context, null, monsterClassLine, source);
-		context.getReferenceContext().importObject(monsterClass);
+		classLoader.parseLine(context, null, monsterClassLine, source);
 
 		final String companionClassLine = "CLASS:TestCompanionClass	HD:8	CLASSTYPE:Companion";
 		companionClass = classLoader.parseLine(context, null, companionClassLine, source);
-		context.getReferenceContext().importObject(companionClass);
 
-		context.commit();
-		BuildUtilities.createFact(context, "ClassType", PCClass.class);
-		FactDefinition<?, String> fd =
-				BuildUtilities.createFact(context, "SpellType", PCClass.class);
-		fd.setSelectable(true);
-
-		SourceFileLoader.processFactDefinitions(context);
-		context.getReferenceContext().buildDerivedObjects();
-		context.resolveDeferredTokens();
+		finishLoad();
 	}
 
 	/**
@@ -479,5 +459,11 @@ public class ChallengeRatingPathfinderTest extends AbstractCharacterTestCase
 		PlayerCharacter pc = getCharacter();
 		pc.setRace(centipedeRace);
 		assertEquals(SettingsHandler.getGame().getCRInteger("1/8"), pc.getDisplay().calcCR(), 0.0);
+	}
+
+	@Override
+	protected void defaultSetupEnd()
+	{
+		//Nothing, we will trigger ourselves
 	}
 }

--- a/code/src/test/pcgen/core/EquipmentTest.java
+++ b/code/src/test/pcgen/core/EquipmentTest.java
@@ -55,8 +55,9 @@ public class EquipmentTest extends AbstractCharacterTestCase
 	private CampaignSourceEntry source;
 
 	@Override
-	public void additionalSetUp() throws PersistenceLayerException
+	public void setUp() throws Exception
 	{
+		super.setUp();
 		try
 		{
 			source = new CampaignSourceEntry(new Campaign(),
@@ -102,7 +103,8 @@ public class EquipmentTest extends AbstractCharacterTestCase
 
 		SettingsHandler.getGame().addPlusCalculation(
 			"WEAPON|(2000*PLUS*PLUS)+(2000*ALTPLUS*ALTPLUS)");
-
+		
+		finishLoad();
 	}
 
 	/*****************************************************************************
@@ -609,5 +611,11 @@ assertNotNull("Eqmod should be present", eqMod);
 		Equipment aEquip = eq.clone();
 		aEquip.addEqModifier(eqMod, true, null);
 		assertSame("Eqmod parent should be the equipment", aEquip, eqMod.getVariableParent().get());
+	}
+
+	@Override
+	protected void defaultSetupEnd()
+	{
+		//Nothing, we will trigger ourselves
 	}
 }

--- a/code/src/test/pcgen/core/PCClassTest.java
+++ b/code/src/test/pcgen/core/PCClassTest.java
@@ -84,6 +84,7 @@ public class PCClassTest extends AbstractCharacterTestCase
 	 */
 	public void testFireNameChangedVariable()
 	{
+		finishLoad();
 		final PCClass myClass = new PCClass();
 		myClass.setName("myClass");
 		myClass.put(StringKey.KEY_NAME, "KEY_myClass");
@@ -123,6 +124,7 @@ public class PCClassTest extends AbstractCharacterTestCase
 	 */
 	public void testMonsterSkillPoints()
 	{
+		finishLoad();
 		// Create a medium bugbear first level
 		PlayerCharacter bugbear = new PlayerCharacter();
 		bugbear.setRace(bugbearRace);
@@ -199,12 +201,6 @@ public class PCClassTest extends AbstractCharacterTestCase
 		final GameMode gameMode = SettingsHandler.getGame();
 		RuleCheck aClassPreRule = gameMode.getModeContext().getReferenceContext()
 				.silentlyGetConstructedCDOMObject(RuleCheck.class, "CLASSPRE");
-		if (aClassPreRule == null)
-		{
-			aClassPreRule = new RuleCheck();
-			aClassPreRule.setName("CLASSPRE");
-			gameMode.getModeContext().getReferenceContext().importObject(aClassPreRule);
-		}
 		aClassPreRule.setDefault(false);
 
 		final PCClass aPrClass = new PCClass();
@@ -229,6 +225,8 @@ public class PCClassTest extends AbstractCharacterTestCase
 		aNqClass.put(VariableKey.getConstant("Foo"), FormulaFactory.ONE);
 		aNqClass.getOriginalClassLevel(2).put(VariableKey.getConstant("Foo"),
 				FormulaFactory.getFormulaFor(2));
+
+		finishLoad();
 
 		// Setup character without prereqs
 		final PlayerCharacter character = getCharacter();
@@ -284,12 +282,6 @@ public class PCClassTest extends AbstractCharacterTestCase
 		final GameMode gameMode = SettingsHandler.getGame();
 		RuleCheck aClassPreRule = gameMode.getModeContext().getReferenceContext()
 				.silentlyGetConstructedCDOMObject(RuleCheck.class, "CLASSPRE");
-		if (aClassPreRule == null)
-		{
-			aClassPreRule = new RuleCheck();
-			aClassPreRule.setName("CLASSPRE");
-			gameMode.getModeContext().getReferenceContext().importObject(aClassPreRule);
-		}
 		aClassPreRule.setDefault(false);
 
 		final PCClass aPrClass = new PCClass();
@@ -314,6 +306,8 @@ public class PCClassTest extends AbstractCharacterTestCase
 		aNqClass.put(VariableKey.getConstant("Foo"), FormulaFactory.ONE);
 		aNqClass.getOriginalClassLevel(2).put(VariableKey.getConstant("Foo"),
 				FormulaFactory.getFormulaFor(2));
+
+		finishLoad();
 
 		// Setup character without prereqs
 		final PlayerCharacter character = getCharacter();
@@ -358,6 +352,7 @@ public class PCClassTest extends AbstractCharacterTestCase
 	 */
 	public void testQualifies()
 	{
+		finishLoad();
 		// Setup character without prereqs
 		final PlayerCharacter character = getCharacter();
 
@@ -471,6 +466,8 @@ public class PCClassTest extends AbstractCharacterTestCase
 		context.unconditionallyProcess(megaCasterClass.getOriginalClassLevel(2), "CAST", "3,1,2,3,4,5,6,7,8,9,10");
 		Globals.getContext().getReferenceContext().importObject(megaCasterClass);
 
+		finishLoad();
+
 		final PlayerCharacter character = getCharacter();
 		assertEquals("Highest spell level for class", 10,
 			character.getSpellSupport(megaCasterClass).getHighestLevelSpell());
@@ -539,8 +536,8 @@ public class PCClassTest extends AbstractCharacterTestCase
 		context.unconditionallyProcess(megaCasterClass.getOriginalClassLevel(2), "KNOWN", "4,2,2,3,4,5,6,7,8,9,10");
 		context.unconditionallyProcess(megaCasterClass.getOriginalClassLevel(2), "CAST", "3,1,2,3,4,5,6,7,8,9,10");
 		Globals.getContext().getReferenceContext().importObject(megaCasterClass);
-		context.getReferenceContext().buildDerivedObjects();
-		context.loadCampaignFacets();
+
+		finishLoad();
 
 		final PlayerCharacter character = getCharacter();
 
@@ -625,8 +622,8 @@ public class PCClassTest extends AbstractCharacterTestCase
 		context.unconditionallyProcess(megaCasterClass.getOriginalClassLevel(2), "KNOWN", "4,2,2,3,4,5,6,7,8,9,10");
 		context.unconditionallyProcess(megaCasterClass.getOriginalClassLevel(2), "CAST", "3,1,2,3,4,5,6,7,8,9,10");
 		Globals.getContext().getReferenceContext().importObject(megaCasterClass);
-		context.getReferenceContext().buildDerivedObjects();
-		context.loadCampaignFacets();
+
+		finishLoad();
 
 		final PlayerCharacter character = getCharacter();
 
@@ -725,14 +722,12 @@ public class PCClassTest extends AbstractCharacterTestCase
 				+ "CLASS:Cleric	STARTSKILLPTS:2\n"
 				+ "2	ABILITY:TestCat|AUTOMATIC|Ability2";
 		PCClass pcclass = parsePCClassText(classPCCText, source);
-		ab1.setCDOMCategory(cat);
-		ab2.setCDOMCategory(cat);
-		context.getReferenceContext().importObject(ab1);
-		context.getReferenceContext().importObject(ab2);
 		CDOMSingleRef<AbilityCategory> acRef =
 				context.getReferenceContext().getCDOMReference(
 					AbilityCategory.class, "TestCat");
-		assertTrue(context.getReferenceContext().resolveReferences(null));
+
+		finishLoad();
+
 		CDOMReference<AbilityList> autoList = AbilityList.getAbilityListReference(acRef, Nature.AUTOMATIC);
 		Collection<CDOMReference<Ability>> mods = pcclass.getListMods(autoList);
 		assertEquals(1, mods.size());
@@ -774,6 +769,7 @@ public class PCClassTest extends AbstractCharacterTestCase
 	 */
 	public void testDefaultLevelsPerFeatMonster()
 	{
+		finishLoad();
 		PlayerCharacter pc = getCharacter();
 		pc.setRace(nymphRace);
 		List<BonusObj> bonusList = nymphClass.getRawBonusList(pc);
@@ -791,6 +787,7 @@ public class PCClassTest extends AbstractCharacterTestCase
 	 */
 	public void testLevelsPerFeatMonster()
 	{
+		finishLoad();
 		PlayerCharacter pc = getCharacter();
 		nymphClass.put(IntegerKey.LEVELS_PER_FEAT, 4);
 		List<BonusObj> bonusList = nymphClass.getRawBonusList(pc);
@@ -810,6 +807,7 @@ public class PCClassTest extends AbstractCharacterTestCase
 	 */
 	public void testDefaultLevelsPerFeatNonMonster()
 	{
+		finishLoad();
 		PlayerCharacter pc = getCharacter();
 		pc.setRace(nymphRace);
 		List<BonusObj> bonusList = humanoidClass.getRawBonusList(pc);
@@ -827,6 +825,7 @@ public class PCClassTest extends AbstractCharacterTestCase
 	 */
 	public void testLevelsPerFeatNonMonster()
 	{
+		finishLoad();
 		PlayerCharacter pc = getCharacter();
 		pc.setRace(nymphRace);
 		humanoidClass.put(IntegerKey.LEVELS_PER_FEAT, 4);
@@ -902,13 +901,11 @@ public class PCClassTest extends AbstractCharacterTestCase
 		PCClassLoader classLoader = new PCClassLoader();
 		LoadContext context = Globals.getContext();
 		humanoidClass = classLoader.parseLine(context, null, classDef, source);
-		Globals.getContext().getReferenceContext().importObject(humanoidClass);
 
 		classDef =
 				"CLASS:Nymph		KEY:KEY_Nymph	CLASSTYPE:Monster	HD:6	STARTSKILLPTS:6	MODTOSKILLS:YES	";
 		classLoader = new PCClassLoader();
 		nymphClass = classLoader.parseLine(context, null, classDef, source);
-		Globals.getContext().getReferenceContext().importObject(nymphClass);
 
 		CDOMDirectSingleRef<SizeAdjustment> mediumRef = CDOMDirectSingleRef.getRef(medium);
 		CDOMDirectSingleRef<SizeAdjustment> largeRef = CDOMDirectSingleRef.getRef(large);
@@ -970,5 +967,11 @@ public class PCClassTest extends AbstractCharacterTestCase
 		nqClass.put(VariableKey.getConstant("Foo"), FormulaFactory.ONE);
 		nqClass.getOriginalClassLevel(2).put(VariableKey.getConstant("Foo"),
 				FormulaFactory.getFormulaFor(2));
+	}
+	
+	@Override
+	protected void defaultSetupEnd()
+	{
+		//Nothing, we will trigger ourselves
 	}
 }

--- a/code/src/test/pcgen/core/PlayerCharacterSpellTest.java
+++ b/code/src/test/pcgen/core/PlayerCharacterSpellTest.java
@@ -55,12 +55,6 @@ public class PlayerCharacterSpellTest extends AbstractCharacterTestCase
 	protected void setUp() throws Exception
 	{
 		super.setUp();
-		Globals.getContext().loadCampaignFacets();
-	}
-
-	@Override
-	protected void additionalSetUp() throws Exception
-	{
 		LoadContext context = Globals.getContext();
 		CampaignSourceEntry source = TestHelper.createSource(getClass());
 
@@ -79,7 +73,6 @@ public class PlayerCharacterSpellTest extends AbstractCharacterTestCase
 			source);
 		classLoader.parseClassLevelLine(context, divineClass, 1, source,
 			"CAST:5,4	BONUS:DOMAIN|NUMBER|2	BONUS:VAR|DomainLVL|CL");
-		context.getReferenceContext().importObject(divineClass);
 		
 		final String domainLine = "Sun	SPELLLEVEL:DOMAIN|Sun=1|KEY_domainSpell";
 		GenericLoader<Domain> domainLoader = new GenericLoader<>(Domain.class);
@@ -92,7 +85,8 @@ public class PlayerCharacterSpellTest extends AbstractCharacterTestCase
 				context.getListContext().addToMasterList("CLASSES", classSpell,
 					ref, classSpell);
 		edge.setAssociation(AssociationKey.SPELL_LEVEL, 1);
-		context.commit();
+
+		finishLoad();
 	}
 
 	/**
@@ -127,5 +121,11 @@ public class PlayerCharacterSpellTest extends AbstractCharacterTestCase
 		assertEquals("Incorrect number of spell lists in class list", 1, spellLists.size());
 		int level = SpellLevel.getFirstLevelForKey(classSpell, spellLists, pc);
 		assertEquals("Incorrect spell level in class list", 1, level);
+	}
+
+	@Override
+	protected void defaultSetupEnd()
+	{
+		//Nothing, we will trigger ourselves
 	}
 }

--- a/code/src/test/pcgen/core/analysis/SpellLevelTest.java
+++ b/code/src/test/pcgen/core/analysis/SpellLevelTest.java
@@ -85,11 +85,7 @@ public class SpellLevelTest extends AbstractCharacterTestCase
 			.getManufacturerId(BuildUtilities.getFeatCat()).getActiveObject("Spell bonanza");
 
 		// Do the post parsing cleanup
-		context.resolveDeferredTokens();
-		context.getReferenceContext().buildDeferredObjects();
-		context.getReferenceContext().buildDerivedObjects();
-		context.getReferenceContext().validate(null);
-		assertTrue(context.getReferenceContext().resolveReferences(null));
+		finishLoad();
 
 		PlayerCharacter aPC = getCharacter();
 
@@ -108,4 +104,9 @@ public class SpellLevelTest extends AbstractCharacterTestCase
 		
 	}
 
+	@Override
+	protected void defaultSetupEnd()
+	{
+		//Nothing, we will trigger ourselves
+	}
 }

--- a/code/src/test/pcgen/core/bonus/BonusTest.java
+++ b/code/src/test/pcgen/core/bonus/BonusTest.java
@@ -72,6 +72,7 @@ public class BonusTest extends AbstractCharacterTestCase
 		rideSkill.setName("Ride");
 		rideSkill.put(StringKey.KEY_NAME, "Ride");
 		rideSkill.addToListFor(ListKey.TYPE, Type.getConstant("DEX"));
+		context.getReferenceContext().importObject(rideSkill);
 		final Ability skillFocus = new Ability();
 		skillFocus.setName("Skill Focus");
 		skillFocus.put(StringKey.KEY_NAME, "Skill Focus");
@@ -84,11 +85,15 @@ public class BonusTest extends AbstractCharacterTestCase
 		saddle.setName("Saddle, Test");
 		saddle.addToListFor(ListKey.TYPE, Type.getConstant("SADDLE"));
 
+		finishLoad();
+
 		final PlayerCharacter pc = getCharacter();
 		BonusActivation.activateBonuses(rideSkill, pc);
 		double iBonus = saddleBonus.resolve(pc, "").doubleValue();
 		assertEquals("Bonus value", -5.0, iBonus, 0.05);
-		assertTrue("No saddle, should have a penalty", pc.isApplied(saddleBonus));
+		BonusObj appliedBonus = rideSkill.getListFor(ListKey.BONUS).get(0);
+		assertTrue("No saddle, should have a penalty", pc.isApplied(appliedBonus));
+		assertEquals(appliedBonus.toString(), saddleBonus.toString());
 
 		pc.addEquipment(saddle);
 		final EquipSet eqSet = new EquipSet("Test", "Test", "", saddle);
@@ -110,7 +115,6 @@ public class BonusTest extends AbstractCharacterTestCase
 		Ability dummyFeat = new Ability();
 		dummyFeat.setName("DummyFeat");
 		dummyFeat.setCDOMCategory(BuildUtilities.getFeatCat());
-		final PlayerCharacter pc = getCharacter();
 
 		// Create a variable
 		dummyFeat.put(VariableKey.getConstant("NegLevels"), FormulaFactory.ZERO);
@@ -135,6 +139,9 @@ public class BonusTest extends AbstractCharacterTestCase
 			equip.addToListFor(ListKey.BONUS, aBonus);
 		}
 
+		finishLoad();
+
+		final PlayerCharacter pc = getCharacter();
 		assertEquals("Variable value", 0.0, pc
 			.getVariableValue("NegLevels", "").doubleValue(), 0.05);
 		addAbility(BuildUtilities.getFeatCat(), dummyFeat);
@@ -207,6 +214,7 @@ public class BonusTest extends AbstractCharacterTestCase
 	 */
 	public void testBonuswithLISTValue()
 	{
+		finishLoad();
 		final PlayerCharacter character = getCharacter();
 		LoadContext context = Globals.getContext();
 
@@ -235,6 +243,7 @@ public class BonusTest extends AbstractCharacterTestCase
 
 	public void testBonuswithLISTValueTwoAssoc()
 	{
+		finishLoad();
 		final PlayerCharacter character = getCharacter();
 		LoadContext context = Globals.getContext();
 
@@ -272,6 +281,7 @@ public class BonusTest extends AbstractCharacterTestCase
 
 	public void testBonuswithLISTValueTwoAssocInfoList()
 	{
+		finishLoad();
 		final PlayerCharacter character = getCharacter();
 		LoadContext context = Globals.getContext();
 
@@ -315,9 +325,10 @@ public class BonusTest extends AbstractCharacterTestCase
 	 */
 	public void testSpellKnownBonusWithLISTValue()
 	{
-		final PlayerCharacter character = getCharacter();
 		LoadContext context = Globals.getContext();
 		context.getReferenceContext().constructNowIfNecessary(PCClass.class, "Wizard");
+		finishLoad();
+		final PlayerCharacter character = getCharacter();
 
 		BonusObj bonus = Bonus.newBonus(context, "SPELLKNOWN|%LIST|1");
 		List<BonusObj> bonusList = new ArrayList<>();
@@ -337,5 +348,11 @@ public class BonusTest extends AbstractCharacterTestCase
 		assertEquals(1, bonusPairs.size());
 		BonusPair bp = bonusPairs.get(0);
 		assertEquals("SPELLKNOWN.CLASS.Wizard;LEVEL.1", bp.fullyQualifiedBonusType);
+	}
+
+	@Override
+	protected void defaultSetupEnd()
+	{
+		//Nothing, we will trigger ourselves
 	}
 }

--- a/code/src/test/pcgen/core/prereq/PreFactSetTest.java
+++ b/code/src/test/pcgen/core/prereq/PreFactSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright James Dempsey, 2015
+* Copyright James Dempsey, 2015
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -34,11 +34,12 @@ public class PreFactSetTest extends AbstractCharacterTestCase
 {
 
 	@Override
-	protected void additionalSetUp() throws Exception
+	public void setUp() throws Exception
 	{
+		super.setUp();
 		LoadContext context = Globals.getContext();
 		BuildUtilities.createFactSet(context, "PANTHEON", Deity.class);
-		super.additionalSetUp();
+		finishLoad();
 	}
 
 	/**
@@ -73,5 +74,11 @@ public class PreFactSetTest extends AbstractCharacterTestCase
 
 		assertTrue("Character's deity should match pantheon", PrereqHandler.passes(prereq,
 			character, null));
+	}
+
+	@Override
+	protected void defaultSetupEnd()
+	{
+		//Nothing, we will trigger ourselves
 	}
 }

--- a/code/src/test/pcgen/core/prereq/PreFactTest.java
+++ b/code/src/test/pcgen/core/prereq/PreFactTest.java
@@ -34,12 +34,12 @@ public class PreFactTest extends AbstractCharacterTestCase
 {
 
 	@Override
-	protected void additionalSetUp() throws Exception
+	public void setUp() throws Exception
 	{
+		super.setUp();
 		LoadContext context = Globals.getContext();
 		BuildUtilities.createFact(context, "Abb", Race.class);
-		
-		super.additionalSetUp();
+		finishLoad();
 	}
 
 	/**
@@ -68,5 +68,11 @@ public class PreFactTest extends AbstractCharacterTestCase
 
 		assertTrue("Character should be a matching race", PrereqHandler.passes(prereq,
 			character, null));
+	}
+
+	@Override
+	protected void defaultSetupEnd()
+	{
+		//Nothing, we will trigger ourselves
 	}
 }

--- a/code/src/test/pcgen/core/prereq/PreSpellDescriptorTest.java
+++ b/code/src/test/pcgen/core/prereq/PreSpellDescriptorTest.java
@@ -36,12 +36,6 @@ public class PreSpellDescriptorTest extends AbstractCharacterTestCase
 	protected void setUp() throws Exception
 	{
 		super.setUp();
-		Globals.getContext().loadCampaignFacets();
-	}
-
-	@Override
-	protected void additionalSetUp() throws Exception
-	{
 		LoadContext context = Globals.getContext();
 		wiz = context.getReferenceContext().constructCDOMObject(PCClass.class, "Wizard");
 		BuildUtilities.setFact(wiz, "SpellType", "Arcane");
@@ -83,6 +77,8 @@ public class PreSpellDescriptorTest extends AbstractCharacterTestCase
 		context.getReferenceContext().importObject(cure);
 		context.unconditionallyProcess(cure, "CLASSES", "Cleric=1");
 		context.unconditionallyProcess(cure, "DESCRIPTOR", "Useful");
+		
+		finishLoad();
 	}
 
 	public void testSimpleDescriptor() throws Exception
@@ -169,4 +165,9 @@ public class PreSpellDescriptorTest extends AbstractCharacterTestCase
 		assertFalse(passes);
 	}
 
+	@Override
+	protected void defaultSetupEnd()
+	{
+		//Nothing, we will trigger ourselves
+	}
 }

--- a/code/src/test/pcgen/core/prereq/PreSpellSchoolTest.java
+++ b/code/src/test/pcgen/core/prereq/PreSpellSchoolTest.java
@@ -36,12 +36,6 @@ public class PreSpellSchoolTest extends AbstractCharacterTestCase
 	protected void setUp() throws Exception
 	{
 		super.setUp();
-		Globals.getContext().loadCampaignFacets();
-	}
-
-	@Override
-	protected void additionalSetUp() throws Exception
-	{
 		LoadContext context = Globals.getContext();
 		wiz = context.getReferenceContext().constructCDOMObject(PCClass.class, "Wizard");
 		BuildUtilities.setFact(wiz, "SpellType", "Arcane");
@@ -83,6 +77,8 @@ public class PreSpellSchoolTest extends AbstractCharacterTestCase
 		context.getReferenceContext().importObject(cure);
 		context.unconditionallyProcess(cure, "CLASSES", "Cleric=1");
 		context.unconditionallyProcess(cure, "SCHOOL", "Useful");
+		
+		finishLoad();
 	}
 
 	public void testSimpleSchool() throws Exception
@@ -168,5 +164,11 @@ public class PreSpellSchoolTest extends AbstractCharacterTestCase
 		character.incrementClassLevel(1, cle);
 		passes = PrereqHandler.passes(prereq, character, null);
 		assertFalse(passes);
+	}
+
+	@Override
+	protected void defaultSetupEnd()
+	{
+		//Nothing, we will trigger ourselves
 	}
 }

--- a/code/src/test/pcgen/core/prereq/PreSpellSubSchoolTest.java
+++ b/code/src/test/pcgen/core/prereq/PreSpellSubSchoolTest.java
@@ -36,12 +36,6 @@ public class PreSpellSubSchoolTest extends AbstractCharacterTestCase
 	protected void setUp() throws Exception
 	{
 		super.setUp();
-		Globals.getContext().loadCampaignFacets();
-	}
-
-	@Override
-	protected void additionalSetUp() throws Exception
-	{
 		LoadContext context = Globals.getContext();
 		wiz = context.getReferenceContext().constructCDOMObject(PCClass.class, "Wizard");
 		BuildUtilities.setFact(wiz, "SpellType", "Arcane");
@@ -83,6 +77,8 @@ public class PreSpellSubSchoolTest extends AbstractCharacterTestCase
 		context.getReferenceContext().importObject(cure);
 		context.unconditionallyProcess(cure, "CLASSES", "Cleric=1");
 		context.unconditionallyProcess(cure, "SUBSCHOOL", "Useful");
+		
+		finishLoad();
 	}
 
 	public void testSimpleSUBSCHOOL() throws Exception
@@ -168,5 +164,11 @@ public class PreSpellSubSchoolTest extends AbstractCharacterTestCase
 		character.incrementClassLevel(1, cle);
 		passes = PrereqHandler.passes(prereq, character, null);
 		assertFalse(passes);
+	}
+
+	@Override
+	protected void defaultSetupEnd()
+	{
+		//Nothing, we will trigger ourselves
 	}
 }

--- a/code/src/test/pcgen/core/prereq/PreSpellTypeTest.java
+++ b/code/src/test/pcgen/core/prereq/PreSpellTypeTest.java
@@ -33,8 +33,9 @@ public class PreSpellTypeTest extends AbstractCharacterTestCase
 	private PCClass cle;
 
 	@Override
-	protected void additionalSetUp() throws Exception
+	public void setUp() throws Exception
 	{
+		super.setUp();
 		LoadContext context = Globals.getContext();
 		wiz = context.getReferenceContext().constructCDOMObject(PCClass.class, "Wizard");
 		BuildUtilities.setFact(wiz, "SpellType", "Arcane");
@@ -76,6 +77,8 @@ public class PreSpellTypeTest extends AbstractCharacterTestCase
 		context.getReferenceContext().importObject(cure);
 		context.unconditionallyProcess(cure, "CLASSES", "Cleric=1");
 		context.unconditionallyProcess(cure, "TYPE", "Divine");
+
+		finishLoad();
 	}
 
 	public void testSimpleType() throws Exception
@@ -188,5 +191,11 @@ public class PreSpellTypeTest extends AbstractCharacterTestCase
 		character.incrementClassLevel(1, cle);
 		passes = PrereqHandler.passes(prereq, character, null);
 		assertFalse(passes);
+	}
+
+	@Override
+	protected void defaultSetupEnd()
+	{
+		//Nothing, we will trigger ourselves
 	}
 }

--- a/code/src/test/pcgen/gui2/facade/CompanionSupportFacadeImplTest.java
+++ b/code/src/test/pcgen/gui2/facade/CompanionSupportFacadeImplTest.java
@@ -56,6 +56,8 @@ public class CompanionSupportFacadeImplTest extends AbstractCharacterTestCase
 	{
 		super.setUp();
 		
+		companionList = Globals.getContext().getReferenceContext().constructNowIfNecessary(CompanionList.class,
+				"Familiar");
 		uiDelegate = new MockUIDelegate();
 		todoManager = new TodoManager();
 		ListFacade<CampaignFacade> campaigns = new DefaultListFacade<>();
@@ -69,6 +71,7 @@ public class CompanionSupportFacadeImplTest extends AbstractCharacterTestCase
 			companionList.getKeyName());
 		FollowerOption option = new FollowerOption(race, ref);
 		masterRace.addToListFor(ListKey.COMPANIONLIST, option);
+		finishLoad();
 	}
 
 	/**
@@ -106,10 +109,8 @@ public class CompanionSupportFacadeImplTest extends AbstractCharacterTestCase
 	}
 
 	@Override
-	protected void additionalSetUp() throws Exception
+	protected void defaultSetupEnd()
 	{
-		companionList = Globals.getContext().getReferenceContext().constructNowIfNecessary(CompanionList.class,
-			"Familiar");
+		//Nothing, we will trigger ourselves
 	}
-
 }

--- a/code/src/test/pcgen/gui2/facade/SpellBuilderFacadeImplTest.java
+++ b/code/src/test/pcgen/gui2/facade/SpellBuilderFacadeImplTest.java
@@ -17,13 +17,8 @@
  */
 package pcgen.gui2.facade;
 
-import org.junit.Before;
-import org.junit.Test;
-
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.enumeration.ObjectKey;
-import pcgen.cdom.facet.FacetLibrary;
-import pcgen.cdom.facet.MasterAvailableSpellFacet;
 import pcgen.core.Globals;
 import pcgen.core.PCClass;
 import pcgen.core.PlayerCharacter;
@@ -33,7 +28,11 @@ import pcgen.facade.core.InfoFacade;
 import pcgen.facade.util.ListFacade;
 import pcgen.rules.context.LoadContext;
 import pcgen.util.TestHelper;
+
 import plugin.lsttokens.testsupport.BuildUtilities;
+
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * SpellBuilderFacadeImplTest
@@ -93,13 +92,7 @@ public class SpellBuilderFacadeImplTest extends AbstractCharacterTestCase
 		web = TestHelper.makeSpell("Web");
 		context.unconditionallyProcess(web, "CLASSES", wizardCls.getKeyName()+"=2");
 
-		context.commit();
-
-		context.getReferenceContext().buildDerivedObjects();
-		context.resolveDeferredTokens();
-		assertTrue(context.getReferenceContext().resolveReferences(null));
-		
-		FacetLibrary.getFacet(MasterAvailableSpellFacet.class).initialize(context);
+		finishLoad();
 	}
 
 	@Test
@@ -127,22 +120,22 @@ public class SpellBuilderFacadeImplTest extends AbstractCharacterTestCase
 		spellBuilder.setSpellLevel(1);
 		ListFacade<InfoFacade> spells = spellBuilder.getSpells();
 		assertNotNull("Spell list should be defined", spells);
-		assertTrue("Spell list should have MM", spells.containsElement(magicMissile));
 		assertEquals("Spell list length", 1, spells.getSize());
+		assertTrue("Spell list should have MM", spells.containsElement(magicMissile));
 
 		spellBuilder.setSpellLevel(2);
 		spells = spellBuilder.getSpells();
 		assertNotNull("Spell list should be defined", spells);
+		assertEquals("Spell list length", 1, spells.getSize());
 		assertTrue("Spell list should have Web", spells.containsElement(web));
 		assertFalse("Spell list should not have MM", spells.containsElement(magicMissile));
-		assertEquals("Spell list length", 1, spells.getSize());
 
 		spellBuilder.setClass(divineCls);
 		spellBuilder.setSpellLevel(1);
 		spells = spellBuilder.getSpells();
 		assertNotNull("Spell list should be defined", spells);
-		assertTrue("Spell list should have CLW", spells.containsElement(clw));
 		assertEquals("Spell list length", 1, spells.getSize());
+		assertTrue("Spell list should have CLW", spells.containsElement(clw));
 		
 	}
 
@@ -157,4 +150,12 @@ public class SpellBuilderFacadeImplTest extends AbstractCharacterTestCase
 		assertNotNull("Unable to create SpellBuilderFacadeImpl", spellBuilder);
 		return spellBuilder;
 	}
+
+	@Override
+	protected void defaultSetupEnd()
+	{
+		//We'll take care of it ourselves
+	}
+	
+	
 }

--- a/code/src/test/pcgen/io/ExportHandlerTest.java
+++ b/code/src/test/pcgen/io/ExportHandlerTest.java
@@ -92,8 +92,6 @@ public class ExportHandlerTest extends AbstractCharacterTestCase
 	protected void setUp() throws Exception
 	{
 		super.setUp();
-		PlayerCharacter character = getCharacter();
-		LoadContext context = Globals.getContext();
 
 		final LevelInfo levelInfo = new LevelInfo();
 		levelInfo.setLevelString("LEVEL");
@@ -102,9 +100,8 @@ public class ExportHandlerTest extends AbstractCharacterTestCase
 		GameMode gamemode = SettingsHandler.getGame();
 		gamemode.addLevelInfo("Default", levelInfo);
 
-		//Stats
-		setPCStat(character, dex, 16);
-		setPCStat(character, intel, 17);
+		LoadContext context = Globals.getContext();
+
 		BonusObj aBonus = Bonus.newBonus(context, "MODSKILLPOINTS|NUMBER|INT");
 		
 		if (aBonus != null)
@@ -112,16 +109,14 @@ public class ExportHandlerTest extends AbstractCharacterTestCase
 			intel.addToListFor(ListKey.BONUS, aBonus);
 		}
 
-		// Race
 		Race testRace = new Race();
 		testRace.setName("TestRace");
-		character.setRace(testRace);
+		context.getReferenceContext().importObject(testRace);
 
-		// Class
 		PCClass myClass = new PCClass();
-		myClass.setName("My Class");
+		myClass.setName("MyClass");
 		myClass.put(FormulaKey.START_SKILL_POINTS, FormulaFactory.getFormulaFor(3));
-		character.incrementClassLevel(5, myClass, true);
+		context.getReferenceContext().importObject(myClass);
 
 		// Skills
 		knowledge = new Skill[2];
@@ -131,18 +126,14 @@ public class ExportHandlerTest extends AbstractCharacterTestCase
 		TestHelper.addType(knowledge[0], "KNOWLEDGE.INT");
 		CDOMDirectSingleRef<PCStat> intelRef = CDOMDirectSingleRef.getRef(intel);
 		knowledge[0].put(ObjectKey.KEY_STAT, intelRef);
-		character.setSkillOrder(knowledge[0], 2);
 		Globals.getContext().getReferenceContext().importObject(knowledge[0]);
-		SkillRankControl.modRanks(8.0, myClass, true, character, knowledge[0]);
 
 		knowledge[1] = new Skill();
 		context.unconditionallyProcess(knowledge[1], "CLASSES", "MyClass");
 		knowledge[1].setName("KNOWLEDGE (RELIGION)");
 		TestHelper.addType(knowledge[1], "KNOWLEDGE.INT");
 		knowledge[1].put(ObjectKey.KEY_STAT, intelRef);
-		character.setSkillOrder(knowledge[1], 3);
 		Globals.getContext().getReferenceContext().importObject(knowledge[1]);
-		SkillRankControl.modRanks(5.0, myClass, true, character, knowledge[1]);
 
 		tumble = new Skill();
 		context.unconditionallyProcess(tumble, "CLASSES", "MyClass");
@@ -150,16 +141,13 @@ public class ExportHandlerTest extends AbstractCharacterTestCase
 		tumble.addToListFor(ListKey.TYPE, Type.getConstant("DEX"));
 		CDOMDirectSingleRef<PCStat> dexRef = CDOMDirectSingleRef.getRef(dex);
 		tumble.put(ObjectKey.KEY_STAT, dexRef);
-		character.setSkillOrder(tumble, 4);
 		Globals.getContext().getReferenceContext().importObject(tumble);
-		SkillRankControl.modRanks(7.0, myClass, true, character, tumble);
 
 		balance = new Skill();
 		context.unconditionallyProcess(balance, "CLASSES", "MyClass");
 		balance.setName("Balance");
 		balance.addToListFor(ListKey.TYPE, Type.getConstant("DEX"));
 		balance.put(ObjectKey.KEY_STAT, dexRef);
-		character.setSkillOrder(balance, 1);
 		aBonus = Bonus.newBonus(context, "SKILL|Balance|2|PRESKILL:1,Tumble=5|TYPE=Synergy.STACK");
 		
 		if (aBonus != null)
@@ -167,10 +155,7 @@ public class ExportHandlerTest extends AbstractCharacterTestCase
 			balance.addToListFor(ListKey.BONUS, aBonus);
 		}
 		Globals.getContext().getReferenceContext().importObject(balance);
-		SkillRankControl.modRanks(4.0, myClass, true, character, balance);
-
-		character.calcActiveBonuses();
-
+		
 		weapon = new Equipment();
 		weapon.setName("TestWpn");
 		weapon.addToListFor(ListKey.TYPE, Type.WEAPON);
@@ -184,8 +169,31 @@ public class ExportHandlerTest extends AbstractCharacterTestCase
 		armor.setName("TestArmorSuit");
 		TestHelper.addType(armor, "armor.suit");
 
-		context.getReferenceContext().buildDerivedObjects();
-		context.getReferenceContext().resolveReferences(null);
+		finishLoad();
+
+		PlayerCharacter character = getCharacter();
+		//Stats
+		setPCStat(character, dex, 16);
+		setPCStat(character, intel, 17);
+
+		// Race
+		character.setRace(testRace);
+
+		// Class
+		character.incrementClassLevel(5, myClass, true);
+
+		character.setSkillOrder(balance, 1);
+		character.setSkillOrder(knowledge[0], 2);
+		character.setSkillOrder(knowledge[1], 3);
+		character.setSkillOrder(tumble, 4);
+		SkillRankControl.modRanks(7.0, myClass, true, character, tumble);
+		SkillRankControl.modRanks(8.0, myClass, true, character, knowledge[0]);
+
+		SkillRankControl.modRanks(5.0, myClass, true, character, knowledge[1]);
+		SkillRankControl.modRanks(4.0, myClass, true, character, balance);
+
+		character.calcActiveBonuses();
+
 	}
 
 	@Override
@@ -473,4 +481,12 @@ public class ExportHandlerTest extends AbstractCharacterTestCase
 
 		return retWriter.toString();
 	}
+
+	@Override
+	protected void defaultSetupEnd()
+	{
+		//We will handle this locally
+	}
+	
+	
 }

--- a/code/src/test/pcgen/io/PCGVer2ParserCharacterTest.java
+++ b/code/src/test/pcgen/io/PCGVer2ParserCharacterTest.java
@@ -38,15 +38,16 @@ public class PCGVer2ParserCharacterTest extends AbstractCharacterTestCase
 {
 
 	@Override
-	protected void additionalSetUp() throws Exception
+	protected void setUp() throws Exception
 	{
-		super.additionalSetUp();
+		super.setUp();
 		LoadContext context = Globals.getContext();
 		Race rakshasha =
 				context.getReferenceContext().constructCDOMObject(Race.class, "Rakshasa");
 		context
 			.unconditionallyProcess(rakshasha, "ADD", "SPELLCASTER|Sorcerer");
 		context.getReferenceContext().constructCDOMObject(PCClass.class, "Sorcerer");
+		finishLoad();
 	}
 
 	/**
@@ -72,5 +73,11 @@ public class PCGVer2ParserCharacterTest extends AbstractCharacterTestCase
 		PersistentTransitionChoice<?> tc = rakshasha.getListFor(ListKey.ADD).get(0);
 		List<Object> assocList = pc.getAssocList(tc, AssociationListKey.ADD);
 		assertEquals("Number of associations for ADD " + assocList, 1, assocList.size());
+	}
+
+	@Override
+	protected void defaultSetupEnd()
+	{
+		//Nothing, we will trigger ourselves
 	}
 }

--- a/code/src/test/pcgen/io/exporttoken/SpellMemTokenTest.java
+++ b/code/src/test/pcgen/io/exporttoken/SpellMemTokenTest.java
@@ -73,12 +73,6 @@ public class SpellMemTokenTest extends AbstractCharacterTestCase
 	protected void setUp() throws Exception
 	{
 		super.setUp();
-		Globals.getContext().loadCampaignFacets();
-	}
-
-    @Override
-	protected void additionalSetUp() throws Exception
-	{
 		LoadContext context = Globals.getContext();
 
 		// Human
@@ -116,6 +110,7 @@ public class SpellMemTokenTest extends AbstractCharacterTestCase
 		context.getReferenceContext().constructCDOMObject(Domain.class, "Fire");
 		
 		context.getReferenceContext().importObject(divineClass);
+		finishLoad();
 	}
 
     @Override
@@ -211,5 +206,11 @@ public class SpellMemTokenTest extends AbstractCharacterTestCase
 		assertEquals("Retrieve spell from prepared list of divine caster.",
 			"Test Spell", token.getToken("SPELLMEM.0.2.1.0.NAME", character,
 				null));
+	}
+
+	@Override
+	protected void defaultSetupEnd()
+	{
+		//Nothing, we will trigger ourselves
 	}
 }

--- a/code/src/test/plugin/exporttokens/SkillSitTokenTest.java
+++ b/code/src/test/plugin/exporttokens/SkillSitTokenTest.java
@@ -69,7 +69,6 @@ public class SkillSitTokenTest extends AbstractCharacterTestCase
 	protected void setUp() throws Exception
 	{
 		super.setUp();
-		PlayerCharacter character = getCharacter();
 
 		final LevelInfo levelInfo = new LevelInfo();
 		levelInfo.setLevelString("LEVEL");
@@ -78,10 +77,6 @@ public class SkillSitTokenTest extends AbstractCharacterTestCase
 		GameMode gamemode = SettingsHandler.getGame();
 		gamemode.addLevelInfo("Default", levelInfo);
 
-		//Stats
-		setPCStat(character, dex, 16);
-		setPCStat(character, intel, 17);
-		
 		LoadContext context = Globals.getContext();
 		BonusObj aBonus = Bonus.newBonus(context, "MODSKILLPOINTS|NUMBER|INT");
 		
@@ -93,13 +88,13 @@ public class SkillSitTokenTest extends AbstractCharacterTestCase
 		// Race
 		Race testRace = new Race();
 		testRace.setName("TestRace");
-		character.setRace(testRace);
+		context.getReferenceContext().importObject(testRace);
 
 		// Class
 		PCClass myClass = new PCClass();
-		myClass.setName("My Class");
+		myClass.setName("MyClass");
 		myClass.put(FormulaKey.START_SKILL_POINTS, FormulaFactory.getFormulaFor(3));
-		character.incrementClassLevel(5, myClass, true);
+		context.getReferenceContext().importObject(myClass);
 
 		//Skills
 		knowledge = new Skill[2];
@@ -115,7 +110,6 @@ public class SkillSitTokenTest extends AbstractCharacterTestCase
 		{
 			knowledge[0].addToListFor(ListKey.BONUS, aBonus);
 		}
-		SkillRankControl.modRanks(8.0, myClass, true, character, knowledge[0]);
 
 		knowledge[1] = new Skill();
 		context.unconditionallyProcess(knowledge[1], "CLASSES", "MyClass");
@@ -128,7 +122,6 @@ public class SkillSitTokenTest extends AbstractCharacterTestCase
 			knowledge[1].addToListFor(ListKey.BONUS, aBonus);
 		}
 		context.getReferenceContext().importObject(knowledge[1]);
-		SkillRankControl.modRanks(5.0, myClass, true, character, knowledge[1]);
 
 		tumble = new Skill();
 		context.unconditionallyProcess(tumble, "CLASSES", "MyClass");
@@ -139,7 +132,6 @@ public class SkillSitTokenTest extends AbstractCharacterTestCase
 		CDOMDirectSingleRef<PCStat> dexRef = CDOMDirectSingleRef.getRef(dex);
 		tumble.put(ObjectKey.KEY_STAT, dexRef);
 		context.getReferenceContext().importObject(tumble);
-		SkillRankControl.modRanks(7.0, myClass, true, character, tumble);
 
 		balance = new Skill();
 		context.unconditionallyProcess(balance, "CLASSES", "MyClass");
@@ -154,10 +146,22 @@ public class SkillSitTokenTest extends AbstractCharacterTestCase
 			balance.addToListFor(ListKey.BONUS, aBonus);
 		}
 		context.getReferenceContext().importObject(balance);
-		SkillRankControl.modRanks(4.0, myClass, true, character, balance);
 
-		context.getReferenceContext().buildDerivedObjects();
-		context.getReferenceContext().resolveReferences(null);
+		finishLoad();
+
+		PlayerCharacter character = getCharacter();
+
+		//Stats
+		setPCStat(character, dex, 16);
+		setPCStat(character, intel, 17);
+		
+		character.setRace(testRace);
+		character.incrementClassLevel(5, myClass, true);
+		
+		SkillRankControl.modRanks(8.0, myClass, true, character, knowledge[0]);
+		SkillRankControl.modRanks(5.0, myClass, true, character, knowledge[1]);
+		SkillRankControl.modRanks(7.0, myClass, true, character, tumble);
+		SkillRankControl.modRanks(4.0, myClass, true, character, balance);
 
 		character.calcActiveBonuses();
 	}
@@ -246,5 +250,11 @@ public class SkillSitTokenTest extends AbstractCharacterTestCase
 			character, null));
 		assertEquals("SkillToken", "Tumble (On Hot Concrete)",
 			token.getToken("SKILLSIT.TUMBLE=On Hot Concrete", character, null));
+	}
+
+	@Override
+	protected void defaultSetupEnd()
+	{
+		//We will handle this locally
 	}
 }

--- a/code/src/test/plugin/exporttokens/SkillTokenTest.java
+++ b/code/src/test/plugin/exporttokens/SkillTokenTest.java
@@ -76,7 +76,6 @@ public class SkillTokenTest extends AbstractCharacterTestCase
 	protected void setUp() throws Exception
 	{
 		super.setUp();
-		PlayerCharacter character = getCharacter();
 
 		final LevelInfo levelInfo = new LevelInfo();
 		levelInfo.setLevelString("LEVEL");
@@ -85,10 +84,6 @@ public class SkillTokenTest extends AbstractCharacterTestCase
 		GameMode gamemode = SettingsHandler.getGame();
 		gamemode.addLevelInfo("Default", levelInfo);
 
-		//Stats
-		setPCStat(character, dex, 16);
-		setPCStat(character, intel, 17);
-		
 		LoadContext context = Globals.getContext();
 		BonusObj aBonus = Bonus.newBonus(context, "MODSKILLPOINTS|NUMBER|INT");
 		
@@ -100,13 +95,13 @@ public class SkillTokenTest extends AbstractCharacterTestCase
 		// Race
 		Race testRace = new Race();
 		testRace.setName("TestRace");
-		character.setRace(testRace);
+		context.getReferenceContext().importObject(testRace);
 
 		// Class
 		PCClass myClass = new PCClass();
-		myClass.setName("My Class");
+		myClass.setName("MyClass");
 		myClass.put(FormulaKey.START_SKILL_POINTS, FormulaFactory.getFormulaFor(3));
-		character.incrementClassLevel(5, myClass, true);
+		context.getReferenceContext().importObject(myClass);
 
 		//Skills
 		knowledge = new Skill[2];
@@ -117,7 +112,6 @@ public class SkillTokenTest extends AbstractCharacterTestCase
 		CDOMDirectSingleRef<PCStat> intelRef = CDOMDirectSingleRef.getRef(intel);
 		knowledge[0].put(ObjectKey.KEY_STAT, intelRef);
 		context.getReferenceContext().importObject(knowledge[0]);
-		SkillRankControl.modRanks(8.0, myClass, true, character, knowledge[0]);
 
 		knowledge[1] = new Skill();
 		context.unconditionallyProcess(knowledge[1], "CLASSES", "MyClass");
@@ -125,7 +119,6 @@ public class SkillTokenTest extends AbstractCharacterTestCase
 		TestHelper.addType(knowledge[1], "KNOWLEDGE.INT");
 		knowledge[1].put(ObjectKey.KEY_STAT, intelRef);
 		context.getReferenceContext().importObject(knowledge[1]);
-		SkillRankControl.modRanks(5.0, myClass, true, character, knowledge[1]);
 
 		tumble = new Skill();
 		context.unconditionallyProcess(tumble, "CLASSES", "MyClass");
@@ -134,7 +127,6 @@ public class SkillTokenTest extends AbstractCharacterTestCase
 		CDOMDirectSingleRef<PCStat> dexRef = CDOMDirectSingleRef.getRef(dex);
 		tumble.put(ObjectKey.KEY_STAT, dexRef);
 		context.getReferenceContext().importObject(tumble);
-		SkillRankControl.modRanks(7.0, myClass, true, character, tumble);
 
 		balance = new Skill();
 		context.unconditionallyProcess(balance, "CLASSES", "MyClass");
@@ -148,10 +140,20 @@ public class SkillTokenTest extends AbstractCharacterTestCase
 			balance.addToListFor(ListKey.BONUS, aBonus);
 		}
 		context.getReferenceContext().importObject(balance);
+		
+		finishLoad();
+		
+		PlayerCharacter character = getCharacter();
+		//Stats
+		setPCStat(character, dex, 16);
+		setPCStat(character, intel, 17);
+		
+		character.setRace(testRace);
+		character.incrementClassLevel(5, myClass, true);
 		SkillRankControl.modRanks(4.0, myClass, true, character, balance);
-
-		context.getReferenceContext().buildDerivedObjects();
-		context.getReferenceContext().resolveReferences(null);
+		SkillRankControl.modRanks(8.0, myClass, true, character, knowledge[0]);
+		SkillRankControl.modRanks(5.0, myClass, true, character, knowledge[1]);
+		SkillRankControl.modRanks(7.0, myClass, true, character, tumble);
 
 		character.calcActiveBonuses();
 	}
@@ -254,4 +256,12 @@ public class SkillTokenTest extends AbstractCharacterTestCase
 		assertEquals("SkillTypeToken", "10", token.getToken(
 			"SKILLTYPE.1.DEX.TOTAL", character, null));
 	}
+
+	@Override
+	protected void defaultSetupEnd()
+	{
+		//Handle locally
+	}
+	
+	
 }

--- a/code/src/testcommon/plugin/lsttokens/testsupport/BuildUtilities.java
+++ b/code/src/testcommon/plugin/lsttokens/testsupport/BuildUtilities.java
@@ -122,7 +122,7 @@ public final class BuildUtilities
 	{
 		FactDefinition<?, String> fd = new FactDefinition<>();
 		fd.setUsableLocation(cls);
-		fd.setName("*" + factname);
+		fd.setName("TS_" + factname);
 		fd.setFactName(factname);
 		fd.setFormatManager(new StringManager());
 		context.getReferenceContext().importObject(fd);
@@ -141,7 +141,7 @@ public final class BuildUtilities
 	{
 		FactSetDefinition<?, String> fd = new FactSetDefinition<>();
 		fd.setUsableLocation(cls);
-		fd.setName("*" + factsetname);
+		fd.setName("TS_" + factsetname);
 		fd.setFactSetName(factsetname);
 		fd.setFormatManager(new StringManager());
 		context.getReferenceContext().importObject(fd);


### PR DESCRIPTION
This is another portion of fixing the problems we have in master and eventually lifting the code freeze.

This changes how certain tests behave. Due to some enhancements deployed over the last few days, a number of features have interacted, causing a few badly behaved unit tests to be exposed in their less than stellar behavior. Some of these unit tests required additional setup for a test before they "finish the load" and resolve references. In order to accommodate that, a fairly significant change to AbstractCharacterTestCase was required. This will fix a number of unit tests that are currently failing (3 ish?)