### PR TITLE
[build] modernize our gradle a bit.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,6 +114,7 @@ sourceSets {
         }
         compileClasspath += sourceSets.main.output
         runtimeClasspath += sourceSets.main.output
+
     }
     itest {
         java {
@@ -123,7 +124,6 @@ sourceSets {
         runtimeClasspath += sourceSets.main.output
         compileClasspath += sourceSets.test.compileClasspath
         runtimeClasspath += sourceSets.test.runtimeClasspath
-
     }
     slowtest {
         java {
@@ -135,6 +135,15 @@ sourceSets {
         runtimeClasspath += sourceSets.test.runtimeClasspath
 
     }
+}
+
+configurations {
+    testImplementation.extendsFrom implementation
+    testRuntimeOnly.extendsFrom runtimeOnly
+    itestImplementation.extendsFrom testImplementation
+    itestRuntimeOnly.extendsFrom testRuntimeOnly
+    slowtestImplementation.extendsFrom testImplementation
+    slowtestRuntimeOnly.extendsFrom testRuntimeOnly
 }
 
 /* Copy 'master' outputsheets into different genre folders */
@@ -162,40 +171,38 @@ compileJava {
 }
 
 dependencies {
-    compile group: 'cobra', name: 'cobra', version:'0.98.4-pcgen'
-    compile group: 'commons-io', name: 'commons-io', version:'2.6'
-    compile group: 'org.springframework', name: 'spring-core', version:'5.1.4.RELEASE'
-    compile group: 'org.springframework', name: 'spring-beans', version:'5.1.4.RELEASE'
-    compile group: 'org.springframework', name: 'spring-web', version:'5.1.4.RELEASE'
-    compile group: 'skinlf', name: 'skinlf', version: '1.2.3'
-    compile group: 'org.apache.commons', name: 'commons-lang3', version:'3.8.1'
-    compile group: 'org.apache.xmlgraphics', name: 'fop', version:'2.3'
-    compile group: 'org.apache.commons', name: 'commons-collections4', version: '4.2'
-    compile group: 'jep', name: 'jep', version:'2.4.1'
-    compile group: 'org.freemarker', name: 'freemarker', version:'2.3.28'
-    compile group: 'org.jdom', name: 'jdom2', version:'2.0.6'
-    compile group: 'xalan', name: 'xalan', version:'2.7.2'
-    compile group: 'net.sourceforge.argparse4j', name: 'argparse4j', version: '0.8.1'
-    compile group: 'org.mozilla', name: 'rhino', version:'1.7.10'
+    implementation group: 'cobra', name: 'cobra', version:'0.98.4-pcgen'
+    implementation group: 'commons-io', name: 'commons-io', version:'2.6'
+    implementation group: 'org.springframework', name: 'spring-core', version:'5.1.4.RELEASE'
+    implementation group: 'org.springframework', name: 'spring-beans', version:'5.1.4.RELEASE'
+    implementation group: 'org.springframework', name: 'spring-web', version:'5.1.4.RELEASE'
+    implementation group: 'skinlf', name: 'skinlf', version: '1.2.3'
+    implementation group: 'org.apache.commons', name: 'commons-lang3', version:'3.8.1'
+    implementation group: 'org.apache.xmlgraphics', name: 'fop', version:'2.3'
+    implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.2'
+    implementation group: 'jep', name: 'jep', version:'2.4.1'
+    implementation group: 'org.freemarker', name: 'freemarker', version:'2.3.28'
+    implementation group: 'org.jdom', name: 'jdom2', version:'2.0.6'
+    implementation group: 'xalan', name: 'xalan', version:'2.7.2'
+    implementation group: 'net.sourceforge.argparse4j', name: 'argparse4j', version: '0.8.1'
+    implementation group: 'org.mozilla', name: 'rhino', version:'1.7.10'
 
-    compile group: 'org.xmlunit', name: 'xmlunit-core', version:'2.6.2'
+    implementation group: 'org.xmlunit', name: 'xmlunit-core', version:'2.6.2'
     implementation group: 'net.sourceforge.pcgen', name: 'PCGen-base', version:'1.0.170'
     implementation group: 'net.sourceforge.pcgen', name: 'PCGen-Formula', version:'1.0.195'
-    compile group: 'xml-apis', name: 'xml-apis', version:'1.3.04'
+    implementation group: 'xml-apis', name: 'xml-apis', version:'1.3.04'
 
     compileOnly group: 'org.jetbrains', name: 'annotations', version:'16.0.3'
     compileOnly group: 'com.yuvimasory', name: 'orange-extensions', version: '1.3.0'
 
-    testCompile group: 'org.junit.platform', name: 'junit-platform-runner', version: '1.3.2'
-    testCompile group: 'org.junit.platform', name: 'junit-platform-launcher', version: '1.3.2'
+    testImplementation group: 'org.junit.platform', name: 'junit-platform-runner', version: '1.3.2'
+    testImplementation group: 'org.junit.platform', name: 'junit-platform-launcher', version: '1.3.2'
     testImplementation group: 'org.junit.jupiter', name:  'junit-jupiter-api', version: '5.3.2'
-    testImplementation group: 'org.junit.jupiter', name:  'junit-jupiter-params', version: '5.3.2'
-    testRuntime group: 'org.junit.vintage', name: 'junit-vintage-engine', version: '5.3.2'
-    testRuntime group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.3.2'
+    testRuntimeOnly group: 'org.junit.vintage', name: 'junit-vintage-engine', version: '5.3.2'
+    testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.3.2'
 
     testImplementation group: 'org.hamcrest', name: 'hamcrest', version: '2.1'
-
-    testCompile group: 'org.xmlunit', name: 'xmlunit-matchers', version:'2.6.2'
+    testImplementation group: 'org.xmlunit', name: 'xmlunit-matchers', version:'2.6.2'
 }
 
 ant.importBuild 'build-gradle.xml'


### PR DESCRIPTION
Gradle has a habit of constantly requiring new syntax or features.
Follow along.

-  switch from 'compile' to 'implementation' and 'api' (we have none in
this project)
- use newer getters/setters
- avoid some cross-configuration setting
- update to gradle 5.1.1 (possible dup of existing PR)