### PR TITLE
[*] Remove extranious "message" from several unit tests

### DIFF
--- a/code/src/utest/plugin/lsttokens/MoveLstTest.java
+++ b/code/src/utest/plugin/lsttokens/MoveLstTest.java
@@ -127,7 +127,7 @@ public class MoveLstTest extends AbstractGlobalTokenTestCase
 		String[] unparsed = getWriteToken().unparse(primaryContext, primaryProf);
 		assertNotNull(unparsed);
 		assertEquals(1, unparsed.length);
-		assertEquals("Expected item to be equal", "Walk,30", unparsed[0]);
+		assertEquals("Walk,30", unparsed[0]);
 	}
 
 	@Test

--- a/code/src/utest/plugin/lsttokens/TypeLstTest.java
+++ b/code/src/utest/plugin/lsttokens/TypeLstTest.java
@@ -95,18 +95,18 @@ public class TypeLstTest extends AbstractGlobalTypeSafeListTestCase
 		String[] unparsed;
 		assertTrue(parse("REMOVE.TestWP1"));
 		unparsed = getWriteToken().unparse(primaryContext, primaryProf);
-		assertNull("Expected item to be equal", unparsed);
+		assertNull(unparsed);
 
 		assertTrue(parse("TestWP1"));
 		assertTrue(parse("ADD.TestWP2"));
 		unparsed = getWriteToken().unparse(primaryContext, primaryProf);
-		assertEquals("Expected item to be equal", "TestWP1"
+		assertEquals("TestWP1"
 			+ getJoinCharacter() + "TestWP2", unparsed[0]);
 		if (isClearLegal())
 		{
 			assertTrue(parse(Constants.LST_DOT_CLEAR));
 			unparsed = getWriteToken().unparse(primaryContext, primaryProf);
-			assertNull("Expected item to be null", unparsed);
+			assertNull(unparsed);
 		}
 	}
 
@@ -117,11 +117,11 @@ public class TypeLstTest extends AbstractGlobalTypeSafeListTestCase
 		assertTrue(parse("TestWP1"));
 		assertTrue(parse("TestWP2"));
 		unparsed = getWriteToken().unparse(primaryContext, primaryProf);
-		assertEquals("Expected item to be equal", "TestWP1"
+		assertEquals("TestWP1"
 			+ getJoinCharacter() + "TestWP2", unparsed[0]);
 		assertTrue(parse("REMOVE.TestWP1"));
 		unparsed = getWriteToken().unparse(primaryContext, primaryProf);
-		assertEquals("Expected item to be equal", "TestWP2", unparsed[0]);
+		assertEquals("TestWP2", unparsed[0]);
 	}
 
 	@Test

--- a/code/src/utest/plugin/lsttokens/choose/NoChoiceTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/choose/NoChoiceTokenTest.java
@@ -30,6 +30,8 @@ import plugin.lsttokens.testsupport.CDOMTokenLoader;
 import plugin.lsttokens.testsupport.ConsolidationRule;
 import plugin.lsttokens.testsupport.TokenRegistration;
 
+import org.junit.jupiter.api.BeforeEach;
+
 public class NoChoiceTokenTest extends AbstractCDOMTokenTestCase<CDOMObject>
 {
 
@@ -38,6 +40,7 @@ public class NoChoiceTokenTest extends AbstractCDOMTokenTestCase<CDOMObject>
 	static CDOMTokenLoader<CDOMObject> loader =
 			new CDOMTokenLoader<>();
 
+	@BeforeEach
 	@Override
 	public void setUp() throws PersistenceLayerException, URISyntaxException
 	{

--- a/code/src/utest/plugin/lsttokens/choose/UserInputTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/choose/UserInputTokenTest.java
@@ -30,6 +30,8 @@ import plugin.lsttokens.testsupport.CDOMTokenLoader;
 import plugin.lsttokens.testsupport.ConsolidationRule;
 import plugin.lsttokens.testsupport.TokenRegistration;
 
+import org.junit.jupiter.api.BeforeEach;
+
 public class UserInputTokenTest extends AbstractCDOMTokenTestCase<CDOMObject>
 {
 
@@ -38,6 +40,8 @@ public class UserInputTokenTest extends AbstractCDOMTokenTestCase<CDOMObject>
 	static CDOMTokenLoader<CDOMObject> loader =
 			new CDOMTokenLoader<>();
 
+
+	@BeforeEach
 	@Override
 	public void setUp() throws PersistenceLayerException, URISyntaxException
 	{

--- a/code/src/utest/plugin/lsttokens/equipment/AltTypeTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/equipment/AltTypeTokenTest.java
@@ -89,18 +89,18 @@ public class AltTypeTokenTest extends AbstractTypeSafeListTestCase<Equipment, Ty
 		String[] unparsed;
 		assertTrue(parse("REMOVE.TestWP1"));
 		unparsed = getToken().unparse(primaryContext, primaryProf);
-		assertNull("Expected item to be equal", unparsed);
+		assertNull(unparsed);
 
 		assertTrue(parse("TestWP1"));
 		assertTrue(parse("ADD.TestWP2"));
 		unparsed = getToken().unparse(primaryContext, primaryProf);
-		assertEquals("Expected item to be equal", "TestWP1"
+		assertEquals("TestWP1"
 			+ getJoinCharacter() + "TestWP2", unparsed[0]);
 		if (isClearLegal())
 		{
 			assertTrue(parse(Constants.LST_DOT_CLEAR));
 			unparsed = getToken().unparse(primaryContext, primaryProf);
-			assertNull("Expected item to be null", unparsed);
+			assertNull(unparsed);
 		}
 	}
 
@@ -111,11 +111,11 @@ public class AltTypeTokenTest extends AbstractTypeSafeListTestCase<Equipment, Ty
 		assertTrue(parse("TestWP1"));
 		assertTrue(parse("TestWP2"));
 		unparsed = getToken().unparse(primaryContext, primaryProf);
-		assertEquals("Expected item to be equal", "TestWP1"
+		assertEquals("TestWP1"
 			+ getJoinCharacter() + "TestWP2", unparsed[0]);
 		assertTrue(parse("REMOVE.TestWP1"));
 		unparsed = getToken().unparse(primaryContext, primaryProf);
-		assertEquals("Expected item to be equal", "TestWP2", unparsed[0]);
+		assertEquals("TestWP2", unparsed[0]);
 	}
 
 	@Test

--- a/code/src/utest/plugin/lsttokens/kit/funds/FundsTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/kit/funds/FundsTokenTest.java
@@ -17,13 +17,13 @@
  */
 package plugin.lsttokens.kit.funds;
 
-import org.junit.Test;
-
 import pcgen.core.kit.KitFunds;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.rules.persistence.CDOMSubLineLoader;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.testsupport.AbstractKitTokenTestCase;
+
+import org.junit.Test;
 
 public class FundsTokenTest extends AbstractKitTokenTestCase<KitFunds>
 {

--- a/code/src/utest/plugin/lsttokens/pcclass/HDTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/pcclass/HDTokenTest.java
@@ -120,7 +120,7 @@ public class HDTokenTest extends AbstractCDOMTokenTestCase<PCClass>
 		assertTrue(parse("5"));
 		assertTrue(parse("1"));
 		String[] unparsed = getToken().unparse(primaryContext, primaryProf);
-		assertEquals("Expected item to be equal", "1", unparsed[0]);
+		assertEquals("1", unparsed[0]);
 	}
 
 	@Test

--- a/code/src/utest/plugin/lsttokens/spell/ClassesTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/spell/ClassesTokenTest.java
@@ -395,13 +395,13 @@ public class ClassesTokenTest extends AbstractCDOMTokenTestCase<Spell>
 		String[] unparsed;
 		assertTrue(parse("Wizard=-1"));
 		unparsed = getToken().unparse(primaryContext, primaryProf);
-		assertNull("Expected item to be null", unparsed);
+		assertNull(unparsed);
 		assertTrue(parse("Wizard=1"));
 		unparsed = getToken().unparse(primaryContext, primaryProf);
-		assertEquals("Expected item to be equal", "Wizard=1", unparsed[0]);
+		assertEquals("Wizard=1", unparsed[0]);
 		assertTrue(parse("Wizard=-1"));
 		unparsed = getToken().unparse(primaryContext, primaryProf);
-		assertNull("Expected item to be null", unparsed);
+		assertNull(unparsed);
 	}
 
 	@Test
@@ -410,7 +410,7 @@ public class ClassesTokenTest extends AbstractCDOMTokenTestCase<Spell>
 		String[] unparsed;
 		assertTrue(parse("TYPE.Arcane=1"));
 		unparsed = getToken().unparse(primaryContext, primaryProf);
-		assertEquals("Expected item to be equal", "TYPE=Arcane=1", unparsed[0]);
+		assertEquals("TYPE=Arcane=1", unparsed[0]);
 	}
 
 	@Override

--- a/code/src/utest/plugin/lsttokens/spell/DomainsTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/spell/DomainsTokenTest.java
@@ -19,9 +19,6 @@ package plugin.lsttokens.spell;
 
 import java.net.URISyntaxException;
 
-import org.junit.Before;
-import org.junit.Test;
-
 import pcgen.cdom.base.Constants;
 import pcgen.cdom.list.DomainSpellList;
 import pcgen.core.spell.Spell;
@@ -31,10 +28,14 @@ import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import plugin.lsttokens.testsupport.AbstractCDOMTokenTestCase;
 import plugin.lsttokens.testsupport.CDOMTokenLoader;
 import plugin.lsttokens.testsupport.ConsolidationRule;
-import plugin.lsttokens.testsupport.TokenRegistration;
 import plugin.lsttokens.testsupport.ConsolidationRule.AppendingConsolidation;
+import plugin.lsttokens.testsupport.TokenRegistration;
 import plugin.pretokens.parser.PreRaceParser;
 import plugin.pretokens.writer.PreRaceWriter;
+
+import org.junit.Before;
+import org.junit.Test;
+
 
 public class DomainsTokenTest extends AbstractCDOMTokenTestCase<Spell>
 {
@@ -342,13 +343,13 @@ public class DomainsTokenTest extends AbstractCDOMTokenTestCase<Spell>
 		String[] unparsed;
 		assertTrue(parse("Fire=-1"));
 		unparsed = getToken().unparse(primaryContext, primaryProf);
-		assertNull("Expected item to be null", unparsed);
+		assertNull(unparsed);
 		assertTrue(parse("Fire=1"));
 		unparsed = getToken().unparse(primaryContext, primaryProf);
-		assertEquals("Expected item to be equal", "Fire=1", unparsed[0]);
+		assertEquals("Fire=1", unparsed[0]);
 		assertTrue(parse("Fire=-1"));
 		unparsed = getToken().unparse(primaryContext, primaryProf);
-		assertNull("Expected item to be null", unparsed);
+		assertNull(unparsed);
 	}
 
 	@Override

--- a/code/src/utest/plugin/lsttokens/template/SubraceTokenTest.java
+++ b/code/src/utest/plugin/lsttokens/template/SubraceTokenTest.java
@@ -91,15 +91,15 @@ public class SubraceTokenTest extends
 		assertTrue(parse("YES"));
 		unparsed = getToken().unparse(primaryContext, primaryProf);
 		assertEquals(1, unparsed.length);
-		assertEquals("Expected item to be equal", "YES", unparsed[0]);
+		assertEquals("YES", unparsed[0]);
 		assertTrue(parse("TestWP1"));
 		unparsed = getToken().unparse(primaryContext, primaryProf);
 		assertEquals(1, unparsed.length);
-		assertEquals("Expected item to be equal", "TestWP1", unparsed[0]);
+		assertEquals("TestWP1", unparsed[0]);
 		assertTrue(parse("YES"));
 		unparsed = getToken().unparse(primaryContext, primaryProf);
 		assertEquals(1, unparsed.length);
-		assertEquals("Expected item to be equal", "YES", unparsed[0]);
+		assertEquals("YES", unparsed[0]);
 	}
 
 	@Test

--- a/code/src/utest/plugin/lsttokens/testsupport/AbstractGlobalIntegerTokenTestCase.java
+++ b/code/src/utest/plugin/lsttokens/testsupport/AbstractGlobalIntegerTokenTestCase.java
@@ -180,14 +180,14 @@ public abstract class AbstractGlobalIntegerTokenTestCase extends
 			assertTrue(parse("5"));
 			assertTrue(parse("1"));
 			String[] unparsed = getWriteToken().unparse(primaryContext, primaryProf);
-			assertEquals("Expected item to be equal", "1", unparsed[0]);
+			assertEquals("1", unparsed[0]);
 		}
 		else
 		{
 			assertTrue(parse("-2"));
 			assertTrue(parse("-4"));
 			String[] unparsed = getWriteToken().unparse(primaryContext, primaryProf);
-			assertEquals("Expected item to be equal", "-4", unparsed[0]);
+			assertEquals("-4", unparsed[0]);
 		}
 	}
 

--- a/code/src/utest/plugin/lsttokens/testsupport/AbstractIntegerTokenTestCase.java
+++ b/code/src/utest/plugin/lsttokens/testsupport/AbstractIntegerTokenTestCase.java
@@ -181,14 +181,14 @@ public abstract class AbstractIntegerTokenTestCase<T extends CDOMObject>
 			assertTrue(parse("5"));
 			assertTrue(parse("1"));
 			String[] unparsed = getToken().unparse(primaryContext, primaryProf);
-			assertEquals("Expected item to be equal", "1", unparsed[0]);
+			assertEquals("1", unparsed[0]);
 		}
 		else
 		{
 			assertTrue(parse("-2"));
 			assertTrue(parse("-4"));
 			String[] unparsed = getToken().unparse(primaryContext, primaryProf);
-			assertEquals("Expected item to be equal", "-4", unparsed[0]);
+			assertEquals("-4", unparsed[0]);
 		}
 	}
 

--- a/code/src/utest/plugin/lsttokens/testsupport/AbstractTypeSafeListTestCase.java
+++ b/code/src/utest/plugin/lsttokens/testsupport/AbstractTypeSafeListTestCase.java
@@ -309,13 +309,13 @@ public abstract class AbstractTypeSafeListTestCase<T extends CDOMObject, LT>
 		assertTrue(parse("TestWP1"));
 		assertTrue(parse("TestWP2"));
 		unparsed = getToken().unparse(primaryContext, primaryProf);
-		assertEquals("Expected item to be equal", "TestWP1"
+		assertEquals("TestWP1"
 				+ getJoinCharacter() + "TestWP2", unparsed[0]);
 		if (isClearDotLegal())
 		{
 			assertTrue(parse(".CLEAR.TestWP1"));
 			unparsed = getToken().unparse(primaryContext, primaryProf);
-			assertEquals("Expected item to be equal", "TestWP2", unparsed[0]);
+			assertEquals("TestWP2", unparsed[0]);
 		}
 	}
 


### PR DESCRIPTION
This message will make it harder to convert from Junit 3/4 to 5.