### PR TITLE
[build] revert change to impl and back to compile

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -178,7 +178,6 @@ dependencies {
     compile group: 'net.sourceforge.argparse4j', name: 'argparse4j', version: '0.8.1'
     compile group: 'org.mozilla', name: 'rhino', version:'1.7.10'
 
-    compile group: 'org.xmlunit', name: 'xmlunit-core', version:'2.6.2'
     implementation group: 'net.sourceforge.pcgen', name: 'PCGen-base', version:'1.0.170'
     implementation group: 'net.sourceforge.pcgen', name: 'PCGen-Formula', version:'1.0.195'
     compile group: 'xml-apis', name: 'xml-apis', version:'1.3.04'
@@ -195,7 +194,8 @@ dependencies {
 
     testImplementation group: 'org.hamcrest', name: 'hamcrest', version: '2.1'
 
-    testCompile group: 'org.xmlunit', name: 'xmlunit-matchers', version:'2.6.2'
+    slowtestImplementation group: 'org.xmlunit', name: 'xmlunit-core', version:'2.6.2'
+    slowtestImplementation group: 'org.xmlunit', name: 'xmlunit-matchers', version:'2.6.2'
 }
 
 ant.importBuild 'build-gradle.xml'

--- a/build.gradle
+++ b/build.gradle
@@ -177,10 +177,11 @@ dependencies {
     compile group: 'xalan', name: 'xalan', version:'2.7.2'
     compile group: 'net.sourceforge.argparse4j', name: 'argparse4j', version: '0.8.1'
     compile group: 'org.mozilla', name: 'rhino', version:'1.7.10'
-
-    implementation group: 'net.sourceforge.pcgen', name: 'PCGen-base', version:'1.0.170'
-    implementation group: 'net.sourceforge.pcgen', name: 'PCGen-Formula', version:'1.0.195'
     compile group: 'xml-apis', name: 'xml-apis', version:'1.3.04'
+
+    compile group: 'net.sourceforge.pcgen', name: 'PCGen-base', version:'1.0.170'
+    compile group: 'net.sourceforge.pcgen', name: 'PCGen-Formula', version:'1.0.195'
+    
 
     compileOnly group: 'org.jetbrains', name: 'annotations', version:'16.0.3'
     compileOnly group: 'com.yuvimasory', name: 'orange-extensions', version: '1.3.0'


### PR DESCRIPTION
I need to make sure I more fully understand the implications of
'implementation' on code we distribute or use in later tasks. Revert for 
now.

(also fix the grouping of one dep)

depends on #5072