### PR TITLE
Add hashCode and equals to TrackingManufacturer

### DIFF
--- a/code/src/java/pcgen/rules/context/TrackingManufacturer.java
+++ b/code/src/java/pcgen/rules/context/TrackingManufacturer.java
@@ -18,6 +18,7 @@
 package pcgen.rules.context;
 
 import java.util.Collection;
+import java.util.Objects;
 import java.util.Optional;
 
 import pcgen.base.util.FormatManager;
@@ -40,8 +41,8 @@ class TrackingManufacturer<T extends Loadable> implements ReferenceManufacturer<
 
 	protected TrackingManufacturer(TrackingReferenceContext trc, ReferenceManufacturer<T> mfg)
 	{
-		context = trc;
-		rm = mfg;
+		context = Objects.requireNonNull(trc);
+		rm = Objects.requireNonNull(mfg);
 	}
 
 	@Override
@@ -283,4 +284,19 @@ class TrackingManufacturer<T extends Loadable> implements ReferenceManufacturer<
 	{
 		return rm.getPersistentFormat();
 	}
+
+	@Override
+	public int hashCode()
+	{
+		return 37 + rm.hashCode();
+	}
+
+	@Override
+	public boolean equals(Object obj)
+	{
+		return (obj instanceof TrackingManufacturer)
+			&& rm.equals(((TrackingManufacturer<?>) obj).rm);
+	}
+
+
 }


### PR DESCRIPTION
This eliminates a situation where the Formatting system can get
confused when there is more than one TrackingManufacturer, resulting
in confusion over whether there is a default value for a specific
format (in this case of CDOMObject, such as PCAlignment)