### PR TITLE
Tokenize AgeSet information

### DIFF
--- a/code/pluginbuild.xml
+++ b/code/pluginbuild.xml
@@ -2101,7 +2101,7 @@ jar-all-plugins - Generate the plugin jar files
 		</jar>
 	</target>
 
-	<target name="jar-lst-plugins" depends="jar-lst-global-plugins, jar-lst-ability-plugins, jar-lst-add-plugins, jar-lst-auto-plugins, jar-lst-campaign-plugins, jar-lst-choose-plugins, jar-lst-class-plugins, jar-lst-pcclass-level-plugins, jar-lst-companionmod-plugins, jar-lst-datacontrol-plugins, jar-lst-diety-plugins, jar-lst-domain-plugins, jar-lst-equipment-plugins, jar-lst-equipmentmodifier-plugins, jar-lst-equipmentmodifier-choose-plugins, jar-lst-race-plugins, jar-lst-skill-plugins, jar-lst-spell-plugins, jar-lst-subclass-plugins, jar-lst-substitutionlevel-plugins, jar-lst-tempbonus-plugins, jar-lst-template-plugins, jar-lst-weaponprof-plugins, jar-lst-kit-plugins" description="Build (Link) Lst Token plugin jar files">
+	<target name="jar-lst-plugins" depends="jar-lst-global-plugins, jar-lst-ability-plugins, jar-lst-add-plugins, jar-lst-ageset-plugins, jar-lst-auto-plugins, jar-lst-campaign-plugins, jar-lst-choose-plugins, jar-lst-class-plugins, jar-lst-pcclass-level-plugins, jar-lst-companionmod-plugins, jar-lst-datacontrol-plugins, jar-lst-diety-plugins, jar-lst-domain-plugins, jar-lst-equipment-plugins, jar-lst-equipmentmodifier-plugins, jar-lst-equipmentmodifier-choose-plugins, jar-lst-race-plugins, jar-lst-skill-plugins, jar-lst-spell-plugins, jar-lst-subclass-plugins, jar-lst-substitutionlevel-plugins, jar-lst-tempbonus-plugins, jar-lst-template-plugins, jar-lst-weaponprof-plugins, jar-lst-kit-plugins" description="Build (Link) Lst Token plugin jar files">
 	</target>
 
 	<target name="jar-lst-global-plugins" depends="makeplugindirs" description="Build (Link) Global Lst Token plugin jar files">
@@ -2623,6 +2623,24 @@ jar-all-plugins - Generate the plugin jar files
 			<fileset dir="${build.classes.dir}">
 				<patternset>
 					<include name="plugin/lsttokens/add/TemplateToken.class" />
+				</patternset>
+			</fileset>
+		</jar>
+	</target>
+
+	<target name="jar-lst-ageset-plugins" depends="makeplugindirs" description="Build (Link) AgeSet Token plugin jar files">
+		<!-- AgeSet tokens-->
+		<jar jarfile="${lstplugins.dir}/AgeSetLstToken-BONUS.jar" manifest="${src.java.dir}/plugin/lsttokens/manifest.mf">
+			<fileset dir="${build.classes.dir}">
+				<patternset>
+					<include name="plugin/lsttokens/gamemode/ageset/BonusToken.class" />
+				</patternset>
+			</fileset>
+		</jar>
+		<jar jarfile="${lstplugins.dir}/AgeSetLstToken-KIT.jar" manifest="${src.java.dir}/plugin/lsttokens/manifest.mf">
+			<fileset dir="${build.classes.dir}">
+				<patternset>
+					<include name="plugin/lsttokens/gamemode/ageset/KitToken.class" />
 				</patternset>
 			</fileset>
 		</jar>

--- a/code/src/java/pcgen/core/AgeSet.java
+++ b/code/src/java/pcgen/core/AgeSet.java
@@ -16,55 +16,86 @@
  */
 package pcgen.core;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import pcgen.cdom.base.BonusContainer;
 import pcgen.cdom.base.Constants;
+import pcgen.cdom.base.Loadable;
 import pcgen.cdom.base.TransitionChoice;
 import pcgen.core.bonus.BonusObj;
 
 /**
  * This represents the AGESET entries in the BioSettings Game Mode file
  */
-public class AgeSet implements BonusContainer
+public class AgeSet implements BonusContainer, Loadable
 {
 
+	/**
+	 * The (lazily instantiated) list of bonuses in this AgeSet.
+	 */
 	private List<BonusObj> bonuses = null;
+	
+	/**
+	 * The (lazily instantiated) list of kits in this AgeSet.
+	 */
 	private List<TransitionChoice<Kit>> kits = null;
-	private final String name;
-	private final int index;
+	
+	/**
+	 * The name of this AgeSet.
+	 */
+	private String name;
+	
+	/**
+	 * The AgeSet Index of this AgeSet.
+	 */
+	private int index;
+	
+	/**
+	 * The source URI of this AgeSet.
+	 */
+	private URI sourceURI;
 
-	public AgeSet(String ageName, int currentAgeSetIndex)
-	{
-		name = ageName;
-		index = currentAgeSetIndex;
-	}
-
-	public void addBonuses(List<BonusObj> list)
-	{
-		if (bonuses == null)
-		{
-			bonuses = new ArrayList<>(list);
-		}
-	}
-
+	/**
+	 * Returns true if this AgeSet has BONUS objects.
+	 * 
+	 * @return true if this AgeSet has BONUS objects; false otherwise
+	 */
 	public boolean hasBonuses()
 	{
 		return bonuses != null && !bonuses.isEmpty();
 	}
 
+	/**
+	 * Returns the AgeSet Index of this AgeSet.
+	 * 
+	 * @return the AgeSet Index of this AgeSet
+	 */
 	public int getIndex()
 	{
 		return index;
 	}
 
-	public String getName()
+	/**
+	 * Sets the AgeSet Index on this AgeSet.
+	 * 
+	 * @param ageSetIndex
+	 *            The AgeSet Index to be placed on this AgeSet.
+	 */
+	public void setAgeIndex(int ageSetIndex)
 	{
-		return name;
+		index = ageSetIndex;
 	}
 
+	/**
+	 * Gets the List of Bonus objects on this AgeSet. Will not return null (returns empty
+	 * list for no Bonuses).
+	 * 
+	 * @return The List of Bonus objects on this AgeSet
+	 */
 	public List<BonusObj> getBonuses()
 	{
 		if (bonuses == null)
@@ -74,14 +105,27 @@ public class AgeSet implements BonusContainer
 		return Collections.unmodifiableList(bonuses);
 	}
 
-	public void addKits(List<TransitionChoice<Kit>> list)
+	/**
+	 * Adds the given Bonus to the list of Bonus objects on this AgeSet.
+	 * 
+	 * @param bon
+	 *            The Bonus to be added to the list of Bonus objects on this AgeSet
+	 */
+	public void addBonus(BonusObj bon)
 	{
-		if (kits == null)
+		if (bonuses == null)
 		{
-			kits = new ArrayList<>(list);
+			bonuses = new ArrayList<>();
 		}
+		bonuses.add(bon);
 	}
 
+	/**
+	 * Gets the List of Kit objects on this AgeSet. Will not return null (returns empty
+	 * list for no Kits).
+	 * 
+	 * @return The List of Kit objects on this AgeSet
+	 */
 	public List<TransitionChoice<Kit>> getKits()
 	{
 		if (kits == null)
@@ -89,6 +133,21 @@ public class AgeSet implements BonusContainer
 			return Collections.emptyList();
 		}
 		return Collections.unmodifiableList(kits);
+	}
+
+	/**
+	 * Adds the given Kit to the list of Kit objects on this AgeSet.
+	 * 
+	 * @param tc
+	 *            The Kit to be added to the list of Kit objects on this AgeSet
+	 */
+	public void addKit(TransitionChoice<Kit> tc)
+	{
+		if (kits == null)
+		{
+			kits = new ArrayList<>();
+		}
+		kits.add(tc);
 	}
 
 	public String getLSTformat()
@@ -113,6 +172,9 @@ public class AgeSet implements BonusContainer
 		return sb.toString();
 	}
 
+	/*
+	 * Begin items implementing BonusContainer interface
+	 */
 	@Override
 	public void activateBonuses(PlayerCharacter pc)
 	{
@@ -144,6 +206,57 @@ public class AgeSet implements BonusContainer
 
 		return aList;
 	}
+	/*
+	 * End items implementing BonusContainer interface
+	 */
+
+	/*
+	 * Begin items implementing the Loadable interface
+	 */
+	@Override
+	public String getKeyName()
+	{
+		return name;
+	}
+
+	@Override
+	public String getDisplayName()
+	{
+		return name;
+	}
+
+	@Override
+	public void setName(String name)
+	{
+		this.name = name;
+	}
+
+	@Override
+	public URI getSourceURI()
+	{
+		return sourceURI;
+	}
+
+	@Override
+	public void setSourceURI(URI source)
+	{
+		this.sourceURI = source;
+	}
+
+	@Override
+	public boolean isInternal()
+	{
+		return false;
+	}
+
+	@Override
+	public boolean isType(String type)
+	{
+		return false;
+	}
+	/*
+	 * End items implementing the Loadable interface
+	 */
 
 	@Override
 	public int hashCode()
@@ -161,36 +274,11 @@ public class AgeSet implements BonusContainer
 		if (o instanceof AgeSet)
 		{
 			AgeSet other = (AgeSet) o;
-			if (bonuses == null)
-			{
-				if (other.bonuses != null)
-				{
-					return false;
-				}
-			}
-			else
-			{
-				if (!bonuses.equals(other.bonuses))
-				{
-					return false;
-				}
-			}
-			if (kits == null)
-			{
-				if (other.kits != null)
-				{
-					return false;
-				}
-			}
-			else
-			{
-				if (!kits.equals(other.kits))
-				{
-					return false;
-				}
-			}
-			return (index == other.index) && name.equals(other.name);
+			return (index == other.index) && name.equals(other.name)
+				&& Objects.equals(bonuses, other.bonuses)
+				&& Objects.equals(kits, other.kits);
 		}
 		return false;
 	}
+
 }

--- a/code/src/java/pcgen/core/BioSet.java
+++ b/code/src/java/pcgen/core/BioSet.java
@@ -605,7 +605,7 @@ public final class BioSet extends PObject implements NonInteractive
 		AgeSet old = ageMap.get(region, ageSet.getIndex());
 		if (old != null)
 		{
-			if (ageSet.hasBonuses() || !ageSet.getKits().isEmpty() || !ageSet.getName().equals(old.getName()))
+			if (ageSet.hasBonuses() || !ageSet.getKits().isEmpty() || !ageSet.getKeyName().equals(old.getKeyName()))
 			{
 				Logging.errorPrint(
 					"Found second (non-identical) AGESET " + "in Bio Settings " + sourceURI + " for Region: "
@@ -619,7 +619,7 @@ public final class BioSet extends PObject implements NonInteractive
 
 	public Integer addToNameMap(AgeSet ageSet)
 	{
-		return ageNames.put(ageSet.getName(), ageSet.getIndex());
+		return ageNames.put(ageSet.getKeyName(), ageSet.getIndex());
 	}
 
 	public Set<String> getAgeCategories()

--- a/code/src/java/pcgen/gui2/facade/CharacterFacadeImpl.java
+++ b/code/src/java/pcgen/gui2/facade/CharacterFacadeImpl.java
@@ -2669,7 +2669,7 @@ public class CharacterFacadeImpl
 		AgeSet ageSet = charDisplay.getAgeSet();
 		if (ageSet != null)
 		{
-			String ageCatName = ageSet.getName();
+			String ageCatName = ageSet.getKeyName();
 			for (String ageCatFacade : ageCategoryList)
 			{
 				if (ageCatFacade.equals(ageCatName))

--- a/code/src/java/pcgen/output/model/AgeSetModel.java
+++ b/code/src/java/pcgen/output/model/AgeSetModel.java
@@ -50,7 +50,7 @@ public class AgeSetModel implements TemplateScalarModel
 	@Override
 	public String getAsString() throws TemplateModelException
 	{
-		return set.getName();
+		return set.getKeyName();
 	}
 
 }

--- a/code/src/java/pcgen/persistence/lst/BioSetLoader.java
+++ b/code/src/java/pcgen/persistence/lst/BioSetLoader.java
@@ -23,30 +23,28 @@ import java.util.List;
 import java.util.Optional;
 import java.util.StringTokenizer;
 
-import pcgen.cdom.base.TransitionChoice;
-import pcgen.cdom.enumeration.ListKey;
 import pcgen.cdom.enumeration.Region;
 import pcgen.core.AgeSet;
 import pcgen.core.BioSet;
 import pcgen.core.GameMode;
-import pcgen.core.Kit;
-import pcgen.core.PObject;
 import pcgen.core.SystemCollections;
-import pcgen.core.bonus.BonusObj;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.SystemLoader;
 import pcgen.persistence.lst.prereq.PreParserFactory;
 import pcgen.rules.context.LoadContext;
 import pcgen.util.Logging;
 
+import org.apache.commons.lang3.StringUtils;
+
 public final class BioSetLoader extends LstLineFileLoader
 {
 	/**
 	 * The current Region being processed
 	 */
-	private static Optional<Region> region = Optional.empty();
+	private Optional<Region> region = Optional.empty();
 
 	BioSet bioSet = new BioSet();
+
 	/**
 	 * The age set (bracket) currently being processed. Used by the parseLine
 	 * method to hold state between calls.
@@ -56,7 +54,7 @@ public final class BioSetLoader extends LstLineFileLoader
 	/**
 	 * Clear the Region.
 	 */
-	public static void clear()
+	public void clear()
 	{
 		region = Optional.empty();
 	}
@@ -65,7 +63,7 @@ public final class BioSetLoader extends LstLineFileLoader
 	public void loadLstFile(LoadContext context, URI fileName) throws PersistenceLayerException
 	{
 		currentAgeSetIndex = 0;
-		final GameMode game = SystemCollections.getGameModeNamed(gameMode);
+		GameMode game = SystemCollections.getGameModeNamed(gameMode);
 		bioSet = game.getBioSet();
 		super.loadLstFile(context, fileName);
 		game.setBioSet(bioSet);
@@ -74,6 +72,11 @@ public final class BioSetLoader extends LstLineFileLoader
 	@Override
 	public void parseLine(LoadContext context, String lstLine, URI sourceURI)
 	{
+		if (lstLine.startsWith("#"))
+		{
+			//Is a comment
+			return;
+		}
 		if (lstLine.startsWith("AGESET:"))
 		{
 			String line = lstLine.substring(7);
@@ -88,48 +91,55 @@ public final class BioSetLoader extends LstLineFileLoader
 			try
 			{
 				currentAgeSetIndex = Integer.parseInt(ageIndexString);
-				StringTokenizer colToken = new StringTokenizer(line.substring(pipeLoc + 1), SystemLoader.TAB_DELIM);
-				AgeSet ageSet = new AgeSet(colToken.nextToken().intern(), currentAgeSetIndex);
-				while (colToken.hasMoreTokens())
-				{
-					parseTokens(context, ageSet, colToken);
-				}
-
-				ageSet = bioSet.addToAgeMap(region, ageSet, sourceURI);
-				Integer oldIndex = bioSet.addToNameMap(ageSet);
-				if (oldIndex != null && oldIndex != currentAgeSetIndex)
-				{
-					Logging.errorPrint("Incompatible Index for AGESET " + "in Bio Settings " + sourceURI + ": "
-						+ oldIndex + " and " + currentAgeSetIndex + " for " + ageSet.getName());
-				}
-
 			}
 			catch (NumberFormatException e)
 			{
 				Logging.errorPrint("Illegal Index for AGESET " + "in Bio Settings " + sourceURI + ": " + ageIndexString
 					+ " was not an integer");
 			}
+			StringTokenizer colToken = new StringTokenizer(line.substring(pipeLoc + 1), SystemLoader.TAB_DELIM);
+			AgeSet ageSet = new AgeSet();
+			ageSet.setSourceURI(sourceURI);
+			ageSet.setAgeIndex(currentAgeSetIndex);
+			ageSet.setName(colToken.nextToken().intern());
+			while (colToken.hasMoreTokens())
+			{
+				try
+				{
+					LstUtils.processToken(context, ageSet, sourceURI,
+						colToken.nextToken());
+				}
+				catch (PersistenceLayerException e)
+				{
+					Logging.errorPrint(
+						"Error in token parse: " + e.getLocalizedMessage());
+				}
+			}
+
+			ageSet = bioSet.addToAgeMap(region, ageSet, sourceURI);
+			Integer oldIndex = bioSet.addToNameMap(ageSet);
+			if (oldIndex != null && oldIndex != currentAgeSetIndex)
+			{
+				Logging.errorPrint("Incompatible Index for AGESET " + "in Bio Settings " + sourceURI + ": "
+						+ oldIndex + " and " + currentAgeSetIndex + " for " + ageSet.getDisplayName());
+			}
+			
 		}
-		else
+		else if (lstLine.startsWith("REGION:"))
 		{
-			final StringTokenizer colToken = new StringTokenizer(lstLine, SystemLoader.TAB_DELIM);
-			String colString;
-			String raceName = "";
+			region = Optional.of(Region.getConstant(lstLine.substring(7).intern()));
+		}
+		else if (lstLine.startsWith("RACENAME:"))
+		{
+			StringTokenizer colToken = new StringTokenizer(lstLine, SystemLoader.TAB_DELIM);
+			String raceName = colToken.nextToken().substring(9).intern();
 			List<String> preReqList = null;
 
 			while (colToken.hasMoreTokens())
 			{
-				colString = colToken.nextToken();
+				String colString = colToken.nextToken();
 
-				if (colString.startsWith("RACENAME:"))
-				{
-					raceName = colString.substring(9);
-				}
-				else if (colString.startsWith("REGION:"))
-				{
-					region = Optional.of(Region.getConstant(colString.substring(7).intern()));
-				}
-				else if (PreParserFactory.isPreReqString(colString))
+				if (PreParserFactory.isPreReqString(colString))
 				{
 					if (preReqList == null)
 					{
@@ -155,72 +165,14 @@ public final class BioSetLoader extends LstLineFileLoader
 						aString = sBuf.toString();
 					}
 
-					bioSet.addToUserMap(region, raceName.intern(), aString.intern(), currentAgeSetIndex);
+					bioSet.addToUserMap(region, raceName, aString.intern(), currentAgeSetIndex);
 				}
 			}
 		}
-	}
-
-	private void parseTokens(LoadContext context, AgeSet ageSet, StringTokenizer tok)
-	{
-		final PObject dummy = new PObject();
-		try
+		else if (!StringUtils.isEmpty(lstLine))
 		{
-			while (tok.hasMoreTokens())
-			{
-				// in the code below, I use "new String()" to unlink the string from the containing file to save memory,
-				// but I don't intern() the string because it's not fully parsed yet so don't want to add permgen
-				// overhead to a string that's just going to get GC'd eventually
-				//
-				// This pessimization might be removable if we get all impls of CDOMToken.parseToken() to intern. But
-				// right now there are too many of them...
-
-				String currentTok = tok.nextToken();
-				if (currentTok.startsWith("BONUS:"))
-				{
-					if (context.processToken(dummy, "BONUS", new String(currentTok.substring(6))))
-					{
-						context.commit();
-					}
-					else
-					{
-						context.rollback();
-						Logging.errorPrint("Error in BONUS parse: " + currentTok);
-						Logging.replayParsedMessages();
-					}
-				}
-				else if (currentTok.startsWith("KIT:"))
-				{
-					if (context.processToken(dummy, "KIT", new String(currentTok.substring(4))))
-					{
-						context.commit();
-					}
-					else
-					{
-						context.rollback();
-						Logging.errorPrint("Error in KIT parse: " + currentTok);
-						Logging.replayParsedMessages();
-					}
-				}
-				else
-				{
-					Logging.errorPrint("Unexpected token in AGESET: " + currentTok);
-				}
-			}
-			List<BonusObj> bonuses = dummy.getListFor(ListKey.BONUS);
-			if (bonuses != null)
-			{
-				ageSet.addBonuses(bonuses);
-			}
-			List<TransitionChoice<Kit>> kits = dummy.getListFor(ListKey.KIT_CHOICE);
-			if (kits != null)
-			{
-				ageSet.addKits(kits);
-			}
-		}
-		catch (PersistenceLayerException e)
-		{
-			Logging.errorPrint("Error in token parse: " + e.getLocalizedMessage());
+			Logging.errorPrint("Unable to process line " + lstLine
+				+ "in Bio Settings " + sourceURI);
 		}
 	}
 }

--- a/code/src/java/plugin/exporttokens/deprecated/AgeToken.java
+++ b/code/src/java/plugin/exporttokens/deprecated/AgeToken.java
@@ -49,7 +49,7 @@ public class AgeToken extends AbstractExportToken
 		}
 		else if ("AGE.CATEGORY".equals(tokenSource))
 		{
-			retString = display.getAgeSet().getName();
+			retString = display.getAgeSet().getDisplayName();
 		}
 
 		return retString;

--- a/code/src/java/plugin/lsttokens/gamemode/ageset/BonusToken.java
+++ b/code/src/java/plugin/lsttokens/gamemode/ageset/BonusToken.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2019 Tom Parker <thpr@users.sourceforge.net>
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 51 Franklin Street,
+ * Fifth Floor, Boston, MA 02110-1301, USA
+ */
+package plugin.lsttokens.gamemode.ageset;
+
+import java.util.Set;
+import java.util.TreeSet;
+
+import pcgen.core.AgeSet;
+import pcgen.core.bonus.Bonus;
+import pcgen.core.bonus.BonusObj;
+import pcgen.rules.context.LoadContext;
+import pcgen.rules.persistence.token.CDOMPrimaryToken;
+import pcgen.rules.persistence.token.ParseResult;
+
+/**
+ * Implements the BONUS token for AgeSet objects.
+ */
+public class BonusToken implements CDOMPrimaryToken<AgeSet>
+{
+	@Override
+	public String getTokenName()
+	{
+		return "BONUS";
+	}
+
+	@Override
+	public ParseResult parseToken(LoadContext context, AgeSet obj, String value)
+	{
+		BonusObj bon = Bonus.newBonus(context, value);
+		if (bon == null)
+		{
+			return new ParseResult.Fail(
+				getTokenName() + " was given invalid bonus: " + value);
+		}
+		bon.setTokenSource(getTokenName());
+		obj.addBonus(bon);
+		return ParseResult.SUCCESS;
+	}
+
+	@Override
+	public String[] unparse(LoadContext context, AgeSet obj)
+	{
+		String tokenName = getTokenName();
+		Set<String> bonusSet = new TreeSet<>();
+		for (BonusObj bonus : obj.getBonuses())
+		{
+			if (tokenName.equals(bonus.getTokenSource()))
+			{
+				String bonusString = bonus.getLSTformat();
+				bonusSet.add(bonusString);
+			}
+		}
+		if (bonusSet.isEmpty())
+		{
+			// This is okay - just no BONUSes from this token
+			return null;
+		}
+		return bonusSet.toArray(new String[bonusSet.size()]);
+	}
+
+	@Override
+	public Class<AgeSet> getTokenClass()
+	{
+		return AgeSet.class;
+	}
+}

--- a/code/src/java/plugin/lsttokens/gamemode/ageset/KitToken.java
+++ b/code/src/java/plugin/lsttokens/gamemode/ageset/KitToken.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2019 (C) Thomas Parker <thpr@users.sourceforge.net>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+package plugin.lsttokens.gamemode.ageset;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.StringTokenizer;
+import java.util.TreeSet;
+
+import pcgen.base.formula.Formula;
+import pcgen.cdom.base.CDOMObject;
+import pcgen.cdom.base.CDOMReference;
+import pcgen.cdom.base.ChoiceActor;
+import pcgen.cdom.base.ChoiceSet;
+import pcgen.cdom.base.ConcreteTransitionChoice;
+import pcgen.cdom.base.Constants;
+import pcgen.cdom.base.FormulaFactory;
+import pcgen.cdom.base.NonInteractive;
+import pcgen.cdom.base.TransitionChoice;
+import pcgen.cdom.base.Ungranted;
+import pcgen.cdom.choiceset.QualifiedDecorator;
+import pcgen.cdom.choiceset.ReferenceChoiceSet;
+import pcgen.core.AgeSet;
+import pcgen.core.Kit;
+import pcgen.core.PlayerCharacter;
+import pcgen.rules.context.LoadContext;
+import pcgen.rules.persistence.token.AbstractTokenWithSeparator;
+import pcgen.rules.persistence.token.CDOMPrimaryToken;
+import pcgen.rules.persistence.token.ParseResult;
+
+/**
+ * Implements the KIT token for AgeSet objects.
+ */
+public class KitToken extends AbstractTokenWithSeparator<AgeSet>
+		implements CDOMPrimaryToken<AgeSet>, ChoiceActor<Kit>
+{
+
+	private static final Class<Kit> KIT_CLASS = Kit.class;
+
+	@Override
+	public String getTokenName()
+	{
+		return "KIT";
+	}
+
+	@Override
+	protected char separator()
+	{
+		return '|';
+	}
+
+	@Override
+	protected ParseResult parseTokenWithSeparator(LoadContext context, AgeSet obj, String value)
+	{
+		if (obj instanceof Ungranted)
+		{
+			return new ParseResult.Fail(
+				"Cannot use " + getTokenName() + " on an Ungranted object type: " + obj.getClass().getSimpleName());
+		}
+		if (obj instanceof NonInteractive)
+		{
+			return new ParseResult.Fail("Cannot use " + getTokenName() + " on an Non-Interactive object type: "
+				+ obj.getClass().getSimpleName());
+		}
+		StringTokenizer tok = new StringTokenizer(value, Constants.PIPE);
+		Formula count = FormulaFactory.getFormulaFor(tok.nextToken());
+		if (!count.isValid())
+		{
+			return new ParseResult.Fail("Count in " + getTokenName() + " was not valid: " + count.toString());
+		}
+		if (!count.isStatic())
+		{
+			return new ParseResult.Fail("Count in " + getTokenName() + " must be a number");
+		}
+		if (count.resolveStatic().intValue() <= 0)
+		{
+			return new ParseResult.Fail("Count in " + getTokenName() + " must be > 0");
+		}
+		if (!tok.hasMoreTokens())
+		{
+			return new ParseResult.Fail(
+				getTokenName() + " must have a | separating " + "count from the list of possible values: " + value);
+		}
+		List<CDOMReference<Kit>> refs = new ArrayList<>();
+
+		while (tok.hasMoreTokens())
+		{
+			String token = tok.nextToken();
+			CDOMReference<Kit> ref;
+			if (Constants.LST_ALL.equals(token))
+			{
+				ref = context.getReferenceContext().getCDOMAllReference(KIT_CLASS);
+			}
+			else
+			{
+				ref = context.getReferenceContext().getCDOMReference(KIT_CLASS, token);
+			}
+			refs.add(ref);
+		}
+
+		ReferenceChoiceSet<Kit> rcs = new ReferenceChoiceSet<>(refs);
+		if (!rcs.getGroupingState().isValid())
+		{
+			return new ParseResult.Fail(
+				"Non-sensical " + getTokenName() + ": Contains ANY and a specific reference: " + value);
+		}
+		ChoiceSet<Kit> cs = new ChoiceSet<>(getTokenName(), new QualifiedDecorator<>(rcs));
+		cs.setTitle("Kit Selection");
+		TransitionChoice<Kit> tc = new ConcreteTransitionChoice<>(cs, count);
+		obj.addKit(tc);
+		tc.setRequired(false);
+		tc.setChoiceActor(this);
+		return ParseResult.SUCCESS;
+	}
+
+	@Override
+	public String[] unparse(LoadContext context, AgeSet ageSet)
+	{
+		Set<String> set = new TreeSet<>();
+		for (TransitionChoice<Kit> tc : ageSet.getKits())
+		{
+			StringBuilder sb = new StringBuilder();
+			sb.append(tc.getCount());
+			sb.append(Constants.PIPE);
+			sb.append(tc.getChoices().getLSTformat().replaceAll(Constants.COMMA, Constants.PIPE));
+			set.add(sb.toString());
+		}
+		return set.toArray(new String[set.size()]);
+	}
+
+	@Override
+	public Class<AgeSet> getTokenClass()
+	{
+		return AgeSet.class;
+	}
+
+	@Override
+	public void applyChoice(CDOMObject owner, Kit choice, PlayerCharacter pc)
+	{
+		Kit.applyKit(choice, pc);
+	}
+
+	@Override
+	public boolean allow(Kit choice, PlayerCharacter pc, boolean allowStack)
+	{
+		for (Kit k : pc.getKitInfo())
+		{
+			if (k.getKeyName().equalsIgnoreCase(choice.getKeyName()))
+			{
+				return false;
+			}
+		}
+		return true;
+	}
+}

--- a/code/src/utest/pcgen/cdom/facet/analysis/AgeSetFacetTest.java
+++ b/code/src/utest/pcgen/cdom/facet/analysis/AgeSetFacetTest.java
@@ -37,6 +37,9 @@ public class AgeSetFacetTest extends AbstractItemFacetTest<AgeSet>
 	@Override
 	protected AgeSet getItem()
 	{
-		return new AgeSet("AgeSet" + n, n++);
+		AgeSet ageSet = new AgeSet();
+		ageSet.setName("AgeSet" + n);
+		ageSet.setAgeIndex(n++);
+		return ageSet;
 	}
 }


### PR DESCRIPTION
(1) Allows comment lines in BioSettings file (starting with # as other LST files)
(2) Takes the two behaviors of AgeSet and makes them into proper tokens (Avoid Dummy PObjects)
(3) Makes a few stricter changes to BioSettings files
(3a) REGION must be on own line [I think this is done in practice anyway]
(3b) Other functional Lines must start with RACENAME: [I think this is done in practice anyway]
(4) AgeSet is Loadable (zero arg constructor) to enable future work