### PR TITLE
Fix a test equality issue injected during a test conversion.

### DIFF
--- a/code/src/itest/pcgen/io/testsupport/AbstractGlobalTargetedSaveRestoreTest.java
+++ b/code/src/itest/pcgen/io/testsupport/AbstractGlobalTargetedSaveRestoreTest.java
@@ -575,14 +575,14 @@ public abstract class AbstractGlobalTargetedSaveRestoreTest<T extends CDOMObject
 		abil.put(ObjectKey.MULTIPLE_ALLOWED, true);
 		Object o = prepare(target);
 		finishLoad();
-		assertEquals(0.0, SkillRankControl.getTotalRank(pc, granted), 1.0);
+		assertEquals(0.0, SkillRankControl.getTotalRank(pc, granted), 0.1);
 		applyObject(target);
 		pc.setDirty(true);
 		pc.calcActiveBonuses();
-		assertEquals(1.0, SkillRankControl.getTotalRank(pc, granted), 1.0);
+		assertEquals(1.0, SkillRankControl.getTotalRank(pc, granted), 0.1);
 		runRoundRobin(getPreEqualityCleanup());
-		Assert.assertThat((double) SkillRankControl.getTotalRank(pc, granted), closeTo(1.0f, 0.1));
-		Assert.assertThat((double) SkillRankControl.getTotalRank(reloadedPC, granted), closeTo(1.0f, 0.1));
+		assertEquals(1.0, SkillRankControl.getTotalRank(pc, granted), 0.1);
+		assertEquals(1.0, SkillRankControl.getTotalRank(reloadedPC, granted), 0.1);
 		remove(o);
 		reloadedPC.setDirty(true);
 		//This fails (see CODE-2387)


### PR DESCRIPTION
Note the test was testing for +/- 1.0, which is a huge range and would
cause errors to be missed.
Converted two other items to assertEquals that were not converted in
PR #4472 for some reason.