### PR TITLE
Revert change to XMLUnit items

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -177,6 +177,7 @@ dependencies {
     compile group: 'xalan', name: 'xalan', version:'2.7.2'
     compile group: 'net.sourceforge.argparse4j', name: 'argparse4j', version: '0.8.1'
     compile group: 'org.mozilla', name: 'rhino', version:'1.7.10'
+    compile group: 'org.xmlunit', name: 'xmlunit-core', version:'2.6.2'
     compile group: 'xml-apis', name: 'xml-apis', version:'1.3.04'
 
     compile group: 'net.sourceforge.pcgen', name: 'PCGen-base', version:'1.0.170'
@@ -195,8 +196,7 @@ dependencies {
 
     testImplementation group: 'org.hamcrest', name: 'hamcrest', version: '2.1'
 
-    slowtestImplementation group: 'org.xmlunit', name: 'xmlunit-core', version:'2.6.2'
-    slowtestImplementation group: 'org.xmlunit', name: 'xmlunit-matchers', version:'2.6.2'
+    testCompile group: 'org.xmlunit', name: 'xmlunit-matchers', version:'2.6.2'
 }
 
 ant.importBuild 'build-gradle.xml'

--- a/build.gradle
+++ b/build.gradle
@@ -178,7 +178,6 @@ dependencies {
     compile group: 'net.sourceforge.argparse4j', name: 'argparse4j', version: '0.8.1'
     compile group: 'org.mozilla', name: 'rhino', version:'1.7.10'
     compile group: 'org.xmlunit', name: 'xmlunit-core', version:'2.6.2'
-    compile group: 'xml-apis', name: 'xml-apis', version:'1.3.04'
 
     compile group: 'net.sourceforge.pcgen', name: 'PCGen-base', version:'1.0.170'
     compile group: 'net.sourceforge.pcgen', name: 'PCGen-Formula', version:'1.0.200'
@@ -196,6 +195,7 @@ dependencies {
 
     testImplementation group: 'org.hamcrest', name: 'hamcrest', version: '2.1'
 
+    testCompile group: 'xml-apis', name: 'xml-apis', version:'1.3.04'
     testCompile group: 'org.xmlunit', name: 'xmlunit-matchers', version:'2.6.2'
 }
 


### PR DESCRIPTION
Necessary to allow the unit tests to be run by hand in eclipse.
Updated per Eitan's comments on a previous PR.
