### PR TITLE
CODE-3363: avoid exception with missing MOVE type

### DIFF
--- a/code/src/java/pcgen/cdom/facet/analysis/MovementResultFacet.java
+++ b/code/src/java/pcgen/cdom/facet/analysis/MovementResultFacet.java
@@ -147,7 +147,7 @@ public class MovementResultFacet extends AbstractStorageFacet<CharID>
 	{
 		private final Map<MovementType, Double> moveRates = new LinkedHashMap<>();
 
-		public int countMovementTypes()
+		private int countMovementTypes()
 		{
 			return moveRates.size();
 		}
@@ -155,7 +155,7 @@ public class MovementResultFacet extends AbstractStorageFacet<CharID>
 		/**
 		 * recalculate all the move rates and modifiers
 		 */
-		public void adjustMoveRates(CharID id)
+		private void adjustMoveRates(CharID id)
 		{
 			Race race = raceFacet.get(id);
 			if (race == null)
@@ -210,7 +210,7 @@ public class MovementResultFacet extends AbstractStorageFacet<CharID>
 		 * get the base MOVE: plus any bonuses from BONUS:MOVE additions takes
 		 * into account Armor restrictions to movement and load carried
 		 * 
-		 * @param moveIdx
+		 * @param id
 		 * @return movement
 		 */
 		public double movementOfType(CharID id, MovementType moveType)
@@ -311,7 +311,7 @@ public class MovementResultFacet extends AbstractStorageFacet<CharID>
 		 */
 		public double getMovementOfType(MovementType moveType)
 		{
-			return moveRates.get(moveType);
+			return moveRates.getOrDefault(moveType, 0.0);
 		}
 
 		/**

--- a/code/src/utest/pcgen/cdom/facet/analysis/MovementResultFacetTest.java
+++ b/code/src/utest/pcgen/cdom/facet/analysis/MovementResultFacetTest.java
@@ -1,0 +1,21 @@
+package pcgen.cdom.facet.analysis;
+
+import org.junit.jupiter.api.Test;
+import pcgen.cdom.enumeration.CharID;
+import pcgen.cdom.enumeration.DataSetID;
+import pcgen.cdom.enumeration.MovementType;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MovementResultFacetTest {
+
+    @Test
+    void getMovementOfTypeHasZeroDefault() {
+        MovementResultFacet movementResultFacet = new MovementResultFacet();
+        MovementType movementType = MovementType.getConstant("CRAWL");
+        DataSetID datasetID = DataSetID.getID();
+        CharID charID = CharID.getID(datasetID);
+        double movementOfType = movementResultFacet.getMovementOfType(charID, movementType);
+        assertEquals(0.0, movementOfType, 0.1);
+    }
+}


### PR DESCRIPTION
Without this change, the PREREQ testers for movement throw an exception
if they try to find a movement speed the character doesn't have.