### PR TITLE
TokenFamily: avoid swallowing exception source

### DIFF
--- a/code/src/java/pcgen/rules/persistence/util/TokenFamily.java
+++ b/code/src/java/pcgen/rules/persistence/util/TokenFamily.java
@@ -290,33 +290,22 @@ public final class TokenFamily implements Comparable<TokenFamily>
 		typeMap = new TreeMap<>();
 		Class<TokenFamily> cl = TokenFamily.class;
 		Field[] fields = cl.getDeclaredFields();
-		for (int i = 0; i < fields.length; i++)
-		{
-			int mod = fields[i].getModifiers();
+		for (Field field : fields) {
+			int mod = field.getModifiers();
 
-			if (Modifier.isStatic(mod) && Modifier.isFinal(mod) && Modifier.isPublic(mod))
-			{
-				try
-				{
-					Object o = fields[i].get(null);
-					if (cl.equals(o.getClass()))
-					{
+			if (Modifier.isStatic(mod) && Modifier.isFinal(mod) && Modifier.isPublic(mod)) {
+				try {
+					Object o = field.get(null);
+					if (cl.equals(o.getClass())) {
 						TokenFamily tObj = cl.cast(o);
-						if (typeMap.containsKey(tObj.rev))
-						{
+						if (typeMap.containsKey(tObj.rev)) {
 							throw new UnreachableError("Attempt to redefine constant value " + tObj.rev + " to "
-								+ fields[i].getName() + ", value was " + typeMap.get(tObj.rev));
+									+ field.getName() + ", value was " + typeMap.get(tObj.rev));
 						}
 						typeMap.put(tObj.rev, tObj);
 					}
-				}
-				catch (IllegalArgumentException e)
-				{
-					throw new UnreachableError("Attempt to fetch field failed: " + e.getMessage());
-				}
-				catch (IllegalAccessException e)
-				{
-					throw new UnreachableError("Attempt to fetch field failed for access: " + e.getMessage());
+				} catch (IllegalArgumentException | IllegalAccessException e) {
+					throw new UnreachableError("Attempt to fetch field failed: ", e);
 				}
 			}
 		}


### PR DESCRIPTION
Generally we should avoid calling toMessage and adding it to a string.
Instead, we should use it as a 'source' in a Throwable.