### PR TITLE
EquipInfoTab: remove unused buttons

### DIFF
--- a/code/src/java/pcgen/gui2/tabs/EquipInfoTab.java
+++ b/code/src/java/pcgen/gui2/tabs/EquipInfoTab.java
@@ -97,7 +97,6 @@ import org.apache.commons.lang3.StringUtils;
  * character. Each set of distribution information is called an EquipSet.
  * Multiple EquipSets can be managed to reflect different configurations.
  */
-@SuppressWarnings("serial")
 public class EquipInfoTab extends FlippingSplitPane implements CharacterInfoTab, TodoHandler
 {
 
@@ -116,10 +115,6 @@ public class EquipInfoTab extends FlippingSplitPane implements CharacterInfoTab,
 	private final JComboBox equipSetBox;
 	private final JButton newSetButton;
 	private final JButton removeSetButton;
-	private final JButton exportTemplateButton;
-	private final JButton viewBrowserButton;
-	private final JButton exportFileButton;
-	private final JButton setNoteButton;
 	private final JButton expandAllButton;
 	private final JButton collapseAllButton;
 	private final JLabel weightLabel;
@@ -167,10 +162,6 @@ public class EquipInfoTab extends FlippingSplitPane implements CharacterInfoTab,
 		this.equipSetBox = new JComboBox<>();
 		this.newSetButton = new JButton();
 		this.removeSetButton = new JButton();
-		this.exportTemplateButton = new JButton();
-		this.viewBrowserButton = new JButton();
-		this.exportFileButton = new JButton();
-		this.setNoteButton = new JButton();
 		this.expandAllButton = new JButton();
 		this.collapseAllButton = new JButton();
 		this.weightLabel = new JLabel();
@@ -185,11 +176,6 @@ public class EquipInfoTab extends FlippingSplitPane implements CharacterInfoTab,
 		newSetButton.setMargin(new Insets(0, 0, 0, 0));
 		FontManipulation.small(removeSetButton);
 		removeSetButton.setMargin(new Insets(0, 0, 0, 0));
-
-		exportTemplateButton.setText(LanguageBundle.getString("in_equipExportTemplate")); //$NON-NLS-1$
-		viewBrowserButton.setText(LanguageBundle.getString("in_equipViewBrowser")); //$NON-NLS-1$
-		exportFileButton.setText(LanguageBundle.getString("in_equipExportFile")); //$NON-NLS-1$
-		setNoteButton.setText(LanguageBundle.getString("in_equipSetNote")); //$NON-NLS-1$
 
 		setOrientation(HORIZONTAL_SPLIT);
 		FlippingSplitPane splitPane = new FlippingSplitPane(VERTICAL_SPLIT, "EquipMain");
@@ -252,23 +238,12 @@ public class EquipInfoTab extends FlippingSplitPane implements CharacterInfoTab,
 		equipPane.add(box);
 		equipPane.add(Box.createVerticalStrut(3));
 
-		box = Box.createHorizontalBox();
-		box.add(exportTemplateButton);
-		exportTemplateButton.setEnabled(false);
-		box.add(Box.createHorizontalStrut(3));
-		box.add(viewBrowserButton);
-		viewBrowserButton.setEnabled(false);
-		box.add(Box.createHorizontalStrut(3));
-		box.add(exportFileButton);
-		exportFileButton.setEnabled(false);
-		box.add(Box.createHorizontalStrut(3));
-		box.add(setNoteButton);
-		setNoteButton.setEnabled(false);
-		box.add(Box.createHorizontalStrut(3));
-		box.add(expandAllButton);
-		box.add(Box.createHorizontalStrut(3));
-		box.add(collapseAllButton);
-		equipPane.add(box);
+		Box horizontalBox = Box.createHorizontalBox();
+		horizontalBox.add(Box.createHorizontalStrut(3));
+		horizontalBox.add(expandAllButton);
+		horizontalBox.add(Box.createHorizontalStrut(3));
+		horizontalBox.add(collapseAllButton);
+		equipPane.add(horizontalBox);
 		equipPane.add(Box.createVerticalStrut(3));
 
 		panel.add(equipPane, BorderLayout.NORTH);

--- a/code/src/java/pcgen/gui2/tabs/EquipInfoTab.java
+++ b/code/src/java/pcgen/gui2/tabs/EquipInfoTab.java
@@ -172,6 +172,11 @@ public class EquipInfoTab extends FlippingSplitPane implements CharacterInfoTab,
 
 	private void initComponents()
 	{
+		FontManipulation.small(expandAllButton);
+		expandAllButton.setMargin(new Insets(0, -2,0,-2));
+		FontManipulation.small(collapseAllButton);
+		collapseAllButton.setMargin(new Insets(0, -2,0,-2));
+
 		FontManipulation.small(newSetButton);
 		newSetButton.setMargin(new Insets(0, 0, 0, 0));
 		FontManipulation.small(removeSetButton);
@@ -226,25 +231,19 @@ public class EquipInfoTab extends FlippingSplitPane implements CharacterInfoTab,
 		box.add(new JLabel(LanguageBundle.getString("in_equipWeightLabel"))); //$NON-NLS-1$
 		box.add(Box.createHorizontalStrut(5));
 		box.add(weightLabel);
-		box.add(Box.createHorizontalGlue());
+		box.add(Box.createHorizontalStrut(5));
 		box.add(new JLabel(LanguageBundle.getString("in_equipLoadLabel"))); //$NON-NLS-1$
 		box.add(Box.createHorizontalStrut(5));
 		box.add(loadLabel);
 		box.add(Box.createHorizontalStrut(5));
 		box.add(limitLabel);
+		box.add(Box.createHorizontalStrut(3));
+		box.add(expandAllButton);
+		box.add(collapseAllButton);
 		box.add(Box.createHorizontalGlue());
-
-		equipPane.add(Box.createVerticalStrut(3));
 		equipPane.add(box);
-		equipPane.add(Box.createVerticalStrut(3));
 
-		Box horizontalBox = Box.createHorizontalBox();
-		horizontalBox.add(Box.createHorizontalStrut(3));
-		horizontalBox.add(expandAllButton);
-		horizontalBox.add(Box.createHorizontalStrut(3));
-		horizontalBox.add(collapseAllButton);
-		equipPane.add(horizontalBox);
-		equipPane.add(Box.createVerticalStrut(3));
+		box.add(Box.createHorizontalStrut(3));
 
 		panel.add(equipPane, BorderLayout.NORTH);
 

--- a/code/src/java/pcgen/resources/lang/LanguageBundle.properties
+++ b/code/src/java/pcgen/resources/lang/LanguageBundle.properties
@@ -2874,10 +2874,6 @@ in_source_gamemode={0} Mode
 
 # gui2 EquipInfo tab
 in_equipCannotEquipToLocation=The item {0} cannot be equipped to the location {1}
-in_equipExportTemplate=Export Template
-in_equipViewBrowser=View in Browser
-in_equipExportFile=Export to File
-in_equipSetNote=Set Note
 in_equipNodeOverfull=The {0} slot has too many items - some need to be unequipped. 
 
 in_equipListFull=Full Listing

--- a/code/src/java/pcgen/resources/lang/LanguageBundle_es.properties
+++ b/code/src/java/pcgen/resources/lang/LanguageBundle_es.properties
@@ -2876,10 +2876,6 @@ in_source_gamemode={0} Modo
 
 # gui2 EquipInfo tab
 in_equipCannotEquipToLocation=El elemento {0} no se puede equipar en la ubicaci\u00F3n {1}
-in_equipExportTemplate=Exportar Plantilla
-in_equipViewBrowser=Ver en el Navegador
-in_equipExportFile=Exportar a un Archivo
-in_equipSetNote=Conjunto de Notas
 in_equipNodeOverfull=La ranura {0} tiene demasiados elementos - algunos necesitan ser desequipados.
 
 in_equipListFull=Listado Completo

--- a/code/src/java/pcgen/resources/lang/LanguageBundle_fr.properties
+++ b/code/src/java/pcgen/resources/lang/LanguageBundle_fr.properties
@@ -2784,10 +2784,6 @@ in_source_gamemode=Mode {0}
 
 # gui2 EquipInfo tab
 in_equipCannotEquipToLocation=L\u2019objet {0} ne peut \u00EAtre \u00E9quip\u00E9 \u00E0 l\u2019endroit {1}
-in_equipExportTemplate=Exporter un mod\u00E8le
-in_equipViewBrowser=Afficher dans le navigateur
-in_equipExportFile=Exporter vers un fichier
-in_equipSetNote=D\u00E9finir la note
 
 in_equipListFull=Liste compl\u00E8te
 in_equipListUnequipped=Non \u00E9quip\u00E9

--- a/code/src/java/pcgen/resources/lang/LanguageBundle_it.properties
+++ b/code/src/java/pcgen/resources/lang/LanguageBundle_it.properties
@@ -2676,10 +2676,6 @@ in_source_gamemode=Modalit\u00E0 {0}
 
 # gui2 EquipInfo tab
 in_equipCannotEquipToLocation=L'oggetto {0} non pu\u00F2 essere equipaggiato nel posto {1}
-in_equipExportTemplate=Esporta Archetipo
-in_equipViewBrowser=Mostra nel Browser
-in_equipExportFile=Esporta in File
-in_equipSetNote=Imposta Note
 
 in_equipView=Mostra Equipaggiamento
 in_equipSetLabel=Insieme di Equipaggiamento:

--- a/code/src/java/pcgen/resources/lang/cleaned.properties
+++ b/code/src/java/pcgen/resources/lang/cleaned.properties
@@ -2640,10 +2640,6 @@ in_source_gamemode={0} Mode
 
 # gui2 EquipInfo tab
 in_equipCannotEquipToLocation=The item {0} cannot be equipped to the location {1}
-in_equipExportTemplate=Export Template
-in_equipViewBrowser=View in Browser
-in_equipExportFile=Export to File
-in_equipSetNote=Set Note
 
 in_equipView=Equip View
 in_equipSetLabel=Equip Set:


### PR DESCRIPTION
These are four buttons on the EquipInfo Tab that appear to be completely 
unused. It seems they either used to be useful, or only there for a future
plan.

Note that other changes are mostly UI simplifications post-deletion. Ideally this change should be _rebased_ as the deletion and UI changes are two different commits.