### PR TITLE
PCGenActionMenu: delete unsupported actions

### DIFF
--- a/code/src/java/pcgen/gui2/PCGenActionMap.java
+++ b/code/src/java/pcgen/gui2/PCGenActionMap.java
@@ -27,17 +27,8 @@ import javax.swing.ActionMap;
 import javax.swing.JOptionPane;
 
 import gmgen.GMGenSystem;
-import pcgen.core.Kit;
-import pcgen.core.PCClass;
-import pcgen.core.PCStat;
-import pcgen.core.PCTemplate;
-import pcgen.core.Race;
-import pcgen.core.Skill;
-import pcgen.facade.core.AbilityFacade;
 import pcgen.facade.core.CharacterFacade;
-import pcgen.facade.core.ItemFacade;
 import pcgen.facade.core.SourceSelectionFacade;
-import pcgen.facade.core.SpellFacade;
 import pcgen.facade.util.ReferenceFacade;
 import pcgen.facade.util.event.ReferenceEvent;
 import pcgen.facade.util.event.ReferenceListener;
@@ -91,10 +82,7 @@ public final class PCGenActionMap extends ActionMap
 	public static final String EXIT_COMMAND = FILE_COMMAND + ".exit";
 	//the Edit menu commands
 	public static final String EDIT_COMMAND = "edit";
-	public static final String UNDO_COMMAND = EDIT_COMMAND + ".undo";
-	public static final String REDO_COMMAND = EDIT_COMMAND + ".redo";
 	public static final String ADD_KIT_COMMAND = EDIT_COMMAND + ".addkit";
-	public static final String GENERATE_COMMAND = EDIT_COMMAND + ".regenerate";
 	public static final String TEMP_BONUS_COMMAND = EDIT_COMMAND + ".tempbonus";
 	public static final String EQUIPMENTSET_COMMAND = EDIT_COMMAND + ".equipmentset";
 	//the Source menu commands
@@ -106,25 +94,6 @@ public final class PCGenActionMap extends ActionMap
 	public static final String INSTALL_DATA_COMMAND = SOURCES_COMMAND + ".installData";
 	//the tools menu commands
 	public static final String TOOLS_COMMAND = "tools";
-	public static final String FILTERS_COMMAND = TOOLS_COMMAND + ".filters";
-	public static final String KIT_FILTERS_COMMAND = FILTERS_COMMAND + ".kit";
-	public static final String RACE_FILTERS_COMMAND = FILTERS_COMMAND + ".race";
-	public static final String TEMPLATE_FILTERS_COMMAND = FILTERS_COMMAND + ".template";
-	public static final String CLASS_FILTERS_COMMAND = FILTERS_COMMAND + ".class";
-	public static final String ABILITY_FILTERS_COMMAND = FILTERS_COMMAND + ".ability";
-	public static final String SKILL_FILTERS_COMMAND = FILTERS_COMMAND + ".skill";
-	public static final String EQUIPMENT_FILTERS_COMMAND = FILTERS_COMMAND + ".equipment";
-	public static final String SPELL_FILTERS_COMMAND = FILTERS_COMMAND + ".spell";
-	public static final String GENERATORS_COMMAND = TOOLS_COMMAND + ".generators";
-	public static final String TREASURE_GENERATORS_COMMAND = GENERATORS_COMMAND + ".treasure";
-	public static final String RACE_GENERATORS_COMMAND = GENERATORS_COMMAND + ".race";
-	public static final String TEMPLATE_GENERATORS_COMMAND = GENERATORS_COMMAND + ".template";
-	public static final String CLASS_GENERATORS_COMMAND = GENERATORS_COMMAND + ".class";
-	public static final String STAT_GENERATORS_COMMAND = GENERATORS_COMMAND + ".stat";
-	public static final String ABILITY_GENERATORS_COMMAND = GENERATORS_COMMAND + ".ability";
-	public static final String SKILL_GENERATORS_COMMAND = GENERATORS_COMMAND + ".skill";
-	public static final String EQUIPMENT_GENERATORS_COMMAND = GENERATORS_COMMAND + ".equipment";
-	public static final String SPELL_GENERATORS_COMMAND = GENERATORS_COMMAND + ".spell";
 	public static final String PREFERENCES_COMMAND = TOOLS_COMMAND + ".preferences";
 	public static final String GMGEN_COMMAND = TOOLS_COMMAND + ".gmgen";
 	public static final String LOG_COMMAND = TOOLS_COMMAND + ".log";
@@ -134,7 +103,6 @@ public final class PCGenActionMap extends ActionMap
 	public static final String SOLVERVIEW_COMMAND = TOOLS_COMMAND + ".solverview";
 	//the help menu commands
 	public static final String HELP_COMMAND = "help";
-	public static final String HELP_CONTEXT_COMMAND = HELP_COMMAND + ".context";
 	public static final String HELP_DOCS_COMMAND = HELP_COMMAND + ".docs";
 	public static final String HELP_OGL_COMMAND = HELP_COMMAND + ".ogl";
 	public static final String HELP_TIPOFTHEDAY_COMMAND = HELP_COMMAND + ".tod";
@@ -183,10 +151,7 @@ public final class PCGenActionMap extends ActionMap
 		put(EXIT_COMMAND, new ExitAction());
 
 		put(EDIT_COMMAND, new EditAction());
-		put(UNDO_COMMAND, new UndoAction());
-		put(REDO_COMMAND, new RedoAction());
 		put(ADD_KIT_COMMAND, new AddKitAction());
-		put(GENERATE_COMMAND, new GenerateAction());
 		put(EQUIPMENTSET_COMMAND, new EquipmentSetAction());
 		put(TEMP_BONUS_COMMAND, new TempBonusAction());
 		put(PREFERENCES_COMMAND, new PreferencesAction());
@@ -197,49 +162,11 @@ public final class PCGenActionMap extends ActionMap
 		put(COREVIEW_COMMAND, new CoreViewAction());
 		put(SOLVERVIEW_COMMAND, new SolverViewAction());
 		put(INSTALL_DATA_COMMAND, new InstallDataAction());
-		put(FILTERS_COMMAND, new FiltersAction());
-		put(KIT_FILTERS_COMMAND, new DefaultFiltersAction("mnuToolsFiltersKit", KIT_FILTERS_COMMAND, Kit.class));
-		put(RACE_FILTERS_COMMAND,
-			new DefaultFiltersAction("mnuToolsFiltersRace", RACE_FILTERS_COMMAND, Race.class));
-		put(TEMPLATE_FILTERS_COMMAND,
-			new DefaultFiltersAction("mnuToolsFiltersTemplate", TEMPLATE_FILTERS_COMMAND, PCTemplate.class));
-		put(CLASS_FILTERS_COMMAND,
-			new DefaultFiltersAction("mnuToolsFiltersClass", CLASS_FILTERS_COMMAND, PCClass.class));
-		put(ABILITY_FILTERS_COMMAND,
-			new DefaultFiltersAction("mnuToolsFiltersAbility", ABILITY_FILTERS_COMMAND, AbilityFacade.class));
-		put(SKILL_FILTERS_COMMAND,
-			new DefaultFiltersAction("mnuToolsFiltersSkill", SKILL_FILTERS_COMMAND, Skill.class));
-		put(EQUIPMENT_FILTERS_COMMAND,
-			new DefaultFiltersAction("mnuToolsFiltersEquipment", EQUIPMENT_FILTERS_COMMAND, ItemFacade.class));
-		put(SPELL_FILTERS_COMMAND,
-			new DefaultFiltersAction("mnuToolsFiltersSpell", SPELL_GENERATORS_COMMAND, SpellFacade.class));
-		put(SOURCES_COMMAND, new SourcesAction());
-		put(SOURCES_LOAD_COMMAND, new LoadSourcesAction());
 		put(SOURCES_LOAD_SELECT_COMMAND, new LoadSourcesSelectAction());
 		put(SOURCES_RELOAD_COMMAND, new ReloadSourcesAction());
 		put(SOURCES_UNLOAD_COMMAND, new UnloadSourcesAction());
-		put(GENERATORS_COMMAND, new GeneratorsAction());
-		put(TREASURE_GENERATORS_COMMAND, new TreasureGeneratorsAction());
-		put(STAT_GENERATORS_COMMAND,
-			new DefaultGeneratorsAction("mnuToolsGeneratorsStat", STAT_GENERATORS_COMMAND, PCStat.class));
-		put(RACE_GENERATORS_COMMAND,
-			new DefaultGeneratorsAction("mnuToolsGeneratorsRace", RACE_GENERATORS_COMMAND, Race.class));
-		put(TEMPLATE_GENERATORS_COMMAND, new DefaultGeneratorsAction("mnuToolsGeneratorsTemplate",
-			TEMPLATE_GENERATORS_COMMAND, PCTemplate.class));
-		put(CLASS_GENERATORS_COMMAND,
-			new DefaultGeneratorsAction("mnuToolsGeneratorsClass", CLASS_GENERATORS_COMMAND, PCClass.class));
-		put(ABILITY_GENERATORS_COMMAND,
-			new DefaultGeneratorsAction("mnuToolsGeneratorsAbility", ABILITY_GENERATORS_COMMAND, AbilityFacade.class));
-		put(SKILL_GENERATORS_COMMAND,
-			new DefaultGeneratorsAction("mnuToolsGeneratorsSkill", SKILL_GENERATORS_COMMAND, Skill.class));
-		put(EQUIPMENT_GENERATORS_COMMAND,
-			new DefaultGeneratorsAction("mnuToolsGeneratorsEquipment", EQUIPMENT_GENERATORS_COMMAND, ItemFacade.class));
-		put(SPELL_GENERATORS_COMMAND,
-			new DefaultGeneratorsAction("mnuToolsGeneratorsSpell", SPELL_GENERATORS_COMMAND, SpellFacade.class));
-		put(TOOLS_COMMAND, new ToolsAction());
 
 		put(HELP_COMMAND, new HelpAction());
-		put(HELP_CONTEXT_COMMAND, new ContextHelpAction());
 		put(HELP_DOCS_COMMAND, new DocsHelpAction());
 		put(HELP_OGL_COMMAND, new OGLHelpAction());
 		put(HELP_TIPOFTHEDAY_COMMAND, new TipOfTheDayHelpAction());
@@ -252,40 +179,6 @@ public final class PCGenActionMap extends ActionMap
 		public EditAction()
 		{
 			super(MNU_EDIT);
-		}
-
-	}
-
-	private class UndoAction extends PCGenAction//extends CharacterAction
-	{
-
-		public UndoAction()
-		{
-			super("mnuEditUndo", UNDO_COMMAND, "shortcut Z");
-			setEnabled(false);
-		}
-
-		@Override
-		public void actionPerformed(ActionEvent e)
-		{
-			throw new UnsupportedOperationException("Not supported yet.");
-		}
-
-	}
-
-	private class RedoAction extends PCGenAction//extends CharacterAction
-	{
-
-		public RedoAction()
-		{
-			super("mnuEditRedo", REDO_COMMAND, "shortcut Y");
-			setEnabled(false);
-		}
-
-		@Override
-		public void actionPerformed(ActionEvent e)
-		{
-			throw new UnsupportedOperationException("Not supported yet.");
 		}
 
 	}
@@ -305,23 +198,6 @@ public final class PCGenActionMap extends ActionMap
 			KitSelectionDialog kitDialog = new KitSelectionDialog(frame, frame.getSelectedCharacterRef().get());
 			Utility.setComponentRelativeLocation(frame, kitDialog);
 			kitDialog.setVisible(true);
-		}
-
-	}
-
-	private class GenerateAction extends PCGenAction //extends CharacterAction
-	{
-
-		public GenerateAction()
-		{
-			super("mnuEditGenerate");
-			setEnabled(false);
-		}
-
-		@Override
-		public void actionPerformed(ActionEvent e)
-		{
-			throw new UnsupportedOperationException("Not supported yet.");
 		}
 
 	}
@@ -824,32 +700,6 @@ public final class PCGenActionMap extends ActionMap
 
 	}
 
-	private class SourcesAction extends PCGenAction
-	{
-
-		public SourcesAction()
-		{
-			super("mnuSources");
-		}
-
-		@Override
-		public void actionPerformed(ActionEvent e)
-		{
-			throw new UnsupportedOperationException("Not supported yet.");
-		}
-
-	}
-
-	private class LoadSourcesAction extends PCGenAction
-	{
-
-		public LoadSourcesAction()
-		{
-			super("mnuSourcesLoad");
-		}
-
-	}
-
 	private class LoadSourcesSelectAction extends PCGenAction
 	{
 
@@ -934,89 +784,12 @@ public final class PCGenActionMap extends ActionMap
 
 	}
 
-	private class GeneratorsAction extends PCGenAction
-	{
-
-		public GeneratorsAction()
-		{
-			super("mnuToolsGenerators");
-			setEnabled(false);
-		}
-
-	}
-
-	private class FiltersAction extends PCGenAction
-	{
-
-		public FiltersAction()
-		{
-			super("mnuToolsFilters");
-			setEnabled(false);
-		}
-
-		@Override
-		public void actionPerformed(ActionEvent e)
-		{
-			throw new UnsupportedOperationException("Not supported yet.");
-		}
-
-	}
-
-	private class TreasureGeneratorsAction extends PCGenAction
-	{
-
-		public TreasureGeneratorsAction()
-		{
-			super("mnuToolsGeneratorsTreasure", TREASURE_GENERATORS_COMMAND, "shortcut T");
-		}
-
-		@Override
-		public void actionPerformed(ActionEvent e)
-		{
-			throw new UnsupportedOperationException("Not supported yet.");
-		}
-
-	}
-
-	private class ToolsAction extends PCGenAction
-	{
-
-		public ToolsAction()
-		{
-			super(MNU_TOOLS);
-		}
-
-		@Override
-		public void actionPerformed(ActionEvent e)
-		{
-			throw new UnsupportedOperationException("Not supported yet.");
-		}
-
-	}
-
 	private class HelpAction extends PCGenAction
 	{
 
 		public HelpAction()
 		{
 			super("mnuHelp", HELP_COMMAND);
-		}
-
-	}
-
-	private class ContextHelpAction extends PCGenAction
-	{
-
-		public ContextHelpAction()
-		{
-			super("mnuHelpContext", HELP_CONTEXT_COMMAND, Icons.ContextualHelp16);
-			setEnabled(false);
-		}
-
-		@Override
-		public void actionPerformed(ActionEvent e)
-		{
-			throw new UnsupportedOperationException("Not supported yet.");
 		}
 
 	}
@@ -1094,43 +867,6 @@ public final class PCGenActionMap extends ActionMap
 
 	}
 
-	private class DefaultGeneratorsAction extends PCGenAction
-	{
-
-		private final Class<?> generatorClass;
-
-		public DefaultGeneratorsAction(String prop, String command, Class<?> generatorClass)
-		{
-			super(prop, command);
-			this.generatorClass = generatorClass;
-		}
-
-		@Override
-		public void actionPerformed(ActionEvent e)
-		{
-			throw new UnsupportedOperationException("Not supported yet.");
-		}
-
-	}
-
-	private class DefaultFiltersAction extends PCGenAction
-	{
-
-		private final Class<?> filterClass;
-
-		public DefaultFiltersAction(String prop, String command, Class<?> filterClass)
-		{
-			super(prop, command);
-			this.filterClass = filterClass;
-		}
-
-		@Override
-		public void actionPerformed(ActionEvent e)
-		{
-			throw new UnsupportedOperationException("Not supported yet.");
-		}
-
-	}
 
 	private abstract class CharacterAction extends PCGenAction
 	{

--- a/code/src/java/pcgen/gui2/PCGenMenuBar.java
+++ b/code/src/java/pcgen/gui2/PCGenMenuBar.java
@@ -85,7 +85,8 @@ public final class PCGenMenuBar extends JMenuBar implements CharacterSelectionLi
 
 	private JMenu createEditMenu()
 	{
-		JMenu menu = new JMenu(actionMap.get(PCGenActionMap.EDIT_COMMAND));
+		JMenu menu = new JMenu();
+		menu.setText(LanguageBundle.getString("in_mnuEdit"));
 		menu.setMnemonic(KeyEvent.VK_E);
 		menu.add(new JMenuItem(actionMap.get(PCGenActionMap.ADD_KIT_COMMAND)));
 		menu.addSeparator();
@@ -111,7 +112,9 @@ public final class PCGenMenuBar extends JMenuBar implements CharacterSelectionLi
 
 	private JMenu createSourcesMenu()
 	{
-		JMenu menu = new JMenu(actionMap.get(PCGenActionMap.SOURCES_COMMAND));
+		JMenu menu = new JMenu();
+		menu.setText(LanguageBundle.getString("in_mnuSources"));
+		menu.setToolTipText(LanguageBundle.getString("in_mnuSourcesTip"));
 		menu.add(new JMenuItem(actionMap.get(PCGenActionMap.SOURCES_LOAD_SELECT_COMMAND)));
 		menu.addSeparator();
 		menu.add(new QuickSourceMenu());
@@ -126,29 +129,8 @@ public final class PCGenMenuBar extends JMenuBar implements CharacterSelectionLi
 
 	private JMenu createToolsMenu()
 	{
-		JMenu menu = new JMenu(actionMap.get(PCGenActionMap.TOOLS_COMMAND));
-
-		JMenu filtersMenu = new JMenu(actionMap.get(PCGenActionMap.FILTERS_COMMAND));
-		filtersMenu.add(new JMenuItem(actionMap.get(PCGenActionMap.KIT_FILTERS_COMMAND)));
-		filtersMenu.add(new JMenuItem(actionMap.get(PCGenActionMap.RACE_FILTERS_COMMAND)));
-		filtersMenu.add(new JMenuItem(actionMap.get(PCGenActionMap.CLASS_FILTERS_COMMAND)));
-		filtersMenu.add(new JMenuItem(actionMap.get(PCGenActionMap.ABILITY_FILTERS_COMMAND)));
-		filtersMenu.add(new JMenuItem(actionMap.get(PCGenActionMap.SKILL_FILTERS_COMMAND)));
-		filtersMenu.add(new JMenuItem(actionMap.get(PCGenActionMap.EQUIPMENT_FILTERS_COMMAND)));
-		filtersMenu.add(new JMenuItem(actionMap.get(PCGenActionMap.SPELL_FILTERS_COMMAND)));
-		filtersMenu.add(new JMenuItem(actionMap.get(PCGenActionMap.TEMPLATE_FILTERS_COMMAND)));
-
-		JMenu generatorsMenu = new JMenu(actionMap.get(PCGenActionMap.GENERATORS_COMMAND));
-		generatorsMenu.add(new JMenuItem(actionMap.get(PCGenActionMap.TREASURE_GENERATORS_COMMAND)));
-		generatorsMenu.addSeparator();
-		generatorsMenu.add(new JMenuItem(actionMap.get(PCGenActionMap.STAT_GENERATORS_COMMAND)));
-		generatorsMenu.add(new JMenuItem(actionMap.get(PCGenActionMap.RACE_GENERATORS_COMMAND)));
-		generatorsMenu.add(new JMenuItem(actionMap.get(PCGenActionMap.CLASS_GENERATORS_COMMAND)));
-		generatorsMenu.add(new JMenuItem(actionMap.get(PCGenActionMap.ABILITY_GENERATORS_COMMAND)));
-		generatorsMenu.add(new JMenuItem(actionMap.get(PCGenActionMap.SKILL_GENERATORS_COMMAND)));
-		generatorsMenu.add(new JMenuItem(actionMap.get(PCGenActionMap.EQUIPMENT_GENERATORS_COMMAND)));
-		generatorsMenu.add(new JMenuItem(actionMap.get(PCGenActionMap.SPELL_GENERATORS_COMMAND)));
-		generatorsMenu.add(new JMenuItem(actionMap.get(PCGenActionMap.TEMPLATE_GENERATORS_COMMAND)));
+		JMenu menu = new JMenu();
+		menu.setText(LanguageBundle.getString("in_mnuTools"));
 		menu.add(new JMenuItem(actionMap.get(PCGenActionMap.PREFERENCES_COMMAND)));
 		menu.addSeparator();
 		menu.add(new JMenuItem(actionMap.get(PCGenActionMap.GMGEN_COMMAND)));
@@ -163,7 +145,8 @@ public final class PCGenMenuBar extends JMenuBar implements CharacterSelectionLi
 
 	private JMenu createHelpMenu()
 	{
-		JMenu menu = new JMenu(actionMap.get(PCGenActionMap.HELP_COMMAND));
+		JMenu menu = new JMenu();
+		menu.setText(LanguageBundle.getString("in_mnuHelp"));
 		menu.add(new JMenuItem(actionMap.get(PCGenActionMap.HELP_DOCS_COMMAND)));
 		menu.addSeparator();
 		menu.add(new JMenuItem(actionMap.get(PCGenActionMap.HELP_OGL_COMMAND)));
@@ -269,13 +252,17 @@ public final class PCGenMenuBar extends JMenuBar implements CharacterSelectionLi
 
 	}
 
-	private class QuickSourceMenu extends AbstractRadioListMenu<SourceSelectionFacade>
+	private final class QuickSourceMenu extends AbstractRadioListMenu<SourceSelectionFacade>
 			implements ReferenceListener<SourceSelectionFacade>
 	{
 
-		public QuickSourceMenu()
+		private QuickSourceMenu()
 		{
+
 			super(actionMap.get(PCGenActionMap.SOURCES_LOAD_COMMAND));
+			super.setText(LanguageBundle.getString("in_mnuSourcesLoad"));
+
+
 			ReferenceFacade<SourceSelectionFacade> ref = uiContext.getCurrentSourceSelectionRef();
 			setSelectedItem(ref.get());
 			ListFacade<SourceSelectionFacade> sources = FacadeFactory.getDisplayedSourceSelections();


### PR DESCRIPTION
I'd be happy to work on or implement some of these in the future, but
its confusing when you accidentally press a key to see an exception.
Also, it makes it seem like there is more implemented than actually
exists.

This also adds missing tooltips and missing localization to menu items.