### PR TITLE
[CoreUtility] speed up file reading.

### DIFF
--- a/code/src/java/pcgen/core/utils/CoreUtility.java
+++ b/code/src/java/pcgen/core/utils/CoreUtility.java
@@ -116,12 +116,10 @@ public final class CoreUtility
 	{
 		switch (url.getProtocol().toLowerCase(Locale.ENGLISH))
 		{
-			case "http":
-			case "ftp":
-			case "https":
-				return true;
-			default:
+			case "file":
 				return false;
+			default:
+				return true;
 		}
 	}
 

--- a/code/src/java/pcgen/gui2/converter/LSTConverter.java
+++ b/code/src/java/pcgen/gui2/converter/LSTConverter.java
@@ -299,7 +299,7 @@ public class LSTConverter extends Observable
 
 	private String load(URI uri, Loader loader) throws InterruptedException, PersistenceLayerException
 	{
-		StringBuilder dataBuffer;
+		String dataBuffer;
 		context.setSourceURI(uri);
 		context.setExtractURI(uri);
 		try
@@ -315,7 +315,7 @@ public class LSTConverter extends Observable
 		}
 
 		StringBuilder resultBuffer = new StringBuilder(dataBuffer.length());
-		final String aString = dataBuffer.toString();
+		final String aString = dataBuffer;
 
 		String[] fileLines = aString.split(LstFileLoader.LINE_SEPARATOR_REGEXP);
 		for (int line = 0; line < fileLines.length; line++)

--- a/code/src/java/pcgen/persistence/SourceFileLoader.java
+++ b/code/src/java/pcgen/persistence/SourceFileLoader.java
@@ -270,8 +270,8 @@ public class SourceFileLoader extends PCGenTask implements Observer
 		{
 			try
 			{
-				StringBuilder dataBuffer = LstFileLoader.readFromURI(licenseFile.getURI());
-				licenses.add(dataBuffer.toString());
+				String dataBuffer = LstFileLoader.readFromURI(licenseFile.getURI());
+				licenses.add(dataBuffer);
 			}
 			catch (PersistenceLayerException e)
 			{
@@ -300,12 +300,9 @@ public class SourceFileLoader extends PCGenTask implements Observer
 	 */
 	private int countTotalFilesToLoad()
 	{
-		int count = 0;
-		for (ListKey<?> lk : fileLists.getKeySet())
-		{
-			count += fileLists.sizeOfListFor(lk);
-		}
-		return count;
+		return fileLists.getKeySet().stream()
+		                .mapToInt(fileLists::sizeOfListFor)
+		                .sum();
 	}
 
 	private void addCustomFilesToStartOfList()

--- a/code/src/java/pcgen/persistence/lst/LstLineFileLoader.java
+++ b/code/src/java/pcgen/persistence/lst/LstLineFileLoader.java
@@ -59,13 +59,12 @@ public abstract class LstLineFileLoader extends Observable
 	 */
 	public void loadLstFile(LoadContext context, URI uri) throws PersistenceLayerException
 	{
-		StringBuilder dataBuffer = LstFileLoader.readFromURI(uri);
-		final String aString = dataBuffer.toString();
+		String dataBuffer = LstFileLoader.readFromURI(uri);
 		if (context != null)
 		{
 			context.setSourceURI(uri);
 		}
-		loadLstString(context, uri, aString);
+		loadLstString(context, uri, dataBuffer);
 	}
 
 	/**

--- a/code/src/java/pcgen/persistence/lst/LstObjectFileLoader.java
+++ b/code/src/java/pcgen/persistence/lst/LstObjectFileLoader.java
@@ -304,7 +304,7 @@ public abstract class LstObjectFileLoader<T extends CDOMObject> extends Observab
 		setChanged();
 		URI uri = sourceEntry.getURI();
 		notifyObservers(uri);
-		StringBuilder dataBuffer;
+		String dataBuffer;
 		try
 		{
 			dataBuffer = LstFileLoader.readFromURI(uri);
@@ -317,7 +317,7 @@ public abstract class LstObjectFileLoader<T extends CDOMObject> extends Observab
 			setChanged();
 			return;
 		}
-		String aString = dataBuffer.toString();
+		String aString = dataBuffer;
 		if (context != null)
 		{
 			context.setSourceURI(uri);

--- a/code/src/java/pcgen/persistence/lst/VariableLoader.java
+++ b/code/src/java/pcgen/persistence/lst/VariableLoader.java
@@ -101,7 +101,7 @@ public class VariableLoader extends Observable
 		URI uri = sourceEntry.getURI();
 		notifyObservers(uri);
 
-		StringBuilder dataBuffer;
+		String dataBuffer;
 
 		try
 		{
@@ -116,7 +116,7 @@ public class VariableLoader extends Observable
 			return;
 		}
 
-		String aString = dataBuffer.toString();
+		String aString = dataBuffer;
 		if (context != null)
 		{
 			context.setSourceURI(uri);
@@ -163,7 +163,6 @@ public class VariableLoader extends Observable
 					if (Logging.isDebugMode())
 					{
 						Logging.errorPrint(LanguageBundle.getString("Errors.LstFileLoader.Ignoring"), t);
-						t.printStackTrace();
 					}
 				}
 			}


### PR DESCRIPTION
The previous code makes an attempt to be fast by reading into a
StringBuilder and using a buffer, but in reality the JVM can do a better
job than we can.

We can do even better if we were to hide the 'reader' abstraction and
handle files differently from net URLs.

- while here: fix a security issue where we default to assuming URLs are
non-net. This would break with e.g. h2 or QUIC schemes.