### PR TITLE
PCGenStatusBar: only react to click, not release

### DIFF
--- a/code/src/java/pcgen/gui2/PCGenStatusBar.java
+++ b/code/src/java/pcgen/gui2/PCGenStatusBar.java
@@ -180,7 +180,7 @@ public final class PCGenStatusBar extends JPanel
 	private class LoadStatusMouseAdapter extends MouseAdapter
 	{
 		@Override
-		public void mouseReleased(MouseEvent arg0)
+		public void mouseClicked(MouseEvent arg0)
 		{
 			frame.getActionMap().get(PCGenActionMap.LOG_COMMAND).actionPerformed(null);
 		}


### PR DESCRIPTION
When the mouse is released after being moved, most users don't expect
the UI to react. Override the correct item to react to this.