### PR TITLE
[*] avoid calling string.intern()

### DIFF
--- a/code/src/java/pcgen/core/Equipment.java
+++ b/code/src/java/pcgen/core/Equipment.java
@@ -2988,7 +2988,7 @@ public final class Equipment extends PObject
 
 			if (aString.startsWith("NAME" + endPart))
 			{
-				setName(aString.substring(4 + endPartLen).intern());
+				setName(aString.substring(4 + endPartLen));
 				put(StringKey.OUTPUT_NAME, getDisplayName());
 			}
 			else if (aString.startsWith("KEY" + endPart))

--- a/code/src/java/pcgen/core/bonus/Bonus.java
+++ b/code/src/java/pcgen/core/bonus/Bonus.java
@@ -122,10 +122,10 @@ public final class Bonus
 			return null;
 		}
 
-		aBonus.putOriginalString(bonusString.intern());
-		aBonus.setBonusName(bonusName.intern());
-		aBonus.setTypeOfBonus(typeOfBonus.intern());
-		Formula val = aBonus.setValue(bValue.intern());
+		aBonus.putOriginalString(bonusString);
+		aBonus.setBonusName(bonusName);
+		aBonus.setTypeOfBonus(typeOfBonus);
+		Formula val = aBonus.setValue(bValue);
 		if (!val.isValid())
 		{
 			Logging.errorPrint(
@@ -173,7 +173,7 @@ public final class Bonus
 						aBonus.setStackingFlag(StackType.STACK);
 					}
 				}
-				final boolean result = aBonus.addType(bonusType.intern());
+				final boolean result = aBonus.addType(bonusType);
 
 				if (!result)
 				{
@@ -188,7 +188,7 @@ public final class Bonus
 
 		if (equalOffset >= 0)
 		{
-			aBonus.setVariable(bonusName.substring(equalOffset + 1).intern());
+			aBonus.setVariable(bonusName.substring(equalOffset + 1));
 		}
 
 		if (!aBonus.requiresRealCaseTarget())

--- a/code/src/java/pcgen/persistence/lst/AbilityLoader.java
+++ b/code/src/java/pcgen/persistence/lst/AbilityLoader.java
@@ -53,7 +53,7 @@ public class AbilityLoader extends LstObjectFileLoader<Ability>
 
 		if (colToken.hasMoreTokens())
 		{
-			anAbility.setName(colToken.nextToken().intern());
+			anAbility.setName(colToken.nextToken());
 			anAbility.put(ObjectKey.SOURCE_CAMPAIGN, source.getCampaign());
 			anAbility.setSourceURI(source.getURI());
 			List<String> additionalTokens = new ArrayList<>();

--- a/code/src/java/pcgen/persistence/lst/BioSetLoader.java
+++ b/code/src/java/pcgen/persistence/lst/BioSetLoader.java
@@ -101,7 +101,7 @@ public final class BioSetLoader extends LstLineFileLoader
 			AgeSet ageSet = new AgeSet();
 			ageSet.setSourceURI(sourceURI);
 			ageSet.setAgeIndex(currentAgeSetIndex);
-			ageSet.setName(colToken.nextToken().intern());
+			ageSet.setName(colToken.nextToken());
 			while (colToken.hasMoreTokens())
 			{
 				try
@@ -127,12 +127,12 @@ public final class BioSetLoader extends LstLineFileLoader
 		}
 		else if (lstLine.startsWith("REGION:"))
 		{
-			region = Optional.of(Region.getConstant(lstLine.substring(7).intern()));
+			region = Optional.of(Region.getConstant(lstLine.substring(7)));
 		}
 		else if (lstLine.startsWith("RACENAME:"))
 		{
 			StringTokenizer colToken = new StringTokenizer(lstLine, SystemLoader.TAB_DELIM);
-			String raceName = colToken.nextToken().substring(9).intern();
+			String raceName = colToken.nextToken().substring(9);
 			List<String> preReqList = null;
 
 			while (colToken.hasMoreTokens())
@@ -165,7 +165,7 @@ public final class BioSetLoader extends LstLineFileLoader
 						aString = sBuf.toString();
 					}
 
-					bioSet.addToUserMap(region, raceName, aString.intern(), currentAgeSetIndex);
+					bioSet.addToUserMap(region, raceName, aString, currentAgeSetIndex);
 				}
 			}
 		}

--- a/code/src/java/pcgen/persistence/lst/GenericLoader.java
+++ b/code/src/java/pcgen/persistence/lst/GenericLoader.java
@@ -48,13 +48,9 @@ public class GenericLoader<T extends CDOMObject> extends LstObjectFileLoader<T>
 					"Class for GenericLoader must have public zero-argument constructor");
 			}
 		}
-		catch (SecurityException e)
+		catch (SecurityException | NoSuchMethodException e)
 		{
-			throw new IllegalArgumentException("Class for GenericLoader must have public zero-argument constructor");
-		}
-		catch (NoSuchMethodException e)
-		{
-			throw new IllegalArgumentException("Class for GenericLoader must have zero-argument constructor");
+			throw new IllegalArgumentException("Class for GenericLoader must have public zero-argument constructor", e);
 		}
 		baseClass = cl;
 	}
@@ -70,7 +66,6 @@ public class GenericLoader<T extends CDOMObject> extends LstObjectFileLoader<T>
 			try
 			{
 				po = baseClass.newInstance();
-				newConstructionActions(context, po);
 			}
 			catch (InstantiationException | IllegalAccessException e)
 			{
@@ -86,7 +81,7 @@ public class GenericLoader<T extends CDOMObject> extends LstObjectFileLoader<T>
 		final StringTokenizer colToken = new StringTokenizer(lstLine, SystemLoader.TAB_DELIM);
 		if (colToken.hasMoreTokens())
 		{
-			po.setName(colToken.nextToken().intern());
+			po.setName(colToken.nextToken());
 			po.put(ObjectKey.SOURCE_CAMPAIGN, source.getCampaign());
 			po.setSourceURI(source.getURI());
 			if (isnew)
@@ -104,11 +99,6 @@ public class GenericLoader<T extends CDOMObject> extends LstObjectFileLoader<T>
 		// One line each; finish the object and return null
 		completeObject(context, source, po);
 		return null;
-	}
-
-	protected void newConstructionActions(LoadContext context, T po)
-	{
-		//Nothing by default
 	}
 
 	@Override

--- a/code/src/java/pcgen/persistence/lst/KitLoader.java
+++ b/code/src/java/pcgen/persistence/lst/KitLoader.java
@@ -103,7 +103,7 @@ public final class KitLoader extends LstObjectFileLoader<Kit>
 			String firstToken = st.nextToken();
 			int colonLoc = firstToken.indexOf(':');
 			target = context.getReferenceContext().constructCDOMObject(Kit.class,
-				firstToken.substring(colonLoc + 1).intern());
+				firstToken.substring(colonLoc + 1));
 			target.put(ObjectKey.SOURCE_CAMPAIGN, source.getCampaign());
 			target.setSourceURI(source.getURI());
 			context.addStatefulInformation(target);
@@ -126,7 +126,7 @@ public final class KitLoader extends LstObjectFileLoader<Kit>
 
 				String key = token.substring(0, cLoc);
 				String value = (cLoc == token.length() - 1) ? null : token.substring(cLoc + 1);
-				if (context.processToken(target, key.intern(), value.intern()))
+				if (context.processToken(target, key, value))
 				{
 					context.commit();
 				}
@@ -149,7 +149,7 @@ public final class KitLoader extends LstObjectFileLoader<Kit>
 				if (!region.equalsIgnoreCase(Constants.LST_NONE))
 				{
 					// Add a real prereq for the REGION: tag
-					if (context.addStatefulToken("PREREGION:" + region.intern()))
+					if (context.addStatefulToken("PREREGION:" + region))
 					{
 						context.commit();
 					}
@@ -166,7 +166,7 @@ public final class KitLoader extends LstObjectFileLoader<Kit>
 				while (st.hasMoreTokens())
 				{
 					String gt = st.nextToken();
-					if (!context.addStatefulToken(gt.intern()))
+					if (!context.addStatefulToken(gt))
 					{
 						Logging.errorPrint(
 							"Invalid Stateful Token: '" + gt + "' on line :" + inputLine + " in " + source.getURI());

--- a/code/src/java/pcgen/persistence/lst/LevelLoader.java
+++ b/code/src/java/pcgen/persistence/lst/LevelLoader.java
@@ -73,7 +73,6 @@ public final class LevelLoader
 			}
 			else
 			{
-				value = value.intern();
 				gameMode.addXPTableName(value);
 				return value;
 			}
@@ -108,7 +107,7 @@ public final class LevelLoader
 
 			if (token != null)
 			{
-				final String value = colString.substring(idxColon + 1).intern();
+				final String value = colString.substring(idxColon + 1);
 				LstUtils.deprecationCheck(token, levelInfo.getLevelString(), source, value);
 				if (!token.parse(levelInfo, value))
 				{

--- a/code/src/java/pcgen/persistence/lst/LstUtils.java
+++ b/code/src/java/pcgen/persistence/lst/LstUtils.java
@@ -134,8 +134,8 @@ public final class LstUtils
 			return false;
 		}
 
-		String key = token.substring(0, colonLoc).intern();
-		String value = (colonLoc == token.length() - 1) ? null : token.substring(colonLoc + 1).intern();
+		String key = token.substring(0, colonLoc);
+		String value = (colonLoc == (token.length() - 1)) ? null : token.substring(colonLoc + 1);
 		boolean successful = context.processToken(po, key, value);
 		if (successful)
 		{

--- a/code/src/java/pcgen/persistence/lst/PCClassLoader.java
+++ b/code/src/java/pcgen/persistence/lst/PCClassLoader.java
@@ -67,7 +67,7 @@ public final class PCClassLoader extends LstObjectFileLoader<PCClass>
 				if (subClass == null)
 				{
 					subClass = new SubClass();
-					subClass.setName(n.intern());
+					subClass.setName(n);
 					subClass.put(ObjectKey.SOURCE_CAMPAIGN, source.getCampaign());
 					subClass.setSourceURI(source.getURI());
 					target.addSubClass(subClass);
@@ -81,7 +81,7 @@ public final class PCClassLoader extends LstObjectFileLoader<PCClass>
 				{
 					subClass = subClassList.get(subClassList.size() - 1);
 					subClass.addToListFor(ListKey.SUB_CLASS_LEVEL,
-						new DeferredLine(source, lstLine.substring(14).intern()));
+						new DeferredLine(source, lstLine.substring(14)));
 				}
 			}
 			return target;
@@ -117,7 +117,7 @@ public final class PCClassLoader extends LstObjectFileLoader<PCClass>
 				if (substitutionClass == null)
 				{
 					substitutionClass = new SubstitutionClass();
-					substitutionClass.setName(name.intern());
+					substitutionClass.setName(name);
 					substitutionClass.put(ObjectKey.SOURCE_CAMPAIGN, source.getCampaign());
 					substitutionClass.setSourceURI(source.getURI());
 					target.addSubstitutionClass(substitutionClass);
@@ -136,7 +136,7 @@ public final class PCClassLoader extends LstObjectFileLoader<PCClass>
 				{
 					substitutionClass = substitutionClassList.get(substitutionClassList.size() - 1);
 					substitutionClass.addToListFor(ListKey.SUB_CLASS_LEVEL,
-						new DeferredLine(source, lstLine.substring(18).intern()));
+						new DeferredLine(source, lstLine.substring(18)));
 				}
 			}
 			return target;
@@ -173,7 +173,7 @@ public final class PCClassLoader extends LstObjectFileLoader<PCClass>
 					completeObject(context, source, pcClass);
 				}
 				pcClass = new PCClass();
-				pcClass.setName(name.intern());
+				pcClass.setName(name);
 				pcClass.setSourceURI(source.getURI());
 				pcClass.put(ObjectKey.SOURCE_CAMPAIGN, source.getCampaign());
 				context.addStatefulInformation(pcClass);
@@ -183,7 +183,7 @@ public final class PCClassLoader extends LstObjectFileLoader<PCClass>
 			else if (name.endsWith(".MOD"))
 			{
 				pcClass = context.getReferenceContext().silentlyGetConstructedCDOMObject(PCClass.class,
-					name.substring(0, name.length() - 4).intern());
+					name.substring(0, name.length() - 4));
 			}
 			parseLineIntoClass(context, pcClass, source, restOfLine);
 		}
@@ -275,7 +275,7 @@ public final class PCClassLoader extends LstObjectFileLoader<PCClass>
 
 			String key = token.substring(0, colonLoc);
 			String value = (colonLoc == token.length() - 1) ? null : token.substring(colonLoc + 1);
-			if (context.processToken(classlevel, key.intern(), value.intern()))
+			if (context.processToken(classlevel, key, value))
 			{
 				context.commit();
 			}
@@ -317,7 +317,7 @@ public final class PCClassLoader extends LstObjectFileLoader<PCClass>
 
 			String key = token.substring(0, colonLoc);
 			String value = (colonLoc == token.length() - 1) ? null : token.substring(colonLoc + 1);
-			if (context.processToken(pcClass, key.intern(), value.intern()))
+			if (context.processToken(pcClass, key, value))
 			{
 				context.commit();
 			}

--- a/code/src/java/pcgen/persistence/lst/VariableLoader.java
+++ b/code/src/java/pcgen/persistence/lst/VariableLoader.java
@@ -45,7 +45,7 @@ public class VariableLoader extends Observable
 		//Need the IF so that it is not an empty line causing issues
 		if (colToken.hasMoreTokens())
 		{
-			String tok = colToken.nextToken().intern();
+			String tok = colToken.nextToken();
 			if (tok.indexOf(':') == -1)
 			{
 				tok = "GLOBAL:" + tok;

--- a/code/src/java/pcgen/rules/context/LoadContextInst.java
+++ b/code/src/java/pcgen/rules/context/LoadContextInst.java
@@ -447,7 +447,7 @@ abstract class LoadContextInst implements LoadContext
 		{
 			stateful = new ObjectCache();
 		}
-		return processToken(stateful, s.substring(0, colonLoc).intern(), s.substring(colonLoc + 1).intern());
+		return processToken(stateful, s.substring(0, colonLoc), s.substring(colonLoc + 1));
 	}
 
 	@Override

--- a/code/src/java/plugin/lsttokens/eqslot/NumslotsToken.java
+++ b/code/src/java/plugin/lsttokens/eqslot/NumslotsToken.java
@@ -37,8 +37,8 @@ public class NumslotsToken implements EquipSlotLstToken
 
 			if (cTok.countTokens() == 2)
 			{
-				final String eqSlotType = cTok.nextToken().intern();
-				final String aNum = cTok.nextToken().intern();
+				final String eqSlotType = cTok.nextToken();
+				final String aNum = cTok.nextToken();
 				if (!getTokenName().equals(eqSlotType))
 				{
 					Globals.setEquipSlotTypeCount(eqSlotType, aNum);

--- a/code/src/java/plugin/lsttokens/gamemode/MenuentryToken.java
+++ b/code/src/java/plugin/lsttokens/gamemode/MenuentryToken.java
@@ -20,7 +20,7 @@ public class MenuentryToken implements GameModeLstToken
 	@Override
 	public boolean parse(GameMode gameMode, String value, URI source)
 	{
-		gameMode.setModeName(value.replace('|', '\n').intern());
+		gameMode.setModeName(value.replace('|', '\n'));
 		return true;
 	}
 }


### PR DESCRIPTION
See https://shipilev.net/jvm/anatomy-quarks/10-string-intern for some
useful information.  In addition, we don't actually rely on the strings
being interned (equality check is usually done via .equals() instead of
==).