### PR TITLE
[SpellFacade] pull public functions into interface

### DIFF
--- a/code/src/java/pcgen/core/character/CharacterSpell.java
+++ b/code/src/java/pcgen/core/character/CharacterSpell.java
@@ -191,15 +191,9 @@ public final class CharacterSpell implements Comparable<CharacterSpell>
 		{
 			return false;
 		}
-		for (SpellInfo s : infoList)
-		{
-			if (s.getActualLevel() == level)
-			{
-				return true;
-			}
-		}
 
-		return false;
+		return infoList.stream()
+		               .anyMatch(spellInfo -> spellInfo.getActualLevel() == level);
 	}
 
 	public boolean hasSpellInfoFor(String bookName)

--- a/code/src/java/pcgen/core/character/SpellInfo.java
+++ b/code/src/java/pcgen/core/character/SpellInfo.java
@@ -18,6 +18,7 @@
 package pcgen.core.character;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import pcgen.core.Ability;
@@ -134,7 +135,7 @@ public final class SpellInfo implements Comparable<SpellInfo>
 		this.numPages = numPages;
 	}
 
-	public void addFeatsToList(final List<Ability> aList)
+	public void addFeatsToList(final Collection<Ability> aList)
 	{
 		if (featList == null)
 		{

--- a/code/src/java/pcgen/facade/core/SpellFacade.java
+++ b/code/src/java/pcgen/facade/core/SpellFacade.java
@@ -17,6 +17,9 @@
  */
 package pcgen.facade.core;
 
+import pcgen.core.character.CharacterSpell;
+import pcgen.core.character.SpellInfo;
+
 public interface SpellFacade extends InfoFacade
 {
 
@@ -36,5 +39,9 @@ public interface SpellFacade extends InfoFacade
 	 * @return The tme it takes to cast the spell.
 	 */
 	public String getCastTime();
+
+	public CharacterSpell getCharSpell();
+
+	public SpellInfo getSpellInfo();
 
 }

--- a/code/src/java/pcgen/gui2/facade/Gui2InfoFactory.java
+++ b/code/src/java/pcgen/gui2/facade/Gui2InfoFactory.java
@@ -28,6 +28,7 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -1592,14 +1593,9 @@ public class Gui2InfoFactory implements InfoFactory
 	@Override
 	public String getHTMLInfo(SpellFacade spell)
 	{
-		if (spell == null || !(spell instanceof SpellFacadeImplem))
-		{
-			return EMPTY_STRING;
-		}
-
-		SpellFacadeImplem sfi = (SpellFacadeImplem) spell;
-		CharacterSpell cs = sfi.getCharSpell();
-		SpellInfo si = sfi.getSpellInfo();
+		Objects.requireNonNull(spell);
+		CharacterSpell cs = spell.getCharSpell();
+		SpellInfo si = spell.getSpellInfo();
 		Spell aSpell = cs.getSpell();
 
 		if (aSpell == null)
@@ -1759,7 +1755,7 @@ public class Gui2InfoFactory implements InfoFactory
 					}
 					int level = spellInfo.getActualLevel();
 
-					int count = spellCountMap.containsKey(level) ? spellCountMap.get(level) : 0;
+					int count = spellCountMap.getOrDefault(level, 0);
 					count += spellInfo.getTimes();
 					spellCountMap.put(level, count);
 					if (level > highestSpellLevel)
@@ -1788,7 +1784,7 @@ public class Gui2InfoFactory implements InfoFactory
 				for (int i = 0; i <= highestSpellLevel; ++i)
 				{
 					b.append("<td><font size=-1><center>"); //$NON-NLS-1$
-					b.append(String.valueOf(spellCountMap.get(i) == null ? 0 : spellCountMap.get(i)));
+					b.append(String.valueOf(spellCountMap.getOrDefault(i, 0)));
 					b.append("</center></font></td>"); //$NON-NLS-1$
 				}
 				b.append("</tr></table>"); //$NON-NLS-1$

--- a/code/src/java/pcgen/gui2/facade/SpellFacadeImplem.java
+++ b/code/src/java/pcgen/gui2/facade/SpellFacadeImplem.java
@@ -129,7 +129,8 @@ public class SpellFacadeImplem implements SpellFacade, SortKeyAware
 	/**
 	 * @return the charSpell
 	 */
-	CharacterSpell getCharSpell()
+	@Override
+	public CharacterSpell getCharSpell()
 	{
 		return charSpell;
 	}
@@ -137,7 +138,8 @@ public class SpellFacadeImplem implements SpellFacade, SortKeyAware
 	/**
 	 * @return the spellInfo
 	 */
-	SpellInfo getSpellInfo()
+	@Override
+	public SpellInfo getSpellInfo()
 	{
 		return spellInfo;
 	}
@@ -148,19 +150,19 @@ public class SpellFacadeImplem implements SpellFacade, SortKeyAware
 		StringBuilder buff = new StringBuilder();
 		if (spell != null)
 		{
-			buff.append(spell.toString());
+			buff.append(spell);
 		}
 		else if (charSpell != null)
 		{
-			buff.append(charSpell.toString());
+			buff.append(charSpell);
 		}
 		if (charSpell != null && charSpell.getOwner() instanceof Domain)
 		{
-			buff.append(" [").append(charSpell.getOwner().toString()).append("]");
+			buff.append(" [").append(charSpell.getOwner()).append("]");
 		}
 		if (spellInfo != null)
 		{
-			buff.append(spellInfo.toString());
+			buff.append(spellInfo);
 		}
 		return buff.toString();
 	}


### PR DESCRIPTION
There is only implementation of SpellFacade. This assumption is used in
the character output code in order to get at the underlying impl of the
facade. Fix this by just pulling the impl functions into the interface.