### PR TITLE
CODE-3248: store language choosers in CharacterFacadeImpl

### DIFF
--- a/code/src/java/pcgen/gui2/facade/CharacterFacadeImpl.java
+++ b/code/src/java/pcgen/gui2/facade/CharacterFacadeImpl.java
@@ -2166,7 +2166,11 @@ public class CharacterFacadeImpl
 				currBonusLangs.add(lang);
 			}
 		}
-		int bonusLangRemain = bonusLangMax - currBonusLangs.size();
+		int bonusLangRemain = 0;
+		if (!theCharacter.getRace().getDisplayName().equals("<none selected>"))
+		{
+			bonusLangRemain = bonusLangMax - currBonusLangs.size();
+		}
 		if (!allowBonusLangAfterFirst && !atFirstLvl)
 		{
 			bonusLangRemain = 0;

--- a/code/src/java/pcgen/gui2/facade/CharacterFacadeImpl.java
+++ b/code/src/java/pcgen/gui2/facade/CharacterFacadeImpl.java
@@ -2167,7 +2167,7 @@ public class CharacterFacadeImpl
 			}
 		}
 		int bonusLangRemain = 0;
-		if (!theCharacter.getRace().getDisplayName().equals("<none selected>"))
+		if (theCharacter.getRace().isUnselected())
 		{
 			bonusLangRemain = bonusLangMax - currBonusLangs.size();
 		}
@@ -2218,13 +2218,15 @@ public class CharacterFacadeImpl
 
 			/* Ensure the bonus language chooser is removed, if it exists.*/
 			Iterator<LanguageChooserFacade> itr = langChoosersList.iterator();
-			while (itr.hasNext())
+			if (itr.hasNext())
 			{
-				LanguageChooserFacade chooser = itr.next();
-				/* If we find an add bonus chooser, remove it.*/
-				if (chooser.getName().equals(LanguageBundle.getString("in_sumLangBonus")))
+				for (LanguageChooserFacade chooser = itr.next();  itr.hasNext();)
 				{
-					itr.remove();
+					/* If we find an add bonus chooser, remove it.*/
+					if (chooser.getName().equals(LanguageBundle.getString("in_sumLangBonus")))
+					{
+						itr.remove();
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Store the language choosers list in the CharacterFacadeImpl after creation, so we can add to it later, when changes are triggered.

Mainly, we want to ensure the bonus language chooser is not available on a new character if there is no race, but this will also handle instances of bonus languages being added by intelligence increase, or other general triggers that call `refreshLanguageList`.

It will also remove the bonus chooser if it exists, and bonus languages remaining has been set to 0, or race was removed.

Coincidentally, this also removes the bonus language todo's if a race is not selected, or is removed.