### PR TITLE
[build] update build-scan to 2.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ import org.apache.tools.ant.filters.FixCrLfFilter
 import org.apache.tools.ant.taskdefs.condition.Os
 
 plugins {
-    id 'com.gradle.build-scan' version '2.2.1'
+    id 'com.gradle.build-scan' version '2.3'
     id 'eclipse'
     id 'application'
     id 'build-dashboard'


### PR DESCRIPTION
- Added support for plugin composite builds.
- Added support for continuous builds.
- Added support for capturing the details of annotation processors used during Java compilation.