### PR TITLE
CODE-3380: [*] Rename GlobalScope to GlobalPCScope

### DIFF
--- a/code/src/java/applicationContext.xml
+++ b/code/src/java/applicationContext.xml
@@ -689,7 +689,7 @@
 	<!-- END Facet Definitions -->
 
 	<!--  Scope Definitions -->
-	<bean id="globalLegalScope" class="pcgen.cdom.formula.scope.GlobalScope"/>
+	<bean id="globalLegalScope" class="pcgen.cdom.formula.scope.GlobalPCScope"/>
 	<bean id="saveLegalScope" class="pcgen.cdom.formula.scope.SaveScope">
 		<property name="parent" ref="globalLegalScope"/>
 	</bean>

--- a/code/src/java/pcgen/cdom/facet/ScopeFacet.java
+++ b/code/src/java/pcgen/cdom/facet/ScopeFacet.java
@@ -24,7 +24,7 @@ import pcgen.base.formula.base.ScopeInstanceFactory;
 import pcgen.base.formula.base.VarScoped;
 import pcgen.cdom.enumeration.CharID;
 import pcgen.cdom.facet.base.AbstractItemFacet;
-import pcgen.cdom.formula.scope.GlobalScope;
+import pcgen.cdom.formula.scope.GlobalPCScope;
 
 /**
  * ScopeFacet stores the relationship from a Character, LegalScope, and
@@ -44,7 +44,7 @@ public class ScopeFacet extends AbstractItemFacet<CharID, ScopeInstanceFactory>
 	 */
 	public ScopeInstance getGlobalScope(CharID id)
 	{
-		return get(id).getGlobalInstance(GlobalScope.GLOBAL_SCOPE_NAME);
+		return get(id).getGlobalInstance(GlobalPCScope.GLOBAL_SCOPE_NAME);
 	}
 
 	/**

--- a/code/src/java/pcgen/cdom/formula/scope/DynamicScope.java
+++ b/code/src/java/pcgen/cdom/formula/scope/DynamicScope.java
@@ -30,9 +30,9 @@ import pcgen.rules.context.LoadContext;
 public class DynamicScope implements PCGenScope
 {
 	/**
-	 * The parent PCGenScope for all DynamicScope objects is the GlobalScope.
+	 * The parent PCGenScope for all DynamicScope objects is the GlobalPCScope.
 	 */
-	private static final Optional<PCGenScope> PARENT_SCOPE = Optional.of(SpringHelper.getBean(GlobalScope.class));
+	private static final Optional<PCGenScope> PARENT_SCOPE = Optional.of(SpringHelper.getBean(GlobalPCScope.class));
 
 	/**
 	 * The DynamicCategory indicating the objects contained by this DynamicScope.

--- a/code/src/java/pcgen/cdom/formula/scope/GlobalPCScope.java
+++ b/code/src/java/pcgen/cdom/formula/scope/GlobalPCScope.java
@@ -1,16 +1,16 @@
 /*
  * Copyright 2015 (C) Tom Parker <thpr@users.sourceforge.net>
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2.1 of the License, or (at your option)
  * any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -25,7 +25,7 @@ import pcgen.rules.context.LoadContext;
 /**
  * This is the global variable scope
  */
-public class GlobalScope implements PCGenScope
+public class GlobalPCScope implements PCGenScope
 {
 	/**
 	 * The name of the Global Scope for PCGen characters, publicly available for reuse...

--- a/code/src/java/pcgen/cdom/formula/scope/LegalScopeUtilities.java
+++ b/code/src/java/pcgen/cdom/formula/scope/LegalScopeUtilities.java
@@ -30,7 +30,7 @@ public final class LegalScopeUtilities
 
 	public static void loadLegalScopeLibrary(ScopeManagerInst library)
 	{
-		library.registerScope(SpringHelper.getBean(GlobalScope.class));
+		library.registerScope(SpringHelper.getBean(GlobalPCScope.class));
 		library.registerScope(SpringHelper.getBean(EquipmentScope.class));
 		library.registerScope(SpringHelper.getBean(EquipmentPartScope.class));
 		library.registerScope(SpringHelper.getBean(SaveScope.class));

--- a/code/src/java/pcgen/persistence/SourceFileLoader.java
+++ b/code/src/java/pcgen/persistence/SourceFileLoader.java
@@ -51,7 +51,7 @@ import pcgen.cdom.enumeration.SourceFormat;
 import pcgen.cdom.enumeration.StringKey;
 import pcgen.cdom.enumeration.Type;
 import pcgen.cdom.formula.scope.EquipmentPartScope;
-import pcgen.cdom.formula.scope.GlobalScope;
+import pcgen.cdom.formula.scope.GlobalPCScope;
 import pcgen.cdom.inst.GlobalModifiers;
 import pcgen.cdom.util.CControl;
 import pcgen.cdom.util.ControlUtilities;
@@ -711,7 +711,7 @@ public class SourceFileLoader extends PCGenTask implements Observer
 
 	private static void defineVariable(VariableContext varContext, FormatManager<?> formatManager, String varName)
 	{
-		LegalScope varScope = varContext.getScope(GlobalScope.GLOBAL_SCOPE_NAME);
+		LegalScope varScope = varContext.getScope(GlobalPCScope.GLOBAL_SCOPE_NAME);
 		varContext.assertLegalVariableID(varName, varScope, formatManager);
 	}
 

--- a/code/src/java/pcgen/rules/context/LoadContextInst.java
+++ b/code/src/java/pcgen/rules/context/LoadContextInst.java
@@ -38,7 +38,7 @@ import pcgen.cdom.enumeration.DataSetID;
 import pcgen.cdom.facet.DataSetInitializationFacet;
 import pcgen.cdom.facet.FacetInitialization;
 import pcgen.cdom.facet.FacetLibrary;
-import pcgen.cdom.formula.scope.GlobalScope;
+import pcgen.cdom.formula.scope.GlobalPCScope;
 import pcgen.cdom.formula.scope.PCGenScope;
 import pcgen.cdom.grouping.GroupingCollection;
 import pcgen.cdom.grouping.GroupingInfo;
@@ -530,7 +530,7 @@ abstract class LoadContextInst implements LoadContext
 	{
 		if (legalScope == null)
 		{
-			legalScope = var.getScope(GlobalScope.GLOBAL_SCOPE_NAME);
+			legalScope = var.getScope(GlobalPCScope.GLOBAL_SCOPE_NAME);
 		}
 		return legalScope;
 	}

--- a/code/src/java/plugin/lsttokens/variable/GlobalToken.java
+++ b/code/src/java/plugin/lsttokens/variable/GlobalToken.java
@@ -20,7 +20,7 @@ package plugin.lsttokens.variable;
 import pcgen.base.formula.exception.LegalVariableException;
 import pcgen.base.util.FormatManager;
 import pcgen.cdom.content.DatasetVariable;
-import pcgen.cdom.formula.scope.GlobalScope;
+import pcgen.cdom.formula.scope.GlobalPCScope;
 import pcgen.cdom.formula.scope.PCGenScope;
 import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.token.AbstractNonEmptyToken;
@@ -94,7 +94,7 @@ public class GlobalToken extends AbstractNonEmptyToken<DatasetVariable> implemen
 	public String[] unparse(LoadContext context, DatasetVariable dv)
 	{
 		PCGenScope scope = dv.getScope();
-		if (scope != null && !scope.getName().equals(GlobalScope.GLOBAL_SCOPE_NAME))
+		if (scope != null && !scope.getName().equals(GlobalPCScope.GLOBAL_SCOPE_NAME))
 		{
 			//is a local variable
 			return null;

--- a/code/src/java/plugin/lsttokens/variable/LocalToken.java
+++ b/code/src/java/plugin/lsttokens/variable/LocalToken.java
@@ -22,7 +22,7 @@ import pcgen.base.formula.exception.LegalVariableException;
 import pcgen.base.util.FormatManager;
 import pcgen.cdom.base.Constants;
 import pcgen.cdom.content.DatasetVariable;
-import pcgen.cdom.formula.scope.GlobalScope;
+import pcgen.cdom.formula.scope.GlobalPCScope;
 import pcgen.cdom.formula.scope.PCGenScope;
 import pcgen.rules.context.LoadContext;
 import pcgen.rules.context.VariableContext;
@@ -117,7 +117,7 @@ public class LocalToken extends AbstractNonEmptyToken<DatasetVariable> implement
 	public String[] unparse(LoadContext context, DatasetVariable dv)
 	{
 		PCGenScope scope = dv.getScope();
-		if (scope == null || scope.getName().equals(GlobalScope.GLOBAL_SCOPE_NAME))
+		if (scope == null || scope.getName().equals(GlobalPCScope.GLOBAL_SCOPE_NAME))
 		{
 			//Global variable
 			return null;

--- a/code/src/utest/pcgen/base/solver/SetSolverManagerTest.java
+++ b/code/src/utest/pcgen/base/solver/SetSolverManagerTest.java
@@ -54,7 +54,7 @@ import pcgen.cdom.content.ProcessCalculation;
 import pcgen.cdom.formula.ManagerKey;
 import pcgen.cdom.formula.local.ModifierDecoration;
 import pcgen.cdom.formula.scope.EquipmentScope;
-import pcgen.cdom.formula.scope.GlobalScope;
+import pcgen.cdom.formula.scope.GlobalPCScope;
 import pcgen.cdom.formula.scope.PCGenScope;
 import pcgen.cdom.formula.scope.SkillScope;
 import pcgen.core.Skill;
@@ -72,7 +72,7 @@ import org.junit.jupiter.api.Test;
 class SetSolverManagerTest
 {
 
-	private final PCGenScope globalScope = new GlobalScope();
+	private final PCGenScope globalScope = new GlobalPCScope();
 	private TrackingVariableCache vc;
 	private ScopeManagerInst vsLib;
 	private VariableManager sl;
@@ -190,7 +190,7 @@ class SetSolverManagerTest
 		manager.createChannel(varIDa);
 		vc.put(varIDa, 3);
 		ScopeInstance globalInst =
-				siFactory.getGlobalInstance(GlobalScope.GLOBAL_SCOPE_NAME);
+				siFactory.getGlobalInstance(GlobalPCScope.GLOBAL_SCOPE_NAME);
 		VariableID varIDq = sl.getVariableID(globalInst, "SkillVar");
 		manager.createChannel(varIDq);
 		VariableID varIDr = sl.getVariableID(globalInst, "ResultVar");

--- a/code/src/utest/pcgen/cdom/base/FormulaFactoryTest.java
+++ b/code/src/utest/pcgen/cdom/base/FormulaFactoryTest.java
@@ -9,7 +9,7 @@ import pcgen.base.formula.base.ManagerFactory;
 import pcgen.base.formula.inst.NEPFormula;
 import pcgen.base.formula.inst.ScopeManagerInst;
 import pcgen.base.solver.FormulaSetupFactory;
-import pcgen.cdom.formula.scope.GlobalScope;
+import pcgen.cdom.formula.scope.GlobalPCScope;
 import pcgen.cdom.formula.scope.PCGenScope;
 
 import org.junit.jupiter.api.AfterEach;
@@ -28,7 +28,7 @@ class FormulaFactoryTest
 	{
 		arrayManager = new ArrayFormatManager<>(FormatUtilities.NUMBER_MANAGER,
 			'\n', ',');
-		varScope = new GlobalScope();
+		varScope = new GlobalPCScope();
 		FormulaSetupFactory formulaSetupFactory = new FormulaSetupFactory();
 		ScopeManagerInst legalScopeManager = new ScopeManagerInst();
 		formulaSetupFactory

--- a/code/src/utest/pcgen/cdom/formula/VariableChannelTest.java
+++ b/code/src/utest/pcgen/cdom/formula/VariableChannelTest.java
@@ -31,7 +31,7 @@ import pcgen.base.solver.Modifier;
 import pcgen.base.solver.SolverManager;
 import pcgen.cdom.enumeration.CharID;
 import pcgen.cdom.enumeration.DataSetID;
-import pcgen.cdom.formula.scope.GlobalScope;
+import pcgen.cdom.formula.scope.GlobalPCScope;
 import pcgen.cdom.formula.scope.PCGenScope;
 import pcgen.cdom.formula.testsupport.AbstractModifier;
 import pcgen.facade.util.event.ReferenceEvent;
@@ -58,7 +58,7 @@ public class VariableChannelTest extends AbstractFormulaTestCase
 		FormulaUtilities.loadBuiltInOperators(getOperatorLibrary());
 
 		manager = context.getVariableContext().generateSolverManager(getVariableStore());
-		globalScope = context.getVariableContext().getScope(GlobalScope.GLOBAL_SCOPE_NAME);
+		globalScope = context.getVariableContext().getScope(GlobalPCScope.GLOBAL_SCOPE_NAME);
 		ScopeInstanceFactory sif = getFormulaManager().getScopeInstanceFactory();
 		globalInstance = sif.getGlobalInstance(globalScope.getName());
 	}

--- a/code/src/utest/pcgen/cdom/helper/BridgeListenerTest.java
+++ b/code/src/utest/pcgen/cdom/helper/BridgeListenerTest.java
@@ -33,7 +33,7 @@ import pcgen.cdom.enumeration.DataSetID;
 import pcgen.cdom.facet.base.AbstractSourcedListFacet;
 import pcgen.cdom.formula.PCGenScoped;
 import pcgen.cdom.formula.VariableChangeEvent;
-import pcgen.cdom.formula.scope.GlobalScope;
+import pcgen.cdom.formula.scope.GlobalPCScope;
 import pcgen.core.PCTemplate;
 import pcgen.core.Race;
 import pcgen.facade.util.event.ReferenceEvent;
@@ -95,7 +95,7 @@ public class BridgeListenerTest
 		CharID id = CharID.getID(dsID);
 		AbstractSourcedListFacet<CharID, PCGenScoped> target = new Target();
 		BridgeListener bridge = new BridgeListener(id, target);
-		GlobalScope scope = new GlobalScope();
+		GlobalPCScope scope = new GlobalPCScope();
 		ScopeInstance instance =
 				new SimpleScopeInstance(Optional.empty(), scope, owner);
 		TransparentFormatManager<PCTemplate> formatManager =
@@ -128,7 +128,7 @@ public class BridgeListenerTest
 		CharID id = CharID.getID(dsID);
 		AbstractSourcedListFacet<CharID, PCGenScoped> target = new Target();
 		BridgeListener bridge = new BridgeListener(id, target);
-		GlobalScope scope = new GlobalScope();
+		GlobalPCScope scope = new GlobalPCScope();
 		ScopeInstance instance =
 				new SimpleScopeInstance(Optional.empty(), scope, owner);
 		TransparentFormatManager<PCTemplate[]> formatManager =

--- a/code/src/utest/plugin/function/GetFactFunctionTest.java
+++ b/code/src/utest/plugin/function/GetFactFunctionTest.java
@@ -38,7 +38,7 @@ import pcgen.base.util.BasicIndirect;
 import pcgen.cdom.content.fact.FactDefinition;
 import pcgen.cdom.enumeration.FactKey;
 import pcgen.cdom.formula.ManagerKey;
-import pcgen.cdom.formula.scope.GlobalScope;
+import pcgen.cdom.formula.scope.GlobalPCScope;
 import pcgen.core.Skill;
 import pcgen.rules.context.AbstractReferenceContext;
 import pcgen.util.enumeration.Visibility;
@@ -160,7 +160,7 @@ public class GetFactFunctionTest extends AbstractFormulaTestCase
 	{
 		VariableLibrary vl = getVariableLibrary();
 		LegalScope globalScope =
-				context.getVariableContext().getScope(GlobalScope.GLOBAL_SCOPE_NAME);
+				context.getVariableContext().getScope(GlobalPCScope.GLOBAL_SCOPE_NAME);
 		vl.assertLegalVariableID("SkillVar", globalScope,
 			context.getManufacturer("SKILL"));
 
@@ -184,7 +184,7 @@ public class GetFactFunctionTest extends AbstractFormulaTestCase
 		Skill skillalt = new Skill();
 		skillalt.setName("SkillAlt");
 		ScopeInstance globalInst = getFormulaManager().getScopeInstanceFactory()
-			.getGlobalInstance(GlobalScope.GLOBAL_SCOPE_NAME);
+			.getGlobalInstance(GlobalPCScope.GLOBAL_SCOPE_NAME);
 		VariableID varIDq = vl.getVariableID(globalInst, "SkillVar");
 		getVariableStore().put(varIDq, skill);
 		context.getReferenceContext().importObject(skill);

--- a/code/src/utest/plugin/function/GetOtherFunctionTest.java
+++ b/code/src/utest/plugin/function/GetOtherFunctionTest.java
@@ -38,7 +38,7 @@ import pcgen.base.formula.parse.SimpleNode;
 import pcgen.base.formula.visitor.ReconstructionVisitor;
 import pcgen.base.formula.visitor.SemanticsVisitor;
 import pcgen.cdom.formula.ManagerKey;
-import pcgen.cdom.formula.scope.GlobalScope;
+import pcgen.cdom.formula.scope.GlobalPCScope;
 import pcgen.core.Skill;
 import pcgen.rules.context.AbstractReferenceContext;
 import pcgen.rules.context.VariableContext;
@@ -147,7 +147,7 @@ public class GetOtherFunctionTest extends AbstractFormulaTestCase
 		VariableLibrary vl = getVariableLibrary();
 		VariableContext variableContext = context.getVariableContext();
 		LegalScope skillScope = variableContext.getScope("PC.SKILL");
-		LegalScope globalScope = variableContext.getScope(GlobalScope.GLOBAL_SCOPE_NAME);
+		LegalScope globalScope = variableContext.getScope(GlobalPCScope.GLOBAL_SCOPE_NAME);
 		vl.assertLegalVariableID("LocalVar", skillScope, numberManager);
 		vl.assertLegalVariableID("SkillVar", globalScope, context.getManufacturer("SKILL"));
 
@@ -171,7 +171,7 @@ public class GetOtherFunctionTest extends AbstractFormulaTestCase
 		VariableID varIDa = vl.getVariableID(scopeInsta, "LocalVar");
 		getVariableStore().put(varIDa, 3);
 		ScopeInstance globalInst =
-				scopeInstanceFactory.getGlobalInstance(GlobalScope.GLOBAL_SCOPE_NAME);
+				scopeInstanceFactory.getGlobalInstance(GlobalPCScope.GLOBAL_SCOPE_NAME);
 		VariableID varIDq = vl.getVariableID(globalInst, "SkillVar");
 		getVariableStore().put(varIDq, skill);
 		context.getReferenceContext().importObject(skill);

--- a/code/src/utest/plugin/function/InputFunctionTest.java
+++ b/code/src/utest/plugin/function/InputFunctionTest.java
@@ -29,7 +29,7 @@ import pcgen.cdom.facet.ScopeFacet;
 import pcgen.cdom.facet.SolverManagerFacet;
 import pcgen.cdom.facet.VariableStoreFacet;
 import pcgen.cdom.formula.VariableChannel;
-import pcgen.cdom.formula.scope.GlobalScope;
+import pcgen.cdom.formula.scope.GlobalPCScope;
 import pcgen.output.channel.ChannelUtilities;
 import plugin.function.testsupport.AbstractFormulaTestCase;
 import plugin.function.testsupport.TestUtilities;
@@ -100,7 +100,7 @@ public class InputFunctionTest extends AbstractFormulaTestCase
 	{
 		ScopeInstanceFactory instFactory = scopeFacet.get(id);
 		ScopeInstance globalInstance =
-				instFactory.getGlobalInstance(GlobalScope.GLOBAL_SCOPE_NAME);
+				instFactory.getGlobalInstance(GlobalPCScope.GLOBAL_SCOPE_NAME);
 		context.getVariableContext().assertLegalVariableID(ChannelUtilities.createVarName("STR"),
 			globalInstance.getLegalScope(), numberManager);
 		VariableChannel<Number> strChannel = (VariableChannel<Number>) context

--- a/code/src/utest/plugin/function/testsupport/AbstractFormulaTestCase.java
+++ b/code/src/utest/plugin/function/testsupport/AbstractFormulaTestCase.java
@@ -41,7 +41,7 @@ import pcgen.cdom.facet.FacetLibrary;
 import pcgen.cdom.facet.LoadContextFacet;
 import pcgen.cdom.formula.ManagerKey;
 import pcgen.cdom.formula.MonitorableVariableStore;
-import pcgen.cdom.formula.scope.GlobalScope;
+import pcgen.cdom.formula.scope.GlobalPCScope;
 import pcgen.rules.context.ConsolidatedListCommitStrategy;
 import pcgen.rules.context.LoadContext;
 import pcgen.rules.context.RuntimeLoadContext;
@@ -177,7 +177,7 @@ public abstract class AbstractFormulaTestCase
 	protected ScopeInstance getGlobalScopeInst()
 	{
 		return getFormulaManager().getScopeInstanceFactory()
-			.getGlobalInstance(GlobalScope.GLOBAL_SCOPE_NAME);
+			.getGlobalInstance(GlobalPCScope.GLOBAL_SCOPE_NAME);
 	}
 
 	protected FormulaManager getFormulaManager()

--- a/code/src/utest/plugin/modifier/bool/SetBooleanModifierTest.java
+++ b/code/src/utest/plugin/modifier/bool/SetBooleanModifierTest.java
@@ -24,7 +24,7 @@ import pcgen.base.calculation.FormulaModifier;
 import pcgen.base.format.BooleanManager;
 import pcgen.base.formula.base.ManagerFactory;
 import pcgen.base.util.FormatManager;
-import pcgen.cdom.formula.scope.GlobalScope;
+import pcgen.cdom.formula.scope.GlobalPCScope;
 import pcgen.cdom.formula.scope.PCGenScope;
 import pcgen.rules.persistence.token.ModifierFactory;
 import plugin.modifier.testsupport.EvalManagerUtilities;
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 public class SetBooleanModifierTest
 {
 
-	private final PCGenScope varScope = new GlobalScope();
+	private final PCGenScope varScope = new GlobalPCScope();
 	private FormatManager<Boolean> booleanManager = new BooleanManager();
 
 	@Test

--- a/code/src/utest/plugin/modifier/number/AddNumberModifierTest.java
+++ b/code/src/utest/plugin/modifier/number/AddNumberModifierTest.java
@@ -25,7 +25,7 @@ import pcgen.base.calculation.FormulaModifier;
 import pcgen.base.format.NumberManager;
 import pcgen.base.formula.base.ManagerFactory;
 import pcgen.base.util.FormatManager;
-import pcgen.cdom.formula.scope.GlobalScope;
+import pcgen.cdom.formula.scope.GlobalPCScope;
 import pcgen.cdom.formula.scope.PCGenScope;
 import pcgen.rules.persistence.token.ModifierFactory;
 import plugin.modifier.testsupport.EvalManagerUtilities;
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.Test;
 
 class AddNumberModifierTest
 {
-	private final PCGenScope varScope = new GlobalScope();
+	private final PCGenScope varScope = new GlobalPCScope();
 	private FormatManager<Number> numManager = new NumberManager();
 
 	@Test

--- a/code/src/utest/plugin/modifier/number/DivideNumberModifierTest.java
+++ b/code/src/utest/plugin/modifier/number/DivideNumberModifierTest.java
@@ -25,7 +25,7 @@ import pcgen.base.calculation.FormulaModifier;
 import pcgen.base.format.NumberManager;
 import pcgen.base.formula.base.ManagerFactory;
 import pcgen.base.util.FormatManager;
-import pcgen.cdom.formula.scope.GlobalScope;
+import pcgen.cdom.formula.scope.GlobalPCScope;
 import pcgen.cdom.formula.scope.PCGenScope;
 import plugin.modifier.testsupport.EvalManagerUtilities;
 
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.Test;
 public class DivideNumberModifierTest
 {
 
-	private final PCGenScope varScope = new GlobalScope();
+	private final PCGenScope varScope = new GlobalPCScope();
 	private final FormatManager<Number> numManager = new NumberManager();
 
 	@Test

--- a/code/src/utest/plugin/modifier/number/MaxNumberModifierTest.java
+++ b/code/src/utest/plugin/modifier/number/MaxNumberModifierTest.java
@@ -25,7 +25,7 @@ import pcgen.base.calculation.FormulaModifier;
 import pcgen.base.format.NumberManager;
 import pcgen.base.formula.base.ManagerFactory;
 import pcgen.base.util.FormatManager;
-import pcgen.cdom.formula.scope.GlobalScope;
+import pcgen.cdom.formula.scope.GlobalPCScope;
 import pcgen.cdom.formula.scope.PCGenScope;
 import pcgen.rules.persistence.token.ModifierFactory;
 import plugin.modifier.testsupport.EvalManagerUtilities;
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 
 public class MaxNumberModifierTest
 {
-	private final PCGenScope varScope = new GlobalScope();
+	private final PCGenScope varScope = new GlobalPCScope();
 	private final FormatManager<Number> numManager = new NumberManager();
 
 	@Test

--- a/code/src/utest/plugin/modifier/number/MinNumberModifierTest.java
+++ b/code/src/utest/plugin/modifier/number/MinNumberModifierTest.java
@@ -25,7 +25,7 @@ import pcgen.base.calculation.FormulaModifier;
 import pcgen.base.format.NumberManager;
 import pcgen.base.formula.base.ManagerFactory;
 import pcgen.base.util.FormatManager;
-import pcgen.cdom.formula.scope.GlobalScope;
+import pcgen.cdom.formula.scope.GlobalPCScope;
 import pcgen.cdom.formula.scope.PCGenScope;
 import pcgen.rules.persistence.token.ModifierFactory;
 import plugin.modifier.testsupport.EvalManagerUtilities;
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 
 public class MinNumberModifierTest
 {
-	private final PCGenScope varScope = new GlobalScope();
+	private final PCGenScope varScope = new GlobalPCScope();
 	FormatManager<Number> numManager = new NumberManager();
 
 

--- a/code/src/utest/plugin/modifier/number/MultiplyNumberModifierTest.java
+++ b/code/src/utest/plugin/modifier/number/MultiplyNumberModifierTest.java
@@ -25,7 +25,7 @@ import pcgen.base.calculation.FormulaModifier;
 import pcgen.base.format.NumberManager;
 import pcgen.base.formula.base.ManagerFactory;
 import pcgen.base.util.FormatManager;
-import pcgen.cdom.formula.scope.GlobalScope;
+import pcgen.cdom.formula.scope.GlobalPCScope;
 import pcgen.cdom.formula.scope.PCGenScope;
 import pcgen.rules.persistence.token.ModifierFactory;
 import plugin.modifier.testsupport.EvalManagerUtilities;
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.Test;
 public class MultiplyNumberModifierTest
 {
 
-	private final PCGenScope varScope = new GlobalScope();
+	private final PCGenScope varScope = new GlobalPCScope();
 	private final FormatManager<Number> numManager = new NumberManager();
 
 	@Test

--- a/code/src/utest/plugin/modifier/number/SetNumberModifierTest.java
+++ b/code/src/utest/plugin/modifier/number/SetNumberModifierTest.java
@@ -28,7 +28,7 @@ import pcgen.base.formula.base.ManagerFactory;
 import pcgen.base.formula.inst.ScopeManagerInst;
 import pcgen.base.solver.FormulaSetupFactory;
 import pcgen.base.util.FormatManager;
-import pcgen.cdom.formula.scope.GlobalScope;
+import pcgen.cdom.formula.scope.GlobalPCScope;
 import pcgen.cdom.formula.scope.PCGenScope;
 import plugin.modifier.testsupport.EvalManagerUtilities;
 
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.Test;
 public class SetNumberModifierTest
 {
 
-	private final PCGenScope varScope = new GlobalScope();
+	private final PCGenScope varScope = new GlobalPCScope();
 	FormatManager<Number> numManager = new NumberManager();
 
 	@Test

--- a/code/src/utest/plugin/modifier/orderedpair/SetOrderedPairModifierTest.java
+++ b/code/src/utest/plugin/modifier/orderedpair/SetOrderedPairModifierTest.java
@@ -25,7 +25,7 @@ import pcgen.base.format.OrderedPairManager;
 import pcgen.base.formula.base.ManagerFactory;
 import pcgen.base.math.OrderedPair;
 import pcgen.base.util.FormatManager;
-import pcgen.cdom.formula.scope.GlobalScope;
+import pcgen.cdom.formula.scope.GlobalPCScope;
 import pcgen.cdom.formula.scope.PCGenScope;
 import pcgen.rules.persistence.token.ModifierFactory;
 import plugin.modifier.testsupport.EvalManagerUtilities;
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.Test;
 class SetOrderedPairModifierTest
 {
 
-	private final PCGenScope varScope = new GlobalScope();
+	private final PCGenScope varScope = new GlobalPCScope();
 	private FormatManager<OrderedPair> opManager = new OrderedPairManager();
 
 	@Test

--- a/code/src/utest/plugin/modifier/string/SetStringModifierTest.java
+++ b/code/src/utest/plugin/modifier/string/SetStringModifierTest.java
@@ -24,7 +24,7 @@ import pcgen.base.calculation.FormulaModifier;
 import pcgen.base.format.StringManager;
 import pcgen.base.formula.base.ManagerFactory;
 import pcgen.base.util.FormatManager;
-import pcgen.cdom.formula.scope.GlobalScope;
+import pcgen.cdom.formula.scope.GlobalPCScope;
 import pcgen.cdom.formula.scope.PCGenScope;
 import pcgen.rules.persistence.token.ModifierFactory;
 import plugin.modifier.testsupport.EvalManagerUtilities;
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 public class SetStringModifierTest
 {
 
-	private final PCGenScope varScope = new GlobalScope();
+	private final PCGenScope varScope = new GlobalPCScope();
 	private FormatManager<String> stringManager = new StringManager();
 
 	@Test


### PR DESCRIPTION
We should do this because it is true. Also, because we are soon going to
introduce a new "EQ" scope that differs from the PC scope.