### PR TITLE
NEWTAG-627: Add getDatasetID to PCGenIdentifier interface

### DIFF
--- a/code/src/java/pcgen/cdom/base/PCGenIdentifier.java
+++ b/code/src/java/pcgen/cdom/base/PCGenIdentifier.java
@@ -17,6 +17,8 @@
  */
 package pcgen.cdom.base;
 
+import pcgen.cdom.enumeration.DataSetID;
+
 /**
  * This interface represents an identifier (like a CharID) so that certain classes can use
  * Generics to have a minimal compile requirement of using an expected identifier rather
@@ -24,5 +26,8 @@ package pcgen.cdom.base;
  */
 public interface PCGenIdentifier
 {
-	//Intentionally Empty Interface
+	/**
+	 * @return the owned DataSetID under which variable was created.
+	 */
+	public DataSetID getDataSetID();
 }

--- a/code/src/java/pcgen/cdom/enumeration/CharID.java
+++ b/code/src/java/pcgen/cdom/enumeration/CharID.java
@@ -83,4 +83,10 @@ public final class CharID implements TypeSafeConstant, PCGenIdentifier
 		id.myFacetCache = AbstractStorageFacet.peekAtCache(id);
 		return id;
 	}
+
+	@Override
+	public DataSetID getDataSetID()
+	{
+		return this.datasetID;
+	}
 }

--- a/code/src/java/pcgen/cdom/enumeration/DataSetID.java
+++ b/code/src/java/pcgen/cdom/enumeration/DataSetID.java
@@ -70,4 +70,10 @@ public final class DataSetID implements TypeSafeConstant, PCGenIdentifier
 		id.myFacetCache = AbstractStorageFacet.peekAtCache(id);
 		return id;
 	}
+
+	@Override
+	public DataSetID getDataSetID()
+	{
+		return this;
+	}
 }


### PR DESCRIPTION
This is in preparation for  ResultFacet and VariableStoreFacet taking a
DatasetID instead of a CharID