### PR TITLE
Allow BaseSize Code control to be used independently of PCSIZE Control

### DIFF
--- a/code/src/java/applicationContext.xml
+++ b/code/src/java/applicationContext.xml
@@ -539,6 +539,7 @@
 		<property name="templateFacet" ref="templateFacet"/>
 		<property name="raceFacet" ref="raceFacet"/>
 		<property name="levelFacet" ref="levelFacet"/>
+		<property name="resultFacet" ref="resultFacet"/>
 		<property name="consolidationFacet" ref="consolidationFacet" />
 	</bean>
 	<bean id="skillFacet" class="pcgen.cdom.facet.model.SkillFacet">

--- a/code/src/java/pcgen/cdom/facet/model/SizeFacet.java
+++ b/code/src/java/pcgen/cdom/facet/model/SizeFacet.java
@@ -32,17 +32,18 @@ import pcgen.cdom.facet.BonusCheckingFacet;
 import pcgen.cdom.facet.CDOMObjectConsolidationFacet;
 import pcgen.cdom.facet.FacetLibrary;
 import pcgen.cdom.facet.FormulaResolvingFacet;
-import pcgen.cdom.facet.PlayerCharacterTrackingFacet;
+import pcgen.cdom.facet.LoadContextFacet;
 import pcgen.cdom.facet.analysis.LevelFacet;
 import pcgen.cdom.facet.analysis.LevelFacet.LevelChangeEvent;
 import pcgen.cdom.facet.analysis.LevelFacet.LevelChangeListener;
+import pcgen.cdom.facet.analysis.ResultFacet;
 import pcgen.cdom.facet.base.AbstractDataFacet;
 import pcgen.cdom.facet.event.DataFacetChangeEvent;
 import pcgen.cdom.facet.event.DataFacetChangeListener;
 import pcgen.cdom.util.CControl;
+import pcgen.cdom.util.ControlUtilities;
 import pcgen.core.Globals;
 import pcgen.core.PCTemplate;
-import pcgen.core.PlayerCharacter;
 import pcgen.core.Race;
 import pcgen.core.SizeAdjustment;
 import pcgen.core.analysis.SizeUtilities;
@@ -63,10 +64,11 @@ public class SizeFacet extends AbstractDataFacet<CharID, SizeAdjustment>
 	private FormulaResolvingFacet formulaResolvingFacet;
 	private BonusCheckingFacet bonusCheckingFacet;
 	private LevelFacet levelFacet;
+	private ResultFacet resultFacet;
 
 	private CDOMObjectConsolidationFacet consolidationFacet;
 
-	private PlayerCharacterTrackingFacet trackingFacet = FacetLibrary.getFacet(PlayerCharacterTrackingFacet.class);
+	private LoadContextFacet loadContextFacet = FacetLibrary.getFacet(LoadContextFacet.class);
 
 	/**
 	 * Returns the integer indicating the racial size for the Player Character
@@ -80,11 +82,12 @@ public class SizeFacet extends AbstractDataFacet<CharID, SizeAdjustment>
 	 */
 	public int racialSizeInt(CharID id)
 	{
-		PlayerCharacter pc = trackingFacet.getPC(id);
-		String baseSizeControl = pc.getControl(CControl.BASESIZE);
+		String baseSizeControl = ControlUtilities.getControlToken(
+			loadContextFacet.get(id.getDatasetID()).get(), CControl.BASESIZE);
 		if (baseSizeControl != null)
 		{
-			SizeAdjustment baseSize = (SizeAdjustment) pc.getGlobal(baseSizeControl);
+			SizeAdjustment baseSize = (SizeAdjustment) resultFacet
+					.getGlobalVariable(id, baseSizeControl);
 			return baseSize.get(IntegerKey.SIZEORDER);
 		}
 		else
@@ -100,11 +103,12 @@ public class SizeFacet extends AbstractDataFacet<CharID, SizeAdjustment>
 
 	private int calcRacialSizeInt(CharID id)
 	{
-		PlayerCharacter pc = trackingFacet.getPC(id);
-		String baseSizeControl = pc.getControl(CControl.BASESIZE);
+		String baseSizeControl = ControlUtilities.getControlToken(
+			loadContextFacet.get(id.getDatasetID()).get(), CControl.BASESIZE);
 		if (baseSizeControl != null)
 		{
-			SizeAdjustment baseSize = (SizeAdjustment) pc.getGlobal(baseSizeControl);
+			SizeAdjustment baseSize = (SizeAdjustment) resultFacet
+				.getGlobalVariable(id, baseSizeControl);
 			return baseSize.get(IntegerKey.SIZEORDER);
 		}
 		else
@@ -406,6 +410,11 @@ public class SizeFacet extends AbstractDataFacet<CharID, SizeAdjustment>
 	public void setLevelFacet(LevelFacet levelFacet)
 	{
 		this.levelFacet = levelFacet;
+	}
+
+	public void setResultFacet(ResultFacet resultFacet)
+	{
+		this.resultFacet = resultFacet;
 	}
 
 	public void setConsolidationFacet(CDOMObjectConsolidationFacet consolidationFacet)

--- a/code/src/java/pcgen/core/PlayerCharacter.java
+++ b/code/src/java/pcgen/core/PlayerCharacter.java
@@ -10106,16 +10106,7 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 	 */
 	public int racialSizeInt()
 	{
-		String baseSizeControl = getControl(CControl.BASESIZE);
-		if (baseSizeControl != null)
-		{
-			SizeAdjustment baseSize = (SizeAdjustment) getGlobal(baseSizeControl);
-			return baseSize.get(IntegerKey.SIZEORDER);
-		}
-		else
-		{
-			return sizeFacet.racialSizeInt(id);
-		}
+		return sizeFacet.racialSizeInt(id);
 	}
 
 	public String getGenderString()

--- a/code/src/utest/pcgen/cdom/facet/model/SizeFacetTest.java
+++ b/code/src/utest/pcgen/cdom/facet/model/SizeFacetTest.java
@@ -19,6 +19,7 @@ package pcgen.cdom.facet.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.lang.ref.WeakReference;
 import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
@@ -31,7 +32,9 @@ import pcgen.cdom.enumeration.IntegerKey;
 import pcgen.cdom.enumeration.ListKey;
 import pcgen.cdom.enumeration.ObjectKey;
 import pcgen.cdom.facet.BonusCheckingFacet;
+import pcgen.cdom.facet.FacetLibrary;
 import pcgen.cdom.facet.FormulaResolvingFacet;
+import pcgen.cdom.facet.LoadContextFacet;
 import pcgen.cdom.facet.analysis.LevelFacet;
 import pcgen.core.Globals;
 import pcgen.core.PCTemplate;
@@ -39,6 +42,8 @@ import pcgen.core.Race;
 import pcgen.core.SettingsHandler;
 import pcgen.core.SizeAdjustment;
 import pcgen.rules.context.AbstractReferenceContext;
+import pcgen.rules.context.LoadContext;
+
 import plugin.lsttokens.testsupport.BuildUtilities;
 
 import org.junit.jupiter.api.BeforeAll;
@@ -63,10 +68,12 @@ class SizeFacetTest
 	private Map<CharID, Double> bonusInfo;
 	private static SizeAdjustment t, s, m, l, h;
 
+	private static LoadContext context;
+
 	@BeforeEach
 	void setUp() throws Exception
 	{
-		DataSetID cid = DataSetID.getID();
+		DataSetID cid = context.getDataSetID();
 		id = CharID.getID(cid);
 		altid = CharID.getID(cid);
 		facet = getMockFacet();
@@ -80,7 +87,10 @@ class SizeFacetTest
 	static void staticSetUp()
 	{
 		SettingsHandler.getGame().clearLoadContext();
-		AbstractReferenceContext ref = Globals.getContext().getReferenceContext();
+		context = Globals.getContext();
+		AbstractReferenceContext ref = context.getReferenceContext();
+		FacetLibrary.getFacet(LoadContextFacet.class).set(context.getDataSetID(),
+			new WeakReference<>(context));
 		t = BuildUtilities.createSize("Tiny", 0);
 		ref.importObject(t);
 		s = BuildUtilities.createSize("Small", 1);


### PR DESCRIPTION
The previous design seems to have assumed they would be used together,
but that shouldn't be necessary.  Because SizeFacet's PC Size
calculation depends on the base size, we need to intercept that within
the Facet and not only do the code control interception in the case when
the base size is requested from PlayerCharacter.