### PR TITLE
[NEWTAG-620] WEAPONHANDS Code Control

### DIFF
--- a/code/pluginbuild.xml
+++ b/code/pluginbuild.xml
@@ -6217,6 +6217,13 @@ jar-all-plugins - Generate the plugin jar files
 				</patternset>
 			</fileset>
 		</jar>
+		<jar jarfile="${systemlstplugins.dir}/GameMode-CodeControlToken-WEAPONHANDS.jar" manifest="${src.java.dir}/plugin/lsttokens/manifest.mf">
+			<fileset dir="${build.classes.dir}">
+				<patternset>
+					<include name="plugin/lsttokens/gamemode/codecontrol/WeaponHandsToken.class" />
+				</patternset>
+			</fileset>
+		</jar>
 		<!-- GameMode: EqSizePenalty tokens-->
 		<jar jarfile="${systemlstplugins.dir}/GameMode-EqSizePenaltyToken-BONUS.jar" manifest="${src.java.dir}/plugin/lsttokens/manifest.mf">
 			<fileset dir="${build.classes.dir}">

--- a/code/src/java/pcgen/cdom/util/CControl.java
+++ b/code/src/java/pcgen/cdom/util/CControl.java
@@ -93,6 +93,11 @@ public final class CControl
 	public static final String PCSIZE = "PCSIZE";
 
 	/**
+	 * Code control to take # of weapon hands off of WieldCategory
+	 */
+	public static final String WEAPONHANDS = "WEAPONHANDS";
+
+	/**
 	 * Code Control for the Alignment Input Channel.
 	 */
 	public static final CControl ALIGNMENTINPUT = new CControl("ALIGNMENTINPUT", "Alignment", Optional.of("ALIGNMENTFEATURE"), "ALIGNMENT", true, true);

--- a/code/src/java/pcgen/core/Equipment.java
+++ b/code/src/java/pcgen/core/Equipment.java
@@ -5026,7 +5026,7 @@ public final class Equipment extends PObject
 	 * @param pc The PlayerCharacter wielding the weapon.
 	 * @return true if the weapon can be used one handed.
 	 */
-	public boolean isWeaponOneHanded(final PlayerCharacter pc)
+	public boolean isWeaponOneHanded(PlayerCharacter pc)
 	{
 
 		if (pc == null && !isWeapon())
@@ -5035,7 +5035,20 @@ public final class Equipment extends PObject
 		}
 
 		WieldCategory wCat = getEffectiveWieldCategory(pc);
-		return wCat != null && wCat.getHandsRequired() == 1;
+		return wCat != null && getHandsRequired(pc, wCat) == 1;
+	}
+
+	private int getHandsRequired(PlayerCharacter pc, WieldCategory wCat)
+	{
+		String handsControl = pc.getControl(CControl.WEAPONHANDS);
+		if (handsControl != null)
+		{
+			return ((Number) pc.getGlobal(handsControl)).intValue();
+		}
+		else
+		{
+			return wCat.getHandsRequired();
+		}
 	}
 
 	/**
@@ -5045,7 +5058,7 @@ public final class Equipment extends PObject
 	 * @param pc The PlayerCharacter wielding the weapon.
 	 * @return true if the weapon is too large or too small.
 	 */
-	public boolean isWeaponOutsizedForPC(final PlayerCharacter pc)
+	public boolean isWeaponOutsizedForPC(PlayerCharacter pc)
 	{
 
 		if (pc == null || !isWeapon())
@@ -5054,26 +5067,12 @@ public final class Equipment extends PObject
 		}
 
 		final WieldCategory wCat = getEffectiveWieldCategory(pc);
-
-		return wCat != null && (wCat.getHandsRequired() > 2 || wCat.getHandsRequired() < 0);
-	}
-
-	/**
-	 * Tests is the weapon is too large for the PC to use.
-	 * 
-	 * @param pc The PlayerCharacter wielding the weapon
-	 * @return true if the weapon is too large.
-	 */
-	public boolean isWeaponTooLargeForPC(final PlayerCharacter pc)
-	{
-
-		if (pc == null || !isWeapon())
+		if (wCat == null)
 		{
 			return false;
 		}
-
-		WieldCategory wieldCategory = getEffectiveWieldCategory(pc);
-		return wieldCategory != null && wieldCategory.getHandsRequired() > 2;
+		int handsRequired = getHandsRequired(pc, wCat);
+		return (handsRequired > 2 || handsRequired < 0);
 	}
 
 	/**
@@ -5083,7 +5082,7 @@ public final class Equipment extends PObject
 	 *            The PlayerCharacter wielding the weapon.
 	 * @return true if the weapon is two-handed for the specified pc
 	 */
-	public boolean isWeaponTwoHanded(final PlayerCharacter pc)
+	public boolean isWeaponTwoHanded(PlayerCharacter pc)
 	{
 
 		if (pc == null || !isWeapon())
@@ -5092,7 +5091,7 @@ public final class Equipment extends PObject
 		}
 
 		WieldCategory wieldCategory = getEffectiveWieldCategory(pc);
-		return wieldCategory != null && wieldCategory.getHandsRequired() == 2;
+		return wieldCategory != null && getHandsRequired(pc, wieldCategory) == 2;
 	}
 
 	/**
@@ -5175,7 +5174,7 @@ public final class Equipment extends PObject
 					iHands = 2;
 				}
 			}
-			while (wCat.getHandsRequired() < iHands)
+			while (getHandsRequired(aPC, wCat) < iHands)
 			{
 				wCat = wCat.getWieldCategoryStep(1);
 			}

--- a/code/src/java/plugin/encounter/EncounterPlugin.java
+++ b/code/src/java/plugin/encounter/EncounterPlugin.java
@@ -1106,7 +1106,7 @@ public class EncounterPlugin extends MouseAdapter implements InteractivePlugin, 
 		}
 
 		// Don't allow weapons that are too large for PC
-		if (eqI.isWeaponTooLargeForPC(pc))
+		if (eqI.isWeaponOutsizedForPC(pc))
 		{
 			return false;
 		}

--- a/code/src/java/plugin/lsttokens/gamemode/codecontrol/WeaponHandsToken.java
+++ b/code/src/java/plugin/lsttokens/gamemode/codecontrol/WeaponHandsToken.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016 (C) Thomas Parker <thpr@users.sourceforge.net>
+ * 
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+package plugin.lsttokens.gamemode.codecontrol;
+
+import pcgen.cdom.inst.CodeControl;
+import pcgen.cdom.util.CControl;
+import pcgen.rules.persistence.token.AbstractStringStoringToken;
+
+public class WeaponHandsToken extends AbstractStringStoringToken<CodeControl>
+{
+	@Override
+	public String getTokenName()
+	{
+		return CControl.WEAPONHANDS;
+	}
+
+	@Override
+	public Class<CodeControl> getTokenClass()
+	{
+		return CodeControl.class;
+	}
+}

--- a/code/src/java/plugin/lsttokens/gamemode/wieldcategory/HandsToken.java
+++ b/code/src/java/plugin/lsttokens/gamemode/wieldcategory/HandsToken.java
@@ -17,6 +17,8 @@
  */
 package plugin.lsttokens.gamemode.wieldcategory;
 
+import pcgen.cdom.util.CControl;
+import pcgen.cdom.util.ControlUtilities;
 import pcgen.core.character.WieldCategory;
 import pcgen.rules.context.LoadContext;
 import pcgen.rules.persistence.token.AbstractNonEmptyToken;
@@ -35,6 +37,11 @@ public class HandsToken extends AbstractNonEmptyToken<WieldCategory> implements 
 	@Override
 	public ParseResult parseNonEmptyToken(LoadContext context, WieldCategory wc, String value)
 	{
+		if (ControlUtilities.hasControlToken(context, CControl.WEAPONHANDS))
+		{
+			return new ParseResult.Fail(getTokenName()
+				+ " is disabled when WEAPONHANDS control is used: " + value);
+		}
 		//TODO zero and 999 are magical values :(
 		try
 		{


### PR DESCRIPTION
Adds WEAPONHANDS Code Control to disable use of HANDS: on WieldCategory.

WARNING: This will only be (easily) usable in game modes where the # of hands does not need to change based on wield category.  Other systems might be possible, but that is unlikely until a WieldCategory code control exists (those systems will likely require two changes at once)
