### PR TITLE
Equipment: remove some unused code; combine two functions

### DIFF
--- a/code/src/java/pcgen/core/Equipment.java
+++ b/code/src/java/pcgen/core/Equipment.java
@@ -23,7 +23,6 @@ import java.io.Serializable;
 import java.math.BigDecimal;
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -2197,7 +2196,7 @@ public final class Equipment extends PObject
 	 * 
 	 * @return true if the Equipment can take children.
 	 */
-	public boolean acceptsChildren()
+	public boolean isContainer()
 	{
 		return get(ObjectKey.CONTAINER_WEIGHT_CAPACITY) != null;
 	}
@@ -3599,7 +3598,7 @@ public final class Equipment extends PObject
 		final StringBuilder tempStringBuilder = new StringBuilder(getChildCount() * 20);
 
 		// Make sure there's no bug here.
-		if (pc != null && acceptsChildren() && (getContainedWeight(pc, true) >= 0.0f))
+		if (pc != null && isContainer() && (getContainedWeight(pc, true) >= 0.0f))
 		{
 			tempStringBuilder
 				.append(Globals.getGameModeUnitSet().displayWeightInUnitSet(getContainedWeight(pc, true).doubleValue()))
@@ -5675,18 +5674,6 @@ public final class Equipment extends PObject
 		return containerCapacityString;
 	}
 
-	/**
-	 * Convenience method. <p> <br>
-	 * author: Thomas Behr 27-03-02
-	 * 
-	 * @return {@code true}, if this instance is a container;
-	 *         {@code false}, otherwise
-	 */
-	public boolean isContainer()
-	{
-		return acceptsChildren();
-	}
-
 	private List<EquipmentHead> heads = new ArrayList<>();
 
 	public EquipmentHead getEquipmentHead(int index)
@@ -6169,7 +6156,7 @@ public final class Equipment extends PObject
 		if (alterAC != null)
 		{
 			Object o = pc.getLocal(this, alterAC);
-			return ((Boolean) o).booleanValue();
+			return (Boolean) o;
 		}
 
 		return getRawBonusList(pc).stream().anyMatch(bonus -> bonus.getBonusInfo().equalsIgnoreCase("AC"));
@@ -6268,7 +6255,7 @@ public final class Equipment extends PObject
 	@Override
 	public List<String> getChildTypes()
 	{
-		return Arrays.asList(new String[]{"EQUIPMENT.PART"});
+		return Collections.singletonList("EQUIPMENT.PART");
 	}
 
 	@Override

--- a/code/src/java/pcgen/core/PlayerCharacter.java
+++ b/code/src/java/pcgen/core/PlayerCharacter.java
@@ -7635,7 +7635,7 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 
 		if (addAll && mergeItem && (existingSet != null))
 		{
-			newQty = tempQty + getEquippedQty(eSet, eqI).floatValue();
+			newQty = tempQty + getEquippedQty(eSet, eqI);
 			existingSet.setQty(newQty);
 			eqI.setQty(newQty);
 			eqI.setNumberCarried(newQty);

--- a/code/src/java/pcgen/core/term/PCCountContainersTermEvaluator.java
+++ b/code/src/java/pcgen/core/term/PCCountContainersTermEvaluator.java
@@ -45,7 +45,7 @@ public class PCCountContainersTermEvaluator extends BasePCTermEvaluator implemen
 
 		for (Equipment eq : eList)
 		{
-			if (eq.acceptsChildren())
+			if (eq.isContainer())
 			{
 				aList.add(eq);
 			}

--- a/code/src/java/pcgen/core/term/PCCountEqTypeTermEvaluator.java
+++ b/code/src/java/pcgen/core/term/PCCountEqTypeTermEvaluator.java
@@ -55,7 +55,7 @@ public class PCCountEqTypeTermEvaluator extends BasePCTermEvaluator implements T
 			final List<Equipment> equipList = pc.getEquipmentListInOutputOrder(merge);
 			for (Equipment eq : equipList)
 			{
-				if (eq.acceptsChildren())
+				if (eq.isContainer())
 				{
 					aList.add(eq);
 				}

--- a/code/src/java/pcgen/facade/core/EquipmentBuilderFacade.java
+++ b/code/src/java/pcgen/facade/core/EquipmentBuilderFacade.java
@@ -68,14 +68,6 @@ public interface EquipmentBuilderFacade
 	public EquipmentFacade getEquipment();
 
 	/**
-	 * Is the modifier able to be added to the item of equipment?
-	 * @param eqMod The equipment modifier to be checked.
-	 * @param head The equipment head that is being modified.
-	 * @return True if it can be added, false if not.
-	 */
-	public boolean canAddModifier(EquipmentModifier eqMod, EquipmentHead head);
-
-	/**
 	 * Can this item of equipment be resized?
 	 * @return true if the item can be resized
 	 */

--- a/code/src/java/pcgen/gui2/facade/EquipmentBuilderFacadeImpl.java
+++ b/code/src/java/pcgen/gui2/facade/EquipmentBuilderFacadeImpl.java
@@ -19,6 +19,7 @@ package pcgen.gui2.facade;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
@@ -42,6 +43,7 @@ import pcgen.facade.core.AbilityFacade;
 import pcgen.facade.core.EquipmentBuilderFacade;
 import pcgen.facade.core.EquipmentFacade;
 import pcgen.facade.core.InfoFacade;
+import pcgen.facade.core.SpellBuilderFacade;
 import pcgen.facade.core.UIDelegate;
 import pcgen.facade.util.DefaultListFacade;
 import pcgen.facade.util.DefaultReferenceFacade;
@@ -212,7 +214,7 @@ public class EquipmentBuilderFacadeImpl implements EquipmentBuilderFacade
 		}
 
 		equip.removeListFor(ListKey.SPECIAL_PROPERTIES);
-		if (!aString.equals(""))
+		if (!aString.isEmpty())
 		{
 			equip.addToListFor(ListKey.SPECIAL_PROPERTIES, SpecialProperty.createFromLst(aString));
 		}
@@ -362,12 +364,6 @@ public class EquipmentBuilderFacadeImpl implements EquipmentBuilderFacade
 	}
 
 	@Override
-	public boolean canAddModifier(EquipmentModifier eqMod, EquipmentHead head)
-	{
-		return equip.canAddModifier(character, eqMod, head.isPrimary());
-	}
-
-	@Override
 	public boolean isResizable()
 	{
 		return Globals.canResizeHaveEffect(equip, equip.typeList());
@@ -402,7 +398,7 @@ public class EquipmentBuilderFacadeImpl implements EquipmentBuilderFacade
 	{
 		String choiceValue = eqMod.getSafe(StringKey.CHOICE_STRING).substring(15);
 
-		SpellBuilderFacadeImpl spellBuilderFI = new SpellBuilderFacadeImpl(choiceValue, character, equip);
+		SpellBuilderFacade spellBuilderFI = new SpellBuilderFacadeImpl(choiceValue, character, equip);
 		if (!delegate.showCustomSpellDialog(spellBuilderFI))
 		{
 			return false;
@@ -420,10 +416,7 @@ public class EquipmentBuilderFacadeImpl implements EquipmentBuilderFacade
 		int casterLevel = spellBuilderFI.getCasterLevelRef().get();
 		ListFacade<AbilityFacade> metamagicFeatsList = spellBuilderFI.getSelectedMetamagicFeats();
 		Object[] metamagicFeats = new Object[metamagicFeatsList.getSize()];
-		for (int i = 0; i < metamagicFeats.length; i++)
-		{
-			metamagicFeats[i] = metamagicFeatsList.getElementAt(i);
-		}
+		Arrays.setAll(metamagicFeats, metamagicFeatsList::getElementAt);
 
 		int charges = getNumCharges(eqMod);
 

--- a/code/src/java/pcgen/io/exporttoken/EqTypeToken.java
+++ b/code/src/java/pcgen/io/exporttoken/EqTypeToken.java
@@ -64,7 +64,7 @@ public class EqTypeToken extends EqToken
 		{
 			for (Equipment eq : pc.getEquipmentListInOutputOrder(merge))
 			{
-				if (eq.acceptsChildren())
+				if (eq.isContainer())
 				{
 					eqList.add(eq);
 				}


### PR DESCRIPTION
- acceptsChildren and isContainer are identical. Combine them and pick
  better name.
- remove canAddModifier from EquipmentBuilderFacade, it is unused. We
	should possibly actually use it instead of removing it.