### PR TITLE
[gui3] use FXML instead of creating nodes in code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ plugins {
 
 javafx {
     version = "12.0.1"
-    modules = [ 'javafx.controls', 'javafx.web', 'javafx.swing' ]
+    modules = [ 'javafx.controls', 'javafx.web', 'javafx.swing', 'javafx.fxml' ]
 }
 
 group = 'net.sourceforge.pcgen'
@@ -101,12 +101,14 @@ sourceSets {
             srcDirs 'code/src/java'
         }
         resources {
-            srcDirs = ['code/src/java', 'code/resources']
+            // first path is deprecated. New resources belong in resources.
+            srcDirs = ['code/src/java', 'code/src/resources']
             include '**/*.properties'
             include '**/*.xml'
             include '**/*.gif'
             include '**/*.png'
             include '**/*.jpg'
+            include '**/*.fxml'
         }
     }
     test {

--- a/code/src/java/pcgen/gui2/PCGenFrame.java
+++ b/code/src/java/pcgen/gui2/PCGenFrame.java
@@ -101,7 +101,8 @@ import pcgen.gui2.tools.CharacterSelectionListener;
 import pcgen.gui2.tools.Icons;
 import pcgen.gui2.tools.Utility;
 import pcgen.gui2.util.ShowMessageGuiObserver;
-import pcgen.gui3.SimpleHtmlPanel;
+import pcgen.gui3.JFXPanelFromResource;
+import pcgen.gui3.SimpleHtmlPanelController;
 import pcgen.io.PCGFile;
 import pcgen.persistence.SourceFileLoader;
 import pcgen.system.CharacterManager;
@@ -116,6 +117,7 @@ import pcgen.util.Logging;
 import pcgen.util.chooser.ChooserFactory;
 import pcgen.util.chooser.RandomChooser;
 
+import javafx.application.Platform;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -1738,9 +1740,9 @@ public final class PCGenFrame extends JFrame implements UIDelegate, CharacterSel
 		jPanel.add(jClose);
 		jClose.addActionListener(evt -> aFrame.dispose());
 
-
-		SimpleHtmlPanel htmlPanel = new SimpleHtmlPanel();
-		htmlPanel.setHtml(htmlString);
+		var htmlPanel = new JFXPanelFromResource<>(SimpleHtmlPanelController.class, "SimpleHtmlPanel.fxml");
+		String finalHtmlString = htmlString;
+		Platform.runLater(() -> htmlPanel.getController().setHtml(finalHtmlString));
 
 		aFrame.getContentPane().setLayout(new BorderLayout());
 		aFrame.getContentPane().add(htmlPanel, BorderLayout.CENTER);
@@ -1774,8 +1776,8 @@ public final class PCGenFrame extends JFrame implements UIDelegate, CharacterSel
 		jPanel1.add(jLabel1, BorderLayout.NORTH);
 		jPanel1.add(jLabel2, BorderLayout.SOUTH);
 
-		SimpleHtmlPanel htmlPanel = new SimpleHtmlPanel();
-		htmlPanel.setHtml(text);
+		var htmlPanel = new JFXPanelFromResource<>(SimpleHtmlPanelController.class, "SimpleHtmlPanel.fxml");
+		Platform.runLater(() -> htmlPanel.getController().setHtml(text));
 
 		jPanel3.add(jCheckBox1);
 		jPanel3.add(jClose);

--- a/code/src/java/pcgen/gui3/JFXPanelFromResource.java
+++ b/code/src/java/pcgen/gui3/JFXPanelFromResource.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 (C) Eitan Adler <lists@eitanadler.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.     See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+package pcgen.gui3;
+
+import java.io.IOException;
+
+import pcgen.util.Logging;
+
+import javafx.application.Platform;
+import javafx.embed.swing.JFXPanel;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Scene;
+
+/**
+ * Displays HTML content as a "panel".
+ * @param <T> The class of the controller
+ */
+public final class JFXPanelFromResource<T> extends JFXPanel
+{
+
+	private final FXMLLoader fxmlLoader = new FXMLLoader();
+
+	/**
+	 * @param klass the class that contains the resource load
+	 * @param resourceName the relative filename of the FXML file to load.
+	 */
+	public JFXPanelFromResource(Class<T> klass, String resourceName)
+	{
+		Platform.runLater(() -> {
+			fxmlLoader.setLocation(klass.getResource(resourceName));
+			try
+			{
+				Scene scene = fxmlLoader.load();
+				this.setScene(scene);
+			} catch (IOException e)
+			{
+				Logging.errorPrint("failed to load stream fxml", e);
+			}
+		});
+	}
+
+	/**
+	 * @return controller for the loaded FXML file
+	 */
+	public T getController()
+	{
+		return fxmlLoader.getController();
+	}
+}

--- a/code/src/java/pcgen/gui3/SimpleHtmlPanelController.java
+++ b/code/src/java/pcgen/gui3/SimpleHtmlPanelController.java
@@ -19,24 +19,20 @@
 package pcgen.gui3;
 
 import javafx.application.Platform;
-import javafx.embed.swing.JFXPanel;
-import javafx.scene.Scene;
+import javafx.fxml.FXML;
 import javafx.scene.web.WebView;
 
 /**
  * Displays HTML content as a "panel".
  */
-public final class SimpleHtmlPanel extends JFXPanel
+public final class SimpleHtmlPanelController
 {
+	@FXML
 	private WebView browser;
 
-	public SimpleHtmlPanel()
-	{
-		Platform.runLater(() -> {
-			browser = new WebView();
-			browser.setContextMenuEnabled(true);
-			this.setScene(new Scene(browser));
-		});
+	@FXML // This method is called by the FXMLLoader when initialization is complete
+	void initialize() {
+
 	}
 
 	public void setHtml(String html)

--- a/code/src/resources/pcgen/gui3/SimpleHtmlPanel.fxml
+++ b/code/src/resources/pcgen/gui3/SimpleHtmlPanel.fxml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.Scene?>
+<?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.web.WebView?>
+
+<!--
+  * Copyright 2019 (C) Eitan Adler <lists@eitanadler.com>
+  *
+  * This library is free software; you can redistribute it and/or
+  * modify it under the terms of the GNU Lesser General Public
+  * License as published by the Free Software Foundation; either
+  * version 2.1 of the License, or (at your option) any later version.
+  *
+  * This library is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.     See the GNU
+  * Lesser General Public License for more details.
+  *
+  * You should have received a copy of the GNU Lesser General Public
+  * License along with this library; if not, write to the Free Software
+  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+  -->
+
+<Scene xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="pcgen.gui3.SimpleHtmlPanelController">
+    <AnchorPane>
+        <WebView fx:id="browser"/>
+    </AnchorPane>
+</Scene>


### PR DESCRIPTION
This continues to more fully decouple code from UI. Further it makes the
notion of a controller "real" in pcgen.

Long term we may even have people who edit the UI that don't need code
permissions or info.

While this is a trivial example, I'm trying to figure out the right
pattern for UI in pcgen.