### PR TITLE
gui utils: remove unused showMessageDialog function

### DIFF
--- a/code/src/java/pcgen/core/utils/ShowMessageDelegate.java
+++ b/code/src/java/pcgen/core/utils/ShowMessageDelegate.java
@@ -30,12 +30,6 @@ public final class ShowMessageDelegate extends Observable
 	{
 	}
 
-	public static void showMessageDialog(final Object message, final String title, final MessageType messageType,
-		final Object parent)
-	{
-		showMessageDialog(new MessageWrapper(message, title, messageType, parent));
-	}
-
 	public static void showMessageDialog(final Object message, final String title, final MessageType messageType)
 	{
 		showMessageDialog(new MessageWrapper(message, title, messageType));


### PR DESCRIPTION
This is prep work for migrating JOptionPane to JavaFX