### PR TITLE
[*] avoid setting Java thread priority

### DIFF
--- a/code/src/java/pcgen/gui2/tabs/InfoTabbedPane.java
+++ b/code/src/java/pcgen/gui2/tabs/InfoTabbedPane.java
@@ -346,7 +346,6 @@ public final class InfoTabbedPane extends JTabbedPane implements CharacterSelect
 				{
 					Thread thread = new Thread(r);
 					thread.setDaemon(true);
-					thread.setPriority(Thread.NORM_PRIORITY);
 					thread.setName("tab-info-thread"); //$NON-NLS-1$
 					return thread;
 				}

--- a/code/src/java/pcgen/system/PluginClassLoader.java
+++ b/code/src/java/pcgen/system/PluginClassLoader.java
@@ -57,7 +57,6 @@ class PluginClassLoader extends PCGenTask
 	private final ExecutorService dispatcher = Executors.newSingleThreadExecutor(r -> {
 		Thread thread = new Thread(r, "Plugin-loading-thread");
 		thread.setDaemon(true);
-		thread.setPriority(Thread.NORM_PRIORITY);
 		return thread;
 	});
 	private final LinkedList<File> jarFiles = new LinkedList<>();


### PR DESCRIPTION
Thread priorities are non-portable and mostly meaningless.