### PR TITLE
PCGenUIManager: handle null pcgenFrame

### DIFF
--- a/code/src/java/pcgen/gui2/PCGenUIManager.java
+++ b/code/src/java/pcgen/gui2/PCGenUIManager.java
@@ -75,12 +75,15 @@ public final class PCGenUIManager
 
 	public static void closePCGen()
 	{
-		if (!pcgenFrame.closeAllCharacters())
+		if (pcgenFrame != null)
 		{
-			return;
-		}
+			if (!pcgenFrame.closeAllCharacters())
+			{
+				return;
+			}
 
-		pcgenFrame.dispose();
+			pcgenFrame.dispose();
+		}
 		Main.shutdown();
 	}
 


### PR DESCRIPTION
It is possible that pcgenFrame is null when cmd-q is hit. Handle this
case by ignoring the frame and just shutting down.