### PR TITLE
PCGenPreloader: fix runtime of preloader

### DIFF
--- a/code/src/java/pcgen/gui3/preloader/PCGenPreloader.java
+++ b/code/src/java/pcgen/gui3/preloader/PCGenPreloader.java
@@ -73,7 +73,8 @@ public class PCGenPreloader implements PCGenTaskListener
 	public PCGenPreloaderController getController()
 	{
 		return CompletableFuture
-				.supplyAsync(loader::<PCGenPreloaderController>getController)
+				.supplyAsync(loader::<PCGenPreloaderController>getController,
+						Platform::runLater)
 				.join();
 	}
 


### PR DESCRIPTION
we require a non-null controller which is only guaranteed to exist after
the UI is initialized. Since we can't know when it is safe to run,
serialize getting the controller on the UI thread.