### PR TITLE
Remove 'version' from some plugins

### DIFF
--- a/code/src/java/pcgen/gui2/doomsdaybook/NameGenPanel.java
+++ b/code/src/java/pcgen/gui2/doomsdaybook/NameGenPanel.java
@@ -36,7 +36,6 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.Vector;
-import java.util.prefs.Preferences;
 
 import javax.swing.BoxLayout;
 import javax.swing.ComboBoxModel;
@@ -81,7 +80,6 @@ import org.xml.sax.InputSource;
  */
 public class NameGenPanel extends JPanel
 {
-	private final Preferences namePrefs = Preferences.userNodeForPackage(NameGenPanel.class);
 	private final Map<String, List<RuleSet>> categories = new HashMap<>();
 	private JButton generateButton;
 	private JButton jButton1;
@@ -126,9 +124,7 @@ public class NameGenPanel extends JPanel
 	/** Creates new form NameGenPanel */
 	public NameGenPanel()
 	{
-		initComponents();
-		initPrefs();
-		loadData(new File("."));
+		this(new File("."));
 	}
 
 	/**
@@ -139,7 +135,6 @@ public class NameGenPanel extends JPanel
 	public NameGenPanel(File dataPath)
 	{
 		initComponents();
-		initPrefs();
 		loadData(dataPath);
 	}
 
@@ -176,29 +171,6 @@ public class NameGenPanel extends JPanel
 
 			return null;
 		}
-	}
-
-	/**
-	 *  Initialization of the bulk of preferences.  sets the defaults
-	 *  if this is the first time you have used this version
-	 */
-	private void initPrefs()
-	{
-		boolean prefsSet = namePrefs.getBoolean("arePrefsSet", false);
-
-		if (!prefsSet)
-		{
-			namePrefs.putBoolean("arePrefsSet", true);
-		}
-
-		double version = namePrefs.getDouble("Version", 0);
-
-		if ((version < 0.5) || !prefsSet)
-		{
-			namePrefs.putDouble("Version", 0.5);
-		}
-
-		namePrefs.putDouble("SubVersion", 0);
 	}
 
 	private void setMeaningText(String meaning)

--- a/code/src/java/plugin/initiative/gui/Initiative.java
+++ b/code/src/java/plugin/initiative/gui/Initiative.java
@@ -151,11 +151,6 @@ public class Initiative extends javax.swing.JPanel
 
 	private final PCGenMessageHandler messageHandler;
 
-	/*
-	 *  History:
-	 *  March 20, 2003: Cleanup for Version 1.0
-	 */
-
 	/**  Creates new form Initiative */
 	public Initiative()
 	{
@@ -1003,8 +998,7 @@ public class Initiative extends javax.swing.JPanel
 	}
 
 	/**
-	 *  Initialization of the bulk of preferences.  sets the defaults
-	 *  if this is the first time you have used this version
+	 *  Initialization of the bulk of preferences.
 	 */
 	private void initPrefs()
 	{
@@ -1013,12 +1007,6 @@ public class Initiative extends javax.swing.JPanel
 		if (!prefsSet)
 		{
 			SettingsHandler.setGMGenOption(InitiativePlugin.LOG_NAME + ".arePrefsSet", true);
-		}
-
-		Double version = SettingsHandler.getGMGenOption(InitiativePlugin.LOG_NAME + ".Version", 0.0);
-
-		if ((version < 1.0) || !prefsSet)
-		{
 			SettingsHandler.setGMGenOption(InitiativePlugin.LOG_NAME + ".doSpells", true);
 			SettingsHandler.setGMGenOption(InitiativePlugin.LOG_NAME + ".doDeath", true);
 			SettingsHandler.setGMGenOption(InitiativePlugin.LOG_NAME + ".doHP", true);
@@ -1047,8 +1035,6 @@ public class Initiative extends javax.swing.JPanel
 			SettingsHandler.setGMGenOption(InitiativePlugin.LOG_NAME + ".ColumnWidth.9", 50);
 			SettingsHandler.setGMGenOption(InitiativePlugin.LOG_NAME + ".NumberOfColumns", 10);
 			SettingsHandler.setGMGenOption(InitiativePlugin.LOG_NAME + ".DividerLocation", 450);
-			SettingsHandler.setGMGenOption(InitiativePlugin.LOG_NAME + ".SubVersion", 1.0);
-			SettingsHandler.setGMGenOption(InitiativePlugin.LOG_NAME + ".Version", 1.0);
 		}
 	}
 


### PR DESCRIPTION
NameGenPanel and Initiative have their own notion of "version". Aside
from almost never changing, this adds complexity for little gain.
Remove.