### PR TITLE
CODE-3401: Cleanup: Make FormatManager in scope an Optional

### DIFF
--- a/code/src/java/pcgen/cdom/facet/ModifierFacet.java
+++ b/code/src/java/pcgen/cdom/facet/ModifierFacet.java
@@ -17,6 +17,8 @@
  */
 package pcgen.cdom.facet;
 
+import java.util.Optional;
+
 import pcgen.base.calculation.FormulaModifier;
 import pcgen.base.formula.base.ScopeInstance;
 import pcgen.base.formula.base.VarScoped;
@@ -74,12 +76,13 @@ public class ModifierFacet implements DataFacetChangeListener<CharID, PCGenScope
 		PCGenScope legalScope = (PCGenScope) source.getLegalScope();
 		LoadContext context = loadContextFacet.get(id.getDatasetID()).get();
 		Modifier<T> returnValue;
-		try
+		Optional<FormatManager<?>> formatManager = legalScope.getFormatManager(context);
+		if (formatManager.isPresent())
 		{
-			FormatManager<?> formatManager = legalScope.getFormatManager(context);
-			returnValue = new DefinedWrappingModifier<>(modifier, "this", thisValue, formatManager);
+			returnValue = new DefinedWrappingModifier<>(modifier, "this",
+				thisValue, formatManager.get());
 		}
-		catch (UnsupportedOperationException e)
+		else
 		{
 			returnValue = new ModifierDecoration<>(modifier);
 		}

--- a/code/src/java/pcgen/cdom/facet/RemoteModifierFacet.java
+++ b/code/src/java/pcgen/cdom/facet/RemoteModifierFacet.java
@@ -17,6 +17,7 @@
  */
 package pcgen.cdom.facet;
 
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 
@@ -34,6 +35,7 @@ import pcgen.cdom.facet.event.DataFacetChangeListener;
 import pcgen.cdom.facet.model.VarScopedFacet;
 import pcgen.cdom.formula.PCGenScoped;
 import pcgen.cdom.formula.local.DefinedWrappingModifier;
+import pcgen.cdom.formula.local.ModifierDecoration;
 import pcgen.cdom.formula.local.RemoteWrappingModifier;
 import pcgen.cdom.formula.scope.PCGenScope;
 import pcgen.rules.context.LoadContext;
@@ -106,25 +108,28 @@ public class RemoteModifierFacet extends AbstractAssociationFacet<CharID, Remote
 	{
 		PCGenScope sourceScope = (PCGenScope) sourceInstance.getLegalScope();
 		LoadContext context = loadContextFacet.get(id.getDatasetID()).get();
+		Optional<FormatManager<?>> sourceFormatManager = sourceScope.getFormatManager(context);
+		PCGenScope targetScope = (PCGenScope) targetInstance.getLegalScope();
+		Optional<FormatManager<?>> targetFormatManager = targetScope.getFormatManager(context);
 		Modifier<T> returnValue;
-		try
+		if (sourceFormatManager.isPresent() && targetFormatManager.isPresent())
 		{
-			FormatManager<?> sourceFormatManager = sourceScope.getFormatManager(context);
-			PCGenScope targetScope = (PCGenScope) targetInstance.getLegalScope();
-			FormatManager<?> targetFormatManager = targetScope.getFormatManager(context);
-			returnValue =
-					new RemoteWrappingModifier<>(modifier, source, sourceFormatManager, target, targetFormatManager);
+			returnValue = new RemoteWrappingModifier<>(modifier, source,
+				sourceFormatManager.get(), target, targetFormatManager.get());
 		}
-		catch (UnsupportedOperationException e)
+		else if (sourceFormatManager.isPresent())
 		{
-			/*
-			 * Assume this failure is from sourceScope.getFormatManager, as it will fail
-			 * if the source is a GlobalModifier, so source() cannot be used... but we
-			 * still want to define target().
-			 */
-			PCGenScope targetScope = (PCGenScope) targetInstance.getLegalScope();
-			FormatManager<?> targetFormatManager = targetScope.getFormatManager(context);
-			returnValue = new DefinedWrappingModifier<>(modifier, "target", target, targetFormatManager);
+			returnValue = new DefinedWrappingModifier<>(modifier, "source",
+				source, sourceFormatManager.get());
+		}
+		else if (sourceFormatManager.isPresent())
+		{
+			returnValue = new DefinedWrappingModifier<>(modifier, "target",
+				target, targetFormatManager.get());
+		}
+		else
+		{
+			returnValue = new ModifierDecoration<>(modifier);
 		}
 		return returnValue;
 	}

--- a/code/src/java/pcgen/cdom/formula/scope/DynamicScope.java
+++ b/code/src/java/pcgen/cdom/formula/scope/DynamicScope.java
@@ -73,9 +73,8 @@ public class DynamicScope implements PCGenScope
 	}
 
 	@Override
-	public FormatManager<Dynamic> getFormatManager(LoadContext context)
+	public Optional<FormatManager<?>> getFormatManager(LoadContext context)
 	{
-		return formatManager;
+		return Optional.of(formatManager);
 	}
-
 }

--- a/code/src/java/pcgen/cdom/formula/scope/EquipmentPartScope.java
+++ b/code/src/java/pcgen/cdom/formula/scope/EquipmentPartScope.java
@@ -63,8 +63,8 @@ public class EquipmentPartScope implements PCGenScope
 	}
 
 	@Override
-	public FormatManager<?> getFormatManager(LoadContext context)
+	public Optional<FormatManager<?>> getFormatManager(LoadContext context)
 	{
-		throw new UnsupportedOperationException("Equipment Part does not have a format");
+		return Optional.empty();
 	}
 }

--- a/code/src/java/pcgen/cdom/formula/scope/EquipmentScope.java
+++ b/code/src/java/pcgen/cdom/formula/scope/EquipmentScope.java
@@ -58,8 +58,8 @@ public class EquipmentScope implements PCGenScope
 	}
 
 	@Override
-	public FormatManager<?> getFormatManager(LoadContext context)
+	public Optional<FormatManager<?>> getFormatManager(LoadContext context)
 	{
-		throw new UnsupportedOperationException("Equipment Part does not have a format");
+		return Optional.empty();
 	}
 }

--- a/code/src/java/pcgen/cdom/formula/scope/GlobalEQScope.java
+++ b/code/src/java/pcgen/cdom/formula/scope/GlobalEQScope.java
@@ -50,8 +50,8 @@ public class GlobalEQScope implements PCGenScope
 	}
 
 	@Override
-	public FormatManager<?> getFormatManager(LoadContext context)
+	public Optional<FormatManager<?>> getFormatManager(LoadContext context)
 	{
-		throw new UnsupportedOperationException("Global Scope does not have a format");
+		return Optional.empty();
 	}
 }

--- a/code/src/java/pcgen/cdom/formula/scope/GlobalPCScope.java
+++ b/code/src/java/pcgen/cdom/formula/scope/GlobalPCScope.java
@@ -45,8 +45,8 @@ public class GlobalPCScope implements PCGenScope
 	}
 
 	@Override
-	public FormatManager<?> getFormatManager(LoadContext context)
+	public Optional<FormatManager<?>> getFormatManager(LoadContext context)
 	{
-		throw new UnsupportedOperationException("Global Scope does not have a format");
+		return Optional.empty();
 	}
 }

--- a/code/src/java/pcgen/cdom/formula/scope/PCGenScope.java
+++ b/code/src/java/pcgen/cdom/formula/scope/PCGenScope.java
@@ -37,5 +37,5 @@ public interface PCGenScope extends LegalScope
 	 *            The LoadContext used to resolve the actual FormatManager
 	 * @return The FormatManager used to process objects that are within this PCGenScope
 	 */
-	public FormatManager<?> getFormatManager(LoadContext context);
+	public Optional<FormatManager<?>> getFormatManager(LoadContext context);
 }

--- a/code/src/java/pcgen/cdom/formula/scope/RaceScope.java
+++ b/code/src/java/pcgen/cdom/formula/scope/RaceScope.java
@@ -58,8 +58,8 @@ public class RaceScope implements PCGenScope
 	}
 
 	@Override
-	public FormatManager<Race> getFormatManager(LoadContext context)
+	public Optional<FormatManager<?>> getFormatManager(LoadContext context)
 	{
-		return context.getReferenceContext().getManufacturer(Race.class);
+		return Optional.of(context.getReferenceContext().getManufacturer(Race.class));
 	}
 }

--- a/code/src/java/pcgen/cdom/formula/scope/SaveScope.java
+++ b/code/src/java/pcgen/cdom/formula/scope/SaveScope.java
@@ -58,8 +58,8 @@ public class SaveScope implements PCGenScope
 	}
 
 	@Override
-	public FormatManager<PCCheck> getFormatManager(LoadContext context)
+	public Optional<FormatManager<?>> getFormatManager(LoadContext context)
 	{
-		return context.getReferenceContext().getManufacturer(PCCheck.class);
+		return Optional.of(context.getReferenceContext().getManufacturer(PCCheck.class));
 	}
 }

--- a/code/src/java/pcgen/cdom/formula/scope/SizeScope.java
+++ b/code/src/java/pcgen/cdom/formula/scope/SizeScope.java
@@ -58,8 +58,8 @@ public class SizeScope implements PCGenScope
 	}
 
 	@Override
-	public FormatManager<SizeAdjustment> getFormatManager(LoadContext context)
+	public Optional<FormatManager<?>> getFormatManager(LoadContext context)
 	{
-		return context.getReferenceContext().getManufacturer(SizeAdjustment.class);
+		return Optional.of(context.getReferenceContext().getManufacturer(SizeAdjustment.class));
 	}
 }

--- a/code/src/java/pcgen/cdom/formula/scope/SkillScope.java
+++ b/code/src/java/pcgen/cdom/formula/scope/SkillScope.java
@@ -58,8 +58,8 @@ public class SkillScope implements PCGenScope
 	}
 
 	@Override
-	public FormatManager<Skill> getFormatManager(LoadContext context)
+	public Optional<FormatManager<?>> getFormatManager(LoadContext context)
 	{
-		return context.getReferenceContext().getManufacturer(Skill.class);
+		return Optional.of(context.getReferenceContext().getManufacturer(Skill.class));
 	}
 }

--- a/code/src/java/pcgen/cdom/formula/scope/StatScope.java
+++ b/code/src/java/pcgen/cdom/formula/scope/StatScope.java
@@ -58,8 +58,8 @@ public class StatScope implements PCGenScope
 	}
 
 	@Override
-	public FormatManager<PCStat> getFormatManager(LoadContext context)
+	public Optional<FormatManager<?>> getFormatManager(LoadContext context)
 	{
-		return context.getReferenceContext().getManufacturer(PCStat.class);
+		return Optional.of(context.getReferenceContext().getManufacturer(PCStat.class));
 	}
 }

--- a/code/src/java/pcgen/cdom/grouping/GroupingInfo.java
+++ b/code/src/java/pcgen/cdom/grouping/GroupingInfo.java
@@ -234,7 +234,7 @@ public class GroupingInfo<T>
 	@SuppressWarnings("unchecked")
 	public Class<T> getManagedClass(LoadContext context)
 	{
-		return (Class<T>) scope.getFormatManager(context).getManagedClass();
+		return (Class<T>) scope.getFormatManager(context).get().getManagedClass();
 	}
 
 }

--- a/code/src/java/plugin/function/GetOtherFunction.java
+++ b/code/src/java/plugin/function/GetOtherFunction.java
@@ -76,8 +76,11 @@ public class GetOtherFunction implements FormulaFunction
 		Node scopeNode = args[0];
 		if (!(scopeNode instanceof ASTQuotString))
 		{
-			throw new SemanticsFailureException("Parse Error: Invalid Scope Node: " + scopeNode.getClass().getName()
-				+ " found in location requiring a" + " Static String (first arg cannot be evaluated)");
+			throw new SemanticsFailureException(
+				"Parse Error: Invalid Scope Node: "
+					+ scopeNode.getClass().getName()
+					+ " found in location requiring a"
+					+ " Static String (first arg cannot be evaluated)");
 		}
 		ASTQuotString qs = (ASTQuotString) scopeNode;
 		String legalScopeName = qs.getText();
@@ -88,33 +91,34 @@ public class GetOtherFunction implements FormulaFunction
 			throw new SemanticsFailureException(
 				"Parse Error: Invalid Scope Name: " + legalScopeName + " was not a defined scope");
 		}
-		FormatManager<?> formatManager;
-		try
-		{
-			LoadContext context = semantics.get(ManagerKey.CONTEXT);
-			formatManager = legalScope.getFormatManager(context);
-		}
-		catch (UnsupportedOperationException e)
-		{
-			throw new SemanticsFailureException("Parse Error: Invalid Scope Name: " + legalScopeName
-				+ " found in location requiring a deterministic scope");
-		}
-		FormatManager<?> objectFormat = (FormatManager<?>) args[1].jjtAccept(visitor,
-			semantics.getWith(FormulaSemantics.ASSERTED, Optional.of(formatManager)));
-		if (!formatManager.equals(objectFormat))
+		LoadContext context = semantics.get(ManagerKey.CONTEXT);
+		Optional<FormatManager<?>> formatManager = legalScope.getFormatManager(context);
+		if (formatManager.isEmpty())
 		{
 			throw new SemanticsFailureException(
-				"Parse Error: Invalid Object Format: " + objectFormat.getIdentifierType()
-					+ " found in a getOther call that asserted " + formatManager.getIdentifierType());
+				"Parse Error: Invalid Scope Name: " + legalScopeName
+					+ " found in location requiring a deterministic scope");
+		}
+		FormatManager<?> objectFormat = (FormatManager<?>) args[1].jjtAccept(visitor,
+			semantics.getWith(FormulaSemantics.ASSERTED, formatManager));
+		if (!formatManager.get().equals(objectFormat))
+		{
+			throw new SemanticsFailureException(
+				"Parse Error: Invalid Object Format: "
+					+ objectFormat.getIdentifierType()
+					+ " found in a getOther call that asserted "
+					+ formatManager.get().getIdentifierType());
 		}
 		if (VarScoped.class.isAssignableFrom(objectFormat.getManagedClass()))
 		{
-			return (FormatManager<?>) args[2].jjtAccept(visitor, semantics.getWith(FormulaSemantics.SCOPE, legalScope));
+			return (FormatManager<?>) args[2].jjtAccept(visitor,
+				semantics.getWith(FormulaSemantics.SCOPE, legalScope));
 		}
 		else
 		{
 			throw new SemanticsFailureException(
-				"Parse Error: Invalid Object Format: " + objectFormat + " is not capable of holding variables");
+				"Parse Error: Invalid Object Format: " + objectFormat
+					+ " is not capable of holding variables");
 		}
 	}
 
@@ -126,7 +130,7 @@ public class GetOtherFunction implements FormulaFunction
 		PCGenScope legalScope = (PCGenScope) formulaManager.getScopeInstanceFactory().getScope(legalScopeName);
 		LoadContext context = manager.get(ManagerKey.CONTEXT);
 		VarScoped vs = (VarScoped) args[1].jjtAccept(visitor,
-			manager.getWith(EvaluationManager.ASSERTED, Optional.of(legalScope.getFormatManager(context))));
+			manager.getWith(EvaluationManager.ASSERTED, legalScope.getFormatManager(context)));
 		FormulaManager fm = manager.get(EvaluationManager.FMANAGER);
 		ScopeInstanceFactory siFactory = fm.getScopeInstanceFactory();
 		Optional<String> localScopeName = vs.getLocalScopeName();
@@ -146,7 +150,7 @@ public class GetOtherFunction implements FormulaFunction
 		PCGenScope legalScope = (PCGenScope) scopeInstanceFactory.getScope(legalScopeName);
 		LoadContext context = fdm.get(ManagerKey.CONTEXT);
 		args[1].jjtAccept(visitor, fdm.getWith(DependencyManager.VARSTRATEGY, Optional.of(ts))
-			.getWith(DependencyManager.ASSERTED, Optional.of(legalScope.getFormatManager(context))));
+			.getWith(DependencyManager.ASSERTED, legalScope.getFormatManager(context)));
 		DynamicDependency dd = new DynamicDependency(ts.getControlVar(), LegalScope.getFullName(legalScope));
 		fdm.get(DependencyManager.DYNAMIC).addDependency(dd);
 		DependencyManager dynamic = fdm.getWith(DependencyManager.VARSTRATEGY, Optional.of(dd));

--- a/code/src/java/plugin/function/GroupFunction.java
+++ b/code/src/java/plugin/function/GroupFunction.java
@@ -92,19 +92,25 @@ public class GroupFunction implements FormulaFunction
 		String scopeName = ((ASTQuotString) args[0]).getText();
 		LoadContext context = semantics.get(ManagerKey.CONTEXT);
 		PCGenScope scope = context.getVariableContext().getScope(scopeName);
-		FormatManager<?> formatManager = scope.getFormatManager(context);
-
+		Optional<FormatManager<?>> possibleFormatManager = scope.getFormatManager(context);
+		if (possibleFormatManager.isEmpty())
+		{
+			throw new SemanticsFailureException(
+				"Parse Error: Invalid first argument: Scope: " + scopeName
+					+ " does not support Groups (no format)");
+		}
+		FormatManager<?> formatManager = possibleFormatManager.get();
 		if (!(formatManager instanceof ReferenceManufacturer))
 		{
 			throw new SemanticsFailureException(
-				"Parse Error: Invalid first argument: Format: " + scopeName
+				"Parse Error: Invalid first argument: Scope: " + scopeName
 					+ " does not support Groups");
 		}
 		if (!(PCGenScoped.class
 			.isAssignableFrom(formatManager.getManagedClass())))
 		{
 			throw new SemanticsFailureException(
-				"Parse Error: Invalid first argument: Format: " + scopeName
+				"Parse Error: Invalid first argument: Scope: " + scopeName
 					+ " must be Scoped");
 		}
 
@@ -125,7 +131,7 @@ public class GroupFunction implements FormulaFunction
 		@SuppressWarnings("unchecked")
 		ReferenceManufacturer<? extends PCGenScoped> refMfg =
 				(ReferenceManufacturer<? extends PCGenScoped>) scope
-					.getFormatManager(context);
+					.getFormatManager(context).get();
 
 		String groupingName = (String) args[1].jjtAccept(visitor,
 			manager.getWith(EvaluationManager.ASSERTED,

--- a/code/src/java/plugin/lsttokens/ModifyLst.java
+++ b/code/src/java/plugin/lsttokens/ModifyLst.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import pcgen.base.calculation.FormulaModifier;
@@ -169,20 +170,16 @@ public class ModifyLst extends AbstractNonEmptyToken<VarHolder>
 	{
 		FormulaManager formulaManager =
 				context.getVariableContext().getFormulaManager();
-		FormatManager<?> formatManager;
-		try
+		Optional<FormatManager<?>> formatManager = scope.getFormatManager(context);
+		if (formatManager.isEmpty())
 		{
-			formatManager = scope.getFormatManager(context);
-		}
-		catch (UnsupportedOperationException e)
-		{
-			return formulaManager;
 			//Okay, we won't add this()
+			return formulaManager;
 		}
 		//Note: Passing new Object() as DefinedValue is a dummy
 		FunctionLibrary functionLibrary = new DefinedWrappingLibrary(
 			formulaManager.get(FormulaManager.FUNCTION), "this", new Object(),
-			formatManager);
+			formatManager.get());
 		return formulaManager.getWith(FormulaManager.FUNCTION, functionLibrary);
 	}
 

--- a/code/src/java/plugin/lsttokens/ModifyOtherLst.java
+++ b/code/src/java/plugin/lsttokens/ModifyOtherLst.java
@@ -19,6 +19,7 @@ package plugin.lsttokens;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.StringJoiner;
 
 import pcgen.base.formula.base.FormulaManager;
@@ -31,7 +32,7 @@ import pcgen.cdom.base.VarContainer;
 import pcgen.cdom.base.VarHolder;
 import pcgen.cdom.content.RemoteModifier;
 import pcgen.cdom.content.VarModifier;
-import pcgen.cdom.formula.local.RemoteWrappingLibrary;
+import pcgen.cdom.formula.local.DefinedWrappingLibrary;
 import pcgen.cdom.formula.scope.PCGenScope;
 import pcgen.cdom.grouping.GroupingCollection;
 import pcgen.rules.context.AbstractObjectContext.DummyCDOMObject;
@@ -110,11 +111,26 @@ public class ModifyOtherLst extends AbstractNonEmptyToken<VarHolder>
 		FormulaManager formulaManager =
 				context.getVariableContext().getFormulaManager();
 		FunctionLibrary functionManager = formulaManager.get(FormulaManager.FUNCTION);
-		FormatManager<?> sourceFormatManager = scope.getFormatManager(context);
-		FormatManager<?> targetFormatManager = scope.getFormatManager(context);
-		functionManager =
-				new RemoteWrappingLibrary(functionManager, new DummyCDOMObject(),
-					sourceFormatManager, new DummyCDOMObject(), targetFormatManager);
+		boolean modified = false;
+		Optional<FormatManager<?>> sourceFormatManager = scope.getFormatManager(context);
+		if (sourceFormatManager.isPresent())
+		{
+			functionManager = new DefinedWrappingLibrary(functionManager,
+				"source", new DummyCDOMObject(), sourceFormatManager.get());
+			modified = true;
+		}
+		Optional<FormatManager<?>> targetFormatManager = scope.getFormatManager(context);
+		if (targetFormatManager.isPresent())
+		{
+			functionManager = new DefinedWrappingLibrary(functionManager,
+				"target", new DummyCDOMObject(), targetFormatManager.get());
+			modified = true;
+		}
+		if (!modified)
+		{
+			//Fine then :P
+			return formulaManager;
+		}
 		return formulaManager.getWith(FormulaManager.FUNCTION, functionManager);
 	}
 


### PR DESCRIPTION
This avoid catching runtime UnsupportedOperationException, which seemed
like bad behavior

Note: some situations assumed the format existed, so some bug fixes are embedded
