### PR TITLE
CODE-3159: Auto generation of equipment: remove feature

### DIFF
--- a/code/src/java/pcgen/cdom/base/Constants.java
+++ b/code/src/java/pcgen/cdom/base/Constants.java
@@ -185,22 +185,6 @@ public interface Constants
 	String SYSTEM_GMGEN = "GMGen"; //$NON-NLS-1$
 
 	/********************************************************************
-	 * What equipment to auto generate
-	 ********************************************************************/
-
-	/** Auto-generate the racial equipment. */
-	int AUTOGEN_RACIAL = 1;
-
-	/** Auto-generate the masterwork equipment. */
-	int AUTOGEN_MASTERWORK = 2;
-
-	/** Auto-generate the magic equipment. */
-	int AUTOGEN_MAGIC = 3;
-
-	/** Auto-generate equipment made from exotic materials. */
-	int AUTOGEN_EXOTIC_MATERIAL = 4;
-
-	/********************************************************************
 	 * Character stat generation methods
 	 ********************************************************************/
 

--- a/code/src/java/pcgen/core/CustomData.java
+++ b/code/src/java/pcgen/core/CustomData.java
@@ -29,9 +29,9 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.SortedMap;
 
 import pcgen.cdom.base.Constants;
 import pcgen.cdom.enumeration.StringKey;
@@ -267,14 +267,7 @@ public final class CustomData
 
 		ensureCustomDirExists();
 
-		final BufferedWriter bw = getCustomEquipmentWriter();
-
-		if (bw == null)
-		{
-			return;
-		}
-
-		try
+		try(BufferedWriter bw = getCustomEquipmentWriter())
 		{
 			bw.write(AUTO_GEN_WARN_LINE_1);
 			bw.newLine();
@@ -293,17 +286,6 @@ public final class CustomData
 		{
 			Logging.errorPrint("Error in writeCustomItems", e);
 		}
-		finally
-		{
-			try
-			{
-				bw.close();
-			}
-			catch (IOException ex)
-			{
-				Logging.errorPrint("Error in writeCustomItems while closing", ex);
-			}
-		}
 	}
 
 	/**
@@ -313,7 +295,7 @@ public final class CustomData
 	{
 		ensureCustomDirExists();
 		final BufferedWriter bw = getPurchaseModeWriter();
-		final SortedMap<Integer, PointBuyCost> pbStatCosts = SettingsHandler.getGame().getPointBuyStatCostMap();
+		final Map<Integer, PointBuyCost> pbStatCosts = SettingsHandler.getGame().getPointBuyStatCostMap();
 
 		if (bw == null || pbStatCosts == null)
 		{
@@ -427,7 +409,7 @@ public final class CustomData
 		try
 		{
 			//return new BufferedReader(new FileReader(path));
-			return new BufferedReader(new InputStreamReader(new FileInputStream(path), "UTF-8"));
+			return new BufferedReader(new InputStreamReader(new FileInputStream(path), StandardCharsets.UTF_8));
 		}
 		catch (IOException e)
 		{

--- a/code/src/java/pcgen/core/SettingsHandler.java
+++ b/code/src/java/pcgen/core/SettingsHandler.java
@@ -57,10 +57,6 @@ import org.apache.commons.lang3.SystemUtils;
  **/
 public final class SettingsHandler
 {
-	private static boolean autogenExoticMaterial = false;
-	private static boolean autogenMagic = false;
-	private static boolean autogenMasterwork = false;
-	private static boolean autogenRacial = false;
 
 	//
 	// For EqBuilder
@@ -170,61 +166,6 @@ public final class SettingsHandler
 	public static String getDefaultOSType()
 	{
 		return defaultOSType;
-	}
-
-	public static void setAutogen(final int idx, final boolean bFlag)
-	{
-		switch (idx)
-		{
-			case Constants.AUTOGEN_RACIAL:
-				setAutogenRacial(bFlag);
-
-				break;
-
-			case Constants.AUTOGEN_MASTERWORK:
-				setAutogenMasterwork(bFlag);
-
-				break;
-
-			case Constants.AUTOGEN_MAGIC:
-				setAutogenMagic(bFlag);
-
-				break;
-
-			case Constants.AUTOGEN_EXOTIC_MATERIAL:
-				setAutogenExoticMaterial(bFlag);
-
-				break;
-
-			default:
-				break;
-		}
-	}
-
-	public static boolean getAutogen(final int idx)
-	{
-		if (!wantToLoadMasterworkAndMagic())
-		{
-			switch (idx)
-			{
-				case Constants.AUTOGEN_RACIAL:
-					return isAutogenRacial();
-
-				case Constants.AUTOGEN_MASTERWORK:
-					return isAutogenMasterwork();
-
-				case Constants.AUTOGEN_MAGIC:
-					return isAutogenMagic();
-
-				case Constants.AUTOGEN_EXOTIC_MATERIAL:
-					return isAutogenExoticMaterial();
-
-				default:
-					break;
-			}
-		}
-
-		return false;
 	}
 
 	/**
@@ -805,10 +746,6 @@ public final class SettingsHandler
 			SourceFormat.values()[getPCGenOption("sourceDisplay", SourceFormat.LONG.ordinal())]); //$NON-NLS-1$
 
 		setAlwaysOverwrite(getPCGenOption("alwaysOverwrite", false)); //$NON-NLS-1$
-		setAutogenExoticMaterial(getPCGenOption("autoGenerateExoticMaterial", false)); //$NON-NLS-1$
-		setAutogenMagic(getPCGenOption("autoGenerateMagic", false)); //$NON-NLS-1$
-		setAutogenMasterwork(getPCGenOption("autoGenerateMasterwork", false)); //$NON-NLS-1$
-		setAutogenRacial(getPCGenOption("autoGenerateRacial", false)); //$NON-NLS-1$
 		setCreatePcgBackup(getPCGenOption("createPcgBackup", true));
 		setCustomizerSplit1(getPCGenOption("customizer.split1", -1)); //$NON-NLS-1$
 		setCustomizerSplit2(getPCGenOption("customizer.split2", -1)); //$NON-NLS-1$
@@ -1063,10 +1000,6 @@ public final class SettingsHandler
 		setRuleChecksInOptions("ruleChecks"); //$NON-NLS-1$
 
 		setPCGenOption("alwaysOverwrite", getAlwaysOverwrite()); //$NON-NLS-1$
-		setPCGenOption("autoGenerateExoticMaterial", isAutogenExoticMaterial()); //$NON-NLS-1$
-		setPCGenOption("autoGenerateMagic", isAutogenMagic()); //$NON-NLS-1$
-		setPCGenOption("autoGenerateMasterwork", isAutogenMasterwork()); //$NON-NLS-1$
-		setPCGenOption("autoGenerateRacial", isAutogenRacial()); //$NON-NLS-1$
 		setPCGenOption("createPcgBackup", getCreatePcgBackup()); //$NON-NLS-1$
 		setPCGenOption("customizer.split1", getCustomizerSplit1()); //$NON-NLS-1$
 		setPCGenOption("customizer.split2", getCustomizerSplit2()); //$NON-NLS-1$
@@ -1693,26 +1626,6 @@ public final class SettingsHandler
 			+ Constants.LINE_SEPARATOR;
 	}
 
-	static boolean isAutogenExoticMaterial()
-	{
-		return autogenExoticMaterial;
-	}
-
-	static boolean isAutogenMagic()
-	{
-		return autogenMagic;
-	}
-
-	static boolean isAutogenMasterwork()
-	{
-		return autogenMasterwork;
-	}
-
-	static boolean isAutogenRacial()
-	{
-		return autogenRacial;
-	}
-
 	static void setPreviewTabShown(final boolean showPreviewTab)
 	{
 		previewTabShown = showPreviewTab;
@@ -1721,26 +1634,6 @@ public final class SettingsHandler
 	static boolean isPreviewTabShown()
 	{
 		return previewTabShown;
-	}
-
-	private static void setAutogenExoticMaterial(final boolean aBool)
-	{
-		autogenExoticMaterial = aBool;
-	}
-
-	private static void setAutogenMagic(final boolean aBool)
-	{
-		autogenMagic = aBool;
-	}
-
-	private static void setAutogenMasterwork(final boolean aBool)
-	{
-		autogenMasterwork = aBool;
-	}
-
-	private static void setAutogenRacial(final boolean aBool)
-	{
-		autogenRacial = aBool;
 	}
 
 	private static Properties getFilterSettings()

--- a/code/src/java/pcgen/gui2/prefs/EquipmentPanel.java
+++ b/code/src/java/pcgen/gui2/prefs/EquipmentPanel.java
@@ -22,20 +22,15 @@ import java.awt.GridBagLayout;
 import java.awt.Insets;
 
 import javax.swing.BorderFactory;
-import javax.swing.ButtonGroup;
-import javax.swing.JCheckBox;
 import javax.swing.JLabel;
-import javax.swing.JRadioButton;
 import javax.swing.JSpinner;
 import javax.swing.SpinnerNumberModel;
 import javax.swing.border.Border;
 import javax.swing.border.TitledBorder;
 
-import pcgen.cdom.base.Constants;
 import pcgen.core.SettingsHandler;
 import pcgen.gui2.tools.Utility;
 import pcgen.system.LanguageBundle;
-import pcgen.system.PCGenSettings;
 
 /**
  * The Class {@code EquipmentPanel} is responsible for
@@ -54,35 +49,15 @@ public final class EquipmentPanel extends PCGenPrefsPanel
 	private static final int SPELLLVLMIN = 0;
 	private static final int SPELLLVLMAX = 9;
 
-	private static final String IN_ANY_AUTO_EQUIP =
-			LanguageBundle.getString("in_Prefs_anyAutoEquip"); //$NON-NLS-1$
-	private static final String IN_AUTO_EQUIP =
-			LanguageBundle.getString("in_Prefs_autoEquip"); //$NON-NLS-1$
-	private static final String IN_AUTO_EQUIP_RACE =
-			LanguageBundle.getString("in_Prefs_autoEquipRace"); //$NON-NLS-1$
-	private static final String IN_AUTO_EQUIP_MASTERWORK =
-			LanguageBundle.getString("in_Prefs_autoEquipMasterwork"); //$NON-NLS-1$
-	private static final String IN_AUTO_EQUIP_MAGIC =
-			LanguageBundle.getString("in_Prefs_autoEquipMagic"); //$NON-NLS-1$
-	private static final String IN_AUTO_EQUIP_EXOTIC =
-			LanguageBundle.getString("in_Prefs_autoEquipExotic"); //$NON-NLS-1$
-	private static final String IN_NO_AUTO_EQUIP =
-			LanguageBundle.getString("in_Prefs_noAutoEquip"); //$NON-NLS-1$
 	private static final String IN_POTION_MAX =
 			LanguageBundle.getString("in_Prefs_potionMax"); //$NON-NLS-1$
 	private static final String IN_WAND_MAX =
 			LanguageBundle.getString("in_Prefs_wandMax"); //$NON-NLS-1$
 
-	private final JCheckBox autoMethod1 = new JCheckBox();
-	private final JCheckBox autoMethod2 = new JCheckBox();
-	private final JCheckBox autoMethod3 = new JCheckBox();
-	private final JCheckBox autoMethod4 = new JCheckBox();
 	private final JSpinner potionMaxLevel = new JSpinner();
 	private final SpinnerNumberModel potionModel;
 	private final JSpinner wandMaxLevel = new JSpinner();
 	private final SpinnerNumberModel wandModel;
-	private final JRadioButton autoEquipCreate;
-	private final JRadioButton noAutoEquipCreate;
 
 	/**
 	 * Instantiates a new equipment panel.
@@ -92,7 +67,6 @@ public final class EquipmentPanel extends PCGenPrefsPanel
 		GridBagLayout gridbag = new GridBagLayout();
 		GridBagConstraints c = new GridBagConstraints();
 		JLabel label;
-		ButtonGroup exclusiveGroup;
 		Border etched = null;
 		TitledBorder title1 = BorderFactory.createTitledBorder(etched, IN_EQUIPMENT);
 
@@ -102,7 +76,6 @@ public final class EquipmentPanel extends PCGenPrefsPanel
 		c.fill = GridBagConstraints.HORIZONTAL;
 		c.anchor = GridBagConstraints.LINE_START;
 		c.insets = new Insets(2, 2, 2, 2);
-		exclusiveGroup = new ButtonGroup();
 
 		Utility.buildConstraints(c, 0, 1, 2, 1, 0, 0);
 		label = new JLabel(IN_POTION_MAX);
@@ -128,51 +101,8 @@ public final class EquipmentPanel extends PCGenPrefsPanel
 		gridbag.setConstraints(wandMaxLevel, c);
 		this.add(wandMaxLevel);
 
-		Utility.buildConstraints(c, 0, 3, GridBagConstraints.REMAINDER, 1, 0, 0);
-		label = new JLabel(IN_ANY_AUTO_EQUIP);
-		gridbag.setConstraints(label, c);
-		this.add(label);
-
-		Utility.buildConstraints(c, 1, 4, GridBagConstraints.REMAINDER, 1, 0, 0);
-		noAutoEquipCreate = new JRadioButton(IN_NO_AUTO_EQUIP);
-		gridbag.setConstraints(noAutoEquipCreate, c);
-		this.add(noAutoEquipCreate);
-		exclusiveGroup.add(noAutoEquipCreate);
-
-		Utility.buildConstraints(c, 1, 5, GridBagConstraints.REMAINDER, 1, 0, 0);
-		autoEquipCreate = new JRadioButton(IN_AUTO_EQUIP);
-		gridbag.setConstraints(autoEquipCreate, c);
-		this.add(autoEquipCreate);
-		exclusiveGroup.add(autoEquipCreate);
-
 		Utility.buildConstraints(c, 0, 6, 1, 1, 0, 0);
 		label = new JLabel(BLANK_TEXT);
-		gridbag.setConstraints(label, c);
-		this.add(label);
-
-		Utility.buildConstraints(c, 1, 6, GridBagConstraints.REMAINDER, 1, 0, 0);
-		autoMethod1.setText(IN_AUTO_EQUIP_RACE);
-		gridbag.setConstraints(autoMethod1, c);
-		this.add(autoMethod1);
-
-		Utility.buildConstraints(c, 1, 7, GridBagConstraints.REMAINDER, 1, 0, 0);
-		autoMethod2.setText(IN_AUTO_EQUIP_MASTERWORK);
-		gridbag.setConstraints(autoMethod2, c);
-		this.add(autoMethod2);
-
-		Utility.buildConstraints(c, 1, 8, GridBagConstraints.REMAINDER, 1, 0, 0);
-		autoMethod3.setText(IN_AUTO_EQUIP_MAGIC);
-		gridbag.setConstraints(autoMethod3, c);
-		this.add(autoMethod3);
-
-		Utility.buildConstraints(c, 1, 9, GridBagConstraints.REMAINDER, 1, 0, 0);
-		autoMethod4.setText(IN_AUTO_EQUIP_EXOTIC);
-		gridbag.setConstraints(autoMethod4, c);
-		this.add(autoMethod4);
-
-		Utility.buildConstraints(c, 0, 20, 10, 1, 1, 1);
-		c.fill = GridBagConstraints.BOTH;
-		label = new JLabel();
 		gridbag.setConstraints(label, c);
 		this.add(label);
 	}
@@ -188,15 +118,6 @@ public final class EquipmentPanel extends PCGenPrefsPanel
 	{
 		SettingsHandler.setMaxPotionSpellLevel(potionModel.getNumber().intValue());
 		SettingsHandler.setMaxWandSpellLevel(wandModel.getNumber().intValue());
-		SettingsHandler.setWantToLoadMasterworkAndMagic(false); // Turn it off temporarily so we can set the values
-		SettingsHandler.setAutogen(Constants.AUTOGEN_RACIAL, autoMethod1.isSelected());
-		SettingsHandler.setAutogen(Constants.AUTOGEN_MASTERWORK, autoMethod2.isSelected());
-		SettingsHandler.setAutogen(Constants.AUTOGEN_MAGIC, autoMethod3.isSelected());
-		SettingsHandler.setAutogen(Constants.AUTOGEN_EXOTIC_MATERIAL, autoMethod4.isSelected());
-
-		SettingsHandler.setWantToLoadMasterworkAndMagic(noAutoEquipCreate.isSelected()); // Now set it properly
-		PCGenSettings.OPTIONS_CONTEXT.setBoolean(PCGenSettings.OPTION_AUTOCREATE_MW_MAGIC_EQUIP,
-			autoEquipCreate.isSelected());
 	}
 
 	@Override
@@ -204,23 +125,6 @@ public final class EquipmentPanel extends PCGenPrefsPanel
 	{
 		potionModel.setValue(SettingsHandler.getMaxPotionSpellLevel());
 		wandModel.setValue(SettingsHandler.getMaxWandSpellLevel());
-
-		if (PCGenSettings.OPTIONS_CONTEXT.initBoolean(PCGenSettings.OPTION_AUTOCREATE_MW_MAGIC_EQUIP, false))
-		{
-			autoEquipCreate.setSelected(true);
-		}
-		else
-		{
-			noAutoEquipCreate.setSelected(true);
-		}
-		// Turn off temporarily so we get current setting
-		SettingsHandler.setWantToLoadMasterworkAndMagic(false); 
-		autoMethod1.setSelected(SettingsHandler.getAutogen(Constants.AUTOGEN_RACIAL));
-		autoMethod2.setSelected(SettingsHandler.getAutogen(Constants.AUTOGEN_MASTERWORK));
-		autoMethod3.setSelected(SettingsHandler.getAutogen(Constants.AUTOGEN_MAGIC));
-		autoMethod4.setSelected(SettingsHandler.getAutogen(Constants.AUTOGEN_EXOTIC_MATERIAL));
-		// Reset its state now we are done
-		SettingsHandler.setWantToLoadMasterworkAndMagic(noAutoEquipCreate.isSelected());
 	}
 
 }

--- a/code/src/java/pcgen/persistence/SourceFileLoader.java
+++ b/code/src/java/pcgen/persistence/SourceFileLoader.java
@@ -65,7 +65,6 @@ import pcgen.core.Deity;
 import pcgen.core.Description;
 import pcgen.core.Domain;
 import pcgen.core.Equipment;
-import pcgen.core.EquipmentList;
 import pcgen.core.EquipmentModifier;
 import pcgen.core.GameMode;
 import pcgen.core.Globals;
@@ -495,12 +494,6 @@ public class SourceFileLoader extends PCGenTask implements Observer
 			// Verify weapons are melee or ranged
 			verifyWeaponsMeleeOrRanged(context);
 
-			//  Auto-gen additional equipment
-			if (PCGenSettings.OPTIONS_CONTEXT.initBoolean(PCGenSettings.OPTION_AUTOCREATE_MW_MAGIC_EQUIP, false))
-			{
-				EquipmentList.autoGenerateEquipment();
-			}
-
 			for (Campaign campaign : selectedCampaigns)
 			{
 				sourcesSet.add(SourceFormat.getFormattedString(campaign, SourceFormat.MEDIUM, true));
@@ -828,25 +821,15 @@ public class SourceFileLoader extends PCGenTask implements Observer
 
 		final BufferedReader br = CustomData.getCustomEquipmentReader();
 
-		// Why is this here?  This implies it is somehow
-		// order-independent and should precede the opening of
-		// the file.  This is almost assuredly a bug of some
-		// kind waiting to happen.  Aha!  Just look at what is
-		// in the "finally" clause below.  --bko XXX
-		EquipmentList.setAutoGeneration(true);
-
-		/*
-		 * if (br == null) { return; }
-		 */
 		try
 		{
-			while (br != null)
+			if (br != null)
 			{
 				String aLine = br.readLine();
 
 				if (aLine == null)
 				{
-					break;
+					return;
 				}
 
 				if (aLine.startsWith("BASEITEM:"))
@@ -855,7 +838,7 @@ public class SourceFileLoader extends PCGenTask implements Observer
 
 					if (idx < 10)
 					{
-						continue;
+						return;
 					}
 
 					final String baseItemKey = aLine.substring(9, idx);
@@ -884,22 +867,6 @@ public class SourceFileLoader extends PCGenTask implements Observer
 		{
 			logError("Error when loading custom items", e);
 		}
-		finally
-		{
-			EquipmentList.setAutoGeneration(false);
-
-			try
-			{
-				if (br != null)
-				{
-					br.close();
-				}
-			}
-			catch (IOException ex)
-			{
-				logError("Error when closing infile after loading custom items", ex);
-			}
-		}
 	}
 
 	/**
@@ -911,7 +878,7 @@ public class SourceFileLoader extends PCGenTask implements Observer
 	 *             if a weapon is neither melee or ranged, indicating the name
 	 *             of the weapon that caused the error
 	 */
-	private void verifyWeaponsMeleeOrRanged(LoadContext context) throws PersistenceLayerException
+	private static void verifyWeaponsMeleeOrRanged(LoadContext context) throws PersistenceLayerException
 	{
 		//
 		// Check all the weapons to see if they are either Melee or Ranged, to avoid

--- a/code/src/resources/pcgen/lang/LanguageBundle.properties
+++ b/code/src/resources/pcgen/lang/LanguageBundle.properties
@@ -1890,20 +1890,7 @@ in_Prefs_potionMax=Potion Maximum Spell Level
 
 in_Prefs_wandMax=Wand Maximum Spell Level
 
-in_Prefs_anyAutoEquip=Equipment Auto Creation
-
-in_Prefs_noAutoEquip=Load From lst Files Only
 in_Prefs_noMinBelow0=Purchase Score Minimum value is 0\!
-
-in_Prefs_autoEquip=Automatically Generate Equipment
-
-in_Prefs_autoEquipRace=Racially Resized Armor, Shields and Clothing
-
-in_Prefs_autoEquipMasterwork=Masterwork
-
-in_Prefs_autoEquipMagic=Magic (+1 to +5)
-
-in_Prefs_autoEquipExotic=Exotic Materials
 
 in_Prefs_language=Language
 

--- a/code/src/resources/pcgen/lang/LanguageBundle_de.properties
+++ b/code/src/resources/pcgen/lang/LanguageBundle_de.properties
@@ -996,20 +996,6 @@ in_Prefs_potionMax=Maximale Spruchstufe bei Zaubertr\u00E4nken
 
 in_Prefs_wandMax=Maximale Spruchstufe bei Zauberst\u00E4ben 
 
-in_Prefs_anyAutoEquip=Ausr\u00FCstung automatisch erstellen\u003A
-
-in_Prefs_noAutoEquip=Nur aus .lst Dateien laden
-
-in_Prefs_autoEquip=Ausr\u00FCstung automatisch erstellen
-
-in_Prefs_autoEquipRace=R\u00FCstungen, Schilde und Kleidung in volksspezifischen Gr\u00F6\u00DFen
-
-in_Prefs_autoEquipMasterwork=Meisterhafte Arbeit
-
-in_Prefs_autoEquipMagic=Magisch (+1 bis +5)
-
-in_Prefs_autoEquipExotic=Exotische Materialien
-
 in_Prefs_language=Sprache
 
 in_Prefs_langEnglish=Englisch

--- a/code/src/resources/pcgen/lang/LanguageBundle_es.properties
+++ b/code/src/resources/pcgen/lang/LanguageBundle_es.properties
@@ -1892,20 +1892,7 @@ in_Prefs_potionMax=Nivel M\u00E1ximo de Conjuro para Pociones
 
 in_Prefs_wandMax=Nivel M\u00E1ximo de Conjuro para Varitas
 
-in_Prefs_anyAutoEquip=Auto Creaci\u00F3n de Equipo
-
-in_Prefs_noAutoEquip=Cargar solo archivos .LST
 in_Prefs_noMinBelow0=Purchase Score Minimum value is 0\!
-
-in_Prefs_autoEquip=Generar Equipo Autom\u00E1ticamente
-
-in_Prefs_autoEquipRace=Adaptar las Armaduras, Escudos y Ropas al tama\u00F1o de la raza
-
-in_Prefs_autoEquipMasterwork=De Gran Calidad
-
-in_Prefs_autoEquipMagic=M\u00E1gicos (+1 a +5)
-
-in_Prefs_autoEquipExotic=Materiales Ex\u00F3ticos
 
 in_Prefs_language=Idiomas
 

--- a/code/src/resources/pcgen/lang/LanguageBundle_fr.properties
+++ b/code/src/resources/pcgen/lang/LanguageBundle_fr.properties
@@ -1812,20 +1812,7 @@ in_Prefs_potionMax=Niveau maximum de sort des potions
 
 in_Prefs_wandMax=Niveau maximum de sort des baguettes
 
-in_Prefs_anyAutoEquip=Cr\u00E9ation automatique de l'\u00E9quipement
-
-in_Prefs_noAutoEquip=Charger des fichiers lst seulement
 in_Prefs_noMinBelow0=La valeur minimale d\u2019achat d\u2019attribut est 0\u202F!
-
-in_Prefs_autoEquip=Cr\u00E9er automatiquement de l'\u00E9quipement
-
-in_Prefs_autoEquipRace=Ajuster les armes, boucliers et v\u00EAtements pour les races
-
-in_Prefs_autoEquipMasterwork=De ma\u00EEtre
-
-in_Prefs_autoEquipMagic=Magique (+1 \u00E0 +5)
-
-in_Prefs_autoEquipExotic=Mat\u00E9riaux exotiques
 
 in_Prefs_language=Langue
 

--- a/code/src/resources/pcgen/lang/LanguageBundle_it.properties
+++ b/code/src/resources/pcgen/lang/LanguageBundle_it.properties
@@ -1757,20 +1757,6 @@ in_Prefs_potionMax=Livello massimo delle pozioni
 
 in_Prefs_wandMax=Massimo livello di incantesimo per le bacchette
 
-in_Prefs_anyAutoEquip=Creazione dell'Equipaggiamento
-
-in_Prefs_noAutoEquip=Carica Solo da File lst
-
-in_Prefs_autoEquip=Genera Equipaggiamento Automaticamente
-
-in_Prefs_autoEquipRace=Armature, Scudi ed Abbigliamento ridimensionati in base alla razza
-
-in_Prefs_autoEquipMasterwork=Perfetta
-
-in_Prefs_autoEquipMagic=Magico (+1 a +5)
-
-in_Prefs_autoEquipExotic=Materiali Esotici
-
 in_Prefs_language=Lingua
 
 in_Prefs_langEnglish=Inglese

--- a/code/src/resources/pcgen/lang/LanguageBundle_pt.properties
+++ b/code/src/resources/pcgen/lang/LanguageBundle_pt.properties
@@ -1820,20 +1820,6 @@ in_Prefs_potionMax=N\u00EDvel M\u00E1ximo de Magia em Po\u00E7\u00E3o
 
 in_Prefs_wandMax=N\u00EDvel M\u00E1ximo de Magia em Varinha
 
-in_Prefs_anyAutoEquip=Auto Cria\u00E7\u00E3o de Equipamento
-
-in_Prefs_noAutoEquip=Carregar Apenas dos Arquivos lst
-
-in_Prefs_autoEquip=Gerar Equipamento Automaticamente
-
-in_Prefs_autoEquipRace=Armadura, Escudos e Indument\u00E1ria com Tamanho Racial
-
-in_Prefs_autoEquipMasterwork=Obra-Prima
-
-in_Prefs_autoEquipMagic=M\u00E1gico (+1 a +5)
-
-in_Prefs_autoEquipExotic=Materiais Ex\u00F3ticos
-
 in_Prefs_language=Idioma
 
 in_Prefs_langEnglish=Ingl\u00EAs

--- a/code/src/resources/pcgen/lang/cleaned.properties
+++ b/code/src/resources/pcgen/lang/cleaned.properties
@@ -1739,20 +1739,6 @@ in_Prefs_potionMax=Potion Maximum Spell Level
 
 in_Prefs_wandMax=Wand Maximum Spell Level
 
-in_Prefs_anyAutoEquip=Equipment Auto Creation
-
-in_Prefs_noAutoEquip=Load From lst Files Only
-
-in_Prefs_autoEquip=Automatically Generate Equipment
-
-in_Prefs_autoEquipRace=Racially Resized Armor, Shields and Clothing
-
-in_Prefs_autoEquipMasterwork=Masterwork
-
-in_Prefs_autoEquipMagic=Magic (+1 to +5)
-
-in_Prefs_autoEquipExotic=Exotic Materials
-
 in_Prefs_language=Language
 
 in_Prefs_langEnglish=English


### PR DESCRIPTION
Much of this feature has been broken for some time. It
- teaches code too much about the data
- makes several assumptions about naming of items which should
not be required.
- introduces a performance penalty of having so many items.
- requires hacks in data where the auto-gen item may conflict with
special rules around some of the items

as such, remove it.

Ref: CODE-3123, CODE-3409, CODE-761, CODE-1873, CODE-3159