### PR TITLE
PluginPanel: remove checkboxes for systems

### DIFF
--- a/code/src/java/gmgen/gui/PreferencesPluginsPanel.java
+++ b/code/src/java/gmgen/gui/PreferencesPluginsPanel.java
@@ -23,31 +23,25 @@ import java.awt.BorderLayout;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.swing.AbstractButton;
 import javax.swing.BoxLayout;
-import javax.swing.ButtonGroup;
 import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import javax.swing.JRadioButton;
 import javax.swing.JScrollPane;
-import javax.swing.border.TitledBorder;
 
 import pcgen.cdom.base.Constants;
 import pcgen.core.SettingsHandler;
 import pcgen.system.LanguageBundle;
 
-/**
- *
- */
 class PreferencesPluginsPanel extends gmgen.gui.PreferencesPanel
 {
 	private static final Map<String, PluginRef> PLUGIN_MAP = new HashMap<>();
 
 	private JPanel mainPanel;
-	private JScrollPane jScrollPane1;
 
 	/** Creates new form PreferencesDamagePanel */
-	public PreferencesPluginsPanel()
+	PreferencesPluginsPanel()
 	{
 		initComponents();
 		initPreferences();
@@ -74,87 +68,49 @@ class PreferencesPluginsPanel extends gmgen.gui.PreferencesPanel
 
 	private void initComponents()
 	{
-		jScrollPane1 = new JScrollPane();
+		JScrollPane jScrollPane1 = new JScrollPane();
 		mainPanel = new JPanel();
 
 		setLayout(new BorderLayout());
 
-		mainPanel.setLayout(new BoxLayout(mainPanel, BoxLayout.Y_AXIS));
+		mainPanel.setLayout(new BoxLayout(mainPanel, BoxLayout.PAGE_AXIS));
 
 		PreferencesPluginsPanel.PLUGIN_MAP.forEach((key, pluginRef) -> mainPanel.add(pluginRef));
 
 		jScrollPane1.setViewportView(mainPanel);
 		add(jScrollPane1, BorderLayout.CENTER);
-		add(new JLabel(LanguageBundle.getString("in_Prefs_restartInfo")), BorderLayout.SOUTH);
+		add(new JLabel(LanguageBundle.getString("in_Prefs_restartInfo")), BorderLayout.PAGE_END);
 	}
 
 	private static final class PluginRef extends JPanel
 	{
 		private final String pluginName;
-		private final String pluginTitle;
-		private final String defaultSystem;
-		private JCheckBox checkBox;
-		private JRadioButton pcgenButton;
-		private JRadioButton gmgenButton;
+		private AbstractButton checkBox;
 
-		private PluginRef(String pluginName, String pluginTitle, String defaultSystem)
+		private PluginRef(String pluginName)
 		{
 			this.pluginName = pluginName;
-			this.pluginTitle = pluginTitle;
-			this.defaultSystem = defaultSystem;
 			initComponents();
 		}
 
 		private void initComponents()
 		{
 			checkBox = new JCheckBox();
-			pcgenButton = new JRadioButton();
-			gmgenButton = new JRadioButton();
-			ButtonGroup pluginGroup = new ButtonGroup();
 
-			setLayout(new BoxLayout(this, BoxLayout.X_AXIS));
-			setBorder(
-				new TitledBorder(null, pluginTitle, TitledBorder.DEFAULT_JUSTIFICATION, TitledBorder.DEFAULT_POSITION));
-
+			setLayout(new BoxLayout(this, BoxLayout.LINE_AXIS));
 			checkBox.setText(LanguageBundle.getString(pcgen.gui2.dialog.PreferencesDialog.LB_PREFS_PLUGINS_RUN));
 			add(checkBox);
-
-			pcgenButton
-				.setText(LanguageBundle.getString(pcgen.gui2.dialog.PreferencesDialog.LB_PREFS_PLUGIN_PCGEN_WIN));
-			pluginGroup.add(pcgenButton);
-			add(pcgenButton);
-
-			gmgenButton
-				.setText(LanguageBundle.getString(pcgen.gui2.dialog.PreferencesDialog.LB_PREFS_PLUGIN_GMGEN_WIN));
-			pluginGroup.add(gmgenButton);
-			add(gmgenButton);
 		}
 
 		public void initPreferences()
 		{
 			checkBox.setSelected(SettingsHandler.getGMGenOption(pluginName + ".Load", true));
-			String system = SettingsHandler.getGMGenOption(pluginName + ".System", defaultSystem);
-			if (system.equals(Constants.SYSTEM_PCGEN))
-			{
-				pcgenButton.setSelected(true);
-			}
-			else
-			{
-				gmgenButton.setSelected(true);
-			}
 		}
 
 		public void applyPreferences()
 		{
 			SettingsHandler.setGMGenOption(pluginName + ".Load", checkBox.isSelected());
-			if (pcgenButton.isSelected())
-			{
-				SettingsHandler.setGMGenOption(pluginName + ".System", Constants.SYSTEM_PCGEN);
-			}
-			else
-			{
-				SettingsHandler.setGMGenOption(pluginName + ".System", Constants.SYSTEM_GMGEN);
-			}
+			SettingsHandler.setGMGenOption(pluginName + ".System", Constants.SYSTEM_GMGEN);
 		}
 	}
 }

--- a/code/src/java/pcgen/gui2/dialog/PreferencesDialog.java
+++ b/code/src/java/pcgen/gui2/dialog/PreferencesDialog.java
@@ -20,6 +20,7 @@ package pcgen.gui2.dialog;
 
 import java.awt.BorderLayout;
 import java.awt.CardLayout;
+import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
@@ -30,14 +31,12 @@ import java.util.List;
 
 import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
-import javax.swing.ButtonGroup;
 import javax.swing.JCheckBox;
 import javax.swing.JComponent;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
-import javax.swing.JRadioButton;
 import javax.swing.JScrollPane;
 import javax.swing.JSplitPane;
 import javax.swing.JTabbedPane;
@@ -89,8 +88,6 @@ public final class PreferencesDialog extends AbstractPreferencesDialog
 	private static final String IN_APPERANCE = LanguageBundle.getString("in_Prefs_appearance"); //$NON-NLS-1$
 	private static final String IN_CHARACTER = LanguageBundle.getString("in_Prefs_character"); //$NON-NLS-1$
 	public static final String LB_PREFS_PLUGINS_RUN = "in_Prefs_pluginsRun"; //$NON-NLS-1$
-	public static final String LB_PREFS_PLUGIN_PCGEN_WIN = "in_Prefs_pluginPcgenWin"; //$NON-NLS-1$
-	public static final String LB_PREFS_PLUGIN_GMGEN_WIN = "in_Prefs_pluginGMGenWin"; //$NON-NLS-1$
 
 	private DefaultTreeModel settingsModel;
 	private FlippingSplitPane splitPane;
@@ -161,7 +158,7 @@ public final class PreferencesDialog extends AbstractPreferencesDialog
 		rootNode.add(pluginNode);
 	}
 
-	public void applyPluginPreferences()
+	private void applyPluginPreferences()
 	{
 		pluginsPanel.applyPreferences();
 	}
@@ -199,25 +196,22 @@ public final class PreferencesDialog extends AbstractPreferencesDialog
 
 	private static JPanel buildEmptyPanel(String title, String messageText)
 	{
-		GridBagLayout gridbag = new GridBagLayout();
-		GridBagConstraints c = new GridBagConstraints();
-		JLabel label;
 		JPanel panel = new JPanel();
 		Border etched = null;
 		TitledBorder title1 = BorderFactory.createTitledBorder(etched, title);
 
 		title1.setTitleJustification(TitledBorder.LEFT);
 		panel.setBorder(title1);
-		gridbag = new GridBagLayout();
+		GridBagLayout gridbag = new GridBagLayout();
 		panel.setLayout(gridbag);
-		c = new GridBagConstraints();
+		GridBagConstraints c = new GridBagConstraints();
 		c.fill = GridBagConstraints.HORIZONTAL;
 		c.anchor = GridBagConstraints.CENTER;
 		c.insets = new Insets(2, 2, 2, 2);
 
 		Utility.buildConstraints(c, 5, 20, 1, 1, 1, 1);
 		c.fill = GridBagConstraints.BOTH;
-		label = new JLabel(messageText, SwingConstants.CENTER);
+		Component label = new JLabel(messageText, SwingConstants.CENTER);
 		gridbag.setConstraints(label, c);
 		panel.add(label);
 
@@ -389,10 +383,6 @@ public final class PreferencesDialog extends AbstractPreferencesDialog
 	{
 		setOptionsBasedOnControls();
 		applyPluginPreferences();
-
-		// We need to update the menus/toolbar since
-		// some of those depend on the options
-		//PCGen_Frame1.enableDisableMenuItems();
 	}
 }
 
@@ -404,7 +394,7 @@ class PreferencesPluginsPanel extends gmgen.gui.PreferencesPanel
 	private JScrollPane jScrollPane1;
 
 	/** Creates new form PreferencesDamagePanel */
-	public PreferencesPluginsPanel()
+	PreferencesPluginsPanel()
 	{
 		for (PluginManager.PluginInfo info : PluginManager.getInstance().getPluginInfoList())
 		{
@@ -441,14 +431,14 @@ class PreferencesPluginsPanel extends gmgen.gui.PreferencesPanel
 
 		setLayout(new BorderLayout());
 
-		mainPanel.setLayout(new BoxLayout(mainPanel, BoxLayout.Y_AXIS));
+		mainPanel.setLayout(new BoxLayout(mainPanel, BoxLayout.PAGE_AXIS));
 
 		pluginMap.values()
 		         .forEach(pluginRef -> mainPanel.add(pluginRef));
 
 		jScrollPane1.setViewportView(mainPanel);
 		add(jScrollPane1, BorderLayout.CENTER);
-		add(new JLabel(LanguageBundle.getString("in_Prefs_restartInfo")), BorderLayout.SOUTH); //$NON-NLS-1$
+		add(new JLabel(LanguageBundle.getString("in_Prefs_restartInfo")), BorderLayout.PAGE_END); //$NON-NLS-1$
 	}
 
 	private void addPanel(String pluginName, String pluginTitle, String defaultSystem)
@@ -464,69 +454,36 @@ class PreferencesPluginsPanel extends gmgen.gui.PreferencesPanel
 	{
 		private final String pluginName;
 		private final String pluginTitle;
-		private final String defaultSystem;
 		private JCheckBox checkBox;
-		private JRadioButton pcgenButton;
-		private JRadioButton gmgenButton;
 
-		public PluginRef(String pluginName, String pluginTitle, String defaultSystem)
+		private PluginRef(String pluginName, String pluginTitle, String defaultSystem)
 		{
 			this.pluginName = pluginName;
 			this.pluginTitle = pluginTitle;
-			this.defaultSystem = defaultSystem;
 			initComponents();
 		}
 
 		private void initComponents()
 		{
 			checkBox = new JCheckBox();
-			pcgenButton = new JRadioButton();
-			gmgenButton = new JRadioButton();
-			ButtonGroup pluginGroup = new ButtonGroup();
 
-			setLayout(new BoxLayout(this, BoxLayout.X_AXIS));
+			setLayout(new BoxLayout(this, BoxLayout.LINE_AXIS));
 			setBorder(
 				new TitledBorder(null, pluginTitle, TitledBorder.DEFAULT_JUSTIFICATION, TitledBorder.DEFAULT_POSITION));
 
 			checkBox.setText(LanguageBundle.getString(PreferencesDialog.LB_PREFS_PLUGINS_RUN));
 			add(checkBox);
-
-			pcgenButton.setText(LanguageBundle.getString(PreferencesDialog.LB_PREFS_PLUGIN_PCGEN_WIN));
-			pcgenButton.setEnabled(false);
-			pluginGroup.add(pcgenButton);
-			add(pcgenButton);
-
-			gmgenButton.setText(LanguageBundle.getString(PreferencesDialog.LB_PREFS_PLUGIN_GMGEN_WIN));
-			pluginGroup.add(gmgenButton);
-			add(gmgenButton);
 		}
 
 		public void initPreferences()
 		{
 			checkBox.setSelected(PCGenSettings.GMGEN_OPTIONS_CONTEXT.initBoolean(pluginName + ".Load", true));
-			//String system = PCGenSettings.GMGEN_OPTIONS_CONTEXT.initProperty(pluginName + ".System", defaultSystem);
-			String system = Constants.SYSTEM_GMGEN;
-			if (system.equals(Constants.SYSTEM_PCGEN))
-			{
-				pcgenButton.setSelected(true);
-			}
-			else
-			{
-				gmgenButton.setSelected(true);
-			}
 		}
 
 		public void applyPreferences()
 		{
 			PCGenSettings.GMGEN_OPTIONS_CONTEXT.setBoolean(pluginName + ".Load", checkBox.isSelected());
-			if (pcgenButton.isSelected())
-			{
-				PCGenSettings.GMGEN_OPTIONS_CONTEXT.setProperty(pluginName + ".System", Constants.SYSTEM_PCGEN);
-			}
-			else
-			{
-				PCGenSettings.GMGEN_OPTIONS_CONTEXT.setProperty(pluginName + ".System", Constants.SYSTEM_GMGEN);
-			}
+			PCGenSettings.GMGEN_OPTIONS_CONTEXT.setProperty(pluginName + ".System", Constants.SYSTEM_GMGEN);
 		}
 	}
 }

--- a/code/src/resources/pcgen/lang/LanguageBundle.properties
+++ b/code/src/resources/pcgen/lang/LanguageBundle.properties
@@ -2146,8 +2146,6 @@ in_Prefs_cost=Cost
 in_Prefs_plugins=Plugins
 in_Prefs_pluginsTitle=Plugin Launch
 in_Prefs_pluginsRun=Run this plugin?
-in_Prefs_pluginPcgenWin=PCGen Window
-in_Prefs_pluginGMGenWin=GMGen Window
 in_Prefs_plus=+
 
 in_Prefs_restartInfo=Note: Changes to these settings will not take effect until PCGen is restarted.

--- a/code/src/resources/pcgen/lang/LanguageBundle_es.properties
+++ b/code/src/resources/pcgen/lang/LanguageBundle_es.properties
@@ -2146,8 +2146,6 @@ in_Prefs_cost=Costo
 in_Prefs_plugins=Plugins
 in_Prefs_pluginsTitle=Ejecutar Plugin
 in_Prefs_pluginsRun=Ejecutar este Plugin?
-in_Prefs_pluginPcgenWin=Ventana de PCGen
-in_Prefs_pluginGMGenWin=Ventana de GMGen
 in_Prefs_plus=+
 
 in_Prefs_restartInfo=Nota: Los cambios en estos ajustes no tendr\u00E1n efecto hasta que se reinicie PCGen.

--- a/code/src/resources/pcgen/lang/LanguageBundle_fr.properties
+++ b/code/src/resources/pcgen/lang/LanguageBundle_fr.properties
@@ -2064,8 +2064,6 @@ in_Prefs_cost=Co\u00FBt
 in_Prefs_plugins=Modules
 in_Prefs_pluginsTitle=Lancer module
 in_Prefs_pluginsRun=Ex\u00E9cuter ce module
-in_Prefs_pluginPcgenWin=Fen\u00EAtre PCGen
-in_Prefs_pluginGMGenWin=Fen\u00EAtre GMGen
 in_Prefs_plus=+
 
 in_Prefs_restartInfo=Remarque\u202F: Les changements de ces r\u00E9glages n\u2019auront lieu qu\u2019apr\u00E8s le red\u00E9marrage de PCGen.

--- a/code/src/resources/pcgen/lang/LanguageBundle_it.properties
+++ b/code/src/resources/pcgen/lang/LanguageBundle_it.properties
@@ -2925,7 +2925,4 @@ in_Prefs_generateTempFileWithPdf=Scrivi file intermedi quando esporti pdf
 
 in_Prefs_pluginsTitle=Esecuzione Plugin
 in_Prefs_pluginsRun=Eseguo questo plugin?
-in_Prefs_pluginPcgenWin=Finestra di PCGen
-in_Prefs_pluginGMGenWin=Finestra di GMGen
-
 in_plugin_charactersheet_name=Scheda del Personaggio


### PR DESCRIPTION
PCGen is always disabled, and thus there is no choice. This simplifies
the plugin-loading UI quite a bit.