### PR TITLE
pmd: reduce number of exclusions (part 2)

### DIFF
--- a/code/src/java/gmgen/plugin/Combatant.java
+++ b/code/src/java/gmgen/plugin/Combatant.java
@@ -143,6 +143,7 @@ public abstract class Combatant implements InitHolder
 	 *@param  columnOrder  The current table's column order
 	 *@return              The Row Vector
 	 */
+	@SuppressWarnings({"UseOfObsoleteCollectionType", "PMD.ReplaceVectorWithList"})
 	@Override
 	public Vector<Object> getRowVector(final List<String> columnOrder)
 	{

--- a/code/src/java/gmgen/plugin/Effect.java
+++ b/code/src/java/gmgen/plugin/Effect.java
@@ -51,6 +51,7 @@ public class Effect extends Event
 	 *@param  columnOrder  The current table's column order
 	 *@return              The Row Vector
 	 */
+	@SuppressWarnings({"UseOfObsoleteCollectionType", "PMD.ReplaceVectorWithList"})
 	@Override
 	public Vector<Object> getRowVector(List<String> columnOrder)
 	{

--- a/code/src/java/gmgen/plugin/Event.java
+++ b/code/src/java/gmgen/plugin/Event.java
@@ -218,6 +218,7 @@ public class Event implements InitHolder
 	 *@param  columnOrder  The current table's column order
 	 *@return              The Row Vector
 	 */
+	@SuppressWarnings({"UseOfObsoleteCollectionType", "PMD.ReplaceVectorWithList"})
 	@Override
 	public Vector<Object> getRowVector(List<String> columnOrder)
 	{

--- a/code/src/java/gmgen/plugin/InitHolder.java
+++ b/code/src/java/gmgen/plugin/InitHolder.java
@@ -52,6 +52,7 @@ public interface InitHolder
 	 *@param  columnOrder  The current table's column order
 	 *@return              The Row Vector
 	 */
+	@SuppressWarnings({"UseOfObsoleteCollectionType", "PMD.ReplaceVectorWithList"})
 	public Vector<Object> getRowVector(List<String> columnOrder);
 
 	/**

--- a/code/src/java/gmgen/plugin/InitHolderList.java
+++ b/code/src/java/gmgen/plugin/InitHolderList.java
@@ -55,6 +55,7 @@ public class InitHolderList extends ArrayList<InitHolder>
 	 *          table object.
 	 * @return The Vector that contains a table row.
 	 */
+	@SuppressWarnings({"UseOfObsoleteCollectionType", "PMD.ReplaceVectorWithList"})
 	public Vector<Object> getRowVector(int i, List<String> columnOrder)
 	{
 		return this.get(i).getRowVector(columnOrder);

--- a/code/src/java/gmgen/plugin/Spell.java
+++ b/code/src/java/gmgen/plugin/Spell.java
@@ -76,6 +76,7 @@ public class Spell extends Event
 	 *@param  columnOrder  The current table's column order
 	 *@return              The Row Vector
 	 */
+	@SuppressWarnings({"UseOfObsoleteCollectionType", "PMD.ReplaceVectorWithList"})
 	@Override
 	public Vector<Object> getRowVector(List<String> columnOrder)
 	{

--- a/code/src/java/pcgen/core/RollingMethods.java
+++ b/code/src/java/pcgen/core/RollingMethods.java
@@ -242,6 +242,7 @@ public final class RollingMethods
 		 * rolls the dice on the randomizer, and pushes the result back onto the stack.
 		 * Logging is performed if it is turned on.</p>
 		 */
+		@SuppressWarnings({"UseOfObsoleteCollectionType", "PMD.ReplaceVectorWithList"})
 		@Override
 		public void run(final Stack stack) throws ParseException
 		{

--- a/code/src/java/pcgen/core/kit/KitTemplate.java
+++ b/code/src/java/pcgen/core/kit/KitTemplate.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.List;
 
 import pcgen.base.util.HashMapToList;
+import pcgen.base.util.MapToList;
 import pcgen.cdom.base.Constants;
 import pcgen.cdom.reference.CDOMSingleRef;
 import pcgen.core.Kit;
@@ -77,13 +78,9 @@ public class KitTemplate extends BaseKit
 	@Override
 	public boolean testApply(Kit aKit, PlayerCharacter aPC, List<String> warnings)
 	{
-		HashMapToList<PCTemplate, PCTemplate> selectedMap = buildSelectedTemplateMap(aPC, false);
+		MapToList<PCTemplate, PCTemplate> selectedMap = buildSelectedTemplateMap(aPC, false);
 
-		if (!selectedMap.isEmpty())
-		{
-			return true;
-		}
-		return false;
+		return !selectedMap.isEmpty();
 	}
 
 	/**

--- a/code/src/java/pcgen/gui2/doomsdaybook/NameGenPanel.java
+++ b/code/src/java/pcgen/gui2/doomsdaybook/NameGenPanel.java
@@ -77,8 +77,8 @@ import org.xml.sax.InputSource;
 
 /**
  * Main panel of the random name generator.
- * 
  */
+@SuppressWarnings({"UseOfObsoleteCollectionType", "PMD.ReplaceVectorWithList"})
 public class NameGenPanel extends JPanel
 {
 	private final Preferences namePrefs = Preferences.userNodeForPackage(NameGenPanel.class);

--- a/code/src/java/pcgen/gui2/tabs/AbilitiesInfoTab.java
+++ b/code/src/java/pcgen/gui2/tabs/AbilitiesInfoTab.java
@@ -274,15 +274,15 @@ public class AbilitiesInfoTab extends SharedTabPane implements CharacterInfoTab,
 			}
 		}
 
-		private class TabInfo
+		@SuppressWarnings({"UseOfObsoleteCollectionType", "PMD.ReplaceHashtableWithMap", "serial"})
+		private final class TabInfo
 		{
-
 			public final String title;
-			public final Hashtable<Object, Object> tabData;
-			public final DefaultListFacade<AbilityCategory> categoryList;
-			public final DefaultListFacade<AbilityCategory> fullCategoryList;
+			private final Hashtable<Object, Object> tabData;
+			private final DefaultListFacade<AbilityCategory> categoryList;
+			private final DefaultListFacade<AbilityCategory> fullCategoryList;
 
-			public TabInfo(String title, CharacterFacade character)
+			private TabInfo(String title, CharacterFacade character)
 			{
 				this.title = title;
 				this.categoryList = new DefaultListFacade<>();

--- a/code/src/java/pcgen/gui2/tabs/AbilityChooserTab.java
+++ b/code/src/java/pcgen/gui2/tabs/AbilityChooserTab.java
@@ -86,7 +86,7 @@ import pcgen.system.LanguageBundle;
  *
  * @see pcgen.gui2.tabs.CharacterInfoTab
  */
-@SuppressWarnings("serial")
+@SuppressWarnings({"UseOfObsoleteCollectionType", "PMD.ReplaceHashtableWithMap", "serial"})
 public class AbilityChooserTab extends FlippingSplitPane implements StateEditable, TodoHandler
 {
 

--- a/code/src/java/pcgen/gui2/util/treetable/DefaultSortableTreeTableNode.java
+++ b/code/src/java/pcgen/gui2/util/treetable/DefaultSortableTreeTableNode.java
@@ -25,9 +25,7 @@ import java.util.Vector;
 
 import pcgen.gui2.util.table.Row;
 
-/**
- *
- */
+@SuppressWarnings({"UseOfObsoleteCollectionType", "PMD.ReplaceVectorWithList"})
 public class DefaultSortableTreeTableNode extends DefaultTreeTableNode implements SortableTreeTableNode
 {
 

--- a/code/src/java/pcgen/gui2/util/treeview/TreeViewTableModel.java
+++ b/code/src/java/pcgen/gui2/util/treeview/TreeViewTableModel.java
@@ -42,6 +42,7 @@ import pcgen.util.CollectionMaps;
 import pcgen.util.ListMap;
 import pcgen.util.Logging;
 
+@SuppressWarnings({"UseOfObsoleteCollectionType", "PMD.ReplaceVectorWithList"})
 public class TreeViewTableModel<E> extends AbstractTreeTableModel implements SortableTreeTableModel
 {
 

--- a/code/src/java/plugin/encounter/EncounterPlugin.java
+++ b/code/src/java/plugin/encounter/EncounterPlugin.java
@@ -85,6 +85,7 @@ import gmgen.pluginmgr.messages.RequestAddTabToGMGenMessage;
  * } is a plugin for the {@code GMGenSystem}, is called by the
  * {@code PluginLoader} and will create a model and a view for this plugin.
  */
+@SuppressWarnings({"UseOfObsoleteCollectionType", "PMD.ReplaceVectorWithList"})
 public class EncounterPlugin extends MouseAdapter implements InteractivePlugin, ActionListener, ItemListener
 {
 	/** Directory where Data for this plug-in is expected to be. */

--- a/code/src/java/plugin/initiative/gui/AttackDialog.java
+++ b/code/src/java/plugin/initiative/gui/AttackDialog.java
@@ -62,6 +62,7 @@ import plugin.initiative.AttackModel;
  * dialog displays a {@code JComboBox} which displays attackable combatants.  Changing
  * selections changes the AC value and re-calculates the attack rolls.</p>
  */
+@SuppressWarnings({"UseOfObsoleteCollectionType", "PMD.ReplaceVectorWithList"})
 public class AttackDialog extends JDialog
 {
 	/** <p>List of resulting damage values, one for each successful attack.</p> */

--- a/code/src/java/plugin/initiative/gui/Initiative.java
+++ b/code/src/java/plugin/initiative/gui/Initiative.java
@@ -96,6 +96,7 @@ import org.jdom2.input.SAXBuilder;
 import org.jdom2.output.Format;
 import org.jdom2.output.XMLOutputter;
 
+@SuppressWarnings({"UseOfObsoleteCollectionType", "PMD.ReplaceVectorWithList"})
 public class Initiative extends javax.swing.JPanel
 {
 	//** End Dynamic Components **

--- a/code/src/java/plugin/notes/gui/NotesTreeNode.java
+++ b/code/src/java/plugin/notes/gui/NotesTreeNode.java
@@ -117,6 +117,7 @@ public class NotesTreeNode implements MutableTreeNode, DocumentListener
 	 * than Vector due to the TreeNode interface which uses Enumeration as 
 	 * the return type of children();
 	 */
+	@SuppressWarnings({"UseOfObsoleteCollectionType", "PMD.ReplaceVectorWithList"})
 	protected Vector<MutableTreeNode> children;
 
 	/** true if the node is able to have children. */

--- a/code/src/java/plugin/notes/gui/NotesView.java
+++ b/code/src/java/plugin/notes/gui/NotesView.java
@@ -115,6 +115,7 @@ import javafx.stage.FileChooser;
  *  This class is the main view for the Notes Plugin. Mostof the work is done
  *  here and in the NotesTreeNode Class.
  */
+@SuppressWarnings({"UseOfObsoleteCollectionType", "PMD.ReplaceVectorWithList"})
 public class NotesView extends JPanel
 {
 

--- a/code/src/java/plugin/overland/gui/OverPanel.java
+++ b/code/src/java/plugin/overland/gui/OverPanel.java
@@ -76,7 +76,7 @@ public class OverPanel extends javax.swing.JPanel
 	private javax.swing.JComboBox cmbAnimal;
 	private javax.swing.JComboBox cmbFood;
 	private javax.swing.JComboBox cmbInn;
-	private JComboBox cmbFile;
+	private JComboBox<TravelMethod> cmbFile;
 	private javax.swing.JLabel jLabel11;
 	private javax.swing.JLabel jLabel15;
 	private javax.swing.JLabel jLabel16;
@@ -136,6 +136,7 @@ public class OverPanel extends javax.swing.JPanel
 	private RoomBoard rb;
 
 	/** holds the travel methods */
+	@SuppressWarnings({"UseOfObsoleteCollectionType", "PMD.ReplaceVectorWithList"})
 	private Vector<TravelMethod> tms;
 
 	// ### Constructors ###
@@ -933,7 +934,7 @@ public class OverPanel extends javax.swing.JPanel
 		nf.setMaximumFractionDigits(2); //This will display other numbers
 		gp.setMaximumFractionDigits(3); //This will correctly display currency
 
-		aModel = new DefaultComboBoxModel(tms);
+		aModel = new DefaultComboBoxModel<>(tms);
 		cmbFile.setModel(aModel);
 		cmbFile.addItemListener(new ItemListener()
 		{

--- a/code/src/java/plugin/overland/model/TravelMethodFactory.java
+++ b/code/src/java/plugin/overland/model/TravelMethodFactory.java
@@ -79,6 +79,7 @@ public class TravelMethodFactory
 
 	// ### Factory methods ###
 
+	@SuppressWarnings({"UseOfObsoleteCollectionType", "PMD.ReplaceVectorWithList"})
 	public static Vector<TravelMethod> load(File datadir)
 	{
 		//Create a new list for the travel methods

--- a/code/standards/ruleset.xml
+++ b/code/standards/ruleset.xml
@@ -29,8 +29,6 @@
         <exclude name="PositionLiteralsFirstInCaseInsensitiveComparisons"/>
         <exclude name="PositionLiteralsFirstInComparisons"/>
         <exclude name="PreserveStackTrace"/>
-        <exclude name="ReplaceHashtableWithMap"/>
-        <exclude name="ReplaceVectorWithList"/>
         <exclude name="SwitchStmtsShouldHaveDefault"/>
         <exclude name="SystemPrintln"/>
         <exclude name="UnusedFormalParameter"/>


### PR DESCRIPTION
Annotate use of Hashtable and Vector that can't be avoided. This should
allow pmd to check for such usages infecting other parts of the
codebase.