### PR TITLE
Tab Display Style: remove it

### DIFF
--- a/code/src/java/pcgen/cdom/base/Constants.java
+++ b/code/src/java/pcgen/cdom/base/Constants.java
@@ -237,35 +237,6 @@ public interface Constants
 	int CHOOSER_SINGLE_CHOICE_METHOD_SELECT_EXIT = 2;
 
 	/********************************************************************
-	 * How to display the PC's name
-	 ********************************************************************/
-
-	/**
-	 * A constant used to define the style of name that will be used for
-	 * this PC.  This option selects the plain unadorned name. */
-	int DISPLAY_STYLE_NAME = 0;
-
-	/**
-	 * A constant used to define the style of name that will be used for
-	 * this PC.  This option selects  */
-	int DISPLAY_STYLE_NAME_CLASS = 1;
-
-	/**
-	 * A constant used to define the style of name that will be used for
-	 * this PC.  This option appends the PC's race to its name.  */
-	int DISPLAY_STYLE_NAME_RACE = 2;
-
-	/**
-	 * A constant used to define the style of name that will be used for
-	 * this PC.  This option appends the PC's class to its name. */
-	int DISPLAY_STYLE_NAME_RACE_CLASS = 3;
-
-	/**
-	 * A constant used to define the style of name that will be used for
-	 * this PC.  This option appends the PC's race  and class to its name. */
-	int DISPLAY_STYLE_NAME_FULL = 4;
-
-	/********************************************************************
 	 * How to roll hitpoints
 	 ********************************************************************/
 

--- a/code/src/java/pcgen/core/SettingsHandler.java
+++ b/code/src/java/pcgen/core/SettingsHandler.java
@@ -137,7 +137,6 @@ public final class SettingsHandler
 	private static final File TEMP_PATH = new File(getTmpPath());
 	private static boolean useHigherLevelSlotsDefault = false;
 	private static boolean wantToLoadMasterworkAndMagic = false;
-	private static int nameDisplayStyle = Constants.DISPLAY_STYLE_NAME;
 	private static boolean weaponProfPrintout = Constants.DEFAULT_PRINTOUT_WEAPONPROF;
 	private static String postExportCommandStandard = ""; //$NON-NLS-1$
 	private static String postExportCommandPDF = ""; //$NON-NLS-1$
@@ -717,12 +716,6 @@ public final class SettingsHandler
 	{
 		return maxWandSpellLevel;
 	}
-	
-	public static int getNameDisplayStyle()
-	{
-		return nameDisplayStyle;
-	}
-
 	public static SortedProperties getOptions()
 	{
 		return OPTIONS;
@@ -1093,7 +1086,6 @@ public final class SettingsHandler
 		setPCGenOption("looknFeel", getLookAndFeel()); //$NON-NLS-1$
 		setPCGenOption("maxPotionSpellLevel", getMaxPotionSpellLevel()); //$NON-NLS-1$
 		setPCGenOption("maxWandSpellLevel", getMaxWandSpellLevel()); //$NON-NLS-1$
-		setPCGenOption("nameDisplayStyle", getNameDisplayStyle()); //$NON-NLS-1$
 		setPCGenOption("postExportCommandStandard", SettingsHandler.getPostExportCommandStandard()); //$NON-NLS-1$
 		setPCGenOption("postExportCommandPDF", SettingsHandler.getPostExportCommandPDF()); //$NON-NLS-1$
 		setPCGenOption("prereqFailColor", "0x" + Integer.toHexString(getPrereqFailColor())); //$NON-NLS-1$ //$NON-NLS-2$

--- a/code/src/java/pcgen/core/display/CharacterDisplay.java
+++ b/code/src/java/pcgen/core/display/CharacterDisplay.java
@@ -1268,124 +1268,12 @@ public class CharacterDisplay
 	{
 		final String custom = getSafeStringFor(PCStringKey.TABNAME);
 
-		if (!Constants.EMPTY_STRING.equals(custom))
+		if (custom != null && !custom.isEmpty())
 		{
 			return custom;
 		}
 
-		final StringBuilder displayName = new StringBuilder(100).append(getName());
-
-		// TODO - i18n
-		switch (SettingsHandler.getNameDisplayStyle())
-		{
-			case Constants.DISPLAY_STYLE_NAME:
-				break;
-
-			case Constants.DISPLAY_STYLE_NAME_CLASS:
-				displayName.append(" the ").append(getDisplayClassName());
-
-				break;
-
-			case Constants.DISPLAY_STYLE_NAME_RACE:
-				displayName.append(" the ").append(getDisplayRaceName());
-
-				break;
-
-			case Constants.DISPLAY_STYLE_NAME_RACE_CLASS:
-				displayName.append(" the ").append(getDisplayRaceName()).append(' ').append(getDisplayClassName());
-
-				break;
-
-			case Constants.DISPLAY_STYLE_NAME_FULL:
-				return getFullDisplayName();
-
-			default:
-				break; // custom broken
-		}
-
-		return displayName.toString();
-	}
-
-	/**
-	 * Returns a very descriptive name for the character.
-	 * 
-	 * The format is [name] the [level]th level [race name] [classes]
-	 * 
-	 * @return A descriptive string name for the character.
-	 */
-	public String getFullDisplayName()
-	{
-		final int levels = getTotalLevels();
-		final String displayClass;
-
-		// If you aren't multi-classed, don't display redundant class level
-		// information in addition to the total PC level
-		displayClass = (classFacet.getCount(id) > 1) ? getFullDisplayClassName() : getDisplayClassName();
-
-		return getName() + " the " + levels + getOrdinal(levels) + " level " + getDisplayRaceName() + ' '
-			+ displayClass;
-	}
-
-	private static String getOrdinal(final int cardinal)
-	{
-		switch (cardinal)
-		{
-			case 1:
-				return "st";
-
-			case 2:
-				return "nd";
-
-			case 3:
-				return "rd";
-
-			default:
-				return "th";
-		}
-	}
-
-	private String getDisplayClassName()
-	{
-		ArrayList<PCClass> classList = getClassList();
-		return (classFacet.isEmpty(id) ? "Nobody" : getDisplayClassName(classList.get(classList.size() - 1)));
-	}
-
-	private String getDisplayRaceName()
-	{
-		Race race = getRace();
-		if (race.isUnselected())
-		{
-			return "Nothing";
-		}
-		return getRace().toString();
-	}
-
-	private String getFullDisplayClassName()
-	{
-		if (classFacet.isEmpty(id))
-		{
-			return "Nobody";
-		}
-
-		final StringBuilder buf = new StringBuilder(50);
-
-		boolean first = true;
-		for (PCClass c : getClassSet())
-		{
-			if (!first)
-			{
-				buf.append('/');
-				first = false;
-			}
-			buf.append(getFullDisplayClassName(c));
-		}
-
-		return buf.toString();
-	}
-
-	public String getFullDisplayClassName(PCClass pcClass)
-	{
-		return getDisplayClassName(pcClass) + " " + getLevel(pcClass);
+		return getName();
 	}
 
 	public String getDisplayClassName(PCClass pcClass)

--- a/code/src/java/pcgen/io/IOConstants.java
+++ b/code/src/java/pcgen/io/IOConstants.java
@@ -407,8 +407,6 @@ interface IOConstants
 
 	/** SYNERGY */
 	String TAG_SYNERGY = "SYNERGY";
-	/** TABLABEL */
-	String TAG_TABLABEL = "TABLABEL";
 	/** TABNAME */
 	String TAG_TABNAME = "TABNAME";
 

--- a/code/src/java/pcgen/io/PCGVer2Creator.java
+++ b/code/src/java/pcgen/io/PCGVer2Creator.java
@@ -165,7 +165,6 @@ public final class PCGVer2Creator
 		 * UNLIMITEDPOOLCHECKED:Y or N
 		 * POOLPOINTS:>numeric value 0-?<
 		 * GAMEMODE:DnD
-		 * TABLABEL:0
 		 * AUTOSPELLS:Y or N
 		 * AUTOCOMPANIONS:Y or N
 		 *
@@ -186,7 +185,6 @@ public final class PCGVer2Creator
 		//appendUnlimitedPoolCheckedLine(buffer);
 		appendPoolPointsLine(buffer);
 		appendGameModeLine(buffer);
-		appendTabLabelLine(buffer);
 		appendAutoSpellsLine(buffer);
 		appendUseHigherSpellSlotsLines(buffer);
 		appendLoadCompanionLine(buffer);
@@ -1646,13 +1644,6 @@ public final class PCGVer2Creator
 		buffer.append(IOConstants.LINE_SEP);
 		buffer.append(IOConstants.TAG_POOLPOINTSAVAIL).append(':');
 		buffer.append(thePC.getPointBuyPoints());
-		buffer.append(IOConstants.LINE_SEP);
-	}
-
-	private static void appendTabLabelLine(StringBuilder buffer)
-	{
-		buffer.append(IOConstants.TAG_TABLABEL).append(':');
-		buffer.append(SettingsHandler.getNameDisplayStyle());
 		buffer.append(IOConstants.LINE_SEP);
 	}
 


### PR DESCRIPTION
As it happens, the tab display style heavily depends on the code 
understanding details like "race" or "class" and can be fully replaced by
having a "tab label" in the file (which there is). If we ever want to bring
it back, we'll need a data driven list of options and format strings.


Depends on #5586