### PR TITLE
Avoid explicitly throwing unchecked exceptions

### DIFF
--- a/code/src/java/pcgen/core/AbilityUtilities.java
+++ b/code/src/java/pcgen/core/AbilityUtilities.java
@@ -113,7 +113,6 @@ public final class AbilityUtilities
 	 * @throws GroupingMismatchException If there are mismatched brackets
 	 */
 	public static String getUndecoratedName(final String name, final Collection<String> specifics)
-		throws GroupingMismatchException
 	{
 		LastGroupSeparator lgs = new LastGroupSeparator(name);
 		String subName = lgs.process();

--- a/code/src/java/pcgen/core/utils/LastGroupSeparator.java
+++ b/code/src/java/pcgen/core/utils/LastGroupSeparator.java
@@ -114,7 +114,7 @@ public class LastGroupSeparator
 	public static class GroupingMismatchException extends IllegalStateException
 	{
 
-		public GroupingMismatchException(String base)
+		private GroupingMismatchException(String base)
 		{
 			super(base);
 		}

--- a/code/src/java/pcgen/gui2/facade/CharacterFacadeImpl.java
+++ b/code/src/java/pcgen/gui2/facade/CharacterFacadeImpl.java
@@ -2518,10 +2518,9 @@ public class CharacterFacadeImpl
 	 * part of the CharacterFacade and should only be used by the 
 	 * ChracterManager class.
 	 * 
-	 * @throws NullPointerException
 	 * @throws IOException If the write fails
 	 */
-	public void save() throws NullPointerException, IOException
+	public void save() throws IOException
 	{
 		GameMode mode = dataSet.getGameMode();
 		List<Campaign> campaigns = ListFacades.wrap(dataSet.getCampaigns());

--- a/code/src/java/pcgen/persistence/SourceFileLoader.java
+++ b/code/src/java/pcgen/persistence/SourceFileLoader.java
@@ -1170,7 +1170,7 @@ public class SourceFileLoader extends PCGenTask implements Observer
 		}
 
 		@Override
-		public void close() throws SecurityException
+		public void close()
 		{
 			// Nothing to do
 		}

--- a/code/src/java/plugin/initiative/gui/OpposedCheckDialog.java
+++ b/code/src/java/plugin/initiative/gui/OpposedCheckDialog.java
@@ -27,7 +27,6 @@ import java.awt.Dimension;
 import java.awt.Frame;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
-import java.awt.HeadlessException;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.Transferable;
 import java.awt.datatransfer.UnsupportedFlavorException;
@@ -141,7 +140,6 @@ class OpposedCheckDialog extends JDialog
 	 * @throws HeadlessException if running without a gui
 	 */
 	OpposedCheckDialog(Frame owner, List<InitHolder> rollingGroup, List<InitHolder> availableGroup)
-		throws HeadlessException
 	{
 		super(owner);
 		initializeLists(rollingGroup, availableGroup);


### PR DESCRIPTION
Java does not actually enforce that unchecked exceptions declared on
functions are caught. As such, remove it from the decl and leave it in
the documentation only (or just remove if unneeded).