### PR TITLE
EquipmentPreferencesPanelController: move data into model

### DIFF
--- a/code/src/java/pcgen/gui3/preferences/EquipmentPreferencesModel.java
+++ b/code/src/java/pcgen/gui3/preferences/EquipmentPreferencesModel.java
@@ -26,16 +26,42 @@ import javafx.beans.property.SimpleIntegerProperty;
  */
 class EquipmentPreferencesModel
 {
+	static class Bounds
+	{
+		private Bounds(final int min, final int max)
+		{
+			this.min = min;
+			this.max = max;
+		}
+
+		public final int min;
+		public final int max;
+	}
+
 	private final IntegerProperty maxPotionLevel = new SimpleIntegerProperty();
+	private final Bounds maxPotionLevelBounds = new Bounds(1, 9);
 	private final IntegerProperty maxWandLevel = new SimpleIntegerProperty();
+	private final Bounds maxWandLevelBounds = new Bounds(1, 9);
 
 	IntegerProperty maxPotionLevelProperty()
 	{
 		return maxPotionLevel;
 	}
 
+	Bounds getMaxPotionLevelBounds()
+	{
+		return maxPotionLevelBounds;
+	}
+
 	IntegerProperty maxWandLevelProperty()
 	{
 		return maxWandLevel;
 	}
+
+	Bounds getMaxWandLevelBounds()
+	{
+		return maxWandLevelBounds;
+	}
+
+
 }

--- a/code/src/java/pcgen/gui3/preferences/EquipmentPreferencesPanelController.java
+++ b/code/src/java/pcgen/gui3/preferences/EquipmentPreferencesPanelController.java
@@ -44,6 +44,19 @@ public class EquipmentPreferencesPanelController implements ResettableController
 	@FXML
 	void initialize()
 	{
+		var potionValueFactory =
+				new SpinnerValueFactory.IntegerSpinnerValueFactory(model.getMaxPotionLevelBounds().min,
+						model.getMaxWandLevelBounds().max,
+						SettingsHandler.maxPotionSpellLevel().getValue(), 1
+				);
+		potionSpinner.setValueFactory(potionValueFactory);
+		var wandValueFactory =
+				new SpinnerValueFactory.IntegerSpinnerValueFactory(model.getMaxWandLevelBounds().min,
+						model.getMaxWandLevelBounds().max,
+						SettingsHandler.maxWandSpellLevel().getValue(), 1
+				);
+		wandSpinner.setValueFactory(wandValueFactory);
+
 		// TODO: consider adding an apply button that sets values rather than using binding directly
 		model.maxPotionLevelProperty().bind(potionSpinner.valueProperty());
 		model.maxWandLevelProperty().bind(wandSpinner.valueProperty());
@@ -56,11 +69,8 @@ public class EquipmentPreferencesPanelController implements ResettableController
 
 	@Override
 	public void reset()  {
-		// TODO shouldn't the constants come from the model?
-		potionSpinner.setValueFactory(new SpinnerValueFactory.IntegerSpinnerValueFactory(0, 9,
-				SettingsHandler.maxPotionSpellLevel().getValue(), 1));
-		wandSpinner.setValueFactory(new SpinnerValueFactory.IntegerSpinnerValueFactory(0, 9,
-				SettingsHandler.maxWandSpellLevel().getValue(), 1));
+		potionSpinner.getValueFactory().setValue(SettingsHandler.maxPotionSpellLevel().getValue());
+		wandSpinner.getValueFactory().setValue(SettingsHandler.maxWandSpellLevel().getValue());
 	}
 
 	@Override


### PR DESCRIPTION
This moves the bounds data into the model. It also set the valueFactory
(enforcing the bounds) into the init function rather than relying on it
happening during an early `reset()` call.