### PR TITLE
GMGen: eliminate "check newest version"

### DIFF
--- a/code/src/java/gmgen/GMGenSystem.java
+++ b/code/src/java/gmgen/GMGenSystem.java
@@ -75,9 +75,6 @@ public final class GMGenSystem extends JFrame
 		implements ChangeListener, MenuListener, ActionListener, PCGenMessageHandler
 {
 
-	// Serial UID
-	private static final long serialVersionUID = -7372446160499882872L;
-
 	// menu elements used with CommonMenuText.name(...)
 	private static final String MNU_SAVE = "mnuSave"; //$NON-NLS-1$
 	private static final String MNU_OPEN = "mnuOpen"; //$NON-NLS-1$
@@ -120,7 +117,6 @@ public final class GMGenSystem extends JFrame
 	private JMenuItem pasteEditItem;
 	private JMenuItem preferencesEditItem;
 	private JMenuItem exitFileItem;
-	private JMenuItem versionToolsItem;
 
 	/**
 	 * The new menu item in the file menu.
@@ -136,12 +132,6 @@ public final class GMGenSystem extends JFrame
 	 * The save menu item in the file menu.
 	 */
 	public JMenuItem saveFileItem;
-
-	// Separators
-	private JSeparator editSeparator1;
-	private JSeparator fileSeparator1;
-	private JSeparator fileSeparator2;
-	private JSeparator toolsSeparator1;
 
 	// Tree for the preferences dialog
 	private final PreferencesRootTreeNode rootNode = new PreferencesRootTreeNode();
@@ -244,7 +234,7 @@ public final class GMGenSystem extends JFrame
 		/*
 		 * Preferences on the Macintosh is in the application menu.
 		 */
-		editMenu.add(editSeparator1);
+		editMenu.add(new JSeparator());
 		CommonMenuText.name(preferencesEditItem, PCGenActionMap.MNU_TOOLS_PREFERENCES);
 		editMenu.add(preferencesEditItem);
 		preferencesEditItem.setEnabled(true);
@@ -255,14 +245,6 @@ public final class GMGenSystem extends JFrame
 			preferencesEditItem.removeActionListener(aListenerArray);
 		}
 		preferencesEditItem.addActionListener(this::mPreferencesActionPerformed);
-	}
-
-	/**
-	 * Exits GMGen, the Mac way.
-	 */
-	public void exitFormMac()
-	{
-		this.setVisible(false);
 	}
 
 	/**
@@ -312,15 +294,6 @@ public final class GMGenSystem extends JFrame
 	public void handleToolsMenu()
 	{
 		// TODO
-	}
-
-	/**
-	 * launches the preferences dialog on a mac.
-	 */
-	public void mPreferencesActionPerformedMac()
-	{
-		PreferencesDialog dialog = new PreferencesDialog(this, true, rootNode);
-		dialog.setVisible(true);
 	}
 
 	/**
@@ -450,24 +423,14 @@ public final class GMGenSystem extends JFrame
 		copyEditItem.setEnabled(false);
 		pasteEditItem.setEnabled(false);
 		preferencesEditItem.setEnabled(true);
-		versionToolsItem.setEnabled(false);
 	}
 
 	// Create tools menu
 	private void createToolsMenu()
 	{
 		toolsMenu = new JMenu();
-		toolsSeparator1 = new JSeparator();
-		versionToolsItem = new JMenuItem();
-
 		CommonMenuText.name(toolsMenu, PCGenActionMap.MNU_TOOLS);
 		toolsMenu.addMenuListener(this);
-
-		CommonMenuText.name(versionToolsItem, "mnuGetNew"); //$NON-NLS-1$
-		toolsMenu.add(versionToolsItem);
-
-		toolsMenu.add(toolsSeparator1);
-
 		systemMenuBar.add(toolsMenu);
 	}
 
@@ -478,7 +441,6 @@ public final class GMGenSystem extends JFrame
 		cutEditItem = new JMenuItem();
 		copyEditItem = new JMenuItem();
 		pasteEditItem = new JMenuItem();
-		editSeparator1 = new JSeparator();
 		preferencesEditItem = new JMenuItem();
 
 		// EDIT MENU
@@ -494,7 +456,7 @@ public final class GMGenSystem extends JFrame
 		CommonMenuText.name(pasteEditItem, MNU_PASTE);
 		editMenu.add(pasteEditItem);
 
-		editMenu.add(editSeparator1);
+		editMenu.add(new JSeparator());
 
 		CommonMenuText.name(preferencesEditItem, PCGenActionMap.MNU_TOOLS_PREFERENCES);
 		editMenu.add(preferencesEditItem);
@@ -517,9 +479,7 @@ public final class GMGenSystem extends JFrame
 		fileMenu = new JMenu();
 		newFileItem = new JMenuItem();
 		openFileItem = new JMenuItem();
-		fileSeparator1 = new JSeparator();
 		saveFileItem = new JMenuItem();
-		fileSeparator2 = new JSeparator();
 		exitFileItem = new JMenuItem();
 
 		CommonMenuText.name(fileMenu, PCGenActionMap.MNU_FILE);
@@ -527,7 +487,7 @@ public final class GMGenSystem extends JFrame
 
 		createFileNewMenuItem();
 		createFileOpenMenuItem();
-		fileMenu.add(fileSeparator1);
+		fileMenu.add(new JSeparator());
 		createFileSaveMenuItem();
 
 		// Exit is quit on the Macintosh is in the application menu.
@@ -562,7 +522,7 @@ public final class GMGenSystem extends JFrame
 
 	private void exitForMacOSX()
 	{
-		fileMenu.add(fileSeparator2);
+		fileMenu.add(new JSeparator());
 		CommonMenuText.name(exitFileItem, MNU_EXIT);
 		fileMenu.add(exitFileItem);
 		exitFileItem.addActionListener(this);

--- a/code/src/resources/pcgen/lang/LanguageBundle.properties
+++ b/code/src/resources/pcgen/lang/LanguageBundle.properties
@@ -2922,10 +2922,6 @@ in_uichooser_bad_param=Unrecognised parameter "{0}" for CHOOSE:USERINPUT
 ### GMGen localization
 # {0} is application name (GMGen)
 in_gmgen_frameTitle={0} System
-in_mnuGetNew=Get Newest Version
-# Mnemonic for in_mnuGetNew
-in_mn_mnuGetNew=G
-in_mnuGetNewTip=
 in_mnuCut=Cut
 # Mnemonic for in_mnuCut
 in_mn_mnuCut=t

--- a/code/src/resources/pcgen/lang/LanguageBundle_es.properties
+++ b/code/src/resources/pcgen/lang/LanguageBundle_es.properties
@@ -2924,10 +2924,6 @@ in_uichooser_bad_param=par\u00E1metro no reconocido "{0}" para elige: EntradaUsu
 ### GMGen localization
 # {0} is application name (GMGen)
 in_gmgen_frameTitle=({0}) Herramientas para el Director de Juego 
-in_mnuGetNew=Obtener nuevas versi\u00F3n
-# Mnemonic for in_mnuGetNew
-in_mn_mnuGetNew=G
-in_mnuGetNewTip=
 in_mnuCut=Cortar
 # Mnemonic for in_mnuCut
 in_mn_mnuCut=t

--- a/code/src/resources/pcgen/lang/LanguageBundle_fr.properties
+++ b/code/src/resources/pcgen/lang/LanguageBundle_fr.properties
@@ -2831,10 +2831,6 @@ in_uichooser_bad_param=Param\u00E8tre \u00AB\u202F{0}\u202F\u00BB non reconnu po
 ### GMGen localization
 # {0} is application name (GMGen)
 in_gmgen_frameTitle=Syst\u00E8me {0}
-in_mnuGetNew=Obtenir la version la plus r\u00E9cente
-# Mnemonic for in_mnuGetNew
-in_mn_mnuGetNew=O
-in_mnuGetNewTip=
 in_mnuCut=Couper
 # Mnemonic for in_mnuCut
 in_mn_mnuCut=u

--- a/code/src/resources/pcgen/lang/LanguageBundle_it.properties
+++ b/code/src/resources/pcgen/lang/LanguageBundle_it.properties
@@ -2666,9 +2666,6 @@ in_spellEmptySpellList=Lista degli incantesimi vuota
 ### GMGen localization
 # {0} is application name (GMGen)
 in_gmgen_frameTitle=Sistema {0}
-in_mnuGetNew=Ottieni Versione Pi\u00F9 Recente
-# Mnemonic for in_mnuGetNew
-in_mn_mnuGetNew=G
 in_mnuCut=Taglia
 # Mnemonic for in_mnuCut
 in_mn_mnuCut=t

--- a/code/src/resources/pcgen/lang/LanguageBundle_ja.properties
+++ b/code/src/resources/pcgen/lang/LanguageBundle_ja.properties
@@ -1321,7 +1321,6 @@ in_spellSpellResist=\u546A\u6587\u62B5\u6297
 ### GMGen localization
 # {0} is application name (GMGen)
 in_gmgen_frameTitle={0}\u30B7\u30B9\u30C6\u30E0
-# Mnemonic for in_mnuGetNew
 # Mnemonic for in_mnuCut
 # Mnemonic for in_mnuCopy
 # Mnemonic for in_mnuPaste


### PR DESCRIPTION
As much as I'd like an online version check, we don't have one right
now. Remove code to simplify future efforts to migrate this code to
JavaFX