### PR TITLE
browserPath: remove setting

### DIFF
--- a/code/src/java/pcgen/core/SettingsHandler.java
+++ b/code/src/java/pcgen/core/SettingsHandler.java
@@ -71,9 +71,6 @@ public final class SettingsHandler
 	// Map of RuleCheck keys and their settings
 	private static final Map<String, String> ruleCheckMap = new HashMap<>();
 
-	/** That browserPath is set to null is intentional. */
-	private static String browserPath = null; //Intentional null
-
 	private static Dimension customizerDimension = null;
 	private static Point customizerLeftUpperCorner = null;
 	private static int customizerSplit1 = -1;
@@ -186,26 +183,6 @@ public final class SettingsHandler
 	public static File getBackupPcgPath()
 	{
 		return backupPcgPath;
-	}
-
-	/**
-	 * Sets the external browser path to use.
-	 *
-	 * @param  path  the {@code String} representing the path
-	 **/
-	public static void setBrowserPath(final String path)
-	{
-		browserPath = path;
-	}
-
-	/**
-	 * Returns the external browser path to use.
-	 *
-	 * @return    the {@code browserPath} property
-	 */
-	public static String getBrowserPath()
-	{
-		return browserPath;
 	}
 
 	/**
@@ -646,32 +623,18 @@ public final class SettingsHandler
 
 	public static void getOptionsFromProperties(final PlayerCharacter aPC)
 	{
-		Dimension d = new Dimension(0, 0);
-
-		final String tempBrowserPath = getPCGenOption("browserPath", ""); //$NON-NLS-1$ //$NON-NLS-2$
-
-		if (!"".equals(tempBrowserPath)) //$NON-NLS-1$
-		{
-			setBrowserPath(tempBrowserPath);
-		}
-		else
-		{
-			setBrowserPath(null);
-		}
-
 		setLeftUpperCorner(new Point(getPCGenOption("windowLeftUpperCorner.X", -1.0).intValue(), //$NON-NLS-1$
 			getPCGenOption("windowLeftUpperCorner.Y", -1.0).intValue())); //$NON-NLS-1$
 
 		setWindowState(getPCGenOption("windowState", Frame.NORMAL)); //$NON-NLS-1$
 
-		Double dw = getPCGenOption("windowWidth", 0.0); //$NON-NLS-1$
-		Double dh = getPCGenOption("windowHeight", 0.0); //$NON-NLS-1$
-
 		setCustomizerLeftUpperCorner(new Point(getPCGenOption(
 			"customizer.windowLeftUpperCorner.X", -1.0).intValue(), //$NON-NLS-1$
 			getPCGenOption("customizer.windowLeftUpperCorner.Y", -1.0).intValue())); //$NON-NLS-1$
-		dw = getPCGenOption("customizer.windowWidth", 0.0); //$NON-NLS-1$
-		dh = getPCGenOption("customizer.windowHeight", 0.0); //$NON-NLS-1$
+		//$NON-NLS-1$
+		Double dw = getPCGenOption("customizer.windowWidth", 0.0); //$NON-NLS-1$
+		//$NON-NLS-1$
+		Double dh = getPCGenOption("customizer.windowHeight", 0.0); //$NON-NLS-1$
 
 		if (!CoreUtility.doublesEqual(dw.doubleValue(), 0.0) && !CoreUtility.doublesEqual(dh.doubleValue(), 0.0))
 		{
@@ -871,15 +834,6 @@ public final class SettingsHandler
 		else
 		{
 			getOptions().setProperty("gmgen.files.gmgenPluginDir", ""); //$NON-NLS-1$ //$NON-NLS-2$
-		}
-
-		if (getBrowserPath() != null)
-		{
-			setPCGenOption("browserPath", getBrowserPath()); //$NON-NLS-1$
-		}
-		else
-		{
-			setPCGenOption("browserPath", ""); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 
 		if (getGame() != null)

--- a/code/src/java/pcgen/gui2/prefs/LocationPanel.java
+++ b/code/src/java/pcgen/gui2/prefs/LocationPanel.java
@@ -32,7 +32,6 @@ import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JFileChooser;
 import javax.swing.JLabel;
-import javax.swing.JOptionPane;
 import javax.swing.JRadioButton;
 import javax.swing.JTextField;
 import javax.swing.border.Border;
@@ -41,7 +40,6 @@ import javax.swing.text.JTextComponent;
 
 import pcgen.core.utils.MessageType;
 import pcgen.core.utils.ShowMessageDelegate;
-import pcgen.gui2.tools.DesktopBrowserLauncher;
 import pcgen.gui2.tools.Utility;
 import pcgen.system.ConfigurationSettings;
 import pcgen.system.ConfigurationSettings.SettingsFilesPath;
@@ -60,8 +58,6 @@ public class LocationPanel extends PCGenPrefsPanel
 {
 	private static final String IN_LOCATION = LanguageBundle.getString("in_Prefs_location");
 
-	private static final String IN_BROWSER_PATH = LanguageBundle.getString("in_Prefs_browserPath");
-	private static final String IN_CLEAR_BROWSER_PATH = LanguageBundle.getString("in_Prefs_clearBrowserPath");
 	private static final String IN_CHOOSE = "...";
 
 	private final ButtonGroup groupFilesDir;
@@ -70,8 +66,6 @@ public class LocationPanel extends PCGenPrefsPanel
 	private final JRadioButton usersFilesDirRadio;
 	private final JCheckBox pcgenCreateBackupCharacter = new JCheckBox();
 
-	private final JButton browserPathButton;
-	private final JButton clearBrowserPathButton;
 	private final JButton pcgenCharacterDirButton;
 	private final JButton pcgenCustomDirButton;
 	private final JButton pcgenVendorDataDirButton;
@@ -85,7 +79,6 @@ public class LocationPanel extends PCGenPrefsPanel
 	private final JButton pcgenSystemDirButton;
 	private final JButton pcgenBackupCharacterDirButton;
 
-	private final JTextField browserPath;
 	private final JTextField pcgenCharacterDir;
 	private final JTextField pcgenCustomDir;
 	private final JTextField pcgenVendorDataDir;
@@ -118,29 +111,6 @@ public class LocationPanel extends PCGenPrefsPanel
 		constraints.fill = GridBagConstraints.HORIZONTAL;
 		constraints.anchor = GridBagConstraints.WEST;
 		constraints.insets = new Insets(2, 2, 2, 2);
-
-		Utility.buildConstraints(constraints, 0, 0, 1, 1, 0, 0);
-		JLabel label = new JLabel(IN_BROWSER_PATH + ": ");
-		gridbag.setConstraints(label, constraints);
-		this.add(label);
-		Utility.buildConstraints(constraints, 1, 0, 1, 1, 1, 0);
-		browserPath = new JTextField(String.valueOf(PCGenSettings.getBrowserPath()));
-
-		// sage_sam 9 April 2003
-		browserPath.addFocusListener(textFieldListener);
-		gridbag.setConstraints(browserPath, constraints);
-		this.add(browserPath);
-		Utility.buildConstraints(constraints, 2, 0, 1, 1, 0, 0);
-		browserPathButton = new JButton(IN_CHOOSE);
-		gridbag.setConstraints(browserPathButton, constraints);
-		this.add(browserPathButton);
-		browserPathButton.addActionListener(prefsButtonHandler);
-
-		Utility.buildConstraints(constraints, 1, 1, 1, 1, 0, 0);
-		clearBrowserPathButton = new JButton(IN_CLEAR_BROWSER_PATH);
-		gridbag.setConstraints(clearBrowserPathButton, constraints);
-		this.add(clearBrowserPathButton);
-		clearBrowserPathButton.addActionListener(prefsButtonHandler);
 
 		Utility.buildConstraints(constraints, 0, 2, 1, 1, 0, 0);
 		JLabel in_prefs_pcgenCharacterDir = new JLabel(LanguageBundle.getString("in_Prefs_pcgenCharacterDir") + ": ");
@@ -428,8 +398,6 @@ public class LocationPanel extends PCGenPrefsPanel
 	@Override
 	public void setOptionsBasedOnControls()
 	{
-		// Location -- added 10 April 2000 by sage_sam
-		PCGenSettings.getInstance().setProperty(PCGenSettings.BROWSER_PATH, browserPath.getText());
 		PCGenSettings.getInstance().setProperty(PCGenSettings.PCG_SAVE_PATH, pcgenCharacterDir.getText());
 		PCGenSettings.getInstance().setProperty(PCGenSettings.CHAR_PORTRAITS_PATH, pcgenPortraitsDir.getText());
 		PCGenSettings.getInstance().setProperty(PCGenSettings.CUSTOM_DATA_DIR, pcgenCustomDir.getText());
@@ -486,30 +454,6 @@ public class LocationPanel extends PCGenPrefsPanel
 			if (source == null)
 			{
 				// Do nothing
-			}
-			else if (source == browserPathButton)
-			{
-				DesktopBrowserLauncher.selectDefaultBrowser();
-				browserPath.setText(String.valueOf(PCGenSettings.getBrowserPath()));
-			}
-			else if (source == clearBrowserPathButton)
-			{
-				// If none is set, there is nothing to clear
-				if (PCGenSettings.getBrowserPath() == null)
-				{
-					return;
-				}
-
-				final int choice =
-						JOptionPane.showConfirmDialog(null, LanguageBundle.getString("in_Prefs_clearBrowserWarn"),
-							LanguageBundle.getString("in_Prefs_clearBrowserTitle"), JOptionPane.YES_NO_OPTION);
-
-				if (choice == JOptionPane.YES_OPTION)
-				{
-					PCGenSettings.getInstance().setProperty(PCGenSettings.BROWSER_PATH, "");
-				}
-
-				browserPath.setText(String.valueOf(PCGenSettings.getBrowserPath()));
 			}
 			else if (source == pcgenCharacterDirButton)
 			{

--- a/code/src/java/pcgen/gui2/tools/DesktopBrowserLauncher.java
+++ b/code/src/java/pcgen/gui2/tools/DesktopBrowserLauncher.java
@@ -26,11 +26,12 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 
-import javax.swing.JFileChooser;
+import pcgen.system.LanguageBundle;
+import pcgen.util.Logging;
 
-import pcgen.system.PCGenSettings;
-
-import org.apache.commons.lang3.SystemUtils;
+import javafx.scene.control.Alert;
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.Dialog;
 
 /**
  * Provide an utility method to open files with {@link Desktop}.
@@ -39,8 +40,6 @@ public final class DesktopBrowserLauncher
 {
 
 	private static final Desktop DESKTOP = Desktop.getDesktop();
-	private static final Boolean IS_BROWSE_SUPPORTED =
-			Desktop.isDesktopSupported() && DESKTOP.isSupported(Action.BROWSE);
 
 	private DesktopBrowserLauncher()
 	{
@@ -84,46 +83,18 @@ public final class DesktopBrowserLauncher
 	 */
 	private static void viewInBrowser(URI uri) throws IOException
 	{
-		// Windows tends to lock up or not actually
-		// display anything unless we've specified a
-		// default browser, so at least make the user
-		// aware that (s)he needs one. If they don't
-		// pick one and it doesn't work, at least they
-		// might know enough to try selecting one the
-		// next time.
-		if (!IS_BROWSE_SUPPORTED && SystemUtils.IS_OS_WINDOWS
-				&& (PCGenSettings.getBrowserPath() == null))
+		if (Desktop.isDesktopSupported() && DESKTOP.isSupported(Action.BROWSE))
 		{
-			selectDefaultBrowser();
+			DESKTOP.browse(uri);
+		} else
+		{
+			Dialog<ButtonType> alert = new Alert(Alert.AlertType.WARNING);
+			Logging.debugPrint("unable to browse to " + uri);
+			alert.setTitle(LanguageBundle.getString("in_err_browser_err"));
+			alert.setContentText(LanguageBundle.getFormattedString("in_err_browser_uri", uri));
+			alert.showAndWait();
 		}
 
-		DESKTOP.browse(uri);
 	}
 
-	/**
-	 * Sets the default browser.
-	 */
-	public static void selectDefaultBrowser()
-	{
-		final JFileChooser fc = new JFileChooser();
-		fc.setDialogTitle("Find and select your preferred html browser.");
-
-		if (SystemUtils.IS_OS_MAC || SystemUtils.IS_OS_MAC_OSX)
-		{
-			fc.putClientProperty("JFileChooser.appBundleIsTraversable", "never");
-		}
-
-		if (PCGenSettings.getBrowserPath() != null)
-		{
-			fc.setCurrentDirectory(new File(PCGenSettings.getBrowserPath()));
-		}
-
-		final int returnVal = fc.showOpenDialog(null);
-
-		if (returnVal == JFileChooser.APPROVE_OPTION)
-		{
-			final File file = fc.getSelectedFile();
-			PCGenSettings.OPTIONS_CONTEXT.setProperty(PCGenSettings.BROWSER_PATH, file.getAbsolutePath());
-		}
-	}
 }

--- a/code/src/java/pcgen/system/PCGenSettings.java
+++ b/code/src/java/pcgen/system/PCGenSettings.java
@@ -54,7 +54,6 @@ public final class PCGenSettings extends PropertyContext
 	public static final String OPTION_ALLOW_OVERRIDE_DUPLICATES = "allowOverrideDuplicates";
 	public static final String OPTION_SKILL_FILTER = "skillsOutputFilter";
 	public static final String OPTION_GENERATE_TEMP_FILE_WITH_PDF = "generateTempFileWithPdf";
-	public static final String BROWSER_PATH = "browserPath";
 	/**
 	 * The key for the path to the character files.
 	 */
@@ -130,11 +129,6 @@ public final class PCGenSettings extends PropertyContext
 	public static String getBackupPcgDir()
 	{
 		return getInstance().getProperty(BACKUP_PCG_PATH);
-	}
-
-	public static String getBrowserPath()
-	{
-		return OPTIONS_CONTEXT.getProperty(BROWSER_PATH);
 	}
 
 	public static boolean getCreatePcgBackup()

--- a/code/src/resources/pcgen/lang/LanguageBundle.properties
+++ b/code/src/resources/pcgen/lang/LanguageBundle.properties
@@ -460,6 +460,7 @@ in_loadPartyNoSources=Could not find source files for party: {0}
 # Error Messages
 
 in_err_browser_err=Couldn't launch browser
+in_err_browser_uri=Unable to view {0}
 
 #About dialog
 in_abt_title=About PCGen
@@ -1910,14 +1911,6 @@ in_Prefs_location=Location
 
 in_Prefs_badMaxFixing=Bad value for purchase maximum score, fixing...
 in_Prefs_badMinFixing=Bad value for purchase minimum score, fixing...
-in_Prefs_browserPath=Browser Path: 
-
-in_Prefs_clearBrowserPath=Clear Browser Path
-
-in_Prefs_clearBrowserTitle=Clear default browser
-
-in_Prefs_clearBrowserWarn=Are you sure you want to clear the default browser?
-
 in_Prefs_pcgenCharacterDir=PCGen Character Directory: 
 
 in_Prefs_pcgenPortraitsDir=PCGen Portraits Directory: 

--- a/code/src/resources/pcgen/lang/LanguageBundle_de.properties
+++ b/code/src/resources/pcgen/lang/LanguageBundle_de.properties
@@ -1006,10 +1006,6 @@ in_Prefs_langPortuguese=Portugiesisch
 
 in_Prefs_location=Pfad
 
-in_Prefs_browserPath=Browser Pfad...
-
-in_Prefs_clearBrowserPath=Browser Pfad l\u00F6schen
-
 in_Prefs_pcgenDataDir=PCGen Data Pfad...
 
 in_Prefs_pcgenSystemDir=PCGen System Pfad...

--- a/code/src/resources/pcgen/lang/LanguageBundle_es.properties
+++ b/code/src/resources/pcgen/lang/LanguageBundle_es.properties
@@ -1910,14 +1910,6 @@ in_Prefs_location=Carpetas
 
 in_Prefs_badMaxFixing=Valor incorrecto para los puntos m\u00E1ximos de compra, corrigiendo...
 in_Prefs_badMinFixing=Valor incorrecto para los puntos m\u00EDnimo de compra, corrigiendo...
-in_Prefs_browserPath=Ruta del Navegador por defecto 
-
-in_Prefs_clearBrowserPath=Quitar ruta del navegador
-
-in_Prefs_clearBrowserTitle=Quitar el navegador predeterminado
-
-in_Prefs_clearBrowserWarn=\u00BFEst\u00E1 seguro que desea quitar el navegador predeterminado?
-
 in_Prefs_pcgenCharacterDir=Carpeta de los Personajes 
 
 in_Prefs_pcgenPortraitsDir=Carpeta de los Retratos 

--- a/code/src/resources/pcgen/lang/LanguageBundle_fr.properties
+++ b/code/src/resources/pcgen/lang/LanguageBundle_fr.properties
@@ -1830,14 +1830,6 @@ in_Prefs_location=Emplacement
 
 in_Prefs_badMaxFixing=Mauvaise valeur maximale d\u2019achat d\u2019attribut, correction appliqu\u00E9es\u2026
 in_Prefs_badMinFixing=Mauvaise valeur minimale d\u2019achat d\u2019attribut, correction appliqu\u00E9es\u2026
-in_Prefs_browserPath=Emplacement du navigateur Web\u202F:
-
-in_Prefs_clearBrowserPath=Vider le chemin d\u2019acc\u00E8s du navigateur Web
-
-in_Prefs_clearBrowserTitle=Vider le navigateur Web par d\u00E9faut
-
-in_Prefs_clearBrowserWarn=\u00CAtes-vous certain de vouloir vider le navigateur Web par d\u00E9faut\u202F?
-
 in_Prefs_pcgenCharacterDir=R\u00E9pertoire des personnages\u202F:
 
 in_Prefs_pcgenPortraitsDir=R\u00E9pertoire des portraits\u202F:

--- a/code/src/resources/pcgen/lang/LanguageBundle_it.properties
+++ b/code/src/resources/pcgen/lang/LanguageBundle_it.properties
@@ -1771,14 +1771,6 @@ in_Prefs_langSystem=Usa il linguaggio di default del sistema operativo
 
 in_Prefs_location=Percorsi
 
-in_Prefs_browserPath=Percorso del browser
-
-in_Prefs_clearBrowserPath=Elimina il Percorso per il browser
-
-in_Prefs_clearBrowserTitle=Elimina il browser di default
-
-in_Prefs_clearBrowserWarn=Sei sicuro di voler cancellare il browser di default?
-
 in_Prefs_pcgenCharacterDir=Cartella dei Personaggi:
 
 in_Prefs_pcgenPortraitsDir=Cartella dei Ritratti: 

--- a/code/src/resources/pcgen/lang/LanguageBundle_pt.properties
+++ b/code/src/resources/pcgen/lang/LanguageBundle_pt.properties
@@ -1830,14 +1830,6 @@ in_Prefs_langPortuguese=Portugu\u00EAs (em constru\u00E7\u00E3o)
 
 in_Prefs_location=Localiza\u00E7\u00E3o
 
-in_Prefs_browserPath=Caminho do Navegador
-
-in_Prefs_clearBrowserPath=Limpar Caminho do Navegador
-
-in_Prefs_clearBrowserTitle=Limpar navegador padr\u00E3o
-
-in_Prefs_clearBrowserWarn=Voc\u00EA tem certeza que quer limpar o navegador padr\u00E3o?
-
 in_Prefs_pcgenCharacterDir=Diret\u00F3rio de Personagem (Character) do Pcgen
 
 in_Prefs_pcgenCharacterDirTitle=Encontrar o novo diret\u00F3rio de personagem do pcgen

--- a/code/src/resources/pcgen/lang/cleaned.properties
+++ b/code/src/resources/pcgen/lang/cleaned.properties
@@ -1753,14 +1753,6 @@ in_Prefs_langSystem=Use default operating system language
 
 in_Prefs_location=Location
 
-in_Prefs_browserPath=Browser Path
-
-in_Prefs_clearBrowserPath=Clear Browser Path
-
-in_Prefs_clearBrowserTitle=Clear default browser
-
-in_Prefs_clearBrowserWarn=Are you sure you want to clear the default browser?
-
 in_Prefs_pcgenCharacterDir=PCGen Character Directory
 
 in_Prefs_pcgenBackupCharacterDir=PCGen Character Backup Directory


### PR DESCRIPTION
This setting is actually ignored by PCGen in favour of using the Desktop
class introduced in Java 6. As such, completely eliminate the setting
and the UI to set it.