### PR TITLE
ExportHandler: use a non-deprecated ctor for config

### DIFF
--- a/code/src/java/pcgen/io/ExportHandler.java
+++ b/code/src/java/pcgen/io/ExportHandler.java
@@ -20,6 +20,8 @@
  */
 package pcgen.io;
 
+import static freemarker.template.Configuration.VERSION_2_3_20;
+
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -95,7 +97,6 @@ import pcgen.util.enumeration.View;
 import freemarker.template.Configuration;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
-import freemarker.template.Version;
 
 /**
  * This class deals with exporting a PC to various types of output sheets 
@@ -271,9 +272,8 @@ public final class ExportHandler
 		try
 		{
 			// Set Directory for templates
-			Configuration cfg = new Configuration();
+			Configuration cfg = new Configuration(VERSION_2_3_20);
 			cfg.setDirectoryForTemplateLoading(templateFile.getParentFile());
-			cfg.setIncompatibleImprovements(new Version("2.3.20"));
 
 			// load template
 			Template template = cfg.getTemplate(templateFile.getName());


### PR DESCRIPTION
Configuration now directly takes a version number for bug-fixes. I did
not test new configurations but we are notably behind: all versions
between 2.3.21 and 2.3.28 introduced changes.

Note that some tests set a newer version.