### PR TITLE
DesktopHandler: handle unsupported platforms

### DIFF
--- a/code/src/java/gmgen/GMGenSystem.java
+++ b/code/src/java/gmgen/GMGenSystem.java
@@ -51,7 +51,7 @@ import gmgen.pluginmgr.messages.RequestAddTabToGMGenMessage;
 import gmgen.util.LogUtilities;
 import pcgen.core.SettingsHandler;
 import pcgen.gui2.PCGenActionMap;
-import pcgen.gui2.plaf.DesktopHandler;
+import pcgen.gui3.application.DesktopHandler;
 import pcgen.gui2.tools.CommonMenuText;
 import pcgen.gui2.tools.Icons;
 import pcgen.pluginmgr.PCGenMessage;

--- a/code/src/java/pcgen/gui2/PCGenUIManager.java
+++ b/code/src/java/pcgen/gui2/PCGenUIManager.java
@@ -24,7 +24,7 @@ import javax.swing.UnsupportedLookAndFeelException;
 import gmgen.GMGenSystem;
 import pcgen.gui2.dialog.PreferencesDialog;
 import pcgen.gui2.facade.GMGenMessageHandler;
-import pcgen.gui2.plaf.DesktopHandler;
+import pcgen.gui3.application.DesktopHandler;
 import pcgen.pluginmgr.PCGenMessageHandler;
 import pcgen.pluginmgr.PluginManager;
 import pcgen.system.Main;

--- a/code/src/java/pcgen/gui3/application/DesktopHandler.java
+++ b/code/src/java/pcgen/gui3/application/DesktopHandler.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright 2019 (C) Eitan Adler <lists@eitanadler.com>
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
@@ -13,15 +15,14 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
-package pcgen.gui2.plaf;
+
+package pcgen.gui3.application;
 
 import java.awt.Desktop;
+import java.awt.Desktop.Action;
 import java.awt.desktop.AboutEvent;
-import java.awt.desktop.AboutHandler;
 import java.awt.desktop.PreferencesEvent;
-import java.awt.desktop.PreferencesHandler;
 import java.awt.desktop.QuitEvent;
-import java.awt.desktop.QuitHandler;
 import java.awt.desktop.QuitResponse;
 
 import pcgen.gui2.PCGenUIManager;
@@ -49,13 +50,27 @@ public final class DesktopHandler
 		}
 		initialized = true;
 
+		if (!Desktop.isDesktopSupported())
+		{
+			return;
+		}
+
 		Desktop theDesktop = Desktop.getDesktop();
-		theDesktop.setAboutHandler(new OSXAboutHandler());
-		theDesktop.setPreferencesHandler(new OSXPreferencesHandler());
-		theDesktop.setQuitHandler(new OSXQuitHandler());
+		if (theDesktop.isSupported(Action.APP_ABOUT))
+		{
+			theDesktop.setAboutHandler(new AboutHandler());
+		}
+		if (theDesktop.isSupported(Action.APP_PREFERENCES))
+		{
+			theDesktop.setPreferencesHandler(new PreferencesHandler());
+		}
+		if (theDesktop.isSupported(Action.APP_QUIT_HANDLER))
+		{
+			theDesktop.setQuitHandler(new QuitHandler());
+		}
 	}
 
-	private static class OSXAboutHandler implements AboutHandler
+	private static class AboutHandler implements java.awt.desktop.AboutHandler
 	{
 		@Override
 		public void handleAbout(final AboutEvent aboutEvent)
@@ -64,7 +79,7 @@ public final class DesktopHandler
 		}
 	}
 
-	private static class OSXPreferencesHandler implements PreferencesHandler
+	private static class PreferencesHandler implements java.awt.desktop.PreferencesHandler
 	{
 		@Override
 		public void handlePreferences(final PreferencesEvent preferencesEvent)
@@ -73,7 +88,7 @@ public final class DesktopHandler
 		}
 	}
 
-	private static class OSXQuitHandler implements QuitHandler
+	private static class QuitHandler implements java.awt.desktop.QuitHandler
 	{
 		@Override
 		public void handleQuitRequestWith(final QuitEvent quitEvent, final QuitResponse quitResponse)
@@ -81,5 +96,4 @@ public final class DesktopHandler
 			PCGenUIManager.closePCGen();
 		}
 	}
-
 }


### PR DESCRIPTION
- test for "supported" before using a feature
- avoid platform specific names
- move to gui3 since it is a "converted" class