### PR TITLE
HtmlSheetSupport: make it possible to interrupt the refresher

### DIFF
--- a/code/src/java/pcgen/gui2/tabs/models/HtmlSheetSupport.java
+++ b/code/src/java/pcgen/gui2/tabs/models/HtmlSheetSupport.java
@@ -118,7 +118,7 @@ public class HtmlSheetSupport
 		}
 		if (refresher != null && !refresher.isDone())
 		{
-			refresher.cancel(false);
+			refresher.cancel(true);
 		}
 		refresher = new Refresher();
 		executor.execute(refresher);


### PR DESCRIPTION
If we have multiple changes, permit the latest one to go through.