### PR TITLE
ImageCache: eliminate hack for old JDKs

### DIFF
--- a/code/src/java/pcgen/gui2/tabs/models/HtmlSheetSupport.java
+++ b/code/src/java/pcgen/gui2/tabs/models/HtmlSheetSupport.java
@@ -18,19 +18,12 @@
  */
 package pcgen.gui2.tabs.models;
 
-import java.awt.Image;
-import java.awt.Toolkit;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.InvocationTargetException;
-import java.net.URL;
-import java.util.Collections;
-import java.util.Dictionary;
-import java.util.Enumeration;
-import java.util.HashMap;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -38,7 +31,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.ThreadFactory;
 
-import javax.swing.ImageIcon;
 import javax.swing.JEditorPane;
 import javax.swing.SwingUtilities;
 import javax.swing.text.EditorKit;
@@ -65,7 +57,6 @@ public class HtmlSheetSupport
 	private WeakReference<CharacterFacade> characterRef;
 	private final File templateFile;
 	private final JEditorPane htmlPane;
-	private ImageCache cache = new ImageCache();
 	private FutureTask<HTMLDocument> refresher = null;
 	private boolean installed = false;
 	private String missingSheetMsg;
@@ -176,80 +167,8 @@ public class HtmlSheetSupport
 
 			doc.setBase(templateFile.getParentFile().toURI().toURL());
 			doc.putProperty("IgnoreCharsetDirective", true);
-			// XXX - This is a hack specific to Sun's JDK 5.0 and in no
-			// way should be trusted to work in future java releases
-			// (though it still might) - Connor Petty
-			doc.putProperty("imageCache", cache);
 			kit.read(reader, doc, 0);
 			return doc;
-		}
-
-	}
-
-	/**
-	 * A cache for images loaded onto the info pane.
-	 */
-	private static class ImageCache extends Dictionary<URL, Image>
-	{
-
-		private HashMap<URL, Image> cache = new HashMap<>();
-
-		@Override
-		public int size()
-		{
-			return cache.size();
-		}
-
-		@Override
-		public boolean isEmpty()
-		{
-			return cache.isEmpty();
-		}
-
-		@Override
-		public Enumeration<URL> keys()
-		{
-			return Collections.enumeration(cache.keySet());
-		}
-
-		@Override
-		public Enumeration<Image> elements()
-		{
-			return Collections.enumeration(cache.values());
-		}
-
-		@Override
-		public Image get(Object key)
-		{
-			if (!(key instanceof URL))
-			{
-				return null;
-			}
-			URL src = (URL) key;
-			if (!cache.containsKey(src))
-			{
-				Image newImage = Toolkit.getDefaultToolkit().createImage(src);
-				if (newImage != null)
-				{
-					// Force the image to be loaded by using an ImageIcon.
-					ImageIcon ii = new ImageIcon();
-					ii.setImage(newImage);
-				}
-				cache.put(src, newImage);
-			}
-			return cache.get(src);
-		}
-
-		@Override
-		public Image put(URL key, Image value)
-		{
-			return cache.put(key, value);
-		}
-
-		@Override
-		public Image remove(Object key)
-		{
-			return cache.remove(key);
 		}
 
 	}


### PR DESCRIPTION
While it is possible that newer JDKs can still make use of this cache,
we'll be modifying the code in the near future to covert to JavaFX.