### PR TITLE
FlippingSplitPane: reduce differences between two versions

### DIFF
--- a/code/src/java/gmgen/gui/FlippingSplitPane.java
+++ b/code/src/java/gmgen/gui/FlippingSplitPane.java
@@ -71,8 +71,6 @@ import pcgen.system.LanguageBundle;
  */
 public class FlippingSplitPane extends JSplitPane
 {
-	private static final long serialVersionUID = -6343545558990369582L;
-
 	/**
 	 * Icon for Center item in popup menu.
 	 */
@@ -450,21 +448,6 @@ public class FlippingSplitPane extends JSplitPane
 		FlippingSplitPane.maybeSetLockedComponent(getRightComponent(), this.locked);
 	}
 
-	//     private class KeyboardShiftHomeAction extends AbstractAction
-	//     {
-	//         public void actionPerformed(ActionEvent e)
-	// 	{
-	// 	    centerDividerLocations();
-	//         }
-	//     }
-	//     private class KeyboardShiftEndAction extends AbstractAction
-	//     {
-	//         public void actionPerformed(ActionEvent e)
-	// 	{
-	// 	    resetToPreferredSizes();
-	//         }
-	//     }
-
 	/**
 	 * {@code setupExtensions} installs the mouse listener for the popup menu,
 	 * and fixes some egregious defaults in {@code JSplitPane}.
@@ -477,14 +460,6 @@ public class FlippingSplitPane extends JSplitPane
 		{
 			((BasicSplitPaneUI) anUi).getDivider().addMouseListener(new PopupListener());
 		}
-
-		// 	// See source for JSplitPane for this junk.
-		// 	ActionMap map = (ActionMap) UIManager.get("SplitPane.actionMap");
-		// 	map.put("selectCenter", new KeyboardShiftHomeAction()); // XXX
-		// 	map.put("selectReset", new KeyboardShiftEndAction()); // XXX
-		// 	SwingUtilities.replaceUIActionMap(this, map);
-		// This is *so* much better than squishing the top/left
-		// component into oblivion.
 		setResizeWeight(0.5);
 	}
 

--- a/code/src/java/gmgen/gui/Utilities.java
+++ b/code/src/java/gmgen/gui/Utilities.java
@@ -25,7 +25,7 @@ import javax.swing.ImageIcon;
 /**
  * Utility Code for manipulating the GUI
  */
-final class Utilities
+public final class Utilities
 {
 
 	private Utilities()
@@ -42,7 +42,7 @@ final class Utilities
 	 *
 	 * @return {@code ImageIcon}, the icon or {@code null} on failure
 	 */
-	static ImageIcon getImageIcon(final String location)
+	public static ImageIcon getImageIcon(final String location)
 	{
 		return getImageIcon(location, null);
 	}

--- a/code/src/java/pcgen/gui2/equip/EquipCustomPanel.java
+++ b/code/src/java/pcgen/gui2/equip/EquipCustomPanel.java
@@ -121,7 +121,6 @@ public class EquipCustomPanel extends FlippingSplitPane
 	 */
 	public EquipCustomPanel(CharacterFacade character, EquipmentBuilderFacade builder)
 	{
-		super("customEquip");
 		this.character = character;
 		this.builder = builder;
 		validHeads = new DefaultListFacade<>(builder.getEquipmentHeads());
@@ -201,7 +200,7 @@ public class EquipCustomPanel extends FlippingSplitPane
 		bannerBox.add(Box.createHorizontalGlue());
 		upperPanel.add(bannerBox, BorderLayout.NORTH);
 
-		FlippingSplitPane topPane = new FlippingSplitPane("equipCustTop");
+		FlippingSplitPane topPane = new FlippingSplitPane();
 		upperPanel.add(topPane, BorderLayout.CENTER);
 
 		JPanel availPanel = new JPanel(new BorderLayout());
@@ -280,7 +279,7 @@ public class EquipCustomPanel extends FlippingSplitPane
 		selPanel.add(box, BorderLayout.SOUTH);
 
 		topPane.setRightComponent(selPanel);
-		FlippingSplitPane bottomPane = new FlippingSplitPane("equipCustBottom");
+		FlippingSplitPane bottomPane = new FlippingSplitPane();
 		bottomPane.setLeftComponent(equipModInfoPane);
 		bottomPane.setRightComponent(equipInfoPane);
 		setBottomComponent(bottomPane);

--- a/code/src/java/pcgen/gui2/kits/KitPanel.java
+++ b/code/src/java/pcgen/gui2/kits/KitPanel.java
@@ -83,7 +83,6 @@ public class KitPanel extends FlippingSplitPane
 	 */
 	public KitPanel(CharacterFacade character)
 	{
-		super("kit");
 		this.character = character;
 		this.availableTable = new FilteredTreeViewTable<>();
 		this.selectedTable = new FilteredTreeViewTable<>();
@@ -100,7 +99,7 @@ public class KitPanel extends FlippingSplitPane
 	private void initComponents()
 	{
 		renderer.setCharacter(character);
-		FlippingSplitPane topPane = new FlippingSplitPane("kitTop");
+		FlippingSplitPane topPane = new FlippingSplitPane();
 		setTopComponent(topPane);
 		setOrientation(VERTICAL_SPLIT);
 

--- a/code/src/java/pcgen/gui2/sources/AdvancedSourceSelectionPanel.java
+++ b/code/src/java/pcgen/gui2/sources/AdvancedSourceSelectionPanel.java
@@ -135,8 +135,8 @@ class AdvancedSourceSelectionPanel extends JPanel
 
 	private void initComponents()
 	{
-		FlippingSplitPane mainPane = new FlippingSplitPane(JSplitPane.VERTICAL_SPLIT, "advSrcMain");
-		FlippingSplitPane topPane = new FlippingSplitPane("advSrcTop");
+		FlippingSplitPane mainPane = new FlippingSplitPane(JSplitPane.VERTICAL_SPLIT);
+		FlippingSplitPane topPane = new FlippingSplitPane();
 		topPane.setResizeWeight(0.6);
 		JPanel panel = new JPanel(new BorderLayout());
 		panel.add(new JLabel(LanguageBundle.getString("in_src_gameLabel")), BorderLayout.WEST); //$NON-NLS-1$

--- a/code/src/java/pcgen/gui2/sources/SourceSelectionDialog.java
+++ b/code/src/java/pcgen/gui2/sources/SourceSelectionDialog.java
@@ -517,7 +517,7 @@ public class SourceSelectionDialog extends JDialog implements ActionListener, Ch
 				}
 
 			});
-			FlippingSplitPane mainPane = new FlippingSplitPane(JSplitPane.HORIZONTAL_SPLIT, "quickSrcMain");
+			FlippingSplitPane mainPane = new FlippingSplitPane(JSplitPane.HORIZONTAL_SPLIT);
 			mainPane.setTopComponent(new JScrollPane(sourceList));
 
 			linkAction.install();

--- a/code/src/java/pcgen/gui2/tabs/AbilityChooserTab.java
+++ b/code/src/java/pcgen/gui2/tabs/AbilityChooserTab.java
@@ -103,7 +103,6 @@ public class AbilityChooserTab extends FlippingSplitPane implements StateEditabl
 
 	public AbilityChooserTab()
 	{
-		super("ability");
 		this.availableTreeViewPanel = new FilteredTreeViewTable<>();
 		this.selectedTreeViewPanel = new JTreeTable();
 		this.categoryTable = new JTable();
@@ -170,7 +169,7 @@ public class AbilityChooserTab extends FlippingSplitPane implements StateEditabl
 		filterPanel.add(categoryBar, BorderLayout.NORTH);
 		filterPanel.add(new JScrollPane(categoryTable), BorderLayout.CENTER);
 
-		FlippingSplitPane bottomPane = new FlippingSplitPane(JSplitPane.HORIZONTAL_SPLIT, "abilityBottom");
+		FlippingSplitPane bottomPane = new FlippingSplitPane(JSplitPane.HORIZONTAL_SPLIT);
 		bottomPane.setLeftComponent(filterPanel);
 		bottomPane.setRightComponent(infoPane);
 		setBottomComponent(bottomPane);

--- a/code/src/java/pcgen/gui2/tabs/CharacterSheetInfoTab.java
+++ b/code/src/java/pcgen/gui2/tabs/CharacterSheetInfoTab.java
@@ -76,7 +76,7 @@ public class CharacterSheetInfoTab extends FlippingSplitPane implements Characte
 	@SuppressWarnings("serial")
 	public CharacterSheetInfoTab()
 	{
-		super("CharSheet");
+		super();
 		this.csheet = new CharacterSheetPanel();
 		this.sheetBox = new JComboBox<>();
 		this.equipSetTable = TableUtils.createDefaultTable();
@@ -105,7 +105,7 @@ public class CharacterSheetInfoTab extends FlippingSplitPane implements Characte
 		});
 		box.add(sheetBox);
 		panel.add(box, BorderLayout.NORTH);
-		FlippingSplitPane subPane = new FlippingSplitPane("CharSheetLeft");
+		FlippingSplitPane subPane = new FlippingSplitPane();
 		subPane.setOrientation(VERTICAL_SPLIT);
 		equipSetTable.getTableHeader().setReorderingAllowed(false);
 		JScrollPane pane = TableUtils.createRadioBoxSelectionPane(equipSetTable, equipSetRowTable);

--- a/code/src/java/pcgen/gui2/tabs/ClassInfoTab.java
+++ b/code/src/java/pcgen/gui2/tabs/ClassInfoTab.java
@@ -102,7 +102,7 @@ public class ClassInfoTab extends FlippingSplitPane implements CharacterInfoTab
 
 	public ClassInfoTab()
 	{
-		super("Class");
+		super();
 		this.availableTable = new FilteredTreeViewTable<>();
 		this.classTable = TableUtils.createDefaultTable();
 		this.addButton = new JButton();
@@ -118,7 +118,7 @@ public class ClassInfoTab extends FlippingSplitPane implements CharacterInfoTab
 
 	private void initComponents()
 	{
-		FlippingSplitPane topPane = new FlippingSplitPane("ClassTop");
+		FlippingSplitPane topPane = new FlippingSplitPane();
 		setTopComponent(topPane);
 		setOrientation(VERTICAL_SPLIT);
 

--- a/code/src/java/pcgen/gui2/tabs/CompanionInfoTab.java
+++ b/code/src/java/pcgen/gui2/tabs/CompanionInfoTab.java
@@ -115,7 +115,6 @@ public class CompanionInfoTab extends FlippingSplitPane implements CharacterInfo
 
 	public CompanionInfoTab()
 	{
-		super("Companion");
 		this.companionsTable = new JTreeTable()
 		{
 			@Override

--- a/code/src/java/pcgen/gui2/tabs/DescriptionInfoTab.java
+++ b/code/src/java/pcgen/gui2/tabs/DescriptionInfoTab.java
@@ -73,7 +73,7 @@ public class DescriptionInfoTab extends FlippingSplitPane implements CharacterIn
 	 */
 	public DescriptionInfoTab()
 	{
-		super("Desc"); //$NON-NLS-1$
+		super(); //$NON-NLS-1$
 		this.portraitPane = new PortraitInfoPane();
 		this.bioPane = new BiographyInfoPane();
 		this.histPane = new CampaignHistoryInfoPane();

--- a/code/src/java/pcgen/gui2/tabs/DomainInfoTab.java
+++ b/code/src/java/pcgen/gui2/tabs/DomainInfoTab.java
@@ -110,7 +110,7 @@ public class DomainInfoTab extends FlippingSplitPane implements CharacterInfoTab
 
 	public DomainInfoTab()
 	{
-		super("Domain");
+		super();
 		this.deityTable = new FilteredTreeViewTable<>();
 		this.domainTable = new JDynamicTable();
 		this.domainRowHeaderTable = TableUtils.createDefaultTable();
@@ -152,7 +152,7 @@ public class DomainInfoTab extends FlippingSplitPane implements CharacterInfoTab
 		box.add(Box.createHorizontalGlue());
 		panel.add(box, BorderLayout.SOUTH);
 
-		FlippingSplitPane splitPane = new FlippingSplitPane("DomainTop");
+		FlippingSplitPane splitPane = new FlippingSplitPane();
 		splitPane.setLeftComponent(panel);
 
 		panel = new JPanel(new BorderLayout());
@@ -182,7 +182,7 @@ public class DomainInfoTab extends FlippingSplitPane implements CharacterInfoTab
 
 		splitPane.setRightComponent(panel);
 		setTopComponent(splitPane);
-		splitPane = new FlippingSplitPane("DomainBottom");
+		splitPane = new FlippingSplitPane();
 		splitPane.setLeftComponent(deityInfo);
 		splitPane.setRightComponent(domainInfo);
 		setBottomComponent(splitPane);

--- a/code/src/java/pcgen/gui2/tabs/EquipInfoTab.java
+++ b/code/src/java/pcgen/gui2/tabs/EquipInfoTab.java
@@ -126,7 +126,6 @@ public class EquipInfoTab extends FlippingSplitPane implements CharacterInfoTab,
 
 	public EquipInfoTab()
 	{
-		super("Equip");
 		//TODO: remove this when optimized sorting is implemented
 		this.equipmentTable = new JDynamicTable()
 		{
@@ -185,7 +184,7 @@ public class EquipInfoTab extends FlippingSplitPane implements CharacterInfoTab,
 		removeSetButton.setMargin(new Insets(0, 0, 0, 0));
 
 		setOrientation(HORIZONTAL_SPLIT);
-		FlippingSplitPane splitPane = new FlippingSplitPane(VERTICAL_SPLIT, "EquipMain");
+		FlippingSplitPane splitPane = new FlippingSplitPane(VERTICAL_SPLIT);
 
 		JPanel panel = new JPanel(new BorderLayout());
 

--- a/code/src/java/pcgen/gui2/tabs/PurchaseInfoTab.java
+++ b/code/src/java/pcgen/gui2/tabs/PurchaseInfoTab.java
@@ -135,7 +135,6 @@ public class PurchaseInfoTab extends FlippingSplitPane implements CharacterInfoT
 	 */
 	public PurchaseInfoTab()
 	{
-		super("Purchase"); //$NON-NLS-1$
 		this.availableTable = new FilteredTreeViewTable<>();
 		this.purchasedTable = new FilteredTreeViewTable<>();
 		this.equipmentRenderer = new EquipmentRenderer();
@@ -160,7 +159,7 @@ public class PurchaseInfoTab extends FlippingSplitPane implements CharacterInfoT
 	private void initComponents()
 	{
 		setOrientation(VERTICAL_SPLIT);
-		FlippingSplitPane splitPane = new FlippingSplitPane("PurchaseTop"); //$NON-NLS-1$
+		FlippingSplitPane splitPane = new FlippingSplitPane(); //$NON-NLS-1$
 		splitPane.setOrientation(HORIZONTAL_SPLIT);
 		{ // Top Left panel
 			FilterBar<CharacterFacade, EquipmentFacade> filterBar = new FilterBar<>();
@@ -222,7 +221,7 @@ public class PurchaseInfoTab extends FlippingSplitPane implements CharacterInfoT
 			splitPane.setRightComponent(panel);
 		}
 		setTopComponent(splitPane);
-		splitPane = new FlippingSplitPane("PurchaseBottom"); //$NON-NLS-1$
+		splitPane = new FlippingSplitPane(); //$NON-NLS-1$
 		splitPane.setOrientation(HORIZONTAL_SPLIT);
 		{// Bottom Left Panel
 			JPanel panel = new JPanel();

--- a/code/src/java/pcgen/gui2/tabs/RaceInfoTab.java
+++ b/code/src/java/pcgen/gui2/tabs/RaceInfoTab.java
@@ -86,7 +86,7 @@ public class RaceInfoTab extends FlippingSplitPane implements CharacterInfoTab
 
 	public RaceInfoTab()
 	{
-		super("Race");
+		super();
 		this.raceTable = new FilteredTreeViewTable<>();
 		this.selectedTable = new FilteredTreeViewTable<>();
 		this.infoPane = new InfoPane(LanguageBundle.getString("in_irRaceInfo")); //$NON-NLS-1$
@@ -100,7 +100,7 @@ public class RaceInfoTab extends FlippingSplitPane implements CharacterInfoTab
 
 	private void initComponents()
 	{
-		FlippingSplitPane topPane = new FlippingSplitPane("RaceTop");
+		FlippingSplitPane topPane = new FlippingSplitPane();
 		setTopComponent(topPane);
 		setOrientation(VERTICAL_SPLIT);
 

--- a/code/src/java/pcgen/gui2/tabs/SkillInfoTab.java
+++ b/code/src/java/pcgen/gui2/tabs/SkillInfoTab.java
@@ -102,7 +102,7 @@ public class SkillInfoTab extends FlippingSplitPane implements CharacterInfoTab,
 
 	public SkillInfoTab()
 	{
-		super("Skill");
+		super();
 		this.skillTable = new FilteredTreeViewTable<>();
 		this.skillpointTable = new JTable();
 		this.infoPane = new InfoPane();
@@ -169,7 +169,7 @@ public class SkillInfoTab extends FlippingSplitPane implements CharacterInfoTab,
 				new FlippingSplitPane(JSplitPane.HORIZONTAL_SPLIT, true, availPanel, skillPanel, "SkillTop");
 		setTopComponent(topPane);
 
-		FlippingSplitPane bottomPane = new FlippingSplitPane(JSplitPane.HORIZONTAL_SPLIT, "SkillBottom");
+		FlippingSplitPane bottomPane = new FlippingSplitPane(JSplitPane.HORIZONTAL_SPLIT);
 		bottomPane.setLeftComponent(tablePanel);
 		tablePanel.setPreferredSize(new Dimension(650, 100));
 		bottomPane.setRightComponent(infoPane);

--- a/code/src/java/pcgen/gui2/tabs/TempBonusInfoTab.java
+++ b/code/src/java/pcgen/gui2/tabs/TempBonusInfoTab.java
@@ -90,7 +90,6 @@ public class TempBonusInfoTab extends FlippingSplitPane implements CharacterInfo
 	 */
 	public TempBonusInfoTab()
 	{
-		super("TempBonus");
 		this.availableTable = new FilteredTreeViewTable<>();
 		this.selectedTable = new FilteredTreeViewTable<>();
 		this.addButton = new JButton();
@@ -102,7 +101,7 @@ public class TempBonusInfoTab extends FlippingSplitPane implements CharacterInfo
 
 	private void initComponents()
 	{
-		FlippingSplitPane topPane = new FlippingSplitPane("TempBonusTop");
+		FlippingSplitPane topPane = new FlippingSplitPane();
 		setTopComponent(topPane);
 		setOrientation(VERTICAL_SPLIT);
 

--- a/code/src/java/pcgen/gui2/tabs/TemplateInfoTab.java
+++ b/code/src/java/pcgen/gui2/tabs/TemplateInfoTab.java
@@ -79,7 +79,6 @@ public class TemplateInfoTab extends FlippingSplitPane implements CharacterInfoT
 
 	public TemplateInfoTab()
 	{
-		super("Template");
 		this.availableTable = new FilteredTreeViewTable<>();
 		this.selectedTable = new FilteredTreeViewTable<>();
 		this.addButton = new JButton();
@@ -92,7 +91,7 @@ public class TemplateInfoTab extends FlippingSplitPane implements CharacterInfoT
 
 	private void initComponents()
 	{
-		FlippingSplitPane topPane = new FlippingSplitPane("TemplateTop");
+		FlippingSplitPane topPane = new FlippingSplitPane();
 		setTopComponent(topPane);
 		setOrientation(VERTICAL_SPLIT);
 

--- a/code/src/java/pcgen/gui2/tabs/spells/SpellBooksTab.java
+++ b/code/src/java/pcgen/gui2/tabs/spells/SpellBooksTab.java
@@ -78,7 +78,6 @@ public class SpellBooksTab extends FlippingSplitPane implements CharacterInfoTab
 
 	public SpellBooksTab()
 	{
-		super("SpellBooks");
 		this.availableTable = new FilteredTreeViewTable<>();
 		this.selectedTable = new JTreeViewTable<>()
 		{
@@ -121,7 +120,7 @@ public class SpellBooksTab extends FlippingSplitPane implements CharacterInfoTab
 		qFilterButton.setText(LanguageBundle.getString("in_igQualFilter")); //$NON-NLS-1$
 		filterBar.addDisplayableFilter(qFilterButton);
 
-		FlippingSplitPane upperPane = new FlippingSplitPane("SpellBooksTop");
+		FlippingSplitPane upperPane = new FlippingSplitPane();
 		JPanel availPanel = FilterUtilities.configureFilteredTreeViewPane(availableTable, filterBar);
 		Box box = Box.createVerticalBox();
 		box.add(Box.createVerticalStrut(5));
@@ -162,7 +161,7 @@ public class SpellBooksTab extends FlippingSplitPane implements CharacterInfoTab
 		upperPane.setResizeWeight(0);
 		setTopComponent(upperPane);
 
-		FlippingSplitPane bottomPane = new FlippingSplitPane("SpellBooksBottom");
+		FlippingSplitPane bottomPane = new FlippingSplitPane();
 		bottomPane.setLeftComponent(spellsPane);
 		bottomPane.setRightComponent(classPane);
 		setBottomComponent(bottomPane);

--- a/code/src/java/pcgen/gui2/tabs/spells/SpellsKnownTab.java
+++ b/code/src/java/pcgen/gui2/tabs/spells/SpellsKnownTab.java
@@ -80,7 +80,6 @@ public class SpellsKnownTab extends FlippingSplitPane implements CharacterInfoTa
 
 	public SpellsKnownTab()
 	{
-		super("SpellsKnown");
 		this.availableTable = new FilteredTreeViewTable<>();
 		this.selectedTable = new JTreeViewTable<>()
 		{
@@ -125,7 +124,7 @@ public class SpellsKnownTab extends FlippingSplitPane implements CharacterInfoTa
 		qFilterButton.setText(LanguageBundle.getString("in_igQualFilter")); //$NON-NLS-1$
 		filterBar.addDisplayableFilter(qFilterButton);
 
-		FlippingSplitPane upperPane = new FlippingSplitPane("SpellsKnownTop");
+		FlippingSplitPane upperPane = new FlippingSplitPane();
 		JPanel availPanel = FilterUtilities.configureFilteredTreeViewPane(availableTable, filterBar);
 		Box box = Box.createVerticalBox();
 		box.add(Box.createVerticalStrut(2));
@@ -197,7 +196,7 @@ public class SpellsKnownTab extends FlippingSplitPane implements CharacterInfoTa
 		upperPane.setResizeWeight(0);
 		setTopComponent(upperPane);
 
-		FlippingSplitPane bottomPane = new FlippingSplitPane("SpellsKnownBottom");
+		FlippingSplitPane bottomPane = new FlippingSplitPane();
 		bottomPane.setLeftComponent(spellsPane);
 		bottomPane.setRightComponent(classPane);
 		setBottomComponent(bottomPane);

--- a/code/src/java/pcgen/gui2/tabs/spells/SpellsPreparedTab.java
+++ b/code/src/java/pcgen/gui2/tabs/spells/SpellsPreparedTab.java
@@ -81,7 +81,6 @@ public class SpellsPreparedTab extends FlippingSplitPane implements CharacterInf
 
 	public SpellsPreparedTab()
 	{
-		super("SpellsPrepared");
 		this.availableTable = new FilteredTreeViewTable<>();
 		this.selectedTable = new JTreeViewTable<>()
 		{
@@ -128,7 +127,7 @@ public class SpellsPreparedTab extends FlippingSplitPane implements CharacterInf
 		qFilterButton.setText(LanguageBundle.getString("in_igQualFilter")); //$NON-NLS-1$
 		filterBar.addDisplayableFilter(qFilterButton);
 
-		FlippingSplitPane upperPane = new FlippingSplitPane("SpellsPreparedTop");
+		FlippingSplitPane upperPane = new FlippingSplitPane();
 		JPanel availPanel = FilterUtilities.configureFilteredTreeViewPane(availableTable, filterBar);
 		Box box = Box.createVerticalBox();
 		box.add(Box.createVerticalStrut(5));
@@ -176,7 +175,7 @@ public class SpellsPreparedTab extends FlippingSplitPane implements CharacterInf
 		upperPane.setResizeWeight(0);
 		setTopComponent(upperPane);
 
-		FlippingSplitPane bottomPane = new FlippingSplitPane("SpellsPreparedBottom");
+		FlippingSplitPane bottomPane = new FlippingSplitPane();
 		bottomPane.setLeftComponent(spellsPane);
 		bottomPane.setRightComponent(classPane);
 		setBottomComponent(bottomPane);

--- a/code/src/java/pcgen/gui2/tools/FlippingSplitPane.java
+++ b/code/src/java/pcgen/gui2/tools/FlippingSplitPane.java
@@ -25,6 +25,7 @@ import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
 
 import javax.swing.AbstractAction;
+import javax.swing.ImageIcon;
 import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
@@ -33,10 +34,9 @@ import javax.swing.JSplitPane;
 import javax.swing.plaf.SplitPaneUI;
 import javax.swing.plaf.basic.BasicSplitPaneUI;
 
-import pcgen.gui2.UIPropertyContext;
+import gmgen.gui.Utilities;
 import pcgen.gui2.util.event.PopupMouseAdapter;
 import pcgen.system.LanguageBundle;
-import pcgen.system.PropertyContext;
 
 /**
  * {@code FlippingSplitPane} is an improved version of
@@ -72,35 +72,47 @@ import pcgen.system.PropertyContext;
  */
 public class FlippingSplitPane extends JSplitPane
 {
-	/** Preferences key for storing the preferred divider location. */
-	private static final String DIVIDER_LOC_PREF_KEY = "location"; //$NON-NLS-1$
+	/**
+	 * Icon for Center item in popup menu.
+	 */
+	private static final ImageIcon CENTER_ICON = Utilities.getImageIcon("resources/MediaStop16.gif");
 
-	private static final long serialVersionUID = 735390251967305647L;
+	/**
+	 * Icon for Flip item in popup menu.
+	 */
+	private static final ImageIcon FLIP_ICON = Utilities.getImageIcon("resources/Refresh16.gif");
+
+	/**
+	 * Icon for Reset item in popup menu.
+	 */
+	private static final ImageIcon RESET_ICON = Utilities.getImageIcon("resources/Redo16.gif");
+
+	/**
+	 * Icon for Lock/Unlock item in popup menu
+	 */
+	private static final ImageIcon LOCK_ICON = Utilities.getImageIcon("resources/Bookmarks16.gif");
+
 
 	private final LockAction lockAction = new LockAction();
-	private JPopupMenu popupMenu = null;
-	private PropertyContext baseContext;
-	private final String prefsKey;
+	private JPopupMenu popupMenu;
 
 	/**
 	 * Creates a new {@code FlippingSplitPane}.  Panes begin as unlocked
 	 */
-	public FlippingSplitPane(String prefsKey)
+	public FlippingSplitPane()
 	{
-		this.prefsKey = prefsKey;
-		initComponent();
+		setupExtensions();
 	}
 
 	/**
 	 * Creates a new {@code FlippingSplitPane}.  Panes begin as unlocked, and
 	 * otherwise take the defaults of {@link JSplitPane#JSplitPane(int)}.
 	 */
-	public FlippingSplitPane(int newOrientation, String prefsKey)
+	public FlippingSplitPane(int newOrientation)
 	{
 		super(newOrientation);
 
-		this.prefsKey = prefsKey;
-		initComponent();
+		setupExtensions();
 	}
 
 	/**
@@ -113,8 +125,7 @@ public class FlippingSplitPane extends JSplitPane
 	{
 		super(newOrientation, newLeftComponent, newRightComponent);
 
-		this.prefsKey = prefsKey;
-		initComponent();
+		setupExtensions();
 	}
 
 	/**
@@ -127,8 +138,7 @@ public class FlippingSplitPane extends JSplitPane
 	{
 		super(newOrientation, newContinuousLayout, newLeftComponent, newRightComponent);
 
-		this.prefsKey = prefsKey;
-		initComponent();
+		setupExtensions();
 	}
 
 	/**
@@ -151,16 +161,6 @@ public class FlippingSplitPane extends JSplitPane
 		maybeSetContinuousLayoutComponent(getRightComponent(), newContinuousLayout);
 	}
 
-	private void setInitialDividerLocation()
-	{
-		PropertyContext context = baseContext.createChildContext(prefsKey);
-		int location = context.getInt(DIVIDER_LOC_PREF_KEY, -1);
-		if (location >= 0)
-		{
-			setDividerLocation(location);
-		}
-	}
-
 	/**
 	 * {@code setDividerLocation} calls {@link JSplitPane#setDividerLocation(int)}
 	 * unless the {@code FlippingSplitPane} is locked.
@@ -170,8 +170,6 @@ public class FlippingSplitPane extends JSplitPane
 	@Override
 	public void setDividerLocation(int location)
 	{
-		PropertyContext context = baseContext.createChildContext(prefsKey);
-		context.setInt(DIVIDER_LOC_PREF_KEY, location);
 		if (isLocked())
 		{
 			super.setDividerLocation(getLastDividerLocation());
@@ -189,6 +187,7 @@ public class FlippingSplitPane extends JSplitPane
 		{
 			return;
 		}
+
 		super.setDividerSize(newSize);
 		maybeSetDividerSizeComponent(getLeftComponent(), newSize);
 		maybeSetDividerSizeComponent(getRightComponent(), newSize);
@@ -241,8 +240,7 @@ public class FlippingSplitPane extends JSplitPane
 	}
 
 	/**
-	 * {@code resetToPreferredSizes} recursively calls {@link
-	 * JSplitPane#resetToPreferredSizes} on {@code FlippingSplitPane}
+	 * {@code resetToPreferredSizes} recursively calls  on {@code FlippingSplitPane}
 	 * components.
 	 */
 	@Override
@@ -440,10 +438,10 @@ public class FlippingSplitPane extends JSplitPane
 	}
 
 	/**
-	 * {@code initComponent} installs the mouse listener for the popup menu,
+	 * {@code setupExtensions} installs the mouse listener for the popup menu,
 	 * and fixes some egregious defaults in {@code JSplitPane}.
 	 */
-	private void initComponent()
+	private void setupExtensions()
 	{
 		SplitPaneUI anUi = getUI();
 
@@ -452,11 +450,9 @@ public class FlippingSplitPane extends JSplitPane
 			((BasicSplitPaneUI) anUi).getDivider().addMouseListener(new PopupListener());
 		}
 		setResizeWeight(0.5);
-		baseContext = UIPropertyContext.createContext("dividerPrefs");
-		setInitialDividerLocation();
 	}
 
-	private class LockAction extends AbstractAction
+	private final class LockAction extends AbstractAction
 	{
 
 		/**
@@ -471,7 +467,7 @@ public class FlippingSplitPane extends JSplitPane
 
 		public LockAction()
 		{
-			putValue(SMALL_ICON, Icons.Bookmarks16.getImageIcon());
+			putValue(SMALL_ICON, FlippingSplitPane.LOCK_ICON);
 			configureProps();
 		}
 
@@ -545,7 +541,7 @@ public class FlippingSplitPane extends JSplitPane
 		{
 			super(LanguageBundle.getString("in_center"));
 			setMnemonic(LanguageBundle.getMnemonic("in_mn_center"));
-			setIcon(Icons.MediaStop16.getImageIcon());
+			setIcon(FlippingSplitPane.CENTER_ICON);
 
 			addActionListener(this);
 		}
@@ -564,7 +560,7 @@ public class FlippingSplitPane extends JSplitPane
 	/**
 	 * Menu item for Continuous layout item in options menu.
 	 */
-	private class ContinuousLayoutMenuItem extends JCheckBoxMenuItem implements ActionListener
+	private final class ContinuousLayoutMenuItem extends JCheckBoxMenuItem implements ActionListener
 	{
 
 		ContinuousLayoutMenuItem()
@@ -598,7 +594,7 @@ public class FlippingSplitPane extends JSplitPane
 			super(LanguageBundle.getString("in_flip"));
 
 			setMnemonic(LanguageBundle.getMnemonic("in_mn_flip"));
-			setIcon(Icons.Refresh16.getImageIcon());
+			setIcon(FlippingSplitPane.FLIP_ICON);
 
 			addActionListener(this);
 		}
@@ -617,7 +613,7 @@ public class FlippingSplitPane extends JSplitPane
 	/**
 	 * Menu item for One touch expandable item in options menu.
 	 */
-	private class OneTouchExpandableMenuItem extends JCheckBoxMenuItem implements ActionListener
+	private final class OneTouchExpandableMenuItem extends JCheckBoxMenuItem implements ActionListener
 	{
 
 		OneTouchExpandableMenuItem()
@@ -643,7 +639,7 @@ public class FlippingSplitPane extends JSplitPane
 	/**
 	 * Menu for Options item in popup menu.
 	 */
-	private class OptionsMenu extends JMenu
+	private final class OptionsMenu extends JMenu
 	{
 
 		OptionsMenu()
@@ -711,14 +707,14 @@ public class FlippingSplitPane extends JSplitPane
 	/**
 	 * Menu item for Reset item in popup menu.
 	 */
-	private class ResetMenuItem extends JMenuItem implements ActionListener
+	private final class ResetMenuItem extends JMenuItem implements ActionListener
 	{
 
 		ResetMenuItem()
 		{
 			super(LanguageBundle.getString("in_reset"));
 			setMnemonic(LanguageBundle.getMnemonic("in_mn_reset"));
-			setIcon(Icons.Redo16.getImageIcon());
+			setIcon(FlippingSplitPane.RESET_ICON);
 
 			addActionListener(this);
 		}


### PR DESCRIPTION
We have two copies of FlippingSplitPane - both of which are nearly
identical but have different implementations (sometimes due to my
cleanup). In prep for combining them, and then converting them to
JavaFX, reduce the difference between the two.