### PR TITLE
Remove "invalid option text" preference

### DIFF
--- a/code/src/java/pcgen/core/SettingsHandler.java
+++ b/code/src/java/pcgen/core/SettingsHandler.java
@@ -80,8 +80,6 @@ public final class SettingsHandler
 	private static int hpPercent = Constants.DEFAULT_HP_PERCENT;
 	private static boolean ignoreMonsterHDCap = false;
 
-	private static String invalidDmgText;
-	private static String invalidToHitText;
 	private static boolean gearTab_IgnoreCost = false;
 	private static boolean gearTab_AllowDebt = false;
 	private static int gearTab_SellRate = Constants.DEFAULT_GEAR_TAB_SELL_RATE;
@@ -468,32 +466,6 @@ public final class SettingsHandler
 		return ignoreMonsterHDCap;
 	}
 
-	/**
-	 * @param string The invalidDmgText to set.
-	 */
-	public static void setInvalidDmgText(final String string)
-	{
-		SettingsHandler.invalidDmgText = string;
-	}
-
-	public static String getInvalidDmgText()
-	{
-		return invalidDmgText;
-	}
-
-	/**
-	 * @param string The invalidToHitText to set.
-	 */
-	public static void setInvalidToHitText(final String string)
-	{
-		SettingsHandler.invalidToHitText = string;
-	}
-
-	public static String getInvalidToHitText()
-	{
-		return invalidToHitText;
-	}
-
 	public static void setLastTipShown(final int argLastTipShown)
 	{
 		lastTipShown = argLastTipShown;
@@ -574,10 +546,6 @@ public final class SettingsHandler
 		setHPPercent(getPCGenOption("hpPercent", 100)); //$NON-NLS-1$
 		setHPRollMethod(getPCGenOption("hpRollMethod", Constants.HP_STANDARD)); //$NON-NLS-1$
 		setIgnoreMonsterHDCap(getPCGenOption("ignoreMonsterHDCap", false)); //$NON-NLS-1$
-		setInvalidDmgText(getPCGenOption("invalidDmgText", //$NON-NLS-1$
-			LanguageBundle.getString("SettingsHandler.114"))); //$NON-NLS-1$
-		setInvalidToHitText(getPCGenOption("invalidToHitText", //$NON-NLS-1$
-			LanguageBundle.getString("SettingsHandler.114"))); //$NON-NLS-1$
 		setLastTipShown(getPCGenOption("lastTipOfTheDayTipShown", -1)); //$NON-NLS-1$
 		maxWandSpellLevel.set(getPCGenOption("maxWandSpellLevel", 4));
 		maxPotionSpellLevel.set(getPCGenOption("maxPotionSpellLevel", 3));
@@ -763,8 +731,6 @@ public final class SettingsHandler
 		setPCGenOption("hpPercent", getHPPercent()); //$NON-NLS-1$
 		setPCGenOption("hpRollMethod", getHPRollMethod()); //$NON-NLS-1$
 		setPCGenOption("ignoreMonsterHDCap", isIgnoreMonsterHDCap()); //$NON-NLS-1$
-		setPCGenOption("invalidDmgText", getInvalidDmgText()); //$NON-NLS-1$
-		setPCGenOption("invalidToHitText", getInvalidToHitText()); //$NON-NLS-1$
 		setPCGenOption("lastTipOfTheDayTipShown", getLastTipShown()); //$NON-NLS-1$
 		setPCGenOption("loadURLs", loadURLs); //$NON-NLS-1$
 		setPCGenOption("maxPotionSpellLevel", maxPotionSpellLevel().get()); //$NON-NLS-1$

--- a/code/src/java/pcgen/gui2/prefs/OutputPanel.java
+++ b/code/src/java/pcgen/gui2/prefs/OutputPanel.java
@@ -66,8 +66,6 @@ public class OutputPanel extends PCGenPrefsPanel
 	private static final String IN_OUTPUT = LanguageBundle.getString("in_Prefs_output");
 
 	private static final String IN_ALWAYS_OVERWRITE = LanguageBundle.getString("in_Prefs_alwaysOverwrite");
-	private static final String IN_INVALID_TO_HIT_TEXT = LanguageBundle.getString("in_Prefs_invalidToHitText");
-	private static final String IN_INVALID_DMG_TEXT = LanguageBundle.getString("in_Prefs_invalidDmgText");
 	private static final String IN_OUTPUT_SHEET_EQ_SET = LanguageBundle.getString("in_Prefs_templateEqSet");
 	private static final String IN_PAPER_TYPE = LanguageBundle.getString("in_Prefs_paperType");
 	private static final String IN_POST_EXPORT_COMAND_STANDARD =
@@ -106,8 +104,6 @@ public class OutputPanel extends PCGenPrefsPanel
 
 	private final JTextField postExportCommandStandard;
 	private final JTextField postExportCommandPDF;
-	private final JTextField invalidToHitText;
-	private final JTextField invalidDmgText;
 	private final JCheckBox alwaysOverwrite;
 	private final JCheckBox showSingleBoxPerBundle;
 
@@ -270,24 +266,6 @@ public class OutputPanel extends PCGenPrefsPanel
 		gridbag.setConstraints(skillFilter, c);
 		this.add(skillFilter);
 
-		Utility.buildConstraints(c, 0, 12, 1, 1, 0, 0);
-		label = new JLabel(IN_INVALID_TO_HIT_TEXT);
-		gridbag.setConstraints(label, c);
-		this.add(label);
-		Utility.buildConstraints(c, 1, 12, 2, 1, 0, 0);
-		invalidToHitText = new JTextField(String.valueOf(SettingsHandler.getInvalidToHitText()));
-		gridbag.setConstraints(invalidToHitText, c);
-		this.add(invalidToHitText);
-
-		Utility.buildConstraints(c, 0, 13, 1, 1, 0, 0);
-		label = new JLabel(IN_INVALID_DMG_TEXT);
-		gridbag.setConstraints(label, c);
-		this.add(label);
-		Utility.buildConstraints(c, 1, 13, GridBagConstraints.REMAINDER, 1, 0, 0);
-		invalidDmgText = new JTextField(String.valueOf(SettingsHandler.getInvalidDmgText()));
-		gridbag.setConstraints(invalidDmgText, c);
-		this.add(invalidDmgText);
-
 		Utility.buildConstraints(c, 0, 14, 3, 1, 0, 0);
 		alwaysOverwrite = new JCheckBox(IN_ALWAYS_OVERWRITE, SettingsHandler.getAlwaysOverwrite());
 		gridbag.setConstraints(alwaysOverwrite, c);
@@ -363,8 +341,6 @@ public class OutputPanel extends PCGenPrefsPanel
 		SettingsHandler.setPrintSpellsWithPC(printSpellsWithPC.isSelected());
 		SettingsHandler.setPostExportCommandStandard(postExportCommandStandard.getText());
 		SettingsHandler.setPostExportCommandPDF(postExportCommandPDF.getText());
-		SettingsHandler.setInvalidToHitText(invalidToHitText.getText());
-		SettingsHandler.setInvalidDmgText(invalidDmgText.getText());
 		PCGenSettings.OPTIONS_CONTEXT.setInt(PCGenSettings.OPTION_SKILL_FILTER,
 			((SkillFilter) skillFilter.getSelectedItem()).getValue());
 

--- a/code/src/java/pcgen/io/exporttoken/WeaponToken.java
+++ b/code/src/java/pcgen/io/exporttoken/WeaponToken.java
@@ -54,6 +54,7 @@ import pcgen.core.analysis.SizeUtilities;
 import pcgen.core.display.CharacterDisplay;
 import pcgen.core.display.UnarmedDamageDisplay;
 import pcgen.io.ExportHandler;
+import pcgen.system.LanguageBundle;
 import pcgen.util.Delta;
 import pcgen.util.Logging;
 import pcgen.util.enumeration.AttackType;
@@ -1634,13 +1635,13 @@ public class WeaponToken extends Token
 			if ((!isDouble && !isDoubleSplit && (hitMode != HITMODE_THHIT)) || (isDoubleSplit
 				&& (hitMode == HITMODE_BASEHIT || hitMode == HITMODE_OHHIT || hitMode == HITMODE_TWPHITH)))
 			{
-				return SettingsHandler.getInvalidToHitText();
+				return LanguageBundle.getString("SettingsHandler.not.applicable");
 			}
 		}
 
 		if (eq.isMelee() && eq.isWeaponOutsizedForPC(pc) && !eq.isNatural())
 		{
-			return SettingsHandler.getInvalidToHitText();
+			return LanguageBundle.getString("SettingsHandler.not.applicable");
 		}
 
 		int weaponBaseBonus = (int) eq.bonusTo(pc, "WEAPON", "WEAPONBAB", true);
@@ -2209,13 +2210,13 @@ public class WeaponToken extends Token
 			if (!isDouble && !isDoubleSplit && (damageMode != DAMAGEMODE_NORMAL) && (damageMode != DAMAGEMODE_TWOHANDS)
 				&& (damageMode != DAMAGEMODE_DOUBLE))
 			{
-				return SettingsHandler.getInvalidDmgText();
+				return LanguageBundle.getString("SettingsHandler.not.applicable");
 			}
 		}
 
 		if (eq.isMelee() && eq.isWeaponOutsizedForPC(pc) && !eq.isNatural())
 		{
-			return SettingsHandler.getInvalidDmgText();
+			return LanguageBundle.getString("SettingsHandler.not.applicable");
 		}
 
 		if (eq.isWeaponLightForPC(pc) && (hands == 2))

--- a/code/src/java/plugin/exporttokens/deprecated/InvalidTextToken.java
+++ b/code/src/java/plugin/exporttokens/deprecated/InvalidTextToken.java
@@ -18,10 +18,10 @@
  */
 package plugin.exporttokens.deprecated;
 
-import pcgen.core.SettingsHandler;
 import pcgen.core.display.CharacterDisplay;
 import pcgen.io.ExportHandler;
 import pcgen.io.exporttoken.AbstractExportToken;
+import pcgen.system.LanguageBundle;
 import pcgen.util.Logging;
 
 //PAPERINFO
@@ -36,14 +36,13 @@ public class InvalidTextToken extends AbstractExportToken
 	@Override
 	public String getToken(String tokenSource, CharacterDisplay display, ExportHandler eh)
 	{
-		String sourceText = tokenSource.substring(12);
+		String sourceText = tokenSource.substring(getTokenName().length() + 1);
 
 		switch (sourceText)
 		{
 			case "TOHIT":
-				return SettingsHandler.getInvalidToHitText();
 			case "DAMAGE":
-				return SettingsHandler.getInvalidDmgText();
+				return LanguageBundle.getString("SettingsHandler.not.applicable");
 			default:
 				Logging.errorPrint("Invalid INVALIDTEXT token:" + tokenSource);
 				return "";

--- a/code/src/resources/pcgen/lang/LanguageBundle.properties
+++ b/code/src/resources/pcgen/lang/LanguageBundle.properties
@@ -2114,9 +2114,6 @@ in_Prefs_postExportCommandStandard=Post Export Command (Standard):
 #ToolBar Tips. 0 is the name of a game mode.
 in_Prefs_unitSetType=Unit set for {0}
 
-in_Prefs_invalidDmgText=Invalid Damage Text: 
-
-in_Prefs_invalidToHitText=Invalid To-Hit Text: 
 in_Prefs_OK=OK
 in_Prefs_OKTip=Accept these values
 
@@ -2340,7 +2337,7 @@ SettingsHandler.filepaths.readonly=Can''t write filepaths.ini file as the file i
 
 SettingsHandler.filepaths.write=Can''t write filepaths.ini file
 
-SettingsHandler.114=N/A
+SettingsHandler.not.applicable=N/A
 
 SettingsHandler.no.options.file=No options file found, will create one when exiting.
 

--- a/code/src/resources/pcgen/lang/LanguageBundle_es.properties
+++ b/code/src/resources/pcgen/lang/LanguageBundle_es.properties
@@ -2111,9 +2111,6 @@ in_Prefs_postExportCommandStandard=Parametros para la Exportaci\u00F3n a HTML :
 #ToolBar Tips. 0 is the name of a game mode.
 in_Prefs_unitSetType=Tipo de Unidades para {0}
 
-in_Prefs_invalidDmgText=Invalid Damage Text : 
-
-in_Prefs_invalidToHitText=Invalid To-Hit Text : 
 in_Prefs_OK=Aceptar
 in_Prefs_OKTip=Aceptar estos valores
 
@@ -2341,7 +2338,7 @@ SettingsHandler.filepaths.readonly=Imposible escribir el archivo filepaths.ini E
 
 SettingsHandler.filepaths.write=Imposible escribir el archivo filepaths.ini
 
-SettingsHandler.114=N/A
+SettingsHandler.not.applicable=N/A
 
 SettingsHandler.no.options.file=n archivo de opciones se encuentra, crear\u00E1 uno al salir.
 

--- a/code/src/resources/pcgen/lang/LanguageBundle_fr.properties
+++ b/code/src/resources/pcgen/lang/LanguageBundle_fr.properties
@@ -2029,9 +2029,6 @@ in_Prefs_postExportCommandStandard=Commande post-exportation (standard)\u202F:
 #ToolBar Tips. 0 is the name of a game mode.
 in_Prefs_unitSetType=Syst\u00E8me d\u2019unit\u00E9 pour {0}
 
-in_Prefs_invalidDmgText=Texte de d\u00E9g\u00E2ts invalide\u202F: 
-
-in_Prefs_invalidToHitText=Texte de jet pour toucher invalide\u202F: 
 in_Prefs_OK=Valider
 in_Prefs_OKTip=Accepter ces valeurs
 
@@ -2257,7 +2254,7 @@ SettingsHandler.filepaths.readonly=Impossible d\u2019\u00E9crire le fichier file
 
 SettingsHandler.filepaths.write=Impossible d\u2019\u00E9crire le fichier filepaths.ini
 
-SettingsHandler.114=Indisponible
+SettingsHandler.not.applicable=Indisponible
 
 SettingsHandler.no.options.file=Pas de fichier options trouv\u00E9, il sera \u00E9crit lors de la sortie.
 

--- a/code/src/resources/pcgen/lang/LanguageBundle_it.properties
+++ b/code/src/resources/pcgen/lang/LanguageBundle_it.properties
@@ -1946,10 +1946,6 @@ in_Prefs_postExportCommandStandard=Comando Post Esportazione (Standard)
 #ToolBar Tips
 in_Prefs_unitSetType=Unit\u00E0 di misura
 
-in_Prefs_invalidDmgText=Testo non valido nel danno
-
-in_Prefs_invalidToHitText=Valore Per Colpire Non Valido
-
 #Tip of the Day
 in_tod_title=Suggerimento del giorno
 
@@ -2151,7 +2147,7 @@ SettingsHandler.filepaths.readonly=Non posso scrivere il file filepaths.ini vist
 
 SettingsHandler.filepaths.write=Non posso scrivere il file filepaths.ini
 
-SettingsHandler.114=N/D 
+SettingsHandler.not.applicable=N/D
 
 SettingsHandler.no.options.file=Nessun file di opzioni trovato, ne creer\u00F2 uno in uscita.
 

--- a/code/src/testResources/pcgen/lang/cleaned.properties
+++ b/code/src/testResources/pcgen/lang/cleaned.properties
@@ -1838,9 +1838,6 @@ in_Prefs_postExportCommandStandard=Post Export Command (Standard):
 #ToolBar Tips. 0 is the name of a game mode.
 in_Prefs_unitSetType=Unit set for {0}
 
-in_Prefs_invalidDmgText=Invalid Damage Text: 
-
-in_Prefs_invalidToHitText=Invalid To-Hit Text: 
 in_Prefs_OK=OK
 in_Prefs_OKTip=Accept these values
 


### PR DESCRIPTION
There is limited reason to make this a preference: it merely changes the
text that gets printed when an option is not available. Further, it
complicates some of the options dialog, so remove it.