### PR TITLE
SettingsHandler: remove enforceSpendingBeforeLevelUp

### DIFF
--- a/code/src/java/pcgen/core/PlayerCharacter.java
+++ b/code/src/java/pcgen/core/PlayerCharacter.java
@@ -1245,22 +1245,6 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 		}
 		return bonus;
 	}
-
-	/**
-	 * Checks whether a PC is allowed to level up. A PC is not allowed to level
-	 * up if the "Enforce Spending" option is set and he still has unallocated
-	 * skill points and/or feat slots remaining. This can be used to enforce
-	 * correct spending of these resources when creating high-level multiclass
-	 * characters.
-	 *
-	 * @return true if the PC can level up
-	 */
-	public boolean canLevelUp()
-	{
-		return !SettingsHandler.getEnforceSpendingBeforeLevelUp()
-			|| (getSkillPoints() <= 0 && getRemainingFeatPoolPoints() <= 0);
-	}
-
 	/**
 	 * Sets the filename of the character.
 	 *

--- a/code/src/java/pcgen/core/SettingsHandler.java
+++ b/code/src/java/pcgen/core/SettingsHandler.java
@@ -69,7 +69,6 @@ public final class SettingsHandler
 	// Map of RuleCheck keys and their settings
 	private static final Map<String, String> ruleCheckMap = new HashMap<>();
 
-	private static boolean enforceSpendingBeforeLevelUp = false;
 	private static final Properties FILTERSETTINGS = new Properties();
 	public static GameMode game = new GameMode("default");
 	private static boolean loadURLs = false;
@@ -189,21 +188,6 @@ public final class SettingsHandler
 	public static boolean getCreatePcgBackup()
 	{
 		return createPcgBackup;
-	}
-
-	/**
-	 * Sets whether PCgen will enforce the spending of all unallocated feats and skill points
-	 * before allowing the character to level up.
-	 * @param argEnforceSpendingBeforeLevelUp Should spending be enforced?
-	 */
-	private static void setEnforceSpendingBeforeLevelUp(final boolean argEnforceSpendingBeforeLevelUp)
-	{
-		enforceSpendingBeforeLevelUp = argEnforceSpendingBeforeLevelUp;
-	}
-
-	public static boolean getEnforceSpendingBeforeLevelUp()
-	{
-		return enforceSpendingBeforeLevelUp;
 	}
 
 	public static String getFilePaths()
@@ -519,7 +503,6 @@ public final class SettingsHandler
 		setAlwaysOverwrite(getPCGenOption("alwaysOverwrite", false)); //$NON-NLS-1$
 		setCreatePcgBackup(getPCGenOption("createPcgBackup", true));
 		setDefaultOSType(getPCGenOption("defaultOSType", null)); //$NON-NLS-1$
-		setEnforceSpendingBeforeLevelUp(getPCGenOption("enforceSpendingBeforeLevelUp", false)); //$NON-NLS-1$
 		setGearTab_AllowDebt(getPCGenOption("GearTab.allowDebt", false)); //$NON-NLS-1$
 		setGearTab_BuyRate(buyRate);
 		setGearTab_IgnoreCost(getPCGenOption("GearTab.ignoreCost", false)); //$NON-NLS-1$
@@ -718,7 +701,6 @@ public final class SettingsHandler
 		setPCGenOption("saveCustomInLst", isSaveCustomInLst()); //$NON-NLS-1$
 		setPCGenOption("saveOutputSheetWithPC", getSaveOutputSheetWithPC()); //$NON-NLS-1$
 		setPCGenOption("printSpellsWithPC", getPrintSpellsWithPC()); //$NON-NLS-1$
-		setPCGenOption("enforceSpendingBeforeLevelUp", getEnforceSpendingBeforeLevelUp()); //$NON-NLS-1$
 		setPCGenOption("showHPDialogAtLevelUp", getShowHPDialogAtLevelUp()); //$NON-NLS-1$
 		setPCGenOption("showStatDialogAtLevelUp", getShowStatDialogAtLevelUp()); //$NON-NLS-1$
 		setPCGenOption("showTipOfTheDay", getShowTipOfTheDay()); //$NON-NLS-1$

--- a/code/src/java/pcgen/gui2/facade/CharacterFacadeImpl.java
+++ b/code/src/java/pcgen/gui2/facade/CharacterFacadeImpl.java
@@ -873,12 +873,6 @@ public class CharacterFacadeImpl
 			return false;
 		}
 
-		if (!theCharacter.canLevelUp())
-		{
-			delegate.showErrorMessage(Constants.APPLICATION_NAME, LanguageBundle.getString("in_Enforce_rejectLevelUp"));
-			return false;
-		}
-
 		final PCClass aClass = theCharacter.getClassKeyed(theClass.getKeyName());
 
 		// Check if the subclass (if any) is qualified for


### PR DESCRIPTION
There is no UI to change this setting, so it only works for people that
set it in older versions or that manually modified their settings files.
As such, stop enforcing the option.