### PR TITLE
FlippingSplitPane: remove prefsKey

### DIFF
--- a/code/src/java/pcgen/gui2/dialog/PreferencesDialog.java
+++ b/code/src/java/pcgen/gui2/dialog/PreferencesDialog.java
@@ -322,7 +322,7 @@ public final class PreferencesDialog extends AbstractPreferencesDialog
 		});
 
 		// Build the split pane
-		splitPane = new FlippingSplitPane(JSplitPane.HORIZONTAL_SPLIT, settingsScroll, settingsPanel, "Prefs");
+		splitPane = new FlippingSplitPane(JSplitPane.HORIZONTAL_SPLIT, settingsScroll, settingsPanel);
 		splitPane.setOneTouchExpandable(true);
 		splitPane.setDividerSize(10);
 

--- a/code/src/java/pcgen/gui2/tabs/AbilityChooserTab.java
+++ b/code/src/java/pcgen/gui2/tabs/AbilityChooserTab.java
@@ -146,7 +146,7 @@ public class AbilityChooserTab extends FlippingSplitPane implements StateEditabl
 		box.setBorder(new EmptyBorder(0, 0, 5, 0));
 		selPanel.add(box, BorderLayout.SOUTH);
 		FlippingSplitPane topPane =
-				new FlippingSplitPane(JSplitPane.HORIZONTAL_SPLIT, true, availPanel, selPanel, "abilityTop");
+				new FlippingSplitPane(JSplitPane.HORIZONTAL_SPLIT, true, availPanel, selPanel);
 
 		setTopComponent(topPane);
 

--- a/code/src/java/pcgen/gui2/tabs/SkillInfoTab.java
+++ b/code/src/java/pcgen/gui2/tabs/SkillInfoTab.java
@@ -166,7 +166,7 @@ public class SkillInfoTab extends FlippingSplitPane implements CharacterInfoTab,
 		selScrollPane.setPreferredSize(new Dimension(530, 300));
 
 		FlippingSplitPane topPane =
-				new FlippingSplitPane(JSplitPane.HORIZONTAL_SPLIT, true, availPanel, skillPanel, "SkillTop");
+				new FlippingSplitPane(JSplitPane.HORIZONTAL_SPLIT, true, availPanel, skillPanel);
 		setTopComponent(topPane);
 
 		FlippingSplitPane bottomPane = new FlippingSplitPane(JSplitPane.HORIZONTAL_SPLIT);

--- a/code/src/java/pcgen/gui2/tools/FlippingSplitPane.java
+++ b/code/src/java/pcgen/gui2/tools/FlippingSplitPane.java
@@ -120,8 +120,7 @@ public class FlippingSplitPane extends JSplitPane
 	 * otherwise take the defaults of {@link JSplitPane#JSplitPane(int, Component,
 	 * Component)}.
 	 */
-	public FlippingSplitPane(int newOrientation, Component newLeftComponent, Component newRightComponent,
-		String prefsKey)
+	public FlippingSplitPane(int newOrientation, Component newLeftComponent, Component newRightComponent)
 	{
 		super(newOrientation, newLeftComponent, newRightComponent);
 
@@ -134,7 +133,7 @@ public class FlippingSplitPane extends JSplitPane
 	 * Component, Component)}.
 	 */
 	public FlippingSplitPane(int newOrientation, boolean newContinuousLayout, Component newLeftComponent,
-		Component newRightComponent, String prefsKey)
+	                         Component newRightComponent)
 	{
 		super(newOrientation, newContinuousLayout, newLeftComponent, newRightComponent);
 


### PR DESCRIPTION
Now that we no longer persist state, there is no more use for a Prefs
key.