### PR TITLE
AboutDialog: remove l2f license

### DIFF
--- a/code/src/java/pcgen/gui3/dialog/AboutDialogController.java
+++ b/code/src/java/pcgen/gui3/dialog/AboutDialogController.java
@@ -1,5 +1,4 @@
-/*
- * Copyright 2019 (C) Eitan Adler <lists@eitanadler.com>
+/* * Copyright 2019 (C) Eitan Adler <lists@eitanadler.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -134,7 +133,6 @@ public class AboutDialogController
 
 		String s = LanguageBundle.getString("in_abt_lib_apache"); //$NON-NLS-1$
 		s += LanguageBundle.getString("in_abt_lib_jdom"); //$NON-NLS-1$
-		s += LanguageBundle.getString("in_abt_lib_l2f"); //$NON-NLS-1$
 		librariesArea.setText(s);
 
 		String releaseDateStr = PCGenPropBundle.getReleaseDate();

--- a/code/src/resources/pcgen/gui3/dialog/AboutDialog.fxml
+++ b/code/src/resources/pcgen/gui3/dialog/AboutDialog.fxml
@@ -100,9 +100,6 @@
                     </GridPane>
                 </AnchorPane>
             </Tab>
-            <Tab text="%in_abt_license">
-                <TextArea fx:id="licenseArea" text="%in_abt_lib_l2f" wrapText="true"/>
-            </Tab>
             <Tab text="%in_abt_libraries">
                 <TextArea fx:id="librariesArea" wrapText="true"/>
             </Tab>


### PR DESCRIPTION
We no longer distribute L2F, so remove the license from the dialog