### PR TITLE
AboutDialog: remove l2f license; add test

### DIFF
--- a/code/src/java/pcgen/gui3/dialog/AboutDialogController.java
+++ b/code/src/java/pcgen/gui3/dialog/AboutDialogController.java
@@ -1,5 +1,4 @@
-/*
- * Copyright 2019 (C) Eitan Adler <lists@eitanadler.com>
+/* * Copyright 2019 (C) Eitan Adler <lists@eitanadler.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -134,7 +133,6 @@ public class AboutDialogController
 
 		String s = LanguageBundle.getString("in_abt_lib_apache"); //$NON-NLS-1$
 		s += LanguageBundle.getString("in_abt_lib_jdom"); //$NON-NLS-1$
-		s += LanguageBundle.getString("in_abt_lib_l2f"); //$NON-NLS-1$
 		librariesArea.setText(s);
 
 		String releaseDateStr = PCGenPropBundle.getReleaseDate();

--- a/code/src/resources/pcgen/gui3/component/PCGenStatusBar.fxml
+++ b/code/src/resources/pcgen/gui3/component/PCGenStatusBar.fxml
@@ -25,7 +25,7 @@
     <Text fx:id="loadingLabel" BorderPane.alignment="BOTTOM_LEFT"/>
     <Region HBox.hgrow="always"/>
     <StackPane>
-        <ProgressBar fx:id="loadProgress" progress="0.0" BorderPane.alignment="BOTTOM_RIGHT"/>
+        <ProgressBar fx:id="loadProgress" BorderPane.alignment="BOTTOM_RIGHT"/>
         <Label fx:id="progressText" labelFor="$loadProgress"  />
     </StackPane>
 </fx:root>

--- a/code/src/resources/pcgen/gui3/dialog/AboutDialog.fxml
+++ b/code/src/resources/pcgen/gui3/dialog/AboutDialog.fxml
@@ -23,8 +23,8 @@
        xmlns:fx="http://javafx.com/fxml/1"
        fx:controller="pcgen.gui3.dialog.AboutDialogController">
     <AnchorPane>
-        <TabPane>
-            <Tab text="%in_abt_credits">
+        <TabPane id="viewtabs">
+            <Tab id="abt_credits" text="%in_abt_credits">
                 <AnchorPane>
                     <GridPane>
                         <Label text="%in_abt_version"
@@ -100,13 +100,13 @@
                     </GridPane>
                 </AnchorPane>
             </Tab>
-            <Tab text="%in_abt_license">
-                <TextArea fx:id="licenseArea" text="%in_abt_lib_l2f" wrapText="true"/>
+            <Tab id="abt_license" text="%in_abt_license">
+                <TextArea fx:id="licenseArea" wrapText="true"/>
             </Tab>
-            <Tab text="%in_abt_libraries">
+            <Tab id="abt_libraries" text="%in_abt_libraries">
                 <TextArea fx:id="librariesArea" wrapText="true"/>
             </Tab>
-            <Tab text="%in_abt_awards">
+            <Tab id="abt_awards" text="%in_abt_awards">
                 <GridPane>
                     <Label text="%in_abt_awards_2005_ennie" GridPane.columnIndex="0" GridPane.rowIndex="0"/>
                     <ImageView fitHeight="150.0"

--- a/code/src/utest/pcgen/gui3/dialog/AboutDialogTest.java
+++ b/code/src/utest/pcgen/gui3/dialog/AboutDialogTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 (C) Eitan Adler <lists@eitanadler.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+package pcgen.gui3.dialog;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.ResourceBundle;
+
+import pcgen.system.LanguageBundle;
+
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Scene;
+import javafx.stage.Stage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.api.FxAssert;
+import org.testfx.api.FxRobotInterface;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+import org.testfx.matcher.base.NodeMatchers;
+
+@ExtendWith(ApplicationExtension.class)
+class AboutDialogTest
+{
+	@Start
+	private void Start(Stage stage) throws IOException
+	{
+		FXMLLoader loader = new FXMLLoader();
+		URL resource = AboutDialogController.class.getResource("AboutDialog.fxml");
+		assert resource != null;
+		loader.setLocation(resource);
+		// initialize the language bundle
+		LanguageBundle.getString("");
+		ResourceBundle bundle = LanguageBundle.getBundle();
+		assert bundle != null;
+		loader.setResources(bundle);
+		Scene scene = loader.load();
+		stage.setScene(scene);
+		stage.show();
+	}
+
+	@Test
+	void test_about_dialog_loads(final FxRobotInterface robot)
+	{
+		FxAssert.verifyThat("#abt_credits", NodeMatchers.isVisible());
+	}
+
+
+}


### PR DESCRIPTION
- We no longer distribute L2F, so remove the license from the dialog.
- Further, add test to ensure that about dialog continues loading.
- Add some ids to components to facilitate future tests