### PR TITLE
Linux Launch Script: Calcuate free memory from correct value

### DIFF
--- a/code/pcgen.sh
+++ b/code/pcgen.sh
@@ -7,7 +7,7 @@ default_max_memory=512
 
 # Linux /proc/meminfo
 if [ -e "/proc/meminfo" ]; then
-	available_memory=$(grep MemFree: /proc/meminfo | awk '{ print $2; }')
+	available_memory=$(grep MemAvailable: /proc/meminfo | awk '{ print $2; }')
 	echo "Available memory: $available_memory kB"
 
 # BSD (thus MacOSX) memory command line should be in /usr/bin/vm_stat


### PR DESCRIPTION
Make available (free) memory calculation in linux use correct value from /proc/meminfo

In /proc/meminfo, the "MemFree:" value is the amount of non allocated memory. Linux uses available memory as cache to speed-up IO, keeping only a small amount of unused memory as free memory. So the correct calculation to determine the amount of free memory should instead use the "MemAvailable" field.
Fixes PCGen#5796

Test-Plan:
Verified that running `available_memory=$(grep MemAvailable: /proc/meminfo | awk '{ print $2; }') ` on an arch linux subsystem correctly calculated the available memory as opposed to the "MemFree" which was basically empty

```
~$ echo $(grep MemAvailable: /proc/meminfo | awk '{ print $2; }')
3164836
~$ echo $(grep MemFree: /proc/meminfo | awk '{ print $2; }')
104320
```