### PR TITLE
PcgenFtlTestCase: stop deleting output file

### DIFF
--- a/code/src/test/pcgen/inttest/PcgenFtlTestCase.java
+++ b/code/src/test/pcgen/inttest/PcgenFtlTestCase.java
@@ -79,7 +79,6 @@ public abstract class PcgenFtlTestCase
 		outputFolder.mkdirs();
 		String outputFileName = character + ".xml";
 		File outputFileFile = new File(outputFolder, outputFileName);
-		outputFileFile.delete();
 
 		String pccLoc = TestHelper.findDataFolder();
 


### PR DESCRIPTION
This is required to verify output.