### PR TITLE
PreferencesDialog: convert tree to JavaFX

### DIFF
--- a/code/src/java/pcgen/gui2/dialog/PreferencesDialog.java
+++ b/code/src/java/pcgen/gui2/dialog/PreferencesDialog.java
@@ -23,21 +23,12 @@ import java.awt.Dimension;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.swing.BorderFactory;
 import javax.swing.JComponent;
 import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JSplitPane;
-import javax.swing.JTree;
-import javax.swing.ScrollPaneConstants;
-import javax.swing.event.TreeSelectionEvent;
-import javax.swing.event.TreeSelectionListener;
-import javax.swing.tree.DefaultMutableTreeNode;
-import javax.swing.tree.DefaultTreeCellRenderer;
-import javax.swing.tree.DefaultTreeModel;
-import javax.swing.tree.TreePath;
-import javax.swing.tree.TreeSelectionModel;
+import javax.swing.SwingUtilities;
 
 import pcgen.cdom.base.Constants;
 import pcgen.gui2.prefs.CharacterStatsPanel;
@@ -68,6 +59,9 @@ import pcgen.system.LanguageBundle;
 import javafx.embed.swing.JFXPanel;
 import javafx.scene.control.Alert;
 
+import javafx.scene.control.SelectionMode;
+import javafx.scene.control.TreeItem;
+import javafx.scene.control.TreeView;
 
 /**
  *  PCGen preferences dialog
@@ -79,14 +73,11 @@ public final class PreferencesDialog extends AbstractPreferencesDialog
 	private static final String IN_CHARACTER = LanguageBundle.getString("in_Prefs_character"); //$NON-NLS-1$
 	public static final String LB_PREFS_PLUGINS_RUN = "in_Prefs_pluginsRun"; //$NON-NLS-1$
 
-	private DefaultTreeModel settingsModel;
 	private JSplitPane splitPane;
 
 	private JPanel settingsPanel;
 
-	private JScrollPane settingsScroll;
-
-	private JTree settingsTree;
+	private TreeView<String>  settingsTree;
 
 	private List<PCGenPrefsPanel> panelList;
 
@@ -102,16 +93,12 @@ public final class PreferencesDialog extends AbstractPreferencesDialog
 
 	private CopySettingsPanelController copySettingsPanelController;
 
-	//Plugins
-	private PreferencesPluginsPanel pluginsPanel;
-
 	private PreferencesDialog(JFrame parent, boolean modal)
 	{
 		super(parent, Constants.APPLICATION_NAME, modal);
 
 		applyOptionValuesToControls();
-		settingsTree.setSelectionRow(1);
-
+		settingsTree.getSelectionModel().select(1);
 		pack();
 		Utility.setComponentRelativeLocation(getParent(), this);
 	}
@@ -121,21 +108,6 @@ public final class PreferencesDialog extends AbstractPreferencesDialog
 		PreferencesDialog prefsDialog;
 		prefsDialog = new PreferencesDialog(frame, true);
 		prefsDialog.setVisible(true);
-	}
-
-	private void addPluginPanes(DefaultMutableTreeNode rootNode, DefaultMutableTreeNode pluginNode)
-	{
-		if (pluginsPanel == null)
-		{
-			pluginsPanel = new PreferencesPluginsPanel();
-		}
-		settingsPanel.add(pluginsPanel, LanguageBundle.getString("in_Prefs_plugins")); //$NON-NLS-1$
-		rootNode.add(pluginNode);
-	}
-
-	private void applyPluginPreferences()
-	{
-		pluginsPanel.applyPreferences();
 	}
 
 	private void setOptionsBasedOnControls()
@@ -182,11 +154,11 @@ public final class PreferencesDialog extends AbstractPreferencesDialog
 	@Override
 	protected JComponent getCenter()
 	{
-		DefaultMutableTreeNode rootNode = new DefaultMutableTreeNode("Root");
-		DefaultMutableTreeNode characterNode;
-		DefaultMutableTreeNode pcGenNode;
-		DefaultMutableTreeNode appearanceNode;
-		DefaultMutableTreeNode gameModeNode;
+		TreeItem<String> rootNode = new TreeItem<>("Root");
+		TreeItem<String> characterNode;
+		TreeItem<String> pcGenNode;
+		TreeItem<String> appearanceNode;
+		TreeItem<String> gameModeNode;
 
 		panelList = new ArrayList<>(15);
 
@@ -196,7 +168,7 @@ public final class PreferencesDialog extends AbstractPreferencesDialog
 		settingsPanel.setPreferredSize(new Dimension(780, 420));
 
 		// Build the selection tree
-		characterNode = new DefaultMutableTreeNode(IN_CHARACTER);
+		characterNode = new TreeItem<>(IN_CHARACTER);
 		settingsPanel.add(buildEmptyPanel(LanguageBundle.getString("in_Prefs_charTip")), IN_CHARACTER);
 
 		characterStatsPanel = new CharacterStatsPanel(this);
@@ -216,9 +188,9 @@ public final class PreferencesDialog extends AbstractPreferencesDialog
 				"DefaultsPreferencesPanel.fxml",
 				"in_Prefs_defaults");
 		addPanelToTree(characterNode, defaultsPanel);
-		rootNode.add(characterNode);
+		rootNode.getChildren().add(characterNode);
 
-		appearanceNode = new DefaultMutableTreeNode(IN_APPERANCE);
+		appearanceNode = new TreeItem<>(IN_APPERANCE);
 		settingsPanel.add(buildEmptyPanel(LanguageBundle.getString("in_Prefs_appearanceTip")), IN_APPERANCE);
 
 		PCGenPrefsPanel colorsPanel = new ConvertedJavaFXPanel<>(
@@ -240,9 +212,9 @@ public final class PreferencesDialog extends AbstractPreferencesDialog
 				"in_Prefs_levelUp"
 		);
 		addPanelToTree(appearanceNode, levelUpPanel);
-		rootNode.add(appearanceNode);
+		rootNode.getChildren().add(appearanceNode);
 
-		pcGenNode = new DefaultMutableTreeNode(Constants.APPLICATION_NAME);
+		pcGenNode = new TreeItem<>(Constants.APPLICATION_NAME);
 		settingsPanel.add(buildEmptyPanel(LanguageBundle.getString("in_Prefs_pcgenTip")),
 			Constants.APPLICATION_NAME);
 
@@ -272,10 +244,10 @@ public final class PreferencesDialog extends AbstractPreferencesDialog
 				"in_Prefs_sources"
 		);
 		addPanelToTree(pcGenNode, sourcesPanel);
-		rootNode.add(pcGenNode);
+		rootNode.getChildren().add(pcGenNode);
 
 		String in_gamemode = LanguageBundle.getString("in_mnuSettingsCampaign");
-		gameModeNode = new DefaultMutableTreeNode(in_gamemode);
+		gameModeNode = new TreeItem<>(in_gamemode);
 		settingsPanel.add(buildEmptyPanel(LanguageBundle.getString("in_mnuSettingsCampaignTip")), in_gamemode);
 
 		ConvertedJavaFXPanel<CopySettingsPanelController> convertedCopySettingsPanel = new ConvertedJavaFXPanel<>(
@@ -286,58 +258,41 @@ public final class PreferencesDialog extends AbstractPreferencesDialog
 		// "Copy Settings"
 		this.copySettingsPanelController = convertedCopySettingsPanel.getController();
 		addPanelToTree(gameModeNode, convertedCopySettingsPanel);
-		rootNode.add(gameModeNode);
+		rootNode.getChildren().add(gameModeNode);
 
-		DefaultMutableTreeNode pluginNode =
-				new DefaultMutableTreeNode(LanguageBundle.getString("in_Prefs_plugins")); //$NON-NLS-1$
+		TreeItem<String> pluginNode =
+				new TreeItem<>(LanguageBundle.getString("in_Prefs_plugins")); //$NON-NLS-1$
+		PCGenPrefsPanel pluginPanel = new PreferencesPluginsPanel();
+		addPanelToTree(pluginNode, pluginPanel);
 
-		addPluginPanes(rootNode, pluginNode);
+		settingsTree = new TreeView<>();
+		settingsTree.setRoot(rootNode);
 
-		settingsModel = new DefaultTreeModel(rootNode);
-		settingsTree = new JTree(settingsModel);
+		settingsTree.showRootProperty().set(false);
+		settingsTree.selectionModelProperty().get().setSelectionMode(SelectionMode.SINGLE);
 
-		settingsTree.setBorder(BorderFactory.createEmptyBorder(0, 3, 0, 0));
+		settingsTree.getRoot().getChildren().forEach(child -> child.setExpanded(true));
 
-		settingsTree.setRootVisible(false);
-		settingsTree.setShowsRootHandles(true);
-		settingsTree.getSelectionModel().setSelectionMode(TreeSelectionModel.SINGLE_TREE_SELECTION);
-		settingsScroll = new JScrollPane(settingsTree, ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED,
-			ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED);
-
-		// Turn off the icons
-		DefaultTreeCellRenderer renderer = new DefaultTreeCellRenderer();
-		renderer.setLeafIcon(null);
-		renderer.setOpenIcon(null);
-		renderer.setClosedIcon(null);
-		settingsTree.setCellRenderer(renderer);
-
-		// Expand all of the branch nodes
-		settingsTree.expandPath(new TreePath(characterNode.getPath()));
-		settingsTree.expandPath(new TreePath(pcGenNode.getPath()));
-		settingsTree.expandPath(new TreePath(appearanceNode.getPath()));
-		settingsTree.expandPath(new TreePath(gameModeNode.getPath()));
-		settingsTree.expandPath(new TreePath(pluginNode.getPath()));
-
+		settingsTree.getRoot().setExpanded(true);
 		// Add the listener which switches panels when a node of the tree is selected
-		settingsTree.addTreeSelectionListener(new TreeSelectionListener()
-		{
-			@Override
-			public void valueChanged(TreeSelectionEvent e)
-			{
-				DefaultMutableTreeNode node = (DefaultMutableTreeNode) settingsTree.getLastSelectedPathComponent();
+		settingsTree.selectionModelProperty().get().selectedItemProperty().addListener((observable, oldValue,
+		                                                                                  newValue) -> {
+			newValue.getValue();
+			CardLayout cl = (CardLayout) (settingsPanel.getLayout());
 
-				if (node == null)
-				{
-					return;
-				}
+			// this actually gets called by both swing and JavaFX threads.
+			// It appears to be fine to 'invokelater' regardless of the thread
+			// but this is certainly weird
+			// assert we're on a GUI thread mostly to be clear about what we're expecting
+			GuiAssertions.assertIsOnGUIThread();
+			SwingUtilities.invokeLater(() ->
+				cl.show(settingsPanel, newValue.getValue()));
 
-				CardLayout cl = (CardLayout) (settingsPanel.getLayout());
-				cl.show(settingsPanel, String.valueOf(node));
-			}
 		});
 
 		// Build the split pane
-		splitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, settingsScroll, settingsPanel);
+		splitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, GuiUtility.wrapParentAsJFXPanel(settingsTree),
+				settingsPanel);
 		splitPane.setOneTouchExpandable(true);
 		splitPane.setDividerSize(10);
 
@@ -352,10 +307,11 @@ public final class PreferencesDialog extends AbstractPreferencesDialog
 	 * @param parent The node to add the panel to.
 	 * @param prefsPanel The panel to be added.
 	 */
-	private void addPanelToTree(DefaultMutableTreeNode parent, PCGenPrefsPanel prefsPanel)
+	private void addPanelToTree(TreeItem<String> parent, PCGenPrefsPanel prefsPanel)
 	{
 		panelList.add(prefsPanel);
-		parent.add(new DefaultMutableTreeNode(prefsPanel.getTitle()));
+
+		parent.getChildren().add(new TreeItem<>(prefsPanel.getTitle()));
 		JScrollPane rightScroll = new JScrollPane(prefsPanel);
 		settingsPanel.add(rightScroll, prefsPanel.getTitle());
 	}
@@ -379,6 +335,5 @@ public final class PreferencesDialog extends AbstractPreferencesDialog
 	public void applyButtonActionPerformed()
 	{
 		setOptionsBasedOnControls();
-		applyPluginPreferences();
 	}
 }

--- a/code/src/java/pcgen/gui3/GuiAssertions.java
+++ b/code/src/java/pcgen/gui3/GuiAssertions.java
@@ -20,6 +20,8 @@ package pcgen.gui3;
 
 import javax.swing.SwingUtilities;
 
+import pcgen.util.Logging;
+
 import javafx.application.Platform;
 
 /**
@@ -86,6 +88,21 @@ public final class GuiAssertions
 					"expected NOT to be on gui thread - actually on: " + Thread.currentThread().getName());
 		}
 	}
+
+	/**
+	 * This should be rarely used. Instead assert which thread you're actually supposed to be on.
+	 */
+	public static void assertIsOnGUIThread()
+	{
+		Logging.debugPrint("asserting unknown gui thread: actually on: " + Thread.currentThread().getName());
+		if (!Platform.isFxApplicationThread() && !SwingUtilities.isEventDispatchThread())
+		{
+			throw new WrongThreadException(
+					"expected to be on gui thread - actually on: " + Thread.currentThread().getName());
+		}
+	}
+
+
 
 
 }

--- a/code/src/java/pcgen/gui3/JFXPanelFromResource.java
+++ b/code/src/java/pcgen/gui3/JFXPanelFromResource.java
@@ -70,6 +70,12 @@ public final class JFXPanelFromResource<T> extends JFXPanel implements Controlla
 		return GuiUtility.runOnJavaFXThreadNow(fxmlLoader::getController);
 	}
 
+	public T getControllerFromJavaFXThread()
+	{
+		GuiAssertions.assertIsJavaFXThread();
+		return fxmlLoader.getController();
+	}
+
 	public void showAsStage(String title)
 	{
 		Platform.runLater(() -> {

--- a/code/src/java/pcgen/gui3/preferences/ColorsPreferencesPanelController.java
+++ b/code/src/java/pcgen/gui3/preferences/ColorsPreferencesPanelController.java
@@ -22,7 +22,6 @@ import pcgen.gui2.UIPropertyContext;
 import pcgen.gui3.GuiAssertions;
 import pcgen.gui3.ResettableController;
 
-import javafx.application.Platform;
 import javafx.fxml.FXML;
 import javafx.scene.control.ColorPicker;
 
@@ -53,18 +52,16 @@ public class ColorsPreferencesPanelController implements ResettableController
 	@Override
 	public void reset()
 	{
-		GuiAssertions.assertIsNotJavaFXThread();
-		Platform.runLater(() -> {
-			prereqQualifyColor.setValue(UIPropertyContext.getQualifiedColor());
-			prereqFailColor.setValue(UIPropertyContext.getNotQualifiedColor());
-			featAutoColor.setValue(UIPropertyContext.getAutomaticColor());
-			featVirtualColor.setValue(UIPropertyContext.getVirtualColor());
+		GuiAssertions.assertIsJavaFXThread();
+		prereqQualifyColor.setValue(UIPropertyContext.getQualifiedColor());
+		prereqFailColor.setValue(UIPropertyContext.getNotQualifiedColor());
+		featAutoColor.setValue(UIPropertyContext.getAutomaticColor());
+		featVirtualColor.setValue(UIPropertyContext.getVirtualColor());
 
-			sourceStatusRelease.setValue(UIPropertyContext.getSourceStatusReleaseColor());
-			sourceStatusAlpha.setValue(UIPropertyContext.getSourceStatusAlphaColor());
-			sourceStatusBeta.setValue(UIPropertyContext.getSourceStatusBetaColor());
-			sourceStatusTest.setValue(UIPropertyContext.getSourceStatusTestColor());
-		});
+		sourceStatusRelease.setValue(UIPropertyContext.getSourceStatusReleaseColor());
+		sourceStatusAlpha.setValue(UIPropertyContext.getSourceStatusAlphaColor());
+		sourceStatusBeta.setValue(UIPropertyContext.getSourceStatusBetaColor());
+		sourceStatusTest.setValue(UIPropertyContext.getSourceStatusTestColor());
 	}
 
 	@Override

--- a/code/src/java/pcgen/gui3/preferences/ConvertedJavaFXPanel.java
+++ b/code/src/java/pcgen/gui3/preferences/ConvertedJavaFXPanel.java
@@ -19,9 +19,12 @@
 package pcgen.gui3.preferences;
 
 import pcgen.gui2.prefs.PCGenPrefsPanel;
+import pcgen.gui3.GuiAssertions;
 import pcgen.gui3.JFXPanelFromResource;
 import pcgen.gui3.ResettableController;
 import pcgen.system.LanguageBundle;
+
+import javafx.application.Platform;
 
 public final class ConvertedJavaFXPanel<T extends ResettableController> extends PCGenPrefsPanel
 {
@@ -49,7 +52,10 @@ public final class ConvertedJavaFXPanel<T extends ResettableController> extends 
 	@Override
 	public void applyOptionValuesToControls()
 	{
-		panel.getController().reset();
+		GuiAssertions.assertIsNotJavaFXThread();
+		Platform.runLater(() ->
+			panel.getControllerFromJavaFXThread().reset()
+		);
 	}
 
 	@Override

--- a/code/src/java/pcgen/gui3/preferences/CopySettingsPanelController.java
+++ b/code/src/java/pcgen/gui3/preferences/CopySettingsPanelController.java
@@ -107,7 +107,7 @@ public final class CopySettingsPanelController implements ResettableController
 				.getPCGenOption("InfoCharacterSheet." + gmFrom.getName() + ".CurrentSheet", currentICS);
 		SettingsHandler.setPCGenOption("InfoCharacterSheet." + gmTo.getName() + ".CurrentSheet", fromGmICS);
 
-		// Refresh the affected settings panels
+		GuiAssertions.assertIsNotJavaFXThread();
 		affectedPanels.forEach(PCGenPrefsPanel::applyOptionValuesToControls);
 
 		// Let the user know it is done

--- a/code/src/java/pcgen/gui3/preferences/DefaultsPreferencesPanelController.java
+++ b/code/src/java/pcgen/gui3/preferences/DefaultsPreferencesPanelController.java
@@ -77,16 +77,9 @@ public class DefaultsPreferencesPanelController implements ResettableController
 
 	}
 
-	@FXML
-	void initialize()
-	{
-		this.reset();
-	}
-
 	@Override
 	public void reset()
 	{
-
 		/*
 		 * much of this data should be driven by a
 		 * model and the controller should actually be getting

--- a/code/src/java/pcgen/gui3/preferences/DisplayOptionsPreferencesPanelController.java
+++ b/code/src/java/pcgen/gui3/preferences/DisplayOptionsPreferencesPanelController.java
@@ -20,10 +20,10 @@ package pcgen.gui3.preferences;
 
 import pcgen.core.SettingsHandler;
 import pcgen.gui2.UIPropertyContext;
+import pcgen.gui3.GuiAssertions;
 import pcgen.gui3.ResettableController;
 import pcgen.system.PCGenSettings;
 
-import javafx.application.Platform;
 import javafx.fxml.FXML;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ComboBox;
@@ -58,7 +58,8 @@ public class DisplayOptionsPreferencesPanelController implements ResettableContr
 	@Override
 	public void reset()
 	{
-		Platform.runLater(() -> cmbChoiceMethods.getSelectionModel().select(UIPropertyContext.getSingleChoiceAction()));
+		GuiAssertions.assertIsJavaFXThread();
+		cmbChoiceMethods.getSelectionModel().select(UIPropertyContext.getSingleChoiceAction());
 		showSkillModifier.setSelected(
 				PCGenSettings.OPTIONS_CONTEXT.getBoolean(PCGenSettings.OPTION_SHOW_SKILL_MOD_BREAKDOWN, false));
 		showSkillRanks.setSelected(

--- a/code/src/java/pcgen/gui3/preferences/PreferencesPluginsPanel.java
+++ b/code/src/java/pcgen/gui3/preferences/PreferencesPluginsPanel.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import pcgen.cdom.base.Constants;
 import pcgen.gui2.dialog.PreferencesDialog;
+import pcgen.gui2.prefs.PCGenPrefsPanel;
 import pcgen.gui3.GuiUtility;
 import pcgen.pluginmgr.PluginManager;
 import pcgen.system.LanguageBundle;
@@ -36,7 +37,7 @@ import javafx.scene.layout.Pane;
 import javafx.scene.layout.VBox;
 import javafx.scene.text.Text;
 
-public final class PreferencesPluginsPanel extends gmgen.gui.PreferencesPanel
+public final class PreferencesPluginsPanel extends PCGenPrefsPanel
 {
 	private final Map<String, PluginRef> pluginMap = new HashMap<>();
 
@@ -47,24 +48,9 @@ public final class PreferencesPluginsPanel extends gmgen.gui.PreferencesPanel
 	{
 		for (PluginManager.PluginInfo info : PluginManager.getInstance().getPluginInfoList())
 		{
-			addPanel(info.logName, info.pluginName, Constants.SYSTEM_GMGEN);
+			addPanel(info.logName, info.pluginName);
 		}
 		initComponents();
-		initPreferences();
-	}
-
-	@Override
-	public void applyPreferences()
-	{
-		pluginMap.values()
-		         .forEach(PluginRef::applyPreferences);
-	}
-
-	@Override
-	public void initPreferences()
-	{
-		pluginMap.values()
-		         .forEach(PluginRef::initPreferences);
 	}
 
 	@Override
@@ -86,16 +72,36 @@ public final class PreferencesPluginsPanel extends gmgen.gui.PreferencesPanel
 		mainPanel.getChildren().add(new Text(LanguageBundle.getString("in_Prefs_restartInfo")));
 		ScrollPane scrollPane = new ScrollPane(mainPanel);
 		scrollPane.setContent(mainPanel);
-		add(GuiUtility.wrapParentAsJFXPanel(scrollPane));
+		this.add(GuiUtility.wrapParentAsJFXPanel(scrollPane));
 	}
 
-	private void addPanel(String pluginName, String pluginTitle, String defaultSystem)
+	private void addPanel(String pluginName, String pluginTitle)
 	{
 		if (!pluginMap.containsKey(pluginName))
 		{
-			PluginRef pluginRef = new PluginRef(pluginName, pluginTitle, defaultSystem);
+			PluginRef pluginRef = new PluginRef(pluginName, pluginTitle, Constants.SYSTEM_GMGEN);
 			pluginMap.put(pluginName, pluginRef);
 		}
+	}
+
+	@Override
+	public String getTitle()
+	{
+		return LanguageBundle.getString("in_Prefs_plugins");
+	}
+
+	@Override
+	public void applyOptionValuesToControls()
+	{
+		pluginMap.values()
+		         .forEach(PluginRef::initPreferences);
+	}
+
+	@Override
+	public void setOptionsBasedOnControls()
+	{
+		pluginMap.values()
+		         .forEach(PluginRef::applyPreferences);
 	}
 
 	private static final class PluginRef extends Pane

--- a/code/src/java/pcgen/gui3/preferences/SourcesPreferencesPanelController.java
+++ b/code/src/java/pcgen/gui3/preferences/SourcesPreferencesPanelController.java
@@ -30,7 +30,6 @@ import pcgen.system.LanguageBundle;
 import pcgen.system.PCGenSettings;
 import pcgen.util.Logging;
 
-import javafx.application.Platform;
 import javafx.collections.FXCollections;
 import javafx.fxml.FXML;
 import javafx.scene.control.CheckBox;
@@ -131,6 +130,7 @@ public class SourcesPreferencesPanelController implements ResettableController
 	@Override
 	public void reset()
 	{
+		GuiAssertions.assertIsJavaFXThread();
 		campLoad.setSelected(
 				PCGenSettings.OPTIONS_CONTEXT.initBoolean(PCGenSettings.OPTION_AUTOLOAD_SOURCES_AT_START, false));
 		charCampLoad.setSelected(
@@ -151,42 +151,39 @@ public class SourcesPreferencesPanelController implements ResettableController
 		allowMultiLineObjectsSelect
 				.setSelected(PCGenSettings.OPTIONS_CONTEXT.getBoolean(PCGenSettings.OPTION_SOURCES_ALLOW_MULTI_LINE));
 
-		GuiAssertions.assertIsNotJavaFXThread();
-		Platform.runLater(() -> {
-			switch (Globals.getSourceDisplay())
-			{
-				case LONG:
-					sourceOptions.getSelectionModel().select(0);
+		switch (Globals.getSourceDisplay())
+		{
+			case LONG:
+				sourceOptions.getSelectionModel().select(0);
 
-					break;
+				break;
 
-				case MEDIUM:
-					sourceOptions.getSelectionModel().select(1);
+			case MEDIUM:
+				sourceOptions.getSelectionModel().select(1);
 
-					break;
+				break;
 
-				case SHORT:
-					sourceOptions.getSelectionModel().select(2);
+			case SHORT:
+				sourceOptions.getSelectionModel().select(2);
 
-					break;
+				break;
 
-				case PAGE:
-					sourceOptions.getSelectionModel().select(3);
+			case PAGE:
+				sourceOptions.getSelectionModel().select(3);
 
-					break;
+				break;
 
-				case WEB:
-					sourceOptions.getSelectionModel().select(4);
+			case WEB:
+				sourceOptions.getSelectionModel().select(4);
 
-					break;
+				break;
 
-				default:
-					Logging.errorPrint(
-							"In PreferencesDialog.applyOptionValuesToControls " + "(source display) the option "
-									+ Globals.getSourceDisplay() + " is unsupported.");
+			default:
+				Logging.errorPrint(
+						"In PreferencesDialog.applyOptionValuesToControls " + "(source display) the option "
+								+ Globals.getSourceDisplay() + " is unsupported.");
 
-					break;
-			}
-		});
+				break;
+		}
 	}
 }


### PR DESCRIPTION
This also formalizes a bit better which thread to
expect to run applyOptionValuesToControls on. More specifically,
it should always run on the thread of the "type" of control
(that is, converted = javafx; others = swing)