### PR TITLE
PreferencesDialog: downgrade to JSplitPane

### DIFF
--- a/code/src/java/gmgen/gui/PreferencesDialog.java
+++ b/code/src/java/gmgen/gui/PreferencesDialog.java
@@ -37,7 +37,6 @@ import javax.swing.tree.DefaultTreeModel;
 import gmgen.GMGenSystem;
 import pcgen.gui2.dialog.AbstractPreferencesDialog;
 import pcgen.gui2.prefs.PCGenPrefsPanel;
-import pcgen.gui2.tools.FlippingSplitPane;
 
 public class PreferencesDialog extends AbstractPreferencesDialog
 {
@@ -101,7 +100,7 @@ public class PreferencesDialog extends AbstractPreferencesDialog
 	@Override
 	protected JComponent getCenter()
 	{
-		jSplitPane1 = new FlippingSplitPane();
+		jSplitPane1 = new JSplitPane();
 		prefsTree = new javax.swing.JTree();
 		prefsTree.setRootVisible(false);
 		prefsTree.setShowsRootHandles(true);


### PR DESCRIPTION
Much like in 8ea81b0b03f353887a0573fd4a66a25dac8daab8, while
FlippingSplitPane has some nice utility, it isn't required for a
preferences dialog.