### PR TITLE
refactored recursive code to not recreate the same object on each cal…

### DIFF
--- a/code/src/java/pcgen/persistence/RecursiveFileFinder.java
+++ b/code/src/java/pcgen/persistence/RecursiveFileFinder.java
@@ -1,0 +1,47 @@
+package pcgen.persistence;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.net.URI;
+import java.util.List;
+import org.apache.commons.lang3.StringUtils;
+
+public class RecursiveFileFinder
+{
+
+	private final FilenameFilter pccFileFilter;
+
+	public RecursiveFileFinder()
+	{
+		pccFileFilter = (parentDir, fileName) -> StringUtils.endsWithIgnoreCase(fileName, ".pcc")
+				|| new File(parentDir, fileName).isDirectory();
+	}
+
+	/**
+	 * Recursively looks inside a given directory for PCC files
+	 * and adds them to the {@link #campaignFiles campaignFiles} list.
+	 *  @param aDirectory    The directory to search.
+	 * @param campaignFiles
+	 */
+	public void findFiles(final File aDirectory, List<URI> campaignFiles)
+	{
+		if (!aDirectory.isDirectory())
+		{
+			return;
+		}
+		_findFiles(aDirectory, campaignFiles);
+	}
+
+	private void _findFiles(File aDirectory, List<URI> campaignFiles)
+	{
+		for (final File file : aDirectory.listFiles(pccFileFilter))
+		{
+			if (file.isDirectory())
+			{
+				_findFiles(file, campaignFiles);
+				continue;
+			}
+			campaignFiles.add(file.toURI());
+		}
+	}
+}

--- a/code/src/utest/pcgen/persistence/RecursiveFileFinderTest.java
+++ b/code/src/utest/pcgen/persistence/RecursiveFileFinderTest.java
@@ -1,0 +1,31 @@
+package pcgen.persistence;
+
+import java.io.File;
+import java.net.URI;
+import java.util.LinkedList;
+import java.util.List;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import org.junit.Test;
+import pcgen.system.ConfigurationSettings;
+
+public class RecursiveFileFinderTest {
+
+	@Test
+	public void parseMainPCCDir(){
+		List<URI> files = new LinkedList<>();
+		new RecursiveFileFinder().findFiles(new File(ConfigurationSettings.getPccFilesDir()), files);
+
+		assertThat(files, hasSize(greaterThan(605)));
+	}
+
+	@Test
+	public void fakeFile(){
+		List<URI> files = new LinkedList<>();
+		new RecursiveFileFinder().findFiles(new File("FakeFile"), files);
+
+		assertThat(files, hasSize(0));
+	}
+}


### PR DESCRIPTION
what i have done here is refactored this code a bit to remove unnessesary item creation from a recursive method and also remove an if check that can only be true on the first call in the recursive stack.

based on my measurements it reduces load time from 12 to 9 seconds

also note that i have named a method _findFiles.  I did this because i've seen it used to denote a private method that is only to be called by the method of the same name.  i can rename it.