### PR TITLE
 InfoGuidePane: don't call pane.setOpaque

### DIFF
--- a/code/src/java/pcgen/gui2/InfoGuidePane.java
+++ b/code/src/java/pcgen/gui2/InfoGuidePane.java
@@ -73,12 +73,10 @@ class InfoGuidePane extends JComponent implements UIResource
 
 	private static JFXPanelFromResource<SimpleHtmlPanelController> createHtmlPane()
 	{
-		var pane = new JFXPanelFromResource<>(
+		return new JFXPanelFromResource<>(
 				SimpleHtmlPanelController.class,
 				"SimpleHtmlPanel.fxml"
 		);
-		pane.setOpaque(false);
-		return pane;
 	}
 
 	private void initComponents()


### PR DESCRIPTION
This value gets ignored by the callee, so just remove it.