### PR TITLE
build: remove build-scan plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,6 @@
 import org.apache.tools.ant.filters.FixCrLfFilter
 
 plugins {
-    id 'com.gradle.build-scan' version '2.3'
     id 'eclipse'
     id 'application'
     id 'build-dashboard'

--- a/code/gradle/reporting.gradle
+++ b/code/gradle/reporting.gradle
@@ -5,11 +5,6 @@
  * Usage: gradle allReports
  */
 
-buildScan {
-	termsOfServiceUrl = 'https://gradle.com/terms-of-service';
-	termsOfServiceAgree = 'yes'
-}
-
 checkstyle {
 	configFile = new File('code/standards/checkstyle.xml')
 	configProperties = [samedir: "${rootDir}/code/standards"]


### PR DESCRIPTION
We don't use it much and it adds more complexity (i.e., might cause
failure on windows)