### PR TITLE
JTableMenuButton: avoid reconstructing wrapped corner button

### DIFF
--- a/code/src/java/pcgen/gui2/util/JDynamicTable.java
+++ b/code/src/java/pcgen/gui2/util/JDynamicTable.java
@@ -32,6 +32,7 @@ import pcgen.gui2.util.event.DynamicTableColumnModelListener;
 import pcgen.gui2.util.table.DynamicTableColumnModel;
 import pcgen.gui3.GuiUtility;
 
+import javafx.embed.swing.JFXPanel;
 import javafx.event.ActionEvent;
 import javafx.scene.control.Button;
 import javafx.scene.control.CheckMenuItem;
@@ -67,12 +68,14 @@ public class JDynamicTable extends JTableEx
 
 	};
 	private final Button cornerButton;
+	private final JFXPanel wrappedCornerButton;
 	private DynamicTableColumnModel dynamicColumnModel = null;
 	private final ContextMenu menu = new ContextMenu();
 
 	public JDynamicTable()
 	{
 		this.cornerButton = new JTableMenuButton(menu);
+		this.wrappedCornerButton = GuiUtility.wrapParentAsJFXPanel(cornerButton);
 	}
 
 	@Override
@@ -97,7 +100,7 @@ public class JDynamicTable extends JTableEx
 				scrollPane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
 				scrollPane.setCorner(
 						ScrollPaneConstants.UPPER_TRAILING_CORNER,
-						GuiUtility.wrapParentAsJFXPanel(cornerButton));
+						wrappedCornerButton);
 			}
 		}
 	}

--- a/code/src/java/pcgen/gui2/util/JTreeViewTable.java
+++ b/code/src/java/pcgen/gui2/util/JTreeViewTable.java
@@ -53,6 +53,7 @@ import pcgen.system.PropertyContext;
 import pcgen.util.CollectionMaps;
 import pcgen.util.ListMap;
 
+import javafx.embed.swing.JFXPanel;
 import javafx.event.ActionEvent;
 import javafx.scene.control.Button;
 import javafx.scene.control.CheckMenuItem;
@@ -92,6 +93,7 @@ public class JTreeViewTable<T> extends JTreeTable
 	private static final String VIEW_INDEX_PREFS_KEY = "viewIdx";
 
 	private final Button cornerButton;
+	private final JFXPanel wrappedCornerButton;
 	private DynamicTableColumnModel dynamicColumnModel;
 	protected TreeViewTableModel<T> treetableModel;
 	private TreeViewModel<T> viewModel;
@@ -107,6 +109,7 @@ public class JTreeViewTable<T> extends JTreeTable
 		setAutoCreateRowSorter(false);
 		getTree().setLargeModel(true);
 		this.cornerButton = new JTableMenuButton(cornerPopupMenu);
+		this.wrappedCornerButton = GuiUtility.wrapParentAsJFXPanel(this.cornerButton);
 	}
 
 	private <TM> TreeViewTableModel<TM> createDefaultTreeViewTableModel(DataView<TM> dataView)
@@ -207,7 +210,7 @@ public class JTreeViewTable<T> extends JTreeTable
 				}
 				scrollPane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
 				scrollPane.setCorner(ScrollPaneConstants.UPPER_RIGHT_CORNER,
-						GuiUtility.wrapParentAsJFXPanel(cornerButton));
+						wrappedCornerButton);
 			}
 		}
 	}


### PR DESCRIPTION
This causes an exception JTableMenuButton@684f551b[styleClass=root
button]''is already set as root of another scene