### PR TITLE
Added temporary fix for build error 

### DIFF
--- a/code/src/utest/pcgen/gui3/dialog/AboutDialogTest.java
+++ b/code/src/utest/pcgen/gui3/dialog/AboutDialogTest.java
@@ -41,6 +41,7 @@ class AboutDialogTest
 	@Start
 	private void Start(Stage stage) throws IOException
 	{
+		System.load("C:\\Windows\\System32\\WindowsCodecs.dll");
 		FXMLLoader loader = new FXMLLoader();
 		URL resource = AboutDialogController.class.getResource("AboutDialog.fxml");
 		assert resource != null;

--- a/code/src/utest/pcgen/gui3/dialog/AboutDialogTest.java
+++ b/code/src/utest/pcgen/gui3/dialog/AboutDialogTest.java
@@ -42,10 +42,16 @@ class AboutDialogTest
 	@Start
 	private void Start(Stage stage) throws IOException
 	{
+		/*
+	    TODO Remove once JavaFx is updated to version 13.
+	    This is a temporary fix for https://github.com/javafxports/openjdk-jfx/issues/66.
+	    https://github.com/PCGen/pcgen/pull/5973
+	     */
 	    if (SystemUtils.IS_OS_WINDOWS)
 	    {
             System.load("C:\\Windows\\System32\\WindowsCodecs.dll");
         }
+
 		FXMLLoader loader = new FXMLLoader();
 		URL resource = AboutDialogController.class.getResource("AboutDialog.fxml");
 		assert resource != null;

--- a/code/src/utest/pcgen/gui3/dialog/AboutDialogTest.java
+++ b/code/src/utest/pcgen/gui3/dialog/AboutDialogTest.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.ResourceBundle;
 
+import org.apache.commons.lang3.SystemUtils;
 import pcgen.system.LanguageBundle;
 
 import javafx.fxml.FXMLLoader;
@@ -41,7 +42,10 @@ class AboutDialogTest
 	@Start
 	private void Start(Stage stage) throws IOException
 	{
-		System.load("C:\\Windows\\System32\\WindowsCodecs.dll");
+	    if (SystemUtils.IS_OS_WINDOWS)
+	    {
+            System.load("C:\\Windows\\System32\\WindowsCodecs.dll");
+        }
 		FXMLLoader loader = new FXMLLoader();
 		URL resource = AboutDialogController.class.getResource("AboutDialog.fxml");
 		assert resource != null;

--- a/code/src/utest/pcgen/gui3/preloader/PCGenPreloaderTest.java
+++ b/code/src/utest/pcgen/gui3/preloader/PCGenPreloaderTest.java
@@ -39,6 +39,7 @@ class PCGenPreloaderTest
 	@Start
 	private void Start(Stage stage) throws IOException
 	{
+		System.load("C:\\Windows\\System32\\WindowsCodecs.dll");
 		FXMLLoader loader = new FXMLLoader();
 		loader.setLocation(PCGenPreloader.class.getResource("PCGenPreloader.fxml"));
 		loader.setResources(LanguageBundle.getBundle());

--- a/code/src/utest/pcgen/gui3/preloader/PCGenPreloaderTest.java
+++ b/code/src/utest/pcgen/gui3/preloader/PCGenPreloaderTest.java
@@ -40,10 +40,16 @@ class PCGenPreloaderTest
 	@Start
 	private void Start(Stage stage) throws IOException
 	{
+	    /*
+	    TODO Remove once JavaFx is updated to version 13.
+	    This is a temporary fix for https://github.com/javafxports/openjdk-jfx/issues/66.
+	    https://github.com/PCGen/pcgen/pull/5973
+	     */
 		if (SystemUtils.IS_OS_WINDOWS)
 		{
 			System.load("C:\\Windows\\System32\\WindowsCodecs.dll");
 		}
+
 		FXMLLoader loader = new FXMLLoader();
 		loader.setLocation(PCGenPreloader.class.getResource("PCGenPreloader.fxml"));
 		loader.setResources(LanguageBundle.getBundle());

--- a/code/src/utest/pcgen/gui3/preloader/PCGenPreloaderTest.java
+++ b/code/src/utest/pcgen/gui3/preloader/PCGenPreloaderTest.java
@@ -20,6 +20,7 @@ package pcgen.gui3.preloader;
 
 import java.io.IOException;
 
+import org.apache.commons.lang3.SystemUtils;
 import pcgen.system.LanguageBundle;
 
 import javafx.fxml.FXMLLoader;
@@ -39,7 +40,10 @@ class PCGenPreloaderTest
 	@Start
 	private void Start(Stage stage) throws IOException
 	{
-		System.load("C:\\Windows\\System32\\WindowsCodecs.dll");
+		if (SystemUtils.IS_OS_WINDOWS)
+		{
+			System.load("C:\\Windows\\System32\\WindowsCodecs.dll");
+		}
 		FXMLLoader loader = new FXMLLoader();
 		loader.setLocation(PCGenPreloader.class.getResource("PCGenPreloader.fxml"));
 		loader.setResources(LanguageBundle.getBundle());


### PR DESCRIPTION
This pull request add `System.load("C:\\Windows\\System32\\WindowsCodecs.dll");` to 2 of the tests as a temporary fix to https://github.com/javafxports/openjdk-jfx/issues/66. This was causing `gradlew` builds to fail on my side with `EXCEPTION_ACCESS_VIOLATION` during running `Task :test`.

This commit need to be tested on linux and mac machines as it could cause builds to fail on them. 