### PR TITLE
Fixed clean running after build deleting build folder

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -472,3 +472,5 @@ apply from: 'code/gradle/distribution.gradle'
 apply from: 'code/gradle/reporting.gradle'
 apply from: 'code/gradle/release.gradle'
 
+//Ensures that clean is never run after build and when clean is called it is run before build so it doesn't delete the new build folder.
+build.shouldRunAfter clean

--- a/build.gradle
+++ b/build.gradle
@@ -323,6 +323,9 @@ clean {
     it.dependsOn 'cleanOutput'
 }
 
+//Ensures that clean is never run after build and when clean is called it is run before build so it doesn't delete the new build folder.
+build.mustRunAfter clean
+
 test {
     exclude 'pcgen/testsupport/**'
     useJUnitPlatform()
@@ -471,6 +474,3 @@ apply from: 'code/gradle/autobuild.gradle'
 apply from: 'code/gradle/distribution.gradle'
 apply from: 'code/gradle/reporting.gradle'
 apply from: 'code/gradle/release.gradle'
-
-//Ensures that clean is never run after build and when clean is called it is run before build so it doesn't delete the new build folder.
-build.shouldRunAfter clean


### PR DESCRIPTION
This ensures the clean never runs after build if called in the same dependsOn such as in prepareRelease. 

`task prepareRelease (dependsOn: ['clean', 'build']) {` Without the `shouldRunAfter` (this Pr addition) the build and clean could run in either order. Gradle just cared about them running before `prepareRelease` which often led to the situation of clean running after build and deleting the build folder.

~~I am using `shouldRunAfter` rather than `mustRunAfter` so that clean and build can be run independently as well.~~ - This was incorrect. 