### PR TITLE
FIX CODE-3454: Preferences do not save when applying

### DIFF
--- a/code/src/java/pcgen/gui2/dialog/PreferencesDialog.java
+++ b/code/src/java/pcgen/gui2/dialog/PreferencesDialog.java
@@ -67,16 +67,14 @@ public final class PreferencesDialog extends AbstractDialog
 
 	private void setOptionsBasedOnControls()
 	{
-		GuiAssertions.assertIsNotJavaFXThread();
-
 		forEachLeaf(root, PCGenPrefsPanel::setOptionsBasedOnControls);
 
 		if (SettingsHandler.settingsNeedRestartProperty().get())
 		{
-			Alert alert = GuiUtility.runOnJavaFXThreadNow(() -> new Alert(Alert.AlertType.INFORMATION));
+			Alert alert = new Alert(Alert.AlertType.INFORMATION);
 			alert.setTitle(Constants.APPLICATION_NAME);
 			alert.setContentText(LanguageBundle.getString("in_Prefs_restartRequired"));
-			GuiUtility.runOnJavaFXThreadNow(alert::showAndWait);
+			alert.showAndWait();
 		}
 	}
 

--- a/code/src/java/pcgen/gui2/prefs/CharacterStatsPanel.java
+++ b/code/src/java/pcgen/gui2/prefs/CharacterStatsPanel.java
@@ -195,7 +195,12 @@ public final class CharacterStatsPanel extends PCGenPrefsPanel
 				else
 				{
 					abilitiesRolledButton.setSelected(true);
-					abilityRolledModeCombo.getSelectionModel().select(gameMode.getRollMethodExpressionName());
+					GuiUtility.runOnJavaFXThreadNow(() ->
+					{
+						abilityRolledModeCombo.getSelectionModel().select(gameMode.getRollMethodExpressionName());
+						return true;
+					});
+
 				}
 
 				break;
@@ -228,7 +233,12 @@ public final class CharacterStatsPanel extends PCGenPrefsPanel
 			{
 				if (pModeMethodName[i].equals(methodName))
 				{
-					abilityPurchaseModeCombo.getSelectionModel().select(i);
+					final int iFinal = i;
+					GuiUtility.runOnJavaFXThreadNow(() ->
+					{
+						abilityPurchaseModeCombo.getSelectionModel().select(iFinal);
+						return true;
+					});
 				}
 			}
 		}

--- a/code/src/java/pcgen/gui2/prefs/OutputPanel.java
+++ b/code/src/java/pcgen/gui2/prefs/OutputPanel.java
@@ -217,7 +217,6 @@ public final class OutputPanel extends PCGenPrefsPanel
 	public void setOptionsBasedOnControls()
 	{
 		UIPropertyContext context = UIPropertyContext.getInstance();
-		GuiAssertions.assertIsNotJavaFXThread();
 		Globals.selectPaper(paperType.getSelectionModel().getSelectedItem());
 
 		context.setBoolean(UIPropertyContext.CLEANUP_TEMP_FILES, removeTempFiles.isSelected());

--- a/code/src/java/pcgen/gui2/tools/DesktopBrowserLauncher.java
+++ b/code/src/java/pcgen/gui2/tools/DesktopBrowserLauncher.java
@@ -26,6 +26,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 
+import pcgen.gui3.GuiUtility;
 import pcgen.system.LanguageBundle;
 import pcgen.util.Logging;
 
@@ -86,15 +87,15 @@ public final class DesktopBrowserLauncher
 		if (Desktop.isDesktopSupported() && DESKTOP.isSupported(Action.BROWSE))
 		{
 			DESKTOP.browse(uri);
-		} else
+		}
+		else
 		{
-			Dialog<ButtonType> alert = new Alert(Alert.AlertType.WARNING);
+			Dialog<ButtonType> alert = GuiUtility.runOnJavaFXThreadNow(() ->  new Alert(Alert.AlertType.WARNING));
 			Logging.debugPrint("unable to browse to " + uri);
 			alert.setTitle(LanguageBundle.getString("in_err_browser_err"));
 			alert.setContentText(LanguageBundle.getFormattedString("in_err_browser_uri", uri));
-			alert.showAndWait();
+			GuiUtility.runOnJavaFXThreadNow(alert::showAndWait);
 		}
-
 	}
 
 }

--- a/code/src/java/pcgen/gui3/JFXPanelFromResource.java
+++ b/code/src/java/pcgen/gui3/JFXPanelFromResource.java
@@ -67,7 +67,14 @@ public final class JFXPanelFromResource<T> extends JFXPanel implements Controlla
 	@Override
 	public T getController()
 	{
-		return GuiUtility.runOnJavaFXThreadNow(fxmlLoader::getController);
+		if (Platform.isFxApplicationThread())
+		{
+			return fxmlLoader.getController();
+		}
+		else
+		{
+			return GuiUtility.runOnJavaFXThreadNow(fxmlLoader::getController);
+		}
 	}
 
 	public T getControllerFromJavaFXThread()

--- a/code/src/resources/pcgen/lang/LanguageBundle.properties
+++ b/code/src/resources/pcgen/lang/LanguageBundle.properties
@@ -164,7 +164,7 @@ in_select=Select
 # Mnemonic for in_select, used in install source dialog
 in_mn_select=S
 
-in_ok=_`OK
+in_ok=_OK
 
 in_mn_ok=O
 


### PR DESCRIPTION
- Fix alert when documentation viewer not supported on platform.
- Small typo in OK button text for preferences dialog.

-------------------------------------
More progress on the road to UI working. Some stop gaps to shore up the preferences and the alert for documentation viewer. Also a small typo that didn't warrant a ticket.