### PR TITLE
FIX CODE-3459: Descriptions City Field Does Not Save

### DIFF
--- a/code/src/itest/pcgen/io/testsupport/AbstractSaveRestoreTest.java
+++ b/code/src/itest/pcgen/io/testsupport/AbstractSaveRestoreTest.java
@@ -397,7 +397,7 @@ public abstract class AbstractSaveRestoreTest
 		pc.setStringFor(PCStringKey.PORTRAIT_PATH, "");
 		pc.setStringFor(PCStringKey.BIRTHDAY, "");
 		pc.setStringFor(PCStringKey.DESCRIPTION, "");
-		pc.setStringFor(PCStringKey.RESIDENCE, "");
+		pc.setStringFor(PCStringKey.CITY, "");
 		pc.setStringFor(PCStringKey.PERSONALITY1, "");
 		pc.setStringFor(PCStringKey.EYECOLOR, "");
 		pc.setStringFor(PCStringKey.PLAYERSNAME, "");

--- a/code/src/java/pcgen/gui2/facade/DescriptionFacadeImpl.java
+++ b/code/src/java/pcgen/gui2/facade/DescriptionFacadeImpl.java
@@ -93,7 +93,7 @@ class DescriptionFacadeImpl implements DescriptionFacade
 		bioData.put(BiographyField.LOCATION,
 			new DefaultReferenceFacade<>(charDisplay.getSafeStringFor(PCStringKey.LOCATION)));
 		bioData.put(BiographyField.CITY,
-			new DefaultReferenceFacade<>(charDisplay.getSafeStringFor(PCStringKey.RESIDENCE)));
+			new DefaultReferenceFacade<>(charDisplay.getSafeStringFor(PCStringKey.CITY)));
 		bioData.put(BiographyField.REGION, new DefaultReferenceFacade<>(charDisplay.getRegionString()));
 		bioData.put(BiographyField.PERSONALITY_TRAIT_1,
 			new DefaultReferenceFacade<>(charDisplay.getSafeStringFor(PCStringKey.PERSONALITY1)));

--- a/code/src/java/pcgen/io/PCGVer2Creator.java
+++ b/code/src/java/pcgen/io/PCGVer2Creator.java
@@ -232,7 +232,7 @@ public final class PCGVer2Creator
 		appendHairColorLine(buffer);
 		appendHairStyleLine(buffer);
 		appendLocationLine(buffer);
-		appendResidenceLine(buffer);
+		appendCityLine(buffer);
 		appendBirthdayLine(buffer);
 		appendBirthplaceLine(buffer);
 		appendPersonalityTrait1Line(buffer);
@@ -1797,7 +1797,7 @@ public final class PCGVer2Creator
 		}
 	}
 
-	private void appendResidenceLine(StringBuilder buffer)
+	private void appendCityLine(StringBuilder buffer)
 	{
 		buffer.append(IOConstants.TAG_CITY).append(':');
 		buffer.append(EntityEncoder.encode(charDisplay.getSafeStringFor(PCStringKey.CITY)));

--- a/code/src/java/pcgen/io/PCGVer2Creator.java
+++ b/code/src/java/pcgen/io/PCGVer2Creator.java
@@ -1800,7 +1800,7 @@ public final class PCGVer2Creator
 	private void appendResidenceLine(StringBuilder buffer)
 	{
 		buffer.append(IOConstants.TAG_CITY).append(':');
-		buffer.append(EntityEncoder.encode(charDisplay.getSafeStringFor(PCStringKey.RESIDENCE)));
+		buffer.append(EntityEncoder.encode(charDisplay.getSafeStringFor(PCStringKey.CITY)));
 		buffer.append(IOConstants.LINE_SEP);
 	}
 

--- a/code/src/java/pcgen/io/PCGVer2Parser.java
+++ b/code/src/java/pcgen/io/PCGVer2Parser.java
@@ -1473,7 +1473,7 @@ final class PCGVer2Parser implements PCGParser
 
 	private void parseCityLine(final String line)
 	{
-		thePC.setPCAttribute(PCStringKey.RESIDENCE,
+		thePC.setPCAttribute(PCStringKey.CITY,
 			EntityEncoder.decode(line.substring(IOConstants.TAG_CITY.length() + 1)));
 	}
 

--- a/code/src/java/plugin/pretokens/test/PreCityTester.java
+++ b/code/src/java/plugin/pretokens/test/PreCityTester.java
@@ -31,7 +31,7 @@ public class PreCityTester extends AbstractDisplayPrereqTest implements Prerequi
 	@Override
 	public int passes(final Prerequisite prereq, final CharacterDisplay display, CDOMObject source)
 	{
-		if (display.getSafeStringFor(PCStringKey.RESIDENCE).equalsIgnoreCase(prereq.getKey()))
+		if (display.getSafeStringFor(PCStringKey.CITY).equalsIgnoreCase(prereq.getKey()))
 		{
 			return countedTotal(prereq, 1);
 		}

--- a/code/src/test/pcgen/core/prereq/PreCityTest.java
+++ b/code/src/test/pcgen/core/prereq/PreCityTest.java
@@ -43,7 +43,7 @@ class PreCityTest extends AbstractCharacterTestCase
 	void testCity() throws PersistenceLayerException
 	{
 		final PlayerCharacter character = getCharacter();
-		character.setPCAttribute(PCStringKey.RESIDENCE, "Klamath");
+		character.setPCAttribute(PCStringKey.CITY, "Klamath");
 
 		Prerequisite prereq;
 


### PR DESCRIPTION
- Append CITY instead of RESIDENCE in PCGVer2Creator.
- Complete the rename where applicable of PCStringKey.RESIDENCE =>PCStringKey.CITY .

--------------
Resolves issue of saving the City field to PCG.
