### PR TITLE
FIX GITHUB-6006: d20 Modern statblock1.htm Template does not display

### DIFF
--- a/preview/d20/modern/statblock1.htm
+++ b/preview/d20/modern/statblock1.htm
@@ -120,7 +120,11 @@ $Date$
   </tr>
   <tr valign="top">
     <td width="25%"><b>Skills: </b></td>
-    <td width="75%">|FOR.0,COUNT[SKILLSIT]-1,100,\SKILLSIT.%.NAME\ \SKILLSIT.%.TOTAL\;       , , ,0| </td>
+    <td width="75%">
+|FOR,%skill,0,${count("SKILLSIT", "VIEW=VISIBLE_EXPORT")-1},1,0|
+     |SKILLSIT.%skill.NAME| |SKILLSIT.%skill.TOTAL|,
+|ENDFOR|
+    </td>
   </tr>
   <tr valign="top">
     <td width="25%"><b>Feats: </b></td>


### PR DESCRIPTION
- Replaced inline with standard for loop, strangely one liner would not
expand on character preview tab.

------------------------------
This fix is in response to #6006 on the 6.08 branch. It affects master as well, so please merge to master and cherry pick it back to 6.08 branch. Modern character loading isn't working well on master atm, so to test use 6.08. 