### PR TITLE
FIX GITHUB-5990: Loading Source from Existing Character

### DIFF
--- a/code/src/java/pcgen/gui2/PCGenFrame.java
+++ b/code/src/java/pcgen/gui2/PCGenFrame.java
@@ -1310,6 +1310,10 @@ public final class PCGenFrame extends JFrame implements UIDelegate, CharacterSel
 		{
 			sourceSelectionDialog = new SourceSelectionDialog(this, uiContext);
 		}
+		if (currentSourceSelection.get() != null)
+		{
+			((SourceSelectionDialog) sourceSelectionDialog).setAdvancedSources(currentSourceSelection.get());
+		}
 		sourceSelectionDialog.setLocationRelativeTo(this);
 		sourceSelectionDialog.setVisible(true);
 	}

--- a/code/src/java/pcgen/gui2/sources/SourceSelectionDialog.java
+++ b/code/src/java/pcgen/gui2/sources/SourceSelectionDialog.java
@@ -225,6 +225,18 @@ public class SourceSelectionDialog extends JDialog implements ActionListener, Ch
 		buttonPanel.revalidate();
 	}
 
+	/**
+	 * Set the selected advanced sources for a particular game mode and
+	 * remember them. Overrides existing selections.
+	 *
+	 * @param sourceSel A selection facade of the sources to set.
+	 */
+	public void setAdvancedSources(final SourceSelectionFacade sourceSel)
+	{
+		advancedPanel.setSourceSelection(sourceSel);
+		advancedPanel.rememberSelectedSources();
+	}
+
 	@Override
 	public void stateChanged(ChangeEvent e)
 	{


### PR DESCRIPTION
- When a character loaded and advanced source selections brough up,
always present the character's source selections. Allows easy editting
of sources.

--------------------
Easy feature, fixes #5990. Is fairly handy and took no effort. Not a huge priority for backporting but it would be convenient.