### PR TITLE
FIX GITHUB-5990: Loading Source from Existing Character

### DIFF
--- a/code/src/java/pcgen/gui2/PCGenFrame.java
+++ b/code/src/java/pcgen/gui2/PCGenFrame.java
@@ -1067,6 +1067,12 @@ public final class PCGenFrame extends JFrame implements UIDelegate, CharacterSel
 			}
 			else if (loadSourceSelection(sources))
 			{
+				if (sourceSelectionDialog == null)
+				{
+					sourceSelectionDialog = new SourceSelectionDialog(this, uiContext);
+				}
+				((SourceSelectionDialog) sourceSelectionDialog).setAdvancedSources(sources);
+				currentSourceSelection.set(sources);
 				loadSourcesThenCharacter(pcgFile);
 			}
 			else

--- a/code/src/java/pcgen/gui2/sources/SourceSelectionDialog.java
+++ b/code/src/java/pcgen/gui2/sources/SourceSelectionDialog.java
@@ -225,6 +225,18 @@ public class SourceSelectionDialog extends JDialog implements ActionListener, Ch
 		buttonPanel.revalidate();
 	}
 
+	/**
+	 * Set the selected advanced sources for a particular game mode and
+	 * remember them. Overrides existing selections.
+	 *
+	 * @param sourceSel A selection facade of the sources to set.
+	 */
+	public void setAdvancedSources(final SourceSelectionFacade sourceSel)
+	{
+		advancedPanel.setSourceSelection(sourceSel);
+		advancedPanel.rememberSelectedSources();
+	}
+
 	@Override
 	public void stateChanged(ChangeEvent e)
 	{


### PR DESCRIPTION
- When a character is loaded and advanced source selections brought up,
always present the character's source selections. Allows easy editting
of sources.

-------------------------
Only overwrite sources in advanced selection if user wanted to load sources and only do this when the PCG is loaded for first time. Prevents the clobber issue in last PR.

This isn't a priority to fix on 6.08 but it is definitely very handy and probably a common complaint.