### PR TITLE
[build] remove '=' from dependencyUpdates.resolutionStrategy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -427,7 +427,7 @@ allprojects {
 dependencyUpdates {
     revision='release'
 }
-dependencyUpdates.resolutionStrategy = {
+dependencyUpdates.resolutionStrategy {
     componentSelection { rules ->
         rules.all { ComponentSelection selection ->
             if (['atlassian'].any { qualifier ->


### PR DESCRIPTION
From running it
===
dependencyUpdates.resolutionStrategy Remove the assignment operator, '=', when setting this task property
===