### PR TITLE
FIX CODE-3461: 6.09.01 Crash Log

### DIFF
--- a/code/gradle/release.gradle
+++ b/code/gradle/release.gradle
@@ -190,7 +190,7 @@ task downloadJRE doLast {
             if(os == "mac" && arch == "x32"){
                 return
             }
-            def url = "https://api.adoptopenjdk.net/v2/binary/nightly/openjdk${major}?openjdk_impl=hotspot&os=${os}&arch=${arch}&release=latest&type=jre"
+            def url = "https://api.adoptopenjdk.net/v2/binary/releases/openjdk${major}?openjdk_impl=hotspot&os=${os}&arch=${arch}&release=latest&type=jdk"
             def jreDir = new File("${projectDir}/jre/${os}/jre_${arch}")
             if(!jreDir.exists()){
                 //Only download Windows libraries. Need to add more OS if we go multi OS at any time.

--- a/code/pcgen_JREx32.bat
+++ b/code/pcgen_JREx32.bat
@@ -1,1 +1,1 @@
-"%~dp0jre\jre_x32\bin\java.exe" -jar pcgen.jar -Dsun.java2d.d3d=false
+"jre\windows\jre_x32\bin\java.exe" -jar pcgen.jar -Dsun.java2d.d3d=false

--- a/code/pcgen_JREx64.bat
+++ b/code/pcgen_JREx64.bat
@@ -1,1 +1,1 @@
-"%~dp0jre\jre_x64\bin\java.exe" -jar pcgen.jar -Dsun.java2d.d3d=false
+"jre\windows\jre_x64\bin\java.exe" -jar pcgen.jar -Dsun.java2d.d3d=false


### PR DESCRIPTION
- Project depends on JDK instead of JRE during javaFX transition.
- Bundle latest full release of JDK for forseeable future.
- Use relative path for bat files.