### PR TITLE
Create PCG_SAVE_PATH after selecting options.ini location

### DIFF
--- a/code/src/java/pcgen/system/Main.java
+++ b/code/src/java/pcgen/system/Main.java
@@ -280,7 +280,7 @@ public final class Main
 	public static void loadProperties(boolean useGui)
 	{
 		if ((settingsDir == null)
-			&& (ConfigurationSettings.getSystemProperty(ConfigurationSettings.SETTINGS_FILES_PATH) == null))
+				&& (ConfigurationSettings.getSystemProperty(ConfigurationSettings.SETTINGS_FILES_PATH) == null))
 		{
 			if (!useGui)
 			{
@@ -297,10 +297,26 @@ public final class Main
 
 		//Existing PropertyContexts are registered here
 		PropertyContextFactory defaultFactory = PropertyContextFactory.getDefaultFactory();
-		defaultFactory.registerPropertyContext(PCGenSettings.getInstance());
+		PropertyContext settingscontext = PCGenSettings.getInstance();
+		defaultFactory.registerPropertyContext(settingscontext);
 		defaultFactory.registerPropertyContext(UIPropertyContext.getInstance());
 		defaultFactory.registerPropertyContext(LegacySettings.getInstance());
 		defaultFactory.loadPropertyContexts();
+		//Make savepath directory if it doesn't exist
+		String savepath = settingscontext.getProperty(PCGenSettings.PCG_SAVE_PATH);
+		File savepath_dir = new File(savepath);
+		if (!savepath_dir.exists() && !savepath_dir.isDirectory())
+		{
+			try
+			{
+				Logging.log(Level.INFO, "Making directory " + savepath_dir);
+				savepath_dir.mkdir();
+			}
+			catch (Exception e)
+			{
+				Logging.log(Level.SEVERE, "Unable to create PCG_SAVE_PATH " + savepath_dir + ": " + e );
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
This is not the best fix, I just set it to open the current folder instead of the PCG_SAVE_PATH.  

It seems like we really need to actually create the preset directory paths during the initial load if they don't exist.   

When you first open the app it asks which directory will be your pcgen directory, then it looks for a characters directory in the path of whatever you selected, but nothing actually creates those directories.  So when you go to open the path, java throws a path not found behind the scenes but the user gets no indication.