### PR TITLE
[gradle] Fixed JEP dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -178,7 +178,7 @@ dependencies {
     compile group: 'org.apache.commons', name: 'commons-lang3', version:'3.9'
     compile group: 'org.apache.xmlgraphics', name: 'fop', version:'2.4'
     compile group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
-    compile group: 'jep', name: 'jep', version:'2.4.1'
+    compile group: 'org.scijava', name: 'jep', version:'2.4.2'
     compile group: 'org.freemarker', name: 'freemarker', version:'2.3.29'
     compile group: 'org.jdom', name: 'jdom2', version:'2.0.6'
     compile group: 'xalan', name: 'xalan', version:'2.7.2'


### PR DESCRIPTION
It wouldn't build on my linux machine because the jep url must have been changed recently.