### PR TITLE
Partially revert changes to enumerations

### DIFF
--- a/code/src/java/pcgen/util/enumeration/Tab.java
+++ b/code/src/java/pcgen/util/enumeration/Tab.java
@@ -17,8 +17,6 @@
  */
 package pcgen.util.enumeration;
 
-import org.apache.commons.lang3.EnumUtils;
-
 public enum Tab
 {
 	SUMMARY("Summary", "in_summary"),
@@ -83,6 +81,13 @@ public enum Tab
 
 	public static Tab getTab(String name)
 	{
-		return EnumUtils.getEnumIgnoreCase(Tab.class, name);
+		for (final Tab tab : Tab.values())
+		{
+			if (tab.text.equalsIgnoreCase(name))
+			{
+				return tab;
+			}
+		}
+		return null;
 	}
 }

--- a/code/src/java/pcgen/util/enumeration/View.java
+++ b/code/src/java/pcgen/util/enumeration/View.java
@@ -17,8 +17,6 @@
  */
 package pcgen.util.enumeration;
 
-import org.apache.commons.lang3.EnumUtils;
-
 /**
  * {@code View} is an enumeration of possible view types. It is
  * closely related to the Visibility enumeration.
@@ -55,6 +53,13 @@ public enum View
 	 */
 	public static View getViewFromName(String name)
 	{
-		return EnumUtils.getEnumIgnoreCase(View.class, name);
+		for (final View view : View.values())
+		{
+			if (view.text.equalsIgnoreCase(name))
+			{
+				return view;
+			}
+		}
+		return null;
 	}
 }


### PR DESCRIPTION
The commit 5d56bdf7d3b32cbae141e826947c540ae1f3b4af changes the retrieval of enum entries by name to EnumUtils.getEnumIgnoreCase(). This does not match previous functionality where the given string is checked against the text variable. Therefore, pcgen crashes for enum entries where the name and text do not match.