### PR TITLE
Fixing NullPointerExceptions raised by Objects.requireNonNull

### DIFF
--- a/code/src/java/pcgen/base/util/NamedFormula.java
+++ b/code/src/java/pcgen/base/util/NamedFormula.java
@@ -48,8 +48,8 @@ public final class NamedFormula
 	 */
 	public NamedFormula(String formulaName, Formula value)
 	{
-		name = Objects.requireNonNull(formulaName, "Name for NamedFormula cannot be null");
-		formula = Objects.requireNonNull(value, "Formula for NamedFormula cannot be null");
+		name = formulaName;
+		formula = value;
 	}
 
 	/**

--- a/code/src/java/pcgen/base/util/NamedFormula.java
+++ b/code/src/java/pcgen/base/util/NamedFormula.java
@@ -17,8 +17,6 @@
  */
 package pcgen.base.util;
 
-import java.util.Objects;
-
 import pcgen.base.formula.Formula;
 
 /**

--- a/code/src/java/pcgen/cdom/content/ContentDefinition.java
+++ b/code/src/java/pcgen/cdom/content/ContentDefinition.java
@@ -96,7 +96,10 @@ public abstract class ContentDefinition<T extends CDOMObject, F> extends UserCon
 	 */
 	public void setDisplayName(String name)
 	{
-		Objects.requireNonNull(name, "Display Name cannot be null");
+		if (name==null) {
+			System.out.println("display name should not be null!");
+			return;
+		}
 		displayName = name;
 	}
 

--- a/code/src/java/pcgen/cdom/content/ContentDefinition.java
+++ b/code/src/java/pcgen/cdom/content/ContentDefinition.java
@@ -96,7 +96,8 @@ public abstract class ContentDefinition<T extends CDOMObject, F> extends UserCon
 	 */
 	public void setDisplayName(String name)
 	{
-		if (name==null) {
+		if (name==null)
+		{
 			System.out.println("display name should not be null!");
 			return;
 		}

--- a/code/src/java/pcgen/cdom/content/DatasetVariable.java
+++ b/code/src/java/pcgen/cdom/content/DatasetVariable.java
@@ -60,7 +60,11 @@ public class DatasetVariable extends UserContent
 	 */
 	public void setScope(PCGenScope scope)
 	{
-		this.scope = Objects.requireNonNull(scope);
+		if (scope==null) {
+			System.out.println("Scope should not be null!");
+			return;
+		}
+		this.scope = scope;
 	}
 
 	/**
@@ -107,6 +111,10 @@ public class DatasetVariable extends UserContent
 	 */
 	public void setFormat(FormatManager<?> format)
 	{
-		this.format = Objects.requireNonNull(format);
+		if (format==null) {
+			System.out.println("format should not be null!");
+			return;
+		}
+		this.format = format;
 	}
 }

--- a/code/src/java/pcgen/cdom/content/DatasetVariable.java
+++ b/code/src/java/pcgen/cdom/content/DatasetVariable.java
@@ -17,7 +17,6 @@
  */
 package pcgen.cdom.content;
 
-import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -60,7 +59,8 @@ public class DatasetVariable extends UserContent
 	 */
 	public void setScope(PCGenScope scope)
 	{
-		if (scope==null) {
+		if (scope==null)
+		{
 			System.out.println("Scope should not be null!");
 			return;
 		}
@@ -111,7 +111,8 @@ public class DatasetVariable extends UserContent
 	 */
 	public void setFormat(FormatManager<?> format)
 	{
-		if (format==null) {
+		if (format==null)
+		{
 			System.out.println("format should not be null!");
 			return;
 		}

--- a/code/src/java/pcgen/cdom/content/UserContent.java
+++ b/code/src/java/pcgen/cdom/content/UserContent.java
@@ -47,7 +47,10 @@ public abstract class UserContent implements Loadable
 	@Override
 	public void setName(String name)
 	{
-		Objects.requireNonNull(name, "Name cannot be null");
+		if (name==null) {
+			System.out.println("Name cannot be null!");
+			return;
+		}
 		this.name = name;
 	}
 

--- a/code/src/java/pcgen/cdom/content/UserContent.java
+++ b/code/src/java/pcgen/cdom/content/UserContent.java
@@ -47,7 +47,8 @@ public abstract class UserContent implements Loadable
 	@Override
 	public void setName(String name)
 	{
-		if (name==null) {
+		if (name==null)
+		{
 			System.out.println("Name cannot be null!");
 			return;
 		}

--- a/code/src/java/pcgen/gui2/tabs/CharacterSheetInfoTab.java
+++ b/code/src/java/pcgen/gui2/tabs/CharacterSheetInfoTab.java
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
- */
+ **/
 package pcgen.gui2.tabs;
 
 import java.awt.BorderLayout;
@@ -196,7 +196,10 @@ public class CharacterSheetInfoTab extends FlippingSplitPane implements Characte
 		private BoxHandler(CharacterFacade character)
 		{
 			GuiAssertions.assertIsNotJavaFXThread();
-			this.character = Objects.requireNonNull(character);
+			if (character==null) {
+			    System.out.println("Not expecting a null character in CharacterSheetInfoTab BoxHandler");
+            }
+			this.character = character;
 			// This is the model for ComboBox
 			this.sheetBoxItems = FXCollections.observableArrayList();
 			GameMode game = character.getDataSet().getGameMode();
@@ -262,10 +265,10 @@ public class CharacterSheetInfoTab extends FlippingSplitPane implements Characte
 		{
 			GuiAssertions.assertIsJavaFXThread();
 			File outputSheet = sheetBox.getSelectionModel().getSelectedItem();
-			Objects.requireNonNull(outputSheet);
 			csheet.setCharacterSheet(outputSheet);
 			csheet.refresh();
-			character.setPreviewSheet(outputSheet.getName());
+			if (outputSheet!=null)
+    			character.setPreviewSheet(outputSheet.getName());
 		}
 
 	}

--- a/code/src/java/pcgen/gui2/tabs/CharacterSheetInfoTab.java
+++ b/code/src/java/pcgen/gui2/tabs/CharacterSheetInfoTab.java
@@ -24,7 +24,6 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import javax.swing.Box;
@@ -196,7 +195,8 @@ public class CharacterSheetInfoTab extends FlippingSplitPane implements Characte
 		private BoxHandler(CharacterFacade character)
 		{
 			GuiAssertions.assertIsNotJavaFXThread();
-			if (character==null) {
+			if (character==null)
+			{
 			    System.out.println("Not expecting a null character in CharacterSheetInfoTab BoxHandler");
             }
 			this.character = character;
@@ -268,7 +268,9 @@ public class CharacterSheetInfoTab extends FlippingSplitPane implements Characte
 			csheet.setCharacterSheet(outputSheet);
 			csheet.refresh();
 			if (outputSheet!=null)
-    			character.setPreviewSheet(outputSheet.getName());
+			{
+				character.setPreviewSheet(outputSheet.getName());
+			}
 		}
 
 	}

--- a/code/src/java/pcgen/io/FreeMarkerExportHandler.java
+++ b/code/src/java/pcgen/io/FreeMarkerExportHandler.java
@@ -10,7 +10,6 @@ import java.io.IOException;
 import java.io.Writer;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import pcgen.core.GameMode;
 import pcgen.core.PlayerCharacter;
 import pcgen.core.SettingsHandler;
@@ -40,7 +39,8 @@ public class FreeMarkerExportHandler extends ExportHandler
 	public void write(PlayerCharacter aPC, BufferedWriter out) throws ExportException
 	{
 		File tFile = getTemplateFile();
-		if (tFile==null) {
+		if (tFile==null)
+		{
 			Logging.errorPrint("No template file selected - aborting.");
 			return;
 		}

--- a/code/src/java/pcgen/io/FreeMarkerExportHandler.java
+++ b/code/src/java/pcgen/io/FreeMarkerExportHandler.java
@@ -39,7 +39,11 @@ public class FreeMarkerExportHandler extends ExportHandler
 	@Override
 	public void write(PlayerCharacter aPC, BufferedWriter out) throws ExportException
 	{
-		Objects.requireNonNull(getTemplateFile());
+		File tFile = getTemplateFile();
+		if (tFile==null) {
+			Logging.errorPrint("No template file selected - aborting.");
+			return;
+		}
 		FileAccess.setCurrentOutputFilter(getTemplateFile().getName().substring(0, getTemplateFile().getName().length() - 4));
 
 		exportCharacterUsingFreemarker(aPC, out);

--- a/code/src/java/pcgen/system/application/DeadlockDetectorTask.java
+++ b/code/src/java/pcgen/system/application/DeadlockDetectorTask.java
@@ -25,7 +25,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
-;import pcgen.util.Logging;
+import pcgen.util.Logging;
 
 /**
  * The Class {@code DeadlockDetectorTask} reports any deadlocks detected by Java itself.

--- a/code/src/utest/pcgen/base/util/NamedFormulaTest.java
+++ b/code/src/utest/pcgen/base/util/NamedFormulaTest.java
@@ -41,15 +41,6 @@ class NamedFormulaTest
 		{
 			fail("NamedFormula should not fail due to a null constructor");
 		}
-		try
-		{
-			new NamedFormula("Name", null);
-			fail("Expected NamedFormula to reject null argument in constructor");
-		}
-		catch (NullPointerException e)
-		{
-			// OK
-		}
 	}
 
 	@Test

--- a/code/src/utest/pcgen/base/util/NamedFormulaTest.java
+++ b/code/src/utest/pcgen/base/util/NamedFormulaTest.java
@@ -35,12 +35,11 @@ class NamedFormulaTest
 	{
 		try
 		{
-			new NamedFormula(null, FormulaFactory.getFormulaFor("1"));
-			fail("Expected NamedFormula to reject null argument in constructor");
+			NamedFormula a = new NamedFormula(null, FormulaFactory.getFormulaFor("1"));
 		}
 		catch (NullPointerException e)
 		{
-			// OK
+			fail("NamedFormula should not fail due to a null constructor");
 		}
 		try
 		{


### PR DESCRIPTION
Object.requireNonNull throws an NullPointerException, which is very ugly.  There are lots of these in the code base, which is a lazy way of getting out of methods where a null would be problematic.  This prevents the NPEs - especially the one in CharacterSheetInfoTab.