### PR TITLE
cleaned up Globals and changed a few callers to work with the changes

### DIFF
--- a/code/src/java/pcgen/core/Globals.java
+++ b/code/src/java/pcgen/core/Globals.java
@@ -178,11 +178,13 @@ public final class Globals
 		return ret;
 	}
 
-	private static <T extends CDOMObject> boolean isMatch(List<String> typeList, T anObject) {
+	private static <T extends CDOMObject> boolean isMatch(List<String> typeList, T anObject)
+	{
 		for (final String type : typeList)
 		{
 			final boolean sense = (type.charAt(0) != '!');
-			if (anObject.isType(type) != sense) {
+			if (anObject.isType(type) != sense)
+			{
 				return false;
 			}
 		}

--- a/code/src/java/pcgen/core/Globals.java
+++ b/code/src/java/pcgen/core/Globals.java
@@ -30,9 +30,7 @@ import java.util.Map;
 import java.util.StringTokenizer;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
-
 import javax.swing.JFrame;
-
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.base.SortKeyRequired;
 import pcgen.cdom.content.BaseDice;
@@ -75,11 +73,10 @@ public final class Globals
 
 	/** we need maps for efficient lookups */
 	private static final Map<URI, Campaign> CAMPAIGN_MAP = new HashMap<>();
-	private static final Map<String, String> EQ_SLOT_MAP = new HashMap<>();
+	private static final Map<String, Integer> EQ_SLOT_MAP = new HashMap<>();
 
 	// end of filter creation sets
 	private static JFrame rootFrame;
-	private static final StringBuilder SECTION_15 = new StringBuilder(30000);
 
 	/** whether or not the GUI is used (false for command line) */
 	private static boolean useGUI = true;
@@ -129,7 +126,6 @@ public final class Globals
 	 */
 	public static Campaign getCampaignKeyed(final String aKey)
 	{
-
 		final Campaign campaign = getCampaignKeyedSilently(aKey);
 		if (campaign == null)
 		{
@@ -173,27 +169,24 @@ public final class Globals
 
 		for (final T anObject : aPObjectList)
 		{
-			boolean match = false;
-			for (final String type : typeList)
-			{
-				final boolean sense = (type.charAt(0) != '!');
-				if (anObject.isType(type) == sense)
-				{
-					match = true;
-				}
-				else
-				{
-					match = false;
-					break;
-				}
-			}
-			if (match)
+			if (isMatch(typeList, anObject))
 			{
 				ret.add(anObject);
 			}
 		}
 		ret.trimToSize();
 		return ret;
+	}
+
+	private static <T extends CDOMObject> boolean isMatch(List<String> typeList, T anObject) {
+		for (final String type : typeList)
+		{
+			final boolean sense = (type.charAt(0) != '!');
+			if (anObject.isType(type) != sense) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	// END Game Modes Section.
@@ -222,14 +215,13 @@ public final class Globals
 	 */
 	public static String getDefaultSpellBook()
 	{
-		String book = null;
-
-		if (SettingsHandler.getGame() != null)
+		GameMode game = SettingsHandler.getGameAsProperty().get();
+		if (game != null)
 		{
-			book = SettingsHandler.getGame().getDefaultSpellBook();
+			return game.getDefaultSpellBook();
 		}
 
-		return book;
+		return null;
 	}
 
 	/**
@@ -251,7 +243,7 @@ public final class Globals
 	 * @param aString
 	 * @param aNum
 	 */
-	public static void setEquipSlotTypeCount(final String aString, final String aNum)
+	public static void setEquipSlotTypeCount(final String aString, final int aNum)
 	{
 		EQ_SLOT_MAP.put(aString, aNum);
 	}
@@ -265,13 +257,7 @@ public final class Globals
 	 */
 	public static int getEquipSlotTypeCount(final String aType)
 	{
-		final String aNum = EQ_SLOT_MAP.get(aType);
-
-		if (aNum != null)
-		{
-			return Integer.parseInt(aNum);
-		}
-		return 0;
+		return EQ_SLOT_MAP.computeIfAbsent(aType, s -> 0);
 	}
 
 	/**
@@ -280,7 +266,7 @@ public final class Globals
 	 */
 	public static String getGameModePointPoolName()
 	{
-		return SettingsHandler.getGame().getPointPoolName();
+		return SettingsHandler.getGameAsProperty().get().getPointPoolName();
 	}
 
 	/**
@@ -298,18 +284,7 @@ public final class Globals
 	 */
 	public static UnitSet getGameModeUnitSet()
 	{
-		return SettingsHandler.getGame().getUnitSet();
-	}
-
-	/**
-	 * Return TRUE if in a particular game mode
-	 * @param gameMode
-	 * @return TRUE if in a particular game mode
-	 */
-	public static boolean isInGameMode(final String gameMode)
-	{
-		return gameMode.isEmpty()
-			|| ((SettingsHandler.getGame() != null) && gameMode.equalsIgnoreCase(SettingsHandler.getGame().getName()));
+		return SettingsHandler.getGameAsProperty().get().getUnitSet();
 	}
 
 	/**
@@ -327,7 +302,7 @@ public final class Globals
 	 */
 	public static int getPaperCount()
 	{
-		return SettingsHandler.getGame().getModeContext().getReferenceContext()
+		return SettingsHandler.getGameAsProperty().get().getModeContext().getReferenceContext()
 			.getConstructedObjectCount(PaperInfo.class);
 	}
 
@@ -359,7 +334,7 @@ public final class Globals
 
 	private static List<PaperInfo> getSortedPaperInfo()
 	{
-		List<PaperInfo> items = new ArrayList<>(SettingsHandler.getGame().getModeContext().getReferenceContext()
+		List<PaperInfo> items = new ArrayList<>(SettingsHandler.getGameAsProperty().get().getModeContext().getReferenceContext()
 			.getConstructedCDOMObjects(PaperInfo.class));
 		items.sort(Comparator.comparing(SortKeyRequired::getSortKey));
 		return items;
@@ -385,15 +360,6 @@ public final class Globals
 	public static JFrame getRootFrame()
 	{
 		return rootFrame;
-	}
-
-	/**
-	 * Get the section 15
-	 * @return section 15
-	 */
-	public static StringBuilder getSection15()
-	{
-		return SECTION_15;
 	}
 
 	/**
@@ -529,19 +495,12 @@ public final class Globals
 	/**
 	 * Return true if resizing the equipment will have any "noticable" effect
 	 * checks for cost modification, armor bonus, weight, capacity
-	 * @param aEq
 	 * @param typeList
 	 * @return TRUE or FALSE
 	 */
-	public static boolean canResizeHaveEffect(final Equipment aEq, List<String> typeList)
+	public static boolean canResizeHaveEffect(List<String> typeList)
 	{
-		// cycle through typeList and see if it matches one in the BONUS:ITEMCOST|TYPE=etc on sizeadjustment
-		if (typeList == null)
-		{
-			typeList = aEq.typeList();
-		}
-
-		final List<String> resizeTypeList = SettingsHandler.getGame().getResizableTypeList().stream()
+		final List<String> resizeTypeList = SettingsHandler.getGameAsProperty().get().getResizableTypeList().stream()
 			.map(Type::toString).map(String::toUpperCase).collect(Collectors.toList());
 		return typeList.stream().map(String::toUpperCase).anyMatch(resizeTypeList::contains);
 	}
@@ -553,7 +512,7 @@ public final class Globals
 	 */
 	public static boolean checkRule(final String aKey)
 	{
-		final RuleCheck rule = SettingsHandler.getGame().getModeContext().getReferenceContext()
+		final RuleCheck rule = SettingsHandler.getGameAsProperty().get().getModeContext().getReferenceContext()
 			.silentlyGetConstructedCDOMObject(RuleCheck.class, aKey);
 		if (rule == null)
 		{
@@ -667,7 +626,7 @@ public final class Globals
 
 		// Perform other special cleanup
 		Equipment.clearEquipmentTypes();
-		SettingsHandler.getGame().clearLoadContext();
+		SettingsHandler.getGameAsProperty().get().clearLoadContext();
 
 		RaceType.clearConstants();
 		CNAbilityFactory.reset();
@@ -844,7 +803,7 @@ public final class Globals
 
 	static String getBonusFeatString()
 	{
-		final List<String> bonusFeatLevels = SettingsHandler.getGame().getBonusFeatLevels();
+		final List<String> bonusFeatLevels = SettingsHandler.getGameAsProperty().get().getBonusFeatLevels();
 		if ((bonusFeatLevels == null) || bonusFeatLevels.isEmpty())
 		{
 			// Default to no bonus feats.
@@ -857,7 +816,7 @@ public final class Globals
 	{
 		int num = 0;
 
-		for (final String s : SettingsHandler.getGame().getBonusStatLevels())
+		for (final String s : SettingsHandler.getGameAsProperty().get().getBonusStatLevels())
 		{
 			num = bonusParsing(s, level, num, aPC);
 		}
@@ -1027,7 +986,7 @@ public final class Globals
 
 	public static int getSkillMultiplierForLevel(final int level)
 	{
-		final List<String> sml = SettingsHandler.getGame().getSkillMultiplierLevels();
+		final List<String> sml = SettingsHandler.getGameAsProperty().get().getSkillMultiplierLevels();
 
 		if ((level > sml.size()) || (level <= 0))
 		{
@@ -1079,14 +1038,6 @@ public final class Globals
 		}
 
 		return encumberedMove;
-	}
-
-	// Methods
-
-	static void initCustColumnWidth(final List<String> l)
-	{
-		CUST_COLUMN_WIDTH.clear();
-		CUST_COLUMN_WIDTH.addAll(l);
 	}
 
 	/**
@@ -1158,6 +1109,6 @@ public final class Globals
 
 	public static LoadContext getContext()
 	{
-		return SettingsHandler.getGame().getContext();
+		return SettingsHandler.getGameAsProperty().get().getContext();
 	}
 }

--- a/code/src/java/pcgen/core/kit/KitGear.java
+++ b/code/src/java/pcgen/core/kit/KitGear.java
@@ -235,14 +235,14 @@ public final class KitGear extends BaseKit
 			if (theEquipment.isType("Natural") || (sizeToPC != null && sizeToPC)
 				|| (!theEquipment.isWeapon() && !theEquipment.isAmmunition()))
 			{
-				tryResize = Globals.canResizeHaveEffect(theEquipment, null);
+				tryResize = Globals.canResizeHaveEffect(theEquipment.typeList());
 			}
 		}
 		else
 		{
 			if (sizeToPC != null && sizeToPC)
 			{
-				tryResize = Globals.canResizeHaveEffect(theEquipment, null);
+				tryResize = Globals.canResizeHaveEffect(theEquipment.typeList());
 			}
 			else
 			{

--- a/code/src/java/pcgen/gui2/facade/CharacterFacadeImpl.java
+++ b/code/src/java/pcgen/gui2/facade/CharacterFacadeImpl.java
@@ -3251,7 +3251,7 @@ public class CharacterFacadeImpl
 	{
 		final Equipment equip = (Equipment) equipment;
 		final SizeAdjustment newSize = theCharacter.getSizeAdjustment();
-		if (equip.getSizeAdjustment() == newSize || !Globals.canResizeHaveEffect(equip, null))
+		if (equip.getSizeAdjustment() == newSize || !Globals.canResizeHaveEffect(equip.typeList()))
 		{
 			return equipment;
 		}

--- a/code/src/java/pcgen/gui2/facade/EquipmentBuilderFacadeImpl.java
+++ b/code/src/java/pcgen/gui2/facade/EquipmentBuilderFacadeImpl.java
@@ -367,7 +367,7 @@ public class EquipmentBuilderFacadeImpl implements EquipmentBuilderFacade
 	@Override
 	public boolean isResizable()
 	{
-		return Globals.canResizeHaveEffect(equip, equip.typeList());
+		return Globals.canResizeHaveEffect(equip.typeList());
 	}
 
 	@Override

--- a/code/src/java/pcgen/persistence/lst/CampaignLoader.java
+++ b/code/src/java/pcgen/persistence/lst/CampaignLoader.java
@@ -23,10 +23,8 @@ package pcgen.persistence.lst;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
-
 import pcgen.cdom.base.Constants;
 import pcgen.cdom.enumeration.ListKey;
-import pcgen.cdom.enumeration.SourceFormat;
 import pcgen.core.Campaign;
 import pcgen.core.Globals;
 import pcgen.core.prereq.Prerequisite;
@@ -157,19 +155,6 @@ public class CampaignLoader extends LstLineFileLoader
 		{
 			// Check the campaign's prerequisites, generating errors if any are not met but proceeding
 			validatePrereqs(campaign.getPrerequisiteList());
-			List<String> copyright = campaign.getListFor(ListKey.SECTION_15);
-			if (copyright != null)
-			{
-				StringBuilder sec15 = Globals.getSection15();
-				sec15.append("<br><b>Source Material:</b>");
-				sec15.append(SourceFormat.getFormattedString(campaign, SourceFormat.LONG, true));
-				sec15.append("<br>");
-				sec15.append("<b>Section 15 Entry in Source Material:</b><br>");
-				for (String license : copyright)
-				{
-					sec15.append(license).append("<br>");
-				}
-			}
 
 			// Adds this campaign to the Global container.
 			Globals.addCampaign(campaign);

--- a/code/src/java/plugin/lsttokens/eqslot/NumslotsToken.java
+++ b/code/src/java/plugin/lsttokens/eqslot/NumslotsToken.java
@@ -41,7 +41,7 @@ public class NumslotsToken implements EquipSlotLstToken
 				final String aNum = cTok.nextToken();
 				if (!getTokenName().equals(eqSlotType))
 				{
-					Globals.setEquipSlotTypeCount(eqSlotType, aNum);
+					Globals.setEquipSlotTypeCount(eqSlotType, Integer.parseInt(aNum));
 					SystemCollections.addToBodyStructureList(eqSlotType, gameMode);
 				}
 			}

--- a/code/src/test/pcgen/gui2/facade/EquipmentSetFacadeImplTest.java
+++ b/code/src/test/pcgen/gui2/facade/EquipmentSetFacadeImplTest.java
@@ -503,7 +503,7 @@ public class EquipmentSetFacadeImplTest extends AbstractCharacterTestCase
 			equipSlot.setContainNum(1);
 			equipSlot.setSlotNumType("HANDS");
 			SystemCollections.addToEquipSlotsList(equipSlot, SettingsHandler.getGame().getName());
-			Globals.setEquipSlotTypeCount("HANDS", "2");
+			Globals.setEquipSlotTypeCount("HANDS", 2);
 
 			equipSlot = new EquipSlot();
 			equipSlot.setSlotName(SLOT_RING);
@@ -511,7 +511,7 @@ public class EquipmentSetFacadeImplTest extends AbstractCharacterTestCase
 			equipSlot.setContainNum(2);
 			equipSlot.setSlotNumType("BODY");
 			SystemCollections.addToEquipSlotsList(equipSlot, SettingsHandler.getGame().getName());
-			Globals.setEquipSlotTypeCount("BODY", "1");
+			Globals.setEquipSlotTypeCount("BODY", 1);
 		}
 		uiDelegate = new MockUIDelegate();
 		todoManager = new TodoManager();


### PR DESCRIPTION
- removed the deprecated getGame method in favor of the supported version.
- EQ_SLOT_MAP was only every using integers, so now it uses integers
- canResizeHaveEffect was using a list, with a backup list, but the backup list was only ever populated with the firs list
- getSection15 was the only access to the underlying variable, and it's only modified and never queried.