### PR TITLE
Updated jdk/jre version, updated Gradle commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ dist: xenial
 matrix:
   include:
   - os: linux
-    jdk: openjdk11
+    jdk: openjdk13
   allow_failures:
   - os: osx
     osx_image: xcode9

--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,7 @@ repositories {
     mavenCentral()
     ivy {
         url "http://pcgen.sourceforge.net/mvnrepo"
-	allowInsecureProtocol = true
+        allowInsecureProtocol = true
         patternLayout {
             artifact "[organisation]/jars/[artifact]-[revision].[ext]"
         }
@@ -91,7 +91,7 @@ repositories {
     ivy {
         name "fileRepo"
         url 'http://pc-gen.org/librepo/'
-	allowInsecureProtocol = true
+        allowInsecureProtocol = true
     }
     maven {
         url "https://repository.jboss.org/nexus/content/repositories/thirdparty-releases/"
@@ -172,42 +172,42 @@ compileJava {
 }
 
 dependencies {
-    compile group: 'commons-io', name: 'commons-io', version:'2.6'
+    implementation group: 'commons-io', name: 'commons-io', version:'2.6'
 
-    compile group: 'org.springframework', name: 'spring-web', version:'5.2.5.RELEASE'
-    compile group: 'org.springframework', name: 'spring-core', version:'5.2.5.RELEASE'
-    compile group: 'org.springframework', name: 'spring-beans', version:'5.2.5.RELEASE'
-    compile group: 'org.apache.commons', name: 'commons-lang3', version:'3.9'
+    implementation group: 'org.springframework', name: 'spring-web', version:'5.2.5.RELEASE'
+    implementation group: 'org.springframework', name: 'spring-core', version:'5.2.5.RELEASE'
+    implementation group: 'org.springframework', name: 'spring-beans', version:'5.2.5.RELEASE'
+    implementation group: 'org.apache.commons', name: 'commons-lang3', version:'3.9'
     compile group: 'org.apache.xmlgraphics', name: 'fop', version:'2.4'
-    compile group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
-    compile group: 'org.scijava', name: 'jep', version:'2.4.2'
-    compile group: 'org.freemarker', name: 'freemarker', version:'2.3.30'
-    compile group: 'org.jdom', name: 'jdom2', version:'2.0.6'
-    compile group: 'xalan', name: 'xalan', version:'2.7.2'
-    compile group: 'net.sourceforge.argparse4j', name: 'argparse4j', version: '0.8.1'
-    compile group: 'xml-apis', name: 'xml-apis', version:'1.4.01'
-    compile group: 'org.xmlunit', name: 'xmlunit-core', version:'2.6.4'
-    compile group: 'org.controlsfx', name: 'controlsfx', version:'11.0.1'
+    implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
+    implementation group: 'org.scijava', name: 'jep', version:'2.4.2'
+    implementation group: 'org.freemarker', name: 'freemarker', version:'2.3.30'
+    implementation group: 'org.jdom', name: 'jdom2', version:'2.0.6'
+    implementation group: 'xalan', name: 'xalan', version:'2.7.2'
+    implementation group: 'net.sourceforge.argparse4j', name: 'argparse4j', version: '0.8.1'
+    implementation group: 'xml-apis', name: 'xml-apis', version:'1.4.01'
+    implementation group: 'org.xmlunit', name: 'xmlunit-core', version:'2.6.4'
+    implementation group: 'org.controlsfx', name: 'controlsfx', version:'11.0.1'
 
-    compile group: 'net.sourceforge.pcgen', name: 'PCGen-base', version:'1.0.170'
-    compile group: 'net.sourceforge.pcgen', name: 'PCGen-Formula', version:'1.0.200'
+    implementation group: 'net.sourceforge.pcgen', name: 'PCGen-base', version:'1.0.170'
+    implementation group: 'net.sourceforge.pcgen', name: 'PCGen-Formula', version:'1.0.200'
 
     compileOnly group: 'org.jetbrains', name: 'annotations', version:'19.0.0'
     compileOnly group: 'com.yuvimasory', name: 'orange-extensions', version: '1.3.0'
     compileOnly group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: '3.1.12'
 
-    testCompile group: 'org.junit.platform', name: 'junit-platform-runner', version: '1.6.1'
-    testCompile group: 'org.junit.platform', name: 'junit-platform-launcher', version: '1.6.1'
+    testImplementation group: 'org.junit.platform', name: 'junit-platform-runner', version: '1.6.1'
+    testImplementation group: 'org.junit.platform', name: 'junit-platform-launcher', version: '1.6.1'
     testImplementation group: 'org.junit.jupiter', name:  'junit-jupiter-api', version: '5.6.1'
     testImplementation group: 'org.junit.jupiter', name:  'junit-jupiter-params', version: '5.6.1'
     testImplementation group: 'org.junit.jupiter', name:  'junit-jupiter-params', version: '5.6.1'
-    testRuntime group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.6.1'
+    testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.6.1'
     testImplementation group: 'org.hamcrest', name: 'hamcrest', version: '2.2'
     testImplementation group: 'org.testfx', name: 'testfx-junit5', version: '4.0.16-alpha'
     testImplementation group: 'org.testfx', name: 'openjfx-monocle', version: 'jdk-12.0.1+2'
 
 
-    testCompile group: 'org.xmlunit', name: 'xmlunit-matchers', version:'2.6.4'
+    testImplementation group: 'org.xmlunit', name: 'xmlunit-matchers', version:'2.6.4'
 }
 
 ant.importBuild 'build-gradle.xml'
@@ -221,7 +221,7 @@ configure('jar-all-plugins') {
 
 ext {
     classpath = ""
-    configurations.runtime.each { lib -> classpath += " libs/${lib.name} "}
+    configurations.runtimeClasspath.each { lib -> classpath += " libs/${lib.name} "}
 }
 
 jar {

--- a/code/gradle/release.gradle
+++ b/code/gradle/release.gradle
@@ -176,7 +176,7 @@ launch4j {
 }
 
 task downloadJRE doLast {
-    def major = 11
+    def major = 13
     def archs = ['x64','x32']
     def osList = ['windows', 'mac']
     def extension = 'zip'


### PR DESCRIPTION
Updated the openjdk/openjre version used in the build, fixed as many of the deprecated Gradle commands as I can. The remaining `compile` command, `compile group: 'org.apache.xmlgraphics', name: 'fop', version:'2.4'`, causes the build to fail if updated to `implementation` like the rest of the commands.
When Gradle gets to the point of doing the Windows buils using NSIS, it fails due to no files being found in the `nsis\PCGen_60903_opt\plugin\pdf\libs` folder of the build directory.
Why changing the command from `compile` to `implementation` causes the output library jars to not be build into this folder I don't know yet - I'm still learning Gradle/Java so don't know why this happens.

I can only assume it is due to a change within that task setup for Gradle, and try to have a look at it in future if no-one else has a suggestion to fix it.

On the plus side, the rest of this PR can go in now :)

@karianna this is the second of the reworked PRs, and has now found the cause of the build fail on the original PR