### PR TITLE
Update faqsubmittingabugreport.md

### DIFF
--- a/docs/faqpages/faqsubmittingabugreport.md
+++ b/docs/faqpages/faqsubmittingabugreport.md
@@ -1,6 +1,6 @@
 # The JIRA issue tracker
 
-The PCGen project uses a system named `JIRA`, located at [jira.pcgen.org](http://jira.pcgen.org), to track bug reports and feature requests (*issues*).
+The PCGen project uses a system named `JIRA`, located at [pcgenorg.atlassian.net](http://pcgenorg.atlassian.net), to track bug reports and feature requests (*issues*).
 
 This page explains how to submit bug reports or feature requests for the PCGen project.
 


### PR DESCRIPTION
Changed JIRA bug report link from jira.pcgen.org to pcgenorg.atlassian.net as per bug report DOCS-330 on JIRA.  PCgen still uses JIRA however jira.pcgen.org points to a broken page.  The correct link is pcgenorg.atlassian.net which points to the bug reporting page.