### PR TITLE
Implemented Feature where Inputs on a preview sheet tagged with a tar…

### DIFF
--- a/code/src/java/pcgen/core/PlayerCharacter.java
+++ b/code/src/java/pcgen/core/PlayerCharacter.java
@@ -511,6 +511,7 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 			CNAbilityFactory.getCNAbility(AbilityCategory.LANGBONUS, Nature.VIRTUAL, Globals.getContext()
 				.getReferenceContext().getManufacturerId(AbilityCategory.LANGBONUS).getActiveObject("*LANGBONUS"));
 	private final CodeControl controller;
+	private Map<String, String> previewSheetVars = new HashMap<>();
 
 	/**
 	 * Constructor.
@@ -10087,5 +10088,22 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 	public Gender getGenderObject()
 	{
 		return genderFacet.getGender(id);
+	}
+
+
+	public void addPreviewSheetVar(String key, String value)
+	{
+		setDirty(true);
+		previewSheetVars.put(key, value);
+	}
+
+	public String getPreviewSheetVar(String key)
+	{
+		return previewSheetVars.get(key);
+	}
+
+	public Map<String, String> getPreviewSheetVars()
+	{
+		return previewSheetVars;
 	}
 }

--- a/code/src/java/pcgen/facade/core/CharacterFacade.java
+++ b/code/src/java/pcgen/facade/core/CharacterFacade.java
@@ -873,4 +873,8 @@ public interface CharacterFacade extends CompanionFacade
 	 * otherwise.
 	 */
 	public boolean isFeatureEnabled(String feature);
+
+	public String getPreviewSheetVar(String key);
+
+	public void addPreviewSheetVar(String key, String value);
 }

--- a/code/src/java/pcgen/gui2/csheet/CharacterSheetPanel.java
+++ b/code/src/java/pcgen/gui2/csheet/CharacterSheetPanel.java
@@ -51,86 +51,89 @@ import javafx.scene.web.WebView;
  */
 public final class CharacterSheetPanel extends JFXPanel implements CharacterSelectionListener
 {
-	private WebView browser;
-	private CharacterFacade character;
-	private ExportHandler handler;
+    private PreviewVariablesHandler previewVariableHandler = new PreviewVariablesHandler();
+    private WebView browser;
+    private CharacterFacade character;
+    private ExportHandler handler;
 
-	private final Executor executor = Executors.newSingleThreadExecutor();
+    private final Executor executor = Executors.newSingleThreadExecutor();
 
-	public CharacterSheetPanel()
-	{
-		GuiAssertions.assertIsNotJavaFXThread();
-		Platform.runLater(() -> {
-			browser = new WebView();
-			browser.setContextMenuEnabled(true);
-			browser.getEngine().setJavaScriptEnabled(true);
-			this.setScene(new Scene(browser));
-		});
-	}
+    public CharacterSheetPanel()
+    {
+        GuiAssertions.assertIsNotJavaFXThread();
+        Platform.runLater(() -> {
+            browser = new WebView();
+            previewVariableHandler = new PreviewVariablesHandler();
+            browser.setContextMenuEnabled(true);
+            browser.getEngine().setJavaScriptEnabled(true);
+            browser.getEngine().documentProperty().addListener(previewVariableHandler);
+            this.setScene(new Scene(browser));
+        });
+    }
 
-	public void setCharacterSheet(File sheet)
-	{
-		handler = (sheet == null) ? null : ExportHandler.createExportHandler(sheet);
-	}
+    public void setCharacterSheet(File sheet)
+    {
+        handler = (sheet == null) ? null : ExportHandler.createExportHandler(sheet);
+    }
 
-	/**
-	 * TODO: This is pseudo-async and can be strucutured much better.
-	 * TODO: handle progress reporting from the webview
-	 */
-	public void refresh()
-	{
-		executor.execute(() -> {
-			// loading of the output sheet is much faster than in the past (lobo-browser).
-			// do we still really need a statusbar/progress bar?
-			final PCGenStatusBar statusBar = ((PCGenFrame) Globals.getRootFrame()).getStatusBar();
-			SwingUtilities.invokeLater(() ->
-					statusBar.startShowingProgress(LanguageBundle.getString("in_loadingCharacterPreview"), true)
-			);
+    /**
+     * TODO: This is pseudo-async and can be strucutured much better.
+     * TODO: handle progress reporting from the webview
+     */
+    public void refresh()
+    {
+        executor.execute(() -> {
+            // loading of the output sheet is much faster than in the past (lobo-browser).
+            // do we still really need a statusbar/progress bar?
+            final PCGenStatusBar statusBar = ((PCGenFrame) Globals.getRootFrame()).getStatusBar();
+            SwingUtilities.invokeLater(() ->
+                    statusBar.startShowingProgress(LanguageBundle.getString("in_loadingCharacterPreview"), true)
+            );
 
-			String content;
-			if (handler == null || character == null)
-			{
-				Logging.debugPrint("no character found");
-				content = "<html><body>No Character Found.</body></html>";
-			}
-			else
-			{
-				try
-				{
-					StringWriter out = new StringWriter();
-					BufferedWriter buf = new BufferedWriter(out);
-					Logging.debugPrint("ready to export");
-					character.export(handler, buf);
-					Logging.debugPrint("export complete");
-					content = out.toString();
-				}
-				catch (ExportException e)
-				{
-					content = "<html><body>Exception when exporting</body></html>";
-					Logging.errorPrint("failed to export", e);
-				}
-			}
+            String content;
+            if (handler == null || character == null)
+            {
+                Logging.debugPrint("no character found");
+                content = "<html><body>No Character Found.</body></html>";
+            } else
+                {
+                try
+                {
+                    StringWriter out = new StringWriter();
+                    BufferedWriter buf = new BufferedWriter(out);
+                    Logging.debugPrint("ready to export");
+                    character.export(handler, buf);
+                    Logging.debugPrint("export complete");
+                    content = out.toString();
+                }
+                catch (ExportException e)
+                {
+                    content = "<html><body>Exception when exporting</body></html>";
+                    Logging.errorPrint("failed to export", e);
+                }
+            }
 
-			final String finalContent = content;
-			Platform.runLater(() -> {
-				try
-				{
-					Logging.debugPrint("loading character content");
-					browser.getEngine().loadContent(finalContent);
-				}
-				catch (Throwable e)
-				{
-					Logging.errorPrint("Exception in GUI update", e);
-				}
-				SwingUtilities.invokeLater(statusBar::endShowingProgress);
-			});
-		});
-	}
+            final String finalContent = content;
+            Platform.runLater(() -> {
+                try
+                {
+                    Logging.debugPrint("loading character content");
+                    browser.getEngine().loadContent(finalContent);
+                }
+                catch (Throwable e)
+                {
+                    Logging.errorPrint("Exception in GUI update", e);
+                }
+                SwingUtilities.invokeLater(statusBar::endShowingProgress);
+            });
+        });
+    }
 
-	@Override
-	public void setCharacter(CharacterFacade character)
-	{
-		this.character = character;
-		refresh();
-	}
+    @Override
+    public void setCharacter(CharacterFacade character)
+    {
+        this.character = character;
+        previewVariableHandler.setCharacter(character);
+        refresh();
+    }
 }

--- a/code/src/java/pcgen/gui2/csheet/PreviewVariablesHandler.java
+++ b/code/src/java/pcgen/gui2/csheet/PreviewVariablesHandler.java
@@ -1,0 +1,80 @@
+package pcgen.gui2.csheet;
+
+import com.sun.webkit.dom.HTMLInputElementImpl;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+import org.w3c.dom.html.HTMLInputElement;
+import pcgen.facade.core.CharacterFacade;
+
+/**
+ * A {@link ChangeListener} that decorates a new document in context to automatically save inputs tagged with "target_var"
+ */
+public class PreviewVariablesHandler implements ChangeListener<Document>
+{
+    private CharacterFacade character;
+
+    public void setCharacter(CharacterFacade character)
+    {
+        this.character = character;
+    }
+
+    @Override
+    public void changed(ObservableValue<? extends Document> observableValue, Document oldDoc, Document newDoc)
+    {
+        if (newDoc == null)
+        {
+            return;
+        }
+        NodeList elements = newDoc.getElementsByTagName("input");
+        for (int i = 0; i < elements.getLength(); i++)
+        {
+            HTMLInputElementImpl element = (HTMLInputElementImpl) elements.item(i);
+            String key = getInputKey(element);
+            if (key == null || key.isEmpty())
+            {
+                continue;
+            }
+            setInputValue(element, character.getPreviewSheetVar(key));
+            element.addEventListener("change", evt ->
+            {
+                HTMLInputElement input1 = (HTMLInputElement) evt.getCurrentTarget();
+                character.addPreviewSheetVar(getInputKey(input1), getInputValue(input1));
+            }, false);
+        }
+    }
+
+    private boolean isCheckable(HTMLInputElement input)
+    {
+        String type = input.getAttribute("type").toLowerCase();
+        return "checkbox".equals(type) || "radio".equals(type);
+    }
+
+    private String getInputKey(HTMLInputElement input)
+    {
+        return input.getAttribute("target_var");
+    }
+
+    private String getInputValue(HTMLInputElement input)
+    {
+        if (isCheckable(input))
+        {
+            return Boolean.toString(input.getChecked());
+        } else
+        {
+            return input.getValue();
+        }
+    }
+
+    private void setInputValue(HTMLInputElement input, String previewSheetVar)
+    {
+        if (isCheckable(input))
+        {
+            input.setChecked(Boolean.parseBoolean(previewSheetVar));
+        } else
+        {
+            input.setValue(previewSheetVar);
+        }
+    }
+}

--- a/code/src/java/pcgen/gui2/csheet/PreviewVariablesHandler.java
+++ b/code/src/java/pcgen/gui2/csheet/PreviewVariablesHandler.java
@@ -39,8 +39,8 @@ public class PreviewVariablesHandler implements ChangeListener<Document>
             setInputValue(element, character.getPreviewSheetVar(key));
             element.addEventListener("change", evt ->
             {
-                HTMLInputElement input1 = (HTMLInputElement) evt.getCurrentTarget();
-                character.addPreviewSheetVar(getInputKey(input1), getInputValue(input1));
+                HTMLInputElement input = (HTMLInputElement) evt.getCurrentTarget();
+                character.addPreviewSheetVar(getInputKey(input), getInputValue(input));
             }, false);
         }
     }

--- a/code/src/java/pcgen/gui2/facade/CharacterFacadeImpl.java
+++ b/code/src/java/pcgen/gui2/facade/CharacterFacadeImpl.java
@@ -4129,4 +4129,16 @@ public class CharacterFacadeImpl
 	{
 		return theCharacter.isFeatureEnabled(feature);
 	}
+
+	@Override
+	public String getPreviewSheetVar(String key)
+	{
+		return theCharacter.getPreviewSheetVar(key);
+	}
+
+	@Override
+	public void addPreviewSheetVar(final String key, final String value)
+	{
+		theCharacter.addPreviewSheetVar(key, value);
+	}
 }

--- a/code/src/java/pcgen/io/IOConstants.java
+++ b/code/src/java/pcgen/io/IOConstants.java
@@ -454,4 +454,7 @@ interface IOConstants
 
 	/** USERPOOL - The amount the user has modified the pool by. */
 	String TAG_USERPOOL = "USERPOOL";
+
+	/** PREVIEWVAR - preview sheet variable,  allows preview input fields to be maintained*/
+	String TAG_PREVIEWSHEETVAR = "PREVIEWVAR";
 }

--- a/code/src/java/pcgen/io/PCGVer2Creator.java
+++ b/code/src/java/pcgen/io/PCGVer2Creator.java
@@ -471,12 +471,35 @@ public final class PCGVer2Creator
 		appendSuppressBioFieldLines(buffer);
 
 		/*
+		 *
+		 */
+		appendNewline(buffer);
+		appendPreviewSheetVarLines(buffer);
+
+		/*
 		 * Add one more newline at end of file
 		 */
 		appendNewline(buffer);
 
 		// All done!
 		return buffer.toString();
+	}
+
+	private void appendPreviewSheetVarLines(StringBuilder buffer)
+	{
+		for(Map.Entry<String, String> var : thePC.getPreviewSheetVars().entrySet())
+		{
+			if(var.getValue().isEmpty())
+			{
+				continue;
+			}
+			buffer.append(IOConstants.TAG_PREVIEWSHEETVAR)
+					.append(IOConstants.TAG_END)
+					.append(var.getKey())
+					.append(IOConstants.TAG_SEPARATOR)
+					.append(var.getValue())
+					.append(IOConstants.LINE_SEP);
+		}
 	}
 
 	private void appendCampaignLine(StringBuilder buffer)

--- a/code/src/java/pcgen/io/PCGVer2Creator.java
+++ b/code/src/java/pcgen/io/PCGVer2Creator.java
@@ -474,6 +474,7 @@ public final class PCGVer2Creator
 		 * #Preview Sheet Variables
 		 */
 		appendNewline(buffer);
+		appendComment("Preview Sheet Variables", buffer); //$NON-NLS-1$
 		appendPreviewSheetVarLines(buffer);
 
 		/*

--- a/code/src/java/pcgen/io/PCGVer2Creator.java
+++ b/code/src/java/pcgen/io/PCGVer2Creator.java
@@ -471,7 +471,7 @@ public final class PCGVer2Creator
 		appendSuppressBioFieldLines(buffer);
 
 		/*
-		 *
+		 * #Preview Sheet Variables
 		 */
 		appendNewline(buffer);
 		appendPreviewSheetVarLines(buffer);

--- a/code/src/java/pcgen/io/PCGVer2Parser.java
+++ b/code/src/java/pcgen/io/PCGVer2Parser.java
@@ -1363,6 +1363,14 @@ final class PCGVer2Parser implements PCGParser
 			}
 		}
 
+		if(cache.containsKey(IOConstants.TAG_PREVIEWSHEETVAR))
+		{
+			for(final String line : cache.get(IOConstants.TAG_PREVIEWSHEETVAR))
+			{
+				parsePreviewSheetVarLine(line);
+			}
+		}
+
 	}
 
 	/*
@@ -2296,9 +2304,17 @@ final class PCGVer2Parser implements PCGParser
 	private void parsePreviewSheetLine(final String line)
 	{
 		final StringTokenizer stok = new StringTokenizer(line.substring(IOConstants.TAG_PREVIEWSHEET.length() + 1),
-			IOConstants.TAG_END, false);
+				IOConstants.TAG_END, false);
 
 		thePC.setPreviewSheet(stok.nextToken());
+	}
+
+	private void parsePreviewSheetVarLine(final String line)
+	{
+		final String subLine = line.substring(IOConstants.TAG_PREVIEWSHEETVAR.length() + 1);
+		final StringTokenizer stok = new StringTokenizer(subLine, IOConstants.TAG_SEPARATOR, false);
+
+		thePC.addPreviewSheetVar(stok.nextToken(), stok.nextToken());
 	}
 
 	/*

--- a/preview/d20/fantasy/Standard.htm.ftl
+++ b/preview/d20/fantasy/Standard.htm.ftl
@@ -232,7 +232,7 @@ $Date: 2014-06-12 11:36:12 +1000 (Thu, 12 Jun 2014) $
             <font style="font-size:5pt" color="white"><br />Stamina</font></td>
           <td align="center" class="border9"><b>${pcstring('HP')}</b></td>
           <td align="center"><br /></td>
-          <td align="center" class="border9"><input type="text"/></td>
+          <td align="center" class="border9"><input target_var="PC.HP" type="text"/></td>
           <td align="center"><br /></td>
           <td align="center" class="border9"><input type="text"/></td>
           <td align="center"><br /></td>
@@ -281,7 +281,7 @@ ${pcstring('MOVE.${movement}.NAME')}&nbsp;${pcstring('MOVE.${movement}.RATE')}
             <span class="font6" ><br />Hit Points</span></td>
           <td align="center" class="border9"><b>${pcstring('HP')}</b></td>
           <td align="center"><br /></td>
-          <td align="center" class="border9"><input type="text"/></td>
+          <td align="center" class="border9"><input target_var="PC.HP" type="text"/></td>
           <td align="center"><br /></td>
           <td align="center" class="border9"><input type="text"/></td>
           <td align="center"><br /></td>
@@ -914,7 +914,14 @@ ${pcstring('VAR.CMD_Trip.INTVAL')}
     </tr>
     <tr>
      <td align="left" bgcolor="black" class="border" colspan="2"><font style="font-size:8pt" color="white"><b>&nbsp;Ammunition Used<br /></b></font></td>
-     <td align="center" valign="bottom" bgcolor="white" class="border" colspan="5"><font style="font-size: x-small">&#9744;&#9744;&#9744;&#9744;&#9744; &#9744;&#9744;&#9744;&#9744;&#9744; &#9744;&#9744;&#9744;&#9744;&#9744; &#9744;&#9744;&#9744;&#9744;&#9744;</font></td>
+     <td align="center" valign="bottom" bgcolor="white" class="border" colspan="5"><font style="font-size: x-small">
+<@loop from=0 to=3 ; check_prim_iterator , check_prim_iterator_has_next>
+<@loop from=0 to=4 ; check_sec_iterator , check_sec_iterator_has_next>
+      <input target_var="${pcstring('WEAPON.${weap}.NAME')}_ammo_${check_prim_iterator}_${check_sec_iterator}" type="checkbox"/>
+</@loop>
+&nbsp;
+</@loop>
+     </font></td>
     </tr>
     <tr>
      <td align="left" bgcolor="black" class="border" colspan="2"><font style="font-size:8pt" color="white"><b>&nbsp;Special Properties<br /></b></font></td>
@@ -979,7 +986,14 @@ ${pcstring('VAR.CMD_Trip.INTVAL')}
     </tr>
     <tr>
      <td align="left" bgcolor="black" class="border" colspan="2"><font style="font-size:8pt" color="white"><b>&nbsp;Ammunition Used<br /></b></font></td>
-     <td align="center" valign="bottom" bgcolor="white" class="border" colspan="5"><font style="font-size: x-small">&#9744;&#9744;&#9744;&#9744;&#9744; &#9744;&#9744;&#9744;&#9744;&#9744; &#9744;&#9744;&#9744;&#9744;&#9744; &#9744;&#9744;&#9744;&#9744;&#9744;</font></td>
+     <td align="center" valign="bottom" bgcolor="white" class="border" colspan="5"><font style="font-size: x-small">
+<@loop from=0 to=3 ; check_prim_iterator , check_prim_iterator_has_next>
+<@loop from=0 to=4 ; check_sec_iterator , check_sec_iterator_has_next>
+      <input target_var="${pcstring('WEAPON.${weap}.NAME')}_ammo_${check_prim_iterator}_${check_sec_iterator}" type="checkbox"/>
+</@loop>
+&nbsp;
+</@loop>
+     </font></td>
     </tr>
     <tr>
      <td align="left" bgcolor="black" class="border" colspan="2"><font style="font-size:8pt" color="white"><b>&nbsp;Special Properties<br /></b></font></td>
@@ -1016,7 +1030,14 @@ ${pcstring('VAR.CMD_Trip.INTVAL')}
     </tr>
     <tr>
      <td align="left" bgcolor="black" class="border" colspan="2"><font style="font-size:8pt" color="white"><b>&nbsp;Ammunition Used<br /></b></font></td>
-     <td align="center" valign="bottom" bgcolor="white" class="border" colspan="5"><font style="font-size: x-small">&#9744;&#9744;&#9744;&#9744;&#9744; &#9744;&#9744;&#9744;&#9744;&#9744; &#9744;&#9744;&#9744;&#9744;&#9744; &#9744;&#9744;&#9744;&#9744;&#9744;</font></td>
+     <td align="center" valign="bottom" bgcolor="white" class="border" colspan="5"><font style="font-size: x-small">
+<@loop from=0 to=3 ; check_prim_iterator , check_prim_iterator_has_next>
+<@loop from=0 to=4 ; check_sec_iterator , check_sec_iterator_has_next>
+      <input target_var="${pcstring('WEAPON.${weap}.NAME')}_ammo_${check_prim_iterator}_${check_sec_iterator}" type="checkbox"/>
+</@loop>
+&nbsp;
+</@loop>
+     </font></td>
 </@loop>
     </tr>
     <tr>

--- a/preview/d20/fantasy/common/common-spells.ftl
+++ b/preview/d20/fantasy/common/common-spells.ftl
@@ -253,7 +253,7 @@
    <#else>
     <tr>
      <td align="right"><font style="font-size: medium">
-    <@loop from=1 to=pcvar("SPELLMEM.${class}.${spellbook}.${level}.${spell}.TIMES")>&#9744;</@loop></font>
+    <@loop from=1 to=pcvar("SPELLMEM.${class}.${spellbook}.${level}.${spell}.TIMES") ; slot_num , slot_num_has_next><input target_var="${pcstring('SPELLMEM.${class}.${spellbook}.${level}.${spell}.NAME')}_${slot_num}" type="checkbox"/></@loop></font>
      </td>
    </#if>
      <td class="font9"><b>${pcstring('SPELLMEM.${class}.${spellbook}.${level}.${spell}.NAME')}</b> (DC:${pcstring('SPELLMEM.${class}.${spellbook}.${level}.${spell}.DC')})</td>
@@ -307,7 +307,7 @@
 <@loop from=0 to=pcvar('COUNT[SPELLSINBOOK.${class}.${spellbook}.${level}]-1') ; spell , spell_has_next>
     <tr>
      <td align="right"><font style="font-size: medium">
-	  <@loop from=1 to=pcvar("SPELLMEM.${class}.${spellbook}.${level}.${spell}.TIMES")>&#9744;</@loop></font>
+	  <@loop from=1 to=pcvar("SPELLMEM.${class}.${spellbook}.${level}.${spell}.TIMES") ; spell_slot , spell_slot_has_next><input target_var="${pcstring('SPELLBOOKNAME.${spellbook}')}_${pcstring('SPELLMEM.${class}.${spellbook}.${level}.${spell}.NAME')}+${spell_slot}" type="checkbox"/></@loop></font>
      </td>
      <td class="font9"><b>${pcstring('SPELLMEM.${class}.${spellbook}.${level}.${spell}.BONUSSPELL')}${pcstring('SPELLMEM.${class}.${spellbook}.${level}.${spell}.NAME')}</b> (DC:${pcstring('SPELLMEM.${class}.${spellbook}.${level}.${spell}.DC')})</td>
     </tr>


### PR DESCRIPTION
…get_var attribute are persistent between sessions

* only the pathfinder preview sheet currently has functional persistent inputs
* adding `"target_var"="{varname}"` to an input tag makes the tag persistent
* This should not reduce performance as it's tying listeners to input tags on load