### PR TITLE
CODE-3401: Make Weapon Type Abbreviations Type Safe

### DIFF
--- a/code/src/java/pcgen/core/GameMode.java
+++ b/code/src/java/pcgen/core/GameMode.java
@@ -91,7 +91,7 @@ public final class GameMode implements Comparable<Object>
 	private String spellBaseDC = "0";
 	private String spellBaseConcentration = "";
 	private List<Type> weaponCategories = new ArrayList<>();
-	private String weaponTypes = "";
+	private Map<Type, String> weaponTypes = new HashMap<>();
 	private String weaponReachFormula = "";
 	private Map<Integer, Integer> xpAwardsMap = new HashMap<>();
 	private Map<Integer, String> crStepsMap = new HashMap<>();
@@ -629,9 +629,21 @@ public final class GameMode implements Comparable<Object>
 	 * Get the weapon types.
 	 * @return the weapon types
 	 */
-	public String getWeaponTypes()
+	public Set<Type> getWeaponTypes()
 	{
-		return weaponTypes;
+		return Collections.unmodifiableSet(weaponTypes.keySet());
+	}
+
+	/**
+	 * Gets the abbreviation for the given weapon Type.
+	 * 
+	 * @param type
+	 *            The Type
+	 * @return The abbreviation for the given Type
+	 */
+	public String getWeaponTypeAbbrev(Type type)
+	{
+		return weaponTypes.get(type);
 	}
 
 	/**
@@ -772,9 +784,9 @@ public final class GameMode implements Comparable<Object>
 	 * Add a Weapon Type.
 	 * @param aString
 	 */
-	public void addWeaponType(final String aString)
+	public void addWeaponType(Type type, String abbrev)
 	{
-		weaponTypes += ('|' + aString);
+		weaponTypes.put(type, abbrev);
 	}
 
 	/**

--- a/code/src/java/pcgen/io/exporttoken/WeaponToken.java
+++ b/code/src/java/pcgen/io/exporttoken/WeaponToken.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 import pcgen.base.lang.StringUtil;
 import pcgen.cdom.base.Constants;
@@ -42,6 +43,7 @@ import pcgen.cdom.reference.CDOMSingleRef;
 import pcgen.cdom.util.CControl;
 import pcgen.cdom.util.ControlUtilities;
 import pcgen.core.Equipment;
+import pcgen.core.GameMode;
 import pcgen.core.Globals;
 import pcgen.core.PlayerCharacter;
 import pcgen.core.RuleConstants;
@@ -2548,21 +2550,11 @@ public class WeaponToken extends Token
 
 	private static String weaponTypes(Equipment eq, boolean primary)
 	{
-		StringBuilder wt = new StringBuilder(10);
-		StringTokenizer aTok = new StringTokenizer(SettingsHandler.getGameAsProperty().get().getWeaponTypes(), "|", false);
-
-		while (aTok.countTokens() >= 2)
-		{
-			String type = aTok.nextToken();
-			String abbrev = aTok.nextToken();
-
-			if (eq.isType(type, primary))
-			{
-				wt.append(abbrev);
-			}
-		}
-
-		return wt.toString();
+		GameMode game = SettingsHandler.getGameAsProperty().get();
+		return game.getWeaponTypes().stream()
+			.filter(type -> eq.isType(type, primary))
+			.map(type -> game.getWeaponTypeAbbrev(type))
+			.collect(Collectors.joining());
 	}
 
 	/**

--- a/code/src/java/plugin/lsttokens/gamemode/WeapontypeToken.java
+++ b/code/src/java/plugin/lsttokens/gamemode/WeapontypeToken.java
@@ -1,14 +1,18 @@
 package plugin.lsttokens.gamemode;
 
+import java.io.File;
 import java.net.URI;
 
+import pcgen.cdom.enumeration.Type;
 import pcgen.core.GameMode;
 import pcgen.persistence.lst.GameModeLstToken;
+import pcgen.rules.persistence.token.AbstractToken;
+import pcgen.rules.persistence.token.ParseResult;
 
 /**
  * Class deals with SKILLCOST_CLASS Token
  */
-public class WeapontypeToken implements GameModeLstToken
+public class WeapontypeToken extends AbstractToken implements GameModeLstToken
 {
 
 	@Override
@@ -20,7 +24,15 @@ public class WeapontypeToken implements GameModeLstToken
 	@Override
 	public boolean parse(GameMode gameMode, String value, URI source)
 	{
-		gameMode.addWeaponType(value);
+		ParseResult pr = checkForIllegalSeparator('|', value);
+		if (!pr.passed())
+		{
+			pr.printMessages(new File(gameMode.getFolderName()).toURI());
+			return false;
+		}
+		int pipeLoc = value.indexOf('|');
+		Type type = Type.getConstant(value.substring(0, pipeLoc));
+		gameMode.addWeaponType(type, value.substring(pipeLoc + 1));
 		return true;
 	}
 }


### PR DESCRIPTION
In addition to type safety, follows a better pattern of parsing in the input token rather than at runtime
