### PR TITLE
Clean Actor Tests

### DIFF
--- a/code/src/utest/actor/add/AbilityTokenTest.java
+++ b/code/src/utest/actor/add/AbilityTokenTest.java
@@ -19,8 +19,8 @@ package actor.add;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import pcgen.cdom.base.UserSelection;
 import pcgen.cdom.content.CNAbilityFactory;
@@ -76,7 +76,7 @@ public class AbilityTokenTest extends AbstractCharacterUsingTestCase
 	@Test
 	public void testEncodeChoice()
 	{
-		Ability item = construct("ItemName");
+		Ability item = BuildUtilities.buildFeat(context, "ItemName");
 		CNAbilitySelection as = new CNAbilitySelection(CNAbilityFactory
 			.getCNAbility(BuildUtilities.getFeatCat(), Nature.NORMAL, item));
 		assertEquals("CATEGORY=FEAT|NATURE=NORMAL|ItemName", PCA
@@ -86,16 +86,9 @@ public class AbilityTokenTest extends AbstractCharacterUsingTestCase
 	@Test
 	public void testDecodeChoice()
 	{
-		try
-		{
-			PCA.decodeChoice(context, "CATEGORY=FEAT|NATURE=NORMAL|ItemName");
-			fail();
-		}
-		catch (IllegalArgumentException e)
-		{
-			// OK
-		}
-		Ability item = construct("ItemName");
+		assertThrows(IllegalArgumentException.class, () -> PCA
+			.decodeChoice(context, "CATEGORY=FEAT|NATURE=NORMAL|ItemName"));
+		Ability item = BuildUtilities.buildFeat(context, "ItemName");
 		CNAbilitySelection as = new CNAbilitySelection(CNAbilityFactory
 			.getCNAbility(BuildUtilities.getFeatCat(), Nature.NORMAL, item));
 		assertEquals(as, PCA
@@ -112,8 +105,8 @@ public class AbilityTokenTest extends AbstractCharacterUsingTestCase
 		context.getReferenceContext().importObject(BuildUtilities.getFeatCat());
 		TokenRegistration.register(ADD_TOKEN);
 		TokenRegistration.register(ADD_ABILITY_TOKEN);
-		Ability item = construct("ChooseAbility");
-		Ability parent = construct("Parent");
+		Ability item = BuildUtilities.buildFeat(context, "ChooseAbility");
+		Ability parent = BuildUtilities.buildFeat(context, "Parent");
 		context.getReferenceContext().constructCDOMObject(Language.class, "Foo");
 		context.getReferenceContext().constructCDOMObject(Language.class, "Bar");
 		context.getReferenceContext().constructCDOMObject(Language.class, "Goo");
@@ -195,13 +188,5 @@ public class AbilityTokenTest extends AbstractCharacterUsingTestCase
 		assertFalse(PCA.allow(gooCAS, pc, false));
 		assertFalse(PCA.allow(wowCAS, pc, false));
 		assertFalse(PCA.allow(revFFCAS, pc, false));
-	}
-
-	protected Ability construct(String one)
-	{
-		Ability a = BuildUtilities.getFeatCat().newInstance();
-		a.setName(one);
-		context.getReferenceContext().importObject(a);
-		return a;
 	}
 }

--- a/code/src/utest/actor/choose/AbilitySelectionTokenTest.java
+++ b/code/src/utest/actor/choose/AbilitySelectionTokenTest.java
@@ -63,13 +63,13 @@ public class AbilitySelectionTokenTest
 	@Test
 	public void testEncodeChoice()
 	{
-		Ability item = construct("ItemName");
+		Ability item = BuildUtilities.buildFeat(context, "ItemName");
 		AbilitySelection as = new AbilitySelection(item, null);
 		assertEquals("CATEGORY=FEAT|ItemName", PCA.encodeChoice(as));
-		Ability paren = construct("ParenName (test)");
+		Ability paren = BuildUtilities.buildFeat(context, "ParenName (test)");
 		as = new AbilitySelection(paren, null);
 		assertEquals("CATEGORY=FEAT|ParenName (test)", PCA.encodeChoice(as));
-		Ability sel = construct("ChooseName");
+		Ability sel = BuildUtilities.buildFeat(context, "ChooseName");
 		sel.put(ObjectKey.MULTIPLE_ALLOWED, Boolean.TRUE);
 		StringToken st = new plugin.lsttokens.choose.StringToken();
 		ParseResult pr = st.parseToken(Globals.getContext(), sel, "selection|Acrobatics");
@@ -84,13 +84,13 @@ public class AbilitySelectionTokenTest
 	{
 		assertThrows(IllegalArgumentException.class,
 				() -> PCA.decodeChoice(context, "Category=Special Ability|ItemName"));
-		Ability item = construct("ItemName");
+		Ability item = BuildUtilities.buildFeat(context, "ItemName");
 		AbilitySelection as = new AbilitySelection(item, null);
 		assertEquals(as, PCA.decodeChoice(context, "CATEGORY=FEAT|ItemName"));
-		Ability paren = construct("ParenName (test)");
+		Ability paren = BuildUtilities.buildFeat(context, "ParenName (test)");
 		as = new AbilitySelection(paren, null);
 		assertEquals(as, PCA.decodeChoice(context, "CATEGORY=Feat|ParenName (test)"));
-		Ability sel = construct("ChooseName");
+		Ability sel = BuildUtilities.buildFeat(context, "ChooseName");
 		sel.put(ObjectKey.MULTIPLE_ALLOWED, Boolean.TRUE);
 		StringToken st = new plugin.lsttokens.choose.StringToken();
 		ParseResult pr = st.parseToken(Globals.getContext(), sel, "selection|Acrobatics");
@@ -98,13 +98,5 @@ public class AbilitySelectionTokenTest
 		Globals.getContext().commit();
 		as = new AbilitySelection(sel, "selection");
 		assertEquals(as, PCA.decodeChoice(context, "CATEGORY=Feat|ChooseName|selection"));
-	}
-
-	protected Ability construct(String one)
-	{
-		Ability a = BuildUtilities.getFeatCat().newInstance();
-		a.setName(one);
-		context.getReferenceContext().importObject(a);
-		return a;
 	}
 }

--- a/code/src/utest/actor/choose/AbilityTokenTest.java
+++ b/code/src/utest/actor/choose/AbilityTokenTest.java
@@ -57,18 +57,10 @@ public class AbilityTokenTest
 		context = null;
 	}
 
-	private Ability getObject()
-	{
-		Ability a = BuildUtilities.getFeatCat().newInstance();
-		a.setName(ITEM_NAME);
-		context.getReferenceContext().importObject(a);
-		return a;
-	}
-
 	@Test
 	public void testEncodeChoice()
 	{
-		assertEquals(getExpected(), PCA.encodeChoice(getObject()));
+		assertEquals(getExpected(), PCA.encodeChoice(BuildUtilities.buildFeat(context, ITEM_NAME)));
 	}
 
 	protected String getExpected()
@@ -79,15 +71,16 @@ public class AbilityTokenTest
 	@Test
 	public void testDecodeChoice()
 	{
-		assertEquals(getObject(),
+		assertEquals(BuildUtilities.buildFeat(context, ITEM_NAME),
 			PCA.decodeChoice(context, getExpected(), BuildUtilities.getFeatCat()));
 	}
 
 	@Test
 	public void testLegacyDecodeChoice()
 	{
-		assertEquals(getObject(), PCA.decodeChoice(context, "CATEGORY=FEAT|" + ITEM_NAME,
-			BuildUtilities.getFeatCat()));
+		assertEquals(BuildUtilities.buildFeat(context, ITEM_NAME),
+			PCA.decodeChoice(context, "CATEGORY=FEAT|" + ITEM_NAME,
+				BuildUtilities.getFeatCat()));
 	}
 
 }

--- a/code/src/utest/actor/choose/AlignmentTokenTest.java
+++ b/code/src/utest/actor/choose/AlignmentTokenTest.java
@@ -27,12 +27,12 @@ public class AlignmentTokenTest extends
 		AbstractPersistentCDOMChoiceActorTestCase<PCAlignment>
 {
 
-	static AlignmentToken pca = new AlignmentToken();
+	private static final AlignmentToken PCA = new AlignmentToken();
 
 	@Override
 	public Chooser<PCAlignment> getActor()
 	{
-		return pca;
+		return PCA;
 	}
 
 	@Override

--- a/code/src/utest/actor/choose/ArmorProficiencyTokenTest.java
+++ b/code/src/utest/actor/choose/ArmorProficiencyTokenTest.java
@@ -27,12 +27,12 @@ public class ArmorProficiencyTokenTest extends
 		AbstractPersistentCDOMChoiceActorTestCase<ArmorProf>
 {
 
-	static ArmorProficiencyToken pca = new ArmorProficiencyToken();
+	private static final ArmorProficiencyToken PCA = new ArmorProficiencyToken();
 
 	@Override
 	public Chooser<ArmorProf> getActor()
 	{
-		return pca;
+		return PCA;
 	}
 
 	@Override

--- a/code/src/utest/actor/choose/CheckTokenTest.java
+++ b/code/src/utest/actor/choose/CheckTokenTest.java
@@ -27,12 +27,12 @@ public class CheckTokenTest extends
 		AbstractPersistentCDOMChoiceActorTestCase<PCCheck>
 {
 
-	static CheckToken pca = new CheckToken();
+	private static final CheckToken PCA = new CheckToken();
 
 	@Override
 	public Chooser<PCCheck> getActor()
 	{
-		return pca;
+		return PCA;
 	}
 
 	@Override

--- a/code/src/utest/actor/choose/ClassTokenTest.java
+++ b/code/src/utest/actor/choose/ClassTokenTest.java
@@ -27,12 +27,12 @@ public class ClassTokenTest extends
 		AbstractPersistentCDOMChoiceActorTestCase<PCClass>
 {
 
-	static ClassToken pca = new ClassToken();
+	private static final ClassToken PCA = new ClassToken();
 
 	@Override
 	public Chooser<PCClass> getActor()
 	{
-		return pca;
+		return PCA;
 	}
 
 	@Override

--- a/code/src/utest/actor/choose/DeityTokenTest.java
+++ b/code/src/utest/actor/choose/DeityTokenTest.java
@@ -27,12 +27,12 @@ public class DeityTokenTest extends
 		AbstractPersistentCDOMChoiceActorTestCase<Deity>
 {
 
-	static DeityToken pca = new DeityToken();
+	private static final DeityToken PCA = new DeityToken();
 
 	@Override
 	public Chooser<Deity> getActor()
 	{
-		return pca;
+		return PCA;
 	}
 
 	@Override

--- a/code/src/utest/actor/choose/DomainTokenTest.java
+++ b/code/src/utest/actor/choose/DomainTokenTest.java
@@ -27,12 +27,12 @@ public class DomainTokenTest extends
 		AbstractPersistentCDOMChoiceActorTestCase<Domain>
 {
 
-	static DomainToken pca = new DomainToken();
+	private static final DomainToken PCA = new DomainToken();
 
 	@Override
 	public Chooser<Domain> getActor()
 	{
-		return pca;
+		return PCA;
 	}
 
 	@Override

--- a/code/src/utest/actor/choose/EquipmentTokenTest.java
+++ b/code/src/utest/actor/choose/EquipmentTokenTest.java
@@ -27,12 +27,12 @@ public class EquipmentTokenTest extends
 		AbstractPersistentCDOMChoiceActorTestCase<Equipment>
 {
 
-	static EquipmentToken pca = new EquipmentToken();
+	private static final EquipmentToken PCA = new EquipmentToken();
 
 	@Override
 	public Chooser<Equipment> getActor()
 	{
-		return pca;
+		return PCA;
 	}
 
 	@Override

--- a/code/src/utest/actor/choose/LangTokenTest.java
+++ b/code/src/utest/actor/choose/LangTokenTest.java
@@ -27,12 +27,12 @@ public class LangTokenTest extends
 		AbstractPersistentCDOMChoiceActorTestCase<Language>
 {
 
-	static LangToken pca = new LangToken();
+	private static final LangToken PCA = new LangToken();
 
 	@Override
 	public Chooser<Language> getActor()
 	{
-		return pca;
+		return PCA;
 	}
 
 	@Override

--- a/code/src/utest/actor/choose/NoChoiceTokenTest.java
+++ b/code/src/utest/actor/choose/NoChoiceTokenTest.java
@@ -26,12 +26,12 @@ public class NoChoiceTokenTest extends
 		AbstractPersistentChoiceActorTestCase<String>
 {
 
-	static NoChoiceToken pca = new NoChoiceToken();
+	private static final NoChoiceToken PCA = new NoChoiceToken();
 
 	@Override
 	public Chooser<String> getActor()
 	{
-		return pca;
+		return PCA;
 	}
 
 	@Override

--- a/code/src/utest/actor/choose/PCStatTokenTest.java
+++ b/code/src/utest/actor/choose/PCStatTokenTest.java
@@ -27,12 +27,12 @@ public class PCStatTokenTest extends
 		AbstractPersistentCDOMChoiceActorTestCase<PCStat>
 {
 
-	static PCStatToken pca = new PCStatToken();
+	private static final PCStatToken PCA = new PCStatToken();
 
 	@Override
 	public Chooser<PCStat> getActor()
 	{
-		return pca;
+		return PCA;
 	}
 
 	@Override

--- a/code/src/utest/actor/choose/RaceTokenTest.java
+++ b/code/src/utest/actor/choose/RaceTokenTest.java
@@ -27,12 +27,12 @@ public class RaceTokenTest extends
 		AbstractPersistentCDOMChoiceActorTestCase<Race>
 {
 
-	static RaceToken pca = new RaceToken();
+	private static final RaceToken PCA = new RaceToken();
 
 	@Override
 	public Chooser<Race> getActor()
 	{
-		return pca;
+		return PCA;
 	}
 
 	@Override

--- a/code/src/utest/actor/choose/SchoolsTokenTest.java
+++ b/code/src/utest/actor/choose/SchoolsTokenTest.java
@@ -27,7 +27,7 @@ public class SchoolsTokenTest extends
 		AbstractPersistentChoiceActorTestCase<SpellSchool>
 {
 
-	static final SchoolsToken PCA = new SchoolsToken();
+	private static final SchoolsToken PCA = new SchoolsToken();
 
 	@Override
 	public Chooser<SpellSchool> getActor()

--- a/code/src/utest/actor/choose/ShieldProficiencyTokenTest.java
+++ b/code/src/utest/actor/choose/ShieldProficiencyTokenTest.java
@@ -27,12 +27,12 @@ public class ShieldProficiencyTokenTest extends
 		AbstractPersistentCDOMChoiceActorTestCase<ShieldProf>
 {
 
-	static ShieldProficiencyToken pca = new ShieldProficiencyToken();
+	private static final ShieldProficiencyToken PCA = new ShieldProficiencyToken();
 
 	@Override
 	public Chooser<ShieldProf> getActor()
 	{
-		return pca;
+		return PCA;
 	}
 
 	@Override

--- a/code/src/utest/actor/choose/SizeTokenTest.java
+++ b/code/src/utest/actor/choose/SizeTokenTest.java
@@ -27,7 +27,7 @@ public class SizeTokenTest extends
 		AbstractPersistentCDOMChoiceActorTestCase<SizeAdjustment>
 {
 
-	static final SizeToken PCA = new SizeToken();
+	private static final SizeToken PCA = new SizeToken();
 
 	@Override
 	public Chooser<SizeAdjustment> getActor()

--- a/code/src/utest/actor/choose/SkillTokenTest.java
+++ b/code/src/utest/actor/choose/SkillTokenTest.java
@@ -27,12 +27,12 @@ public class SkillTokenTest extends
 		AbstractPersistentCDOMChoiceActorTestCase<Skill>
 {
 
-	static SkillToken pca = new SkillToken();
+	private static final SkillToken PCA = new SkillToken();
 
 	@Override
 	public Chooser<Skill> getActor()
 	{
-		return pca;
+		return PCA;
 	}
 
 	@Override

--- a/code/src/utest/actor/choose/SpellLevelTokenTest.java
+++ b/code/src/utest/actor/choose/SpellLevelTokenTest.java
@@ -28,12 +28,12 @@ public class SpellLevelTokenTest extends
 		AbstractPersistentChoiceActorTestCase<SpellLevel>
 {
 
-	static SpellLevelToken pca = new SpellLevelToken();
+	private static final SpellLevelToken PCA = new SpellLevelToken();
 
 	@Override
 	public Chooser<SpellLevel> getActor()
 	{
-		return pca;
+		return PCA;
 	}
 
 	@Override

--- a/code/src/utest/actor/choose/SpellsTokenTest.java
+++ b/code/src/utest/actor/choose/SpellsTokenTest.java
@@ -27,12 +27,12 @@ public class SpellsTokenTest extends
 		AbstractPersistentCDOMChoiceActorTestCase<Spell>
 {
 
-	static SpellsToken pca = new SpellsToken();
+	private static final SpellsToken PCA = new SpellsToken();
 
 	@Override
 	public Chooser<Spell> getActor()
 	{
-		return pca;
+		return PCA;
 	}
 
 	@Override

--- a/code/src/utest/actor/choose/StringTokenTest.java
+++ b/code/src/utest/actor/choose/StringTokenTest.java
@@ -26,12 +26,12 @@ public class StringTokenTest extends
 		AbstractPersistentChoiceActorTestCase<String>
 {
 
-	static StringToken pca = new StringToken();
+	private static final StringToken PCA = new StringToken();
 
 	@Override
 	public Chooser<String> getActor()
 	{
-		return pca;
+		return PCA;
 	}
 
 	@Override

--- a/code/src/utest/actor/choose/TemplateTokenTest.java
+++ b/code/src/utest/actor/choose/TemplateTokenTest.java
@@ -27,12 +27,12 @@ public class TemplateTokenTest extends
 		AbstractPersistentCDOMChoiceActorTestCase<PCTemplate>
 {
 
-	static TemplateToken pca = new TemplateToken();
+	private static final TemplateToken PCA = new TemplateToken();
 
 	@Override
 	public Chooser<PCTemplate> getActor()
 	{
-		return pca;
+		return PCA;
 	}
 
 	@Override

--- a/code/src/utest/actor/choose/WeaponProficiencyTokenTest.java
+++ b/code/src/utest/actor/choose/WeaponProficiencyTokenTest.java
@@ -27,12 +27,12 @@ public class WeaponProficiencyTokenTest extends
 		AbstractPersistentCDOMChoiceActorTestCase<WeaponProf>
 {
 
-	static WeaponProficiencyToken pca = new WeaponProficiencyToken();
+	private static final WeaponProficiencyToken PCA = new WeaponProficiencyToken();
 
 	@Override
 	public Chooser<WeaponProf> getActor()
 	{
-		return pca;
+		return PCA;
 	}
 
 	@Override


### PR DESCRIPTION
Makes items private static final rather than just static
Cleans up how exceptions are processed (do it correctly with newer JUnit features)
Use BuildUtilities for common methods when possible
