### PR TITLE
Fixed travis builds failing and removes start script work around

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ matrix:
   - os: linux
     jdk: openjdk14
   - os: osx
-    osx_image: xcode11.3
-    jdk: openjdk14
+    osx_image: xcode12
+    if: tag IS present
 
 script: ./gradlew clean build copyToOutput test compileSlowtest datatest pfinttest allReports buildDist buildNsis pcgenRelease
 # Do not use itest, requires release notes

--- a/code/gradle/distribution.gradle
+++ b/code/gradle/distribution.gradle
@@ -119,15 +119,6 @@ installDist.doLast{
     }
 }
 
-//Workaround for https://github.com/gradle/gradle/issues/10387
-startScripts{
-    doLast {
-        windowsScript.text =
-                windowsScript.text
-                .replace("set JAVA_HOME=\"%~dp0..\"", "set JAVA_HOME=\"%~dp0\"")
-    }
-}
-
 [distZip, distTar, installDist]*.dependsOn createExe
 
 task testZip(type: Zip, dependsOn: ['converterJar', 'copyToLibs', \


### PR DESCRIPTION
Removed workaround for StartScripts block fixed in https://github.com/beryx/badass-runtime-plugin/issues/67.

Removed macos from travis build on normal pull request. Will now only run on tag builds for releases. Macos builds randomly seem to fail due to timeout issues or issues with hdiutil. Believe may be related to this jpackage bug https://bugs.openjdk.java.net/browse/JDK-8238781. For release you may need to on travis click restart build on the macos 2 or 3 times if failing before a successful build. (If macos build fails but linux passes, then release should still appear but will be missing mac installers)

Log from failed build with hdiutil:
```
> Task :jpackage

WARNING: Using incubator modules: jdk.incubator.jpackage

WARNING: Using incubator modules: jdk.incubator.jpackage

java.io.IOException: Command [/usr/bin/hdiutil, detach, -force, -quiet, /var/folders/z3/_825pg0s3jvf0hb_q8kzmg5h0000gn/T/jdk.incubator.jpackage14829197364078939684/images/pcgen] exited with 16 code





> Task :jpackage FAILED



FAILURE: Build failed with an exception.



* What went wrong:

Execution failed for task ':jpackage'.

> Process 'command '/Library/Java/JavaVirtualMachines/openjdk-14.0.2.jdk/Contents/Home/bin/jpackage'' finished with non-zero exit value 1



* Try:

Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.



* Get more help at https://help.gradle.org



Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.

Use '--warning-mode all' to show the individual deprecation warnings.

See https://docs.gradle.org/6.4.1/userguide/command_line_interface.html#sec:command_line_warnings



BUILD FAILED in 37m 44s
```