### PR TITLE
Sanitize filenames when creating them from character name

### DIFF
--- a/code/src/java/pcgen/gui2/PCGenFrame.java
+++ b/code/src/java/pcgen/gui2/PCGenFrame.java
@@ -111,6 +111,7 @@ import pcgen.system.Main;
 import pcgen.system.PCGenPropBundle;
 import pcgen.system.PCGenSettings;
 import pcgen.system.PropertyContext;
+import pcgen.util.FileHelper;
 import pcgen.util.Logging;
 import pcgen.util.chooser.ChoiceHandler;
 import pcgen.util.chooser.ChooserFactory;
@@ -939,7 +940,8 @@ public final class PCGenFrame extends JFrame implements UIDelegate
 		File prevFile = file;
 		if (file == null || StringUtils.isEmpty(file.getName()))
 		{
-			file = new File(parentPath, character.getNameRef().get() + Constants.EXTENSION_CHARACTER_FILE);
+			String characterName = FileHelper.sanitizeFilename(character.getNameRef().get());
+			file = new File(parentPath, characterName + Constants.EXTENSION_CHARACTER_FILE);
 		}
 		chooser.setSelectedFile(file);
 

--- a/code/src/java/pcgen/gui2/dialog/ExportDialog.java
+++ b/code/src/java/pcgen/gui2/dialog/ExportDialog.java
@@ -56,6 +56,7 @@ import javax.swing.filechooser.FileFilter;
 import javax.swing.filechooser.FileNameExtensionFilter;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.filefilter.FileFilterUtils;
 import org.apache.commons.io.filefilter.IOFileFilter;
 import org.apache.commons.io.filefilter.SuffixFileFilter;
@@ -78,6 +79,7 @@ import pcgen.system.BatchExporter;
 import pcgen.system.CharacterManager;
 import pcgen.system.ConfigurationSettings;
 import pcgen.system.PCGenSettings;
+import pcgen.util.FileHelper;
 import pcgen.util.Logging;
 
 /**
@@ -354,6 +356,9 @@ public final class ExportDialog extends JDialog implements ActionListener, ListS
 		{
 			path = new File(PCGenSettings.getPcgDir());
 			name = "Entire Party";
+		}
+		if (name != null) {
+			name = FileHelper.sanitizeFilename(name);
 		}
 		if (pdf)
 		{

--- a/code/src/java/pcgen/util/FileHelper.java
+++ b/code/src/java/pcgen/util/FileHelper.java
@@ -117,4 +117,22 @@ public final class FileHelper
 
 		return relative.getAbsolutePath().substring(root.length(), relative.getAbsolutePath().length());
 	}
+
+	/**
+	 * Remove characters which are not allowed by certain OSes and filesystems. The string returned can be used
+	 * as a filename on all OSes which can run pcgen.
+	 *
+	 * The following characters are removed:
+	 * <ul>
+	 *     <li>&lt;, &gt; :, ", \\, |, ?, * because they are
+	 *     <a href="https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions">restricted on Windows</a></li>
+	 *     <li>/ and U+0000 (Unicode NULL) , restricted on Linux, Mac, and Windows</li>
+	 * </ul>
+	 *
+	 * @param invalidCharacterFilename Filename to sanitize
+	 * @return string with invalid characters removed
+	 */
+	public static String sanitizeFilename(String invalidCharacterFilename) {
+		return invalidCharacterFilename.replaceAll("[\u0000\\\\/:*?\"<>|]", "");
+	}
 }

--- a/code/src/java/plugin/pcgtracker/PCGTrackerPlugin.java
+++ b/code/src/java/plugin/pcgtracker/PCGTrackerPlugin.java
@@ -53,6 +53,7 @@ import pcgen.pluginmgr.messages.PlayerCharacterWasLoadedMessage;
 import pcgen.pluginmgr.messages.RequestOpenPlayerCharacterMessage;
 import pcgen.system.LanguageBundle;
 import pcgen.system.PCGenSettings;
+import pcgen.util.FileHelper;
 import pcgen.util.Logging;
 import plugin.pcgtracker.gui.PCGTrackerView;
 
@@ -328,8 +329,9 @@ public class PCGTrackerPlugin implements InteractivePlugin, java.awt.event.Actio
 
 		if (aPCFileName.isEmpty())
 		{
+			String characterName = FileHelper.sanitizeFilename(aPC.getDisplay().getDisplayName());
 			prevFile = new File(PCGenSettings.getPcgDir(),
-				aPC.getDisplay().getDisplayName() + Constants.EXTENSION_CHARACTER_FILE);
+				characterName + Constants.EXTENSION_CHARACTER_FILE);
 			aPCFileName = prevFile.getAbsolutePath();
 			newPC = true;
 		}

--- a/code/src/test/pcgen/util/FileHelperTest.java
+++ b/code/src/test/pcgen/util/FileHelperTest.java
@@ -183,4 +183,12 @@ public class FileHelperTest extends TestCase
 				"D:\\Temp\\bar.txt", path);
 		}
 	}
+
+	@Test
+	public void testFileNameStripsBadCharacters() {
+		final String invalidCharacterFilename = "Baalgor: <the>/a great?\u0000 * \"SNA|KE EYES\" White\\mane.TXT";
+
+		final String output = FileHelper.sanitizeFilename(invalidCharacterFilename);
+		assertEquals("Baalgor thea great  SNAKE EYES Whitemane.TXT", output);
+	}
 }

--- a/code/src/test/pcgen/util/FileHelperTest.java
+++ b/code/src/test/pcgen/util/FileHelperTest.java
@@ -184,7 +184,6 @@ public class FileHelperTest extends TestCase
 		}
 	}
 
-	@Test
 	public void testFileNameStripsBadCharacters() {
 		final String invalidCharacterFilename = "Baalgor: <the>/a great?\u0000 * \"SNA|KE EYES\" White\\mane.TXT";
 


### PR DESCRIPTION
Resolves CODE-3501, which was caused by using characters from a character name which are not allowed in filenames.