### PR TITLE
Psychic Detective archetype missing Detect Evil on spell list

### DIFF
--- a/data/pathfinder/paizo/roleplaying_game/occult_adventures/oa_spells.lst
+++ b/data/pathfinder/paizo/roleplaying_game/occult_adventures/oa_spells.lst
@@ -2155,6 +2155,7 @@ telekinetic projectile.MOD			CLASSES:Psychic Detective=0
 virtue.MOD						CLASSES:Psychic Detective=0
 #Psychic Detective=1|
 Detect Chaos.MOD					CLASSES:Psychic Detective=1
+Detect Evil.MOD					CLASSES:Psychic Detective=1
 Detect Good.MOD					CLASSES:Psychic Detective=1
 Detect Law.MOD					CLASSES:Psychic Detective=1
 Find Traps.MOD					CLASSES:Psychic Detective=1


### PR DESCRIPTION
The Psychic Detective archetype (Occult Adventures) is supposed to have Detect Evil on their spell list, but it was not. Added it to the Psychic Detective spell list.