### PR TITLE
[bugfix] handle opening debug dialog from status bar

### DIFF
--- a/code/src/java/pcgen/gui2/PCGenActionMap.java
+++ b/code/src/java/pcgen/gui2/PCGenActionMap.java
@@ -241,8 +241,6 @@ public final class PCGenActionMap extends ActionMap
 	private static final class DebugAction extends PCGenAction
 	{
 
-		private DebugDialog dialog;
-
 		private DebugAction()
 		{
 			super("mnuToolsLog", LOG_COMMAND, "F10");
@@ -252,13 +250,7 @@ public final class PCGenActionMap extends ActionMap
 		public void actionPerformed(ActionEvent e)
 		{
 			GuiAssertions.assertIsNotJavaFXThread();
-			Platform.runLater(() -> {
-				if (dialog == null)
-				{
-					dialog = new DebugDialog();
-				}
-				dialog.show();
-			});
+			Platform.runLater(DebugDialog::show);
 		}
 
 	}

--- a/code/src/java/pcgen/gui2/PCGenStatusBar.java
+++ b/code/src/java/pcgen/gui2/PCGenStatusBar.java
@@ -34,6 +34,7 @@ import pcgen.gui2.tools.Icons;
 import pcgen.gui2.util.StatusWorker;
 import pcgen.gui3.GuiAssertions;
 import pcgen.gui3.GuiUtility;
+import pcgen.gui3.dialog.DebugDialog;
 import pcgen.system.PCGenTask;
 import pcgen.util.Logging;
 
@@ -77,7 +78,7 @@ public final class PCGenStatusBar extends JPanel
 		//todo: calculate this rather than hard code
 		wrappedButton.setMaximumSize(new Dimension(750, 20000000));
 		add(wrappedButton);
-		loadStatusButton.setOnAction(this::loadStatusLabelAction);
+		loadStatusButton.setOnAction(PCGenStatusBar::loadStatusLabelAction);
 	}
 
 	public void setContextMessage(String message)
@@ -169,7 +170,7 @@ public final class PCGenStatusBar extends JPanel
 	 */
 	public void startShowingProgress(final String msg, boolean indeterminate)
 	{
-		if (!PCGenStatusBar.this.isValid())
+		if (!this.isValid())
 		{
 			// Do nothing if called during startup or shutdown
 			return;
@@ -197,8 +198,8 @@ public final class PCGenStatusBar extends JPanel
 	/**
 	 * Shows the log window when the load status icon is clicked.
 	 */
-	private void loadStatusLabelAction(final ActionEvent actionEvent)
+	private static void loadStatusLabelAction(final ActionEvent actionEvent)
 	{
-		frame.getActionMap().get(PCGenActionMap.LOG_COMMAND).actionPerformed(null);
+		DebugDialog.show();
 	}
 }


### PR DESCRIPTION
Problem

The status bar is javafx but currently tries to open the debug dialog
through a pattern that expects the swing thread. This prevents opening
the dialog via the button (though F10 works as it is on the swing
thread).

Solution

Rejigger the mechanism of opening the debug dialog to be callable at
multiple sites. This also makes the dialog a singleton as there is no
reason for multiple instances to exist.