### PR TITLE
[bugfix] check warnings in warning list

### DIFF
--- a/code/src/test/pcgen/persistence/lst/DataLoadTest.java
+++ b/code/src/test/pcgen/persistence/lst/DataLoadTest.java
@@ -138,7 +138,7 @@ public class DataLoadTest implements PCGenTaskListener
 			StringUtils.join(errorList, ",\n"), () -> "Errors encountered while loading " + sourceSelection
 		);
 		assertEquals("",
-			StringUtils.join(errorList, ",\n"), () -> "Warnings encountered while loading " + sourceSelection
+			StringUtils.join(warningList, ",\n"), () -> "Warnings encountered while loading " + sourceSelection
 		);
 	}
 


### PR DESCRIPTION
Problem / Solution

We want to check both warnings and errors be empty but we accidentally
check errors twice.