### PR TITLE
combat bonus use classlevel instead of "C"

### DIFF
--- a/data/35e/wizards_of_the_coast/rsrd/monsters/rsrd_classes_monsters_specific.lst
+++ b/data/35e/wizards_of_the_coast/rsrd/monsters/rsrd_classes_monsters_specific.lst
@@ -5,7 +5,7 @@ SOURCELONG:Revised (v.3.5) System Reference Document	SOURCESHORT:RSRD	SOURCEWEB:
 #	the CLASS file features (such as spellcasting)
 
 # Class Name	Hit Dice	Type			Max Level	Source Page				Combat bonus		Save bonus										FACT
-CLASS:Planetar	HD:8		TYPE:Monster	MAXLEVEL:42	SOURCEPAGE:MonstersIntro-A	BONUS:COMBAT|BASEAB|C	BONUS:SAVE|BASE.Fortitude,BASE.Reflex,BASE.Will|classlevel()/2+2	FACT:ClassType|Monster
+CLASS:Planetar	HD:8		TYPE:Monster	MAXLEVEL:42	SOURCEPAGE:MonstersIntro-A	BONUS:COMBAT|BASEAB|classlevel()	BONUS:SAVE|BASE.Fortitude,BASE.Reflex,BASE.Will|classlevel()/2+2	FACT:ClassType|Monster
 # Class Name	Required Race			Reg. Race Type
 CLASS:Planetar	PRERACE:1,Angel (Planetar)	PRERACETYPE:Outsider
 # Class Name	Skill Pts/Lvl	Add INT to Skill Points?


### PR DESCRIPTION
an incomplete bonus is used ("C"), changed to classlevel()