### PR TITLE
Moved PreMult-parser/-tester/-writer to the plugin folder

### DIFF
--- a/code/pluginbuild.xml
+++ b/code/pluginbuild.xml
@@ -8,7 +8,7 @@ STANDARD TARGETS
 
 jar-all-plugins - Generate the plugin jar files
 
- 
+
 -->
 
 <project name="pcgen-plugins">
@@ -1752,6 +1752,15 @@ jar-all-plugins - Generate the plugin jar files
 					<include name="plugin/pretokens/parser/PreMoveParser.class" />
 					<include name="plugin/pretokens/test/PreMoveTester.class" />
 					<include name="plugin/pretokens/writer/PreMoveWriter.class" />
+				</patternset>
+			</fileset>
+		</jar>
+		<jar jarfile="${preplugins.dir}/PreToken-PREMULT.jar" manifest="${src.java.dir}/plugin/lsttokens/manifest.mf">
+			<fileset dir="${build.classes.dir}">
+				<patternset>
+					<include name="plugin/pretokens/parser/PreMultParser.class" />
+					<include name="plugin/pretokens/test/PreMultTester.class" />
+					<include name="plugin/pretokens/writer/PreMultWriter.class" />
 				</patternset>
 			</fileset>
 		</jar>
@@ -5210,6 +5219,14 @@ jar-all-plugins - Generate the plugin jar files
 				</patternset>
 			</fileset>
 		</jar>
+		<jar jarfile="${converterplugins.dir}/ConverterPlugin-PREMULT.jar" manifest="${src.java.dir}/plugin/lsttokens/manifest.mf">
+			<fileset dir="${build.classes.dir}">
+				<patternset>
+					<include name="plugin/converter/PreMultConvertPlugin.class" />
+					<include name="plugin/converter/PreMultInvertedConvertPlugin.class" />
+				</patternset>
+			</fileset>
+		</jar>
 		<jar jarfile="${converterplugins.dir}/ConverterPlugin-PRESKILL.jar" manifest="${src.java.dir}/plugin/lsttokens/manifest.mf">
 			<fileset dir="${build.classes.dir}">
 				<patternset>
@@ -6779,7 +6796,7 @@ jar-all-plugins - Generate the plugin jar files
 			</fileset>
 		</jar>
 	</target>
-	
+
 	<target name="jar-modifier-plugins" depends="jar-modifier-bool-plugins, jar-modifier-cdom-plugins, jar-modifier-dice-plugins, jar-modifier-dynamic-plugins, jar-modifier-number-plugins, jar-modifier-orderedpair-plugins, jar-modifier-set-plugins, jar-modifier-string-plugins" description="Build (Link) Lst Modifier Token plugin jar files">
 	</target>
 

--- a/code/src/java/pcgen/core/prereq/PrerequisiteTestFactory.java
+++ b/code/src/java/pcgen/core/prereq/PrerequisiteTestFactory.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import pcgen.system.LanguageBundle;
 import pcgen.system.PluginLoader;
 import pcgen.util.Logging;
+import plugin.pretokens.test.PreMultTester;
 
 public final class PrerequisiteTestFactory implements PluginLoader
 {
@@ -76,7 +77,7 @@ public final class PrerequisiteTestFactory implements PluginLoader
 		PrerequisiteTest test;
 		if (kind == null)
 		{
-			test = new PreMult();
+			test = new PreMultTester();
 		}
 		else
 		{

--- a/code/src/java/pcgen/persistence/lst/output/prereq/PrerequisiteWriterFactory.java
+++ b/code/src/java/pcgen/persistence/lst/output/prereq/PrerequisiteWriterFactory.java
@@ -30,9 +30,10 @@ import java.util.Map;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.system.PluginLoader;
 import pcgen.util.Logging;
+import plugin.pretokens.writer.PreMultWriter;
 
 /**
- * A Factory for PreReq Writing 
+ * A Factory for PreReq Writing
  */
 public final class PrerequisiteWriterFactory implements PluginLoader
 {
@@ -65,7 +66,7 @@ public final class PrerequisiteWriterFactory implements PluginLoader
 		PrerequisiteWriterInterface test;
 		if (kind == null)
 		{
-			test = new PrerequisiteMultWriter();
+			test = new PreMultWriter();
 		}
 		else
 		{
@@ -111,7 +112,7 @@ public final class PrerequisiteWriterFactory implements PluginLoader
 	{
 		return new Class[]{PrerequisiteWriterInterface.class};
 	}
-	
+
 	public static void clear()
 	{
 		if (instance != null)

--- a/code/src/java/pcgen/persistence/lst/prereq/PreParserFactory.java
+++ b/code/src/java/pcgen/persistence/lst/prereq/PreParserFactory.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import pcgen.base.lang.UnreachableError;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteOperator;
 import pcgen.persistence.PersistenceLayerException;
@@ -35,11 +34,10 @@ import pcgen.util.Logging;
 public final class PreParserFactory implements PluginLoader
 {
 	private static PreParserFactory instance = null;
-	private Map<String, PrerequisiteParserInterface> parserLookup = new HashMap<>();
+	private final Map<String, PrerequisiteParserInterface> parserLookup = new HashMap<>();
 
-	private PreParserFactory() throws PersistenceLayerException
+	private PreParserFactory()
 	{
-		register(new PreMultParser());
 	}
 
 	@Override
@@ -188,14 +186,6 @@ public final class PreParserFactory implements PluginLoader
 		if (instance != null)
 		{
 			instance.parserLookup.clear();
-			try
-			{
-				instance.register(new PreMultParser());
-			}
-			catch (PersistenceLayerException e)
-			{
-				throw new UnreachableError("Should be impossible", e);
-			}
 		}
 	}
 }

--- a/code/src/java/pcgen/persistence/lst/prereq/PrerequisiteParserInterface.java
+++ b/code/src/java/pcgen/persistence/lst/prereq/PrerequisiteParserInterface.java
@@ -28,7 +28,7 @@ import pcgen.persistence.PersistenceLayerException;
  * Interface to the Prerequisite parser. Each Prerequisite
  * is parsed by a separate class, each class implements this
  * interface.
- *
+ * <br>
  * Each class implementing this interface will parse 1 or more
  * prerequisite types. Normally if an implementation handles more
  * than 1 type the types will be very similar (i.e. a single
@@ -41,10 +41,10 @@ public interface PrerequisiteParserInterface
 	 * @return An array of Strings each of which defines a type
 	 * of prerequisite that the parser will parse.
 	 */
-	public String[] kindsHandled();
+	String[] kindsHandled();
 
 	/**
-	 * Parses the.
+	 * Parse the prerequisite expression.
 	 *
 	 * @param kind the kind of the prerequisite (less the "PRE" prefix)
 	 * @param formula The body of the prerequisite;
@@ -56,6 +56,6 @@ public interface PrerequisiteParserInterface
 	 * for any reason a PersistenceLayerException will be thrown.
 	 * @throws PersistenceLayerException the persistence layer exception
 	 */
-	public Prerequisite parse(String kind, String formula, boolean invertResult, boolean overrideQualify)
+	Prerequisite parse(String kind, String formula, boolean invertResult, boolean overrideQualify)
 		throws PersistenceLayerException;
 }

--- a/code/src/java/pcgen/rules/persistence/TokenLibrary.java
+++ b/code/src/java/pcgen/rules/persistence/TokenLibrary.java
@@ -40,7 +40,6 @@ import pcgen.cdom.grouping.GroupingDefinition;
 import pcgen.core.PCClass;
 import pcgen.core.bonus.BonusObj;
 import pcgen.persistence.lst.LstToken;
-import pcgen.persistence.lst.prereq.PreMultParser;
 import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 import pcgen.rules.persistence.token.CDOMCompatibilityToken;
 import pcgen.rules.persistence.token.CDOMInterfaceToken;
@@ -108,7 +107,6 @@ public final class TokenLibrary implements PluginLoader
 		TOKEN_FAMILIES.add(TokenFamily.CURRENT);
 		TokenFamily.REV514.clearTokens();
 		TOKEN_FAMILIES.add(TokenFamily.REV514);
-		addToTokenMap(new PreMultParser());
 	}
 
 	private TokenLibrary()

--- a/code/src/java/pcgen/system/LanguageBundle.java
+++ b/code/src/java/pcgen/system/LanguageBundle.java
@@ -27,7 +27,7 @@ import pcgen.util.Logging;
 
 /**
  * {@code LanguageBundle} manages the localisation of the PCGen interface.
- * It provides a set of features to translate il8n keys into text in the 
+ * It provides a set of features to translate i18n keys into text in the
  * language chosen in preferences.
  *
  */
@@ -158,7 +158,7 @@ public final class LanguageBundle
 	 * Allow pretty formatting of multiplier. For example, if d is 0.5d, it 
 	 * returns x 1/2 ( 
 	 * @param d a double value
-	 * @return a formated String
+	 * @return a formatted String
 	 */
 	public static String getPrettyMultiplier(double d)
 	{

--- a/code/src/java/pcgen/system/PCGenPropBundle.java
+++ b/code/src/java/pcgen/system/PCGenPropBundle.java
@@ -192,7 +192,7 @@ public final class PCGenPropBundle
 	{
 		String result = null;
 
-		// Make sure the value is retrievable (no NullPointerExceptions)				
+		// Make sure the value is retrievable (no NullPointerExceptions)
 		if (propName != null)
 		{
 			try
@@ -201,7 +201,8 @@ public final class PCGenPropBundle
 			}
 			catch (MissingResourceException mre)
 			{
-				result = "Missing property " + propName;
+				Logging.errorPrint("Missing property %s", propName, mre);
+				result = (StringUtils.isNotBlank(fallback) ? fallback : "Missing property " + propName);
 			}
 		}
 

--- a/code/src/java/plugin/converter/PreMultConvertPlugin.java
+++ b/code/src/java/plugin/converter/PreMultConvertPlugin.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2009 Tom Parker <thpr@users.sourceforge.net>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+package plugin.converter;
+
+import pcgen.rules.persistence.token.AbstractPreEqualConvertPlugin;
+
+public class PreMultConvertPlugin extends AbstractPreEqualConvertPlugin
+{
+	@Override
+	public String getProcessedToken()
+	{
+		return "MULT";
+	}
+}

--- a/code/src/java/plugin/converter/PreMultInvertedConvertPlugin.java
+++ b/code/src/java/plugin/converter/PreMultInvertedConvertPlugin.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2009 Tom Parker <thpr@users.sourceforge.net>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+package plugin.converter;
+
+import pcgen.rules.persistence.token.AbstractPreEqualConvertPlugin;
+
+public class PreMultInvertedConvertPlugin extends AbstractPreEqualConvertPlugin
+{
+	@Override
+	public String getProcessedToken()
+	{
+		return "!MULT";
+	}
+}

--- a/code/src/java/plugin/pretokens/parser/PreMultParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreMultParser.java
@@ -15,7 +15,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
-package pcgen.persistence.lst.prereq;
+package plugin.pretokens.parser;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,6 +23,9 @@ import java.util.List;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteOperator;
 import pcgen.persistence.PersistenceLayerException;
+import pcgen.persistence.lst.prereq.AbstractPrerequisiteParser;
+import pcgen.persistence.lst.prereq.PreParserFactory;
+import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 import pcgen.util.Logging;
 
 public class PreMultParser extends AbstractPrerequisiteParser implements PrerequisiteParserInterface

--- a/code/src/java/plugin/pretokens/test/PreMultTester.java
+++ b/code/src/java/plugin/pretokens/test/PreMultTester.java
@@ -16,17 +16,23 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
-package pcgen.core.prereq;
+package plugin.pretokens.test;
 
 import pcgen.cdom.base.CDOMObject;
 import pcgen.core.Equipment;
 import pcgen.core.PlayerCharacter;
+import pcgen.core.prereq.AbstractPrerequisiteTest;
+import pcgen.core.prereq.Prerequisite;
+import pcgen.core.prereq.PrerequisiteException;
+import pcgen.core.prereq.PrerequisiteOperator;
+import pcgen.core.prereq.PrerequisiteTest;
+import pcgen.core.prereq.PrerequisiteTestFactory;
 import pcgen.system.LanguageBundle;
 import pcgen.util.Logging;
 
 import org.apache.commons.lang3.StringUtils;
 
-public class PreMult extends AbstractPrerequisiteTest implements PrerequisiteTest
+public class PreMultTester extends AbstractPrerequisiteTest implements PrerequisiteTest
 {
 
 	@Override
@@ -96,7 +102,7 @@ public class PreMult extends AbstractPrerequisiteTest implements PrerequisiteTes
 			else
 			{
 				str.append(delimiter);
-				if (test instanceof PreMult && !delimiter.equals(""))
+				if (test instanceof PreMultTester && !delimiter.equals(""))
 				{
 					str.append("##BR##");
 				}

--- a/code/src/java/plugin/pretokens/writer/PreMultWriter.java
+++ b/code/src/java/plugin/pretokens/writer/PreMultWriter.java
@@ -21,7 +21,7 @@
  *
  *
  */
-package pcgen.persistence.lst.output.prereq;
+package plugin.pretokens.writer;
 
 import java.io.IOException;
 import java.io.Writer;
@@ -29,15 +29,18 @@ import java.io.Writer;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteOperator;
 import pcgen.persistence.PersistenceLayerException;
+import pcgen.persistence.lst.output.prereq.AbstractPrerequisiteWriter;
+import pcgen.persistence.lst.output.prereq.PrerequisiteWriterFactory;
+import pcgen.persistence.lst.output.prereq.PrerequisiteWriterInterface;
 
-public class PrerequisiteMultWriter extends AbstractPrerequisiteWriter implements PrerequisiteWriterInterface
+public class PreMultWriter extends AbstractPrerequisiteWriter implements PrerequisiteWriterInterface
 {
 	private boolean allSkillTot = false;
 
 	@Override
 	public String kindHandled()
 	{
-		return null;
+		return "mult";
 	}
 
 	@Override
@@ -72,8 +75,8 @@ public class PrerequisiteMultWriter extends AbstractPrerequisiteWriter implement
 				subreq = prereq.getPrerequisites().get(0);
 				final PrerequisiteWriterInterface test =
 						PrerequisiteWriterFactory.getInstance().getWriter(subreq.getKind());
-				if ((test != null) && (test instanceof AbstractPrerequisiteWriter)
-					&& ((AbstractPrerequisiteWriter) test).specialCase(writer, prereq))
+				if ((test instanceof AbstractPrerequisiteWriter)
+						&& ((AbstractPrerequisiteWriter) test).specialCase(writer, prereq))
 				{
 					return;
 				}
@@ -169,10 +172,10 @@ public class PrerequisiteMultWriter extends AbstractPrerequisiteWriter implement
 
 
 	/**
-	 * Identify if this is a PREABILITY which has been converted into a PREMULT 
+	 * Identify if this is a PREABILITY which has been converted into a PREMULT
 	 * to include a negated check, i.e. ensure a particular ability is not
 	 * present in the character.
-	 *   
+	 *
 	 * @param prereq The PREMULT to be checked.
 	 * @return true if this is a negated PREABILITY, false if not.
 	 */
@@ -198,9 +201,9 @@ public class PrerequisiteMultWriter extends AbstractPrerequisiteWriter implement
 	}
 
 	/**
-	 * Restore the format of a prereq such as 
+	 * Restore the format of a prereq such as
 	 * PREABILITY:1,CATEGORY=FEAT,[Surprise Strike]
-	 * 
+	 *
 	 * @param writer The output destination writer.
 	 * @param prereq The prereq to be written, must be a negated PREABILITY
 	 * @throws IOException If the output cannot be written.

--- a/code/src/test/pcgen/core/prereq/PreClassTest.java
+++ b/code/src/test/pcgen/core/prereq/PreClassTest.java
@@ -509,7 +509,7 @@ public class PreClassTest extends AbstractCharacterTestCase
 	}
 
 	@Test
-	public void testOldPreClassLevelMax() throws Exception
+	public void testOldPreClassLevelMax()
 	{
 		final PreClassLevelMaxParser parser = new PreClassLevelMaxParser();
 		try

--- a/code/src/test/pcgen/core/prereq/PreMultTest.java
+++ b/code/src/test/pcgen/core/prereq/PreMultTest.java
@@ -42,6 +42,7 @@ import plugin.pretokens.parser.PreSkillParser;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import plugin.pretokens.test.PreMultTester;
 
 /**
  * {@code PreMultTest} tests that the PreMult class
@@ -118,7 +119,7 @@ public class PreMultTest extends AbstractCharacterTestCase
 				producer.parse("CLASS",
 					"1,SPELLCASTER.Arcane,SPELLCASTER.Arcane=2", false, false);
 
-		final PreMult test = new PreMult();
+		final PreMultTester test = new PreMultTester();
 		final int passes = test.passes(prereq, character, null);
 		assertEquals(1, passes);
 	}
@@ -178,7 +179,7 @@ public class PreMultTest extends AbstractCharacterTestCase
 				producer.parse("FEAT", "3,TYPE=Metamagic,TYPE=ItemCreation",
 					false, false);
 
-		final PreMult test = new PreMult();
+		final PreMultTester test = new PreMultTester();
 		int passes = test.passes(prereq, character, null);
 		assertEquals(0, passes, "No feats should not pass");
 

--- a/code/src/test/pcgen/persistence/lst/prereq/PreMultParserTest.java
+++ b/code/src/test/pcgen/persistence/lst/prereq/PreMultParserTest.java
@@ -28,6 +28,7 @@ import pcgen.util.TestHelper;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import plugin.pretokens.parser.PreMultParser;
 
 /*** Test
 	 * [PREARMORPROF:1,TYPE.Medium],[PREFEAT:1,Armor Proficiency (Medium)]

--- a/code/src/utest/plugin/lsttokens/testsupport/AbstractTokenTestCase.java
+++ b/code/src/utest/plugin/lsttokens/testsupport/AbstractTokenTestCase.java
@@ -50,6 +50,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import plugin.pretokens.parser.PreMultParser;
 import util.FormatSupport;
 import util.TestURI;
 
@@ -73,14 +74,16 @@ public abstract class AbstractTokenTestCase<T extends Loadable>
 	public void setUp() throws PersistenceLayerException, URISyntaxException
 	{
 		TokenRegistration.clearTokens();
+		TokenRegistration.register(new PreMultParser()); // Used in several nested test cases
 		TokenRegistration.register(getToken());
 		resetContext();
 		expectedPrimaryMessageCount = 0;
 	}
 
 	@AfterEach
-	void tearDown() throws Exception
+	void tearDown()
 	{
+		TokenRegistration.clearTokens();
 		primaryContext = null;
 		secondaryContext = null;
 		primaryProf = null;
@@ -159,7 +162,6 @@ public abstract class AbstractTokenTestCase<T extends Loadable>
 		// Ensure the objects are the same
 		isCDOMEqual(primaryProf, secondaryProf);
 		validateUnparse(unparsed);
-		
 	}
 
 	void validateUnparse(String... unparsed)

--- a/code/src/utest/plugin/pretokens/AbstractPreRoundRobin.java
+++ b/code/src/utest/plugin/pretokens/AbstractPreRoundRobin.java
@@ -37,6 +37,7 @@ import pcgen.util.Logging;
 import plugin.lsttokens.testsupport.TokenRegistration;
 
 import org.junit.jupiter.api.BeforeEach;
+import plugin.pretokens.parser.PreMultParser;
 
 public abstract class AbstractPreRoundRobin
 {
@@ -44,6 +45,7 @@ public abstract class AbstractPreRoundRobin
 	void setUp() throws Exception
 	{
 		TokenRegistration.clearTokens();
+		TokenRegistration.register(new PreMultParser()); // Used in many nested tests
 	}
 
 	public final void runRoundRobin(String s)


### PR DESCRIPTION
Corrected failed tests, because they assumed that PREMULT tag is always active. When you run tests individually (e.g. failed ones, there is a chance that PREMULT is not available).
Some minor improvements were suggested by IntelliJ IDEA.
Some typos were fixed.