### PR TITLE
Fixes CODE-3526

### DIFF
--- a/code/src/resources/pcgen/lang/LanguageBundle.properties
+++ b/code/src/resources/pcgen/lang/LanguageBundle.properties
@@ -166,7 +166,7 @@ in_ok=_OK
 
 in_mn_ok=O
 
-in_cancel=_Cancel
+in_cancel=Cancel
 
 in_cancelTip=Cancel this action
 

--- a/code/src/testResources/pcgen/lang/cleaned.properties
+++ b/code/src/testResources/pcgen/lang/cleaned.properties
@@ -148,7 +148,7 @@ in_select=Select
 
 in_ok=_OK
 
-in_cancel=_Cancel
+in_cancel=Cancel
 
 in_apply=_Apply
 


### PR DESCRIPTION
 https://pcgenorg.atlassian.net/browse/CODE-3526
"Typo in cancel dialog button, there's a _ before Cancel in every dialog that has that cancel button".