### PR TITLE
Updated expected templates (csheet files)

### DIFF
--- a/code/testsuite/csheets/35e_Bard.xml
+++ b/code/testsuite/csheets/35e_Bard.xml
@@ -883,7 +883,7 @@ BIO
 			<critical>20/x2</critical>
 			<!-- Should be changed to a variable due to improved crit -->
 		</unarmed>
-		
+
 	</weapons>
 	<!--
 	  ====================================

--- a/code/testsuite/csheets/35e_Bob.xml
+++ b/code/testsuite/csheets/35e_Bob.xml
@@ -929,7 +929,7 @@ BIO
 			<critical>20/x2</critical>
 			<!-- Should be changed to a variable due to improved crit -->
 		</unarmed>
-		
+
 		<weapon>
 			<common>
 				<name>
@@ -946,13 +946,19 @@ BIO
 					<magic_hit>+0</magic_hit>
 					<total_hit>+16/+11/+6</total_hit>
 				</to_hit>
-				<feat></feat>
+				<feat>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</feat>
 				<hand>Both</hand>
 				<num_attacks>3</num_attacks>
 				<reach>5</reach>
 				<size>M</size>
 				<special_properties></special_properties>
-				<template></template>
+				<template>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</template>
 				<type></type>
 				<weight>0</weight>
 				<sequence>0</sequence>

--- a/code/testsuite/csheets/35e_Charlie.xml
+++ b/code/testsuite/csheets/35e_Charlie.xml
@@ -908,7 +908,7 @@ BIO
 			<critical>20/x2</critical>
 			<!-- Should be changed to a variable due to improved crit -->
 		</unarmed>
-		
+
 		<weapon>
 			<common>
 				<name>
@@ -925,13 +925,19 @@ BIO
 					<magic_hit>+0</magic_hit>
 					<total_hit>+5</total_hit>
 				</to_hit>
-				<feat></feat>
+				<feat>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</feat>
 				<hand>Primary</hand>
 				<num_attacks>1</num_attacks>
 				<reach>5</reach>
 				<size>M</size>
 				<special_properties></special_properties>
-				<template></template>
+				<template>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</template>
 				<type></type>
 				<weight>0</weight>
 				<sequence>0</sequence>

--- a/code/testsuite/csheets/35e_CloudGiantHalfDragon.xml
+++ b/code/testsuite/csheets/35e_CloudGiantHalfDragon.xml
@@ -977,7 +977,7 @@ BIO
 			<critical>20/x2</critical>
 			<!-- Should be changed to a variable due to improved crit -->
 		</unarmed>
-		
+
 		<weapon>
 			<common>
 				<name>
@@ -994,13 +994,19 @@ BIO
 					<magic_hit>+0</magic_hit>
 					<total_hit>+30/+30</total_hit>
 				</to_hit>
-				<feat></feat>
+				<feat>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</feat>
 				<hand>Primary</hand>
 				<num_attacks>2</num_attacks>
 				<reach>15</reach>
 				<size>H</size>
 				<special_properties></special_properties>
-				<template></template>
+				<template>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</template>
 				<type>PS</type>
 				<weight>0</weight>
 				<sequence>0</sequence>
@@ -1027,13 +1033,19 @@ BIO
 					<magic_hit>+0</magic_hit>
 					<total_hit>+30/+30</total_hit>
 				</to_hit>
-				<feat></feat>
+				<feat>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</feat>
 				<hand>Carried</hand>
 				<num_attacks>2</num_attacks>
 				<reach>15</reach>
 				<size>H</size>
 				<special_properties></special_properties>
-				<template></template>
+				<template>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</template>
 				<type>B</type>
 				<weight>0</weight>
 				<sequence>1</sequence>
@@ -1060,13 +1072,19 @@ BIO
 					<magic_hit>+0</magic_hit>
 					<total_hit>+25</total_hit>
 				</to_hit>
-				<feat></feat>
+				<feat>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</feat>
 				<hand>Off-hand</hand>
 				<num_attacks>1</num_attacks>
 				<reach>15</reach>
 				<size>H</size>
 				<special_properties></special_properties>
-				<template></template>
+				<template>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</template>
 				<type>BPS</type>
 				<weight>0</weight>
 				<sequence>2</sequence>
@@ -1093,13 +1111,19 @@ BIO
 					<magic_hit>+0</magic_hit>
 					<total_hit>+25</total_hit>
 				</to_hit>
-				<feat></feat>
+				<feat>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</feat>
 				<hand>Off-hand</hand>
 				<num_attacks>1</num_attacks>
 				<reach>15</reach>
 				<size>H</size>
 				<special_properties></special_properties>
-				<template></template>
+				<template>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</template>
 				<type>PS</type>
 				<weight>0</weight>
 				<sequence>3</sequence>

--- a/code/testsuite/csheets/35e_Dave.xml
+++ b/code/testsuite/csheets/35e_Dave.xml
@@ -884,7 +884,7 @@ BIO
 			<critical>20/x2</critical>
 			<!-- Should be changed to a variable due to improved crit -->
 		</unarmed>
-		
+
 	</weapons>
 	<!--
 	  ====================================

--- a/code/testsuite/csheets/35e_Eve.xml
+++ b/code/testsuite/csheets/35e_Eve.xml
@@ -884,7 +884,7 @@ BIO
 			<critical>20/x2</critical>
 			<!-- Should be changed to a variable due to improved crit -->
 		</unarmed>
-		
+
 	</weapons>
 	<!--
 	  ====================================

--- a/code/testsuite/csheets/35e_Fran.xml
+++ b/code/testsuite/csheets/35e_Fran.xml
@@ -891,7 +891,7 @@ BIO
 			<critical>20/x2</critical>
 			<!-- Should be changed to a variable due to improved crit -->
 		</unarmed>
-		
+
 		<weapon>
 			<common>
 				<name>
@@ -908,13 +908,19 @@ BIO
 					<magic_hit>+0</magic_hit>
 					<total_hit>+2/+2/+2/+2/+2/+2</total_hit>
 				</to_hit>
-				<feat></feat>
+				<feat>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</feat>
 				<hand>Primary</hand>
 				<num_attacks>6</num_attacks>
 				<reach>5</reach>
 				<size>M</size>
 				<special_properties></special_properties>
-				<template></template>
+				<template>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</template>
 				<type>BPS</type>
 				<weight>0</weight>
 				<sequence>0</sequence>

--- a/code/testsuite/csheets/35e_Gordon.xml
+++ b/code/testsuite/csheets/35e_Gordon.xml
@@ -858,7 +858,7 @@ BIO
 			<critical>20/x2</critical>
 			<!-- Should be changed to a variable due to improved crit -->
 		</unarmed>
-		
+
 	</weapons>
 	<!--
 	  ====================================

--- a/code/testsuite/csheets/35e_Harold.xml
+++ b/code/testsuite/csheets/35e_Harold.xml
@@ -881,7 +881,7 @@ BIO
 			<critical>20/x2</critical>
 			<!-- Should be changed to a variable due to improved crit -->
 		</unarmed>
-		
+
 	</weapons>
 	<!--
 	  ====================================

--- a/code/testsuite/csheets/35e_Ivan.xml
+++ b/code/testsuite/csheets/35e_Ivan.xml
@@ -872,7 +872,7 @@ BIO
 			<critical>20/x2</critical>
 			<!-- Should be changed to a variable due to improved crit -->
 		</unarmed>
-		
+
 	</weapons>
 	<!--
 	  ====================================

--- a/code/testsuite/csheets/35e_Jango.xml
+++ b/code/testsuite/csheets/35e_Jango.xml
@@ -919,7 +919,7 @@ BIO
 			<critical>20/x2</critical>
 			<!-- Should be changed to a variable due to improved crit -->
 		</unarmed>
-		
+
 	</weapons>
 	<!--
 	  ====================================

--- a/code/testsuite/csheets/35e_JimDop.xml
+++ b/code/testsuite/csheets/35e_JimDop.xml
@@ -920,7 +920,7 @@ BIO
 			<critical>20/x2</critical>
 			<!-- Should be changed to a variable due to improved crit -->
 		</unarmed>
-		
+
 		<weapon>
 			<common>
 				<name>
@@ -937,13 +937,19 @@ BIO
 					<magic_hit>+0</magic_hit>
 					<total_hit>+15/+15</total_hit>
 				</to_hit>
-				<feat></feat>
+				<feat>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</feat>
 				<hand>Carried</hand>
 				<num_attacks>2</num_attacks>
 				<reach>5</reach>
 				<size>M</size>
 				<special_properties></special_properties>
-				<template></template>
+				<template>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</template>
 				<type>PS</type>
 				<weight>0</weight>
 				<sequence>0</sequence>
@@ -970,13 +976,19 @@ BIO
 					<magic_hit>+0</magic_hit>
 					<total_hit>+15</total_hit>
 				</to_hit>
-				<feat></feat>
+				<feat>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</feat>
 				<hand>Primary</hand>
 				<num_attacks>1</num_attacks>
 				<reach>5</reach>
 				<size>M</size>
 				<special_properties></special_properties>
-				<template></template>
+				<template>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</template>
 				<type>B</type>
 				<weight>0</weight>
 				<sequence>1</sequence>
@@ -1003,13 +1015,19 @@ BIO
 					<magic_hit>+0</magic_hit>
 					<total_hit>+10</total_hit>
 				</to_hit>
-				<feat></feat>
+				<feat>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</feat>
 				<hand>Off-hand</hand>
 				<num_attacks>1</num_attacks>
 				<reach>5</reach>
 				<size>M</size>
 				<special_properties></special_properties>
-				<template></template>
+				<template>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</template>
 				<type>BPS</type>
 				<weight>0</weight>
 				<sequence>2</sequence>
@@ -1036,13 +1054,19 @@ BIO
 					<magic_hit>+0</magic_hit>
 					<total_hit>+10</total_hit>
 				</to_hit>
-				<feat></feat>
+				<feat>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</feat>
 				<hand>Off-hand</hand>
 				<num_attacks>1</num_attacks>
 				<reach>5</reach>
 				<size>M</size>
 				<special_properties></special_properties>
-				<template></template>
+				<template>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</template>
 				<type>PS</type>
 				<weight>0</weight>
 				<sequence>3</sequence>

--- a/code/testsuite/csheets/35e_Lauren.xml
+++ b/code/testsuite/csheets/35e_Lauren.xml
@@ -860,7 +860,7 @@ BIO
 			<critical>20/x2</critical>
 			<!-- Should be changed to a variable due to improved crit -->
 		</unarmed>
-		
+
 	</weapons>
 	<!--
 	  ====================================

--- a/code/testsuite/csheets/35e_Mallory.xml
+++ b/code/testsuite/csheets/35e_Mallory.xml
@@ -913,7 +913,7 @@ BIO
 			<critical>20/x2</critical>
 			<!-- Should be changed to a variable due to improved crit -->
 		</unarmed>
-		
+
 	</weapons>
 	<!--
 	  ====================================

--- a/code/testsuite/csheets/35e_Q-PsiCrystal.xml
+++ b/code/testsuite/csheets/35e_Q-PsiCrystal.xml
@@ -846,7 +846,7 @@ BIO
 			<critical>20/x2</critical>
 			<!-- Should be changed to a variable due to improved crit -->
 		</unarmed>
-		
+
 	</weapons>
 	<!--
 	  ====================================

--- a/code/testsuite/csheets/35e_Quasvin.xml
+++ b/code/testsuite/csheets/35e_Quasvin.xml
@@ -885,7 +885,7 @@ BIO
 			<critical>20/x2</critical>
 			<!-- Should be changed to a variable due to improved crit -->
 		</unarmed>
-		
+
 		<weapon>
 			<common>
 				<name>
@@ -902,13 +902,19 @@ BIO
 					<magic_hit>+0</magic_hit>
 					<total_hit>+2</total_hit>
 				</to_hit>
-				<feat></feat>
+				<feat>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</feat>
 				<hand>Primary</hand>
 				<num_attacks>1</num_attacks>
 				<reach>5</reach>
 				<size>M</size>
 				<special_properties></special_properties>
-				<template></template>
+				<template>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</template>
 				<type>P</type>
 				<weight>0</weight>
 				<sequence>0</sequence>

--- a/code/testsuite/csheets/3e_BarJack.xml
+++ b/code/testsuite/csheets/3e_BarJack.xml
@@ -894,7 +894,7 @@ BIO
 			<critical>20/x2</critical>
 			<!-- Should be changed to a variable due to improved crit -->
 		</unarmed>
-		
+
 		<weapon>
 			<common>
 				<name>
@@ -911,13 +911,19 @@ BIO
 					<magic_hit>+0</magic_hit>
 					<total_hit>+3</total_hit>
 				</to_hit>
-				<feat></feat>
+				<feat>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</feat>
 				<hand>Two-Weapons</hand>
 				<num_attacks>1</num_attacks>
 				<reach>5</reach>
 				<size>T</size>
 				<special_properties></special_properties>
-				<template></template>
+				<template>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</template>
 				<type>P</type>
 				<weight>0</weight>
 				<sequence>0</sequence>

--- a/code/testsuite/csheets/3e_BrdJoe.xml
+++ b/code/testsuite/csheets/3e_BrdJoe.xml
@@ -914,7 +914,7 @@ BIO
 			<critical>20/x2</critical>
 			<!-- Should be changed to a variable due to improved crit -->
 		</unarmed>
-		
+
 	</weapons>
 	<!--
 	  ====================================

--- a/code/testsuite/csheets/3e_CleElf.xml
+++ b/code/testsuite/csheets/3e_CleElf.xml
@@ -916,7 +916,7 @@ BIO
 			<critical>20/x2</critical>
 			<!-- Should be changed to a variable due to improved crit -->
 		</unarmed>
-		
+
 		<weapon>
 			<common>
 				<name>
@@ -933,13 +933,19 @@ BIO
 					<magic_hit>+0</magic_hit>
 					<total_hit>+1</total_hit>
 				</to_hit>
-				<feat></feat>
+				<feat>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</feat>
 				<hand>Primary</hand>
 				<num_attacks>1</num_attacks>
 				<reach>5</reach>
 				<size>M</size>
 				<special_properties></special_properties>
-				<template></template>
+				<template>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</template>
 				<type>B</type>
 				<weight>0</weight>
 				<sequence>0</sequence>
@@ -1020,13 +1026,19 @@ BIO
 					<magic_hit>+0</magic_hit>
 					<total_hit>-3</total_hit>
 				</to_hit>
-				<feat></feat>
+				<feat>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</feat>
 				<hand>Carried</hand>
 				<num_attacks>1</num_attacks>
 				<reach>5</reach>
 				<size>S</size>
 				<special_properties></special_properties>
-				<template></template>
+				<template>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</template>
 				<type>S</type>
 				<weight>5</weight>
 				<sequence>2</sequence>

--- a/code/testsuite/csheets/3e_FigFae.xml
+++ b/code/testsuite/csheets/3e_FigFae.xml
@@ -876,7 +876,7 @@ BIO
 			<critical>20/x2</critical>
 			<!-- Should be changed to a variable due to improved crit -->
 		</unarmed>
-		
+
 		<weapon>
 			<common>
 				<name>
@@ -893,13 +893,19 @@ BIO
 					<magic_hit>+0</magic_hit>
 					<total_hit>+3</total_hit>
 				</to_hit>
-				<feat></feat>
+				<feat>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</feat>
 				<hand>Two-Weapons</hand>
 				<num_attacks>1</num_attacks>
 				<reach>5</reach>
 				<size>M</size>
 				<special_properties></special_properties>
-				<template></template>
+				<template>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</template>
 				<type>P</type>
 				<weight>3</weight>
 				<sequence>0</sequence>

--- a/code/testsuite/csheets/3e_MonKee.xml
+++ b/code/testsuite/csheets/3e_MonKee.xml
@@ -915,7 +915,7 @@ BIO
 			<critical>20/x2</critical>
 			<!-- Should be changed to a variable due to improved crit -->
 		</unarmed>
-		
+
 	</weapons>
 	<!--
 	  ====================================

--- a/code/testsuite/csheets/3e_SWizSam.xml
+++ b/code/testsuite/csheets/3e_SWizSam.xml
@@ -891,7 +891,7 @@ BIO
 			<critical>20/x2</critical>
 			<!-- Should be changed to a variable due to improved crit -->
 		</unarmed>
-		
+
 	</weapons>
 	<!--
 	  ====================================

--- a/code/testsuite/csheets/3e_WizShar.xml
+++ b/code/testsuite/csheets/3e_WizShar.xml
@@ -908,7 +908,7 @@ BIO
 			<critical>20/x2</critical>
 			<!-- Should be changed to a variable due to improved crit -->
 		</unarmed>
-		
+
 	</weapons>
 	<!--
 	  ====================================

--- a/code/testsuite/csheets/msrd_Ilyana.xml
+++ b/code/testsuite/csheets/msrd_Ilyana.xml
@@ -42,20 +42,6 @@ BIO
 			<shortform>Tou3,Str3</shortform>
 			<!-- CLASSLIST is not extracted because we can derive it from the information above -->
 		</classes>
-		<deity>
-			<name></name>
-			<alignment></alignment>
-			<description></description>
-			<domainlist></domainlist>
-			<favoredweapon></favoredweapon>
-			<holyitem></holyitem>
-			<pantheonlist></pantheonlist>
-			<source></source>
-			<special_abilities></special_abilities>
-			<appearance></appearance>
-			<title></title>
-			<worshippers></worshippers>
-		</deity>
 		<description></description>
 		<experience>
 			<current>15000</current>
@@ -1009,7 +995,7 @@ BIO
 			<critical>20/x2</critical>
 			<!-- Should be changed to a variable due to improved crit -->
 		</unarmed>
-		
+
 		<weapon>
 			<common>
 				<name>
@@ -1026,13 +1012,19 @@ BIO
 					<magic_hit>+0</magic_hit>
 					<total_hit>+6</total_hit>
 				</to_hit>
-				<feat></feat>
+				<feat>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</feat>
 				<hand>Primary</hand>
 				<num_attacks>1</num_attacks>
 				<reach>5</reach>
 				<size>M</size>
 				<special_properties>Magazine 15,Lic(+1)</special_properties>
-				<template></template>
+				<template>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</template>
 				<type>Ba</type>
 				<weight>6</weight>
 				<sequence>0</sequence>
@@ -1081,13 +1073,19 @@ BIO
 					<magic_hit>+0</magic_hit>
 					<total_hit>+8</total_hit>
 				</to_hit>
-				<feat></feat>
+				<feat>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</feat>
 				<hand>Primary</hand>
 				<num_attacks>1</num_attacks>
 				<reach>5</reach>
 				<size>M</size>
 				<special_properties>Non-Lethal</special_properties>
-				<template></template>
+				<template>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</template>
 				<type></type>
 				<weight>0</weight>
 				<sequence>1</sequence>
@@ -1114,13 +1112,19 @@ BIO
 					<magic_hit>+0</magic_hit>
 					<total_hit>+6</total_hit>
 				</to_hit>
-				<feat></feat>
+				<feat>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</feat>
 				<hand>Carried</hand>
 				<num_attacks>1</num_attacks>
 				<reach>5</reach>
 				<size>M</size>
 				<special_properties></special_properties>
-				<template></template>
+				<template>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</template>
 				<type>Bl</type>
 				<weight>10</weight>
 				<sequence>2</sequence>
@@ -1174,13 +1178,19 @@ BIO
 					<magic_hit>+0</magic_hit>
 					<total_hit>+6</total_hit>
 				</to_hit>
-				<feat></feat>
+				<feat>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</feat>
 				<hand>Carried</hand>
 				<num_attacks>1</num_attacks>
 				<reach>5</reach>
 				<size>M</size>
 				<special_properties></special_properties>
-				<template></template>
+				<template>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</template>
 				<type>P</type>
 				<weight>20</weight>
 				<sequence>3</sequence>

--- a/code/testsuite/csheets/pf_Cleric.xml
+++ b/code/testsuite/csheets/pf_Cleric.xml
@@ -797,7 +797,7 @@ BIO
 			<critical>20/x2</critical>
 			<!-- Should be changed to a variable due to improved crit -->
 		</unarmed>
-
+		
 		<weapon>
 			<common>
 				<name>
@@ -814,19 +814,13 @@ BIO
 					<magic_hit>+1</magic_hit>
 					<total_hit>+3</total_hit>
 				</to_hit>
-				<feat>
-					<hit>+0</hit>
-					<damage>+0</damage>
-				</feat>
+				<feat></feat>
 				<hand>Primary</hand>
 				<num_attacks>1</num_attacks>
 				<reach>5</reach>
 				<size>M</size>
 				<special_properties></special_properties>
-				<template>
-					<hit>+0</hit>
-					<damage>+0</damage>
-				</template>
+				<template></template>
 				<type>BP</type>
 				<weight>6</weight>
 				<sequence>0</sequence>
@@ -880,19 +874,13 @@ BIO
 					<magic_hit>+0</magic_hit>
 					<total_hit>+2</total_hit>
 				</to_hit>
-				<feat>
-					<hit>+0</hit>
-					<damage>+0</damage>
-				</feat>
+				<feat></feat>
 				<hand>Carried</hand>
 				<num_attacks>1</num_attacks>
 				<reach>5</reach>
 				<size>M</size>
 				<special_properties></special_properties>
-				<template>
-					<hit>+0</hit>
-					<damage>+0</damage>
-				</template>
+				<template></template>
 				<type>P</type>
 				<weight>4</weight>
 				<sequence>1</sequence>
@@ -941,19 +929,13 @@ BIO
 					<magic_hit>+0</magic_hit>
 					<total_hit>-2</total_hit>
 				</to_hit>
-				<feat>
-					<hit>+0</hit>
-					<damage>+0</damage>
-				</feat>
+				<feat></feat>
 				<hand>Equipped</hand>
 				<num_attacks>1</num_attacks>
 				<reach>5</reach>
 				<size>M</size>
 				<special_properties></special_properties>
-				<template>
-					<hit>+0</hit>
-					<damage>+0</damage>
-				</template>
+				<template></template>
 				<type></type>
 				<weight>6</weight>
 				<sequence>2</sequence>
@@ -2330,6 +2312,28 @@ BIO
 			<name>Domains</name>
 			<description></description>
 			<type>CLERICCLASSFEATURES.INTERNAL.CLASSFEATURES.DOMAINS.INQUISITORCLASSFEATURES</type>
+			<associated></associated>
+			<count>0</count>
+			<auto>T</auto>
+			<hidden>T</hidden>
+			<virtual>F</virtual>
+			<category>Special Ability</category>
+		</ability_object>
+		<ability_object>
+			<name>Humanoid Traits</name>
+			<description></description>
+			<type></type>
+			<associated></associated>
+			<count>0</count>
+			<auto>T</auto>
+			<hidden>T</hidden>
+			<virtual>F</virtual>
+			<category>Special Ability</category>
+		</ability_object>
+		<ability_object>
+			<name>Human Traits</name>
+			<description></description>
+			<type></type>
 			<associated></associated>
 			<count>0</count>
 			<auto>T</auto>

--- a/code/testsuite/csheets/pf_Cleric.xml
+++ b/code/testsuite/csheets/pf_Cleric.xml
@@ -797,7 +797,7 @@ BIO
 			<critical>20/x2</critical>
 			<!-- Should be changed to a variable due to improved crit -->
 		</unarmed>
-		
+
 		<weapon>
 			<common>
 				<name>
@@ -814,13 +814,19 @@ BIO
 					<magic_hit>+1</magic_hit>
 					<total_hit>+3</total_hit>
 				</to_hit>
-				<feat></feat>
+				<feat>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</feat>
 				<hand>Primary</hand>
 				<num_attacks>1</num_attacks>
 				<reach>5</reach>
 				<size>M</size>
 				<special_properties></special_properties>
-				<template></template>
+				<template>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</template>
 				<type>BP</type>
 				<weight>6</weight>
 				<sequence>0</sequence>
@@ -874,13 +880,19 @@ BIO
 					<magic_hit>+0</magic_hit>
 					<total_hit>+2</total_hit>
 				</to_hit>
-				<feat></feat>
+				<feat>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</feat>
 				<hand>Carried</hand>
 				<num_attacks>1</num_attacks>
 				<reach>5</reach>
 				<size>M</size>
 				<special_properties></special_properties>
-				<template></template>
+				<template>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</template>
 				<type>P</type>
 				<weight>4</weight>
 				<sequence>1</sequence>
@@ -929,13 +941,19 @@ BIO
 					<magic_hit>+0</magic_hit>
 					<total_hit>-2</total_hit>
 				</to_hit>
-				<feat></feat>
+				<feat>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</feat>
 				<hand>Equipped</hand>
 				<num_attacks>1</num_attacks>
 				<reach>5</reach>
 				<size>M</size>
 				<special_properties></special_properties>
-				<template></template>
+				<template>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</template>
 				<type></type>
 				<weight>6</weight>
 				<sequence>2</sequence>
@@ -2312,28 +2330,6 @@ BIO
 			<name>Domains</name>
 			<description></description>
 			<type>CLERICCLASSFEATURES.INTERNAL.CLASSFEATURES.DOMAINS.INQUISITORCLASSFEATURES</type>
-			<associated></associated>
-			<count>0</count>
-			<auto>T</auto>
-			<hidden>T</hidden>
-			<virtual>F</virtual>
-			<category>Special Ability</category>
-		</ability_object>
-		<ability_object>
-			<name>Humanoid Traits</name>
-			<description></description>
-			<type></type>
-			<associated></associated>
-			<count>0</count>
-			<auto>T</auto>
-			<hidden>T</hidden>
-			<virtual>F</virtual>
-			<category>Special Ability</category>
-		</ability_object>
-		<ability_object>
-			<name>Human Traits</name>
-			<description></description>
-			<type></type>
 			<associated></associated>
 			<count>0</count>
 			<auto>T</auto>

--- a/code/testsuite/csheets/pf_Paladin.xml
+++ b/code/testsuite/csheets/pf_Paladin.xml
@@ -849,7 +849,7 @@ BIO
 			<critical>20/x2</critical>
 			<!-- Should be changed to a variable due to improved crit -->
 		</unarmed>
-
+		
 		<weapon>
 			<common>
 				<name>
@@ -866,19 +866,13 @@ BIO
 					<magic_hit>+1</magic_hit>
 					<total_hit>+12/+7</total_hit>
 				</to_hit>
-				<feat>
-					<hit>+0</hit>
-					<damage>+0</damage>
-				</feat>
+				<feat></feat>
 				<hand>Both</hand>
 				<num_attacks>2</num_attacks>
 				<reach>5</reach>
 				<size>M</size>
 				<special_properties>disarm, trip</special_properties>
-				<template>
-					<hit>+0</hit>
-					<damage>+0</damage>
-				</template>
+				<template></template>
 				<type>B</type>
 				<weight>10</weight>
 				<sequence>0</sequence>
@@ -932,19 +926,13 @@ BIO
 					<magic_hit>-1</magic_hit>
 					<total_hit>+10/+5</total_hit>
 				</to_hit>
-				<feat>
-					<hit>+0</hit>
-					<damage>+0</damage>
-				</feat>
+				<feat></feat>
 				<hand>Both</hand>
 				<num_attacks>2</num_attacks>
 				<reach>5</reach>
 				<size>M</size>
 				<special_properties>disarm, trip</special_properties>
-				<template>
-					<hit>+0</hit>
-					<damage>+0</damage>
-				</template>
+				<template></template>
 				<type>B</type>
 				<weight>0</weight>
 				<sequence>1</sequence>
@@ -998,19 +986,13 @@ BIO
 					<magic_hit>+0</magic_hit>
 					<total_hit>+10/+5</total_hit>
 				</to_hit>
-				<feat>
-					<hit>+0</hit>
-					<damage>+0</damage>
-				</feat>
+				<feat></feat>
 				<hand>Equipped</hand>
 				<num_attacks>2</num_attacks>
 				<reach>5</reach>
 				<size>M</size>
 				<special_properties></special_properties>
-				<template>
-					<hit>+0</hit>
-					<damage>+0</damage>
-				</template>
+				<template></template>
 				<type>P</type>
 				<weight>0</weight>
 				<sequence>2</sequence>
@@ -1064,19 +1046,13 @@ BIO
 					<magic_hit>+0</magic_hit>
 					<total_hit>+7/+2</total_hit>
 				</to_hit>
-				<feat>
-					<hit>+0</hit>
-					<damage>+0</damage>
-				</feat>
+				<feat></feat>
 				<hand>Equipped</hand>
 				<num_attacks>2</num_attacks>
 				<reach>5</reach>
 				<size>M</size>
 				<special_properties>splash weapon</special_properties>
-				<template>
-					<hit>+0</hit>
-					<damage>+0</damage>
-				</template>
+				<template></template>
 				<type></type>
 				<weight>1</weight>
 				<sequence>3</sequence>
@@ -1125,19 +1101,13 @@ BIO
 					<magic_hit>+0</magic_hit>
 					<total_hit>+7/+2</total_hit>
 				</to_hit>
-				<feat>
-					<hit>+0</hit>
-					<damage>+0</damage>
-				</feat>
+				<feat></feat>
 				<hand>Equipped</hand>
 				<num_attacks>2</num_attacks>
 				<reach>5</reach>
 				<size>M</size>
 				<special_properties>splash weapon, full-round action to prepare, 50% chance to ignite</special_properties>
-				<template>
-					<hit>+0</hit>
-					<damage>+0</damage>
-				</template>
+				<template></template>
 				<type>F</type>
 				<weight>1</weight>
 				<sequence>4</sequence>
@@ -1186,19 +1156,13 @@ BIO
 					<magic_hit>+0</magic_hit>
 					<total_hit>+10/+5</total_hit>
 				</to_hit>
-				<feat>
-					<hit>+0</hit>
-					<damage>+0</damage>
-				</feat>
+				<feat></feat>
 				<hand>Carried</hand>
 				<num_attacks>2</num_attacks>
 				<reach>5</reach>
 				<size>M</size>
 				<special_properties></special_properties>
-				<template>
-					<hit>+0</hit>
-					<damage>+0</damage>
-				</template>
+				<template></template>
 				<type>PS</type>
 				<weight>0</weight>
 				<sequence>5</sequence>
@@ -1279,19 +1243,13 @@ BIO
 					<magic_hit>+0</magic_hit>
 					<total_hit>+7/+2</total_hit>
 				</to_hit>
-				<feat>
-					<hit>+0</hit>
-					<damage>+0</damage>
-				</feat>
+				<feat></feat>
 				<hand>Not Carried</hand>
 				<num_attacks>2</num_attacks>
 				<reach>5</reach>
 				<size>M</size>
 				<special_properties></special_properties>
-				<template>
-					<hit>+0</hit>
-					<damage>+0</damage>
-				</template>
+				<template></template>
 				<type>P</type>
 				<weight>2</weight>
 				<sequence>7</sequence>
@@ -1340,19 +1298,13 @@ BIO
 					<magic_hit>+0</magic_hit>
 					<total_hit>+10/+5</total_hit>
 				</to_hit>
-				<feat>
-					<hit>+0</hit>
-					<damage>+0</damage>
-				</feat>
+				<feat></feat>
 				<hand>Carried</hand>
 				<num_attacks>2</num_attacks>
 				<reach>5</reach>
 				<size>M</size>
 				<special_properties>silver</special_properties>
-				<template>
-					<hit>+0</hit>
-					<damage>+0</damage>
-				</template>
+				<template></template>
 				<type>S</type>
 				<weight>4</weight>
 				<sequence>8</sequence>
@@ -1406,19 +1358,13 @@ BIO
 					<magic_hit>+0</magic_hit>
 					<total_hit>+10/+5</total_hit>
 				</to_hit>
-				<feat>
-					<hit>+0</hit>
-					<damage>+0</damage>
-				</feat>
+				<feat></feat>
 				<hand>Not Carried</hand>
 				<num_attacks>2</num_attacks>
 				<reach>5</reach>
 				<size>M</size>
 				<special_properties></special_properties>
-				<template>
-					<hit>+0</hit>
-					<damage>+0</damage>
-				</template>
+				<template></template>
 				<type>P</type>
 				<weight>0</weight>
 				<sequence>9</sequence>
@@ -1499,19 +1445,13 @@ BIO
 					<magic_hit>+0</magic_hit>
 					<total_hit>+10/+5</total_hit>
 				</to_hit>
-				<feat>
-					<hit>+0</hit>
-					<damage>+0</damage>
-				</feat>
+				<feat></feat>
 				<hand>Carried</hand>
 				<num_attacks>2</num_attacks>
 				<reach>5</reach>
 				<size>M</size>
 				<special_properties></special_properties>
-				<template>
-					<hit>+0</hit>
-					<damage>+0</damage>
-				</template>
+				<template></template>
 				<type>P</type>
 				<weight>0</weight>
 				<sequence>11</sequence>
@@ -3411,6 +3351,28 @@ BIO
 			<name>Divine Grace</name>
 			<description></description>
 			<type>PALADINCLASSFEATURES.SPECIALQUALITY.SUPERNATURAL</type>
+			<associated></associated>
+			<count>0</count>
+			<auto>T</auto>
+			<hidden>T</hidden>
+			<virtual>F</virtual>
+			<category>Special Ability</category>
+		</ability_object>
+		<ability_object>
+			<name>Humanoid Traits</name>
+			<description></description>
+			<type></type>
+			<associated></associated>
+			<count>0</count>
+			<auto>T</auto>
+			<hidden>T</hidden>
+			<virtual>F</virtual>
+			<category>Special Ability</category>
+		</ability_object>
+		<ability_object>
+			<name>Human Traits</name>
+			<description></description>
+			<type></type>
 			<associated></associated>
 			<count>0</count>
 			<auto>T</auto>

--- a/code/testsuite/csheets/pf_Paladin.xml
+++ b/code/testsuite/csheets/pf_Paladin.xml
@@ -849,7 +849,7 @@ BIO
 			<critical>20/x2</critical>
 			<!-- Should be changed to a variable due to improved crit -->
 		</unarmed>
-		
+
 		<weapon>
 			<common>
 				<name>
@@ -866,13 +866,19 @@ BIO
 					<magic_hit>+1</magic_hit>
 					<total_hit>+12/+7</total_hit>
 				</to_hit>
-				<feat></feat>
+				<feat>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</feat>
 				<hand>Both</hand>
 				<num_attacks>2</num_attacks>
 				<reach>5</reach>
 				<size>M</size>
 				<special_properties>disarm, trip</special_properties>
-				<template></template>
+				<template>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</template>
 				<type>B</type>
 				<weight>10</weight>
 				<sequence>0</sequence>
@@ -926,13 +932,19 @@ BIO
 					<magic_hit>-1</magic_hit>
 					<total_hit>+10/+5</total_hit>
 				</to_hit>
-				<feat></feat>
+				<feat>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</feat>
 				<hand>Both</hand>
 				<num_attacks>2</num_attacks>
 				<reach>5</reach>
 				<size>M</size>
 				<special_properties>disarm, trip</special_properties>
-				<template></template>
+				<template>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</template>
 				<type>B</type>
 				<weight>0</weight>
 				<sequence>1</sequence>
@@ -986,13 +998,19 @@ BIO
 					<magic_hit>+0</magic_hit>
 					<total_hit>+10/+5</total_hit>
 				</to_hit>
-				<feat></feat>
+				<feat>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</feat>
 				<hand>Equipped</hand>
 				<num_attacks>2</num_attacks>
 				<reach>5</reach>
 				<size>M</size>
 				<special_properties></special_properties>
-				<template></template>
+				<template>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</template>
 				<type>P</type>
 				<weight>0</weight>
 				<sequence>2</sequence>
@@ -1046,13 +1064,19 @@ BIO
 					<magic_hit>+0</magic_hit>
 					<total_hit>+7/+2</total_hit>
 				</to_hit>
-				<feat></feat>
+				<feat>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</feat>
 				<hand>Equipped</hand>
 				<num_attacks>2</num_attacks>
 				<reach>5</reach>
 				<size>M</size>
 				<special_properties>splash weapon</special_properties>
-				<template></template>
+				<template>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</template>
 				<type></type>
 				<weight>1</weight>
 				<sequence>3</sequence>
@@ -1101,13 +1125,19 @@ BIO
 					<magic_hit>+0</magic_hit>
 					<total_hit>+7/+2</total_hit>
 				</to_hit>
-				<feat></feat>
+				<feat>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</feat>
 				<hand>Equipped</hand>
 				<num_attacks>2</num_attacks>
 				<reach>5</reach>
 				<size>M</size>
 				<special_properties>splash weapon, full-round action to prepare, 50% chance to ignite</special_properties>
-				<template></template>
+				<template>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</template>
 				<type>F</type>
 				<weight>1</weight>
 				<sequence>4</sequence>
@@ -1156,13 +1186,19 @@ BIO
 					<magic_hit>+0</magic_hit>
 					<total_hit>+10/+5</total_hit>
 				</to_hit>
-				<feat></feat>
+				<feat>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</feat>
 				<hand>Carried</hand>
 				<num_attacks>2</num_attacks>
 				<reach>5</reach>
 				<size>M</size>
 				<special_properties></special_properties>
-				<template></template>
+				<template>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</template>
 				<type>PS</type>
 				<weight>0</weight>
 				<sequence>5</sequence>
@@ -1243,13 +1279,19 @@ BIO
 					<magic_hit>+0</magic_hit>
 					<total_hit>+7/+2</total_hit>
 				</to_hit>
-				<feat></feat>
+				<feat>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</feat>
 				<hand>Not Carried</hand>
 				<num_attacks>2</num_attacks>
 				<reach>5</reach>
 				<size>M</size>
 				<special_properties></special_properties>
-				<template></template>
+				<template>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</template>
 				<type>P</type>
 				<weight>2</weight>
 				<sequence>7</sequence>
@@ -1298,13 +1340,19 @@ BIO
 					<magic_hit>+0</magic_hit>
 					<total_hit>+10/+5</total_hit>
 				</to_hit>
-				<feat></feat>
+				<feat>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</feat>
 				<hand>Carried</hand>
 				<num_attacks>2</num_attacks>
 				<reach>5</reach>
 				<size>M</size>
 				<special_properties>silver</special_properties>
-				<template></template>
+				<template>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</template>
 				<type>S</type>
 				<weight>4</weight>
 				<sequence>8</sequence>
@@ -1358,13 +1406,19 @@ BIO
 					<magic_hit>+0</magic_hit>
 					<total_hit>+10/+5</total_hit>
 				</to_hit>
-				<feat></feat>
+				<feat>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</feat>
 				<hand>Not Carried</hand>
 				<num_attacks>2</num_attacks>
 				<reach>5</reach>
 				<size>M</size>
 				<special_properties></special_properties>
-				<template></template>
+				<template>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</template>
 				<type>P</type>
 				<weight>0</weight>
 				<sequence>9</sequence>
@@ -1445,13 +1499,19 @@ BIO
 					<magic_hit>+0</magic_hit>
 					<total_hit>+10/+5</total_hit>
 				</to_hit>
-				<feat></feat>
+				<feat>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</feat>
 				<hand>Carried</hand>
 				<num_attacks>2</num_attacks>
 				<reach>5</reach>
 				<size>M</size>
 				<special_properties></special_properties>
-				<template></template>
+				<template>
+					<hit>+0</hit>
+					<damage>+0</damage>
+				</template>
 				<type>P</type>
 				<weight>0</weight>
 				<sequence>11</sequence>
@@ -3351,28 +3411,6 @@ BIO
 			<name>Divine Grace</name>
 			<description></description>
 			<type>PALADINCLASSFEATURES.SPECIALQUALITY.SUPERNATURAL</type>
-			<associated></associated>
-			<count>0</count>
-			<auto>T</auto>
-			<hidden>T</hidden>
-			<virtual>F</virtual>
-			<category>Special Ability</category>
-		</ability_object>
-		<ability_object>
-			<name>Humanoid Traits</name>
-			<description></description>
-			<type></type>
-			<associated></associated>
-			<count>0</count>
-			<auto>T</auto>
-			<hidden>T</hidden>
-			<virtual>F</virtual>
-			<category>Special Ability</category>
-		</ability_object>
-		<ability_object>
-			<name>Human Traits</name>
-			<description></description>
-			<type></type>
 			<associated></associated>
 			<count>0</count>
 			<auto>T</auto>


### PR DESCRIPTION
This long PR fixes approximately 26 XML files located in /csheets folder. There are multiple reasons, why this was needed:
1. in the base template, a trailing /t/t was removed, and this change affected all templates
2. A long time ago FEAT and TEMPLATE tokens were replaced withe FEATHIT/-DAMAGE and TEMPLATEHIT/-DAMAGE (appeared somewhere in 2015)
3. The deity tag was removed for an MSRD character, because she doesn't have deity in the rule book.

p.s. not all characters were updated, because for some of them big blocks of data was modified. I need some time to investigate, why this change appeared.
You can squash this PR to a single commit.