### PR TITLE
Fixed: PCClassTest - renamed CLASSTYPE to TYPE in sample data.

### DIFF
--- a/code/src/java/pcgen/cdom/enumeration/FactKey.java
+++ b/code/src/java/pcgen/cdom/enumeration/FactKey.java
@@ -65,7 +65,7 @@ public final class FactKey<T>
 
 	/**
 	 * Returns the FactKey for the given String (the search for the constant is
-	 * case insensitive). If the constant does not already exist, a new FactKey
+	 * case-insensitive). If the constant does not already exist, a new FactKey
 	 * is created with the given String as the name of the FactKey.
 	 * 
 	 * @param name

--- a/code/src/java/pcgen/rules/persistence/CDOMControlLoader.java
+++ b/code/src/java/pcgen/rules/persistence/CDOMControlLoader.java
@@ -42,7 +42,7 @@ public class CDOMControlLoader extends LstLineFileLoader
 
 	public CDOMControlLoader()
 	{
-		//CONSIDER better way to load these?
+		//CONSIDER a better way to load these?
 		addLineLoader(new CDOMSubLineLoader<>("FACTDEF", FactDefinition.class));
 		addLineLoader(new CDOMSubLineLoader<>("FACTSETDEF", FactSetDefinition.class));
 		addLineLoader(new CDOMSubLineLoader<>("DEFAULTVARIABLEVALUE", DefaultVarValue.class));

--- a/code/src/java/pcgen/rules/persistence/TokenSupport.java
+++ b/code/src/java/pcgen/rules/persistence/TokenSupport.java
@@ -238,7 +238,7 @@ public class TokenSupport
 			}
 		}
 		/*
-		 * CONSIDER Better option than toString, given that T != CDOMObject
+		 * CONSIDER a better option than toString, given that T != CDOMObject
 		 */
 		cpr.addErrorMessage(
 			"Illegal " + tokenName + " subtoken '" + key + "' '" + value + "' for " + cl.getName() + ' ' + cdo);

--- a/code/src/test/pcgen/core/PCClassTest.java
+++ b/code/src/test/pcgen/core/PCClassTest.java
@@ -424,7 +424,7 @@ public class PCClassTest extends AbstractCharacterTestCase
 			throw new UnreachableError(e);
 		}
 		PCClass reconstClass;
-		System.out.println("Got text:" + classPCCText);
+		System.out.println("Got text: " + classPCCText);
 		reconstClass = parsePCClassText(classPCCText, source);
 		assertEquals(
 				classPCCText, reconstClass.getPCCText(),
@@ -444,7 +444,7 @@ public class PCClassTest extends AbstractCharacterTestCase
 		classPCCText = humanoidClass.getPCCText();
 		assertNotNull(classPCCText, "PCC Text for race should not be null");
 
-		System.out.println("Got text:" + classPCCText);
+		System.out.println("Got text: " + classPCCText);
 		reconstClass = parsePCClassText(classPCCText, source);
 		assertEquals(
 				classPCCText, reconstClass.getPCCText(),
@@ -456,8 +456,8 @@ public class PCClassTest extends AbstractCharacterTestCase
 				humanoidClass.getOriginalClassLevel(1).getListMods(Spell.SPELLS);
 		Collection<CDOMReference<Spell>> reconstSpells =
 				reconstClass.getOriginalClassLevel(1).getListMods(Spell.SPELLS);
-		assertEquals(startSpells
-			.size(), reconstSpells.size(), "All spell should have been reconstituted.");
+		assertEquals(startSpells.size(), reconstSpells.size(),
+				"All spell should have been reconstituted.");
 		assertEquals(startSpells, reconstSpells, "Spell names should been preserved.");
 
 	}
@@ -861,8 +861,9 @@ public class PCClassTest extends AbstractCharacterTestCase
 		{
 			throw new UnreachableError(e);
 		}
+
 		String classPCCText =
-			"CLASS:Cleric	HD:8		CLASSTYPE:PC	TYPE:Base.PC	ABB:Clr	ABILITY:TestCat|AUTOMATIC|Ability1\n"
+			"CLASS:Cleric	HD:8		TYPE:PC	TYPE:Base.PC	FACT:Abb|Clr	ABILITY:TestCat|AUTOMATIC|Ability1\n"
 				+ "CLASS:Cleric	STARTSKILLPTS:2\n"
 				+ "2	ABILITY:TestCat|AUTOMATIC|Ability2";
 		PCClass pcclass = parsePCClassText(classPCCText, source);
@@ -1004,7 +1005,7 @@ public class PCClassTest extends AbstractCharacterTestCase
 			String line = tok.nextToken();
 			if (!line.trim().isEmpty())
 			{
-				System.out.println("Processing line:'" + line + "'.");
+				System.out.println("Processing line: '" + line + "'.");
 				reconstClass =
 						pcClassLoader.parseLine(Globals.getContext(), reconstClass, line, source);
 			}
@@ -1033,7 +1034,7 @@ public class PCClassTest extends AbstractCharacterTestCase
 			throw new UnreachableError(e);
 		}
 
-		// Create the monseter class type
+		// Create the monster class type
 		GameMode gamemode = SettingsHandler.getGameAsProperty().get();
 		SimpleLoader<ClassType> methodLoader = new SimpleLoader<>(ClassType.class);
 		methodLoader.parseLine(gamemode.getModeContext(),
@@ -1044,7 +1045,7 @@ public class PCClassTest extends AbstractCharacterTestCase
 
 		// Create the humanoid class
 		String classDef =
-				"CLASS:Humanoid	KEY:KEY_Humanoid	HD:8		CLASSTYPE:Monster	STARTSKILLPTS:1	"
+				"CLASS:Humanoid	KEY:KEY_Humanoid	HD:8		TYPE:Monster	STARTSKILLPTS:1	"
 					+ "MODTOSKILLS:NO	MONSKILL:6+INT	MONNONSKILLHD:1|PRESIZELTEQ:M	"
 					+ "MONNONSKILLHD:2|PRESIZEEQ:L";
 		PCClassLoader classLoader = new PCClassLoader();
@@ -1052,7 +1053,7 @@ public class PCClassTest extends AbstractCharacterTestCase
 		humanoidClass = classLoader.parseLine(context, null, classDef, source);
 
 		classDef =
-				"CLASS:Nymph		KEY:KEY_Nymph	CLASSTYPE:Monster	HD:6	STARTSKILLPTS:6	MODTOSKILLS:YES	";
+				"CLASS:Nymph		KEY:KEY_Nymph	TYPE:Monster	HD:6	STARTSKILLPTS:6	MODTOSKILLS:YES	";
 		classLoader = new PCClassLoader();
 		nymphClass = classLoader.parseLine(context, null, classDef, source);
 
@@ -1117,7 +1118,7 @@ public class PCClassTest extends AbstractCharacterTestCase
 		nqClass.getOriginalClassLevel(2).put(VariableKey.getConstant("Foo"),
 				FormulaFactory.getFormulaFor(2));
 	}
-	
+
 	@Override
 	protected void defaultSetupEnd()
 	{


### PR DESCRIPTION
I have also corrected few typos, and removed an empty line.

p.s. FACT|Abb subtoken still shows warnings. They look like
```
LSTERROR main PCClassLoader:324 Illegal FACT subtoken 'Abb' 'Clr' for pcgen.core.PCClass Cleric (Source: null )
LSTERROR main PCClassLoader:324 Failed in parsing typeStr: FACT Abb|Clr for pcgen.core.PCClass Cleric
LSTERROR main PCClassLoader:324 Illegal Token 'FACT' 'Abb|Clr' for pcgen.core.PCClass Cleric in null
```

@karianna I will appreciate if you give me an advice. The code flow is interesting (but strange to me). We add two FACTs by default: CLASSTYPE and SPELLTYPE. But somewhere in the middle, if we add a FACT|Abb, we have to commit our context, otherwise during the parsing the PCClassLoader couldn't find the FACT Abb. I don't know how to fix this (stupid) warning without an explicit commit. I have expected that if the token was parsed, but not committed yet, it can be used by the parser, because (in theory) we will commit at the end of our parsing step.

If you can play with the test case, please help me with it. You can use PCClassTest.testAddAbility to reproduce the warning.

I remember that I removed an explicit commit a long time ago, because there were two commits during setUp, then one commit in finishLoad. It looked messy to me. But I doubt that that change was related to this warning, because I couldn't find in the code where Abb FACT has ever created. Probably these warnings were always ignored.