### PR TITLE
Fixed a bug, when the OutputPanel couldn't show the file chooser dialog

### DIFF
--- a/code/src/java/pcgen/gui2/prefs/OutputPanel.java
+++ b/code/src/java/pcgen/gui2/prefs/OutputPanel.java
@@ -45,6 +45,7 @@ import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
 import javafx.scene.layout.GridPane;
 import javafx.stage.FileChooser;
+import javax.swing.SwingUtilities;
 import org.apache.commons.lang3.BooleanUtils;
 
 /**
@@ -288,16 +289,15 @@ public final class OutputPanel extends PCGenPrefsPanel
 		fileChooser.setTitle(LanguageBundle.getString("in_Prefs_outputSheetHTMLDefaultTitle"));
 		fileChooser.setInitialDirectory(new File(SettingsHandler.getHTMLOutputSheetPath()));
 		fileChooser.setInitialFileName(SettingsHandler.getSelectedCharacterHTMLOutputSheet(null));
-		File newTemplate = GuiUtility.runOnJavaFXThreadNow(() -> fileChooser.showOpenDialog(null));
+		File newTemplate = fileChooser.showOpenDialog(null);
 
 		if (newTemplate != null)
 		{
 			if ((!newTemplate.getName().startsWith("csheet") && !newTemplate.getName().startsWith("psheet")))
 			{
-				ShowMessageDelegate.showMessageDialog(
-						LanguageBundle.getString("in_Prefs_outputSheetDefaultError"), //$NON-NLS-1$
-						Constants.APPLICATION_NAME, MessageType.ERROR
-				);
+				SwingUtilities.invokeLater(() -> ShowMessageDelegate.showMessageDialog(
+					LanguageBundle.getString("in_Prefs_outputSheetDefaultError"), //$NON-NLS-1$
+					Constants.APPLICATION_NAME, MessageType.ERROR));
 			}
 			else
 			{
@@ -310,11 +310,9 @@ public final class OutputPanel extends PCGenPrefsPanel
 					//it must be a psheet
 					SettingsHandler.setSelectedPartyHTMLOutputSheet(newTemplate.getAbsolutePath());
 				}
+				outputSheetHTMLDefault.setText(String.valueOf(SettingsHandler.getSelectedCharacterHTMLOutputSheet(null)));
 			}
 		}
-
-		outputSheetHTMLDefault
-				.setText(String.valueOf(SettingsHandler.getSelectedCharacterHTMLOutputSheet(null)));
 	}
 
 	private void onOutputSheetPDFDefaultButton(final ActionEvent actionEvent)
@@ -323,16 +321,15 @@ public final class OutputPanel extends PCGenPrefsPanel
 		fileChooser.setTitle(LanguageBundle.getString("in_Prefs_outputSheetPDFDefaultTitle"));
 		fileChooser.setInitialDirectory(new File(SettingsHandler.getPDFOutputSheetPath()));
 		fileChooser.setInitialFileName(SettingsHandler.getSelectedCharacterPDFOutputSheet(null));
-		File newTemplate = GuiUtility.runOnJavaFXThreadNow(() -> fileChooser.showOpenDialog(null));
+		File newTemplate = fileChooser.showOpenDialog(null);
 
 		if (newTemplate != null)
 		{
 			if (!newTemplate.getName().startsWith("csheet") && !newTemplate.getName().startsWith("psheet"))
 			{
-				ShowMessageDelegate.showMessageDialog(
+				SwingUtilities.invokeLater(() -> ShowMessageDelegate.showMessageDialog(
 						LanguageBundle.getString("in_Prefs_outputSheetDefaultError"), //$NON-NLS-1$
-						Constants.APPLICATION_NAME, MessageType.ERROR
-				);
+						Constants.APPLICATION_NAME, MessageType.ERROR));
 			}
 			else
 			{
@@ -345,10 +342,9 @@ public final class OutputPanel extends PCGenPrefsPanel
 					//it must be a psheet
 					SettingsHandler.setSelectedPartyPDFOutputSheet(newTemplate.getAbsolutePath());
 				}
+				outputSheetPDFDefault.setText(String.valueOf(SettingsHandler.getSelectedCharacterPDFOutputSheet(null)));
 			}
 		}
-
-		outputSheetPDFDefault.setText(String.valueOf(SettingsHandler.getSelectedCharacterPDFOutputSheet(null)));
 	}
 
 	private void onOutputSheetEqSetButton(final ActionEvent actionEvent)
@@ -357,24 +353,22 @@ public final class OutputPanel extends PCGenPrefsPanel
 		fileChooser.setTitle(LanguageBundle.getString("in_Prefs_templateEqSetTitle"));
 		fileChooser.setInitialDirectory(new File(ConfigurationSettings.getOutputSheetsDir()));
 		fileChooser.setInitialFileName(SettingsHandler.getSelectedEqSetTemplate());
-		File newTemplate = GuiUtility.runOnJavaFXThreadNow(() -> fileChooser.showOpenDialog(null));
+		File newTemplate = fileChooser.showOpenDialog(null);
 
 		if (newTemplate != null)
 		{
 			if (newTemplate.getName().startsWith("eqsheet"))
 			{
 				SettingsHandler.setSelectedEqSetTemplate(newTemplate.getAbsolutePath());
+				outputSheetEqSet.setText(String.valueOf(SettingsHandler.getSelectedEqSetTemplate()));
 			}
 			else
 			{
-				ShowMessageDelegate.showMessageDialog(
+				SwingUtilities.invokeLater(() -> ShowMessageDelegate.showMessageDialog(
 						LanguageBundle.getString("in_Prefs_templateEqSetError"), //$NON-NLS-1$
-						Constants.APPLICATION_NAME, MessageType.ERROR
-				);
+						Constants.APPLICATION_NAME, MessageType.ERROR));
 			}
 		}
-
-		outputSheetEqSet.setText(String.valueOf(SettingsHandler.getSelectedEqSetTemplate()));
 	}
 
 	private void onOutputSheetSpellsDefaultButton(final ActionEvent actionEvent)
@@ -383,7 +377,7 @@ public final class OutputPanel extends PCGenPrefsPanel
 		fileChooser.setTitle(LanguageBundle.getString("in_Prefs_outputSpellSheetDefault"));
 		fileChooser.setInitialDirectory(new File(ConfigurationSettings.getOutputSheetsDir()));
 		fileChooser.setInitialFileName(PCGenSettings.getSelectedSpellSheet());
-		File newTemplate = GuiUtility.runOnJavaFXThreadNow(() -> fileChooser.showOpenDialog(null));
+		File newTemplate = fileChooser.showOpenDialog(null);
 
 		if (newTemplate != null)
 		{
@@ -393,17 +387,15 @@ public final class OutputPanel extends PCGenPrefsPanel
 						PCGenSettings.SELECTED_SPELL_SHEET_PATH,
 						newTemplate.getAbsolutePath()
 				);
+				outputSheetSpellsDefault.setText(PCGenSettings.getSelectedSpellSheet());
 			}
 			else
 			{
-				ShowMessageDelegate.showMessageDialog(
+				SwingUtilities.invokeLater(() -> ShowMessageDelegate.showMessageDialog(
 						LanguageBundle.getString("in_Prefs_outputSheetDefaultError"), //$NON-NLS-1$
-						Constants.APPLICATION_NAME, MessageType.ERROR
-				);
+						Constants.APPLICATION_NAME, MessageType.ERROR));
 			}
 		}
-
-		outputSheetSpellsDefault.setText(PCGenSettings.getSelectedSpellSheet());
 	}
 
 	private enum ExportChoices
@@ -436,7 +428,6 @@ public final class OutputPanel extends PCGenPrefsPanel
 
 		public String getValue()
 		{
-
 			return switch (this)
 					{
 						case ASK -> "";
@@ -462,7 +453,5 @@ public final class OutputPanel extends PCGenPrefsPanel
 				return ExportChoices.NEVER_OPEN;
 			}
 		}
-
 	}
-
 }


### PR DESCRIPTION
This happens because the underlying code works in Swing threads only. Now the entire content of the panel is running in JavaFX thread.

Few empty lines were also removed.

As a symptom, the user sees the error in the logs:

```
023-07-10T00:10:47.285913900 SEVERE JavaFX Application Thread LoggingUncaughtExceptionHandler:32 Uncaught error on thread  Thread[JavaFX Application Thread,5,main] - ignoring
pcgen.gui3.GuiAssertions$WrongThreadException: expected NOT to be on JavaFX thread - actually on: JavaFX Application Thread
        at pcgen.gui3.GuiAssertions.assertIsNotJavaFXThread(GuiAssertions.java:59)
        at pcgen.gui3.GuiUtility.runOnJavaFXThreadNow(GuiUtility.java:56)
        at pcgen.gui2.prefs.OutputPanel.onOutputSheetHTMLDefaultButton(OutputPanel.java:291)
        at javafx.base/com.sun.javafx.event.CompositeEventHandler.dispatchBubblingEvent(CompositeEventHandler.java:86)
        at javafx.base/com.sun.javafx.event.EventHandlerManager.dispatchBubblingEvent(EventHandlerManager.java:234)
        at javafx.base/com.sun.javafx.event.EventHand
```
The PR can be improved further, if (after) all UI parts are migrated to JavaFX. Plus the file chooser is not a dialog window, because JavaFX doesn't have a Scene/Stage that can be used as a parent. The entire window is managed by Swing. That's why keep an eye on an unclosed dialog.

p.p.s If the user doesn't select a file, or selects a wrong one, the false/wrong input is not put into properties, and thus not reflected on UI. Previously the input was cleared by an empty value.