### PR TITLE
Fixed #6901: fixed the Piazo - Near Space cover

### DIFF
--- a/data/starfinder/paizo/near_space/_near_space.pcc
+++ b/data/starfinder/paizo/near_space/_near_space.pcc
@@ -26,7 +26,7 @@ COPYRIGHT:PCGen dataset conversion for "Starfinder Near Space" Copyright 2020, P
 
 
 # COVER should be cover_gameMode_pub_book.file
-COVER:PZO7113_cover.jpg
+COVER:PZO7113_cover.jpeg
 # LOGO should be logo_pub.file
 LOGO:*/_images/logo/Paizo_Publishing.png
 


### PR DESCRIPTION
A simple fix for a failed integration test: `pcgen.persistence.lst -> DataTest`
```
org.opentest4j.AssertionFailedError: Some data files are missing. ==> expected: <> but was: <Missing file starfinder/paizo/near_space/PZO7113_cover.jpg used by starfinder/paizo/near_space/_near_space.pcc<br>>
```