### PR TITLE
OS-538: Solved the bug, when PortraitToken path was encoded

### DIFF
--- a/code/src/java/plugin/exporttokens/PortraitToken.java
+++ b/code/src/java/plugin/exporttokens/PortraitToken.java
@@ -40,7 +40,7 @@ import pcgen.util.Logging;
  * The Class {@code PortraitToken} supports the PORTRAIT
  * token and its and PORTRAIT.THUMB variant.
  *
- * 
+ *
  */
 public class PortraitToken extends AbstractExportToken
 {
@@ -48,6 +48,16 @@ public class PortraitToken extends AbstractExportToken
 	public String getTokenName()
 	{
 		return "PORTRAIT";
+	}
+
+	/**
+	 * True if the token should be encoded during the export
+	 * @return False because the Portrait path must be unchanged
+	 */
+	@Override
+	public boolean isEncoded()
+	{
+		return false;
 	}
 
 	//TODO: Move this to a token that has all of the descriptive stuff about a character
@@ -113,9 +123,9 @@ public class PortraitToken extends AbstractExportToken
 	}
 
 	/**
-	 * Generate a thumbnail image based on the character's portrait and 
+	 * Generate a thumbnail image based on the character's portrait and
 	 * the thumnbnail rectangle.
-	 * 
+	 *
 	 * @param display The character being output.
 	 * @return The thumbnail image, or null if not defined.
 	 */

--- a/code/src/test/pcgen/util/TestHelper.java
+++ b/code/src/test/pcgen/util/TestHelper.java
@@ -28,6 +28,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
+import java.io.StringWriter;
 import java.lang.reflect.Field;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -65,6 +66,7 @@ import pcgen.core.WeaponProf;
 import pcgen.core.bonus.Bonus;
 import pcgen.core.bonus.BonusObj;
 import pcgen.core.spell.Spell;
+import pcgen.io.ExportHandler;
 import pcgen.persistence.CampaignFileLoader;
 import pcgen.persistence.GameModeFileLoader;
 import pcgen.persistence.PersistenceLayerException;
@@ -120,7 +122,7 @@ public class TestHelper
 				.silentlyGetConstructedCDOMObject(SizeAdjustment.class, "M").put(
 						ObjectKey.IS_DEFAULT_SIZE, true);
 	}
-	
+
 	/**
 	 * Make some equipment
 	 * @param input Equipment source line to be parsed
@@ -313,8 +315,8 @@ public class TestHelper
 		return false;
 	}
 
-	
-	
+
+
 	/**
 	 * Set the important info about a WeaponProf
 	 * @param name The weaponprof name
@@ -396,7 +398,7 @@ public class TestHelper
 	}
 
 	/**
-	 * Set the important info about a Kit. Note the key of the kit created will 
+	 * Set the important info about a Kit. Note the key of the kit created will
 	 * be the provided name with KEY_ added at the front. e.g. KEY_name
 	 * @param name The kit name
 	 * @return The kit (which has also been added to global storage)
@@ -425,7 +427,7 @@ public class TestHelper
 		Globals.getContext().getReferenceContext().importObject(aTemplate);
 		return aTemplate;
 	}
-	
+
 	/**
      * Get the Ability Category of the Ability object passed in.  If it does
      * not exist in the game mode, a new object wil be created and added to
@@ -450,7 +452,7 @@ public class TestHelper
 
 	/**
 	 * Checks to see if this PC has the weapon proficiency key aKey
-	 * 
+	 *
 	 * @param aKey
 	 * @return boolean
 	 */
@@ -463,9 +465,9 @@ public class TestHelper
 	}
 
 	/**
-	 * Locate the data folder which contains the primary set of LST data. This 
-	 * defaults to the data folder under the current directory, but can be 
-	 * customised in the config.ini folder. 
+	 * Locate the data folder which contains the primary set of LST data. This
+	 * defaults to the data folder under the current directory, but can be
+	 * customised in the config.ini folder.
 	 * @return The path of the data folder.
 	 */
 	public static String findDataFolder()
@@ -523,7 +525,7 @@ public class TestHelper
 
 		return configFile;
 	}
-	
+
 	public static void loadGameModes(String testConfigFile)
 	{
 		String configFolder = "testsuite";
@@ -585,5 +587,26 @@ public class TestHelper
 			}
 		}
 		return reconstClass;
+	}
+
+	/**
+	 * Evaluate a token, used in several "export" tests. By default, the token encoding is ignored.
+	 * If encoded value is required, use @see pcgen.io.FileAccess#setCurrentOutputFilter(java.lang.String) before
+	 * calling this static method.
+	 *
+	 * @param token the token to evaluate (e.g., any token from @see plugin.exporttokens such as "PORTRAIT")
+	 * @param pc    the pc or a PlayerCharacter object
+	 * @return      the string containing the evaluated token
+	 * @throws IOException Signals that an I/O exception has occurred.
+	 */
+	public static String evaluateToken(String token, PlayerCharacter pc)
+			throws IOException {
+		StringWriter retWriter = new StringWriter();
+		try (BufferedWriter bufWriter = new BufferedWriter(retWriter)) {
+			ExportHandler export = new ExportHandler(new File(""));
+			export.replaceTokenSkipMath(pc, token, bufWriter);
+		}
+
+		return retWriter.toString();
 	}
 }

--- a/code/src/test/plugin/exporttokens/BioTokenTest.java
+++ b/code/src/test/plugin/exporttokens/BioTokenTest.java
@@ -17,17 +17,14 @@
  */
 package plugin.exporttokens;
 
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.IOException;
-import java.io.StringWriter;
 import junit.framework.Test;
 import junit.framework.TestSuite;
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.enumeration.NotePCAttribute;
 import pcgen.core.PlayerCharacter;
-import pcgen.io.ExportHandler;
 import pcgen.io.FileAccess;
+
+import static pcgen.util.TestHelper.evaluateToken;
 
 /**
  * <code>BioTokenTest</code> is ...
@@ -99,27 +96,4 @@ public class BioTokenTest extends AbstractCharacterTestCase
 				"<p>Test bio &lt;br/&gt;entry,</p>\n<p>2nd line,</p>\n<p>Third line,</p>\n<p>last one,</p>";
 		assertEquals("New Style Bio start only", expected, actual);
 	}
-
-	/**
-	 * Evaluate token.
-	 *
-	 * @param token the token
-	 * @param pc the pc
-	 * @return the string
-	 * @throws IOException Signals that an I/O exception has occurred.
-	 */
-	private String evaluateToken(String token, PlayerCharacter pc)
-		throws IOException
-	{
-		StringWriter retWriter = new StringWriter();
-		BufferedWriter bufWriter = new BufferedWriter(retWriter);
-		ExportHandler export = new ExportHandler(new File(""));
-		export.replaceTokenSkipMath(pc, token, bufWriter);
-		retWriter.flush();
-
-		bufWriter.flush();
-
-		return retWriter.toString();
-	}
-
 }

--- a/code/src/test/plugin/exporttokens/CampaignHistoryTokenTest.java
+++ b/code/src/test/plugin/exporttokens/CampaignHistoryTokenTest.java
@@ -17,26 +17,23 @@
  */
 package plugin.exporttokens;
 
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.IOException;
-import java.io.StringWriter;
-
 import org.junit.Before;
 import org.junit.Test;
-
 import pcgen.AbstractCharacterTestCase;
 import pcgen.core.ChronicleEntry;
 import pcgen.core.PlayerCharacter;
-import pcgen.io.ExportHandler;
 import pcgen.io.FileAccess;
 import pcgen.util.TestHelper;
 
+import java.io.IOException;
+
+import static pcgen.util.TestHelper.evaluateToken;
+
 /**
- * CampaignHistoryTokenTest validates the functions of the 
+ * CampaignHistoryTokenTest validates the functions of the
  * CampaignHistoryToken class.
- * 
- * 
+ *
+ *
  */
 public class CampaignHistoryTokenTest  extends AbstractCharacterTestCase
 {
@@ -60,7 +57,7 @@ public class CampaignHistoryTokenTest  extends AbstractCharacterTestCase
 
 		hiddenEntry = TestHelper.buildChronicleEntry(false, "Campaign", "Date", "GM", "Party",
 			"Adventure", 1390, "Chronicle");
-		
+
 		character.addChronicleEntry(visibleEntry);
 		character.addChronicleEntry(hiddenEntry);
 	}
@@ -120,20 +117,4 @@ public class CampaignHistoryTokenTest  extends AbstractCharacterTestCase
 		assertEquals("Invalid visibility", "",
 			evaluateToken("CAMPAIGNHISTORY.LALALA.0.ADVENTURE", character));
 	}
-
-	
-	private String evaluateToken(String token, PlayerCharacter pc)
-		throws IOException
-	{
-		StringWriter retWriter = new StringWriter();
-		BufferedWriter bufWriter = new BufferedWriter(retWriter);
-		ExportHandler export = new ExportHandler(new File(""));
-		export.replaceTokenSkipMath(pc, token, bufWriter);
-		retWriter.flush();
-
-		bufWriter.flush();
-
-		return retWriter.toString();
-	}
-
 }


### PR DESCRIPTION
The image export was broken.

TestHelper got a helper method "evaluateToken", that was used by other test-classes. This is a small refactoring to avoid the duplicated code.

This commit is specific for 6.08 branch.