### PR TITLE
feat(fix): Adding range to Improvised Thrown Weapns (fix for DATA-4370)

### DIFF
--- a/data/pathfinder/paizo/roleplaying_game/core_rulebook/cr_equip_arms_armor.lst
+++ b/data/pathfinder/paizo/roleplaying_game/core_rulebook/cr_equip_arms_armor.lst
@@ -354,15 +354,15 @@ Improvised Weapon (2d8)		PROFICIENCY:WEAPON|Improvised Weapon	TYPE:Weapon.Melee.
 Improvised Weapon (2d10)	PROFICIENCY:WEAPON|Improvised Weapon	TYPE:Weapon.Melee.Improvised	COST:0	WT:12		CRITMULT:x2	CRITRANGE:1	DAMAGE:2d10	WIELD:TwoHanded	SIZE:M
 
 ###Block: Improvised / WT and WIELD guessed based upon equivalents.
-# Equipment Name					Required Weapon Proficiency				Type								Cost		Weight	Crit Mult	Crit Range	Damage	Wield Category	Size
-Improvised Weapon (Thrown) (1d2)		PROFICIENCY:WEAPON|Improvised Weapon (Thrown)	TYPE:Weapon.Ranged.Thrown.Improvised.Improvised Thrown	COST:0	WT:1		CRITMULT:x2	CRITRANGE:1	DAMAGE:1d2	WIELD:OneHanded	SIZE:M
-Improvised Weapon (Thrown) (1d3)		PROFICIENCY:WEAPON|Improvised Weapon (Thrown)	TYPE:Weapon.Ranged.Thrown.Improvised.Improvised Thrown	COST:0	WT:1		CRITMULT:x2	CRITRANGE:1	DAMAGE:1d3	WIELD:OneHanded	SIZE:M
-Improvised Weapon (Thrown) (1d4)		PROFICIENCY:WEAPON|Improvised Weapon (Thrown)	TYPE:Weapon.Ranged.Thrown.Improvised.Improvised Thrown	COST:0	WT:2		CRITMULT:x2	CRITRANGE:1	DAMAGE:1d4	WIELD:OneHanded	SIZE:M
-Improvised Weapon (Thrown) (1d6)		PROFICIENCY:WEAPON|Improvised Weapon (Thrown)	TYPE:Weapon.Ranged.Thrown.Improvised.Improvised Thrown	COST:0	WT:6		CRITMULT:x2	CRITRANGE:1	DAMAGE:1d6	WIELD:OneHanded	SIZE:M
-Improvised Weapon (Thrown) (1d8)		PROFICIENCY:WEAPON|Improvised Weapon (Thrown)	TYPE:Weapon.Ranged.Thrown.Improvised.Improvised Thrown	COST:0	WT:10		CRITMULT:x2	CRITRANGE:1	DAMAGE:1d8	WIELD:OneHanded	SIZE:M
-Improvised Weapon (Thrown) (1d10)		PROFICIENCY:WEAPON|Improvised Weapon (Thrown)	TYPE:Weapon.Ranged.Thrown.Improvised.Improvised Thrown	COST:0	WT:12		CRITMULT:x2	CRITRANGE:1	DAMAGE:1d10	WIELD:OneHanded	SIZE:M
-Improvised Weapon (Thrown) (1d12)		PROFICIENCY:WEAPON|Improvised Weapon (Thrown)	TYPE:Weapon.Ranged.Thrown.Improvised.Improvised Thrown	COST:0	WT:12		CRITMULT:x2	CRITRANGE:1	DAMAGE:1d12	WIELD:TwoHanded	SIZE:M
-Improvised Weapon (Thrown) (2d4)		PROFICIENCY:WEAPON|Improvised Weapon (Thrown)	TYPE:Weapon.Ranged.Thrown.Improvised.Improvised Thrown	COST:0	WT:12		CRITMULT:x2	CRITRANGE:1	DAMAGE:2d4	WIELD:TwoHanded	SIZE:M
-Improvised Weapon (Thrown) (2d6)		PROFICIENCY:WEAPON|Improvised Weapon (Thrown)	TYPE:Weapon.Ranged.Thrown.Improvised.Improvised Thrown	COST:0	WT:12		CRITMULT:x2	CRITRANGE:1	DAMAGE:2d6	WIELD:TwoHanded	SIZE:M
-Improvised Weapon (Thrown) (2d8)		PROFICIENCY:WEAPON|Improvised Weapon (Thrown)	TYPE:Weapon.Ranged.Thrown.Improvised.Improvised Thrown	COST:0	WT:12		CRITMULT:x2	CRITRANGE:1	DAMAGE:2d8	WIELD:TwoHanded	SIZE:M
-Improvised Weapon (Thrown) (2d10)		PROFICIENCY:WEAPON|Improvised Weapon (Thrown)	TYPE:Weapon.Ranged.Thrown.Improvised.Improvised Thrown	COST:0	WT:12		CRITMULT:x2	CRITRANGE:1	DAMAGE:2d10	WIELD:TwoHanded	SIZE:M
+# Equipment Name					Required Weapon Proficiency				Type								Cost		Weight	Crit Mult	Crit Range	Damage	Wield Category	Range	Size
+Improvised Weapon (Thrown) (1d2)		PROFICIENCY:WEAPON|Improvised Weapon (Thrown)	TYPE:Weapon.Ranged.Thrown.Improvised.Improvised Thrown	COST:0	WT:1		CRITMULT:x2	CRITRANGE:1	DAMAGE:1d2	WIELD:OneHanded	RANGE:10	SIZE:M
+Improvised Weapon (Thrown) (1d3)		PROFICIENCY:WEAPON|Improvised Weapon (Thrown)	TYPE:Weapon.Ranged.Thrown.Improvised.Improvised Thrown	COST:0	WT:1		CRITMULT:x2	CRITRANGE:1	DAMAGE:1d3	WIELD:OneHanded	RANGE:10	SIZE:M
+Improvised Weapon (Thrown) (1d4)		PROFICIENCY:WEAPON|Improvised Weapon (Thrown)	TYPE:Weapon.Ranged.Thrown.Improvised.Improvised Thrown	COST:0	WT:2		CRITMULT:x2	CRITRANGE:1	DAMAGE:1d4	WIELD:OneHanded	RANGE:10	SIZE:M
+Improvised Weapon (Thrown) (1d6)		PROFICIENCY:WEAPON|Improvised Weapon (Thrown)	TYPE:Weapon.Ranged.Thrown.Improvised.Improvised Thrown	COST:0	WT:6		CRITMULT:x2	CRITRANGE:1	DAMAGE:1d6	WIELD:OneHanded	RANGE:10	SIZE:M
+Improvised Weapon (Thrown) (1d8)		PROFICIENCY:WEAPON|Improvised Weapon (Thrown)	TYPE:Weapon.Ranged.Thrown.Improvised.Improvised Thrown	COST:0	WT:10		CRITMULT:x2	CRITRANGE:1	DAMAGE:1d8	WIELD:OneHanded	RANGE:10	SIZE:M
+Improvised Weapon (Thrown) (1d10)		PROFICIENCY:WEAPON|Improvised Weapon (Thrown)	TYPE:Weapon.Ranged.Thrown.Improvised.Improvised Thrown	COST:0	WT:12		CRITMULT:x2	CRITRANGE:1	DAMAGE:1d10	WIELD:OneHanded	RANGE:10	SIZE:M
+Improvised Weapon (Thrown) (1d12)		PROFICIENCY:WEAPON|Improvised Weapon (Thrown)	TYPE:Weapon.Ranged.Thrown.Improvised.Improvised Thrown	COST:0	WT:12		CRITMULT:x2	CRITRANGE:1	DAMAGE:1d12	WIELD:TwoHanded	RANGE:10	SIZE:M
+Improvised Weapon (Thrown) (2d4)		PROFICIENCY:WEAPON|Improvised Weapon (Thrown)	TYPE:Weapon.Ranged.Thrown.Improvised.Improvised Thrown	COST:0	WT:12		CRITMULT:x2	CRITRANGE:1	DAMAGE:2d4	WIELD:TwoHanded	RANGE:10	SIZE:M
+Improvised Weapon (Thrown) (2d6)		PROFICIENCY:WEAPON|Improvised Weapon (Thrown)	TYPE:Weapon.Ranged.Thrown.Improvised.Improvised Thrown	COST:0	WT:12		CRITMULT:x2	CRITRANGE:1	DAMAGE:2d6	WIELD:TwoHanded	RANGE:10	SIZE:M
+Improvised Weapon (Thrown) (2d8)		PROFICIENCY:WEAPON|Improvised Weapon (Thrown)	TYPE:Weapon.Ranged.Thrown.Improvised.Improvised Thrown	COST:0	WT:12		CRITMULT:x2	CRITRANGE:1	DAMAGE:2d8	WIELD:TwoHanded	RANGE:10	SIZE:M
+Improvised Weapon (Thrown) (2d10)		PROFICIENCY:WEAPON|Improvised Weapon (Thrown)	TYPE:Weapon.Ranged.Thrown.Improvised.Improvised Thrown	COST:0	WT:12		CRITMULT:x2	CRITRANGE:1	DAMAGE:2d10	WIELD:TwoHanded	RANGE:10	SIZE:M


### PR DESCRIPTION
This fixes [DATA-4370](https://pcgenorg.atlassian.net/browse/DATA-4370) by adding `RANGE:10` to all the improvised thrown weapons added in commit https://github.com/PCGen/pcgen/commit/45ab44c2d7dc15fc0059805111af0e097baf924

[DATA-4370]: https://pcgenorg.atlassian.net/browse/DATA-4370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ