### PR TITLE
support for INFO token export

### DIFF
--- a/code/src/java/pcgen/core/GameMode.java
+++ b/code/src/java/pcgen/core/GameMode.java
@@ -1966,11 +1966,14 @@ public final class GameMode implements Comparable<Object>
 			Class<T> cl = rm.getReferenceClass();
 			mfg = rc.getManufacturer(cl);
 		}
-		for (CDOMReference<T> ref : rm.getAllReferences())
-		{
-			((TransparentReference<T>) ref).resolve(mfg);
+		if (mfg!=null) {
+			for (CDOMReference<T> ref : rm.getAllReferences()) {
+				((TransparentReference<T>) ref).resolve(mfg);
+			}
+			rm.injectConstructed(mfg);
 		}
-		rm.injectConstructed(mfg);
+		else
+			System.out.println("idname="+identityName+" had a null mfg - skipping");
 	}
 
 	public LoadContext getContext()

--- a/code/src/java/pcgen/io/ExportHandler.java
+++ b/code/src/java/pcgen/io/ExportHandler.java
@@ -1619,7 +1619,10 @@ public abstract class ExportHandler
 			else if (TOKEN_MAP.get(firstToken) != null)
 			{
 				Token token = TOKEN_MAP.get(firstToken);
-				if (token.isEncoded())
+				if (tokenString.indexOf(".INFO.")>-1) {
+					FileAccess.encodeWrite(output, token.getInfoToken(tokenString, aPC.getDisplay().getRace()));
+				}
+				else if (token.isEncoded())
 				{
 					FileAccess.encodeWrite(output, token.getToken(tokenString, aPC, this));
 				}

--- a/code/src/java/pcgen/io/exporttoken/Token.java
+++ b/code/src/java/pcgen/io/exporttoken/Token.java
@@ -20,8 +20,11 @@
  */
 package pcgen.io.exporttoken;
 
-import java.util.StringTokenizer;
+import java.text.MessageFormat;
+import java.util.*;
 
+import pcgen.cdom.enumeration.MapKey;
+import pcgen.core.PObject;
 import pcgen.core.PlayerCharacter;
 import pcgen.io.ExportHandler;
 
@@ -98,5 +101,27 @@ public abstract class Token
 			// Handled.  We return the default value in this case.
 		}
 		return retInt;
+	}
+
+	public String getInfoToken(String token, PObject po) {
+		// looking for a token in the form of RACE.INFO.TAG where
+		// RACE indicate which token map to check for a INFO label of TAG to return
+		int i = token.indexOf(".INFO.");
+		String ts = token;
+		if (i>0)
+			ts = token.substring(i+6).toUpperCase();
+		else
+			return token;
+		Set<MapKey<?, ?>> keys = po.getMapKeys();
+		for (MapKey<?, ?> key : keys) {
+			Map<?, ?> key2 = po.getMapFor(key);
+			for(Object k : key2.keySet()) {
+				if (k.toString().equals(ts)) {
+					MessageFormat m = (MessageFormat) key2.get(k);
+					return m.toPattern();
+				}
+			}
+		}
+		return token;
 	}
 }


### PR DESCRIPTION
export sheets can now include TOKEN.INFO.TAG type tokens so export the TAG labeled INFO value from the TOKEN map. e.g. RACE.INFO.SOME_LABEL to export the value of the 'SOME_LABEL' tag from the pc's associated race token map.