### PR TITLE
CASTERLEVEL SPROP fix

### DIFF
--- a/code/src/java/pcgen/core/GameMode.java
+++ b/code/src/java/pcgen/core/GameMode.java
@@ -1966,11 +1966,14 @@ public final class GameMode implements Comparable<Object>
 			Class<T> cl = rm.getReferenceClass();
 			mfg = rc.getManufacturer(cl);
 		}
-		for (CDOMReference<T> ref : rm.getAllReferences())
-		{
-			((TransparentReference<T>) ref).resolve(mfg);
+		if (mfg!=null) {
+			for (CDOMReference<T> ref : rm.getAllReferences()) {
+				((TransparentReference<T>) ref).resolve(mfg);
+			}
+			rm.injectConstructed(mfg);
 		}
-		rm.injectConstructed(mfg);
+		else
+			System.out.println("idname="+identityName+" had a null mfg - skipping");
 	}
 
 	public LoadContext getContext()

--- a/code/src/java/pcgen/core/term/PCCasterLevelTotalTermEvaluator.java
+++ b/code/src/java/pcgen/core/term/PCCasterLevelTotalTermEvaluator.java
@@ -38,27 +38,7 @@ public class PCCasterLevelTotalTermEvaluator extends BasePCTermEvaluator impleme
 	@Override
 	public Float resolve(PlayerCharacter pc)
 	{
-
-		int iLev = 0;
-
-		for (PCClass pcClass : pc.getDisplay().getClassSet())
-		{
-			if (!pcClass.getSpellType().equals(Constants.NONE))
-			{
-				final String classKey = pcClass.getKeyName();
-
-				final int pcBonus = (int) pc.getTotalBonusTo("PCLEVEL", classKey);
-				final int castBonus = (int) pc.getTotalBonusTo("CASTERLEVEL", classKey);
-				final int iClass = (castBonus == 0) ? pc.getDisplay().getLevel(pcClass) : 0;
-
-				String spellType = pcClass.getSpellType();
-
-				iLev += pc.getTotalCasterLevelWithSpellBonus(null, null,
-						spellType, classKey, iClass + pcBonus);
-			}
-		}
-
-		return (float) iLev;
+		return resolve(pc, null);
 	}
 
 	@Override

--- a/code/src/java/pcgen/core/term/PCCasterLevelTotalTermEvaluator.java
+++ b/code/src/java/pcgen/core/term/PCCasterLevelTotalTermEvaluator.java
@@ -21,6 +21,7 @@
 package pcgen.core.term;
 
 import pcgen.cdom.base.Constants;
+import pcgen.core.Equipment;
 import pcgen.core.PCClass;
 import pcgen.core.PlayerCharacter;
 import pcgen.core.character.CharacterSpell;
@@ -33,11 +34,31 @@ public class PCCasterLevelTotalTermEvaluator extends BasePCTermEvaluator impleme
 		this.originalText = originalText;
 	}
 
-	// Makes no sense without a spell
+	// If no spell is given then we just want to total caster level
 	@Override
 	public Float resolve(PlayerCharacter pc)
 	{
-		return 0.0f;
+
+		int iLev = 0;
+
+		for (PCClass pcClass : pc.getDisplay().getClassSet())
+		{
+			if (!pcClass.getSpellType().equals(Constants.NONE))
+			{
+				final String classKey = pcClass.getKeyName();
+
+				final int pcBonus = (int) pc.getTotalBonusTo("PCLEVEL", classKey);
+				final int castBonus = (int) pc.getTotalBonusTo("CASTERLEVEL", classKey);
+				final int iClass = (castBonus == 0) ? pc.getDisplay().getLevel(pcClass) : 0;
+
+				String spellType = pcClass.getSpellType();
+
+				iLev += pc.getTotalCasterLevelWithSpellBonus(null, null,
+						spellType, classKey, iClass + pcBonus);
+			}
+		}
+
+		return (float) iLev;
 	}
 
 	@Override
@@ -65,6 +86,7 @@ public class PCCasterLevelTotalTermEvaluator extends BasePCTermEvaluator impleme
 
 		return (float) iLev;
 	}
+
 
 	@Override
 	public boolean isSourceDependant()

--- a/code/src/java/pcgen/io/ExportHandler.java
+++ b/code/src/java/pcgen/io/ExportHandler.java
@@ -1619,7 +1619,10 @@ public abstract class ExportHandler
 			else if (TOKEN_MAP.get(firstToken) != null)
 			{
 				Token token = TOKEN_MAP.get(firstToken);
-				if (token.isEncoded())
+				if (tokenString.indexOf(".INFO.")>-1) {
+					FileAccess.encodeWrite(output, token.getInfoToken(tokenString, aPC.getDisplay().getRace()));
+				}
+				else if (token.isEncoded())
 				{
 					FileAccess.encodeWrite(output, token.getToken(tokenString, aPC, this));
 				}

--- a/code/src/java/pcgen/io/exporttoken/Token.java
+++ b/code/src/java/pcgen/io/exporttoken/Token.java
@@ -20,8 +20,11 @@
  */
 package pcgen.io.exporttoken;
 
-import java.util.StringTokenizer;
+import java.text.MessageFormat;
+import java.util.*;
 
+import pcgen.cdom.enumeration.MapKey;
+import pcgen.core.PObject;
 import pcgen.core.PlayerCharacter;
 import pcgen.io.ExportHandler;
 
@@ -98,5 +101,27 @@ public abstract class Token
 			// Handled.  We return the default value in this case.
 		}
 		return retInt;
+	}
+
+	public String getInfoToken(String token, PObject po) {
+		// looking for a token in the form of RACE.INFO.TAG where
+		// RACE indicate which token map to check for a INFO label of TAG to return
+		int i = token.indexOf(".INFO.");
+		String ts = token;
+		if (i>0)
+			ts = token.substring(i+6).toUpperCase();
+		else
+			return token;
+		Set<MapKey<?, ?>> keys = po.getMapKeys();
+		for (MapKey<?, ?> key : keys) {
+			Map<?, ?> key2 = po.getMapFor(key);
+			for(Object k : key2.keySet()) {
+				if (k.toString().equals(ts)) {
+					MessageFormat m = (MessageFormat) key2.get(k);
+					return m.toPattern();
+				}
+			}
+		}
+		return token;
 	}
 }


### PR DESCRIPTION
SPROP was not correctly evaluating CASTERLEVEL for use in variable replacement - it was always 0 (which was treated as empty).  Now the term will be the total caster level across all classes.