### PR TITLE
Added logging to catch invalid CHOOSE options

### DIFF
--- a/code/src/java/pcgen/cdom/facet/AddedTemplateFacet.java
+++ b/code/src/java/pcgen/cdom/facet/AddedTemplateFacet.java
@@ -33,6 +33,7 @@ import pcgen.cdom.facet.event.DataFacetChangeListener;
 import pcgen.core.Globals;
 import pcgen.core.PCTemplate;
 import pcgen.core.PlayerCharacter;
+import pcgen.util.Logging;
 
 /**
  * AddedTemplateFacet is a Facet that tracks the Templates that have been added
@@ -151,6 +152,11 @@ public class AddedTemplateFacet extends AbstractSourcedListFacet<CharID, PCTempl
 				availableList.add(pct);
 			}
 		}
+		if(list.isEmpty())
+		{
+			Logging.log(Logging.WARNING, "CHOOSE entry in " + anOwner.getDisplayName()
+					+ " contains no valid templates");
+		}
 		if (availableList.size() == 1)
 		{
 			return availableList.get(0);
@@ -158,6 +164,12 @@ public class AddedTemplateFacet extends AbstractSourcedListFacet<CharID, PCTempl
 		// If we are left without a choice, don't show the chooser.
 		if (availableList.isEmpty())
 		{
+			if(!list.isEmpty())
+			{
+				// We have entries, but none of them apply to our target. Typically fine, but occasionally undesired.
+				Logging.log(Logging.INFO, "CHOOSE entry in " + anOwner.getDisplayName()
+						+ " contains templates, but none qualify");
+			}
 			return null;
 		}
 		List<PCTemplate> selectedList = new ArrayList<>(1);

--- a/code/src/java/plugin/lsttokens/TemplateLst.java
+++ b/code/src/java/plugin/lsttokens/TemplateLst.java
@@ -42,6 +42,7 @@ import pcgen.rules.persistence.TokenUtilities;
 import pcgen.rules.persistence.token.AbstractToken;
 import pcgen.rules.persistence.token.CDOMPrimaryToken;
 import pcgen.rules.persistence.token.ParseResult;
+import pcgen.util.Logging;
 
 public class TemplateLst extends AbstractToken implements CDOMPrimaryToken<CDOMObject>, ChooseSelectionActor<PCTemplate>
 {
@@ -114,6 +115,10 @@ public class TemplateLst extends AbstractToken implements CDOMPrimaryToken<CDOMO
 				CDOMReference<PCTemplate> ref = TokenUtilities.getTypeOrPrimitive(rm, templKey);
 				if (ref == null)
 				{
+					// If we have an invalid template reference, regardless of type, log it
+					Logging.log(Logging.WARNING, "Invalid template reference in TEMPLATE token in " +
+							cdo.getDisplayName() + ": " + templKey);
+
 					return ParseResult.INTERNAL_ERROR;
 				}
 				list.add(ref);


### PR DESCRIPTION
Added some logs - they trigger if a data file has an invalid template item (The TemplateLst.java change) or as specified in CODE-103, a CHOOSE token is specified that has no corresponding template.

One limitation - if a CHOOSE token is VALID, but not REFERENCED, we can't detect it this way. that would require a recursive lookup to check if the valid token is also being accessed in the source and template and character - not easy, not consistent across systems, and not performant without fundamentally changing how the CDOM works.