### PR TITLE
Fix for empty Ranks column on the Skills tab

### DIFF
--- a/code/src/java/pcgen/gui2/tabs/SkillInfoTab.java
+++ b/code/src/java/pcgen/gui2/tabs/SkillInfoTab.java
@@ -123,9 +123,6 @@ public class SkillInfoTab extends FlippingSplitPane implements CharacterInfoTab,
 		setOrientation(VERTICAL_SPLIT);
 		setResizeWeight(0.70);
 
-		JSpinner spinner = new JSpinner();
-		spinner.setEditor(new JSpinner.NumberEditor(spinner, "#0.#")); //$NON-NLS-1$
-		skillTable.setDefaultRenderer(Float.class, new SpinnerRenderer(spinner));
 		skillTable.setDefaultRenderer(Integer.class, new TableCellUtilities.AlignRenderer(SwingConstants.CENTER));
 		skillTable.setDefaultRenderer(String.class, new TableCellUtilities.AlignRenderer(SwingConstants.CENTER));
 		skillTable.setRowHeight(26);


### PR DESCRIPTION
A renderer was being created that wasn't returning a usable TableCellRenderer.  By not registering a "custom" renderer, the default provided by JSpinner is used -- and that one works fine.

There are other references to the SpinnerRenderer that I have not touched but which also may need to be updated.  They are:
* PostLevelUpDialog.java:53
* PostLevelUpDialog.java:134
* EquipmentModels.java:378
* EquipmentModels.java:487
* StatTableModel.java:325

I'd like some eyeballs on both this patch and those other references.  I don't know how to get PCGen through those other code paths, so someone more familiar with PCGen should take a look at those areas to see if the spinners are working properly. 