### PR TITLE
Drop commons-io dependency in favor of JDK equivalents

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -220,7 +220,6 @@ dependencies {
 
     implementation fileTree(dir: 'mods/lib', include: ['javafx.*.jar'])
 
-    implementation 'commons-io:commons-io:2.22.0'
     implementation 'org.springframework:spring-web:7.0.7'
     implementation 'org.springframework:spring-beans:7.0.7'
     implementation 'org.springframework:spring-core:7.0.7'
@@ -313,7 +312,7 @@ jlink {
     options = ['--strip-debug', '--no-header-files', '--no-man-pages']
     addExtraDependencies('javafx')
     forceMerge('jep', 'fop', 'Saxon-HE',
-               'commons-lang3', 'commons-io', 'spring',
+               'commons-lang3', 'spring',
                'freemarker', 'jdom2', 'argparse4j', 'xmlunit', 'controlsfx',
                'annotations', 'spotbugs', 'xmlresolver')
 

--- a/code/src/java/module-info.java
+++ b/code/src/java/module-info.java
@@ -23,7 +23,6 @@ module pcgen {
     requires pcgen.formula;
 
     requires org.apache.commons.lang3;
-    requires org.apache.commons.io;
     requires freemarker;
     requires org.jdom2;
     requires net.sourceforge.argparse4j;

--- a/code/src/java/pcgen/gui2/dialog/PrintPreviewDialog.java
+++ b/code/src/java/pcgen/gui2/dialog/PrintPreviewDialog.java
@@ -34,13 +34,18 @@ import java.awt.print.PrinterJob;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.File;
-import java.io.FilenameFilter;
+import java.io.IOException;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.text.NumberFormat;
-import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.swing.BorderFactory;
 import javax.swing.Box;
@@ -69,15 +74,9 @@ import pcgen.system.ConfigurationSettings;
 import pcgen.util.Logging;
 import pcgen.util.fop.FopTask;
 
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.filefilter.FileFilterUtils;
-import org.apache.commons.io.filefilter.IOFileFilter;
-import org.apache.commons.io.filefilter.SuffixFileFilter;
-import org.apache.commons.io.filefilter.TrueFileFilter;
 import org.apache.fop.apps.FOUserAgent;
 import org.apache.fop.render.awt.AWTRenderer;
 import org.apache.fop.render.awt.viewer.PreviewPanel;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Dialog to allow the preview of character export.
@@ -421,28 +420,30 @@ public final class PrintPreviewDialog extends JDialog implements ActionListener
         return new DefaultComboBoxModel<>(pageNumbers);
     }
 
-    private class SheetLoader extends SwingWorker<Object[], Object> implements FilenameFilter
+    private class SheetLoader extends SwingWorker<Object[], Object>
     {
-
-        @Override
-        public boolean accept(@NotNull File dir, @NotNull String name)
-        {
-            return dir.getName().equalsIgnoreCase("pdf");
-        }
 
         @Override
         protected Object[] doInBackground()
         {
-            IOFileFilter pdfFilter = FileFilterUtils.asFileFilter(this);
-            IOFileFilter suffixFilter = FileFilterUtils.notFileFilter(new SuffixFileFilter(".fo"));
-            IOFileFilter sheetFilter = FileFilterUtils.prefixFileFilter(Constants.CHARACTER_TEMPLATE_PREFIX);
-            IOFileFilter fileFilter = FileFilterUtils.and(pdfFilter, suffixFilter, sheetFilter);
+            Predicate<File> filter = f -> f.getParentFile().getName().equalsIgnoreCase("pdf")
+                    && !f.getName().endsWith(".fo")
+                    && f.getName().startsWith(Constants.CHARACTER_TEMPLATE_PREFIX);
 
-            IOFileFilter dirFilter = TrueFileFilter.INSTANCE;
             File dir = new File(ConfigurationSettings.getOutputSheetsDir());
-            Collection<File> files = FileUtils.listFiles(dir, fileFilter, dirFilter);
-            URI osPath = new File(ConfigurationSettings.getOutputSheetsDir()).toURI();
-            return files.stream().map(v -> osPath.relativize(v.toURI())).toArray();
+            URI osPath = dir.toURI();
+            try (Stream<Path> walk = Files.walk(dir.toPath()))
+            {
+                List<File> files = walk.filter(Files::isRegularFile)
+                                       .map(Path::toFile)
+                                       .filter(filter)
+                                       .collect(Collectors.toList());
+                return files.stream().map(v -> osPath.relativize(v.toURI())).toArray();
+            } catch (IOException ex)
+            {
+                Logging.errorPrint("could not walk output sheets directory " + dir, ex);
+                return new Object[0];
+            }
         }
 
         @Override

--- a/code/src/java/pcgen/gui2/tabs/spells/SpellsKnownTab.java
+++ b/code/src/java/pcgen/gui2/tabs/spells/SpellsKnownTab.java
@@ -31,7 +31,6 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTextField;
 
-import org.apache.commons.io.FilenameUtils;
 import pcgen.core.PCClass;
 import pcgen.facade.core.CharacterFacade;
 import pcgen.facade.core.SpellFacade;
@@ -154,7 +153,8 @@ public class SpellsKnownTab extends FlippingSplitPane implements CharacterInfoTa
 			hbox.add(spellSheetButton);
 			hbox.add(Box.createHorizontalStrut(3));
 
-			String text = FilenameUtils.getName(PCGenSettings.getSelectedSpellSheet());
+			String spellSheetPath = PCGenSettings.getSelectedSpellSheet();
+			String text = spellSheetPath == null ? null : new File(spellSheetPath).getName();
 			spellSheetField.setEditable(false);
 			spellSheetField.setText(text);
 			spellSheetField.setToolTipText(text);

--- a/code/src/java/pcgen/io/ExportUtilities.java
+++ b/code/src/java/pcgen/io/ExportUtilities.java
@@ -29,6 +29,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import freemarker.template.Configuration;
@@ -43,8 +44,6 @@ import freemarker.template.DefaultObjectWrapperBuilder;
 import freemarker.template.ObjectWrapper;
 import freemarker.template.Version;
 import javafx.stage.FileChooser;
-import org.apache.commons.io.filefilter.FileFilterUtils;
-import org.apache.commons.io.filefilter.IOFileFilter;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
 
@@ -140,10 +139,8 @@ public final class ExportUtilities
 
 	public static URI[] getValidFiles(Collection<File> myAllTemplates, SheetFilter sheetFilter, boolean doPartyExport)
 	{
-		IOFileFilter prefixFilter;
 		String outputSheetsDir;
 		String outputSheetDirectory = SettingsHandler.getGameAsProperty().get().getOutputSheetDirectory();
-		IOFileFilter ioFilter = FileFilterUtils.asFileFilter(sheetFilter);
 		if (outputSheetDirectory == null)
 		{
 			outputSheetsDir = ConfigurationSettings.getOutputSheetsDir() + '/' + sheetFilter.getPath();
@@ -154,17 +151,14 @@ public final class ExportUtilities
 					+ sheetFilter.getPath();
 		}
 
-		if (doPartyExport)
-		{
-			prefixFilter = FileFilterUtils.prefixFileFilter(Constants.PARTY_TEMPLATE_PREFIX);
-		} else
-		{
-			prefixFilter = FileFilterUtils.prefixFileFilter(Constants.CHARACTER_TEMPLATE_PREFIX);
-		}
-		IOFileFilter filter = FileFilterUtils.and(prefixFilter, ioFilter);
+		String prefix = doPartyExport ? Constants.PARTY_TEMPLATE_PREFIX : Constants.CHARACTER_TEMPLATE_PREFIX;
+		Predicate<File> filter = f -> f.getName().startsWith(prefix)
+				&& sheetFilter.accept(f.getParentFile(), f.getName());
 
-		List<File> files = FileFilterUtils.filterList(filter, myAllTemplates);
-		Collections.sort(files);
+		List<File> files = myAllTemplates.stream()
+		                                 .filter(filter)
+		                                 .sorted()
+		                                 .collect(Collectors.toList());
 		URI osPath = new File(outputSheetsDir).toURI();
 		URI[] uriList = new URI[files.size()];
 		Arrays.setAll(uriList, i -> osPath.relativize(files.get(i).toURI()));

--- a/code/src/java/pcgen/io/PCGIOHandler.java
+++ b/code/src/java/pcgen/io/PCGIOHandler.java
@@ -34,6 +34,7 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -60,7 +61,6 @@ import pcgen.system.PCGenSettings;
 import pcgen.util.FileHelper;
 import pcgen.util.Logging;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 
@@ -520,7 +520,8 @@ public final class PCGIOHandler extends IOHandler
         String filesLine = StringUtils.join(files, ',');
         try
         {
-            FileUtils.writeLines(partyFile, "UTF-8", Arrays.asList(versionLine, filesLine));
+            String eol = System.lineSeparator();
+            Files.writeString(partyFile.toPath(), versionLine + eol + filesLine + eol, StandardCharsets.UTF_8);
         } catch (IOException ex)
         {
             Logging.errorPrint("Could not save the party file: " + partyFile.getAbsolutePath(), ex);

--- a/code/src/java/pcgen/system/BatchExporter.java
+++ b/code/src/java/pcgen/system/BatchExporter.java
@@ -278,7 +278,7 @@ public class BatchExporter
 		{
 			Logging.errorPrint("Unable to create output file " + outFile.getAbsolutePath(), e);
 			return false;
-		} catch (final ExportException e)
+		} catch (final ExportException _)
 		{
 			// Error will already be reported to the log
 			return false;

--- a/code/src/java/pcgen/system/BatchExporter.java
+++ b/code/src/java/pcgen/system/BatchExporter.java
@@ -439,7 +439,7 @@ public class BatchExporter
 	}
 
 	/**
-	 * Remove any temporary xml files produced while outputting characters. 
+	 * Remove any temporary xml files produced while outputting characters.
 	 */
     static void removeTemporaryFiles()
 	{
@@ -450,23 +450,20 @@ public class BatchExporter
 			return;
 		}
 
-		final String aDirectory = SettingsHandler.getTempPath() + File.separator;
-		new File(aDirectory).list((aFile, aString) -> {
-			try
+		File tempDir = SettingsHandler.getTempPath();
+		File[] tempFiles = tempDir.listFiles(
+				(dir, name) -> name.startsWith(Constants.TEMPORARY_FILE_NAME));
+		if (tempFiles == null)
+		{
+			return;
+		}
+		for (File tf : tempFiles)
+		{
+			if (!tf.delete())
 			{
-				if (aString.startsWith(Constants.TEMPORARY_FILE_NAME))
-				{
-					final File tf = new File(aFile, aString);
-					tf.delete();
-				}
+				Logging.errorPrint("Could not delete temporary file " + tf.getAbsolutePath());
 			}
-			catch (final Exception e)
-			{
-				Logging.errorPrint("removeTemporaryFiles", e);
-			}
-
-			return false;
-		});
+		}
 	}
 
 	/**

--- a/code/src/java/pcgen/system/BatchExporter.java
+++ b/code/src/java/pcgen/system/BatchExporter.java
@@ -355,6 +355,12 @@ public class BatchExporter
 				FopTask task = FopTask.newFopTask(inputStream,
 						isTransformTemplate ? templateFile : null, fileStream);
 				task.run();
+				if (StringUtils.isNotBlank(task.getErrorMessages()))
+				{
+					Logging.errorPrint("BatchExporter.exportPartyToPDF failed: " //$NON-NLS-1$
+						+ task.getErrorMessages());
+					return false;
+				}
 			}
 		}
 		catch (final IOException | ExportException e)

--- a/code/src/java/pcgen/system/BatchExporter.java
+++ b/code/src/java/pcgen/system/BatchExporter.java
@@ -32,6 +32,7 @@ import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.stream.Stream;
 
 import pcgen.cdom.base.Constants;
 import pcgen.core.SettingsHandler;
@@ -443,30 +444,43 @@ public class BatchExporter
 	 */
     static void removeTemporaryFiles()
 	{
-		final boolean cleanUp = UIPropertyContext.getInstance().initBoolean(UIPropertyContext.CLEANUP_TEMP_FILES, true);
-
+		boolean cleanUp = UIPropertyContext.getInstance().initBoolean(UIPropertyContext.CLEANUP_TEMP_FILES, true);
 		if (!cleanUp)
 		{
 			return;
 		}
 
-		File tempDir = SettingsHandler.getTempPath();
-		File[] tempFiles = tempDir.listFiles(
-				(dir, name) -> name.startsWith(Constants.TEMPORARY_FILE_NAME));
-		if (tempFiles == null)
+		Path tempDir = SettingsHandler.getTempPath().toPath();
+		if (!Files.isDirectory(tempDir))
 		{
 			return;
 		}
-		for (File tf : tempFiles)
+
+		try (Stream<Path> entries = Files.list(tempDir))
 		{
-			try
-			{
-				Files.delete(tf.toPath());
-			}
-			catch (IOException ex)
-			{
-				Logging.errorPrint("Could not delete temporary file " + tf.getAbsolutePath(), ex);
-			}
+			entries.filter(BatchExporter::isTemporaryExportFile)
+			       .forEach(BatchExporter::deleteQuietly);
+		}
+		catch (IOException ex)
+		{
+			Logging.errorPrint("Could not list temporary directory " + tempDir, ex);
+		}
+	}
+
+	private static boolean isTemporaryExportFile(Path path)
+	{
+		return path.getFileName().toString().startsWith(Constants.TEMPORARY_FILE_NAME);
+	}
+
+	private static void deleteQuietly(Path path)
+	{
+		try
+		{
+			Files.delete(path);
+		}
+		catch (IOException ex)
+		{
+			Logging.errorPrint("Could not delete temporary file " + path, ex);
 		}
 	}
 

--- a/code/src/java/pcgen/system/BatchExporter.java
+++ b/code/src/java/pcgen/system/BatchExporter.java
@@ -30,6 +30,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 import pcgen.cdom.base.Constants;
@@ -49,7 +50,6 @@ import pcgen.persistence.SourceFileLoader;
 import pcgen.util.Logging;
 import pcgen.util.fop.FopTask;
 
-import org.apache.commons.io.output.TeeOutputStream;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -216,31 +216,33 @@ public class BatchExporter
 		String outFileName = removeFileExtension(outFile.getAbsolutePath());
 		File tempFile = new File(outFileName + (isTransformTemplate ? ".xml" : ".fo"));
 		try (OutputStream fileStream = new BufferedOutputStream(new FileOutputStream(outFile));
-		     ByteArrayOutputStream byteOutputStream = new ByteArrayOutputStream();
-		     OutputStream exportOutput = useTempFile
-					//Output to both the byte stream and to the temp file.
-					? new TeeOutputStream(byteOutputStream, new FileOutputStream(tempFile)) : byteOutputStream)
+		     ByteArrayOutputStream byteOutputStream = new ByteArrayOutputStream())
 		{
-			FopTask task;
 			if (isTransformTemplate)
 			{
-				exportCharacter(character, exportOutput);
-				InputStream inputStream = new ByteArrayInputStream(byteOutputStream.toByteArray());
-				task = FopTask.newFopTask(inputStream, templateFile, fileStream);
+				exportCharacter(character, byteOutputStream);
 			}
 			else
 			{
-				exportCharacter(character, templateFile, exportOutput);
-				InputStream inputStream = new ByteArrayInputStream(byteOutputStream.toByteArray());
-				task = FopTask.newFopTask(inputStream, null, fileStream);
+				exportCharacter(character, templateFile, byteOutputStream);
 			}
-			character.setDefaultOutputSheet(true, templateFile);
-			task.run();
-			if (StringUtils.isNotBlank(task.getErrorMessages()))
+			byte[] exported = byteOutputStream.toByteArray();
+			if (useTempFile)
 			{
-				Logging.errorPrint("BatchExporter.exportCharacterToPDF failed: " //$NON-NLS-1$
-					+ task.getErrorMessages());
-				return false;
+				Files.write(tempFile.toPath(), exported);
+			}
+			try (InputStream inputStream = new ByteArrayInputStream(exported))
+			{
+				FopTask task = FopTask.newFopTask(inputStream,
+						isTransformTemplate ? templateFile : null, fileStream);
+				character.setDefaultOutputSheet(true, templateFile);
+				task.run();
+				if (StringUtils.isNotBlank(task.getErrorMessages()))
+				{
+					Logging.errorPrint("BatchExporter.exportCharacterToPDF failed: " //$NON-NLS-1$
+						+ task.getErrorMessages());
+					return false;
+				}
 			}
 		}
 		catch (final IOException | ExportException e)
@@ -331,27 +333,29 @@ public class BatchExporter
 		String outFileName = removeFileExtension(outFile.getAbsolutePath());
 		File tempFile = new File(outFileName + (isTransformTemplate ? ".xml" : ".fo"));
 		try (BufferedOutputStream fileStream = new BufferedOutputStream(new FileOutputStream(outFile));
-				ByteArrayOutputStream byteOutputStream = new ByteArrayOutputStream();
-				OutputStream exportOutput = useTempFile
-					//Output to both the byte stream and to the temp file.
-					? new TeeOutputStream(byteOutputStream, new FileOutputStream(tempFile)) : byteOutputStream)
+				ByteArrayOutputStream byteOutputStream = new ByteArrayOutputStream())
 		{
-			FopTask task;
 			if (isTransformTemplate)
 			{
-				exportParty(party, exportOutput);
-				ByteArrayInputStream inputStream = new ByteArrayInputStream(byteOutputStream.toByteArray());
-				task = FopTask.newFopTask(inputStream, templateFile, fileStream);
+				exportParty(party, byteOutputStream);
 			}
 			else
 			{
 				SettingsHandler.setSelectedPartyPDFOutputSheet(templateFile.getAbsolutePath());
 
-				exportParty(party, templateFile, exportOutput);
-				ByteArrayInputStream inputStream = new ByteArrayInputStream(byteOutputStream.toByteArray());
-				task = FopTask.newFopTask(inputStream, null, fileStream);
+				exportParty(party, templateFile, byteOutputStream);
 			}
-			task.run();
+			byte[] exported = byteOutputStream.toByteArray();
+			if (useTempFile)
+			{
+				Files.write(tempFile.toPath(), exported);
+			}
+			try (InputStream inputStream = new ByteArrayInputStream(exported))
+			{
+				FopTask task = FopTask.newFopTask(inputStream,
+						isTransformTemplate ? templateFile : null, fileStream);
+				task.run();
+			}
 		}
 		catch (final IOException | ExportException e)
 		{
@@ -542,9 +546,9 @@ public class BatchExporter
 
 	/**
 	 * Create a default character sheet output file name based on the export
-	 * template type and the character file name. The output file will be 
+	 * template type and the character file name. The output file will be
 	 * in the same folder as the character file.
-	 * 
+	 *
 	 * @param characterFilename The path to the character PCG file.
 	 * @return The default output file name.
 	 */
@@ -556,4 +560,5 @@ public class BatchExporter
 		String outputName = charname.substring(0, charname.lastIndexOf('.')) + '.' + extension;
 		return new File(charFile.getParent(), outputName).getAbsolutePath();
 	}
+
 }

--- a/code/src/java/pcgen/system/BatchExporter.java
+++ b/code/src/java/pcgen/system/BatchExporter.java
@@ -49,7 +49,6 @@ import pcgen.persistence.SourceFileLoader;
 import pcgen.util.Logging;
 import pcgen.util.fop.FopTask;
 
-import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.output.TeeOutputStream;
 import org.apache.commons.lang3.StringUtils;
 
@@ -207,14 +206,14 @@ public class BatchExporter
 	public static boolean exportCharacterToPDF(CharacterFacade character, File outFile, File templateFile)
 	{
 
-		String templateExtension = FilenameUtils.getExtension(templateFile.getName());
+		String templateExtension = getFileExtension(templateFile.getName());
 
 		boolean isTransformTemplate =
 				"xslt".equalsIgnoreCase(templateExtension) || "xsl".equalsIgnoreCase(templateExtension);
 
 		boolean useTempFile =
 				PCGenSettings.OPTIONS_CONTEXT.initBoolean(PCGenSettings.OPTION_GENERATE_TEMP_FILE_WITH_PDF, false);
-		String outFileName = FilenameUtils.removeExtension(outFile.getAbsolutePath());
+		String outFileName = removeFileExtension(outFile.getAbsolutePath());
 		File tempFile = new File(outFileName + (isTransformTemplate ? ".xml" : ".fo"));
 		try (OutputStream fileStream = new BufferedOutputStream(new FileOutputStream(outFile));
 		     ByteArrayOutputStream byteOutputStream = new ByteArrayOutputStream();
@@ -329,7 +328,7 @@ public class BatchExporter
 
 		boolean useTempFile =
 				PCGenSettings.OPTIONS_CONTEXT.initBoolean(PCGenSettings.OPTION_GENERATE_TEMP_FILE_WITH_PDF, false);
-		String outFileName = FilenameUtils.removeExtension(outFile.getAbsolutePath());
+		String outFileName = removeFileExtension(outFile.getAbsolutePath());
 		File tempFile = new File(outFileName + (isTransformTemplate ? ".xml" : ".fo"));
 		try (BufferedOutputStream fileStream = new BufferedOutputStream(new FileOutputStream(outFile));
 				ByteArrayOutputStream byteOutputStream = new ByteArrayOutputStream();
@@ -508,6 +507,37 @@ public class BatchExporter
 			template = new File(ConfigurationSettings.getOutputSheetsDir(), "base.xml.ftl");
 		}
 		return template;
+	}
+
+	/**
+	 * Returns the extension of the given file name (text after the last dot in the
+	 * final path segment), or an empty string if there is no extension.
+	 */
+	private static String getFileExtension(String filename)
+	{
+		int slash = Math.max(filename.lastIndexOf('/'), filename.lastIndexOf('\\'));
+		int dot = filename.lastIndexOf('.');
+		if (dot <= slash)
+		{
+			return "";
+		}
+		return filename.substring(dot + 1);
+	}
+
+	/**
+	 * Returns the given path with its extension removed (the last dot in the final
+	 * path segment and everything after it). If the path has no extension, the path
+	 * is returned unchanged.
+	 */
+	private static String removeFileExtension(String path)
+	{
+		int slash = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'));
+		int dot = path.lastIndexOf('.');
+		if (dot <= slash)
+		{
+			return path;
+		}
+		return path.substring(0, dot);
 	}
 
 	/**

--- a/code/src/java/pcgen/system/BatchExporter.java
+++ b/code/src/java/pcgen/system/BatchExporter.java
@@ -512,7 +512,7 @@ public class BatchExporter
 	{
 		Path path = Path.of(ConfigurationSettings.getSystemsDir(), "gameModes",
 				character.getDataSet().getGameMode().getName(), "base.xml.ftl");
-		File template = new File(path.toUri());
+		File template = path.toFile();
 		if (!template.exists())
 		{
 			template = new File(ConfigurationSettings.getOutputSheetsDir(), "base.xml.ftl");

--- a/code/src/java/pcgen/system/BatchExporter.java
+++ b/code/src/java/pcgen/system/BatchExporter.java
@@ -459,9 +459,13 @@ public class BatchExporter
 		}
 		for (File tf : tempFiles)
 		{
-			if (!tf.delete())
+			try
 			{
-				Logging.errorPrint("Could not delete temporary file " + tf.getAbsolutePath());
+				Files.delete(tf.toPath());
+			}
+			catch (IOException ex)
+			{
+				Logging.errorPrint("Could not delete temporary file " + tf.getAbsolutePath(), ex);
 			}
 		}
 	}

--- a/code/src/java/pcgen/system/BatchExporter.java
+++ b/code/src/java/pcgen/system/BatchExporter.java
@@ -383,7 +383,7 @@ public class BatchExporter
 	 */
 	public static boolean exportPartyToNonPDF(PartyFacade party, File outFile, File templateFile)
 	{
-		try (BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(outFile), "UTF-8")))
+		try (BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(outFile), StandardCharsets.UTF_8)))
 		{
 			party.export(ExportHandler.createExportHandler(templateFile), bw);
 			return true;
@@ -406,7 +406,7 @@ public class BatchExporter
 	 */
 	private static void exportParty(PartyFacade party, OutputStream outputStream) throws IOException, ExportException
 	{
-		try (BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(outputStream, "UTF-8")))
+		try (BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(outputStream, StandardCharsets.UTF_8)))
 		{
 			for (final CharacterFacade character : party)
 			{
@@ -429,7 +429,7 @@ public class BatchExporter
 	private static void exportParty(PartyFacade party, File templateFile, OutputStream outputStream)
 		throws IOException, ExportException
 	{
-		try (BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(outputStream, "UTF-8")))
+		try (BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(outputStream, StandardCharsets.UTF_8)))
 		{
 			for (final CharacterFacade character : party)
 			{
@@ -498,7 +498,7 @@ public class BatchExporter
 	private static void exportCharacter(CharacterFacade character, File templateFile, OutputStream outputStream)
 		throws IOException, ExportException
 	{
-		try (BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(outputStream, "UTF-8")))
+		try (BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(outputStream, StandardCharsets.UTF_8)))
 		{
 			character.export(ExportHandler.createExportHandler(templateFile), bw);
 		}

--- a/code/src/java/pcgen/system/BatchExporter.java
+++ b/code/src/java/pcgen/system/BatchExporter.java
@@ -564,7 +564,7 @@ public class BatchExporter
 		File charFile = new File(characterFilename);
 		String charname = charFile.getName();
 		String extension = ExportUtilities.getOutputExtension(exportTemplateFilename, isPdf);
-		String outputName = charname.substring(0, charname.lastIndexOf('.')) + '.' + extension;
+		String outputName = removeFileExtension(charname) + '.' + extension;
 		return new File(charFile.getParent(), outputName).getAbsolutePath();
 	}
 

--- a/code/src/test/pcgen/persistence/lst/DataTest.java
+++ b/code/src/test/pcgen/persistence/lst/DataTest.java
@@ -21,6 +21,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -29,8 +31,10 @@ import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.enumeration.ListKey;
@@ -47,7 +51,6 @@ import pcgen.system.PropertyContextFactory;
 import pcgen.util.Logging;
 import pcgen.util.TestHelper;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -101,9 +104,7 @@ class DataTest
 		List<String> longPaths = new ArrayList<>();
 
 		File dataFolder = new File(dataPath);
-		Collection<File> listFiles =
-				FileUtils.listFiles(dataFolder, new String[]{"pcc", "lst"},
-					true);
+		Collection<File> listFiles = listFilesByExtension(dataFolder, "pcc", "lst");
 		for (File file : listFiles)
 		{
 			String path = file.getAbsolutePath();
@@ -193,8 +194,7 @@ class DataTest
 	void orphanFilesTest() throws IOException
 	{
 		File dataFolder = new File(ConfigurationSettings.getPccFilesDir());
-		Collection<File> listFiles =
-				FileUtils.listFiles(dataFolder, new String[]{"lst"}, true);
+		Collection<File> listFiles = listFilesByExtension(dataFolder, "lst");
 		Collection<String> fileNames = new ArrayList<>(listFiles.size());
 		for (File file : listFiles)
 		{
@@ -223,6 +223,34 @@ class DataTest
 		// TODO Revert back to the below
 		assertEquals("", report, "Some data files are orphaned.");
 		//assertEquals("pathfinder_2e/core_rulebook/c_skills_situation.lst", report, "Some data files are orphaned.");
+	}
+
+	/**
+	 * Recursively lists regular files under {@code root} whose extension matches
+	 * one of the given values (case-sensitive, dot excluded). Mirrors the
+	 * semantics of the previously used {@code FileUtils.listFiles(File,
+	 * String[], boolean)}.
+	 */
+	private static Collection<File> listFilesByExtension(File root, String... extensions)
+	{
+		Set<String> exts = Set.of(extensions);
+		try (Stream<Path> walk = Files.walk(root.toPath()))
+		{
+			return walk.filter(Files::isRegularFile)
+			           .map(Path::toFile)
+			           .filter(f -> exts.contains(extensionOf(f.getName())))
+			           .collect(Collectors.toList());
+		}
+		catch (IOException e)
+		{
+			throw new IllegalStateException("Failed to walk " + root, e);
+		}
+	}
+
+	private static String extensionOf(String filename)
+	{
+		int dot = filename.lastIndexOf('.');
+		return dot < 0 ? "" : filename.substring(dot + 1);
 	}
 
 	private static List<CampaignSourceEntry> getLstFilesForCampaign(CDOMObject campaign)

--- a/code/src/utest/pcgen/io/PCGIOHandlerWriteTest.java
+++ b/code/src/utest/pcgen/io/PCGIOHandlerWriteTest.java
@@ -43,7 +43,7 @@ class PCGIOHandlerWriteTest
 	 * of character file paths.
 	 */
 	@Test
-	public void testWriteProducesVersionAndFilesLines(@TempDir Path tmp) throws IOException
+	void testWriteProducesVersionAndFilesLines(@TempDir Path tmp) throws IOException
 	{
 		File party = tmp.resolve("test.pcp").toFile();
 		File charA = tmp.resolve("a.pcg").toFile();
@@ -66,7 +66,7 @@ class PCGIOHandlerWriteTest
 	 * file ends with the platform line separator.
 	 */
 	@Test
-	public void testWriteEndsWithLineSeparator(@TempDir Path tmp) throws IOException
+	void testWriteEndsWithLineSeparator(@TempDir Path tmp) throws IOException
 	{
 		File party = tmp.resolve("test.pcp").toFile();
 		File charA = tmp.resolve("a.pcg").toFile();
@@ -84,7 +84,7 @@ class PCGIOHandlerWriteTest
 	 * file is encoded in UTF-8 by round-tripping a non-ASCII filename.
 	 */
 	@Test
-	public void testWriteIsUtf8Encoded(@TempDir Path tmp) throws IOException
+	void testWriteIsUtf8Encoded(@TempDir Path tmp) throws IOException
 	{
 		File party = tmp.resolve("test.pcp").toFile();
 		File charA = tmp.resolve("é.pcg").toFile();

--- a/code/src/utest/pcgen/io/PCGIOHandlerWriteTest.java
+++ b/code/src/utest/pcgen/io/PCGIOHandlerWriteTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 (C) Vest <Vest@users.noreply.github.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.io;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * PCGIOHandlerWriteTest checks the party-file format produced by
+ * {@link PCGIOHandler#write(File, List)}.
+ */
+class PCGIOHandlerWriteTest
+{
+
+	/**
+	 * Test method for {@link PCGIOHandler#write(File, List)}: verifies that the
+	 * resulting file contains a VERSION line followed by a comma-separated list
+	 * of character file paths.
+	 */
+	@Test
+	public void testWriteProducesVersionAndFilesLines(@TempDir Path tmp) throws IOException
+	{
+		File party = tmp.resolve("test.pcp").toFile();
+		File charA = tmp.resolve("a.pcg").toFile();
+		File charB = tmp.resolve("b.pcg").toFile();
+		Files.writeString(charA.toPath(), "x");
+		Files.writeString(charB.toPath(), "y");
+
+		PCGIOHandler.write(party, List.of(charA, charB));
+
+		List<String> lines = Files.readAllLines(party.toPath(), StandardCharsets.UTF_8);
+		assertEquals(2, lines.size(), "expected exactly two lines");
+		assertTrue(lines.get(0).startsWith("VERSION:"), "first line should start with VERSION:");
+		assertTrue(lines.get(1).contains("a.pcg"), "second line should reference a.pcg");
+		assertTrue(lines.get(1).contains("b.pcg"), "second line should reference b.pcg");
+		assertTrue(lines.get(1).contains(","), "character paths should be comma-separated");
+	}
+
+	/**
+	 * Test method for {@link PCGIOHandler#write(File, List)}: verifies that the
+	 * file ends with the platform line separator.
+	 */
+	@Test
+	public void testWriteEndsWithLineSeparator(@TempDir Path tmp) throws IOException
+	{
+		File party = tmp.resolve("test.pcp").toFile();
+		File charA = tmp.resolve("a.pcg").toFile();
+		Files.writeString(charA.toPath(), "x");
+
+		PCGIOHandler.write(party, List.of(charA));
+
+		String content = Files.readString(party.toPath(), StandardCharsets.UTF_8);
+		assertTrue(content.endsWith(System.lineSeparator()),
+				"file should end with the platform line separator");
+	}
+
+	/**
+	 * Test method for {@link PCGIOHandler#write(File, List)}: verifies that the
+	 * file is encoded in UTF-8 by round-tripping a non-ASCII filename.
+	 */
+	@Test
+	public void testWriteIsUtf8Encoded(@TempDir Path tmp) throws IOException
+	{
+		File party = tmp.resolve("test.pcp").toFile();
+		File charA = tmp.resolve("é.pcg").toFile();
+		Files.writeString(charA.toPath(), "x");
+
+		PCGIOHandler.write(party, List.of(charA));
+
+		byte[] bytes = Files.readAllBytes(party.toPath());
+		String asUtf8 = new String(bytes, StandardCharsets.UTF_8);
+		assertTrue(asUtf8.contains("é.pcg"),
+				"non-ASCII filename should be readable when decoded as UTF-8");
+	}
+}

--- a/code/src/utest/pcgen/persistence/lst/URIFactoryTest.java
+++ b/code/src/utest/pcgen/persistence/lst/URIFactoryTest.java
@@ -20,7 +20,7 @@ class URIFactoryTest
 		String offset = "data/file.txt";
 		URIFactory uriFactory = new URIFactory(rootURI, offset);
 
-		URI expected = new URI("file:" + System.getProperty("user.dir") + "/data/file.txt");
+		URI expected = new File(System.getProperty("user.dir"), "data/file.txt").toURI();
 		URI result = uriFactory.getURI();
 
 		assertEquals(expected, result);

--- a/code/src/utest/pcgen/util/fop/XsltPdfTemplateCompilationTest.java
+++ b/code/src/utest/pcgen/util/fop/XsltPdfTemplateCompilationTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2026 (C) Vest <Vest@users.noreply.github.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.util.fop;
+
+import net.sf.saxon.s9api.Processor;
+import net.sf.saxon.s9api.SaxonApiException;
+import net.sf.saxon.s9api.XmlProcessingError;
+import net.sf.saxon.s9api.XsltCompiler;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import javax.xml.transform.stream.StreamSource;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Verifies that the stylesheets fixed on this branch no longer trigger
+ * XTSE0710 (unknown attribute set) under Saxon-HE. These files are
+ * fragments included by master stylesheets, so XTSE0650 (unknown template)
+ * is expected and ignored — only undeclared-attribute-set errors are checked.
+ */
+class XsltPdfTemplateCompilationTest
+{
+	private static final Processor PROCESSOR = new Processor(false);
+
+	// TODO: coverage is limited to files fixed on this branch — many other stylesheets have
+	// pre-existing Saxon incompatibilities. Extend this test as those are addressed in future PRs.
+	static Stream<Path> fixedStylesheets()
+	{
+		return Stream.of(
+			Path.of("outputsheets/d20/fantasy/pdf/fantasy_common.xsl"),
+			Path.of("outputsheets/d20/5e/pdf/fantasy_common.xsl"),
+			Path.of("outputsheets/d20/starfinder/pdf/fantasy_common.xsl"),
+			Path.of("outputsheets/d20/pathfinder_2/pdf/fantasy_common.xsl"),
+			Path.of("outputsheets/d20/4e/pdf/fantasy_common.xsl"),
+			Path.of("outputsheets/d20/sagaborn/pdf/fantasy_common.xsl"),
+			Path.of("outputsheets/killshot/pdf/killshot_common.xsl")
+		);
+	}
+
+	@ParameterizedTest(name = "{0}")
+	@MethodSource("fixedStylesheets")
+	void noUndeclaredAttributeSets(Path xslPath)
+	{
+		List<String> errors = new ArrayList<>();
+		XsltCompiler compiler = PROCESSOR.newXsltCompiler();
+		compiler.setErrorReporter(error -> {
+			if (!error.isWarning() && isAttributeSetError(error))
+			{
+				errors.add(formatError(error));
+			}
+		});
+
+		try
+		{
+			compiler.compile(new StreamSource(xslPath.toFile()));
+		}
+		catch (SaxonApiException _)
+		{
+			// Fragment-level compilation failures (XTSE0650, XTSE0165) are
+			// expected; attribute-set errors are captured via the error reporter above.
+		}
+
+		if (!errors.isEmpty())
+		{
+			fail(String.join("\n", errors));
+		}
+	}
+
+	private static boolean isAttributeSetError(XmlProcessingError error)
+	{
+		if (error.getErrorCode() == null)
+		{
+			return false;
+		}
+		String code = error.getErrorCode().getLocalName();
+		// XTSE0710 = unknown attribute set; XTSE0720 = circular attribute set
+		return code.equals("XTSE0710") || code.equals("XTSE0720");
+	}
+
+	private static String formatError(XmlProcessingError error)
+	{
+		var loc = error.getLocation();
+		String location = (loc != null && loc.getSystemId() != null)
+			? "%s:%d ".formatted(loc.getSystemId(), loc.getLineNumber())
+			: "";
+		return "%s[%s] %s".formatted(location, error.getErrorCode().getLocalName(), error.getMessage());
+	}
+}

--- a/outputsheets/d20/4e/pdf/fantasy_common.xsl
+++ b/outputsheets/d20/4e/pdf/fantasy_common.xsl
@@ -732,7 +732,8 @@
 				</fo:table-row>
 			</fo:table-header>
 			<fo:table-footer>
-				<fo:table-row xsl:use-attribute-sets="equipment.title">
+				<fo:table-row>
+					<xsl:call-template name="attrib"><xsl:with-param name="attribute" select="'equipment.title'"/></xsl:call-template>
 					<fo:table-cell padding-top="1pt" number-columns-spanned="2" >
 						<fo:block font-size="7pt">TOTAL WEIGHT CARRIED/VALUE</fo:block>
 					</fo:table-cell>

--- a/outputsheets/d20/5e/pdf/fantasy_common.xsl
+++ b/outputsheets/d20/5e/pdf/fantasy_common.xsl
@@ -786,7 +786,8 @@
 				</fo:table-row>
 			</fo:table-header>
 			<fo:table-footer>
-				<fo:table-row xsl:use-attribute-sets="equipment.title">
+				<fo:table-row>
+					<xsl:call-template name="attrib"><xsl:with-param name="attribute" select="'equipment.title'"/></xsl:call-template>
 					<fo:table-cell padding-top="1pt" number-columns-spanned="2" >
 						<fo:block font-size="7pt">TOTAL WEIGHT CARRIED/VALUE</fo:block>
 					</fo:table-cell>

--- a/outputsheets/d20/fantasy/pdf/fantasy_common.xsl
+++ b/outputsheets/d20/fantasy/pdf/fantasy_common.xsl
@@ -734,7 +734,8 @@
 				</fo:table-row>
 			</fo:table-header>
 			<fo:table-footer>
-				<fo:table-row xsl:use-attribute-sets="equipment.title">
+				<fo:table-row>
+					<xsl:call-template name="attrib"><xsl:with-param name="attribute" select="'equipment.title'"/></xsl:call-template>
 					<fo:table-cell padding-top="1pt" number-columns-spanned="2" >
 						<fo:block font-size="7pt">TOTAL WEIGHT CARRIED/VALUE</fo:block>
 					</fo:table-cell>

--- a/outputsheets/d20/pathfinder_2/pdf/fantasy_common.xsl
+++ b/outputsheets/d20/pathfinder_2/pdf/fantasy_common.xsl
@@ -734,7 +734,8 @@
 				</fo:table-row>
 			</fo:table-header>
 			<fo:table-footer>
-				<fo:table-row xsl:use-attribute-sets="equipment.title">
+				<fo:table-row>
+					<xsl:call-template name="attrib"><xsl:with-param name="attribute" select="'equipment.title'"/></xsl:call-template>
 					<fo:table-cell padding-top="1pt" number-columns-spanned="2" >
 						<fo:block font-size="7pt">TOTAL WEIGHT CARRIED/VALUE</fo:block>
 					</fo:table-cell>

--- a/outputsheets/d20/sagaborn/pdf/fantasy_common.xsl
+++ b/outputsheets/d20/sagaborn/pdf/fantasy_common.xsl
@@ -785,7 +785,8 @@
 				</fo:table-row>
 			</fo:table-header>
 			<fo:table-footer>
-				<fo:table-row xsl:use-attribute-sets="equipment.title">
+				<fo:table-row>
+					<xsl:call-template name="attrib"><xsl:with-param name="attribute" select="'equipment.title'"/></xsl:call-template>
 					<fo:table-cell padding-top="1pt" number-columns-spanned="2" >
 						<fo:block font-size="7pt">TOTAL WEIGHT CARRIED/VALUE</fo:block>
 					</fo:table-cell>

--- a/outputsheets/d20/starfinder/pdf/fantasy_common.xsl
+++ b/outputsheets/d20/starfinder/pdf/fantasy_common.xsl
@@ -519,7 +519,8 @@
 				</fo:table-row>
 			</fo:table-header>
 			<fo:table-footer>
-				<fo:table-row xsl:use-attribute-sets="equipment.title">
+				<fo:table-row>
+					<xsl:call-template name="attrib"><xsl:with-param name="attribute" select="'equipment.title'"/></xsl:call-template>
 					<fo:table-cell padding-top="1pt" number-columns-spanned="2" >
 						<fo:block font-size="7pt">TOTAL WEIGHT CARRIED/VALUE</fo:block>
 					</fo:table-cell>

--- a/outputsheets/killshot/pdf/killshot_common.xsl
+++ b/outputsheets/killshot/pdf/killshot_common.xsl
@@ -421,7 +421,8 @@
 				</fo:table-row>
 			</fo:table-header>
 			<fo:table-footer>
-				<fo:table-row xsl:use-attribute-sets="equipment.title">
+				<fo:table-row>
+					<xsl:call-template name="attrib"><xsl:with-param name="attribute" select="'equipment.title'"/></xsl:call-template>
 					<fo:table-cell padding-top="1pt" number-columns-spanned="2" >
 						<fo:block font-size="7pt">TOTAL WEIGHT CARRIED/VALUE</fo:block>
 					</fo:table-cell>


### PR DESCRIPTION
## Summary

Remove `commons-io` as a direct dependency by migrating its remaining call sites to JDK equivalents. Also fix pre-existing Saxon XSLT compilation errors exposed after the switch from Xalan to Saxon-HE.

## Changes

### commons-io removal
- **`BatchExporter`** — replaced `TeeOutputStream` fan-out with `ByteArrayOutputStream` + sequential `Files.write`; cleaned up `removeTemporaryFiles`, error reporting, and resource handling along the way.
- **`ExportUtilities.getValidFiles`** — `IOFileFilter` / `FileFilterUtils` chain → single `Predicate<File>` + `Stream.filter().sorted()`.
- **`PrintPreviewDialog.SheetLoader`** — `FileUtils.listFiles` + filter chain → `Files.walk` + `Predicate<File>`; dropped the spurious `FilenameFilter` self-implementation.
- **`build.gradle` / `module-info.java`** — dropped the `commons-io` implementation declaration, the `jlink` `forceMerge` entry, and the `requires org.apache.commons.io`.

### XSLT Saxon compatibility fixes
- **`fantasy_common.xsl`** (fantasy, 5e, starfinder, pathfinder_2, 4e, sagaborn) and **`killshot_common.xsl`** — replaced `xsl:use-attribute-sets="equipment.title"` with an equivalent `xsl:call-template name="attrib"` call. Saxon-HE rejects references to undeclared attribute sets at compile time (XTSE0710); the `attrib` template is the correct runtime skinning mechanism.
- **`XsltPdfTemplateCompilationTest`** — new unit test that compiles each fixed stylesheet under Saxon and fails on any XTSE0710/XTSE0720 error, guarding against future regressions.

## Test plan

- [x] `./gradlew compileJava compileTestJava compileItestJava compileSlowtestJava` passes
- [x] PDF character export still produces a valid file
- [x] PDF party export still produces a valid file and surfaces FOP errors
- [x] `XsltPdfTemplateCompilationTest` passes (7/7)
- [ ] Print Preview dialog lists templates and renders a preview

Print Preview is failing because of bugs not related to me.