### PR TITLE
Drop Built-Date, Built-JDK, Created-By from plugin manifests

### DIFF
--- a/code/gradle/plugins.gradle
+++ b/code/gradle/plugins.gradle
@@ -26,10 +26,7 @@ def createJarTask = {taskName, archiveName, description, includePattern ->
             attributes(
                     "Implementation-Title": "PCGen ${taskName.replace('jar', '').toLowerCase()} plugins",
                     "Implementation-Version": project.version,
-                    "Class-Path": "lib/pcgen.jar",
-                    "Built-Date": new Date(),
-                    "Built-JDK": "${System.getProperty('java.vm.version')} (${System.getProperty('java.vendor')})",
-                    "Created-By": "Gradle ${project.gradle.gradleVersion}"
+                    "Class-Path": "lib/pcgen.jar"
             )
         }
 


### PR DESCRIPTION
## Summary

`code/gradle/plugins.gradle:30` set three attributes on every plugin jar manifest. The first one, `Built-Date: new Date()`, was evaluated at configuration time on every Gradle invocation, with two consequences:

1. **Non-reproducible builds.** Two consecutive clean builds produced different bytes inside the manifest, so the resulting jar SHAs differed.
2. **Configuration-cache miss.** Reading the wall-clock during the configuration phase makes the plugin tasks incompatible with Gradle's configuration cache.

The companion `Built-JDK` and `Created-By` attributes are dropped at the same time because they're redundant: nothing in the codebase reads any of the three (`grep -rn 'Built-Date|Built-JDK|Created-By'` returns only the writer line), and the main `pcgen.jar` manifest carries no equivalents — the plugin jars were the odd ones out.

If we want truly reproducible builds, that's a larger, project-wide change: it would have to pin archive timestamps (`preserveFileTimestamps = false`), file ordering (`reproducibleFileOrder = true`), and the JDK/Gradle versions across environments, applied to **all** archive tasks. Keeping `Built-JDK`/`Created-By` on plugin jars only would be inconsistent — leaking environment info from a subset of artifacts without buying real reproducibility. A future PR pursuing full reproducible builds can apply those settings project-wide and reintroduce diagnostic attributes uniformly across every Java module.

## Test plan

- [x] `./gradlew :jarAllPlugins` — all 11 plugin jars build successfully.
- [x] Inspected `plugins/exportplugins.jar` manifest — `Built-Date`, `Built-JDK`, and `Created-By` removed; `Implementation-Title`, `Implementation-Version`, and `Class-Path` retained.
- [x] Reproducibility check: two consecutive clean builds of `:jarExportPlugins` produce byte-identical jars (same SHA-1: \`1b5ed939...\`).
- [x] Build output reports `Configuration cache entry stored.` for `:jarAllPlugins`.