### PR TITLE
TestHelper: load plugins via JUnit extension; cleanup

### DIFF
--- a/.github/workflows/gradle-release-manual.yml
+++ b/.github/workflows/gradle-release-manual.yml
@@ -181,7 +181,7 @@ jobs:
             jdks-
 
       - name: Build, test, and assemble release artifacts
-        run: ./gradlew build compileSlowtest datatest pfinttest pcgenRelease
+        run: ./gradlew build compileSlowtest datatest pfinttest pcgenRelease --stacktrace
 
       - name: Upload release artifacts as workflow artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -151,7 +151,7 @@ jobs:
             jdks-
 
       - name: Build, test, and assemble release artifacts
-        run: ./gradlew build compileSlowtest datatest pfinttest pcgenRelease
+        run: ./gradlew build compileSlowtest datatest pfinttest pcgenRelease --stacktrace
 
       - name: Upload release artifacts as workflow artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/gradle-test.yml
+++ b/.github/workflows/gradle-test.yml
@@ -32,7 +32,7 @@ jobs:
         run: ./gradlew build
 
       - name: Run integration, data, and slow tests
-        run: ./gradlew itest datatest slowtest --stacktrace --info
+        run: ./gradlew itest datatest slowtest
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/gradle-test.yml
+++ b/.github/workflows/gradle-test.yml
@@ -29,10 +29,10 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Build with Gradle Wrapper
-        run: ./gradlew build --stacktrace --info
+        run: ./gradlew build
 
       - name: Run integration, data, and slow tests
-        run: ./gradlew itest datatest slowtest --stacktrace --info
+        run: ./gradlew itest datatest slowtest
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/gradle-test.yml
+++ b/.github/workflows/gradle-test.yml
@@ -32,7 +32,7 @@ jobs:
         run: ./gradlew build
 
       - name: Run integration, data, and slow tests
-        run: ./gradlew itest datatest slowtest
+        run: ./gradlew itest datatest slowtest --stacktrace --info
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/gradle-test.yml
+++ b/.github/workflows/gradle-test.yml
@@ -29,10 +29,10 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Build with Gradle Wrapper
-        run: ./gradlew build
+        run: ./gradlew build --stacktrace
 
       - name: Run integration, data, and slow tests
-        run: ./gradlew itest datatest slowtest
+        run: ./gradlew itest datatest slowtest --stacktrace
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
@@ -50,7 +50,7 @@ jobs:
             PCGen-Formula/build/test-results/**/*.json
 
       - name: Run Coverage
-        run: ./gradlew testCoverage
+        run: ./gradlew testCoverage --stacktrace
 
       - name: Upload Report to artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/gradle-test.yml
+++ b/.github/workflows/gradle-test.yml
@@ -29,10 +29,10 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Build with Gradle Wrapper
-        run: ./gradlew build
+        run: ./gradlew build --stacktrace --info
 
       - name: Run integration, data, and slow tests
-        run: ./gradlew itest datatest slowtest
+        run: ./gradlew itest datatest slowtest --stacktrace --info
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/PCGen-Formula/build.gradle
+++ b/PCGen-Formula/build.gradle
@@ -40,9 +40,7 @@ dependencies {
     testImplementation platform('org.junit:junit-bom:6.1.0')
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testImplementation 'org.junit.jupiter:junit-jupiter-params'
-    testImplementation 'junit:junit:4.13.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
-    testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/PCGen-Formula/code/src/test/pcgen/base/testsupport/AbstractFormulaTestCase.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/testsupport/AbstractFormulaTestCase.java
@@ -18,6 +18,7 @@
 package pcgen.base.testsupport;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Arrays;
 import java.util.List;
@@ -27,7 +28,6 @@ import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
-import junit.framework.TestCase;
 import pcgen.base.formatmanager.FormatManagerLibrary;
 import pcgen.base.formatmanager.FormatUtilities;
 import pcgen.base.formatmanager.OptionalFormatFactory;
@@ -130,7 +130,7 @@ public abstract class AbstractFormulaTestCase
 		boolean isStat = ((Boolean) staticVisitor.visit(node, null)).booleanValue();
 		if (isStat != b)
 		{
-			TestCase.fail("Expected Static (" + b + ") Formula: " + formula);
+			fail("Expected Static (" + b + ") Formula: " + formula);
 		}
 	}
 
@@ -186,7 +186,7 @@ public abstract class AbstractFormulaTestCase
 		{
 			result = Arrays.asList((Object[]) result);
 		}
-		TestCase.fail(
+		fail(
 			"Expected " + valueSimpleName + " (" + valueOf + ") for Formula: "
 				+ formula + ", was " + result + " (" + resultSimpleName + ")");
 	}

--- a/PCGen-Formula/code/src/test/pcgen/base/testsupport/TestUtilities.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/testsupport/TestUtilities.java
@@ -25,7 +25,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import pcgen.base.format.ArrayFormatManager;
 import pcgen.base.format.BooleanManager;
 import pcgen.base.format.NumberManager;
@@ -84,8 +85,7 @@ public final class TestUtilities
 		}
 		catch (ParseException e)
 		{
-			TestCase
-				.fail("Encountered Unexpected Exception: " + e.getMessage());
+			fail("Encountered Unexpected Exception: " + e.getMessage());
 			return null;
 		}
 	}

--- a/build.gradle
+++ b/build.gradle
@@ -240,9 +240,6 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testImplementation 'org.junit.jupiter:junit-jupiter-params'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
-    // JUnit 4 is still used by ~870 legacy tests; pulled in via vintage engine + junit jar.
-    testImplementation 'junit:junit:4.13.2'
-    testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
     testImplementation 'org.hamcrest:hamcrest:3.0'
     testImplementation 'org.testfx:testfx-junit5:4.0.18'
 

--- a/build.gradle
+++ b/build.gradle
@@ -681,7 +681,10 @@ tasks.named("test", Test) {
             '-Dtestfx.headless=true',
             '-Dprism.order=sw',
             // Workaround for TestFX modularity issue. https://github.com/TestFX/TestFX/issues/638
-            '--add-exports', 'javafx.graphics/com.sun.javafx.application=ALL-UNNAMED',
+            // --add-opens (not --add-exports) is required: TestFX's @AfterEach cleanup
+            // does setAccessible(true) on a private field of ParametersImpl, which is
+            // deep reflection — exports alone aren't enough.
+            '--add-opens', 'javafx.graphics/com.sun.javafx.application=ALL-UNNAMED',
             // Required for Monocle.
             '--add-exports', 'javafx.graphics/com.sun.javafx.util=ALL-UNNAMED',
             '--add-exports', 'javafx.base/com.sun.javafx.logging=ALL-UNNAMED',

--- a/code/src/itest/pcgen/cdom/facet/StatIntegrationTest.java
+++ b/code/src/itest/pcgen/cdom/facet/StatIntegrationTest.java
@@ -17,10 +17,10 @@
  */
 package pcgen.cdom.facet;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.base.FormulaFactory;

--- a/code/src/itest/pcgen/io/RaceTargetSaveRestoreTest.java
+++ b/code/src/itest/pcgen/io/RaceTargetSaveRestoreTest.java
@@ -17,9 +17,9 @@
  */
 package pcgen.io;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.cdom.enumeration.SkillCost;
 import pcgen.core.PCClass;

--- a/code/src/itest/plugin/lsttokens/datacontrol/SelectableTokenIntegrationTest.java
+++ b/code/src/itest/plugin/lsttokens/datacontrol/SelectableTokenIntegrationTest.java
@@ -1,10 +1,10 @@
 package plugin.lsttokens.datacontrol;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
 import java.util.Collection;

--- a/code/src/itest/plugin/lsttokens/editcontext/testsupport/AbstractBigDecimalIntegrationTestCase.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/testsupport/AbstractBigDecimalIntegrationTestCase.java
@@ -17,7 +17,7 @@
  */
 package plugin.lsttokens.editcontext.testsupport;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.cdom.base.CDOMObject;
 import pcgen.persistence.PersistenceLayerException;

--- a/code/src/itest/plugin/lsttokens/editcontext/testsupport/AbstractIntegerIntegrationTestCase.java
+++ b/code/src/itest/plugin/lsttokens/editcontext/testsupport/AbstractIntegerIntegrationTestCase.java
@@ -17,7 +17,7 @@
  */
 package plugin.lsttokens.editcontext.testsupport;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URISyntaxException;
 

--- a/code/src/itest/tokencontent/GlobalModifyTest.java
+++ b/code/src/itest/tokencontent/GlobalModifyTest.java
@@ -15,7 +15,7 @@
  */
 package tokencontent;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -69,7 +69,7 @@ public class GlobalModifyTest extends AbstractContentTokenTest
 		if (result != ParseResult.SUCCESS)
 		{
 			result.printMessages(TestURI.getURI());
-			assertEquals("Test Setup Failed", ParseResult.SUCCESS, result);
+			assertEquals(ParseResult.SUCCESS, result, "Test Setup Failed");
 		}
 		finishLoad();
 	}

--- a/code/src/java/pcgen/system/Main.java
+++ b/code/src/java/pcgen/system/Main.java
@@ -323,7 +323,7 @@ public final class Main
 	 * before campaigns reference them. {@link #loadProperties} must already
 	 * have run; that's why it's the caller's responsibility, not ours.
 	 */
-	static void runBootstrapTasks(PCGenTaskListener... listeners)
+	public static void runBootstrapTasks(PCGenTaskListener... listeners)
 	{
 		PCGenTaskExecutor executor = new PCGenTaskExecutor();
 		executor.addPCGenTask(createLoadPluginTask());

--- a/code/src/java/pcgen/system/Main.java
+++ b/code/src/java/pcgen/system/Main.java
@@ -188,12 +188,7 @@ public final class Main
 		new JFXPanel();
 
 		PCGenPreloader splash = new PCGenPreloader();
-		PCGenTaskExecutor executor = new PCGenTaskExecutor();
-		executor.addPCGenTask(createLoadPluginTask());
-		executor.addPCGenTask(new GameModeFileLoader());
-		executor.addPCGenTask(new CampaignFileLoader());
-		executor.addPCGenTaskListener(splash);
-		executor.run();
+		runBootstrapTasks(splash);
 		splash.getController().setProgress(LanguageBundle.getString("in_taskInitUi"), 1.0d);
 		FacadeFactory.initialize();
 		PCGenUIManager.initializeGUI();
@@ -321,16 +316,32 @@ public final class Main
 		return loader;
 	}
 
+	/**
+	 * Run the canonical post-properties bootstrap sequence: load plugins,
+	 * then game modes, then campaigns. Order matters — plugins register
+	 * tokens that GameModeFileLoader relies on, and game modes must exist
+	 * before campaigns reference them. {@link #loadProperties} must already
+	 * have run; that's why it's the caller's responsibility, not ours.
+	 */
+	static void runBootstrapTasks(PCGenTaskListener... listeners)
+	{
+		PCGenTaskExecutor executor = new PCGenTaskExecutor();
+		executor.addPCGenTask(createLoadPluginTask());
+		executor.addPCGenTask(new GameModeFileLoader());
+		executor.addPCGenTask(new CampaignFileLoader());
+		for (PCGenTaskListener listener : listeners)
+		{
+			executor.addPCGenTaskListener(listener);
+		}
+		executor.run();
+	}
+
 	private static boolean startupWithoutGUI()
 	{
 		loadProperties(false);
 		validateEnvironment(false);
 
-		PCGenTaskExecutor executor = new PCGenTaskExecutor();
-		executor.addPCGenTask(createLoadPluginTask());
-		executor.addPCGenTask(new GameModeFileLoader());
-		executor.addPCGenTask(new CampaignFileLoader());
-		executor.run();
+		runBootstrapTasks();
 
 		UIDelegate uiDelegate = new ConsoleUIDelegate();
 

--- a/code/src/test/pcgen/AbstractCharacterTestCase.java
+++ b/code/src/test/pcgen/AbstractCharacterTestCase.java
@@ -46,6 +46,8 @@ import plugin.lsttokens.testsupport.BuildUtilities;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import pcgen.test.PCGenTestEnvironment;
 import util.FormatSupport;
 import util.GameModeSupport;
 
@@ -54,6 +56,7 @@ import util.GameModeSupport;
  * Object.
  */
 @SuppressWarnings("nls")
+@ExtendWith(PCGenTestEnvironment.class)
 public abstract class AbstractCharacterTestCase
 {
 	private PlayerCharacter character = null;
@@ -111,7 +114,6 @@ public abstract class AbstractCharacterTestCase
 		GameModeFileLoader.addDefaultTabInfo(gamemode);
 		SystemCollections.addToGameModeList(gamemode);
 		SettingsHandler.setGame("3.5");
-		TestHelper.loadPlugins();
 
 		Globals.setUseGUI(false);
 		Globals.emptyLists();

--- a/code/src/test/pcgen/AbstractJunit5CharacterTestCase.java
+++ b/code/src/test/pcgen/AbstractJunit5CharacterTestCase.java
@@ -57,6 +57,8 @@ import plugin.lsttokens.testsupport.BuildUtilities;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import pcgen.test.PCGenTestEnvironment;
 import util.FormatSupport;
 import util.GameModeSupport;
 
@@ -65,6 +67,7 @@ import util.GameModeSupport;
  * Object.
  */
 @SuppressWarnings("nls")
+@ExtendWith(PCGenTestEnvironment.class)
 public abstract class AbstractJunit5CharacterTestCase
 {
 	private PlayerCharacter character = null;
@@ -100,7 +103,6 @@ public abstract class AbstractJunit5CharacterTestCase
 	@BeforeEach
 	public void setUp() throws Exception
 	{
-		TestHelper.loadPlugins();
 		final GameMode gamemode = new GameMode("3.5");
 		gamemode.setBonusFeatLevels("3|3");
 		ControlTestSupport.enableFeature(gamemode.getModeContext(), CControl.ALIGNMENTFEATURE);

--- a/code/src/test/pcgen/cdom/helper/AspectTest.java
+++ b/code/src/test/pcgen/cdom/helper/AspectTest.java
@@ -17,7 +17,7 @@
  */
 package pcgen.cdom.helper;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Collections;
 import java.util.List;
@@ -221,15 +221,13 @@ public class AspectTest extends AbstractCharacterTestCase
 		assertEquals("2 test ", aspect.getAspectText(pc, Collections.singletonList(cna)));
 
 		aspect.addVariable("%LIST");
-		assertEquals("Replacement of %LIST failed",
-			"2 test Associated 1 and Associated 2", aspect
-				.getAspectText(pc, Collections.singletonList(cna)));
+		assertEquals("2 test Associated 1 and Associated 2", aspect
+				.getAspectText(pc, Collections.singletonList(cna)), "Replacement of %LIST failed");
 
 		finalizeTest(dummy, "Associated 3", pc, BuildUtilities.getFeatCat());
 		aspect.addVariable("%LIST");
-		assertEquals("Replacement of %LIST failed",
-			"2 test Associated 1, Associated 2, Associated 3", aspect
-				.getAspectText(pc, Collections.singletonList(cna)));
+		assertEquals("2 test Associated 1, Associated 2, Associated 3", aspect
+				.getAspectText(pc, Collections.singletonList(cna)), "Replacement of %LIST failed");
 	}
 	
 

--- a/code/src/test/pcgen/core/BonusManagerTest.java
+++ b/code/src/test/pcgen/core/BonusManagerTest.java
@@ -18,7 +18,7 @@
 package pcgen.core;
 
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.enumeration.ListKey;
@@ -55,7 +55,7 @@ public class BonusManagerTest extends AbstractCharacterTestCase
 		for (int i = 0; i < 10; i++)
 		{
 			pc.calcActiveBonuses();
-			assertEquals("Incorrect bonus total", 3.0, pc.getTotalBonusTo("COMBAT", "AC"), 0.0001);
+			assertEquals(3.0, pc.getTotalBonusTo("COMBAT", "AC"), 0.0001, "Incorrect bonus total");
 		}
 	}
 
@@ -80,7 +80,7 @@ public class BonusManagerTest extends AbstractCharacterTestCase
 		for (int i = 0; i < 10; i++)
 		{
 			pc.calcActiveBonuses();
-			assertEquals("Incorrect bonus total", 3.0, pc.getTotalBonusTo("COMBAT", "AC"), 0.0001);
+			assertEquals(3.0, pc.getTotalBonusTo("COMBAT", "AC"), 0.0001, "Incorrect bonus total");
 		}
 	}
 
@@ -108,7 +108,7 @@ public class BonusManagerTest extends AbstractCharacterTestCase
 		for (int i = 0; i < 10; i++)
 		{
 			pc.calcActiveBonuses();
-			assertEquals("Incorrect bonus total", 3.0, pc.getTotalBonusTo("COMBAT", "AC"), 0.0001);
+			assertEquals(3.0, pc.getTotalBonusTo("COMBAT", "AC"), 0.0001, "Incorrect bonus total");
 		}
 	}
 

--- a/code/src/test/pcgen/core/ChallengeRatingPathfinderTest.java
+++ b/code/src/test/pcgen/core/ChallengeRatingPathfinderTest.java
@@ -17,7 +17,7 @@
  */
 package pcgen.core;
 
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;

--- a/code/src/test/pcgen/core/EquipmentModifierTest.java
+++ b/code/src/test/pcgen/core/EquipmentModifierTest.java
@@ -29,17 +29,19 @@ import pcgen.core.bonus.Bonus;
 import pcgen.core.bonus.BonusObj;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.rules.context.LoadContext;
-import pcgen.util.TestHelper;
+import pcgen.test.PCGenTestEnvironment;
 
 import plugin.lsttokens.testsupport.TokenRegistration;
 
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
  * Equipment Modifer Test 
  */
+@ExtendWith(PCGenTestEnvironment.class)
 class EquipmentModifierTest
 {
 	/**
@@ -48,7 +50,6 @@ class EquipmentModifierTest
 	@BeforeEach
 	void setUp()
 	{
-		TestHelper.loadPlugins();
 	}
 
 	@AfterAll

--- a/code/src/test/pcgen/core/PCClassTest.java
+++ b/code/src/test/pcgen/core/PCClassTest.java
@@ -27,7 +27,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.List;
-import java.util.StringTokenizer;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.base.format.StringManager;
@@ -63,6 +62,7 @@ import pcgen.persistence.lst.FeatLoader;
 import pcgen.persistence.lst.PCClassLoader;
 import pcgen.persistence.lst.SimpleLoader;
 import pcgen.rules.context.LoadContext;
+import pcgen.util.TestHelper;
 import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.pretokens.parser.PreVariableParser;
 
@@ -425,7 +425,7 @@ public class PCClassTest extends AbstractCharacterTestCase
 		}
 		PCClass reconstClass;
 		System.out.println("Got text: " + classPCCText);
-		reconstClass = parsePCClassText(classPCCText, source);
+		reconstClass = TestHelper.parsePCClassText(classPCCText, source);
 		assertEquals(
 				classPCCText, reconstClass.getPCCText(),
 				"getPCCText should be the same after being encoded and reloaded");
@@ -445,7 +445,7 @@ public class PCClassTest extends AbstractCharacterTestCase
 		assertNotNull(classPCCText, "PCC Text for race should not be null");
 
 		System.out.println("Got text: " + classPCCText);
-		reconstClass = parsePCClassText(classPCCText, source);
+		reconstClass = TestHelper.parsePCClassText(classPCCText, source);
 		assertEquals(
 				classPCCText, reconstClass.getPCCText(),
 				"getPCCText should be the same after being encoded and reloaded");
@@ -867,7 +867,7 @@ public class PCClassTest extends AbstractCharacterTestCase
 			"CLASS:Cleric	HD:8		TYPE:PC	TYPE:Base.PC	FACT:Abb|Clr	ABILITY:TestCat|AUTOMATIC|Ability1\n"
 				+ "CLASS:Cleric	STARTSKILLPTS:2\n"
 				+ "2	ABILITY:TestCat|AUTOMATIC|Ability2";
-		PCClass pcclass = parsePCClassText(classPCCText, source);
+		PCClass pcclass = TestHelper.parsePCClassText(classPCCText, source);
 		CDOMSingleRef<AbilityCategory> acRef =
 				context.getReferenceContext().getCDOMReference(
 					AbilityCategory.class, "TestCat");
@@ -985,33 +985,6 @@ public class PCClassTest extends AbstractCharacterTestCase
 		pc.incrementClassLevel(1, humanoidClass);
 		bonusList = pc.getClassKeyed(humanoidClass.getKeyName()).getRawBonusList(pc);
 		assertEquals(3, bonusList.size(), "No new bonus due to the LEVELSPERFEAT");
-	}
-
-	/**
-	 * Parse a class definition and return the populated PCClass object.
-	 *
-	 * @param classPCCText The textual definition of the class.
-	 * @param source The source that the class is from.
-	 * @return The populated class.
-	 * @throws PersistenceLayerException
-	 */
-	private static PCClass parsePCClassText(String classPCCText,
-	                                        CampaignSourceEntry source) throws PersistenceLayerException
-	{
-		PCClassLoader pcClassLoader = new PCClassLoader();
-		PCClass reconstClass = null;
-		StringTokenizer tok = new StringTokenizer(classPCCText, "\n");
-		while (tok.hasMoreTokens())
-		{
-			String line = tok.nextToken();
-			if (!line.trim().isEmpty())
-			{
-				System.out.println("Processing line: '" + line + "'.");
-				reconstClass =
-						pcClassLoader.parseLine(Globals.getContext(), reconstClass, line, source);
-			}
-		}
-		return reconstClass;
 	}
 
 	@BeforeEach

--- a/code/src/test/pcgen/core/PCTemplateTest.java
+++ b/code/src/test/pcgen/core/PCTemplateTest.java
@@ -17,9 +17,9 @@
  */
 package pcgen.core;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -114,10 +114,10 @@ public class PCTemplateTest extends AbstractCharacterTestCase
 		// Add the template to the character
 		PlayerCharacter pc = getCharacter();
 		pc.addTemplate(template);
-		assertTrue("Character should have ability1.", hasAbility(pc, cat,
-			Nature.AUTOMATIC, ab1));
-		assertTrue("Character should have ability2.", hasAbility(pc, cat,
-			Nature.AUTOMATIC, ab2));
+		assertTrue(hasAbility(pc, cat,
+			Nature.AUTOMATIC, ab1), "Character should have ability1.");
+		assertTrue(hasAbility(pc, cat,
+			Nature.AUTOMATIC, ab2), "Character should have ability2.");
 	}
 
 	/**
@@ -180,10 +180,10 @@ public class PCTemplateTest extends AbstractCharacterTestCase
 		pc.addTemplate(template);
 		// Need to do this to populate the ability list
 		//pc.getAutomaticAbilityList(BuildUtilities.getFeatCat());
-		assertTrue("Character should have ability1.", hasAbility(pc, BuildUtilities.getFeatCat(),
-			Nature.AUTOMATIC, ab1));
-		assertTrue("Character should have ability2.", hasAbility(pc, BuildUtilities.getFeatCat(),
-			Nature.AUTOMATIC, ab2));
+		assertTrue(hasAbility(pc, BuildUtilities.getFeatCat(),
+			Nature.AUTOMATIC, ab1), "Character should have ability1.");
+		assertTrue(hasAbility(pc, BuildUtilities.getFeatCat(),
+			Nature.AUTOMATIC, ab2), "Character should have ability2.");
 	}
 
 	/**
@@ -256,21 +256,21 @@ public class PCTemplateTest extends AbstractCharacterTestCase
 		// Add the template to the character
 		PlayerCharacter pc = getCharacter();
 		pc.addTemplate(template);
-		assertFalse("Character should not have ability1.", hasAbility(pc, cat,
-			Nature.AUTOMATIC, ab1));
-		assertTrue("Character should have ability2.", hasAbility(pc, cat,
-			Nature.AUTOMATIC, ab2));
+		assertFalse(hasAbility(pc, cat,
+			Nature.AUTOMATIC, ab1), "Character should not have ability1.");
+		assertTrue(hasAbility(pc, cat,
+			Nature.AUTOMATIC, ab2), "Character should have ability2.");
 		
 		// Level the character up, testing for when the level tag kicks in
 		pc.incrementClassLevel(1, testClass);
 		pc.calcActiveBonuses();
-		assertFalse("Character should not have ability1.", hasAbility(pc, cat,
-			Nature.AUTOMATIC, ab1));
+		assertFalse(hasAbility(pc, cat,
+			Nature.AUTOMATIC, ab1), "Character should not have ability1.");
 
 		pc.incrementClassLevel(1, testClass);
 		pc.calcActiveBonuses();
-		assertTrue("Character should have ability1.", hasAbility(pc, cat,
-			Nature.AUTOMATIC, ab1));
+		assertTrue(hasAbility(pc, cat,
+			Nature.AUTOMATIC, ab1), "Character should have ability1.");
 		
 	}
 
@@ -341,21 +341,21 @@ public class PCTemplateTest extends AbstractCharacterTestCase
 		// Add the template to the character
 		PlayerCharacter pc = getCharacter();
 		pc.addTemplate(template);
-		assertFalse("Character should not have ability1.", hasAbility(pc, BuildUtilities.getFeatCat(),
-			Nature.AUTOMATIC, ab1));
-		assertTrue("Character should have ability2.", hasAbility(pc, BuildUtilities.getFeatCat(),
-			Nature.AUTOMATIC, ab2));
+		assertFalse(hasAbility(pc, BuildUtilities.getFeatCat(),
+			Nature.AUTOMATIC, ab1), "Character should not have ability1.");
+		assertTrue(hasAbility(pc, BuildUtilities.getFeatCat(),
+			Nature.AUTOMATIC, ab2), "Character should have ability2.");
 		
 		// Level the character up, testing for when the level tag kicks in
 		pc.incrementClassLevel(1, testClass);
 		pc.calcActiveBonuses();
-		assertFalse("Character should not have ability1.", hasAbility(pc, BuildUtilities.getFeatCat(),
-			Nature.AUTOMATIC, ab1));
+		assertFalse(hasAbility(pc, BuildUtilities.getFeatCat(),
+			Nature.AUTOMATIC, ab1), "Character should not have ability1.");
 
 		pc.incrementClassLevel(1, testClass);
 		pc.calcActiveBonuses();
-		assertTrue("Character should have ability1.", hasAbility(pc, BuildUtilities.getFeatCat(),
-			Nature.AUTOMATIC, ab1));
+		assertTrue(hasAbility(pc, BuildUtilities.getFeatCat(),
+			Nature.AUTOMATIC, ab1), "Character should have ability1.");
 		
 	}
 

--- a/code/src/test/pcgen/core/PObjectTest.java
+++ b/code/src/test/pcgen/core/PObjectTest.java
@@ -16,9 +16,9 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
 package pcgen.core;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -76,13 +76,13 @@ public class PObjectTest extends AbstractCharacterTestCase
 
 		//		race.setDR("5/Good");
 		race.addToListFor(ListKey.DAMAGE_REDUCTION, new DamageReduction(FormulaFactory.getFormulaFor(5), "Good"));
-		assertEquals("Basic DR set.", "5/Good", race.getListFor(ListKey.DAMAGE_REDUCTION).get(0)
-			.toString());
+		assertEquals("5/Good", race.getListFor(ListKey.DAMAGE_REDUCTION).get(0)
+			.toString(), "Basic DR set.");
 
 		race.removeListFor(ListKey.DAMAGE_REDUCTION);
 		//		race.setDR("0/-");
 		race.addToListFor(ListKey.DAMAGE_REDUCTION, new DamageReduction(FormulaFactory.getFormulaFor(0), "-"));
-		assertEquals("Basic DR set.", "0/-", race.getListFor(ListKey.DAMAGE_REDUCTION).get(0).toString());
+		assertEquals("0/-", race.getListFor(ListKey.DAMAGE_REDUCTION).get(0).toString(), "Basic DR set.");
 
 		//		template.setDR("0/-");
 		template.addToListFor(ListKey.DAMAGE_REDUCTION, new DamageReduction(FormulaFactory.getFormulaFor(0), "-"));
@@ -96,7 +96,7 @@ public class PObjectTest extends AbstractCharacterTestCase
 		pc.setRace(race);
 		pc.addTemplate(template);
 		pc.calcActiveBonuses();
-		assertEquals("Basic DR set.", "1/-", pc.getDisplay().calcDR());
+		assertEquals("1/-", pc.getDisplay().calcDR(), "Basic DR set.");
 	}
 
 	/**
@@ -117,7 +117,7 @@ public class PObjectTest extends AbstractCharacterTestCase
 		race.setName("TestRace");
 		race.put(ObjectKey.CHALLENGE_RATING, new ChallengeRating(FormulaFactory.getFormulaFor(5)));
 		String racePCCText = race.getPCCText();
-		assertNotNull("PCC Text for race should not be null", racePCCText);
+		assertNotNull(racePCCText, "PCC Text for race should not be null");
 
 		GenericLoader<Race> raceLoader = new GenericLoader<>(Race.class);
 		CampaignSourceEntry source;
@@ -132,29 +132,23 @@ public class PObjectTest extends AbstractCharacterTestCase
 		}
 		raceLoader.parseLine(context, null, racePCCText, source);
 		Race reconstRace = context.getReferenceContext().silentlyGetConstructedCDOMObject(Race.class, "TestRace");
-		assertEquals(
-			"getPCCText should be the same after being encoded and reloaded",
-			racePCCText, reconstRace.getPCCText());
-		assertEquals("Racial CR was not restored after saving and reloading.",
-				race.get(ObjectKey.CHALLENGE_RATING), reconstRace
-						.get(ObjectKey.CHALLENGE_RATING));
+		assertEquals(racePCCText, reconstRace.getPCCText(), "getPCCText should be the same after being encoded and reloaded");
+		assertEquals(race.get(ObjectKey.CHALLENGE_RATING), reconstRace
+						.get(ObjectKey.CHALLENGE_RATING), "Racial CR was not restored after saving and reloading.");
 
 		FactKey.getConstant("Abb", new StringManager());
 		PCClass aClass = new PCClass();
 		aClass.setName("TestClass");
 		String classPCCText = aClass.getPCCText();
-		assertNotNull("PCC Text for race should not be null", racePCCText);
+		assertNotNull(racePCCText, "PCC Text for race should not be null");
 
 		PCClassLoader classLoader = new PCClassLoader();
 		PCClass reconstClass =
 				classLoader.parseLine(context, null, classPCCText,
 					source);
-		assertEquals(
-			"getPCCText should be the same after being encoded and reloaded",
-			classPCCText, reconstClass.getPCCText());
-		assertEquals(
-			"Class abbrev was not restored after saving and reloading.", aClass
-				.getAbbrev(), reconstClass.getAbbrev());
+		assertEquals(classPCCText, reconstClass.getPCCText(), "getPCCText should be the same after being encoded and reloaded");
+		assertEquals(aClass
+				.getAbbrev(), reconstClass.getAbbrev(), "Class abbrev was not restored after saving and reloading.");
 
 	}
 
@@ -180,20 +174,20 @@ public class PObjectTest extends AbstractCharacterTestCase
 		BonusAddition.applyBonus("SPELLKNOWN|CLASS=TestPsion;LEVEL=1|1", "TestPsion 1",
 			aPC, pObj);
 		aPC.calcActiveBonuses();
-		assertEquals("Should get 1 bonus known spells", 1, (int) aPC
-			.getTotalBonusTo("SPELLKNOWN", "CLASS.TestPsion;LEVEL.1"));
+		assertEquals(1, (int) aPC
+			.getTotalBonusTo("SPELLKNOWN", "CLASS.TestPsion;LEVEL.1"), "Should get 1 bonus known spells");
 		AbstractCharacterTestCase.applyAbility(aPC, BuildUtilities.getFeatCat(), pObj, "TestPsion 1");
 		BonusAddition.applyBonus("SPELLKNOWN|CLASS=TestPsion;LEVEL=1|1", "TestPsion 1",
 			aPC, pObj);
 		aPC.calcActiveBonuses();
-		assertEquals("Should get 4 bonus known spells", (2 * 2), (int) aPC
-			.getTotalBonusTo("SPELLKNOWN", "CLASS.TestPsion;LEVEL.1"));
+		assertEquals((2 * 2), (int) aPC
+			.getTotalBonusTo("SPELLKNOWN", "CLASS.TestPsion;LEVEL.1"), "Should get 4 bonus known spells");
 		AbstractCharacterTestCase.applyAbility(aPC, BuildUtilities.getFeatCat(), pObj, "TestPsion 1");
 		BonusAddition.applyBonus("SPELLKNOWN|CLASS=TestPsion;LEVEL=1|1", "TestPsion 1",
 			aPC, pObj);
 		aPC.calcActiveBonuses();
-		assertEquals("Should get 9 bonus known spells", (3 * 3), (int) aPC
-			.getTotalBonusTo("SPELLKNOWN", "CLASS.TestPsion;LEVEL.1"));
+		assertEquals((3 * 3), (int) aPC
+			.getTotalBonusTo("SPELLKNOWN", "CLASS.TestPsion;LEVEL.1"), "Should get 9 bonus known spells");
 	}
 
 	/**
@@ -229,12 +223,12 @@ public class PObjectTest extends AbstractCharacterTestCase
 		int baseHP = aPC.hitPoints();
 		AbstractCharacterTestCase.applyAbility(aPC, BuildUtilities.getFeatCat(), pObj, "");
 		aPC.calcActiveBonuses();
-		assertEquals("Should have added 3 HPs", baseHP + 3, aPC.hitPoints());
+		assertEquals(baseHP + 3, aPC.hitPoints(), "Should have added 3 HPs");
 
 		AbstractCharacterTestCase.applyAbility(aPC, BuildUtilities.getFeatCat(), pObj, "");
 		aPC.calcActiveBonuses();
-		assertEquals("2 instances should have added 6 HPs", baseHP + 6, aPC
-			.hitPoints());
+		assertEquals(baseHP + 6, aPC
+			.hitPoints(), "2 instances should have added 6 HPs");
 
 	}
 
@@ -269,12 +263,12 @@ public class PObjectTest extends AbstractCharacterTestCase
 		int baseHP = aPC.hitPoints();
 		AbstractCharacterTestCase.applyAbility(aPC, BuildUtilities.getFeatCat(), pObj, "");
 		aPC.calcActiveBonuses();
-		assertEquals("Should have added 3 HPs", baseHP + 3, aPC.hitPoints());
+		assertEquals(baseHP + 3, aPC.hitPoints(), "Should have added 3 HPs");
 
 		AbstractCharacterTestCase.applyAbility(aPC, BuildUtilities.getFeatCat(), pObj, "");
 		aPC.calcActiveBonuses();
-		assertEquals("2 instances should have added 6 HPs", baseHP + 6, aPC
-			.hitPoints());
+		assertEquals(baseHP + 6, aPC
+			.hitPoints(), "2 instances should have added 6 HPs");
 
 	}
 
@@ -289,26 +283,23 @@ public class PObjectTest extends AbstractCharacterTestCase
 		pobj.addToListFor(ListKey.DESCRIPTION, desc1);
 
 		PlayerCharacter pc = getCharacter();
-		assertEquals("Description should match", "Description 1.", pc
-			.getDescription(pobj));
+		assertEquals("Description 1.", pc
+			.getDescription(pobj), "Description should match");
 
 		final Description desc2 = new Description("Description 2.");
 		pobj.addToListFor(ListKey.DESCRIPTION, desc2);
 
-		assertEquals("Description should match", "Description 1. Description 2.",
-			pc.getDescription(pobj));
+		assertEquals("Description 1. Description 2.", pc.getDescription(pobj), "Description should match");
 
 		final Description desc3 = new Description("Description %1.");
 		desc3.addVariable("\"3\"");
 		pobj.addToListFor(ListKey.DESCRIPTION, desc3);
 
-		assertEquals("Description should match",
-			"Description 1. Description 2. Description 3.", pc
-				.getDescription(pobj));
+		assertEquals("Description 1. Description 2. Description 3.", pc
+				.getDescription(pobj), "Description should match");
 
 		pobj.removeFromListFor(ListKey.DESCRIPTION, desc2);
-		assertEquals("Description should match", "Description 1. Description 3.",
-			pc.getDescription(pobj));
+		assertEquals("Description 1. Description 3.", pc.getDescription(pobj), "Description should match");
 	}
 
 	/**
@@ -372,10 +363,10 @@ public class PObjectTest extends AbstractCharacterTestCase
 		// Add the template to the character
 		PlayerCharacter pc = getCharacter();
 		pc.setRace(race);
-		assertTrue("Character should have ability1.", hasAbility(pc, cat,
-			Nature.AUTOMATIC, ab1));
-		assertTrue("Character should have ability2.", hasAbility(pc, cat,
-			Nature.AUTOMATIC, ab2));
+		assertTrue(hasAbility(pc, cat,
+			Nature.AUTOMATIC, ab1), "Character should have ability1.");
+		assertTrue(hasAbility(pc, cat,
+			Nature.AUTOMATIC, ab2), "Character should have ability2.");
 	}
 
 }

--- a/code/src/test/pcgen/core/PlayerCharacterSpellTest.java
+++ b/code/src/test/pcgen/core/PlayerCharacterSpellTest.java
@@ -17,7 +17,7 @@
  */
 package pcgen.core;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 
@@ -110,9 +110,9 @@ public class PlayerCharacterSpellTest extends AbstractCharacterTestCase
 		pc.addDomain(sunDomain);
 		
 		List<? extends CDOMList<Spell>> spellLists = pc.getSpellLists(sunDomain);
-		assertEquals("Incorrect number of spell lists for domain", 1, spellLists.size());
+		assertEquals(1, spellLists.size(), "Incorrect number of spell lists for domain");
 		int level = SpellLevel.getFirstLevelForKey(domainSpell, spellLists, pc);
-		assertEquals("Incorrect spell level in domain list", 1, level);
+		assertEquals(1, level, "Incorrect spell level in domain list");
 	}
 
 	/**
@@ -126,9 +126,9 @@ public class PlayerCharacterSpellTest extends AbstractCharacterTestCase
 		pc.incrementClassLevel(1, divineClass);
 		
 		List<? extends CDOMList<Spell>> spellLists = pc.getSpellLists(pc.getClassKeyed(divineClass.getKeyName()));
-		assertEquals("Incorrect number of spell lists in class list", 1, spellLists.size());
+		assertEquals(1, spellLists.size(), "Incorrect number of spell lists in class list");
 		int level = SpellLevel.getFirstLevelForKey(classSpell, spellLists, pc);
-		assertEquals("Incorrect spell level in class list", 1, level);
+		assertEquals(1, level, "Incorrect spell level in class list");
 	}
 
 	@Override

--- a/code/src/test/pcgen/core/PrereqHandlerTest.java
+++ b/code/src/test/pcgen/core/PrereqHandlerTest.java
@@ -1,6 +1,6 @@
 package pcgen.core;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.enumeration.StringKey;
@@ -40,16 +40,16 @@ public class PrereqHandlerTest extends AbstractCharacterTestCase
 		pc.setRace(human);
 
 		AlignmentCompat.setCurrentAlignment(pc.getCharID(), le);
-		assertFalse("Non-negate returns false", PrereqHandler.passes(
-				prereq, pc, null));
-		assertFalse("Negate returns false", PrereqHandler.passes(
-				prereqNeg, pc, null));
+		assertFalse(PrereqHandler.passes(
+				prereq, pc, null), "Non-negate returns false");
+		assertFalse(PrereqHandler.passes(
+				prereqNeg, pc, null), "Negate returns false");
 
 		AlignmentCompat.setCurrentAlignment(pc.getCharID(), tn);
-		assertTrue("Non-negate returns true", PrereqHandler.passes(
-				prereq, pc, null));
-		assertTrue("Negate returns true", PrereqHandler.passes(
-				prereqNeg, pc, null));
+		assertTrue(PrereqHandler.passes(
+				prereq, pc, null), "Non-negate returns true");
+		assertTrue(PrereqHandler.passes(
+				prereqNeg, pc, null), "Negate returns true");
 	}
 
 	/**
@@ -68,15 +68,15 @@ public class PrereqHandlerTest extends AbstractCharacterTestCase
 		human.setName("Human");
 		pc.setRace(human);
 
-		assertTrue("No feat should return true", PrereqHandler.passes(prereq,
-			pc, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			pc, null), "No feat should return true");
 
 		final Ability ud = new Ability();
 		ud.setName("Uncanny Dodge");
 		ud.setCDOMCategory(BuildUtilities.getFeatCat());
 		ud.put(StringKey.KEY_NAME, "Uncanny Dodge");
 		addAbility(BuildUtilities.getFeatCat(), ud);
-		assertFalse("Feat should return false", PrereqHandler.passes(prereq,
-			pc, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			pc, null), "Feat should return false");
 	}
 }

--- a/code/src/test/pcgen/core/StatListTest.java
+++ b/code/src/test/pcgen/core/StatListTest.java
@@ -18,7 +18,7 @@
 
 package pcgen.core;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.base.FormulaFactory;
@@ -83,22 +83,22 @@ public class StatListTest extends AbstractCharacterTestCase
 	public void testGetBaseStatFor()
 	{
 		PlayerCharacter pc = getCharacter();
-		assertEquals("Starting STR should be 6", 6, pc.getBaseStatFor(str));
+		assertEquals(6, pc.getBaseStatFor(str), "Starting STR should be 6");
 
 		// Bonus should not affect base stat
 		addAbility(BuildUtilities.getFeatCat(), bonus);
 		pc.calcActiveBonuses();
-		assertEquals("Stat should still be base", 6, pc.getBaseStatFor(str));
+		assertEquals(6, pc.getBaseStatFor(str), "Stat should still be base");
 		
 		pc.addTemplate(locker);
-		assertEquals("Stat should now be locked", 12, pc.getBaseStatFor(str));
+		assertEquals(12, pc.getBaseStatFor(str), "Stat should now be locked");
 
 		addAbility(BuildUtilities.getFeatCat(), lockedBonus);
 		pc.calcActiveBonuses();
-		assertEquals("Stat should still be locked", 12, pc.getBaseStatFor(str));
+		assertEquals(12, pc.getBaseStatFor(str), "Stat should still be locked");
 		
 		pc.addTemplate(unlocker);
-		assertEquals("Stat should now be unlocked", 6, pc.getBaseStatFor(str));
+		assertEquals(6, pc.getBaseStatFor(str), "Stat should now be unlocked");
 	}
 
 	/**
@@ -108,22 +108,22 @@ public class StatListTest extends AbstractCharacterTestCase
 	public void testGetTotalStatFor()
 	{
 		PlayerCharacter pc = getCharacter();
-		assertEquals("Starting STR should be 6", 6, pc.getTotalStatFor(str));
+		assertEquals(6, pc.getTotalStatFor(str), "Starting STR should be 6");
 
 		// Bonus should affect total stat
 		addAbility(BuildUtilities.getFeatCat(), bonus);
 		pc.calcActiveBonuses();
-		assertEquals("Stat should have bonus", 13, pc.getTotalStatFor(str));
+		assertEquals(13, pc.getTotalStatFor(str), "Stat should have bonus");
 		
 		pc.addTemplate(locker);
-		assertEquals("Stat should now be locked", 12, pc.getTotalStatFor(str));
+		assertEquals(12, pc.getTotalStatFor(str), "Stat should now be locked");
 
 		addAbility(BuildUtilities.getFeatCat(), lockedBonus);
 		pc.calcActiveBonuses();
-		assertEquals("Stat should be locked but bonused", 15, pc.getTotalStatFor(str));
+		assertEquals(15, pc.getTotalStatFor(str), "Stat should be locked but bonused");
 
 		pc.addTemplate(unlocker);
-		assertEquals("Stat should now be unlocked", 13, pc.getTotalStatFor(str));
+		assertEquals(13, pc.getTotalStatFor(str), "Stat should now be unlocked");
 	}
 	
 	/**
@@ -133,8 +133,8 @@ public class StatListTest extends AbstractCharacterTestCase
 	public void testMinValueStat()
 	{
 		PlayerCharacter pc = getCharacter();
-		assertEquals("Starting STR should be 6", 6, pc.getTotalStatFor(str));
-		assertEquals("Starting STR mod", -2, pc.getStatModFor(str));
+		assertEquals(6, pc.getTotalStatFor(str), "Starting STR should be 6");
+		assertEquals(-2, pc.getStatModFor(str), "Starting STR mod");
 
 		// With template lock
 		PCTemplate statMinValTemplate = new PCTemplate();
@@ -142,11 +142,11 @@ public class StatListTest extends AbstractCharacterTestCase
 		statMinValTemplate.addToListFor(ListKey.STAT_MINVALUE, new StatLock(
 			CDOMDirectSingleRef.getRef(str), FormulaFactory.getFormulaFor(8)));
 		pc.addTemplate(statMinValTemplate);
-		assertEquals("STR now has minimum value", 8, pc.getTotalStatFor(str));
-		assertEquals("Starting STR mod", -1, pc.getStatModFor(str));
+		assertEquals(8, pc.getTotalStatFor(str), "STR now has minimum value");
+		assertEquals(-1, pc.getStatModFor(str), "Starting STR mod");
 		pc.removeTemplate(statMinValTemplate);
-		assertEquals("STR no longer has minimum value", 6, pc.getTotalStatFor(str));
-		assertEquals("Starting STR mod", -2, pc.getStatModFor(str));
+		assertEquals(6, pc.getTotalStatFor(str), "STR no longer has minimum value");
+		assertEquals(-2, pc.getStatModFor(str), "Starting STR mod");
 	}
 
 }

--- a/code/src/test/pcgen/core/analysis/SpellLevelTest.java
+++ b/code/src/test/pcgen/core/analysis/SpellLevelTest.java
@@ -18,7 +18,7 @@
 
 package pcgen.core.analysis;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -95,17 +95,17 @@ public class SpellLevelTest extends AbstractCharacterTestCase
 		PlayerCharacter aPC = getCharacter();
 
 		Collection<Integer> levels = listManagerFacet.getScopes2(aPC.getCharID(), pcc.get(ObjectKey.CLASS_SPELLLIST));
-		assertEquals("Initial number of spell levels incorrect", 0, levels.size());
+		assertEquals(0, levels.size(), "Initial number of spell levels incorrect");
 		
 		addAbility(BuildUtilities.getFeatCat(), ab1);
 
 		// Now for the tests
 		levels = listManagerFacet.getScopes2(aPC.getCharID(), pcc.get(ObjectKey.CLASS_SPELLLIST));
-		assertEquals("Incorrect number of spell levels returned", 1, levels.size());
-		assertEquals("Incorrect spell level returned", Integer.valueOf(3), levels.iterator().next());
+		assertEquals(1, levels.size(), "Incorrect number of spell levels returned");
+		assertEquals(Integer.valueOf(3), levels.iterator().next(), "Incorrect spell level returned");
 		Collection<Spell> result = listManagerFacet.getSet(aPC.getCharID(), pcc.get(ObjectKey.CLASS_SPELLLIST), 3);
-		assertEquals("Incorrect number of spells returned", 1, result.size());
-		assertEquals("Incorrect spell returned", spell, result.iterator().next());
+		assertEquals(1, result.size(), "Incorrect number of spells returned");
+		assertEquals(spell, result.iterator().next(), "Incorrect spell returned");
 		
 	}
 

--- a/code/src/test/pcgen/core/levelability/AddClassSkillsTest.java
+++ b/code/src/test/pcgen/core/levelability/AddClassSkillsTest.java
@@ -32,7 +32,6 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.StringTokenizer;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.base.lang.UnreachableError;
@@ -48,9 +47,7 @@ import pcgen.core.PCClass;
 import pcgen.core.PCTemplate;
 import pcgen.core.PlayerCharacter;
 import pcgen.core.Skill;
-import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.CampaignSourceEntry;
-import pcgen.persistence.lst.PCClassLoader;
 import pcgen.util.TestHelper;
 
 import org.junit.jupiter.api.AfterEach;
@@ -178,15 +175,7 @@ public class AddClassSkillsTest extends AbstractCharacterTestCase
 		}
 		String classPCCText = "CLASS:Cleric	HD:8		TYPE:Base.PC	ABB:Clr\n"
 				+ "CLASS:Cleric	STARTSKILLPTS:2	CSKILL:KEY_Knowledge (Dungeoneering)";
-		PCClass po;
-		try
-		{
-			po = parsePCClassText(classPCCText, source);
-		}
-		catch (PersistenceLayerException e)
-		{
-			throw new UnreachableError(e);
-		}
+		PCClass po = TestHelper.parsePCClassText(classPCCText, source);
 		getCharacter().incrementClassLevel(1, po, false);
 
 		PCTemplate pct = new PCTemplate();
@@ -224,24 +213,5 @@ public class AddClassSkillsTest extends AbstractCharacterTestCase
 		assertTrue(choiceStrings.contains("Listen"));
 		assertTrue(choiceStrings.contains("Knowledge (Arcana)"));
 	}
-
-	private static PCClass parsePCClassText(String classPCCText,
-											CampaignSourceEntry source) throws PersistenceLayerException
-		{
-			PCClassLoader pcClassLoader = new PCClassLoader();
-			PCClass reconstClass = null;
-			StringTokenizer tok = new StringTokenizer(classPCCText, "\n");
-			while (tok.hasMoreTokens())
-			{
-				String line = tok.nextToken();
-				if (!line.trim().isEmpty())
-				{
-					System.out.println("Processing line:'" + line + "'.");
-					reconstClass =
-							pcClassLoader.parseLine(Globals.getContext(), reconstClass, line, source);
-				}
-			}
-			return reconstClass;
-		}
 
 }

--- a/code/src/test/pcgen/core/levelability/AddClassSkillsTest.java
+++ b/code/src/test/pcgen/core/levelability/AddClassSkillsTest.java
@@ -22,8 +22,8 @@
  * $$id$$
  */
 package pcgen.core.levelability;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
 import java.net.URISyntaxException;

--- a/code/src/test/pcgen/core/prereq/PreAbilityTest.java
+++ b/code/src/test/pcgen/core/prereq/PreAbilityTest.java
@@ -18,8 +18,8 @@
 
 package pcgen.core.prereq;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.enumeration.ListKey;
@@ -58,13 +58,13 @@ public class PreAbilityTest extends AbstractCharacterTestCase
 		Prerequisite prereq =
 				parser.parse("ability", "1,CATEGORY.BARDIC,ANY",
 					false, false);
-		assertFalse("Test any match with no abilities.", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Test any match with no abilities.");
 
 		addAbility(TestHelper.getAbilityCategory(ab2), ab2);
 
-		assertTrue("Test any match with an ability.", PrereqHandler.passes(
-			prereq, character, null));
+		assertTrue(PrereqHandler.passes(
+			prereq, character, null), "Test any match with an ability.");
 		
 	}
 
@@ -86,20 +86,20 @@ public class PreAbilityTest extends AbstractCharacterTestCase
 		Prerequisite prereq2 =
 			parser.parse("ability", "1,CATEGORY.BARDIC,ANY",
 				false, false);
-		assertFalse("Test bardic match with no abilities.", PrereqHandler.passes(
-				prereq2, character, null));
+		assertFalse(PrereqHandler.passes(
+				prereq2, character, null), "Test bardic match with no abilities.");
 		Prerequisite prereq3 =
 			parser.parse("ability", "1,CATEGORY.FEAT,ANY",
 				false, false);
-		assertFalse("Test feat match with no abilities.", PrereqHandler.passes(
-			prereq3, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq3, character, null), "Test feat match with no abilities.");
 
 		addAbility(TestHelper.getAbilityCategory(ab2), ab2);
 
-		assertTrue("Test bardic match with an ability.", PrereqHandler.passes(
-			prereq2, character, null));
-		assertFalse("Test feat match with an ability.", PrereqHandler.passes(
-			prereq3, character, null));
+		assertTrue(PrereqHandler.passes(
+			prereq2, character, null), "Test bardic match with an ability.");
+		assertFalse(PrereqHandler.passes(
+			prereq3, character, null), "Test feat match with an ability.");
 		
 	}
 
@@ -121,27 +121,27 @@ public class PreAbilityTest extends AbstractCharacterTestCase
 		Prerequisite prereq =
 				parser.parse("ability", "1,CATEGORY.BARDIC,KEY_Dancer",
 					false, false);
-		assertFalse("Test any match with no abilities.", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Test any match with no abilities.");
 		Prerequisite prereq2 =
 			parser.parse("ability", "1,CATEGORY.BARDIC,KEY_Alertness",
 				false, false);
-		assertFalse("Test bardic match with no abilities.", PrereqHandler.passes(
-				prereq2, character, null));
+		assertFalse(PrereqHandler.passes(
+				prereq2, character, null), "Test bardic match with no abilities.");
 		Prerequisite prereq3 =
 			parser.parse("ability", "1,CATEGORY.FEAT,KEY_Dancer",
 				false, false);
-		assertFalse("Test feat match with no abilities.", PrereqHandler.passes(
-			prereq3, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq3, character, null), "Test feat match with no abilities.");
 
 		addAbility(TestHelper.getAbilityCategory(ab2), ab2);
 
-		assertTrue("Test any match with an ability.", PrereqHandler.passes(
-			prereq, character, null));
-		assertFalse("Test bardic match with an ability.", PrereqHandler.passes(
-			prereq2, character, null));
-		assertFalse("Test feat match with an ability.", PrereqHandler.passes(
-			prereq3, character, null));
+		assertTrue(PrereqHandler.passes(
+			prereq, character, null), "Test any match with an ability.");
+		assertFalse(PrereqHandler.passes(
+			prereq2, character, null), "Test bardic match with an ability.");
+		assertFalse(PrereqHandler.passes(
+			prereq3, character, null), "Test feat match with an ability.");
 		
 	}
 
@@ -162,26 +162,26 @@ public class PreAbilityTest extends AbstractCharacterTestCase
 		Prerequisite prereq =
 				parser.parse("ability", "1,CATEGORY.BARDIC,TYPE.General", false,
 					false);
-		assertFalse("Test general type match with no abilities.", PrereqHandler
-			.passes(prereq, character, null));
+		assertFalse(PrereqHandler
+			.passes(prereq, character, null), "Test general type match with no abilities.");
 		Prerequisite prereq2 =
 				parser.parse("ability", "1,CATEGORY.BARDIC,TYPE.Bardic", false,
 					false);
-		assertFalse("Test bardic type match with no abilities.", PrereqHandler
-			.passes(prereq2, character, null));
+		assertFalse(PrereqHandler
+			.passes(prereq2, character, null), "Test bardic type match with no abilities.");
 		Prerequisite prereq3 =
 				parser.parse("ability", "1,CATEGORY.BARDIC,TYPE.Fighter", false, false);
-		assertFalse("Test fighter type match with no abilities.", PrereqHandler
-			.passes(prereq3, character, null));
+		assertFalse(PrereqHandler
+			.passes(prereq3, character, null), "Test fighter type match with no abilities.");
 
 		addAbility(TestHelper.getAbilityCategory(ab2), ab2);
 
-		assertTrue("Test general type  match with an ability.", PrereqHandler
-			.passes(prereq, character, null));
-		assertTrue("Test bardic type match with an ability.", PrereqHandler
-			.passes(prereq2, character, null));
-		assertFalse("Test fighter type match with an ability.", PrereqHandler
-			.passes(prereq3, character, null));
+		assertTrue(PrereqHandler
+			.passes(prereq, character, null), "Test general type  match with an ability.");
+		assertTrue(PrereqHandler
+			.passes(prereq2, character, null), "Test bardic type match with an ability.");
+		assertFalse(PrereqHandler
+			.passes(prereq3, character, null), "Test fighter type match with an ability.");
 	}
 
 	/**
@@ -208,27 +208,27 @@ public class PreAbilityTest extends AbstractCharacterTestCase
 		Prerequisite prereq =
 				parser.parse("ability", "1,CATEGORY.BARDIC,KEY_Dancer",
 					false, false);
-		assertFalse("Test any match with no abilities.", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Test any match with no abilities.");
 		Prerequisite prereq2 =
 			parser.parse("ability", "1,CATEGORY.BARDIC,KEY_Alertness",
 				false, false);
-		assertFalse("Test bardic match with no abilities.", PrereqHandler.passes(
-				prereq2, character, null));
+		assertFalse(PrereqHandler.passes(
+				prereq2, character, null), "Test bardic match with no abilities.");
 		Prerequisite prereq3 =
 			parser.parse("ability", "1,CATEGORY.FEAT,KEY_Dancer",
 				false, false);
-		assertFalse("Test feat match with no abilities.", PrereqHandler.passes(
-			prereq3, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq3, character, null), "Test feat match with no abilities.");
 
 		addAbility(TestHelper.getAbilityCategory(ab2), ab2);
 
-		assertTrue("Test any match with an ability.", PrereqHandler.passes(
-			prereq, character, null));
-		assertFalse("Servesas non existant ability should not cause match.", PrereqHandler.passes(
-			prereq2, character, null));
-		assertTrue("Servesas should cause match.", PrereqHandler.passes(
-			prereq3, character, null));
+		assertTrue(PrereqHandler.passes(
+			prereq, character, null), "Test any match with an ability.");
+		assertFalse(PrereqHandler.passes(
+			prereq2, character, null), "Servesas non existant ability should not cause match.");
+		assertTrue(PrereqHandler.passes(
+			prereq3, character, null), "Servesas should cause match.");
 		
 	}
 
@@ -251,26 +251,26 @@ public class PreAbilityTest extends AbstractCharacterTestCase
 		Prerequisite prereq =
 				parser.parse("ability", "1,CATEGORY.BARDIC,TYPE.General", false,
 					false);
-		assertFalse("Test general type match with no abilities.", PrereqHandler
-			.passes(prereq, character, null));
+		assertFalse(PrereqHandler
+			.passes(prereq, character, null), "Test general type match with no abilities.");
 		Prerequisite prereq2 =
 				parser.parse("ability", "1,CATEGORY.BARDIC,TYPE.Bardic", false,
 					false);
-		assertFalse("Test bardic type match with no abilities.", PrereqHandler
-			.passes(prereq2, character, null));
+		assertFalse(PrereqHandler
+			.passes(prereq2, character, null), "Test bardic type match with no abilities.");
 		Prerequisite prereq3 =
 				parser.parse("ability", "1,CATEGORY.BARDIC,TYPE.Fighter", false, false);
-		assertFalse("Test fighter type match with no abilities.", PrereqHandler
-			.passes(prereq3, character, null));
+		assertFalse(PrereqHandler
+			.passes(prereq3, character, null), "Test fighter type match with no abilities.");
 
 		addAbility(TestHelper.getAbilityCategory(ab2), ab2);
 
-		assertTrue("Test general type  match with an ability.", PrereqHandler
-			.passes(prereq, character, null));
-		assertTrue("Test bardic type match with an ability.", PrereqHandler
-			.passes(prereq2, character, null));
-		assertTrue("Test fighter type match with SERVESAS ability.", PrereqHandler
-			.passes(prereq3, character, null));
+		assertTrue(PrereqHandler
+			.passes(prereq, character, null), "Test general type  match with an ability.");
+		assertTrue(PrereqHandler
+			.passes(prereq2, character, null), "Test bardic type match with an ability.");
+		assertTrue(PrereqHandler
+			.passes(prereq3, character, null), "Test fighter type match with SERVESAS ability.");
 	}
 
 	/**
@@ -293,20 +293,20 @@ public class PreAbilityTest extends AbstractCharacterTestCase
 		Prerequisite prereq2 =
 			parser.parse("ability", "1,CATEGORY.BARDIC,ANY",
 				false, false);
-		assertFalse("Test bardic match with no abilities.", PrereqHandler.passes(
-				prereq2, character, null));
+		assertFalse(PrereqHandler.passes(
+				prereq2, character, null), "Test bardic match with no abilities.");
 		Prerequisite prereq3 =
 			parser.parse("ability", "1,CATEGORY.FEAT,ANY",
 				false, false);
-		assertFalse("Test feat match with no abilities.", PrereqHandler.passes(
-			prereq3, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq3, character, null), "Test feat match with no abilities.");
 
 		addAbility(TestHelper.getAbilityCategory(ab2), ab2);
 
-		assertTrue("Test bardic match with an ability.", PrereqHandler.passes(
-			prereq2, character, null));
-		assertTrue("Test feat match with an ability.", PrereqHandler.passes(
-			prereq3, character, null));
+		assertTrue(PrereqHandler.passes(
+			prereq2, character, null), "Test bardic match with an ability.");
+		assertTrue(PrereqHandler.passes(
+			prereq3, character, null), "Test feat match with an ability.");
 		
 	}
 	

--- a/code/src/test/pcgen/core/prereq/PreAlignTest.java
+++ b/code/src/test/pcgen/core/prereq/PreAlignTest.java
@@ -17,9 +17,9 @@
  */
 package pcgen.core.prereq;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.enumeration.ObjectKey;
@@ -59,13 +59,11 @@ public class PreAlignTest extends AbstractCharacterTestCase
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("!PREALIGN:TN");
 
-		assertTrue("Not TN should match character's alignment of NG",
-			PrereqHandler.passes(prereq, character, null));
+		assertTrue(PrereqHandler.passes(prereq, character, null), "Not TN should match character's alignment of NG");
 
 		prereq = factory.parse("!PREALIGN:NG");
 
-		assertFalse("Not TN should not match character's alignment of NG",
-			PrereqHandler.passes(prereq, character, null));
+		assertFalse(PrereqHandler.passes(prereq, character, null), "Not TN should not match character's alignment of NG");
 	}
 
 	/**
@@ -84,24 +82,20 @@ public class PreAlignTest extends AbstractCharacterTestCase
 		prereq.setKey("NG");
 		prereq.setOperator(PrerequisiteOperator.EQ);
 
-		assertTrue("Abbrev NG should match character's alignment of NG",
-			PrereqHandler.passes(prereq, character, null));
+		assertTrue(PrereqHandler.passes(prereq, character, null), "Abbrev NG should match character's alignment of NG");
 
 		prereq = new Prerequisite();
 		prereq.setKind("align");
 		prereq.setKey("LG");
 		prereq.setOperator(PrerequisiteOperator.EQ);
 
-		assertFalse("Abbrev LG should not match character's alignment of NG",
-			PrereqHandler.passes(prereq, character, null));
+		assertFalse(PrereqHandler.passes(prereq, character, null), "Abbrev LG should not match character's alignment of NG");
 
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("PREALIGN:NG");
-		assertTrue("Abbrev NG should match character's alignment of NG",
-			PrereqHandler.passes(prereq, character, null));
+		assertTrue(PrereqHandler.passes(prereq, character, null), "Abbrev NG should match character's alignment of NG");
 		prereq = factory.parse("PREALIGN:LG");
-		assertFalse("Abbrev LG should not match character's alignment of NG",
-			PrereqHandler.passes(prereq, character, null));
+		assertFalse(PrereqHandler.passes(prereq, character, null), "Abbrev LG should not match character's alignment of NG");
 	}
 
 	/**
@@ -117,20 +111,17 @@ public class PreAlignTest extends AbstractCharacterTestCase
 		AlignmentCompat.setCurrentAlignment(character.getCharID(), ng);
 		ChannelUtilities.setControlledChannel(character.getCharID(),
 			CControl.DEITYINPUT, deity);
-		assertEquals("Deity should have been set for character.", deity,
-			ChannelUtilities.readControlledChannel(character.getCharID(),
-				CControl.DEITYINPUT));
+		assertEquals(deity, ChannelUtilities.readControlledChannel(character.getCharID(),
+				CControl.DEITYINPUT), "Deity should have been set for character.");
 
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		Prerequisite prereq = factory.parse("PREALIGN:Deity");
 
-		assertTrue("Number 3 should match deity's alignment of NG",
-			PrereqHandler.passes(prereq, character, null));
+		assertTrue(PrereqHandler.passes(prereq, character, null), "Number 3 should match deity's alignment of NG");
 
 		AlignmentCompat.setCurrentAlignment(character.getCharID(), cg);
 
-		assertFalse("Number 6 should not match deity's alignment of NG",
-			PrereqHandler.passes(prereq, character, null));
+		assertFalse(PrereqHandler.passes(prereq, character, null), "Number 6 should not match deity's alignment of NG");
 	}
 
 	@Test
@@ -141,13 +132,10 @@ public class PreAlignTest extends AbstractCharacterTestCase
 
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		Prerequisite prereq = factory.parse("PREALIGN:LE,NG,NE");
-		assertTrue("LE, NG, or NE should match character's alignment of NG",
-			PrereqHandler.passes(prereq, character, null));
+		assertTrue(PrereqHandler.passes(prereq, character, null), "LE, NG, or NE should match character's alignment of NG");
 
 		prereq = factory.parse("PREALIGN:LE,NE,CE");
-		assertFalse(
-			"LE, NE, or CE should not match character's alignment of NG",
-			PrereqHandler.passes(prereq, character, null));
+		assertFalse(PrereqHandler.passes(prereq, character, null), "LE, NE, or CE should not match character's alignment of NG");
 	}
 
 	@BeforeEach

--- a/code/src/test/pcgen/core/prereq/PreArmorProfTest.java
+++ b/code/src/test/pcgen/core/prereq/PreArmorProfTest.java
@@ -18,9 +18,9 @@
 package pcgen.core.prereq;
 
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -65,8 +65,8 @@ public class PreArmorProfTest extends AbstractCharacterTestCase
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("PREPROFWITHARMOR:1,Chainmail");
 
-		assertFalse("Character has no proficiencies", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Character has no proficiencies");
 
 		final Ability martialProf = 
 			TestHelper.makeAbility("Shield Proficiency (Single)", "FEAT", "General");
@@ -77,18 +77,15 @@ public class PreArmorProfTest extends AbstractCharacterTestCase
 
 		AbstractCharacterTestCase.applyAbility(character, BuildUtilities.getFeatCat(), martialProf, null);
 
-		assertTrue("Character has the Chainmail proficiency.", 
-					PrereqHandler.passes(prereq, character, null));
+		assertTrue(PrereqHandler.passes(prereq, character, null), "Character has the Chainmail proficiency.");
 		
 		prereq = factory.parse("PREPROFWITHARMOR:1,Leather");
 		
-		assertFalse("Character does not have the Leather proficiency", 
-				PrereqHandler.passes(prereq, character, null));
+		assertFalse(PrereqHandler.passes(prereq, character, null), "Character does not have the Leather proficiency");
 		
 		prereq = factory.parse("PREPROFWITHARMOR:1,Full Plate");
 		
-		assertTrue("Character has the Full Plate proficiency.", 
-				PrereqHandler.passes(prereq, character, null));
+		assertTrue(PrereqHandler.passes(prereq, character, null), "Character has the Full Plate proficiency.");
 	}
 
 
@@ -106,8 +103,8 @@ public class PreArmorProfTest extends AbstractCharacterTestCase
 
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("PREPROFWITHARMOR:1,Chainmail,Full Plate");
-		assertFalse("Character has no proficiencies", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Character has no proficiencies");
 
 		final Ability martialProf = 
 			TestHelper.makeAbility("Shield Proficiency (Single)", "FEAT", "General");
@@ -118,18 +115,15 @@ public class PreArmorProfTest extends AbstractCharacterTestCase
 		
 		AbstractCharacterTestCase.applyAbility(character, BuildUtilities.getFeatCat(), martialProf, null);
 
-		assertTrue("Character has one of Chainmail or Full Plate proficiency", 
-			PrereqHandler.passes(prereq, character, null));
+		assertTrue(PrereqHandler.passes(prereq, character, null), "Character has one of Chainmail or Full Plate proficiency");
 
 		prereq = factory.parse("PREPROFWITHARMOR:2,Chainmail,Full Plate");
 
-		assertTrue("Character has both Chainmail and Full Plate proficiency", 
-				PrereqHandler.passes(prereq, character, null));
+		assertTrue(PrereqHandler.passes(prereq, character, null), "Character has both Chainmail and Full Plate proficiency");
 		
 		prereq = factory.parse("PREPROFWITHARMOR:3,Chainmail,Full Plate,Leather");
 
-		assertFalse("Character has both Chainmail and Full Plate proficiency but not Leather", 
-				PrereqHandler.passes(prereq, character, null));
+		assertFalse(PrereqHandler.passes(prereq, character, null), "Character has both Chainmail and Full Plate proficiency but not Leather");
 		
 	}
 	
@@ -148,8 +142,8 @@ public class PreArmorProfTest extends AbstractCharacterTestCase
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("PREPROFWITHARMOR:1,TYPE.Medium");
 
-		assertFalse("Character has no proficiencies", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Character has no proficiencies");
 		
 		final Ability martialProf = 
 			TestHelper.makeAbility("Shield Proficiency (Single)", "FEAT", "General");
@@ -157,8 +151,7 @@ public class PreArmorProfTest extends AbstractCharacterTestCase
 		
 		AbstractCharacterTestCase.applyAbility(character, BuildUtilities.getFeatCat(), martialProf, null);
 		
-		assertTrue("Character has Medium Armor Proficiency", 
-				PrereqHandler.passes(prereq, character, null));
+		assertTrue(PrereqHandler.passes(prereq, character, null), "Character has Medium Armor Proficiency");
 	}
 	
 	/**
@@ -176,8 +169,8 @@ public class PreArmorProfTest extends AbstractCharacterTestCase
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("!PREPROFWITHARMOR:1,Breastplate");
 
-		assertTrue("Character has no proficiencies", PrereqHandler.passes(
-			prereq, character, null));
+		assertTrue(PrereqHandler.passes(
+			prereq, character, null), "Character has no proficiencies");
 
 		final Ability martialProf = 
 			TestHelper.makeAbility("Shield Proficiency (Single)", "FEAT", "General");
@@ -188,18 +181,15 @@ public class PreArmorProfTest extends AbstractCharacterTestCase
 		
 		AbstractCharacterTestCase.applyAbility(character, BuildUtilities.getFeatCat(), martialProf, null);
 
-		assertFalse("Character has the Breastplate proficiency.", 
-					PrereqHandler.passes(prereq, character, null));
+		assertFalse(PrereqHandler.passes(prereq, character, null), "Character has the Breastplate proficiency.");
 		
 		prereq = factory.parse("!PREPROFWITHARMOR:1,Leather");
 		
-		assertTrue("Character does not have the Leather proficiency", 
-				PrereqHandler.passes(prereq, character, null));
+		assertTrue(PrereqHandler.passes(prereq, character, null), "Character does not have the Leather proficiency");
 		
 		prereq = factory.parse("!PREPROFWITHARMOR:1,Chainmail");
 		
-		assertFalse("Character has the Chainmail proficiency.", 
-				PrereqHandler.passes(prereq, character, null));
+		assertFalse(PrereqHandler.passes(prereq, character, null), "Character has the Chainmail proficiency.");
 		
 	}
 	
@@ -219,8 +209,8 @@ public class PreArmorProfTest extends AbstractCharacterTestCase
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("PREPROFWITHARMOR:1,Breastplate");
 
-		assertFalse("Character has no proficiencies", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Character has no proficiencies");
 		
 		final Ability martialProf = 
 			TestHelper.makeAbility("Armor Proficiency (Single)", BuildUtilities.getFeatCat(), "General");
@@ -229,20 +219,16 @@ public class PreArmorProfTest extends AbstractCharacterTestCase
 
 		AbstractCharacterTestCase.applyAbility(character, BuildUtilities.getFeatCat(), martialProf, null);
 
-		assertTrue("Character has the Breastplate proficiency.", 
-					PrereqHandler.passes(prereq, character, null));
+		assertTrue(PrereqHandler.passes(prereq, character, null), "Character has the Breastplate proficiency.");
 		
 		prereq = factory.parse("PREPROFWITHARMOR:1,Chainmail");
-		assertTrue("Character has the Chainmail proficiency.",
-					PrereqHandler.passes(prereq, character, null));
+		assertTrue(PrereqHandler.passes(prereq, character, null), "Character has the Chainmail proficiency.");
 		
 		prereq = factory.parse("PREPROFWITHARMOR:1,Leather");
-		assertFalse("Character does not have the Leather proficiency.",
-					PrereqHandler.passes(prereq, character, null));
+		assertFalse(PrereqHandler.passes(prereq, character, null), "Character does not have the Leather proficiency.");
 		
 		prereq = factory.parse("PREPROFWITHARMOR:1,TYPE.Medium");
-		assertTrue("Character has martial weaponprofs.",
-					PrereqHandler.passes(prereq, character, null));
+		assertTrue(PrereqHandler.passes(prereq, character, null), "Character has martial weaponprofs.");
 		
 	}
 	
@@ -278,10 +264,7 @@ public class PreArmorProfTest extends AbstractCharacterTestCase
 		featLoader.parseLine(Globals.getContext(), bar, barStr, cse);
 		addAbility(BuildUtilities.getFeatCat(), bar);
 		
-		assertEquals("Character should have 50 bonus hp added.",
-					baseHp+50,
-					character.hitPoints()
-					);
+		assertEquals(baseHp+50, character.hitPoints(), "Character should have 50 bonus hp added.");
 		
 		final Ability martialProf = 
 			TestHelper.makeAbility("Shield Proficiency (Single)", "FEAT", "General");
@@ -296,10 +279,7 @@ public class PreArmorProfTest extends AbstractCharacterTestCase
 		featLoader.parseLine(Globals.getContext(), foo, fooStr, cse);
 		addAbility(BuildUtilities.getFeatCat(), foo);
 		
-		assertEquals("Character has the Full Plate proficiency so the bonus should be added",
-					baseHp+50+50,
-					character.hitPoints()
-					);
+		assertEquals(baseHp+50+50, character.hitPoints(), "Character has the Full Plate proficiency so the bonus should be added");
 	
 	}
 

--- a/code/src/test/pcgen/core/prereq/PreArmorTypeTest.java
+++ b/code/src/test/pcgen/core/prereq/PreArmorTypeTest.java
@@ -17,8 +17,8 @@
  */
 package pcgen.core.prereq;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.enumeration.ListKey;
@@ -60,29 +60,29 @@ public class PreArmorTypeTest extends AbstractCharacterTestCase
 		prereq.setOperand("1");
 		prereq.setOperator(PrerequisiteOperator.EQ);
 
-		assertFalse("Doesn't have chainmail equipped", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Doesn't have chainmail equipped");
 
 		armor.setName("Chainmail");
 
-		assertFalse("Chainmail is not equipped", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "Chainmail is not equipped");
 
 		armor.setIsEquipped(true, character);
 		character.doAfavorForAunitTestThatIgnoresEquippingRules();
 
-		assertTrue("Chainmail is equipped", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Chainmail is equipped");
 
 		armor.setName("Chainmail (Masterwork)");
 
-		assertFalse("Should be an exact match only", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Should be an exact match only");
 
 		prereq.setKey("CHAINMAIL%");
 
-		assertTrue("Should be allow wildcard match", PrereqHandler.passes(
-			prereq, character, null));
+		assertTrue(PrereqHandler.passes(
+			prereq, character, null), "Should be allow wildcard match");
 	}
 
 	/**
@@ -108,29 +108,29 @@ public class PreArmorTypeTest extends AbstractCharacterTestCase
 		prereq.setOperand("1");
 		prereq.setOperator(PrerequisiteOperator.EQ);
 
-		assertFalse("Equipment has no type", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "Equipment has no type");
 
 		armor.addType(Type.getConstant("ARMOR"));
 		armor.addType(Type.getConstant("MEDIUM"));
 		
-		assertTrue("Armor is medium", PrereqHandler.passes(prereq, character,
-			null));
+		assertTrue(PrereqHandler.passes(prereq, character,
+			null), "Armor is medium");
 
 		prereq.setKey("TYPE.Heavy");
 
-		assertFalse("Armor is not heavy", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "Armor is not heavy");
 
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("PREARMORTYPE:2,TYPE=Medium,Full%");
 
-		assertFalse("Armor is not Full something", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "Armor is not Full something");
 
 		prereq = factory.parse("PREARMORTYPE:2,TYPE=Medium,Chain%");
-		assertTrue("Armor is medium and Chain", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Armor is medium and Chain");
 	}
 
 	/**
@@ -160,15 +160,15 @@ public class PreArmorTypeTest extends AbstractCharacterTestCase
 		prereq.setOperand("1");
 		prereq.setOperator(PrerequisiteOperator.EQ);
 
-		assertFalse("No armor equipped", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "No armor equipped");
 
 		character.addEquipment(chainmail);
 		chainmail.setIsEquipped(true, character);
 		character.doAfavorForAunitTestThatIgnoresEquippingRules();
 
-		assertTrue("Proficient armor equipped", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Proficient armor equipped");
 
 		chainmail.setIsEquipped(false, character);
 		character.doAfavorForAunitTestThatIgnoresEquippingRules();
@@ -186,7 +186,7 @@ public class PreArmorTypeTest extends AbstractCharacterTestCase
 		fullPlate.setIsEquipped(false, character);
 		character.doAfavorForAunitTestThatIgnoresEquippingRules();
 
-		assertFalse("Not Proficient in armor equipped", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Not Proficient in armor equipped");
 	}
 }

--- a/code/src/test/pcgen/core/prereq/PreAttTest.java
+++ b/code/src/test/pcgen/core/prereq/PreAttTest.java
@@ -17,8 +17,8 @@
  */
 package pcgen.core.prereq;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.base.FormulaFactory;
@@ -64,20 +64,20 @@ public class PreAttTest extends AbstractCharacterTestCase
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("PREATT:6");
 
-		assertTrue("Character's BAB should be 6", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Character's BAB should be 6");
 
 		prereq = factory.parse("PREATT:7");
 
-		assertFalse("Character's BAB should be less than 7", PrereqHandler
-			.passes(prereq, character, null));
+		assertFalse(PrereqHandler
+			.passes(prereq, character, null), "Character's BAB should be less than 7");
 
 		final BonusObj toHitBonus = Bonus.newBonus(context, "COMBAT|TOHIT|1");
 		myClass.getOriginalClassLevel(1).addToListFor(ListKey.BONUS, toHitBonus);
 		character.calcActiveBonuses();
 
-		assertFalse("Character's BAB should be less than 7", PrereqHandler
-			.passes(prereq, character, null));
+		assertFalse(PrereqHandler
+			.passes(prereq, character, null), "Character's BAB should be less than 7");
 	}
 
 	@BeforeEach

--- a/code/src/test/pcgen/core/prereq/PreBirthplaceTest.java
+++ b/code/src/test/pcgen/core/prereq/PreBirthplaceTest.java
@@ -17,8 +17,8 @@
  */
 package pcgen.core.prereq;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.enumeration.PCStringKey;
@@ -50,17 +50,17 @@ class PreBirthplaceTest extends AbstractCharacterTestCase
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("PREBIRTHPLACE:Klamath");
 
-		assertTrue("Character is from Klamath", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Character is from Klamath");
 
 		prereq = factory.parse("PREBIRTHPLACE:KLAMATH");
 
-		assertTrue("Case is not significant", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Case is not significant");
 
 		prereq = factory.parse("PREBIRTHPLACE:Klam");
 
-		assertFalse("Requires a full match", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "Requires a full match");
 	}
 }

--- a/code/src/test/pcgen/core/prereq/PreCSkillTest.java
+++ b/code/src/test/pcgen/core/prereq/PreCSkillTest.java
@@ -17,8 +17,8 @@
  */
 package pcgen.core.prereq;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.base.FormulaFactory;
@@ -67,49 +67,49 @@ public class PreCSkillTest extends AbstractCharacterTestCase
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("PRECSKILL:1,Spot,Listen");
 
-		assertFalse("Character has no class skills", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Character has no class skills");
 
 		character.addLocalCost(myClass, spot, SkillCost.CLASS, myClass);
 		character.setDirty(true); //Need to throw out the cache
 
-		assertTrue("Character has spot class skills", PrereqHandler.passes(
-			prereq, character, null));
+		assertTrue(PrereqHandler.passes(
+			prereq, character, null), "Character has spot class skills");
 
 		character.addLocalCost(myClass, spy1, SkillCost.CLASS, myClass);
 		character.setDirty(true); //Need to throw out the cache
 
-		assertTrue("Character has spot class skills", PrereqHandler.passes(
-			prereq, character, null));
+		assertTrue(PrereqHandler.passes(
+			prereq, character, null), "Character has spot class skills");
 
 		prereq = factory.parse("PRECSKILL:2,TYPE.Spy");
 
-		assertFalse("Character has only one Spy Skill", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Character has only one Spy Skill");
 
 		character.addLocalCost(myClass, spy2, SkillCost.CLASS, myClass);
 		character.setDirty(true); //Need to throw out the cache
 
-		assertTrue("Character has 2 Spy class skills", PrereqHandler.passes(
-			prereq, character, null));
+		assertTrue(PrereqHandler.passes(
+			prereq, character, null), "Character has 2 Spy class skills");
 
 		prereq = factory.parse("PRECSKILL:3,Spot,TYPE.Spy");
 
-		assertTrue("Character has 2 Spy and Spot class skills", PrereqHandler
-			.passes(prereq, character, null));
+		assertTrue(PrereqHandler
+			.passes(prereq, character, null), "Character has 2 Spy and Spot class skills");
 
 		prereq = factory.parse("PRECSKILL:3,Listen,TYPE.Spy");
 
-		assertFalse("Character has only 2 Spy Skills", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Character has only 2 Spy Skills");
 
 		character.addLocalCost(myClass, spy3, SkillCost.CLASS, myClass);
 		character.setDirty(true); //Need to throw out the cache
 
 		prereq = factory.parse("PRECSKILL:3,Listen,TYPE.Spy");
 
-		assertTrue("Character has 3 Spy Skills", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Character has 3 Spy Skills");
 	}
 
 	@Test
@@ -147,32 +147,32 @@ public class PreCSkillTest extends AbstractCharacterTestCase
 		character.addLocalCost(myClass, fee, SkillCost.CLASS, myClass);
 		character.addLocalCost(myClass, foo, SkillCost.CLASS, myClass);
 		prereq = factory.parse("PRECSKILL:1,Bar");		
-		assertTrue("Character has 1 Listen Skill", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Character has 1 Listen Skill");
 		
 		
 		prereq = factory.parse("PRECSKILL:2,Bar,Fee");		
-		assertTrue("Character has a Bar Skill and a Fee Skill", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Character has a Bar Skill and a Fee Skill");
 		
 		prereq = factory.parse("PRECSKILL:2,Baz,Fee");		
-		assertFalse("Character does not have both Baz and Fee Skills", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "Character does not have both Baz and Fee Skills");
 		
 		
 		
 		prereq = factory.parse("PRECSKILL:1,TYPE=Bar");		
-		assertTrue("Character has 1 Bar Type Skill", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Character has 1 Bar Type Skill");
 		
 		
 		prereq = factory.parse("PRECSKILL:2,TYPE=Bar");		
-		assertTrue("Character has 2 Bar Type Skills", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Character has 2 Bar Type Skills");
 		
 		prereq = factory.parse("PRECSKILL:3,TYPE=Bar");		
-		assertFalse("Character has less than 3 Bar Type Skills", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "Character has less than 3 Bar Type Skills");
 		
 		
 	}

--- a/code/src/test/pcgen/core/prereq/PreCampaignTest.java
+++ b/code/src/test/pcgen/core/prereq/PreCampaignTest.java
@@ -17,8 +17,8 @@
  */
 package pcgen.core.prereq;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -89,22 +89,19 @@ public class PreCampaignTest extends AbstractCharacterTestCase
 		
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		Prerequisite preCamp1 = factory.parse("PRECAMPAIGN:1,Camp1");
-		assertFalse("Nonpresent campaign should not be found",
-			PrereqHandler.passes(preCamp1, null, sourceCamp));
+		assertFalse(PrereqHandler.passes(preCamp1, null, sourceCamp), "Nonpresent campaign should not be found");
 
 		uris = new ArrayList<>();
 		uris.add(camp1.getSourceURI());
 		pmgr.setChosenCampaignSourcefiles(uris);
 
-		assertTrue("Present campaign should be found",
-			PrereqHandler.passes(preCamp1, null, sourceCamp));
+		assertTrue(PrereqHandler.passes(preCamp1, null, sourceCamp), "Present campaign should be found");
 
 		uris.add(camp2KeyParent.getSourceURI());
 		pmgr.setChosenCampaignSourcefiles(uris);
 
 		Prerequisite preCamp3 = factory.parse("PRECAMPAIGN:1,Camp3");
-		assertFalse("Present but nested campaign should not be found",
-			PrereqHandler.passes(preCamp3, null, sourceCamp));
+		assertFalse(PrereqHandler.passes(preCamp3, null, sourceCamp), "Present but nested campaign should not be found");
 	}
 	
 	/**
@@ -123,20 +120,17 @@ public class PreCampaignTest extends AbstractCharacterTestCase
 		
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		Prerequisite preCamp1 = factory.parse("PRECAMPAIGN:1,BOOKTYPE=Wild");
-		assertFalse("No typed campaign should be found",
-			PrereqHandler.passes(preCamp1, null, sourceCamp));
+		assertFalse(PrereqHandler.passes(preCamp1, null, sourceCamp), "No typed campaign should be found");
 
 		uris.add(camp6TypeParent.getSourceURI());
 		pmgr.setChosenCampaignSourcefiles(uris);
 
-		assertFalse("Nested typed campaign should not be found",
-			PrereqHandler.passes(preCamp1, null, sourceCamp));
+		assertFalse(PrereqHandler.passes(preCamp1, null, sourceCamp), "Nested typed campaign should not be found");
 
 		uris.add(camp4Wild.getSourceURI());
 		pmgr.setChosenCampaignSourcefiles(uris);
 
-		assertTrue("Typed campaign should be found",
-			PrereqHandler.passes(preCamp1, null, sourceCamp));
+		assertTrue(PrereqHandler.passes(preCamp1, null, sourceCamp), "Typed campaign should be found");
 	}
 	
 	/**
@@ -155,14 +149,12 @@ public class PreCampaignTest extends AbstractCharacterTestCase
 		
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		Prerequisite preCampaign = factory.parse("PRECAMPAIGN:1,INCLUDES=Camp3");
-		assertFalse("Nonpresent campaign should not be found",
-			PrereqHandler.passes(preCampaign, null, sourceCamp));
+		assertFalse(PrereqHandler.passes(preCampaign, null, sourceCamp), "Nonpresent campaign should not be found");
 
 		uris.add(camp2KeyParent.getSourceURI());
 		pmgr.setChosenCampaignSourcefiles(uris);
 
-		assertTrue("Present but nested campaign should be found",
-			PrereqHandler.passes(preCampaign, null, sourceCamp));
+		assertTrue(PrereqHandler.passes(preCampaign, null, sourceCamp), "Present but nested campaign should be found");
 		
 	}
 	
@@ -182,14 +174,12 @@ public class PreCampaignTest extends AbstractCharacterTestCase
 		
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		Prerequisite preCamp1 = factory.parse("PRECAMPAIGN:1,INCLUDESBOOKTYPE=Wild");
-		assertFalse("No typed campaign should be found",
-			PrereqHandler.passes(preCamp1, null, sourceCamp));
+		assertFalse(PrereqHandler.passes(preCamp1, null, sourceCamp), "No typed campaign should be found");
 
 		uris.add(camp6TypeParent.getSourceURI());
 		pmgr.setChosenCampaignSourcefiles(uris);
 
-		assertTrue("Nested typed campaign should be found",
-			PrereqHandler.passes(preCamp1, null, sourceCamp));
+		assertTrue(PrereqHandler.passes(preCamp1, null, sourceCamp), "Nested typed campaign should be found");
 		
 	}
 

--- a/code/src/test/pcgen/core/prereq/PreCheckBaseTest.java
+++ b/code/src/test/pcgen/core/prereq/PreCheckBaseTest.java
@@ -17,8 +17,8 @@
  */
 package pcgen.core.prereq;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.base.FormulaFactory;
@@ -63,20 +63,20 @@ public class PreCheckBaseTest extends AbstractCharacterTestCase
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("PRECHECKBASE:1,Fortitude=0");
 
-		assertTrue("Character's Fort save should be 0", PrereqHandler.passes(
-			prereq, character, null));
+		assertTrue(PrereqHandler.passes(
+			prereq, character, null), "Character's Fort save should be 0");
 
 		prereq = factory.parse("PRECHECKBASE:1,Will=2");
 
-		assertTrue("Character's Will save should be 2", PrereqHandler.passes(
-			prereq, character, null));
+		assertTrue(PrereqHandler.passes(
+			prereq, character, null), "Character's Will save should be 2");
 
 		prereq = factory.parse("PRECHECKBASE:1,Fortitude=1,Will=2");
-		assertTrue("Character's Will save should be 2", PrereqHandler.passes(
-			prereq, character, null));
+		assertTrue(PrereqHandler.passes(
+			prereq, character, null), "Character's Will save should be 2");
 		prereq = factory.parse("PRECHECKBASE:2,Fortitude=1,Will=2");
-		assertFalse("Character's Fort save not 1", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "Character's Fort save not 1");
 	}
 
 	@Test
@@ -97,20 +97,20 @@ public class PreCheckBaseTest extends AbstractCharacterTestCase
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("PRECHECKBASE:1,Fortitude=1");
 
-		assertFalse("Character's base Fort save should be 0", PrereqHandler
-			.passes(prereq, character, null));
+		assertFalse(PrereqHandler
+			.passes(prereq, character, null), "Character's base Fort save should be 0");
 
 		prereq = factory.parse("PRECHECKBASE:1,Will=2");
 
-		assertTrue("Character's Will save should be 2", PrereqHandler.passes(
-			prereq, character, null));
+		assertTrue(PrereqHandler.passes(
+			prereq, character, null), "Character's Will save should be 2");
 
 		prereq = factory.parse("PRECHECKBASE:1,Fortitude=1,Will=3");
-		assertFalse("Character's Will save should be 2", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Character's Will save should be 2");
 		prereq = factory.parse("PRECHECKBASE:2,Fortitude=1,Will=2");
-		assertFalse("Character's base Fort save not 1", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Character's base Fort save not 1");
 	}
 
 	@BeforeEach

--- a/code/src/test/pcgen/core/prereq/PreCheckTest.java
+++ b/code/src/test/pcgen/core/prereq/PreCheckTest.java
@@ -17,8 +17,8 @@
  */
 package pcgen.core.prereq;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.base.FormulaFactory;
@@ -63,20 +63,20 @@ public class PreCheckTest extends AbstractCharacterTestCase
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("PRECHECK:1,Fortitude=0");
 
-		assertTrue("Character's Fort save should be 0", PrereqHandler.passes(
-			prereq, character, null));
+		assertTrue(PrereqHandler.passes(
+			prereq, character, null), "Character's Fort save should be 0");
 
 		prereq = factory.parse("PRECHECK:1,Will=2");
 
-		assertTrue("Character's Will save should be 2", PrereqHandler.passes(
-			prereq, character, null));
+		assertTrue(PrereqHandler.passes(
+			prereq, character, null), "Character's Will save should be 2");
 
 		prereq = factory.parse("PRECHECK:1,Fortitude=1,Will=2");
-		assertTrue("Character's Will save should be 2", PrereqHandler.passes(
-			prereq, character, null));
+		assertTrue(PrereqHandler.passes(
+			prereq, character, null), "Character's Will save should be 2");
 		prereq = factory.parse("PRECHECK:2,Fortitude=1,Will=2");
-		assertFalse("Character's Fort save not 1", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "Character's Fort save not 1");
 	}
 
 	@Test
@@ -97,20 +97,20 @@ public class PreCheckTest extends AbstractCharacterTestCase
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("PRECHECK:1,Fortitude=1");
 
-		assertTrue("Character's Fort save should be 1", PrereqHandler.passes(
-			prereq, character, null));
+		assertTrue(PrereqHandler.passes(
+			prereq, character, null), "Character's Fort save should be 1");
 
 		prereq = factory.parse("PRECHECK:1,Will=2");
 
-		assertTrue("Character's Will save should be 2", PrereqHandler.passes(
-			prereq, character, null));
+		assertTrue(PrereqHandler.passes(
+			prereq, character, null), "Character's Will save should be 2");
 
 		prereq = factory.parse("PRECHECK:1,Fortitude=1,Will=3");
-		assertTrue("Character's Will save should be 2", PrereqHandler.passes(
-			prereq, character, null));
+		assertTrue(PrereqHandler.passes(
+			prereq, character, null), "Character's Will save should be 2");
 		prereq = factory.parse("PRECHECK:2,Fortitude=2,Will=2");
-		assertFalse("Character's Fort save not 1", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "Character's Fort save not 1");
 	}
 
 	@BeforeEach

--- a/code/src/test/pcgen/core/prereq/PreClassTest.java
+++ b/code/src/test/pcgen/core/prereq/PreClassTest.java
@@ -17,9 +17,9 @@
  */
 package pcgen.core.prereq;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.enumeration.ListKey;
@@ -479,32 +479,32 @@ public class PreClassTest extends AbstractCharacterTestCase
 
 		final PlayerCharacter character = getCharacter();
 
-		assertTrue("Should pass with no levels", PrereqHandler.passes(prereq,
-			character, null));
-		assertTrue("Should pass with no levels of either", PrereqHandler
-			.passes(dualPrereq, character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Should pass with no levels");
+		assertTrue(PrereqHandler
+			.passes(dualPrereq, character, null), "Should pass with no levels of either");
 
 		final PCClass pcClass = new PCClass();
 		pcClass.setName("Monk");
 		character.incrementClassLevel(1, pcClass);
-		assertTrue("Should pass with 1 level", PrereqHandler.passes(prereq,
-			character, null));
-		assertTrue("Should pass with 1 level of one", PrereqHandler.passes(
-			dualPrereq, character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Should pass with 1 level");
+		assertTrue(PrereqHandler.passes(
+			dualPrereq, character, null), "Should pass with 1 level of one");
 
 		final PCClass ftrClass = new PCClass();
 		ftrClass.setName("Fighter");
 		character.incrementClassLevel(1, ftrClass);
-		assertTrue("Should pass with 1 level of each", PrereqHandler.passes(
-			dualPrereq, character, null));
+		assertTrue(PrereqHandler.passes(
+			dualPrereq, character, null), "Should pass with 1 level of each");
 
 		character.incrementClassLevel(1, pcClass);
-		assertFalse("Should not pass with 2 levels", PrereqHandler.passes(
-			prereq, character, null));
-		assertFalse("Should not pass with 2 levels of one", PrereqHandler
-			.passes(dualPrereq, character, null));
-		assertTrue("Should pass with 2 levels of one", PrereqHandler.passes(
-			singlePrereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Should not pass with 2 levels");
+		assertFalse(PrereqHandler
+			.passes(dualPrereq, character, null), "Should not pass with 2 levels of one");
+		assertTrue(PrereqHandler.passes(
+			singlePrereq, character, null), "Should pass with 2 levels of one");
 	}
 
 	/**

--- a/code/src/test/pcgen/core/prereq/PreDRTest.java
+++ b/code/src/test/pcgen/core/prereq/PreDRTest.java
@@ -17,8 +17,8 @@
  */
 package pcgen.core.prereq;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.base.FormulaFactory;
@@ -57,16 +57,16 @@ public class PreDRTest extends AbstractCharacterTestCase
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("PREDR:1,+1=10");
 
-		assertFalse("Character has no DR", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "Character has no DR");
 
 		race.addToListFor(ListKey.DAMAGE_REDUCTION, drPlus1);
 		//This weirdness is because we are altering the race after application (no-no at runtime)
 		character.setRace(null);
 		character.setRace(race);
 
-		assertFalse("Character DR not 10", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "Character DR not 10");
 
 		DamageReduction drPlus1_10 = new DamageReduction(FormulaFactory.getFormulaFor(10), "+1");
 		race.addToListFor(ListKey.DAMAGE_REDUCTION, drPlus1_10);
@@ -74,8 +74,8 @@ public class PreDRTest extends AbstractCharacterTestCase
 		character.setRace(null);
 		character.setRace(race);
 
-		assertTrue("Character has DR 10/+1", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Character has DR 10/+1");
 	}
 
 	/**
@@ -94,16 +94,16 @@ public class PreDRTest extends AbstractCharacterTestCase
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("PREDR:1,+1=10,+2=5");
 
-		assertFalse("Character has no DR", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "Character has no DR");
 
 		race.addToListFor(ListKey.DAMAGE_REDUCTION, drPlus1);
 		//This weirdness is because we are altering the race after application (no-no at runtime)
 		character.setRace(null);
 		character.setRace(race);
 
-		assertFalse("Character DR not 10", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "Character DR not 10");
 
 		DamageReduction drPlus2_5 = new DamageReduction(FormulaFactory.getFormulaFor(5), "+2");
 		race.addToListFor(ListKey.DAMAGE_REDUCTION, drPlus2_5);
@@ -111,8 +111,8 @@ public class PreDRTest extends AbstractCharacterTestCase
 		character.setRace(null);
 		character.setRace(race);
 
-		assertTrue("Character has DR 5/+2", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Character has DR 5/+2");
 	}
 
 	@Test
@@ -126,14 +126,14 @@ public class PreDRTest extends AbstractCharacterTestCase
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("PREDR:2,+1=10,+2=5");
 
-		assertFalse("Character has no DR", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "Character has no DR");
 
 		race.addToListFor(ListKey.DAMAGE_REDUCTION, drPlus1);
 		character.setRace(race);
 
-		assertFalse("Character DR not 10", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "Character DR not 10");
 
 		DamageReduction drPlus2_5 = new DamageReduction(FormulaFactory.getFormulaFor(5), "+2");
 		race.addToListFor(ListKey.DAMAGE_REDUCTION, drPlus2_5);
@@ -141,8 +141,8 @@ public class PreDRTest extends AbstractCharacterTestCase
 		character.setRace(null);
 		character.setRace(race);
 
-		assertFalse("Character has DR 5/+2", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "Character has DR 5/+2");
 
 		DamageReduction drPlus1_10 = new DamageReduction(FormulaFactory.getFormulaFor(10), "+1");
 		race.addToListFor(ListKey.DAMAGE_REDUCTION, drPlus1_10);
@@ -150,8 +150,8 @@ public class PreDRTest extends AbstractCharacterTestCase
 		character.setRace(null);
 		character.setRace(race);
 
-		assertTrue("Character has DR 10/+1 and 5/+2", PrereqHandler.passes(
-			prereq, character, null));
+		assertTrue(PrereqHandler.passes(
+			prereq, character, null), "Character has DR 10/+1 and 5/+2");
 	}
 
 	@BeforeEach

--- a/code/src/test/pcgen/core/prereq/PreDeityAlignTest.java
+++ b/code/src/test/pcgen/core/prereq/PreDeityAlignTest.java
@@ -17,9 +17,9 @@
  */
 package pcgen.core.prereq;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.enumeration.ObjectKey;
@@ -55,33 +55,28 @@ public class PreDeityAlignTest extends AbstractCharacterTestCase
 		AlignmentCompat.setCurrentAlignment(character.getCharID(), ng);
 		ChannelUtilities.setControlledChannel(character.getCharID(),
 			CControl.DEITYINPUT, deity);
-		assertEquals("Deity should have been set for character.", deity,
-			ChannelUtilities.readControlledChannel(
-				character.getCharID(), CControl.DEITYINPUT));
+		assertEquals(deity, ChannelUtilities.readControlledChannel(
+				character.getCharID(), CControl.DEITYINPUT), "Deity should have been set for character.");
 
 		Prerequisite prereq = new Prerequisite();
 		prereq.setKind("deityAlign");
 		prereq.setOperand("NG");
 		prereq.setOperator(PrerequisiteOperator.EQ);
 
-		assertTrue("Abbrev NG should match deity's alignment of NG",
-			PrereqHandler.passes(prereq, character, null));
+		assertTrue(PrereqHandler.passes(prereq, character, null), "Abbrev NG should match deity's alignment of NG");
 
 		prereq = new Prerequisite();
 		prereq.setKind("deityAlign");
 		prereq.setOperand("LG");
 		prereq.setOperator(PrerequisiteOperator.EQ);
 
-		assertFalse("Abbrev LG should not match deity's alignment of NG",
-			PrereqHandler.passes(prereq, character, null));
+		assertFalse(PrereqHandler.passes(prereq, character, null), "Abbrev LG should not match deity's alignment of NG");
 
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("PREDEITYALIGN:NG");
-		assertTrue("Abbrev NG should match deity's alignment of NG",
-			PrereqHandler.passes(prereq, character, null));
+		assertTrue(PrereqHandler.passes(prereq, character, null), "Abbrev NG should match deity's alignment of NG");
 		prereq = factory.parse("PREDEITYALIGN:LG");
-		assertFalse("Abbrev LG should not match deity's alignment of NG",
-			PrereqHandler.passes(prereq, character, null));
+		assertFalse(PrereqHandler.passes(prereq, character, null), "Abbrev LG should not match deity's alignment of NG");
 	}
 
 	@BeforeEach

--- a/code/src/test/pcgen/core/prereq/PreDeityDomainTest.java
+++ b/code/src/test/pcgen/core/prereq/PreDeityDomainTest.java
@@ -17,8 +17,8 @@
  */
 package pcgen.core.prereq;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.base.SimpleAssociatedObject;
@@ -60,20 +60,20 @@ public class PreDeityDomainTest extends AbstractCharacterTestCase
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("PREDEITYDOMAIN:1,Good");
 
-		assertFalse("Character has no deity selected", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Character has no deity selected");
 
 		AlignmentCompat.setCurrentAlignment(character.getCharID(), ng);
 		ChannelUtilities.setControlledChannel(character.getCharID(),
 			CControl.DEITYINPUT, deity);
 
-		assertTrue("Character's deity has Good domain", PrereqHandler.passes(
-			prereq, character, null));
+		assertTrue(PrereqHandler.passes(
+			prereq, character, null), "Character's deity has Good domain");
 
 		prereq = factory.parse("PREDEITYDOMAIN:1,Law");
 
-		assertFalse("Character's deity doesn't have Law domain", PrereqHandler
-			.passes(prereq, character, null));
+		assertFalse(PrereqHandler
+			.passes(prereq, character, null), "Character's deity doesn't have Law domain");
 
 	}
 
@@ -87,25 +87,24 @@ public class PreDeityDomainTest extends AbstractCharacterTestCase
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("PREDEITYDOMAIN:1,Good,Law");
 
-		assertFalse("Character has no deity selected", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Character has no deity selected");
 
 		AlignmentCompat.setCurrentAlignment(character.getCharID(), ng);
 		ChannelUtilities.setControlledChannel(character.getCharID(),
 			CControl.DEITYINPUT, deity);
 
-		assertTrue("Character's deity has Good domain", PrereqHandler.passes(
-			prereq, character, null));
+		assertTrue(PrereqHandler.passes(
+			prereq, character, null), "Character's deity has Good domain");
 
 		prereq = factory.parse("PREDEITYDOMAIN:2,Good,Law");
 
-		assertFalse("Character's deity doesn't have Law domain", PrereqHandler
-			.passes(prereq, character, null));
+		assertFalse(PrereqHandler
+			.passes(prereq, character, null), "Character's deity doesn't have Law domain");
 
 		prereq = factory.parse("PREDEITYDOMAIN:2,Good,Animal");
 
-		assertTrue("Character's deity has Good and animal domains",
-			PrereqHandler.passes(prereq, character, null));
+		assertTrue(PrereqHandler.passes(prereq, character, null), "Character's deity has Good and animal domains");
 	}
 
 	@BeforeEach

--- a/code/src/test/pcgen/core/prereq/PreDeityTest.java
+++ b/code/src/test/pcgen/core/prereq/PreDeityTest.java
@@ -17,8 +17,8 @@
  */
 package pcgen.core.prereq;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.base.format.StringManager;
@@ -60,25 +60,25 @@ public class PreDeityTest extends AbstractCharacterTestCase
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("PREDEITY:1,Y");
 
-		assertFalse("Character has no deity selected", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Character has no deity selected");
 
 		prereq = factory.parse("PREDEITY:1,N");
 
-		assertTrue("Character has no deity selected", PrereqHandler.passes(
-			prereq, character, null));
+		assertTrue(PrereqHandler.passes(
+			prereq, character, null), "Character has no deity selected");
 
 		AlignmentCompat.setCurrentAlignment(character.getCharID(), ng);
 		ChannelUtilities.setControlledChannel(character.getCharID(),
 			CControl.DEITYINPUT, deity);
 
-		assertFalse("Character has deity selected", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Character has deity selected");
 
 		prereq = factory.parse("PREDEITY:1,Y");
 
-		assertTrue("Character has deity selected", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Character has deity selected");
 
 	}
 
@@ -97,35 +97,35 @@ public class PreDeityTest extends AbstractCharacterTestCase
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("PREDEITY:1,YES");
 
-		assertFalse("Character has no deity selected", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Character has no deity selected");
 
 		prereq = factory.parse("PREDEITY:1,NO");
 
-		assertTrue("Character has no deity selected", PrereqHandler.passes(
-			prereq, character, null));
+		assertTrue(PrereqHandler.passes(
+			prereq, character, null), "Character has no deity selected");
 
 		AlignmentCompat.setCurrentAlignment(character.getCharID(), ng);
 		ChannelUtilities.setControlledChannel(character.getCharID(),
 			CControl.DEITYINPUT, deity);
 
-		assertFalse("Character has deity selected", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Character has deity selected");
 
 		prereq = factory.parse("PREDEITY:1,YES");
 
-		assertTrue("Character has deity selected", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Character has deity selected");
 
 		prereq = factory.parse("PREDEITY:1,yes");
 
-		assertTrue("Character has deity selected", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Character has deity selected");
 
 		prereq = factory.parse("PREDEITY:1,Yesmeth");
 
-		assertFalse("Character does not have Yesmeth as deity", PrereqHandler
-			.passes(prereq, character, null));
+		assertFalse(PrereqHandler
+			.passes(prereq, character, null), "Character does not have Yesmeth as deity");
 	}
 
 	/**
@@ -143,20 +143,20 @@ public class PreDeityTest extends AbstractCharacterTestCase
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("PREDEITY:1,Test Deity");
 
-		assertFalse("Character has no deity selected", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Character has no deity selected");
 
 		AlignmentCompat.setCurrentAlignment(character.getCharID(), ng);
 		ChannelUtilities.setControlledChannel(character.getCharID(),
 			CControl.DEITYINPUT, deity);
 
-		assertTrue("Character has Test Deity selected", PrereqHandler.passes(
-			prereq, character, null));
+		assertTrue(PrereqHandler.passes(
+			prereq, character, null), "Character has Test Deity selected");
 
 		prereq = factory.parse("PREDEITY:1,Test Deity,Zeus,Odin");
 
-		assertTrue("Character has Test Deity selected", PrereqHandler.passes(
-			prereq, character, null));
+		assertTrue(PrereqHandler.passes(
+			prereq, character, null), "Character has Test Deity selected");
 	}
 
 	/**
@@ -174,35 +174,35 @@ public class PreDeityTest extends AbstractCharacterTestCase
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("PREDEITY:1,YES");
 
-		assertFalse("Character has no deity selected", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Character has no deity selected");
 
 		prereq = factory.parse("PREDEITY:1,NO");
 
-		assertTrue("Character has no deity selected", PrereqHandler.passes(
-			prereq, character, null));
+		assertTrue(PrereqHandler.passes(
+			prereq, character, null), "Character has no deity selected");
 
 		AlignmentCompat.setCurrentAlignment(character.getCharID(), ng);
 		ChannelUtilities.setControlledChannel(character.getCharID(),
 			CControl.DEITYINPUT, deity);
 
-		assertFalse("Character has deity selected", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Character has deity selected");
 
 		prereq = factory.parse("PREDEITY:1,YES");
 
-		assertTrue("Character has deity selected", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Character has deity selected");
 
 		prereq = factory.parse("PREDEITY:1,yes");
 
-		assertTrue("Character has deity selected", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Character has deity selected");
 
 		prereq = factory.parse("PREDEITY:1,Yesmeth");
 
-		assertFalse("Character does not have Yesmeth as deity", PrereqHandler
-			.passes(prereq, character, null));
+		assertFalse(PrereqHandler
+			.passes(prereq, character, null), "Character does not have Yesmeth as deity");
 	}
 
 	/**
@@ -219,19 +219,19 @@ public class PreDeityTest extends AbstractCharacterTestCase
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("PREDEITY:1,PANTHEON.Celtic");
 
-		assertFalse("Character has no deity selected", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Character has no deity selected");
 
 		AlignmentCompat.setCurrentAlignment(character.getCharID(), ng);
 		ChannelUtilities.setControlledChannel(character.getCharID(),
 			CControl.DEITYINPUT, deity);
-		assertTrue("Character has Celtic deity selected", PrereqHandler.passes(
-			prereq, character, null));
+		assertTrue(PrereqHandler.passes(
+			prereq, character, null), "Character has Celtic deity selected");
 
 		prereq = factory.parse("PREDEITY:1,Zeus,PANTHEON.Celtic,Odin");
 
-		assertTrue("Character has Celtic deity selected", PrereqHandler.passes(
-			prereq, character, null));
+		assertTrue(PrereqHandler.passes(
+			prereq, character, null), "Character has Celtic deity selected");
 	}
 
 	@BeforeEach

--- a/code/src/test/pcgen/core/prereq/PreDomainTest.java
+++ b/code/src/test/pcgen/core/prereq/PreDomainTest.java
@@ -17,8 +17,8 @@
  */
 package pcgen.core.prereq;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.base.SimpleAssociatedObject;
@@ -64,21 +64,21 @@ public class PreDomainTest extends AbstractCharacterTestCase
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("PREDOMAIN:1,Good");
 
-		assertFalse("Character has no deity selected", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Character has no deity selected");
 
 		AlignmentCompat.setCurrentAlignment(character.getCharID(), ng);
 		ChannelUtilities.setControlledChannel(character.getCharID(),
 			CControl.DEITYINPUT, deity);
 
-		assertFalse("Character's deity has Good domain", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Character's deity has Good domain");
 
 		character.addDomain(Globals.getContext().getReferenceContext()
 				.silentlyGetConstructedCDOMObject(Domain.class, "Good"));
 
-		assertTrue("Character has Good domain", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Character has Good domain");
 	}
 
 	/**
@@ -97,34 +97,33 @@ public class PreDomainTest extends AbstractCharacterTestCase
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("PREDOMAIN:1,Good,Law");
 
-		assertFalse("Character has no deity selected", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Character has no deity selected");
 
 		AlignmentCompat.setCurrentAlignment(character.getCharID(), ng);
 		ChannelUtilities.setControlledChannel(character.getCharID(),
 			CControl.DEITYINPUT, deity);
 
-		assertFalse("Character's deity has Good domain", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Character's deity has Good domain");
 
 		character.addDomain(Globals.getContext().getReferenceContext()
 				.silentlyGetConstructedCDOMObject(Domain.class, "Good"));
 
-		assertTrue("Character has Good domain", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Character has Good domain");
 
 		prereq = factory.parse("PREDOMAIN:2,Good,Law");
 
-		assertFalse("Character doesn't have Law domain", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Character doesn't have Law domain");
 
 		prereq = factory.parse("PREDOMAIN:2,Good,Animal");
 
 		character.addDomain(Globals.getContext().getReferenceContext()
 				.silentlyGetConstructedCDOMObject(Domain.class, "Animal"));
 
-		assertTrue("Character's deity has Good and animal domains",
-			PrereqHandler.passes(prereq, character, null));
+		assertTrue(PrereqHandler.passes(prereq, character, null), "Character's deity has Good and animal domains");
 	}
 	
 	/**
@@ -143,25 +142,25 @@ public class PreDomainTest extends AbstractCharacterTestCase
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("PREDOMAIN:1,ANY");
 
-		assertFalse("Character has no domains", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Character has no domains");
 
 		character.addDomain(Globals.getContext().getReferenceContext()
 				.silentlyGetConstructedCDOMObject(Domain.class, "Good"));
 
-		assertTrue("Character has one domain", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Character has one domain");
 		
 		prereq = factory.parse("PREDOMAIN:2,ANY");
 
-		assertFalse("Character has only one domain", PrereqHandler.passes(
-				prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+				prereq, character, null), "Character has only one domain");
 		
 		character.addDomain(Globals.getContext().getReferenceContext()
 				.silentlyGetConstructedCDOMObject(Domain.class, "Animal"));
 		
-		assertTrue("Character has two domains", PrereqHandler.passes(
-				prereq, character, null));
+		assertTrue(PrereqHandler.passes(
+				prereq, character, null), "Character has two domains");
 		
 	}
 

--- a/code/src/test/pcgen/core/prereq/PreEquipPrimaryTest.java
+++ b/code/src/test/pcgen/core/prereq/PreEquipPrimaryTest.java
@@ -17,8 +17,8 @@
  */
 package pcgen.core.prereq;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.enumeration.EquipmentLocation;
@@ -71,13 +71,13 @@ public class PreEquipPrimaryTest extends AbstractCharacterTestCase
 
 		dagger.setName("Dagger (Masterwork)");
 
-		assertFalse("Should be an exact match only", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Should be an exact match only");
 
 		prereq.setKey("DAGGER%");
 
-		assertTrue("Should allow wildcard match", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Should allow wildcard match");
 	}
 
 	/**
@@ -102,18 +102,18 @@ public class PreEquipPrimaryTest extends AbstractCharacterTestCase
 		prereq.setOperand("1");
 		prereq.setOperator(PrerequisiteOperator.EQ);
 
-		assertFalse("Equipment has no type", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "Equipment has no type");
 
 		longsword.addType(Type.getConstant("SLASHING"));
 
-		assertTrue("Equipment is slashing", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Equipment is slashing");
 
 		prereq.setKey("TYPE.Armor");
 
-		assertFalse("Equipment is not armor", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "Equipment is not armor");
 	}
 
 	/**
@@ -151,14 +151,14 @@ public class PreEquipPrimaryTest extends AbstractCharacterTestCase
 		longsword.put(ObjectKey.SIZE, mediumRef);
 		longsword.put(ObjectKey.BASESIZE, mediumRef);
 
-		assertTrue("Weapon is M therefore OneHanded", PrereqHandler.passes(
-			prereq, character, null));
+		assertTrue(PrereqHandler.passes(
+			prereq, character, null), "Weapon is M therefore OneHanded");
 
 		longsword.put(ObjectKey.SIZE, largeRef);
 		longsword.put(ObjectKey.BASESIZE, largeRef);
 
-		assertFalse("Weapon is L therefore TwoHanded", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Weapon is L therefore TwoHanded");
 
 		// Test 3.5 style
 		longsword.put(ObjectKey.SIZE, mediumRef);
@@ -166,14 +166,14 @@ public class PreEquipPrimaryTest extends AbstractCharacterTestCase
 		longsword.put(ObjectKey.WIELD, context.getReferenceContext().silentlyGetConstructedCDOMObject(
 				WieldCategory.class, "TwoHanded"));
 
-		assertFalse("Weapon is TwoHanded", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "Weapon is TwoHanded");
 
 		longsword.put(ObjectKey.WIELD, context.getReferenceContext().silentlyGetConstructedCDOMObject(
 				WieldCategory.class, "OneHanded"));
 
-		assertTrue("Weapon is OneHanded", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Weapon is OneHanded");
 
 	}
 }

--- a/code/src/test/pcgen/core/prereq/PreEquipSecondaryTest.java
+++ b/code/src/test/pcgen/core/prereq/PreEquipSecondaryTest.java
@@ -17,8 +17,8 @@
  */
 package pcgen.core.prereq;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.enumeration.EquipmentLocation;
@@ -73,13 +73,13 @@ public class PreEquipSecondaryTest extends AbstractCharacterTestCase
 
 		longsword.setName("Longsword (Masterwork)");
 
-		assertFalse("Should be an exact match only", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Should be an exact match only");
 
 		prereq.setKey("LONGSWORD%");
 
-		assertTrue("Should allow wildcard match", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Should allow wildcard match");
 	}
 
 	/**
@@ -104,18 +104,18 @@ public class PreEquipSecondaryTest extends AbstractCharacterTestCase
 		prereq.setOperand("1");
 		prereq.setOperator(PrerequisiteOperator.EQ);
 
-		assertFalse("Equipment has no type", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "Equipment has no type");
 
 		longsword.addType(Type.WEAPON);
 
-		assertTrue("Equipment is weapon", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Equipment is weapon");
 
 		prereq.setKey("TYPE.Armor");
 
-		assertFalse("Equipment is not armor", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "Equipment is not armor");
 	}
 
 	/**
@@ -153,14 +153,14 @@ public class PreEquipSecondaryTest extends AbstractCharacterTestCase
 		longsword.put(ObjectKey.SIZE, smallRef);
 		longsword.put(ObjectKey.BASESIZE, smallRef);
 
-		assertTrue("Weapon is S therefore Light", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Weapon is S therefore Light");
 
 		longsword.put(ObjectKey.SIZE, mediumRef);
 		longsword.put(ObjectKey.BASESIZE, mediumRef);
 
-		assertFalse("Weapon is M therefore OneHanded", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Weapon is M therefore OneHanded");
 
 		// Test 3.5 style
 		longsword.put(ObjectKey.SIZE, mediumRef);
@@ -168,14 +168,14 @@ public class PreEquipSecondaryTest extends AbstractCharacterTestCase
 		longsword.put(ObjectKey.WIELD, context.getReferenceContext().silentlyGetConstructedCDOMObject(
 				WieldCategory.class, "OneHanded"));
 
-		assertFalse("Weapon is OneHanded", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "Weapon is OneHanded");
 
 		longsword.put(ObjectKey.WIELD, context.getReferenceContext().silentlyGetConstructedCDOMObject(
 				WieldCategory.class, "Light"));
 
-		assertTrue("Weapon is Light", PrereqHandler.passes(prereq, character,
-			null));
+		assertTrue(PrereqHandler.passes(prereq, character,
+			null), "Weapon is Light");
 
 	}
 
@@ -203,19 +203,16 @@ public class PreEquipSecondaryTest extends AbstractCharacterTestCase
 		final Prerequisite prereqDaggerNotSec =
 				PreParserFactory.getInstance().parse(
 					"!PREEQUIPSECONDARY:1,Dagger");
-		assertTrue("Dagger not equipped",
-			PrereqHandler.passes(prereqDaggerNotSec, character, null));
+		assertTrue(PrereqHandler.passes(prereqDaggerNotSec, character, null), "Dagger not equipped");
 
 		character.addEquipment(dagger);
 		dagger.setIsEquipped(true, character);
 		dagger.setLocation(EquipmentLocation.EQUIPPED_PRIMARY);
-		assertTrue("Dagger not equipped",
-			PrereqHandler.passes(prereqDaggerNotSec, character, null));
+		assertTrue(PrereqHandler.passes(prereqDaggerNotSec, character, null), "Dagger not equipped");
 
 		final Prerequisite prereqLongswordNotSec =
 				PreParserFactory.getInstance().parse(
 					"!PREEQUIPSECONDARY:1,Longsword");
-		assertFalse("Longsword equipped",
-			PrereqHandler.passes(prereqLongswordNotSec, character, null));
+		assertFalse(PrereqHandler.passes(prereqLongswordNotSec, character, null), "Longsword equipped");
 	}
 }

--- a/code/src/test/pcgen/core/prereq/PreEquipTest.java
+++ b/code/src/test/pcgen/core/prereq/PreEquipTest.java
@@ -16,8 +16,8 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
 package pcgen.core.prereq;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.enumeration.FormulaKey;
@@ -67,13 +67,13 @@ public class PreEquipTest extends AbstractCharacterTestCase
 
 		longsword.setName("Longsword (Masterwork)");
 
-		assertFalse("Should be an exact match only", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Should be an exact match only");
 
 		prereq.setKey("LONGSWORD%");
 
-		assertTrue("Should be allow wildcard match", PrereqHandler.passes(
-			prereq, character, null));
+		assertTrue(PrereqHandler.passes(
+			prereq, character, null), "Should be allow wildcard match");
 	}
 
 	/**
@@ -99,24 +99,24 @@ public class PreEquipTest extends AbstractCharacterTestCase
 		prereq.setOperand("1");
 		prereq.setOperator(PrerequisiteOperator.EQ);
 
-		assertFalse("Equipment has no type", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "Equipment has no type");
 
 		longsword.addType(Type.WEAPON);
 
-		assertTrue("Equipment is weapon", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Equipment is weapon");
 
 		prereq.setKey("TYPE.Armor");
 
-		assertFalse("Equipment is not armor", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "Equipment is not armor");
 
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("PREEQUIP:2,TYPE=Armor,Longsword%");
 
-		assertFalse("Doesn't have armor equipped", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "Doesn't have armor equipped");
 
 		final Equipment leather = new Equipment();
 		leather.setName("Leather");
@@ -126,8 +126,8 @@ public class PreEquipTest extends AbstractCharacterTestCase
 		leather.setIsEquipped(true, character);
 		character.doAfavorForAunitTestThatIgnoresEquippingRules();
 
-		assertTrue("Armor and sword equipped", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Armor and sword equipped");
 	}
 
 	/**
@@ -164,14 +164,14 @@ public class PreEquipTest extends AbstractCharacterTestCase
 		longsword.put(ObjectKey.SIZE, mediumRef);
 		longsword.put(ObjectKey.BASESIZE, mediumRef);
 
-		assertTrue("Weapon is M therefore OneHanded", PrereqHandler.passes(
-			prereq, character, null));
+		assertTrue(PrereqHandler.passes(
+			prereq, character, null), "Weapon is M therefore OneHanded");
 
 		longsword.put(ObjectKey.SIZE, largeRef);
 		longsword.put(ObjectKey.BASESIZE, largeRef);
 
-		assertFalse("Weapon is L therefore TwoHanded", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Weapon is L therefore TwoHanded");
 
 		// Test 3.5 style
 		longsword.put(ObjectKey.SIZE, mediumRef);
@@ -179,14 +179,14 @@ public class PreEquipTest extends AbstractCharacterTestCase
 		longsword.put(ObjectKey.WIELD, context.getReferenceContext().silentlyGetConstructedCDOMObject(
 				WieldCategory.class, "TwoHanded"));
 
-		assertFalse("Weapon is TwoHanded", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "Weapon is TwoHanded");
 
 		longsword.put(ObjectKey.WIELD, context.getReferenceContext().silentlyGetConstructedCDOMObject(
 				WieldCategory.class, "OneHanded"));
 
-		assertTrue("Weapon is OneHanded", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Weapon is OneHanded");
 
 	}
 }

--- a/code/src/test/pcgen/core/prereq/PreEquipTwoWeaponTest.java
+++ b/code/src/test/pcgen/core/prereq/PreEquipTwoWeaponTest.java
@@ -17,8 +17,8 @@
  */
 package pcgen.core.prereq;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.enumeration.EquipmentLocation;
@@ -71,13 +71,13 @@ public class PreEquipTwoWeaponTest extends AbstractCharacterTestCase
 
 		longsword.setName("Longsword (Large/Masterwork)");
 
-		assertFalse("Should be an exact match only", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Should be an exact match only");
 
 		prereq.setKey("LONGSWORD (LARGE%");
 
-		assertTrue("Should allow wildcard match", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Should allow wildcard match");
 	}
 
 	/**
@@ -102,18 +102,18 @@ public class PreEquipTwoWeaponTest extends AbstractCharacterTestCase
 		prereq.setOperand("1");
 		prereq.setOperator(PrerequisiteOperator.EQ);
 
-		assertFalse("Equipment has no type", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "Equipment has no type");
 
 		longsword.addType(Type.WEAPON);
 
-		assertTrue("Equipment is weapon", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Equipment is weapon");
 
 		prereq.setKey("TYPE.Armor");
 
-		assertFalse("Equipment is not armor", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "Equipment is not armor");
 	}
 
 	/**
@@ -151,14 +151,14 @@ public class PreEquipTwoWeaponTest extends AbstractCharacterTestCase
 		longsword.put(ObjectKey.SIZE, mediumRef);
 		longsword.put(ObjectKey.BASESIZE, mediumRef);
 
-		assertTrue("Weapon is M therefore OneHanded", PrereqHandler.passes(
-			prereq, character, null));
+		assertTrue(PrereqHandler.passes(
+			prereq, character, null), "Weapon is M therefore OneHanded");
 
 		longsword.put(ObjectKey.SIZE, largeRef);
 		longsword.put(ObjectKey.BASESIZE, largeRef);
 
-		assertFalse("Weapon is L therefore TwoHanded", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Weapon is L therefore TwoHanded");
 
 		// Test 3.5 style
 		longsword.put(ObjectKey.SIZE, mediumRef);
@@ -166,14 +166,14 @@ public class PreEquipTwoWeaponTest extends AbstractCharacterTestCase
 		longsword.put(ObjectKey.WIELD, context.getReferenceContext().silentlyGetConstructedCDOMObject(
 				WieldCategory.class, "TwoHanded"));
 
-		assertFalse("Weapon is TwoHanded", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "Weapon is TwoHanded");
 
 		longsword.put(ObjectKey.WIELD, context.getReferenceContext().silentlyGetConstructedCDOMObject(
 				WieldCategory.class, "OneHanded"));
 
-		assertTrue("Weapon is OneHanded", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Weapon is OneHanded");
 
 	}
 }

--- a/code/src/test/pcgen/core/prereq/PreGenderTest.java
+++ b/code/src/test/pcgen/core/prereq/PreGenderTest.java
@@ -17,8 +17,8 @@
  */
 package pcgen.core.prereq;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.enumeration.Gender;
@@ -50,17 +50,17 @@ public class PreGenderTest extends AbstractCharacterTestCase
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("PREGENDER:M");
 
-		assertTrue("Character is Male", PrereqHandler.passes(prereq, character,
-			null));
+		assertTrue(PrereqHandler.passes(prereq, character,
+			null), "Character is Male");
 
 		prereq = factory.parse("PREGENDER:m");
 
-		assertFalse("Case is significant", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "Case is significant");
 
 		prereq = factory.parse("PREGENDER:Moose");
 
-		assertFalse("Requires a full match", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "Requires a full match");
 	}
 }

--- a/code/src/test/pcgen/core/prereq/PreHDTest.java
+++ b/code/src/test/pcgen/core/prereq/PreHDTest.java
@@ -17,8 +17,8 @@
  */
 package pcgen.core.prereq;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.base.FormulaFactory;
@@ -78,33 +78,33 @@ public class PreHDTest extends AbstractCharacterTestCase
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("PREHD:MIN=4");
 
-		assertFalse("Character doesn't have 4 HD", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "Character doesn't have 4 HD");
 
 		prereq = factory.parse("PREHD:MIN=3");
 
-		assertTrue("Character has 3 HD", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Character has 3 HD");
 
 		prereq = factory.parse("PREHD:MIN=1,MAX=3");
 
-		assertTrue("Character has 3 HD", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Character has 3 HD");
 
 		prereq = factory.parse("PREHD:MIN=3,MAX=6");
 
-		assertTrue("Character has 3 HD", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Character has 3 HD");
 
 		prereq = factory.parse("PREHD:MIN=4,MAX=7");
 
-		assertFalse("Character doesn't have 4 HD", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "Character doesn't have 4 HD");
 
 		prereq = factory.parse("PREHD:MIN=1,MAX=2");
 
-		assertFalse("Character doesn't have 2 or less HD", PrereqHandler
-			.passes(prereq, character, null));
+		assertFalse(PrereqHandler
+			.passes(prereq, character, null), "Character doesn't have 2 or less HD");
 	}
 
 	/**
@@ -136,32 +136,32 @@ public class PreHDTest extends AbstractCharacterTestCase
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("PREHD:MIN=4");
 
-		assertFalse("Character doesn't have 4 HD", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "Character doesn't have 4 HD");
 
 		prereq = factory.parse("PREHD:MIN=3");
 
-		assertTrue("Character has 3 HD", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Character has 3 HD");
 
 		prereq = factory.parse("PREHD:MIN=1,MAX=3");
 
-		assertTrue("Character has 3 HD", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Character has 3 HD");
 
 		prereq = factory.parse("PREHD:MIN=3,MAX=6");
 
-		assertTrue("Character has 3 HD", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Character has 3 HD");
 
 		prereq = factory.parse("PREHD:MIN=4,MAX=7");
 
-		assertFalse("Character doesn't have 4 HD", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "Character doesn't have 4 HD");
 
 		prereq = factory.parse("PREHD:MIN=1,MAX=2");
 
-		assertFalse("Character doesn't have 2 or less HD", PrereqHandler
-			.passes(prereq, character, null));
+		assertFalse(PrereqHandler
+			.passes(prereq, character, null), "Character doesn't have 2 or less HD");
 	}
 }

--- a/code/src/test/pcgen/core/prereq/PreHPTest.java
+++ b/code/src/test/pcgen/core/prereq/PreHPTest.java
@@ -18,8 +18,8 @@
 package pcgen.core.prereq;
 
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.base.FormulaFactory;
@@ -69,20 +69,20 @@ public class PreHPTest extends AbstractCharacterTestCase
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("PREHP:4");
 
-		assertTrue("Character should have 4 hp", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Character should have 4 hp");
 
 		prereq = factory.parse("PREHP:5");
 
-		assertFalse("Character should have less than 5 hp", PrereqHandler
-			.passes(prereq, character, null));
+		assertFalse(PrereqHandler
+			.passes(prereq, character, null), "Character should have less than 5 hp");
 
 		final BonusObj hpBonus = Bonus.newBonus(context, "HP|CURRENTMAX|1");
 		myClass.addToListFor(ListKey.BONUS, hpBonus);
 		character.calcActiveBonuses();
 
-		assertTrue("Character should have 5 hp", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Character should have 5 hp");
 	}
 
 	@BeforeEach

--- a/code/src/test/pcgen/core/prereq/PreHandsTest.java
+++ b/code/src/test/pcgen/core/prereq/PreHandsTest.java
@@ -17,8 +17,8 @@
  */
 package pcgen.core.prereq;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.enumeration.IntegerKey;
@@ -54,17 +54,17 @@ public class PreHandsTest extends AbstractCharacterTestCase
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("PREHANDSLT:2");
 
-		assertFalse("Character has more than 1 hand", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Character has more than 1 hand");
 
 		prereq = factory.parse("PREHANDSEQ:2");
 
-		assertTrue("Character has 2 hands", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Character has 2 hands");
 
 		prereq = factory.parse("PREHANDSGT:2");
 
-		assertFalse("Character does not have more than 2 hands", PrereqHandler
-			.passes(prereq, character, null));
+		assertFalse(PrereqHandler
+			.passes(prereq, character, null), "Character does not have more than 2 hands");
 	}
 }

--- a/code/src/test/pcgen/core/prereq/PreItemTest.java
+++ b/code/src/test/pcgen/core/prereq/PreItemTest.java
@@ -17,8 +17,8 @@
  */
 package pcgen.core.prereq;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.enumeration.Type;
@@ -59,13 +59,13 @@ public class PreItemTest extends AbstractCharacterTestCase
 
 		longsword.setName("Longsword (Masterwork)");
 
-		assertFalse("Should be an exact match only", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Should be an exact match only");
 
 		prereq.setKey("LONGSWORD%");
 
-		assertTrue("Should be allow wildcard match", PrereqHandler.passes(
-			prereq, character, null));
+		assertTrue(PrereqHandler.passes(
+			prereq, character, null), "Should be allow wildcard match");
 	}
 
 	/**
@@ -89,24 +89,24 @@ public class PreItemTest extends AbstractCharacterTestCase
 		prereq.setOperand("1");
 		prereq.setOperator(PrerequisiteOperator.EQ);
 
-		assertFalse("Equipment has no type", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "Equipment has no type");
 
 		longsword.addType(Type.WEAPON);
 
-		assertTrue("Equipment is weapon", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Equipment is weapon");
 
 		prereq.setKey("TYPE.Armor");
 
-		assertFalse("Equipment is not armor", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "Equipment is not armor");
 
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("PREITEM:2,TYPE=Armor,Longsword%");
 
-		assertFalse("Doesn't have armor", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "Doesn't have armor");
 
 		final Equipment leather = new Equipment();
 		leather.setName("Leather");
@@ -114,8 +114,8 @@ public class PreItemTest extends AbstractCharacterTestCase
 
 		character.addEquipment(leather);
 
-		assertTrue("Armor and sword present", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Armor and sword present");
 	}
 
 }

--- a/code/src/test/pcgen/core/prereq/PreKitTest.java
+++ b/code/src/test/pcgen/core/prereq/PreKitTest.java
@@ -17,9 +17,9 @@
  */
 package pcgen.core.prereq;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.core.Kit;
@@ -54,7 +54,7 @@ class PreKitTest extends AbstractCharacterTestCase
 		prereq.setOperand("1");
 
 		final boolean passes = PrereqHandler.passes(prereq, character, null);
-		assertTrue("Expected kit to be present", passes);
+		assertTrue(passes, "Expected kit to be present");
 	}
 
 	/**
@@ -73,7 +73,7 @@ class PreKitTest extends AbstractCharacterTestCase
 		prereq.setOperand("1");
 
 		final boolean passes = PrereqHandler.passes(prereq, character, null);
-		assertTrue("Expected kit not to be present", passes);
+		assertTrue(passes, "Expected kit not to be present");
 	}
 
 	/**
@@ -96,7 +96,7 @@ class PreKitTest extends AbstractCharacterTestCase
 		prereq.setOperand("1");
 
 		final boolean passes = PrereqHandler.passes(prereq, character, null);
-		assertTrue("Expected kit not to be present", passes);
+		assertTrue(passes, "Expected kit not to be present");
 	}
 
 	/**
@@ -119,7 +119,7 @@ class PreKitTest extends AbstractCharacterTestCase
 		prereq.setOperand("1");
 
 		final boolean passes = PrereqHandler.passes(prereq, character, null);
-		assertFalse("Expected kit to be present", passes);
+		assertFalse(passes, "Expected kit to be present");
 	}
 
 	/**
@@ -142,7 +142,7 @@ class PreKitTest extends AbstractCharacterTestCase
 		prereq.setOperand("1");
 
 		final boolean passes = PrereqHandler.passes(prereq, character, null);
-		assertTrue("Expected wildcard to match", passes);
+		assertTrue(passes, "Expected wildcard to match");
 	}
 
 	/**

--- a/code/src/test/pcgen/core/prereq/PreLangTest.java
+++ b/code/src/test/pcgen/core/prereq/PreLangTest.java
@@ -16,8 +16,8 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
 package pcgen.core.prereq;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.enumeration.ListKey;
@@ -59,38 +59,38 @@ public class PreLangTest extends AbstractCharacterTestCase
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("PRELANG:1,KEY_Elven");
 
-		assertTrue("Character should have elven", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Character should have elven");
 
 		prereq = factory.parse("PRELANG:1,KEY_Elven,KEY_Dwarven");
 
-		assertTrue("Character should have elven", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Character should have elven");
 
 		prereq = factory.parse("PRELANG:2,KEY_Elven,KEY_Dwarven");
 
-		assertFalse("Character doesn't have Dwarven", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Character doesn't have Dwarven");
 
 		character.addAutoLanguage(dwarven, dwarven);
 
-		assertTrue("Character has Elven and Dwarven", PrereqHandler.passes(
-			prereq, character, null));
+		assertTrue(PrereqHandler.passes(
+			prereq, character, null), "Character has Elven and Dwarven");
 
 		prereq = factory.parse("PRELANG:3,ANY");
 
-		assertFalse("Character doesn't have 3 langs", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Character doesn't have 3 langs");
 
 		character.addAutoLanguage(halfling, halfling);
 
-		assertTrue("Character has Elven, Dwarven, and Halfling", PrereqHandler
-			.passes(prereq, character, null));
+		assertTrue(PrereqHandler
+			.passes(prereq, character, null), "Character has Elven, Dwarven, and Halfling");
 
 		prereq = factory.parse("PRELANG:3,Elven");
 
-		assertFalse("PRE test should look at keys", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "PRE test should look at keys");
 	}
 
 	@BeforeEach

--- a/code/src/test/pcgen/core/prereq/PreLegsTest.java
+++ b/code/src/test/pcgen/core/prereq/PreLegsTest.java
@@ -17,8 +17,8 @@
  */
 package pcgen.core.prereq;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.enumeration.IntegerKey;
@@ -55,24 +55,24 @@ class PreLegsTest extends AbstractCharacterTestCase
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("PRELEGSLT:2");
 
-		assertFalse("Character has more than 1 leg", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Character has more than 1 leg");
 
 		prereq = factory.parse("PRELEGSEQ:2");
 
-		assertTrue("Character has 2 legs", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Character has 2 legs");
 
 		prereq = factory.parse("PRELEGSGT:2");
 
-		assertFalse("Character does not have more than 2 legs", PrereqHandler
-			.passes(prereq, character, null));
+		assertFalse(PrereqHandler
+			.passes(prereq, character, null), "Character does not have more than 2 legs");
 
 		PCTemplate tmpl = new PCTemplate();
 		tmpl.put(IntegerKey.LEGS, 3);
 
 		character.addTemplate(tmpl);
-		assertTrue("Character does have more than 2 legs", PrereqHandler
-			.passes(prereq, character, null));
+		assertTrue(PrereqHandler
+			.passes(prereq, character, null), "Character does have more than 2 legs");
 	}
 }

--- a/code/src/test/pcgen/core/prereq/PreLevelMaxTest.java
+++ b/code/src/test/pcgen/core/prereq/PreLevelMaxTest.java
@@ -17,8 +17,8 @@
  */
 package pcgen.core.prereq;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.base.FormulaFactory;
@@ -65,13 +65,13 @@ public class PreLevelMaxTest extends AbstractCharacterTestCase
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("PRELEVELMAX:1");
 
-		assertTrue("Character is not 2nd level", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Character is not 2nd level");
 
 		character.incrementClassLevel(1, myClass, true);
 
-		assertFalse("Character has 2 levels", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "Character has 2 levels");
 	}
 
 	/**
@@ -93,13 +93,13 @@ public class PreLevelMaxTest extends AbstractCharacterTestCase
 
 		prereq = factory.parse("PRELEVELMAX:3");
 
-		assertTrue("Character doesn't have 4 levels", PrereqHandler.passes(
-			prereq, character, null));
+		assertTrue(PrereqHandler.passes(
+			prereq, character, null), "Character doesn't have 4 levels");
 
 		character.setRace(race);
 
-		assertTrue("Character has 4 levels", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Character has 4 levels");
 	}
 
 	/**
@@ -129,8 +129,8 @@ public class PreLevelMaxTest extends AbstractCharacterTestCase
 		myClass.addToListFor(ListKey.BONUS, levelBonus);
 		character.calcActiveBonuses();
 
-		assertTrue("Character has only 4 levels", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Character has only 4 levels");
 	}
 
 	@BeforeEach

--- a/code/src/test/pcgen/core/prereq/PrePCLevelTest.java
+++ b/code/src/test/pcgen/core/prereq/PrePCLevelTest.java
@@ -15,8 +15,8 @@
  */
 package pcgen.core.prereq;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.base.FormulaFactory;
@@ -62,34 +62,34 @@ public class PrePCLevelTest extends AbstractCharacterTestCase
 
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("PREPCLEVEL:MIN=2");
-		assertFalse("Character is not 2nd level", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "Character is not 2nd level");
 		
 		character.incrementClassLevel(1, myClass, true);
 
-		assertTrue("Character has 2 levels", PrereqHandler.passes(prereq,
-			character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+			character, null), "Character has 2 levels");
 		
 		character.incrementClassLevel(1, myClass, true);
 		prereq = factory.parse("PREPCLEVEL:MIN=2,MAX=3");
-		assertTrue("Character is 2nd or 3rd level", PrereqHandler.passes(prereq,
-				character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+				character, null), "Character is 2nd or 3rd level");
 		
 		character.incrementClassLevel(1, myClass, true);
-		assertFalse("Character is not 2nd or 3rd level", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "Character is not 2nd or 3rd level");
 		
 		prereq = factory.parse("!PREPCLEVEL:MIN=2,MAX=3");
-		assertTrue("Character is 2nd or 3rd level", PrereqHandler.passes(prereq,
-				character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+				character, null), "Character is 2nd or 3rd level");
 
 		prereq = factory.parse("!PREPCLEVEL:MIN=4");
-		assertFalse("Character is 4 or higher level", PrereqHandler.passes(prereq,
-				character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+				character, null), "Character is 4 or higher level");
 		
 		prereq = factory.parse("!PREPCLEVEL:MAX=3");
-		assertTrue("Character is 3rd or higher level", PrereqHandler.passes(prereq,
-				character, null));
+		assertTrue(PrereqHandler.passes(prereq,
+				character, null), "Character is 3rd or higher level");
 	}
 
 	/**
@@ -110,46 +110,46 @@ public class PrePCLevelTest extends AbstractCharacterTestCase
 		final PreParserFactory factory = PreParserFactory.getInstance();
 
 		prereq = factory.parse("PREPCLEVEL:MIN=4");
-		assertFalse("Character doesn't have 4 levels", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Character doesn't have 4 levels");
 
 		character.setRace(race);
 
-		assertFalse("Character has 4 levels", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "Character has 4 levels");
 		
 		prereq = factory.parse("!PREPCLEVEL:MIN=5");
-		assertTrue("Character doesn't have 5 or more levels", PrereqHandler.passes(
-			prereq, character, null));
+		assertTrue(PrereqHandler.passes(
+			prereq, character, null), "Character doesn't have 5 or more levels");
 		
 		prereq = factory.parse("!PREPCLEVEL:MIN=3");
-		assertTrue("Character doesn't have 5 or more levels", PrereqHandler.passes(
-			prereq, character, null));
+		assertTrue(PrereqHandler.passes(
+			prereq, character, null), "Character doesn't have 5 or more levels");
 		
 		prereq = factory.parse("!PREPCLEVEL:MAX=3");
-		assertFalse("Character doesn't have 3 or more levels", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Character doesn't have 3 or more levels");
 
 		prereq = factory.parse("!PREPCLEVEL:MIN=6,MAX=7");
-		assertTrue("Character doesn't have between 6 and 7 levels", PrereqHandler.passes(
-			prereq, character, null));
+		assertTrue(PrereqHandler.passes(
+			prereq, character, null), "Character doesn't have between 6 and 7 levels");
 				
 		prereq = factory.parse("PREPCLEVEL:MIN=4,MAX=6");
-		assertFalse("Character doesn't have 4-6 levels", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Character doesn't have 4-6 levels");
 		
 		prereq = factory.parse("PREPCLEVEL:MIN=6,MAX=7");
-		assertFalse("Character doesn't have 6-7 levels", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Character doesn't have 6-7 levels");
 		
 		prereq = factory.parse("PREPCLEVEL:MAX=7");
-		assertTrue("Character has no more than 5 levels", PrereqHandler.passes(
-			prereq, character, null));
+		assertTrue(PrereqHandler.passes(
+			prereq, character, null), "Character has no more than 5 levels");
 		
 		character.incrementClassLevel(4, myClass, true);
 		prereq = factory.parse("PREPCLEVEL:MAX=6");
-		assertTrue("Character has no more than 6 levels", PrereqHandler.passes(
-			prereq, character, null));
+		assertTrue(PrereqHandler.passes(
+			prereq, character, null), "Character has no more than 6 levels");
 		
 		
 	}
@@ -181,33 +181,33 @@ public class PrePCLevelTest extends AbstractCharacterTestCase
 		myClass.addToListFor(ListKey.BONUS, levelBonus);
 		character.calcActiveBonuses();
 
-		assertFalse("Character has only 4 levels", PrereqHandler.passes(prereq,
-			character, null));
+		assertFalse(PrereqHandler.passes(prereq,
+			character, null), "Character has only 4 levels");
 		
 		
 		prereq = factory.parse("PREPCLEVEL:MAX=6");
-		assertTrue("Character has more than 6 levels", PrereqHandler.passes(prereq,
-				character, null));	
+		assertTrue(PrereqHandler.passes(prereq,
+				character, null), "Character has more than 6 levels");	
 		
 		prereq = factory.parse("!PREPCLEVEL:MAX=6");
-		assertFalse("Character is less than 6 levels", PrereqHandler.passes(prereq,
-				character, null));	
+		assertFalse(PrereqHandler.passes(prereq,
+				character, null), "Character is less than 6 levels");	
 		
 		prereq = factory.parse("!PREPCLEVEL:MIN=5");
-		assertTrue("Character has only 4 levels", PrereqHandler.passes(prereq,
-				character, null));	
+		assertTrue(PrereqHandler.passes(prereq,
+				character, null), "Character has only 4 levels");	
 
 		prereq = factory.parse("PREPCLEVEL:MIN=4,MAX=6");
-		assertFalse("Character does not have 4-6 levels", PrereqHandler.passes(prereq,
-				character, null));	
+		assertFalse(PrereqHandler.passes(prereq,
+				character, null), "Character does not have 4-6 levels");	
 		
 		prereq = factory.parse("PREPCLEVEL:MIN=6,MAX=8");
-		assertFalse("Character does not have 6-8 levels", PrereqHandler.passes(prereq,
-				character, null));	
+		assertFalse(PrereqHandler.passes(prereq,
+				character, null), "Character does not have 6-8 levels");	
 
 		prereq = factory.parse("!PREPCLEVEL:MIN=6,MAX=8");
-		assertTrue("Character is not 6-8 levels", PrereqHandler.passes(prereq,
-				character, null));	
+		assertTrue(PrereqHandler.passes(prereq,
+				character, null), "Character is not 6-8 levels");	
 		
 		
 	}

--- a/code/src/test/pcgen/core/prereq/PreRaceTest.java
+++ b/code/src/test/pcgen/core/prereq/PreRaceTest.java
@@ -17,8 +17,8 @@
  */
 package pcgen.core.prereq;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.enumeration.ListKey;
@@ -154,8 +154,8 @@ public class PreRaceTest extends AbstractCharacterTestCase
 		prereq.setOperator(PrerequisiteOperator.EQ);
 
 		final boolean passes = PrereqHandler.passes(prereq, character, null);
-		assertTrue("Expected prereq " + prereq + " to pass for race " + fake
-			+ " with SERVESAS", passes);
+		assertTrue(passes, "Expected prereq " + prereq + " to pass for race " + fake
+			+ " with SERVESAS");
 	}
 
 	@Test
@@ -175,7 +175,7 @@ public class PreRaceTest extends AbstractCharacterTestCase
 		prereq.setOperator(PrerequisiteOperator.EQ);
 
 		final boolean passes = PrereqHandler.passes(prereq, character, null);
-		assertTrue(prereq + " should pass", passes);
+		assertTrue(passes, prereq + " should pass");
 	}
 
 	@Test
@@ -195,11 +195,11 @@ public class PreRaceTest extends AbstractCharacterTestCase
 		prereq.setOperator(PrerequisiteOperator.LT);
 
 		boolean passes = PrereqHandler.passes(prereq, character, null);
-		assertTrue(prereq + " should pass", passes);
+		assertTrue(passes, prereq + " should pass");
 		
 		prereq.setKey("RACETYPE=Humanoid");
 		passes = PrereqHandler.passes(prereq, character, null);
-		assertFalse(prereq + " should not pass", passes);
+		assertFalse(passes, prereq + " should not pass");
 	}
 	
 	/**
@@ -256,9 +256,9 @@ public class PreRaceTest extends AbstractCharacterTestCase
 
 		prereq.setKey("RACESUBTYPE=SpikyHair");
 		passes = PrereqHandler.passes(prereq, character, null);
-		assertFalse("Prereq " + prereq
+		assertFalse(passes, "Prereq " + prereq
 			+ " should not be passed by character without a "
-			+ "race or servesas link.", passes);
+			+ "race or servesas link.");
 		
 	}
 	
@@ -297,13 +297,13 @@ public class PreRaceTest extends AbstractCharacterTestCase
 		prereq.setOperator(PrerequisiteOperator.EQ);
 
 		boolean passes = PrereqHandler.passes(prereq, character, null);
-		assertTrue("Prereq " + prereq + " should pass due to SERVESAS", passes);
+		assertTrue(passes, "Prereq " + prereq + " should pass due to SERVESAS");
 
 		prereq.setKey("RACETYPE=Smaller");
 		passes = PrereqHandler.passes(prereq, character, null);
-		assertFalse("Prereq " + prereq
+		assertFalse(passes, "Prereq " + prereq
 			+ " should not be passed by character without a "
-			+ "race or servesas link.", passes);
+			+ "race or servesas link.");
 	}
 	
 	/**
@@ -339,13 +339,13 @@ public class PreRaceTest extends AbstractCharacterTestCase
 		prereq.setOperator(PrerequisiteOperator.EQ);
 
 		boolean passes = PrereqHandler.passes(prereq, character, null);
-		assertTrue("Prereq " + prereq + " should pass due to SERVESAS", passes);
+		assertTrue(passes, "Prereq " + prereq + " should pass due to SERVESAS");
 
 		prereq.setKey("TYPE=Smaller");
 		passes = PrereqHandler.passes(prereq, character, null);
-		assertFalse("Prereq " + prereq
+		assertFalse(passes, "Prereq " + prereq
 			+ " should not be passed by character without a "
-			+ "race or servesas link.", passes);
+			+ "race or servesas link.");
 	}
 
 	/**
@@ -379,18 +379,18 @@ public class PreRaceTest extends AbstractCharacterTestCase
 		prereq.setKey("human%");
 		prereq.setOperator(PrerequisiteOperator.EQ);
 		boolean passes = PrereqHandler.passes(prereq, character, null);
-		assertTrue("PRERACE:1,human% should have been passed", passes);
+		assertTrue(passes, "PRERACE:1,human% should have been passed");
 
 		prereq.setKey("NotHuman%");
 		passes = PrereqHandler.passes(prereq, character, null);
-		assertTrue("PRERACE:1,NotHuman% should have been passed", passes);
+		assertTrue(passes, "PRERACE:1,NotHuman% should have been passed");
 
 		prereq.setKey("Elf%");
 		passes = PrereqHandler.passes(prereq, character, null);
-		assertFalse("PRERACE:1,Elf% should not have been passed", passes);
+		assertFalse(passes, "PRERACE:1,Elf% should not have been passed");
 
 		prereq.setKey("Gno%");
 		passes = PrereqHandler.passes(prereq, character, null);
-		assertFalse("PRERACE:1,Gno% should not have been passed", passes);
+		assertFalse(passes, "PRERACE:1,Gno% should not have been passed");
 	}
 }

--- a/code/src/test/pcgen/core/prereq/PreReqHandlerTest.java
+++ b/code/src/test/pcgen/core/prereq/PreReqHandlerTest.java
@@ -26,13 +26,15 @@ import java.util.Locale;
 import pcgen.LocaleDependentTestCase;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.prereq.PreParserFactory;
-import pcgen.util.TestHelper;
+import pcgen.test.PCGenTestEnvironment;
 import plugin.lsttokens.testsupport.TokenRegistration;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+@ExtendWith(PCGenTestEnvironment.class)
 public class PreReqHandlerTest
 {
 
@@ -42,7 +44,6 @@ public class PreReqHandlerTest
 	@BeforeEach
 	void setUp() throws Exception
 	{
-		TestHelper.loadPlugins();
 	}
 
 	@AfterEach

--- a/code/src/test/pcgen/core/prereq/PreRuleTest.java
+++ b/code/src/test/pcgen/core/prereq/PreRuleTest.java
@@ -17,8 +17,8 @@
  */
 package pcgen.core.prereq;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.core.GameMode;
@@ -66,18 +66,18 @@ public class PreRuleTest extends AbstractCharacterTestCase
 	 */
 	private void ruleDisabled() throws PersistenceLayerException
 	{
-		assertFalse("Our rule should start as false", Globals
-			.checkRule("PRERULE"));
+		assertFalse(Globals
+			.checkRule("PRERULE"), "Our rule should start as false");
 
 		PreRuleParser parser = new PreRuleParser();
 		Prerequisite prereq = parser.parse("RULE", "1,PRERULE", false, false);
 
 		boolean passes = PrereqHandler.passes(prereq, getCharacter(), null);
-		assertFalse("PreRule should fail when rule is disabled.", passes);
+		assertFalse(passes, "PreRule should fail when rule is disabled.");
 
 		prereq = parser.parse("RULE", "1,PRERULE", true, false);
 		passes = PrereqHandler.passes(prereq, getCharacter(), null);
-		assertTrue("!PreRule should pass when rule is disabled.", passes);
+		assertTrue(passes, "!PreRule should pass when rule is disabled.");
 	}
 
 	/**
@@ -91,17 +91,17 @@ public class PreRuleTest extends AbstractCharacterTestCase
 				.silentlyGetConstructedCDOMObject(RuleCheck.class, "PRERULE");
 		preRule.setDefault(true);
 		
-		assertTrue("Our rule should now be true", Globals
-			.checkRule("PRERULE"));
+		assertTrue(Globals
+			.checkRule("PRERULE"), "Our rule should now be true");
 
 		PreRuleParser parser = new PreRuleParser();
 		Prerequisite prereq = parser.parse("RULE", "1,PRERULE", false, false);
 
 		boolean passes = PrereqHandler.passes(prereq, getCharacter(), null);
-		assertTrue("PreRule should pass when rule is enabled.", passes);
+		assertTrue(passes, "PreRule should pass when rule is enabled.");
 
 		prereq = parser.parse("RULE", "1,PRERULE", true, false);
 		passes = PrereqHandler.passes(prereq, getCharacter(), null);
-		assertFalse("!PreRule should fail when rule is enabled.", passes);
+		assertFalse(passes, "!PreRule should fail when rule is enabled.");
 	}
 }

--- a/code/src/test/pcgen/core/prereq/PreShieldProfTest.java
+++ b/code/src/test/pcgen/core/prereq/PreShieldProfTest.java
@@ -18,9 +18,9 @@
 package pcgen.core.prereq;
 
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -64,8 +64,8 @@ public class PreShieldProfTest extends AbstractCharacterTestCase
 
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("PREPROFWITHSHIELD:1,Heavy Wooden Shield");
-		assertFalse("Character has no proficiencies", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Character has no proficiencies");
 
 		final Ability martialProf = 
 			TestHelper.makeAbility("Shield Proficiency (Single)", "FEAT", "General");
@@ -75,18 +75,15 @@ public class PreShieldProfTest extends AbstractCharacterTestCase
 		
 		AbstractCharacterTestCase.applyAbility(character, BuildUtilities.getFeatCat(), martialProf, null);
 
-		assertTrue("Character has the Heavy Wooden Shield proficiency.", 
-					PrereqHandler.passes(prereq, character, null));
+		assertTrue(PrereqHandler.passes(prereq, character, null), "Character has the Heavy Wooden Shield proficiency.");
 		
 		prereq = factory.parse("PREPROFWITHSHIELD:1,Light Wooden Shield");
 		
-		assertFalse("Character does not have the Light Wooden Shield proficiency", 
-				PrereqHandler.passes(prereq, character, null));
+		assertFalse(PrereqHandler.passes(prereq, character, null), "Character does not have the Light Wooden Shield proficiency");
 		
 		prereq = factory.parse("PREPROFWITHSHIELD:1,Heavy Steel Shield");
 		
-		assertTrue("Character has the Heavy Steel Shield proficiency.", 
-				PrereqHandler.passes(prereq, character, null));
+		assertTrue(PrereqHandler.passes(prereq, character, null), "Character has the Heavy Steel Shield proficiency.");
 	}
 
 
@@ -105,8 +102,8 @@ public class PreShieldProfTest extends AbstractCharacterTestCase
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("PREPROFWITHSHIELD:1,Heavy Wooden Shield,Full Plate");
 
-		assertFalse("Character has no proficiencies", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Character has no proficiencies");
 
 		final Ability martialProf = 
 			TestHelper.makeAbility("Shield Proficiency (Single)", "FEAT", "General");
@@ -116,18 +113,15 @@ public class PreShieldProfTest extends AbstractCharacterTestCase
 		
 		AbstractCharacterTestCase.applyAbility(character, BuildUtilities.getFeatCat(), martialProf, null);
 
-		assertTrue("Character has one of Heavy Wooden Shield or Full Plate proficiency", 
-			PrereqHandler.passes(prereq, character, null));
+		assertTrue(PrereqHandler.passes(prereq, character, null), "Character has one of Heavy Wooden Shield or Full Plate proficiency");
 
 		prereq = factory.parse("PREPROFWITHSHIELD:2,Heavy Wooden Shield,Full Plate");
 
-		assertTrue("Character has both Heavy Wooden Shield and Full Plate proficiency", 
-				PrereqHandler.passes(prereq, character, null));
+		assertTrue(PrereqHandler.passes(prereq, character, null), "Character has both Heavy Wooden Shield and Full Plate proficiency");
 		
 		prereq = factory.parse("PREPROFWITHSHIELD:3,Heavy Wooden Shield,Full Plate,Light Wooden Shield");
 
-		assertFalse("Character has both Heavy Wooden Shield and Full Plate proficiency but not Light Wooden Shield", 
-				PrereqHandler.passes(prereq, character, null));
+		assertFalse(PrereqHandler.passes(prereq, character, null), "Character has both Heavy Wooden Shield and Full Plate proficiency but not Light Wooden Shield");
 		
 	}
 	
@@ -147,8 +141,8 @@ public class PreShieldProfTest extends AbstractCharacterTestCase
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("PREPROFWITHSHIELD:1,TYPE.Medium");
 
-		assertFalse("Character has no proficiencies", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Character has no proficiencies");
 		
 		final Ability martialProf = 
 			TestHelper.makeAbility("Shield Proficiency (Single)", "FEAT", "General");
@@ -157,8 +151,7 @@ public class PreShieldProfTest extends AbstractCharacterTestCase
 		
 		AbstractCharacterTestCase.applyAbility(character, BuildUtilities.getFeatCat(), martialProf, null);
 		
-		assertTrue("Character has Medium Shield Proficiency", 
-				PrereqHandler.passes(prereq, character, null));
+		assertTrue(PrereqHandler.passes(prereq, character, null), "Character has Medium Shield Proficiency");
 	}
 	
 	/**
@@ -176,8 +169,8 @@ public class PreShieldProfTest extends AbstractCharacterTestCase
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("!PREPROFWITHSHIELD:1,Heavy Steel Shield");
 
-		assertTrue("Character has no proficiencies", PrereqHandler.passes(
-			prereq, character, null));
+		assertTrue(PrereqHandler.passes(
+			prereq, character, null), "Character has no proficiencies");
 
 		final Ability martialProf = 
 			TestHelper.makeAbility("Shield Proficiency (Single)", "FEAT", "General");
@@ -187,18 +180,15 @@ public class PreShieldProfTest extends AbstractCharacterTestCase
 		
 		AbstractCharacterTestCase.applyAbility(character, BuildUtilities.getFeatCat(), martialProf, null);
 
-		assertFalse("Character has the Heavy Steel Shield proficiency.", 
-					PrereqHandler.passes(prereq, character, null));
+		assertFalse(PrereqHandler.passes(prereq, character, null), "Character has the Heavy Steel Shield proficiency.");
 		
 		prereq = factory.parse("!PREPROFWITHSHIELD:1,Light Wooden Shield");
 		
-		assertTrue("Character does not have the Light Wooden Shield proficiency", 
-				PrereqHandler.passes(prereq, character, null));
+		assertTrue(PrereqHandler.passes(prereq, character, null), "Character does not have the Light Wooden Shield proficiency");
 		
 		prereq = factory.parse("!PREPROFWITHSHIELD:1,Heavy Wooden Shield");
 		
-		assertFalse("Character has the Heavy Wooden Shield proficiency.", 
-				PrereqHandler.passes(prereq, character, null));
+		assertFalse(PrereqHandler.passes(prereq, character, null), "Character has the Heavy Wooden Shield proficiency.");
 		
 	}
 	
@@ -218,8 +208,8 @@ public class PreShieldProfTest extends AbstractCharacterTestCase
 		final PreParserFactory factory = PreParserFactory.getInstance();
 		prereq = factory.parse("PREPROFWITHSHIELD:1,Heavy Steel Shield");
 
-		assertFalse("Character has no proficiencies", PrereqHandler.passes(
-			prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+			prereq, character, null), "Character has no proficiencies");
 		
 		final Ability martialProf = 
 			TestHelper.makeAbility("Shield Proficiency (Single)", BuildUtilities.getFeatCat(), "General");
@@ -227,20 +217,16 @@ public class PreShieldProfTest extends AbstractCharacterTestCase
 		
 		AbstractCharacterTestCase.applyAbility(character, BuildUtilities.getFeatCat(), martialProf, null);
 
-		assertTrue("Character has the Heavy Steel Shield proficiency.", 
-					PrereqHandler.passes(prereq, character, null));
+		assertTrue(PrereqHandler.passes(prereq, character, null), "Character has the Heavy Steel Shield proficiency.");
 		
 		prereq = factory.parse("PREPROFWITHSHIELD:1,Heavy Wooden Shield");
-		assertTrue("Character has the Heavy Wooden Shield proficiency.",
-					PrereqHandler.passes(prereq, character, null));
+		assertTrue(PrereqHandler.passes(prereq, character, null), "Character has the Heavy Wooden Shield proficiency.");
 		
 		prereq = factory.parse("PREPROFWITHSHIELD:1,Light Wooden Shield");
-		assertFalse("Character does not have the Light Wooden Shield proficiency.",
-					PrereqHandler.passes(prereq, character, null));
+		assertFalse(PrereqHandler.passes(prereq, character, null), "Character does not have the Light Wooden Shield proficiency.");
 		
 		prereq = factory.parse("PREPROFWITHSHIELD:1,TYPE.Heavy");
-		assertTrue("Character has heavy shield prof.",
-					PrereqHandler.passes(prereq, character, null));
+		assertTrue(PrereqHandler.passes(prereq, character, null), "Character has heavy shield prof.");
 		
 	}
 	
@@ -275,10 +261,7 @@ public class PreShieldProfTest extends AbstractCharacterTestCase
 		featLoader.parseLine(Globals.getContext(), bar, barStr, cse);
 		addAbility(BuildUtilities.getFeatCat(), bar);
 		
-		assertEquals("Character should have 50 bonus hp added.",
-					baseHp+50,
-					character.hitPoints()
-					);
+		assertEquals(baseHp+50, character.hitPoints(), "Character should have 50 bonus hp added.");
 		
 		final Ability martialProf = 
 			TestHelper.makeAbility("Shield Proficiency (Single)", "FEAT", "General");
@@ -293,10 +276,7 @@ public class PreShieldProfTest extends AbstractCharacterTestCase
 		featLoader.parseLine(Globals.getContext(), foo, fooStr, cse);
 		addAbility(BuildUtilities.getFeatCat(), foo);
 		
-		assertEquals("Character has the Full Plate proficiency so the bonus should be added",
-					baseHp+50+50,
-					character.hitPoints()
-					);
+		assertEquals(baseHp+50+50, character.hitPoints(), "Character has the Full Plate proficiency so the bonus should be added");
 	
 	}
 

--- a/code/src/test/pcgen/core/prereq/PreSizeTest.java
+++ b/code/src/test/pcgen/core/prereq/PreSizeTest.java
@@ -23,9 +23,9 @@
  */
 package pcgen.core.prereq;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.core.Equipment;
@@ -70,15 +70,9 @@ public class PreSizeTest extends AbstractCharacterTestCase
 		final PlayerCharacter character = getCharacter();
 		Globals.getContext().getReferenceContext().resolveReferences(null);
 
-		assertEquals("Item one is expected size",
-			3,
-			eq1.sizeInt());
-		assertEquals("Item two is expected size",
-			4,
-			eq2.sizeInt());
-		assertEquals("Item three is expected size",
-			5,
-			eq3.sizeInt());
+		assertEquals(3, eq1.sizeInt(), "Item one is expected size");
+		assertEquals(4, eq2.sizeInt(), "Item two is expected size");
+		assertEquals(5, eq3.sizeInt(), "Item three is expected size");
 
 		Prerequisite prereq;
 
@@ -86,14 +80,14 @@ public class PreSizeTest extends AbstractCharacterTestCase
 
 		prereq = factory.parse("PRESIZEEQ:L");
 
-		assertFalse("Item one is not Large", PrereqHandler.passes(prereq, eq1, character));
-		assertFalse("Item two is not Large", PrereqHandler.passes(prereq, eq2, character));
-		assertTrue("Item three Large", PrereqHandler.passes(prereq, eq3, character));
+		assertFalse(PrereqHandler.passes(prereq, eq1, character), "Item one is not Large");
+		assertFalse(PrereqHandler.passes(prereq, eq2, character), "Item two is not Large");
+		assertTrue(PrereqHandler.passes(prereq, eq3, character), "Item three Large");
 
 		prereq = factory.parse("PRESIZEGT:S");
 
-		assertFalse("Item one is not larger than Small", PrereqHandler.passes(prereq, eq1, character));
-		assertTrue("Item two is larger than Small", PrereqHandler.passes(prereq, eq2, character));
-		assertTrue("Item three larger than Small", PrereqHandler.passes(prereq, eq3, character));
+		assertFalse(PrereqHandler.passes(prereq, eq1, character), "Item one is not larger than Small");
+		assertTrue(PrereqHandler.passes(prereq, eq2, character), "Item two is larger than Small");
+		assertTrue(PrereqHandler.passes(prereq, eq3, character), "Item three larger than Small");
 	}
 }

--- a/code/src/test/pcgen/core/prereq/PreSpellDescriptorTest.java
+++ b/code/src/test/pcgen/core/prereq/PreSpellDescriptorTest.java
@@ -17,8 +17,8 @@
  */
 package pcgen.core.prereq;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.core.Globals;

--- a/code/src/test/pcgen/core/prereq/PreSpellSubSchoolTest.java
+++ b/code/src/test/pcgen/core/prereq/PreSpellSubSchoolTest.java
@@ -17,8 +17,8 @@
  */
 package pcgen.core.prereq;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.core.Globals;

--- a/code/src/test/pcgen/core/prereq/PreStatTest.java
+++ b/code/src/test/pcgen/core/prereq/PreStatTest.java
@@ -17,8 +17,8 @@
  */
 package pcgen.core.prereq;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.core.PlayerCharacter;
@@ -46,13 +46,13 @@ class PreStatTest extends AbstractCharacterTestCase
 		prereq.setOperand("1");
 
 		character.setStat(str, -1);
-		assertFalse("prestat:1,str=1 for str of -1", PrereqHandler.passes(prereq, character, null));
+		assertFalse(PrereqHandler.passes(prereq, character, null), "prestat:1,str=1 for str of -1");
 		character.setStat(str, 0);
-		assertFalse("prestat:1,str=1 for str of 0", PrereqHandler.passes(prereq, character, null));
+		assertFalse(PrereqHandler.passes(prereq, character, null), "prestat:1,str=1 for str of 0");
 		character.setStat(str, 1);
-		assertTrue("prestat:1,str=1 for str of 1", PrereqHandler.passes(prereq, character, null));
+		assertTrue(PrereqHandler.passes(prereq, character, null), "prestat:1,str=1 for str of 1");
 		character.setStat(str, 2);
-		assertTrue("prestat:1,str=1 for str of 2", PrereqHandler.passes(prereq, character, null));
+		assertTrue(PrereqHandler.passes(prereq, character, null), "prestat:1,str=1 for str of 2");
 	}
 
 	/**
@@ -70,13 +70,13 @@ class PreStatTest extends AbstractCharacterTestCase
 		prereq.setOperand("0");
 
 		character.setStat(str, -1);
-		assertFalse("prestat:1,str=1 for str of -1", PrereqHandler.passes(prereq, character, null));
+		assertFalse(PrereqHandler.passes(prereq, character, null), "prestat:1,str=1 for str of -1");
 		character.setStat(str, 0);
-		assertTrue("prestat:1,str=0 for str of 0", PrereqHandler.passes(prereq, character, null));
+		assertTrue(PrereqHandler.passes(prereq, character, null), "prestat:1,str=0 for str of 0");
 		character.setStat(str, 1);
-		assertTrue("prestat:1,str=0 for str of 1", PrereqHandler.passes(prereq, character, null));
+		assertTrue(PrereqHandler.passes(prereq, character, null), "prestat:1,str=0 for str of 1");
 		character.setStat(str, 2);
-		assertTrue("prestat:1,str=0 for str of 2", PrereqHandler.passes(prereq, character, null));
+		assertTrue(PrereqHandler.passes(prereq, character, null), "prestat:1,str=0 for str of 2");
 	}
 
 	/**
@@ -94,13 +94,13 @@ class PreStatTest extends AbstractCharacterTestCase
 		prereq.setOperand("-1");
 
 		character.setStat(str, -2);
-		assertFalse("prestat:1,str=-1 for str of -2", PrereqHandler.passes(prereq, character, null));
+		assertFalse(PrereqHandler.passes(prereq, character, null), "prestat:1,str=-1 for str of -2");
 		character.setStat(str, 0);
-		assertTrue("prestat:1,str=-1 for str of 0", PrereqHandler.passes(prereq, character, null));
+		assertTrue(PrereqHandler.passes(prereq, character, null), "prestat:1,str=-1 for str of 0");
 		character.setStat(str, 1);
-		assertTrue("prestat:1,str=-1 for str of 1", PrereqHandler.passes(prereq, character, null));
+		assertTrue(PrereqHandler.passes(prereq, character, null), "prestat:1,str=-1 for str of 1");
 		character.setStat(str, -1);
-		assertTrue("prestat:1,str=-1 for str of -1", PrereqHandler.passes(prereq, character, null));
+		assertTrue(PrereqHandler.passes(prereq, character, null), "prestat:1,str=-1 for str of -1");
 	}
 
 }

--- a/code/src/test/pcgen/core/prereq/PreSubClassTest.java
+++ b/code/src/test/pcgen/core/prereq/PreSubClassTest.java
@@ -17,7 +17,7 @@
  */
 package pcgen.core.prereq;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.enumeration.StringKey;

--- a/code/src/test/pcgen/core/prereq/PreTemplateTest.java
+++ b/code/src/test/pcgen/core/prereq/PreTemplateTest.java
@@ -17,9 +17,9 @@
  */
 package pcgen.core.prereq;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.core.Globals;

--- a/code/src/test/pcgen/core/prereq/PreTypeTest.java
+++ b/code/src/test/pcgen/core/prereq/PreTypeTest.java
@@ -16,9 +16,9 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
 package pcgen.core.prereq;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.enumeration.ListKey;

--- a/code/src/test/pcgen/core/prereq/PreVarTest.java
+++ b/code/src/test/pcgen/core/prereq/PreVarTest.java
@@ -4,11 +4,11 @@
  */
 package pcgen.core.prereq;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -57,16 +57,16 @@ public class PreVarTest extends AbstractCharacterTestCase
 				"1,count(\"ABILITIES\",\"CATEGORY=BARDIC\",\"NAME=Dancer\")",
 				false, false);
 
-		assertFalse("Test matches with no abilities.", PrereqHandler.passes(
-				prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+				prereq, character, null), "Test matches with no abilities.");
 
 		Ability ab2 = TestHelper.makeAbility("Dancer", "BARDIC",
 				"General.Bardic");
 		ab2.put(ObjectKey.MULTIPLE_ALLOWED, Boolean.FALSE);
 		addAbility(TestHelper.getAbilityCategory(ab2), ab2);
 
-		assertTrue("Test fails with ability present.", PrereqHandler.passes(
-				prereq, character, null));
+		assertTrue(PrereqHandler.passes(
+				prereq, character, null), "Test fails with ability present.");
 	}
 
 	@Test
@@ -80,18 +80,18 @@ public class PreVarTest extends AbstractCharacterTestCase
 		PreVariableParser parser = new PreVariableParser();
 		Prerequisite prereq = parser.parse("VAR", "abs(STR),1,abs(DEX),3",
 				false, false);
-		assertFalse("Test matches with no stats passing", PrereqHandler.passes(
-				prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+				prereq, character, null), "Test matches with no stats passing");
 
 		setPCStat(character, str, 12);
 		character.calcActiveBonuses();
-		assertFalse("Test matches with no stats passing", PrereqHandler.passes(
-				prereq, character, null));
+		assertFalse(PrereqHandler.passes(
+				prereq, character, null), "Test matches with no stats passing");
 
 		setPCStat(character, dex, 16);
 		character.calcActiveBonuses();
-		assertTrue("Test should match now both stats pass", PrereqHandler
-				.passes(prereq, character, null));
+		assertTrue(PrereqHandler
+				.passes(prereq, character, null), "Test should match now both stats pass");
 
 	}
 
@@ -106,18 +106,18 @@ public class PreVarTest extends AbstractCharacterTestCase
 		PreVariableParser parser = new PreVariableParser();
 		Prerequisite prereq = parser.parse("VAR", "abs(STR),1,abs(DEX),3",
 				true, false);
-		assertTrue("Test matches with no stats passing", PrereqHandler.passes(
-				prereq, character, null));
+		assertTrue(PrereqHandler.passes(
+				prereq, character, null), "Test matches with no stats passing");
 
 		setPCStat(character, str, 12);
 		character.calcActiveBonuses();
-		assertTrue("Test matches with no stats passing", PrereqHandler.passes(
-				prereq, character, null));
+		assertTrue(PrereqHandler.passes(
+				prereq, character, null), "Test matches with no stats passing");
 
 		setPCStat(character, dex, 16);
 		character.calcActiveBonuses();
-		assertFalse("Test should match now both stats pass", PrereqHandler
-				.passes(prereq, character, null));
+		assertFalse(PrereqHandler
+				.passes(prereq, character, null), "Test should match now both stats pass");
 
 	}
 

--- a/code/src/test/pcgen/core/term/EvaluatorFactoryTest.java
+++ b/code/src/test/pcgen/core/term/EvaluatorFactoryTest.java
@@ -22,9 +22,11 @@ import pcgen.core.PCStat;
 import pcgen.core.SettingsHandler;
 import pcgen.rules.context.AbstractReferenceContext;
 import pcgen.util.TestHelper;
+import pcgen.test.PCGenTestEnvironment;
 import plugin.lsttokens.testsupport.BuildUtilities;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Copyright (c) 2008 Andrew Wilson <nuance@users.sourceforge.net>.
@@ -44,6 +46,7 @@ import org.junit.jupiter.api.Test;
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
 
+@ExtendWith(PCGenTestEnvironment.class)
 class EvaluatorFactoryTest
 {
 
@@ -11485,8 +11488,6 @@ class EvaluatorFactoryTest
 	{
 		SettingsHandler.readOptionsProperties();
 		SettingsHandler.getOptionsFromProperties(null);
-
-		TestHelper.loadPlugins();
 		EvaluatorFactoryTest.initGameModes();
 	}
 

--- a/code/src/test/pcgen/core/term/PCRacialHDSizeTermEvaluatorTest.java
+++ b/code/src/test/pcgen/core/term/PCRacialHDSizeTermEvaluatorTest.java
@@ -17,7 +17,7 @@
  */
 package pcgen.core.term;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.URI;
 
@@ -109,7 +109,7 @@ public class PCRacialHDSizeTermEvaluatorTest extends AbstractCharacterTestCase
 	{
 		PlayerCharacter pc = getCharacter();
 		pc.setRace(bugbearRace);
-		assertEquals("Bugbear racial HD size should be 8", 8, eval.resolve(pc.getDisplay()), 0.001);
+		assertEquals(8, eval.resolve(pc.getDisplay()), 0.001, "Bugbear racial HD size should be 8");
 	}
 
 	/**
@@ -121,7 +121,7 @@ public class PCRacialHDSizeTermEvaluatorTest extends AbstractCharacterTestCase
 		PlayerCharacter pc = getCharacter();
 		pc.setRace(bugbearRace);
 		pc.incrementClassLevel(1, pcClass);
-		assertEquals("Bugbear racial HD size should be 8", 8, eval.resolve(pc.getDisplay()), 0.001);
+		assertEquals(8, eval.resolve(pc.getDisplay()), 0.001, "Bugbear racial HD size should be 8");
 	}
 
 	/**
@@ -133,6 +133,6 @@ public class PCRacialHDSizeTermEvaluatorTest extends AbstractCharacterTestCase
 		PlayerCharacter pc = getCharacter();
 		pc.setRace(humanRace);
 		pc.incrementClassLevel(1, pcClass);
-		assertEquals("Human racial HD size should be 0", 0, eval.resolve(pc.getDisplay()), 0.001);
+		assertEquals(0, eval.resolve(pc.getDisplay()), 0.001, "Human racial HD size should be 0");
 	}
 }

--- a/code/src/test/pcgen/gui2/facade/CharacterAbilitiesTest.java
+++ b/code/src/test/pcgen/gui2/facade/CharacterAbilitiesTest.java
@@ -17,10 +17,10 @@
  */
 package pcgen.gui2.facade;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.enumeration.ObjectKey;
@@ -60,19 +60,19 @@ public class CharacterAbilitiesTest extends AbstractCharacterTestCase
 		CharacterAbilities ca = new CharacterAbilities(pc, uiDelegate, dataset, todoManager);
 		ca.rebuildAbilityLists();
 		ListFacade<AbilityCategory> categories = ca.getActiveAbilityCategories();
-		assertNotNull("Categories should not be null", categories);
-		assertTrue("Feat should be active", categories.containsElement(BuildUtilities.getFeatCat()));
+		assertNotNull(categories, "Categories should not be null");
+		assertTrue(categories.containsElement(BuildUtilities.getFeatCat()), "Feat should be active");
 		ListFacade<AbilityFacade> abilities = ca.getAbilities(BuildUtilities.getFeatCat());
-		assertNotNull("Feat list should not be null", abilities);
-		assertTrue("Feat list should be empty", abilities.isEmpty());
+		assertNotNull(abilities, "Feat list should not be null");
+		assertTrue(abilities.isEmpty(), "Feat list should be empty");
 		
 		// Add an entry - note rebuild is implicit
 		Ability fencing = TestHelper.makeAbility("fencing", BuildUtilities.getFeatCat(), "sport");
 		addAbility(BuildUtilities.getFeatCat(), fencing);
 		abilities = ca.getAbilities(BuildUtilities.getFeatCat());
-		assertEquals("Feat list should have one entry", 1, abilities.getSize());
+		assertEquals(1, abilities.getSize(), "Feat list should have one entry");
 		Ability abilityFromList = (Ability) abilities.getElementAt(0);
-		assertEquals("Should have found fencing", fencing, abilityFromList);
+		assertEquals(fencing, abilityFromList, "Should have found fencing");
 	}
 
 	/**
@@ -85,11 +85,11 @@ public class CharacterAbilitiesTest extends AbstractCharacterTestCase
 		CharacterAbilities ca = new CharacterAbilities(pc, uiDelegate, dataset, todoManager);
 		ca.rebuildAbilityLists();
 		ListFacade<AbilityCategory> categories = ca.getActiveAbilityCategories();
-		assertNotNull("Categories should not be null", categories);
-		assertTrue("Feat should be active", categories.containsElement(BuildUtilities.getFeatCat()));
+		assertNotNull(categories, "Categories should not be null");
+		assertTrue(categories.containsElement(BuildUtilities.getFeatCat()), "Feat should be active");
 		ListFacade<AbilityFacade> abilities = ca.getAbilities(BuildUtilities.getFeatCat());
-		assertNotNull("Feat list should not be null", abilities);
-		assertTrue("Feat list should be empty", abilities.isEmpty());
+		assertNotNull(abilities, "Feat list should not be null");
+		assertTrue(abilities.isEmpty(), "Feat list should be empty");
 		
 		// Add an entry - note rebuild is implicit
 		Ability reading = TestHelper.makeAbility("reading", BuildUtilities.getFeatCat(), "interest");
@@ -100,18 +100,18 @@ public class CharacterAbilitiesTest extends AbstractCharacterTestCase
 		Globals.getContext().commit();
 		applyAbility(pc, BuildUtilities.getFeatCat(), reading, "Books");
 		abilities = ca.getAbilities(BuildUtilities.getFeatCat());
-		assertFalse("Feat list should not be empty", abilities.isEmpty());
+		assertFalse(abilities.isEmpty(), "Feat list should not be empty");
 		Ability abilityFromList = (Ability) abilities.getElementAt(0);
-		assertEquals("Should have found reading", reading, abilityFromList);
-		assertEquals("Feat list should have one entry", 1, abilities.getSize());
+		assertEquals(reading, abilityFromList, "Should have found reading");
+		assertEquals(1, abilities.getSize(), "Feat list should have one entry");
 
 		// Now add the choice
 		finalizeTest(abilityFromList, "Magazines", pc, BuildUtilities.getFeatCat());
 		ca.rebuildAbilityLists();
 		abilities = ca.getAbilities(BuildUtilities.getFeatCat());
-		assertEquals("Feat list should have one entry", 1, abilities.getSize());
+		assertEquals(1, abilities.getSize(), "Feat list should have one entry");
 		abilityFromList = (Ability) abilities.getElementAt(0);
-		assertEquals("Should have found reading", reading, abilityFromList);
+		assertEquals(reading, abilityFromList, "Should have found reading");
 		
 	}
 	@BeforeEach

--- a/code/src/test/pcgen/gui2/facade/CharacterFacadeImplTest.java
+++ b/code/src/test/pcgen/gui2/facade/CharacterFacadeImplTest.java
@@ -17,8 +17,8 @@
  */
 package pcgen.gui2.facade;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.core.PlayerCharacter;
@@ -52,12 +52,11 @@ public class CharacterFacadeImplTest extends AbstractCharacterTestCase
 		PlayerCharacter pc = new PlayerCharacter();
 		CharacterFacadeImpl charFacade =
 				new CharacterFacadeImpl(pc, uiDelegate, dataset);
-		assertNotNull("Unable to create CharacterFacadeImpl", charFacade);
+		assertNotNull(charFacade, "Unable to create CharacterFacadeImpl");
 		EquipSet defaultEquipSet =
 				pc.getEquipSetByIdPath(EquipSet.DEFAULT_SET_PATH);
-		assertNotNull("Unable to find default equip set", defaultEquipSet);
-		assertEquals("Incorrect id of the default equip set",
-			EquipSet.DEFAULT_SET_PATH, defaultEquipSet.getIdPath());
+		assertNotNull(defaultEquipSet, "Unable to find default equip set");
+		assertEquals(EquipSet.DEFAULT_SET_PATH, defaultEquipSet.getIdPath(), "Incorrect id of the default equip set");
 	}
 
 	@BeforeEach

--- a/code/src/test/pcgen/gui2/facade/CompanionSupportFacadeImplTest.java
+++ b/code/src/test/pcgen/gui2/facade/CompanionSupportFacadeImplTest.java
@@ -17,10 +17,10 @@
  */
 package pcgen.gui2.facade;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.base.BasicClassIdentity;
@@ -104,16 +104,16 @@ public class CompanionSupportFacadeImplTest extends AbstractCharacterTestCase
 		companion.setName("Companion1");
 		CharacterFacadeImpl compFacade = new CharacterFacadeImpl(companion, uiDelegate, dataSetFacade);
 
-		assertNull("No companion type should be set yet.", compFacade.getCompanionType());
-		assertTrue("Master should have no companions", master.getFollowerList().isEmpty());
+		assertNull(compFacade.getCompanionType(), "No companion type should be set yet.");
+		assertTrue(master.getFollowerList().isEmpty(), "Master should have no companions");
 		
 		masterCsfi.addCompanion(compFacade, "Familiar");
 		Follower follower = master.getFollowerList().iterator().next();
-		assertEquals("Companion should be the first follower", companion.getName(), follower.getName());
-		assertEquals("Master should have one companion", 1, master.getFollowerList().size());
+		assertEquals(companion.getName(), follower.getName(), "Companion should be the first follower");
+		assertEquals(1, master.getFollowerList().size(), "Master should have one companion");
 		
-		assertNotNull("Companion should have a master now", companion.getDisplay().getMaster());
-		assertEquals("Companion's master", master.getName(), companion.getDisplay().getMaster().getName());
+		assertNotNull(companion.getDisplay().getMaster(), "Companion should have a master now");
+		assertEquals(master.getName(), companion.getDisplay().getMaster().getName(), "Companion's master");
 	}
 
 	@Override

--- a/code/src/test/pcgen/gui2/facade/EquipmentSetFacadeImplTest.java
+++ b/code/src/test/pcgen/gui2/facade/EquipmentSetFacadeImplTest.java
@@ -1,11 +1,11 @@
 package pcgen.gui2.facade;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -69,10 +69,9 @@ public class EquipmentSetFacadeImplTest extends AbstractCharacterTestCase
 				new EquipmentSetFacadeImpl(uiDelegate, getCharacter(), es,
 					dataset, equipmentList, todoManager, null);
 		ListFacade<EquipNode> nodeList = esfi.getNodes();
-		assertFalse("Expected a non empty node set", nodeList.isEmpty());
-		assertEquals("Incorrect name of base node", Constants.EQUIP_LOCATION_EQUIPPED,
-			nodeList.getElementAt(0).toString());
-		assertEquals("Incorrect nunber of nodes found", NUM_BASE_NODES, nodeList.getSize());
+		assertFalse(nodeList.isEmpty(), "Expected a non empty node set");
+		assertEquals(Constants.EQUIP_LOCATION_EQUIPPED, nodeList.getElementAt(0).toString(), "Incorrect name of base node");
+		assertEquals(NUM_BASE_NODES, nodeList.getSize(), "Incorrect nunber of nodes found");
 	}
 	
 	/**
@@ -100,32 +99,32 @@ public class EquipmentSetFacadeImplTest extends AbstractCharacterTestCase
 				new EquipmentSetFacadeImpl(uiDelegate, pc, es, dataset,
 					equipmentList, todoManager, null);
 		ListFacade<EquipNode> nodeList = esfi.getNodes();
-		assertFalse("Expected a non empty path set", nodeList.isEmpty());
+		assertFalse(nodeList.isEmpty(), "Expected a non empty path set");
 		EquipNode node = nodeList.getElementAt(0);
-		assertEquals("Incorrect body struct name", Constants.EQUIP_LOCATION_EQUIPPED, node.toString());
-		assertEquals("Incorrect body struct type", EquipNode.NodeType.BODY_SLOT, node.getNodeType());
-		assertEquals("Incorrect sort key", "00", node.getSortKey());
-		assertNull("Incorrect parent", node.getParent());
+		assertEquals(Constants.EQUIP_LOCATION_EQUIPPED, node.toString(), "Incorrect body struct name");
+		assertEquals(EquipNode.NodeType.BODY_SLOT, node.getNodeType(), "Incorrect body struct type");
+		assertEquals("00", node.getSortKey(), "Incorrect sort key");
+		assertNull(node.getParent(), "Incorrect parent");
 		node = nodeList.getElementAt(adjustedBaseNodes);
-		assertEquals("Incorrect container name", item.getName(), node.toString());
-		assertEquals("Incorrect container type", EquipNode.NodeType.EQUIPMENT, node.getNodeType());
-		assertEquals("Incorrect sort key", "00|"+item.getName(), node.getSortKey());
-		assertEquals("Incorrect parent", nodeList.getElementAt(0), node.getParent());
+		assertEquals(item.getName(), node.toString(), "Incorrect container name");
+		assertEquals(EquipNode.NodeType.EQUIPMENT, node.getNodeType(), "Incorrect container type");
+		assertEquals("00|"+item.getName(), node.getSortKey(), "Incorrect sort key");
+		assertEquals(nodeList.getElementAt(0), node.getParent(), "Incorrect parent");
 		node = nodeList.getElementAt(adjustedBaseNodes+2);
-		assertEquals("Incorrect item name", item2.getName(), node.toString());
-		assertEquals("Incorrect item type", EquipNode.NodeType.EQUIPMENT, node.getNodeType());
-		assertEquals("Incorrect sort key", "00|"+item.getName()+"|"+item2.getName(), node.getSortKey());
-		assertEquals("Incorrect parent", nodeList.getElementAt(adjustedBaseNodes), node.getParent());
+		assertEquals(item2.getName(), node.toString(), "Incorrect item name");
+		assertEquals(EquipNode.NodeType.EQUIPMENT, node.getNodeType(), "Incorrect item type");
+		assertEquals("00|"+item.getName()+"|"+item2.getName(), node.getSortKey(), "Incorrect sort key");
+		assertEquals(nodeList.getElementAt(adjustedBaseNodes), node.getParent(), "Incorrect parent");
 		node = nodeList.getElementAt(adjustedBaseNodes+1);
-		assertEquals("Incorrect item name", item3.getName(), node.toString());
-		assertEquals("Incorrect item type", EquipNode.NodeType.EQUIPMENT, node.getNodeType());
-		assertEquals("Incorrect sort key", "01|"+item3.getName(), node.getSortKey());
-		assertEquals("Incorrect parent", LOC_HANDS, node.getParent().toString());
+		assertEquals(item3.getName(), node.toString(), "Incorrect item name");
+		assertEquals(EquipNode.NodeType.EQUIPMENT, node.getNodeType(), "Incorrect item type");
+		assertEquals("01|"+item3.getName(), node.getSortKey(), "Incorrect sort key");
+		assertEquals(LOC_HANDS, node.getParent().toString(), "Incorrect parent");
 		node = nodeList.getElementAt(adjustedBaseNodes+2);
 		EquipNode parent = node.getParent();
-		assertEquals("Root incorrect", Constants.EQUIP_LOCATION_EQUIPPED, parent.getParent().toString());
-		assertEquals("Leaf incorrect", item.getName(), parent.toString());
-		assertEquals("Incorrect number of paths found", adjustedBaseNodes+3, nodeList.getSize());
+		assertEquals(Constants.EQUIP_LOCATION_EQUIPPED, parent.getParent().toString(), "Root incorrect");
+		assertEquals(item.getName(), parent.toString(), "Leaf incorrect");
+		assertEquals(adjustedBaseNodes+3, nodeList.getSize(), "Incorrect number of paths found");
 	}
 	
 	/**
@@ -153,16 +152,16 @@ public class EquipmentSetFacadeImplTest extends AbstractCharacterTestCase
 		}
 
 		EquipNode testNode = nodeMap.get("Morningstar");
-		assertNotNull("Morningstar should be present", testNode);
-		assertEquals("Morningstar type", EquipNode.NodeType.EQUIPMENT, testNode.getNodeType());
-		assertEquals("Morningstar location", LOC_PRIMARY, esfi.getLocation(testNode));
+		assertNotNull(testNode, "Morningstar should be present");
+		assertEquals(EquipNode.NodeType.EQUIPMENT, testNode.getNodeType(), "Morningstar type");
+		assertEquals(LOC_PRIMARY, esfi.getLocation(testNode), "Morningstar location");
 
 		// Test for removed slots
 		String[] removedSlots = {"Primary Hand", "Double Weapon", "Both Hands"};
 		for (String slotName : removedSlots)
 		{
 			testNode = nodeMap.get(slotName);
-			assertNull(slotName + " should not be present", testNode);
+			assertNull(testNode, slotName + " should not be present");
 		}
 
 		// Test for still present slots
@@ -170,7 +169,7 @@ public class EquipmentSetFacadeImplTest extends AbstractCharacterTestCase
 		for (String slotName : retainedSlots)
 		{
 			testNode = nodeMap.get(slotName);
-			assertNotNull(slotName + " should be present", testNode);
+			assertNotNull(testNode, slotName + " should be present");
 		}
 		
 	}
@@ -190,42 +189,41 @@ public class EquipmentSetFacadeImplTest extends AbstractCharacterTestCase
 		EquipNode root = esfi.getNodes().getElementAt(0);
 		Equipment item = new Equipment();
 		item.setName("Dart");
-		assertEquals("Initial num carried", 0, item.getCarried(), 0.01);
-		assertEquals("Initial num equipped", 0, item.getNumberEquipped());
-		assertEquals("Initial node list size", NUM_BASE_NODES, esfi.getNodes().getSize());
+		assertEquals(0, item.getCarried(), 0.01, "Initial num carried");
+		assertEquals(0, item.getNumberEquipped(), "Initial num equipped");
+		assertEquals(NUM_BASE_NODES, esfi.getNodes().getSize(), "Initial node list size");
 
 		Equipment addedEquip = (Equipment) esfi.addEquipment(root, item, 2);
-		assertEquals("First add num carried", 2, addedEquip.getCarried(), 0.01);
-		assertEquals("First add num equipped", 2, addedEquip.getNumberEquipped());
-		assertEquals("Should be no sideeffects to num carried", 0, item.getCarried(), 0.01);
-		assertEquals("Should be no sideeffects to equipped", 0, item.getNumberEquipped());
-		assertEquals("First add node list size", NUM_BASE_NODES+1, esfi.getNodes().getSize());
-		assertEquals("generated equip set id", "0.1.01",
-			esfi.getNodes().getElementAt(NUM_BASE_NODES).getIdPath());
+		assertEquals(2, addedEquip.getCarried(), 0.01, "First add num carried");
+		assertEquals(2, addedEquip.getNumberEquipped(), "First add num equipped");
+		assertEquals(0, item.getCarried(), 0.01, "Should be no sideeffects to num carried");
+		assertEquals(0, item.getNumberEquipped(), "Should be no sideeffects to equipped");
+		assertEquals(NUM_BASE_NODES+1, esfi.getNodes().getSize(), "First add node list size");
+		assertEquals("0.1.01", esfi.getNodes().getElementAt(NUM_BASE_NODES).getIdPath(), "generated equip set id");
 
 		Equipment secondEquip = (Equipment) esfi.addEquipment(root, item, 1);
-		assertEquals("Second add num carried", 3, secondEquip.getCarried(), 0.01);
-		assertEquals("Second add num equipped", 3, secondEquip.getNumberEquipped());
-		assertEquals("Should be no sideeffects to num carried", 0, item.getCarried(), 0.01);
-		assertEquals("Should be no sideeffects to equipped", 0, item.getNumberEquipped());
-		assertSame("Same equipment item should have been used", addedEquip, secondEquip);
-		assertEquals("First add node list size", NUM_BASE_NODES+1, esfi.getNodes().getSize());
+		assertEquals(3, secondEquip.getCarried(), 0.01, "Second add num carried");
+		assertEquals(3, secondEquip.getNumberEquipped(), "Second add num equipped");
+		assertEquals(0, item.getCarried(), 0.01, "Should be no sideeffects to num carried");
+		assertEquals(0, item.getNumberEquipped(), "Should be no sideeffects to equipped");
+		assertSame(addedEquip, secondEquip, "Same equipment item should have been used");
+		assertEquals(NUM_BASE_NODES+1, esfi.getNodes().getSize(), "First add node list size");
 
 		EquipNode target =  esfi.getNodes().getElementAt(NUM_BASE_NODES);
 		Equipment removedEquip = (Equipment) esfi.removeEquipment(target, 2);
-		assertEquals("First add num carried", 1, removedEquip.getCarried(), 0.01);
-		assertEquals("First add num equipped", 1, removedEquip.getNumberEquipped());
-		assertSame("Same equipment item should have been used", addedEquip, removedEquip);
-		assertEquals("Should be no sideeffects to num carried", 0, item.getCarried(), 0.01);
-		assertEquals("Should be no sideeffects to equipped", 0, item.getNumberEquipped());
-		assertEquals("First add node list size", NUM_BASE_NODES+1, esfi.getNodes().getSize());
+		assertEquals(1, removedEquip.getCarried(), 0.01, "First add num carried");
+		assertEquals(1, removedEquip.getNumberEquipped(), "First add num equipped");
+		assertSame(addedEquip, removedEquip, "Same equipment item should have been used");
+		assertEquals(0, item.getCarried(), 0.01, "Should be no sideeffects to num carried");
+		assertEquals(0, item.getNumberEquipped(), "Should be no sideeffects to equipped");
+		assertEquals(NUM_BASE_NODES+1, esfi.getNodes().getSize(), "First add node list size");
 
 		esfi.removeEquipment(target, 1);
-		assertEquals("First add num carried", 0, addedEquip.getCarried(), 0.01);
-		assertEquals("First add num equipped", 0, addedEquip.getNumberEquipped());
-		assertEquals("Should be no sideeffects to num carried", 0, item.getCarried(), 0.01);
-		assertEquals("Should be no sideeffects to equipped", 0, item.getNumberEquipped());
-		assertEquals("First add node list size", NUM_BASE_NODES, esfi.getNodes().getSize());
+		assertEquals(0, addedEquip.getCarried(), 0.01, "First add num carried");
+		assertEquals(0, addedEquip.getNumberEquipped(), "First add num equipped");
+		assertEquals(0, item.getCarried(), 0.01, "Should be no sideeffects to num carried");
+		assertEquals(0, item.getNumberEquipped(), "Should be no sideeffects to equipped");
+		assertEquals(NUM_BASE_NODES, esfi.getNodes().getSize(), "First add node list size");
 	}
 
 	/**
@@ -246,40 +244,40 @@ public class EquipmentSetFacadeImplTest extends AbstractCharacterTestCase
 		}
 
 		EquipNode testNode = nodeMap.get("Primary Hand");
-		assertNotNull("Primary Hand should be present", testNode);
-		assertEquals("Primary Hand type", EquipNode.NodeType.PHANTOM_SLOT, testNode.getNodeType());
-		assertEquals("Primary Hand count", 1, esfi.getQuantity(testNode));
+		assertNotNull(testNode, "Primary Hand should be present");
+		assertEquals(EquipNode.NodeType.PHANTOM_SLOT, testNode.getNodeType(), "Primary Hand type");
+		assertEquals(1, esfi.getQuantity(testNode), "Primary Hand count");
 
 		testNode = nodeMap.get("Secondary Hand");
-		assertNotNull("Secondary Hand should be present", testNode);
-		assertEquals("Secondary Hand type", EquipNode.NodeType.PHANTOM_SLOT, testNode.getNodeType());
-		assertEquals("Secondary Hand count", 1, esfi.getQuantity(testNode));
+		assertNotNull(testNode, "Secondary Hand should be present");
+		assertEquals(EquipNode.NodeType.PHANTOM_SLOT, testNode.getNodeType(), "Secondary Hand type");
+		assertEquals(1, esfi.getQuantity(testNode), "Secondary Hand count");
 
 		testNode = nodeMap.get(Constants.EQUIP_LOCATION_SECONDARY + " 1");
-		assertNull(Constants.EQUIP_LOCATION_SECONDARY + " 1 should not be present", testNode);
+		assertNull(testNode, Constants.EQUIP_LOCATION_SECONDARY + " 1 should not be present");
 
 		testNode = nodeMap.get(Constants.EQUIP_LOCATION_SECONDARY + " 2");
-		assertNull(Constants.EQUIP_LOCATION_SECONDARY + " 2 should not be present", testNode);
+		assertNull(testNode, Constants.EQUIP_LOCATION_SECONDARY + " 2 should not be present");
 
 		testNode = nodeMap.get("Double Weapon");
-		assertNotNull("Double Weapon should be present", testNode);
-		assertEquals("Double Weapon type", EquipNode.NodeType.PHANTOM_SLOT, testNode.getNodeType());
-		assertEquals("Double Weapon count", 1, esfi.getQuantity(testNode));
+		assertNotNull(testNode, "Double Weapon should be present");
+		assertEquals(EquipNode.NodeType.PHANTOM_SLOT, testNode.getNodeType(), "Double Weapon type");
+		assertEquals(1, esfi.getQuantity(testNode), "Double Weapon count");
 
 		testNode = nodeMap.get("Both Hands");
-		assertNotNull("Both Hands should be present", testNode);
-		assertEquals("Both Hands type", EquipNode.NodeType.PHANTOM_SLOT, testNode.getNodeType());
-		assertEquals("Both Hands count", 1, esfi.getQuantity(testNode));
+		assertNotNull(testNode, "Both Hands should be present");
+		assertEquals(EquipNode.NodeType.PHANTOM_SLOT, testNode.getNodeType(), "Both Hands type");
+		assertEquals(1, esfi.getQuantity(testNode), "Both Hands count");
 
 		testNode = nodeMap.get("Unarmed");
-		assertNotNull("Unarmed should be present", testNode);
-		assertEquals("Unarmed type", EquipNode.NodeType.PHANTOM_SLOT, testNode.getNodeType());
-		assertEquals("Unarmed count", 1, esfi.getQuantity(testNode));
+		assertNotNull(testNode, "Unarmed should be present");
+		assertEquals(EquipNode.NodeType.PHANTOM_SLOT, testNode.getNodeType(), "Unarmed type");
+		assertEquals(1, esfi.getQuantity(testNode), "Unarmed count");
 
 		testNode = nodeMap.get("Ring");
-		assertNotNull("Ring should be present", testNode);
-		assertEquals("Ring type", EquipNode.NodeType.PHANTOM_SLOT, testNode.getNodeType());
-		assertEquals("Ring count", 2, esfi.getQuantity(testNode));
+		assertNotNull(testNode, "Ring should be present");
+		assertEquals(EquipNode.NodeType.PHANTOM_SLOT, testNode.getNodeType(), "Ring type");
+		assertEquals(2, esfi.getQuantity(testNode), "Ring count");
 	}
 
 	public void testBonusSlot()
@@ -297,15 +295,15 @@ public class EquipmentSetFacadeImplTest extends AbstractCharacterTestCase
 		}
 
 		EquipNode testNode = nodeMap.get("Ring");
-		assertNotNull("Ring should be present", testNode);
-		assertEquals("Ring type", EquipNode.NodeType.PHANTOM_SLOT, testNode.getNodeType());
-		assertEquals("Ring count", 2, esfi.getQuantity(testNode));
+		assertNotNull(testNode, "Ring should be present");
+		assertEquals(EquipNode.NodeType.PHANTOM_SLOT, testNode.getNodeType(), "Ring type");
+		assertEquals(2, esfi.getQuantity(testNode), "Ring count");
 		
 		PCTemplate template = TestHelper.makeTemplate("RingBonus");
 		Globals.getContext().unconditionallyProcess(template, "BONUS",
 				"SLOTS|Ring|1");
 		pc.addTemplate(template);
-		assertEquals("Ring count", 3, esfi.getQuantity(testNode));
+		assertEquals(3, esfi.getQuantity(testNode), "Ring count");
 	}
 	
 	/**
@@ -319,27 +317,27 @@ public class EquipmentSetFacadeImplTest extends AbstractCharacterTestCase
 				new EquipmentSetFacadeImpl(uiDelegate, getCharacter(), es,
 					dataset, equipmentList, todoManager, null);
 
-		assertNull("Null equipment should give null location", esfi.getNaturalWeaponLoc(null));
+		assertNull(esfi.getNaturalWeaponLoc(null), "Null equipment should give null location");
 		
 		Equipment eq = new Equipment();
 		eq.addType(Type.MELEE);
 		eq.addType(Type.WEAPON);
 		EquipNode requiredLoc = esfi.getNaturalWeaponLoc(eq);
-		assertNull("Melee weapon should not have required location.", requiredLoc);
+		assertNull(requiredLoc, "Melee weapon should not have required location.");
 		
 		eq.addType(Type.NATURAL);
 		eq.put(IntegerKey.SLOTS, 0);
 		eq.setName("Sting");
 		requiredLoc = esfi.getNaturalWeaponLoc(eq);
-		assertNotNull("Natural weapon should have required location.", requiredLoc);
-		assertEquals("Incorrect name for secondary natural weapon", "Natural-Secondary", requiredLoc.toString());
-		assertEquals("Natural weapon should replace hands.", "HANDS", requiredLoc.getBodyStructure().toString());
+		assertNotNull(requiredLoc, "Natural weapon should have required location.");
+		assertEquals("Natural-Secondary", requiredLoc.toString(), "Incorrect name for secondary natural weapon");
+		assertEquals("HANDS", requiredLoc.getBodyStructure().toString(), "Natural weapon should replace hands.");
 
 		eq.setModifiedName("Natural/Primary");
 		requiredLoc = esfi.getNaturalWeaponLoc(eq);
-		assertNotNull("Natural weapon should have required location.", requiredLoc);
-		assertEquals("Incorrect name for primary natural weapon", "Natural-Primary", requiredLoc.toString());
-		assertEquals("Natural weapon should replace hands.", "HANDS", requiredLoc.getBodyStructure().toString());
+		assertNotNull(requiredLoc, "Natural weapon should have required location.");
+		assertEquals("Natural-Primary", requiredLoc.toString(), "Incorrect name for primary natural weapon");
+		assertEquals("HANDS", requiredLoc.getBodyStructure().toString(), "Natural weapon should replace hands.");
 	}
 	
 	
@@ -351,22 +349,22 @@ public class EquipmentSetFacadeImplTest extends AbstractCharacterTestCase
 	{
 		EquipmentSetFacadeImpl esfi = prepareEquipmentSet();
 		ListFacade<EquipNode> nodeList = esfi.getNodes();
-		assertFalse("Expected a non empty path set", nodeList.isEmpty());
+		assertFalse(nodeList.isEmpty(), "Expected a non empty path set");
 		EquipNode quarterstaffNode = getEquipNodeByName(nodeList, QUARTERSTAFF);
-		//assertEquals("Incorrect item name", item3.getName(), quarterstaffNode.toString());
-		assertEquals("Incorrect item type", EquipNode.NodeType.EQUIPMENT, quarterstaffNode.getNodeType());
-		assertEquals("Incorrect parent", Constants.EQUIP_LOCATION_EQUIPPED, quarterstaffNode.getParent().toString());
-		assertEquals("Incorrect path", "0.1.02", quarterstaffNode.getIdPath());
+		//assertEquals(item3.getName(), quarterstaffNode.toString(), "Incorrect item name");
+		assertEquals(EquipNode.NodeType.EQUIPMENT, quarterstaffNode.getNodeType(), "Incorrect item type");
+		assertEquals(Constants.EQUIP_LOCATION_EQUIPPED, quarterstaffNode.getParent().toString(), "Incorrect parent");
+		assertEquals("0.1.02", quarterstaffNode.getIdPath(), "Incorrect path");
 		
 		EquipNode bookNode = getEquipNodeByName(nodeList, BOOK);
-		assertEquals("Incorrect path", "0.1.01.01", bookNode.getIdPath());
+		assertEquals("0.1.01.01", bookNode.getIdPath(), "Incorrect path");
 		EquipNode satchelNode = getEquipNodeByName(nodeList, SATCHEL);
-		assertEquals("Incorrect path", "0.1.01", satchelNode.getIdPath());
+		assertEquals("0.1.01", satchelNode.getIdPath(), "Incorrect path");
 		
-		assertTrue("Move up failed unexpectedly", esfi.moveEquipment(quarterstaffNode, -1));
-		assertEquals("Incorrect quarterstaff path", "0.1.01", quarterstaffNode.getIdPath());
-		assertEquals("Incorrect satchel path", "0.1.02", satchelNode.getIdPath());
-		assertEquals("Incorrect book path", "0.1.02.01", bookNode.getIdPath());
+		assertTrue(esfi.moveEquipment(quarterstaffNode, -1), "Move up failed unexpectedly");
+		assertEquals("0.1.01", quarterstaffNode.getIdPath(), "Incorrect quarterstaff path");
+		assertEquals("0.1.02", satchelNode.getIdPath(), "Incorrect satchel path");
+		assertEquals("0.1.02.01", bookNode.getIdPath(), "Incorrect book path");
 	}
 	
 	/**
@@ -377,41 +375,31 @@ public class EquipmentSetFacadeImplTest extends AbstractCharacterTestCase
 	{
 		EquipmentSetFacadeImpl esfi = prepareEquipmentSet();
 		ListFacade<EquipNode> nodeList = esfi.getNodes();
-		assertFalse("Expected a non empty path set", nodeList.isEmpty());
+		assertFalse(nodeList.isEmpty(), "Expected a non empty path set");
 		EquipNode quarterstaffNode = getEquipNodeByName(nodeList, QUARTERSTAFF);
-		//assertEquals("Incorrect item name", item3.getName(), quarterstaffNode.toString());
-		assertEquals("Incorrect item type", EquipNode.NodeType.EQUIPMENT, quarterstaffNode.getNodeType());
-		assertEquals("Incorrect parent", Constants.EQUIP_LOCATION_EQUIPPED, quarterstaffNode.getParent().toString());
-		assertEquals("Incorrect path", "0.1.02", quarterstaffNode.getIdPath());
+		//assertEquals(item3.getName(), quarterstaffNode.toString(), "Incorrect item name");
+		assertEquals(EquipNode.NodeType.EQUIPMENT, quarterstaffNode.getNodeType(), "Incorrect item type");
+		assertEquals(Constants.EQUIP_LOCATION_EQUIPPED, quarterstaffNode.getParent().toString(), "Incorrect parent");
+		assertEquals("0.1.02", quarterstaffNode.getIdPath(), "Incorrect path");
 		
 		EquipNode bookNode = getEquipNodeByName(nodeList, BOOK);
-		assertEquals("Incorrect path", "0.1.01.01", bookNode.getIdPath());
+		assertEquals("0.1.01.01", bookNode.getIdPath(), "Incorrect path");
 		EquipNode satchelNode = getEquipNodeByName(nodeList, SATCHEL);
-		assertEquals("Incorrect path", "0.1.01", satchelNode.getIdPath());
+		assertEquals("0.1.01", satchelNode.getIdPath(), "Incorrect path");
 		EquipNode bedrollNode = getEquipNodeByName(nodeList, BEDROLL);
-		assertEquals("Incorrect path", "0.1.03", bedrollNode.getIdPath());
+		assertEquals("0.1.03", bedrollNode.getIdPath(), "Incorrect path");
 		
-		assertTrue("Move down failed unexpectedly",
-			esfi.moveEquipment(satchelNode, 1));
-		assertEquals("Incorrect quarterstaff path after move down.", "0.1.02",
-			quarterstaffNode.getIdPath());
-		assertEquals("Incorrect satchel path after move down.", "0.1.03",
-			satchelNode.getIdPath());
-		assertEquals("Incorrect book path after move down.", "0.1.03.01",
-			bookNode.getIdPath());
-		assertEquals("Incorrect bedroll path after move down.", "0.1.04",
-			bedrollNode.getIdPath());
+		assertTrue(esfi.moveEquipment(satchelNode, 1), "Move down failed unexpectedly");
+		assertEquals("0.1.02", quarterstaffNode.getIdPath(), "Incorrect quarterstaff path after move down.");
+		assertEquals("0.1.03", satchelNode.getIdPath(), "Incorrect satchel path after move down.");
+		assertEquals("0.1.03.01", bookNode.getIdPath(), "Incorrect book path after move down.");
+		assertEquals("0.1.04", bedrollNode.getIdPath(), "Incorrect bedroll path after move down.");
 		
-		assertTrue("Move to bottom failed unexpectedly",
-			esfi.moveEquipment(satchelNode, 1));
-		assertEquals("Incorrect quarterstaff path after move to bottom.", "0.1.02",
-			quarterstaffNode.getIdPath());
-		assertEquals("Incorrect satchel path after move to bottom.", "0.1.05",
-			satchelNode.getIdPath());
-		assertEquals("Incorrect book path after move to bottom.", "0.1.05.01",
-			bookNode.getIdPath());
-		assertEquals("Incorrect bedroll path after move to bottom.", "0.1.04",
-			bedrollNode.getIdPath());
+		assertTrue(esfi.moveEquipment(satchelNode, 1), "Move to bottom failed unexpectedly");
+		assertEquals("0.1.02", quarterstaffNode.getIdPath(), "Incorrect quarterstaff path after move to bottom.");
+		assertEquals("0.1.05", satchelNode.getIdPath(), "Incorrect satchel path after move to bottom.");
+		assertEquals("0.1.05.01", bookNode.getIdPath(), "Incorrect book path after move to bottom.");
+		assertEquals("0.1.04", bedrollNode.getIdPath(), "Incorrect bedroll path after move to bottom.");
 	}
 	
 

--- a/code/src/test/pcgen/gui2/facade/Gui2InfoFactoryTest.java
+++ b/code/src/test/pcgen/gui2/facade/Gui2InfoFactoryTest.java
@@ -16,8 +16,8 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
 package pcgen.gui2.facade;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.enumeration.ListKey;
@@ -61,13 +61,11 @@ public class Gui2InfoFactoryTest extends AbstractCharacterTestCase
 		Globals.getContext().commit();
 		finalizeTest(choiceAbility, "Perception", pc,
 			BuildUtilities.getFeatCat());
-		assertEquals("Incorrect single choice", "Perception",
-			ca.getChoices(choiceAbility));
+		assertEquals("Perception", ca.getChoices(choiceAbility), "Incorrect single choice");
 
 		finalizeTest(choiceAbility, "Acrobatics", pc,
 			BuildUtilities.getFeatCat());
-		assertEquals("Incorrect multiple choice", "Acrobatics, Perception",
-			ca.getChoices(choiceAbility));
+		assertEquals("Acrobatics, Perception", ca.getChoices(choiceAbility), "Incorrect multiple choice");
 	}
 	
 	/**
@@ -90,10 +88,8 @@ public class Gui2InfoFactoryTest extends AbstractCharacterTestCase
 
 		TempBonusFacadeImpl tbf = new TempBonusFacadeImpl(tbAbility);
 
-		assertEquals("Unexpected temp bonus result",
-			"<html><b><font size=+1>Combat expertise</font></b> (Ability)<br>"
-				+ "<b>Desc:</b>&nbsp;CE Desc<br><b>Source:</b>&nbsp;</html>",
-			infoFactory.getHTMLInfo(tbf));
+		assertEquals("<html><b><font size=+1>Combat expertise</font></b> (Ability)<br>"
+				+ "<b>Desc:</b>&nbsp;CE Desc<br><b>Source:</b>&nbsp;</html>", infoFactory.getHTMLInfo(tbf), "Unexpected temp bonus result");
 	}	
 
 	@BeforeEach

--- a/code/src/test/pcgen/gui2/facade/SpellBuilderFacadeImplTest.java
+++ b/code/src/test/pcgen/gui2/facade/SpellBuilderFacadeImplTest.java
@@ -17,10 +17,10 @@
  */
 package pcgen.gui2.facade;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.enumeration.ObjectKey;
@@ -104,11 +104,11 @@ public class SpellBuilderFacadeImplTest extends AbstractCharacterTestCase
 	{
 		SpellBuilderFacadeImpl spellBuilder = createSpellBuilder();
 		ListFacade<InfoFacade> classes = spellBuilder.getClasses();
-		assertNotNull("Class list should be defined", classes);
-		assertTrue("Class list should have wizard", classes.containsElement(wizardCls));
-		assertTrue("Class list should have divine class", classes.containsElement(divineCls));
-		assertFalse("Class list should not have fighter", classes.containsElement(fighterCls));
-		assertEquals("Class list length", 2, classes.getSize());
+		assertNotNull(classes, "Class list should be defined");
+		assertTrue(classes.containsElement(wizardCls), "Class list should have wizard");
+		assertTrue(classes.containsElement(divineCls), "Class list should have divine class");
+		assertFalse(classes.containsElement(fighterCls), "Class list should not have fighter");
+		assertEquals(2, classes.getSize(), "Class list length");
 		
 		
 	}
@@ -123,23 +123,23 @@ public class SpellBuilderFacadeImplTest extends AbstractCharacterTestCase
 		spellBuilder.setClass(wizardCls);
 		spellBuilder.setSpellLevel(1);
 		ListFacade<InfoFacade> spells = spellBuilder.getSpells();
-		assertNotNull("Spell list should be defined", spells);
-		assertEquals("Spell list length", 1, spells.getSize());
-		assertTrue("Spell list should have MM", spells.containsElement(magicMissile));
+		assertNotNull(spells, "Spell list should be defined");
+		assertEquals(1, spells.getSize(), "Spell list length");
+		assertTrue(spells.containsElement(magicMissile), "Spell list should have MM");
 
 		spellBuilder.setSpellLevel(2);
 		spells = spellBuilder.getSpells();
-		assertNotNull("Spell list should be defined", spells);
-		assertEquals("Spell list length", 1, spells.getSize());
-		assertTrue("Spell list should have Web", spells.containsElement(web));
-		assertFalse("Spell list should not have MM", spells.containsElement(magicMissile));
+		assertNotNull(spells, "Spell list should be defined");
+		assertEquals(1, spells.getSize(), "Spell list length");
+		assertTrue(spells.containsElement(web), "Spell list should have Web");
+		assertFalse(spells.containsElement(magicMissile), "Spell list should not have MM");
 
 		spellBuilder.setClass(divineCls);
 		spellBuilder.setSpellLevel(1);
 		spells = spellBuilder.getSpells();
-		assertNotNull("Spell list should be defined", spells);
-		assertEquals("Spell list length", 1, spells.getSize());
-		assertTrue("Spell list should have CLW", spells.containsElement(clw));
+		assertNotNull(spells, "Spell list should be defined");
+		assertEquals(1, spells.getSize(), "Spell list length");
+		assertTrue(spells.containsElement(clw), "Spell list should have CLW");
 		
 	}
 
@@ -148,10 +148,10 @@ public class SpellBuilderFacadeImplTest extends AbstractCharacterTestCase
 		PlayerCharacter pc = getCharacter();
 		CharacterFacadeImpl charFacade =
 				new CharacterFacadeImpl(pc, uiDelegate, dataset);
-		assertNotNull("Unable to create CharacterFacadeImpl", charFacade);
+		assertNotNull(charFacade, "Unable to create CharacterFacadeImpl");
 		
 		SpellBuilderFacadeImpl spellBuilder = new SpellBuilderFacadeImpl("", pc, null);
-		assertNotNull("Unable to create SpellBuilderFacadeImpl", spellBuilder);
+		assertNotNull(spellBuilder, "Unable to create SpellBuilderFacadeImpl");
 		return spellBuilder;
 	}
 

--- a/code/src/test/pcgen/io/PCGVer2ParserCharacterTest.java
+++ b/code/src/test/pcgen/io/PCGVer2ParserCharacterTest.java
@@ -17,7 +17,7 @@
  */
 package pcgen.io;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 
@@ -78,7 +78,7 @@ public class PCGVer2ParserCharacterTest extends AbstractCharacterTestCase
 		
 		PersistentTransitionChoice<?> tc = rakshasha.getListFor(ListKey.ADD).get(0);
 		List<Object> assocList = pc.getAssocList(tc, AssociationListKey.ADD);
-		assertEquals("Number of associations for ADD " + assocList, 1, assocList.size());
+		assertEquals(1, assocList.size(), "Number of associations for ADD " + assocList);
 	}
 
 	@Override

--- a/code/src/test/pcgen/io/exporttoken/AbilityListTokenTest.java
+++ b/code/src/test/pcgen/io/exporttoken/AbilityListTokenTest.java
@@ -19,7 +19,7 @@ package pcgen.io.exporttoken;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.closeTo;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 
@@ -85,20 +85,11 @@ public class AbilityListTokenTest extends AbstractCharacterTestCase
 		ExportHandler eh = ExportHandler.createExportHandler(null);
 		PlayerCharacter character = getCharacter();
 
-		assertEquals(
-			"ABILITYLIST.FEAT",
-			tok.getToken("ABILITYLIST.FEAT", character, eh), "Perform (Dance), Perform (Oratory), Silent Step"
-		);
+		assertEquals(tok.getToken("ABILITYLIST.FEAT", character, eh), "Perform (Dance), Perform (Oratory), Silent Step", "ABILITYLIST.FEAT");
 
-		assertEquals(
-			"ABILITYLIST.FEAT.TYPE=Fighter",
-			tok.getToken("ABILITYLIST.FEAT.TYPE=Fighter", character, eh), "Perform (Dance), Perform (Oratory)"
-		);
+		assertEquals(tok.getToken("ABILITYLIST.FEAT.TYPE=Fighter", character, eh), "Perform (Dance), Perform (Oratory)", "ABILITYLIST.FEAT.TYPE=Fighter");
 
-		assertEquals(
-			"ABILITYLIST.FEAT.!TYPE=Fighter",
-			tok.getToken("ABILITYLIST.FEAT.!TYPE=Fighter", character, eh), "Silent Step"
-		);
+		assertEquals(tok.getToken("ABILITYLIST.FEAT.!TYPE=Fighter", character, eh), "Silent Step", "ABILITYLIST.FEAT.!TYPE=Fighter");
 	}
 
 	/**
@@ -111,10 +102,7 @@ public class AbilityListTokenTest extends AbstractCharacterTestCase
 		ExportHandler eh = ExportHandler.createExportHandler(null);
 		PlayerCharacter character = getCharacter();
 
-		assertEquals(
-			"ABILITYLIST.BARDIC",
-			tok.getToken("ABILITYLIST.BARDIC", character, eh), "Perform (Dance)"
-		);
+		assertEquals(tok.getToken("ABILITYLIST.BARDIC", character, eh), "Perform (Dance)", "ABILITYLIST.BARDIC");
 	}
 
 	/**
@@ -186,15 +174,13 @@ public class AbilityListTokenTest extends AbstractCharacterTestCase
 				"|FOR,%feat,0,count(\"ABILITIES\",\"CATEGORY=FEAT\",\"VISIBILITY=VISIBLE\")-1,1,0|";
 
 		List<String> result = ExportHandler.getParameters(testStr);
-		assertEquals("Complex split len", 6, result.size());
-		assertEquals("Complex split combined token 0", "|FOR", result.get(0));
-		assertEquals("Complex split combined token 1", "%feat", result.get(1));
-		assertEquals("Complex split combined token 2", "0", result.get(2));
-		assertEquals("Complex split combined token 3",
-			"count(\"ABILITIES\",\"CATEGORY=FEAT\",\"VISIBILITY=VISIBLE\")-1",
-			result.get(3));
-		assertEquals("Complex split combined token 4", "1", result.get(4));
-		assertEquals("Complex split combined token 5", "0|", result.get(5));
+		assertEquals(6, result.size(), "Complex split len");
+		assertEquals("|FOR", result.get(0), "Complex split combined token 0");
+		assertEquals("%feat", result.get(1), "Complex split combined token 1");
+		assertEquals("0", result.get(2), "Complex split combined token 2");
+		assertEquals("count(\"ABILITIES\",\"CATEGORY=FEAT\",\"VISIBILITY=VISIBLE\")-1", result.get(3), "Complex split combined token 3");
+		assertEquals("1", result.get(4), "Complex split combined token 4");
+		assertEquals("0|", result.get(5), "Complex split combined token 5");
 	}
 
 	@Test
@@ -204,6 +190,6 @@ public class AbilityListTokenTest extends AbstractCharacterTestCase
 				"|FOR,%equip1,0,(COUNT[EQUIPMENT.MERGELOC.Not.Coin.NOT.Gem]-1)/2,1,0|";
 
 		List<String> result = ExportHandler.getParameters(testStr);
-		assertEquals("Complex split len", 6, result.size());
+		assertEquals(6, result.size(), "Complex split len");
 	}
 }

--- a/code/src/test/pcgen/io/exporttoken/SpellMemTokenTest.java
+++ b/code/src/test/pcgen/io/exporttoken/SpellMemTokenTest.java
@@ -17,7 +17,7 @@
  */
 package pcgen.io.exporttoken;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 
@@ -133,14 +133,12 @@ public class SpellMemTokenTest extends AbstractCharacterTestCase
 		String result =
 				character.addSpell(charSpell, null, arcaneClass.getKeyName(),
 					Globals.getDefaultSpellBook(), 1, 1);
-		assertEquals("No CHA, so should reject attempt to add spell",
-			"You can only learn 0 spells for level 1 "
-				+ "\nand there are no higher-level slots available.", result);
+		assertEquals("You can only learn 0 spells for level 1 "
+				+ "\nand there are no higher-level slots available.", result, "No CHA, so should reject attempt to add spell");
 
 		SpellMemToken token = new SpellMemToken();
-		assertEquals("Retrieve spell from known list of arcane caster.",
-			"Test Spell", token.getToken("SPELLMEM.0.0.1.0.NAME", character,
-				null));
+		assertEquals("Test Spell", token.getToken("SPELLMEM.0.0.1.0.NAME", character,
+				null), "Retrieve spell from known list of arcane caster.");
 	}
 
 	/**
@@ -169,31 +167,26 @@ public class SpellMemTokenTest extends AbstractCharacterTestCase
 		String result =
 				character.addSpell(charSpell, null, divineClass.getKeyName(),
 					Globals.getDefaultSpellBook(), 1, 1);
-		assertEquals("Known spells already has all spells, should reject.",
-			"The Known Spells spellbook contains all spells of this level that you "
-				+ "know. You cannot place spells in multiple times.", result);
+		assertEquals("The Known Spells spellbook contains all spells of this level that you "
+				+ "know. You cannot place spells in multiple times.", result, "Known spells already has all spells, should reject.");
 		result =
 				character.addSpell(charSpell, null, divineClass.getKeyName(),
 					spellBook, 1, 1);
-		assertEquals("No WIS, so should reject attempt to add spell",
-			"You can only prepare 0 spells for level 1 "
-				+ "\nand there are no higher-level slots available.", result);
+		assertEquals("You can only prepare 0 spells for level 1 "
+				+ "\nand there are no higher-level slots available.", result, "No WIS, so should reject attempt to add spell");
 
 		setPCStat(character, wis, 12);
 		character.calcActiveBonuses();
 		result =
 				character.addSpell(charSpell, null, divineClass.getKeyName(),
 					spellBook, 1, 1);
-		assertEquals("Should be no error messages from adding spell", "",
-			result);
+		assertEquals("", result, "Should be no error messages from adding spell");
 
 		SpellMemToken token = new SpellMemToken();
-		assertEquals("Retrieve spell from known list of divine caster.",
-			"Test Spell", token.getToken("SPELLMEM.0.0.1.0.NAME", character,
-				null));
-		assertEquals("Retrieve spell from prepared list of divine caster.",
-			"Test Spell", token.getToken("SPELLMEM.0.2.1.0.NAME", character,
-				null));
+		assertEquals("Test Spell", token.getToken("SPELLMEM.0.0.1.0.NAME", character,
+				null), "Retrieve spell from known list of divine caster.");
+		assertEquals("Test Spell", token.getToken("SPELLMEM.0.2.1.0.NAME", character,
+				null), "Retrieve spell from prepared list of divine caster.");
 	}
 
 	@Override

--- a/code/src/test/pcgen/io/exporttoken/TextTokenTest.java
+++ b/code/src/test/pcgen/io/exporttoken/TextTokenTest.java
@@ -17,7 +17,7 @@
  */
 package pcgen.io.exporttoken;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.enumeration.PCStringKey;
@@ -57,27 +57,21 @@ public class TextTokenTest extends AbstractCharacterTestCase
 		ExportHandler eh = ExportHandler.createExportHandler(null);
 		PlayerCharacter character = getCharacter();
 
-		assertEquals("TEXT.LOWER.NAME",
-			"the vitamins are in my fresh brussels sprouts", tok.getToken(
-				"TEXT.LOWER.NAME", character, eh));
-		assertEquals("TEXT.UPPER.NAME",
-			"THE VITAMINS ARE IN MY FRESH BRUSSELS SPROUTS", tok.getToken(
-				"TEXT.UPPER.NAME", character, eh));
-		assertEquals("TEXT.SENTENCE.NAME",
-			"The vitamins are in my fresh brussels sprouts", tok.getToken(
-				"TEXT.SENTENCE.NAME", character, eh));
-		assertEquals("TEXT.SENTENCE.NAME",
-			"The vitamins are in my fresh brussels sprouts", tok.getToken(
-				"TEXT.SENTENCE.NAME", character, eh));
+		assertEquals("the vitamins are in my fresh brussels sprouts", tok.getToken(
+				"TEXT.LOWER.NAME", character, eh), "TEXT.LOWER.NAME");
+		assertEquals("THE VITAMINS ARE IN MY FRESH BRUSSELS SPROUTS", tok.getToken(
+				"TEXT.UPPER.NAME", character, eh), "TEXT.UPPER.NAME");
+		assertEquals("The vitamins are in my fresh brussels sprouts", tok.getToken(
+				"TEXT.SENTENCE.NAME", character, eh), "TEXT.SENTENCE.NAME");
+		assertEquals("The vitamins are in my fresh brussels sprouts", tok.getToken(
+				"TEXT.SENTENCE.NAME", character, eh), "TEXT.SENTENCE.NAME");
 		character.setPCAttribute(PCStringKey.NAME, "The Vitamins are in my Fresh Brussels Sprouts");
-		assertEquals("TEXT.SENTENCE.INTERESTS",
-			"One potatoe. Two potatoe. More", tok.getToken(
-				"TEXT.SENTENCE.INTERESTS", character, eh));
-		assertEquals("TEXT.TITLE.NAME",
-			"The Vitamins Are In My Fresh Brussels Sprouts", tok.getToken(
-				"TEXT.TITLE.NAME", getCharacter(), eh));
-		assertEquals("TEXT.TITLE.NAME", "One Potatoe. Two Potatoe. More", tok
-			.getToken("TEXT.TITLE.INTERESTS", character, eh));
+		assertEquals("One potatoe. Two potatoe. More", tok.getToken(
+				"TEXT.SENTENCE.INTERESTS", character, eh), "TEXT.SENTENCE.INTERESTS");
+		assertEquals("The Vitamins Are In My Fresh Brussels Sprouts", tok.getToken(
+				"TEXT.TITLE.NAME", getCharacter(), eh), "TEXT.TITLE.NAME");
+		assertEquals("One Potatoe. Two Potatoe. More", tok
+			.getToken("TEXT.TITLE.INTERESTS", character, eh), "TEXT.TITLE.NAME");
 	}
 
 	/**
@@ -91,44 +85,44 @@ public class TextTokenTest extends AbstractCharacterTestCase
 		PlayerCharacter character = getCharacter();
 
 		ChannelUtilities.setControlledChannel(character.getCharID(), CControl.AGEINPUT, 1);
-		assertEquals("Suffix 1", "st", tok.getToken("TEXT.NUMSUFFIX.AGE",
-			getCharacter(), eh));
+		assertEquals("st", tok.getToken("TEXT.NUMSUFFIX.AGE",
+			getCharacter(), eh), "Suffix 1");
 		ChannelUtilities.setControlledChannel(character.getCharID(), CControl.AGEINPUT, 2);
-		assertEquals("Suffix 2", "nd", tok.getToken("TEXT.NUMSUFFIX.AGE",
-			getCharacter(), eh));
+		assertEquals("nd", tok.getToken("TEXT.NUMSUFFIX.AGE",
+			getCharacter(), eh), "Suffix 2");
 		ChannelUtilities.setControlledChannel(character.getCharID(), CControl.AGEINPUT, 3);
-		assertEquals("Suffix 3", "rd", tok.getToken("TEXT.NUMSUFFIX.AGE",
-			getCharacter(), eh));
+		assertEquals("rd", tok.getToken("TEXT.NUMSUFFIX.AGE",
+			getCharacter(), eh), "Suffix 3");
 		ChannelUtilities.setControlledChannel(character.getCharID(), CControl.AGEINPUT, 4);
-		assertEquals("Suffix 4", "th", tok.getToken("TEXT.NUMSUFFIX.AGE",
-			getCharacter(), eh));
+		assertEquals("th", tok.getToken("TEXT.NUMSUFFIX.AGE",
+			getCharacter(), eh), "Suffix 4");
 		ChannelUtilities.setControlledChannel(character.getCharID(), CControl.AGEINPUT, 11);
-		assertEquals("Suffix 11", "th", tok.getToken("TEXT.NUMSUFFIX.AGE",
-			getCharacter(), eh));
+		assertEquals("th", tok.getToken("TEXT.NUMSUFFIX.AGE",
+			getCharacter(), eh), "Suffix 11");
 		ChannelUtilities.setControlledChannel(character.getCharID(), CControl.AGEINPUT, 12);
-		assertEquals("Suffix 12", "th", tok.getToken("TEXT.NUMSUFFIX.AGE",
-			getCharacter(), eh));
+		assertEquals("th", tok.getToken("TEXT.NUMSUFFIX.AGE",
+			getCharacter(), eh), "Suffix 12");
 		ChannelUtilities.setControlledChannel(character.getCharID(), CControl.AGEINPUT, 13);
-		assertEquals("Suffix 13", "th", tok.getToken("TEXT.NUMSUFFIX.AGE",
-			getCharacter(), eh));
+		assertEquals("th", tok.getToken("TEXT.NUMSUFFIX.AGE",
+			getCharacter(), eh), "Suffix 13");
 		ChannelUtilities.setControlledChannel(character.getCharID(), CControl.AGEINPUT, 14);
-		assertEquals("Suffix 14", "th", tok.getToken("TEXT.NUMSUFFIX.AGE",
-			getCharacter(), eh));
+		assertEquals("th", tok.getToken("TEXT.NUMSUFFIX.AGE",
+			getCharacter(), eh), "Suffix 14");
 		ChannelUtilities.setControlledChannel(character.getCharID(), CControl.AGEINPUT, 21);
-		assertEquals("Suffix 21", "st", tok.getToken("TEXT.NUMSUFFIX.AGE",
-			getCharacter(), eh));
+		assertEquals("st", tok.getToken("TEXT.NUMSUFFIX.AGE",
+			getCharacter(), eh), "Suffix 21");
 		ChannelUtilities.setControlledChannel(character.getCharID(), CControl.AGEINPUT, 22);
-		assertEquals("Suffix 22", "nd", tok.getToken("TEXT.NUMSUFFIX.AGE",
-			getCharacter(), eh));
+		assertEquals("nd", tok.getToken("TEXT.NUMSUFFIX.AGE",
+			getCharacter(), eh), "Suffix 22");
 		ChannelUtilities.setControlledChannel(character.getCharID(), CControl.AGEINPUT, 23);
-		assertEquals("Suffix 23", "rd", tok.getToken("TEXT.NUMSUFFIX.AGE",
-			getCharacter(), eh));
+		assertEquals("rd", tok.getToken("TEXT.NUMSUFFIX.AGE",
+			getCharacter(), eh), "Suffix 23");
 		ChannelUtilities.setControlledChannel(character.getCharID(), CControl.AGEINPUT, 24);
-		assertEquals("Suffix 24", "th", tok.getToken("TEXT.NUMSUFFIX.AGE",
-			getCharacter(), eh));
+		assertEquals("th", tok.getToken("TEXT.NUMSUFFIX.AGE",
+			getCharacter(), eh), "Suffix 24");
 		ChannelUtilities.setControlledChannel(character.getCharID(), CControl.AGEINPUT, 133);
-		assertEquals("Suffix 133", "rd", tok.getToken("TEXT.NUMSUFFIX.AGE",
-			getCharacter(), eh));
+		assertEquals("rd", tok.getToken("TEXT.NUMSUFFIX.AGE",
+			getCharacter(), eh), "Suffix 133");
 	}
 
 	/**
@@ -140,20 +134,20 @@ public class TextTokenTest extends AbstractCharacterTestCase
 		TextToken tok = new TextToken();
 		ExportHandler eh = ExportHandler.createExportHandler(null);
 
-		assertEquals("Suffix 1", "st", tok.getToken("TEXT.NUMSUFFIX.1",
-			getCharacter(), eh));
-		assertEquals("Suffix 2", "nd", tok.getToken("TEXT.NUMSUFFIX.2",
-			getCharacter(), eh));
-		assertEquals("Suffix 3", "rd", tok.getToken("TEXT.NUMSUFFIX.3",
-			getCharacter(), eh));
-		assertEquals("Suffix 4", "th", tok.getToken("TEXT.NUMSUFFIX.4",
-			getCharacter(), eh));
-		assertEquals("Suffix 12", "th", tok.getToken("TEXT.NUMSUFFIX.12",
-			getCharacter(), eh));
-		assertEquals("Suffix 133", "rd", tok.getToken("TEXT.NUMSUFFIX.133",
-			getCharacter(), eh));
-		assertEquals("Suffix 133", "rd", tok.getToken("TEXT.NUMSUFFIX.133.0",
-			getCharacter(), eh));
+		assertEquals("st", tok.getToken("TEXT.NUMSUFFIX.1",
+			getCharacter(), eh), "Suffix 1");
+		assertEquals("nd", tok.getToken("TEXT.NUMSUFFIX.2",
+			getCharacter(), eh), "Suffix 2");
+		assertEquals("rd", tok.getToken("TEXT.NUMSUFFIX.3",
+			getCharacter(), eh), "Suffix 3");
+		assertEquals("th", tok.getToken("TEXT.NUMSUFFIX.4",
+			getCharacter(), eh), "Suffix 4");
+		assertEquals("th", tok.getToken("TEXT.NUMSUFFIX.12",
+			getCharacter(), eh), "Suffix 12");
+		assertEquals("rd", tok.getToken("TEXT.NUMSUFFIX.133",
+			getCharacter(), eh), "Suffix 133");
+		assertEquals("rd", tok.getToken("TEXT.NUMSUFFIX.133.0",
+			getCharacter(), eh), "Suffix 133");
 	}
 
 }

--- a/code/src/test/pcgen/io/exporttoken/VarTokenTest.java
+++ b/code/src/test/pcgen/io/exporttoken/VarTokenTest.java
@@ -17,7 +17,7 @@
  */
 package pcgen.io.exporttoken;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.base.FormulaFactory;
@@ -59,22 +59,22 @@ public class VarTokenTest extends AbstractCharacterTestCase
 	@Test
 	public void testPositiveFractOutput()
 	{
-		assertEquals("VAR.Pos", "100.35", new VarToken().getToken("VAR.Pos",
-			getCharacter(), null));
-		assertEquals("VAR.Pos.INTVAL", "100", new VarToken().getToken(
-			"VAR.Pos.INTVAL", getCharacter(), null));
-		assertEquals("VAR.Pos.NOSIGN", "100.35", new VarToken().getToken(
-			"VAR.Pos.NOSIGN", getCharacter(), null));
-		assertEquals("VAR.Pos.NOSIGN.INTVAL", "100", new VarToken().getToken(
-			"VAR.Pos.NOSIGN.INTVAL", getCharacter(), null));
-		assertEquals("VAR.Pos.INTVAL.NOSIGN", "100", new VarToken().getToken(
-			"VAR.Pos.INTVAL.NOSIGN", getCharacter(), null));
-		assertEquals("VAR.Pos.SIGN", "+100.35", new VarToken().getToken(
-			"VAR.Pos.SIGN", getCharacter(), null));
-		assertEquals("VAR.Pos.SIGN.INTVAL", "+100", new VarToken().getToken(
-			"VAR.Pos.SIGN.INTVAL", getCharacter(), null));
-		assertEquals("VAR.Pos.INTVAL.SIGN", "+100", new VarToken().getToken(
-			"VAR.Pos.INTVAL.SIGN", getCharacter(), null));
+		assertEquals("100.35", new VarToken().getToken("VAR.Pos",
+			getCharacter(), null), "VAR.Pos");
+		assertEquals("100", new VarToken().getToken(
+			"VAR.Pos.INTVAL", getCharacter(), null), "VAR.Pos.INTVAL");
+		assertEquals("100.35", new VarToken().getToken(
+			"VAR.Pos.NOSIGN", getCharacter(), null), "VAR.Pos.NOSIGN");
+		assertEquals("100", new VarToken().getToken(
+			"VAR.Pos.NOSIGN.INTVAL", getCharacter(), null), "VAR.Pos.NOSIGN.INTVAL");
+		assertEquals("100", new VarToken().getToken(
+			"VAR.Pos.INTVAL.NOSIGN", getCharacter(), null), "VAR.Pos.INTVAL.NOSIGN");
+		assertEquals("+100.35", new VarToken().getToken(
+			"VAR.Pos.SIGN", getCharacter(), null), "VAR.Pos.SIGN");
+		assertEquals("+100", new VarToken().getToken(
+			"VAR.Pos.SIGN.INTVAL", getCharacter(), null), "VAR.Pos.SIGN.INTVAL");
+		assertEquals("+100", new VarToken().getToken(
+			"VAR.Pos.INTVAL.SIGN", getCharacter(), null), "VAR.Pos.INTVAL.SIGN");
 	}
 
 	/**
@@ -83,22 +83,22 @@ public class VarTokenTest extends AbstractCharacterTestCase
 	@Test
 	public void testNegativeFractOutput()
 	{
-		assertEquals("VAR.Neg", "-555.55", new VarToken().getToken("VAR.Neg",
-			getCharacter(), null));
-		assertEquals("VAR.Neg.INTVAL", "-555", new VarToken().getToken(
-			"VAR.Neg.INTVAL", getCharacter(), null));
-		assertEquals("VAR.Neg.NOSIGN", "-555.55", new VarToken().getToken(
-			"VAR.Neg.NOSIGN", getCharacter(), null));
-		assertEquals("VAR.Neg.NOSIGN.INTVAL", "-555", new VarToken().getToken(
-			"VAR.Neg.NOSIGN.INTVAL", getCharacter(), null));
-		assertEquals("VAR.Neg.INTVAL.NOSIGN", "-555", new VarToken().getToken(
-			"VAR.Neg.INTVAL.NOSIGN", getCharacter(), null));
-		assertEquals("VAR.Neg.SIGN", "-555.55", new VarToken().getToken(
-			"VAR.Neg.SIGN", getCharacter(), null));
-		assertEquals("VAR.Neg.SIGN.INTVAL", "-555", new VarToken().getToken(
-			"VAR.Neg.SIGN.INTVAL", getCharacter(), null));
-		assertEquals("VAR.Neg.INTVAL.SIGN", "-555", new VarToken().getToken(
-			"VAR.Neg.INTVAL.SIGN", getCharacter(), null));
+		assertEquals("-555.55", new VarToken().getToken("VAR.Neg",
+			getCharacter(), null), "VAR.Neg");
+		assertEquals("-555", new VarToken().getToken(
+			"VAR.Neg.INTVAL", getCharacter(), null), "VAR.Neg.INTVAL");
+		assertEquals("-555.55", new VarToken().getToken(
+			"VAR.Neg.NOSIGN", getCharacter(), null), "VAR.Neg.NOSIGN");
+		assertEquals("-555", new VarToken().getToken(
+			"VAR.Neg.NOSIGN.INTVAL", getCharacter(), null), "VAR.Neg.NOSIGN.INTVAL");
+		assertEquals("-555", new VarToken().getToken(
+			"VAR.Neg.INTVAL.NOSIGN", getCharacter(), null), "VAR.Neg.INTVAL.NOSIGN");
+		assertEquals("-555.55", new VarToken().getToken(
+			"VAR.Neg.SIGN", getCharacter(), null), "VAR.Neg.SIGN");
+		assertEquals("-555", new VarToken().getToken(
+			"VAR.Neg.SIGN.INTVAL", getCharacter(), null), "VAR.Neg.SIGN.INTVAL");
+		assertEquals("-555", new VarToken().getToken(
+			"VAR.Neg.INTVAL.SIGN", getCharacter(), null), "VAR.Neg.INTVAL.SIGN");
 	}
 
 	/**
@@ -107,22 +107,22 @@ public class VarTokenTest extends AbstractCharacterTestCase
 	@Test
 	public void testPositiveIntOutput()
 	{
-		assertEquals("VAR.PosInt", "105.0", new VarToken().getToken(
-			"VAR.PosInt", getCharacter(), null));
-		assertEquals("VAR.PosInt.INTVAL", "105", new VarToken().getToken(
-			"VAR.PosInt.INTVAL", getCharacter(), null));
-		assertEquals("VAR.PosInt.NOSIGN", "105.0", new VarToken().getToken(
-			"VAR.PosInt.NOSIGN", getCharacter(), null));
-		assertEquals("VAR.PosInt.NOSIGN.INTVAL", "105", new VarToken()
-			.getToken("VAR.PosInt.NOSIGN.INTVAL", getCharacter(), null));
-		assertEquals("VAR.PosInt.INTVAL.NOSIGN", "105", new VarToken()
-			.getToken("VAR.PosInt.INTVAL.NOSIGN", getCharacter(), null));
-		assertEquals("VAR.PosInt.SIGN", "+105.0", new VarToken().getToken(
-			"VAR.PosInt.SIGN", getCharacter(), null));
-		assertEquals("VAR.PosInt.SIGN.INTVAL", "+105", new VarToken().getToken(
-			"VAR.PosInt.SIGN.INTVAL", getCharacter(), null));
-		assertEquals("VAR.PosInt.INTVAL.SIGN", "+105", new VarToken().getToken(
-			"VAR.PosInt.INTVAL.SIGN", getCharacter(), null));
+		assertEquals("105.0", new VarToken().getToken(
+			"VAR.PosInt", getCharacter(), null), "VAR.PosInt");
+		assertEquals("105", new VarToken().getToken(
+			"VAR.PosInt.INTVAL", getCharacter(), null), "VAR.PosInt.INTVAL");
+		assertEquals("105.0", new VarToken().getToken(
+			"VAR.PosInt.NOSIGN", getCharacter(), null), "VAR.PosInt.NOSIGN");
+		assertEquals("105", new VarToken()
+			.getToken("VAR.PosInt.NOSIGN.INTVAL", getCharacter(), null), "VAR.PosInt.NOSIGN.INTVAL");
+		assertEquals("105", new VarToken()
+			.getToken("VAR.PosInt.INTVAL.NOSIGN", getCharacter(), null), "VAR.PosInt.INTVAL.NOSIGN");
+		assertEquals("+105.0", new VarToken().getToken(
+			"VAR.PosInt.SIGN", getCharacter(), null), "VAR.PosInt.SIGN");
+		assertEquals("+105", new VarToken().getToken(
+			"VAR.PosInt.SIGN.INTVAL", getCharacter(), null), "VAR.PosInt.SIGN.INTVAL");
+		assertEquals("+105", new VarToken().getToken(
+			"VAR.PosInt.INTVAL.SIGN", getCharacter(), null), "VAR.PosInt.INTVAL.SIGN");
 	}
 
 	/**
@@ -131,22 +131,22 @@ public class VarTokenTest extends AbstractCharacterTestCase
 	@Test
 	public void testNegativeIntOutput()
 	{
-		assertEquals("VAR.NegInt", "-560.0", new VarToken().getToken(
-			"VAR.NegInt", getCharacter(), null));
-		assertEquals("VAR.NegInt.INTVAL", "-560", new VarToken().getToken(
-			"VAR.NegInt.INTVAL", getCharacter(), null));
-		assertEquals("VAR.NegInt.NOSIGN", "-560.0", new VarToken().getToken(
-			"VAR.NegInt.NOSIGN", getCharacter(), null));
-		assertEquals("VAR.NegInt.NOSIGN.INTVAL", "-560", new VarToken()
-			.getToken("VAR.NegInt.NOSIGN.INTVAL", getCharacter(), null));
-		assertEquals("VAR.NegInt.INTVAL.NOSIGN", "-560", new VarToken()
-			.getToken("VAR.NegInt.INTVAL.NOSIGN", getCharacter(), null));
-		assertEquals("VAR.NegInt.SIGN", "-560.0", new VarToken().getToken(
-			"VAR.NegInt.SIGN", getCharacter(), null));
-		assertEquals("VAR.NegInt.SIGN.INTVAL", "-560", new VarToken().getToken(
-			"VAR.NegInt.SIGN.INTVAL", getCharacter(), null));
-		assertEquals("VAR.NegInt.INTVAL.SIGN", "-560", new VarToken().getToken(
-			"VAR.NegInt.INTVAL.SIGN", getCharacter(), null));
+		assertEquals("-560.0", new VarToken().getToken(
+			"VAR.NegInt", getCharacter(), null), "VAR.NegInt");
+		assertEquals("-560", new VarToken().getToken(
+			"VAR.NegInt.INTVAL", getCharacter(), null), "VAR.NegInt.INTVAL");
+		assertEquals("-560.0", new VarToken().getToken(
+			"VAR.NegInt.NOSIGN", getCharacter(), null), "VAR.NegInt.NOSIGN");
+		assertEquals("-560", new VarToken()
+			.getToken("VAR.NegInt.NOSIGN.INTVAL", getCharacter(), null), "VAR.NegInt.NOSIGN.INTVAL");
+		assertEquals("-560", new VarToken()
+			.getToken("VAR.NegInt.INTVAL.NOSIGN", getCharacter(), null), "VAR.NegInt.INTVAL.NOSIGN");
+		assertEquals("-560.0", new VarToken().getToken(
+			"VAR.NegInt.SIGN", getCharacter(), null), "VAR.NegInt.SIGN");
+		assertEquals("-560", new VarToken().getToken(
+			"VAR.NegInt.SIGN.INTVAL", getCharacter(), null), "VAR.NegInt.SIGN.INTVAL");
+		assertEquals("-560", new VarToken().getToken(
+			"VAR.NegInt.INTVAL.SIGN", getCharacter(), null), "VAR.NegInt.INTVAL.SIGN");
 	}
 
 }

--- a/code/src/test/pcgen/persistence/lst/DataLoadTest.java
+++ b/code/src/test/pcgen/persistence/lst/DataLoadTest.java
@@ -39,8 +39,6 @@ import pcgen.core.SystemCollections;
 import pcgen.facade.core.SourceSelectionFacade;
 import pcgen.facade.core.UIDelegate;
 import pcgen.gui2.facade.MockUIDelegate;
-import pcgen.persistence.CampaignFileLoader;
-import pcgen.persistence.GameModeFileLoader;
 import pcgen.persistence.SourceFileLoader;
 import pcgen.system.ConfigurationSettings;
 import pcgen.system.FacadeFactory;
@@ -162,12 +160,7 @@ public class DataLoadTest implements PCGenTaskListener
 		configFactory.registerAndLoadPropertyContext(ConfigurationSettings
 			.getInstance(TEST_CONFIG_FILE));
 		Main.loadProperties(false);
-		PCGenTask loadPluginTask = Main.createLoadPluginTask();
-		loadPluginTask.run();
-		PCGenTask gameModeFileLoader = new GameModeFileLoader();
-		gameModeFileLoader.run();
-		PCGenTask campaignFileLoader = new CampaignFileLoader();
-		campaignFileLoader.run();
+		Main.runBootstrapTasks();
 	}
 
 	private static List<SourceSelectionFacade> getBasicSources()

--- a/code/src/test/pcgen/persistence/lst/DataTest.java
+++ b/code/src/test/pcgen/persistence/lst/DataTest.java
@@ -40,13 +40,10 @@ import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.enumeration.ListKey;
 import pcgen.core.Campaign;
 import pcgen.core.Globals;
-import pcgen.persistence.CampaignFileLoader;
-import pcgen.persistence.GameModeFileLoader;
 import pcgen.persistence.lst.utils.VariableReport;
 import pcgen.persistence.lst.utils.VariableReport.ReportFormat;
 import pcgen.system.ConfigurationSettings;
 import pcgen.system.Main;
-import pcgen.system.PCGenTask;
 import pcgen.system.PropertyContextFactory;
 import pcgen.util.Logging;
 import pcgen.util.TestHelper;
@@ -286,11 +283,6 @@ class DataTest
 		PropertyContextFactory configFactory = new PropertyContextFactory(SystemUtils.USER_DIR);
 		configFactory.registerAndLoadPropertyContext(ConfigurationSettings.getInstance(TEST_CONFIG_FILE));
 		Main.loadProperties(false);
-		PCGenTask loadPluginTask = Main.createLoadPluginTask();
-		loadPluginTask.run();
-		PCGenTask gameModeFileLoader = new GameModeFileLoader();
-		gameModeFileLoader.run();
-		PCGenTask campaignFileLoader = new CampaignFileLoader();
-		campaignFileLoader.run();
+		Main.runBootstrapTasks();
 	}
 }

--- a/code/src/test/pcgen/persistence/lst/FeatTest.java
+++ b/code/src/test/pcgen/persistence/lst/FeatTest.java
@@ -14,17 +14,19 @@ import pcgen.core.Campaign;
 import pcgen.core.Globals;
 import pcgen.core.SettingsHandler;
 import pcgen.persistence.PersistenceLayerException;
-import pcgen.util.TestHelper;
+import pcgen.test.PCGenTestEnvironment;
 import plugin.lsttokens.testsupport.BuildUtilities;
 import plugin.lsttokens.testsupport.TokenRegistration;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
  * JUnit testcases for {@code pcgen.core.Feat}.
  */
+@ExtendWith(PCGenTestEnvironment.class)
 public class FeatTest
 {
 	/**
@@ -33,7 +35,6 @@ public class FeatTest
 	@BeforeEach
 	public void setUp() throws Exception
 	{
-		TestHelper.loadPlugins();
 		Globals.getContext().getReferenceContext().importObject(BuildUtilities.getFeatCat());
 	}
 

--- a/code/src/test/pcgen/persistence/lst/InstallLoaderTest.java
+++ b/code/src/test/pcgen/persistence/lst/InstallLoaderTest.java
@@ -31,16 +31,18 @@ import pcgen.cdom.enumeration.ObjectKey;
 import pcgen.cdom.enumeration.StringKey;
 import pcgen.core.InstallableCampaign;
 import pcgen.persistence.PersistenceLayerException;
-import pcgen.util.TestHelper;
+import pcgen.test.PCGenTestEnvironment;
 import plugin.lsttokens.testsupport.TokenRegistration;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
  * A collection of tests to validate the functioning of the InstallLoader class.
  */
+@ExtendWith(PCGenTestEnvironment.class)
 public final class InstallLoaderTest
 {
 	private static final String PUBNAMESHORT = "PCGen";
@@ -84,7 +86,6 @@ public final class InstallLoaderTest
 	@BeforeEach
 	public void setUp() throws Exception
 	{
-		TestHelper.loadPlugins();
 	}
 
 	@AfterEach

--- a/code/src/test/pcgen/persistence/lst/MigrationLoaderTest.java
+++ b/code/src/test/pcgen/persistence/lst/MigrationLoaderTest.java
@@ -30,14 +30,16 @@ import pcgen.core.SettingsHandler;
 import pcgen.core.SystemCollections;
 import pcgen.core.system.MigrationRule;
 import pcgen.core.system.MigrationRule.ObjectType;
-import pcgen.util.TestHelper;
+import pcgen.test.PCGenTestEnvironment;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.Test;
 
 /**
  * MigrationLoaderTest checks the function of the MigrationLoader class.
  */
+@ExtendWith(PCGenTestEnvironment.class)
 public class MigrationLoaderTest
 {
 	MigrationLoader migrationLoader = new MigrationLoader();
@@ -47,7 +49,6 @@ public class MigrationLoaderTest
 	public void setUp() throws Exception
 	{
 		sourceURI = new URI("http://www.pcgen.org");
-		TestHelper.loadPlugins();
 	}
 	
 	@Test

--- a/code/src/test/pcgen/persistence/lst/PObjectLoaderTest.java
+++ b/code/src/test/pcgen/persistence/lst/PObjectLoaderTest.java
@@ -41,12 +41,14 @@ import pcgen.core.prereq.Prerequisite;
 import pcgen.rules.context.AbstractReferenceContext;
 import pcgen.rules.context.LoadContext;
 import pcgen.util.Logging;
-import pcgen.util.TestHelper;
+import pcgen.test.PCGenTestEnvironment;
 import plugin.lsttokens.testsupport.BuildUtilities;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.Test;
 
+@ExtendWith(PCGenTestEnvironment.class)
 class PObjectLoaderTest
 {
 	/**
@@ -55,7 +57,6 @@ class PObjectLoaderTest
 	@BeforeEach
 	public void setUp() throws Exception
 	{
-		TestHelper.loadPlugins();
 	}
 
 	@Test

--- a/code/src/test/pcgen/persistence/lst/output/prereq/PrerequisiteWriterTest.java
+++ b/code/src/test/pcgen/persistence/lst/output/prereq/PrerequisiteWriterTest.java
@@ -38,8 +38,10 @@ import pcgen.persistence.GameModeFileLoader;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.prereq.PreParserFactory;
 import pcgen.util.TestHelper;
+import pcgen.test.PCGenTestEnvironment;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.Test;
 import util.Alignment;
 
@@ -47,6 +49,7 @@ import util.Alignment;
  * Tests PrerequisiteWriter code
  * TODO: convert to ParamertizedTest
  */
+@ExtendWith(PCGenTestEnvironment.class)
 class PrerequisiteWriterTest
 {
 	private static final FormatManager<String> STR_MGR = new StringManager();
@@ -416,7 +419,6 @@ class PrerequisiteWriterTest
     @BeforeEach
     void setUp() throws Exception
 	{
-		TestHelper.loadPlugins();
 		Globals.setUseGUI(false);
 		Globals.emptyLists();
 		GameMode gamemode = new GameMode("3.5");

--- a/code/src/test/pcgen/persistence/lst/prereq/PreCheckParserTest.java
+++ b/code/src/test/pcgen/persistence/lst/prereq/PreCheckParserTest.java
@@ -18,7 +18,7 @@
  */
 package pcgen.persistence.lst.prereq;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import pcgen.EnUsLocaleDependentTestCase;
 import pcgen.core.prereq.Prerequisite;

--- a/code/src/test/pcgen/persistence/lst/prereq/PreEquipTest.java
+++ b/code/src/test/pcgen/persistence/lst/prereq/PreEquipTest.java
@@ -22,7 +22,7 @@
  */
 package pcgen.persistence.lst.prereq;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import pcgen.EnUsLocaleDependentTestCase;
 import pcgen.core.prereq.Prerequisite;

--- a/code/src/test/pcgen/persistence/lst/prereq/PreItemTest.java
+++ b/code/src/test/pcgen/persistence/lst/prereq/PreItemTest.java
@@ -17,7 +17,7 @@
  */
 package pcgen.persistence.lst.prereq;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import pcgen.EnUsLocaleDependentTestCase;
 import pcgen.core.prereq.Prerequisite;

--- a/code/src/test/pcgen/persistence/lst/prereq/PreKitParserTest.java
+++ b/code/src/test/pcgen/persistence/lst/prereq/PreKitParserTest.java
@@ -17,7 +17,7 @@
  */
 package pcgen.persistence.lst.prereq;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import pcgen.EnUsLocaleDependentTestCase;
 import pcgen.core.prereq.Prerequisite;

--- a/code/src/test/pcgen/persistence/lst/prereq/PreLanguageParserTest.java
+++ b/code/src/test/pcgen/persistence/lst/prereq/PreLanguageParserTest.java
@@ -18,7 +18,7 @@
  */
 package pcgen.persistence.lst.prereq;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import pcgen.EnUsLocaleDependentTestCase;
 import pcgen.core.prereq.Prerequisite;

--- a/code/src/test/pcgen/persistence/lst/prereq/PreMoveParserTest.java
+++ b/code/src/test/pcgen/persistence/lst/prereq/PreMoveParserTest.java
@@ -5,7 +5,7 @@
  */
 package pcgen.persistence.lst.prereq;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import pcgen.EnUsLocaleDependentTestCase;
 import pcgen.core.prereq.Prerequisite;

--- a/code/src/test/pcgen/persistence/lst/prereq/PreMultParserTest.java
+++ b/code/src/test/pcgen/persistence/lst/prereq/PreMultParserTest.java
@@ -24,9 +24,10 @@ import static org.junit.jupiter.api.Assertions.fail;
 import pcgen.EnUsLocaleDependentTestCase;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.persistence.PersistenceLayerException;
-import pcgen.util.TestHelper;
+import pcgen.test.PCGenTestEnvironment;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.Test;
 import plugin.pretokens.parser.PreMultParser;
 
@@ -34,13 +35,13 @@ import plugin.pretokens.parser.PreMultParser;
 	 * [PREARMORPROF:1,TYPE.Medium],[PREFEAT:1,Armor Proficiency (Medium)]
  */
 @SuppressWarnings("nls")
+@ExtendWith(PCGenTestEnvironment.class)
 class PreMultParserTest extends EnUsLocaleDependentTestCase
 {
 
 	@BeforeEach
 	void setUp()
 	{
-		TestHelper.loadPlugins();
 	}
 
 	@Test

--- a/code/src/test/pcgen/persistence/lst/prereq/PreParserFactoryTest.java
+++ b/code/src/test/pcgen/persistence/lst/prereq/PreParserFactoryTest.java
@@ -18,7 +18,7 @@
  */
 package pcgen.persistence.lst.prereq;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Locale;
 

--- a/code/src/test/pcgen/persistence/lst/prereq/PreStatParserTest.java
+++ b/code/src/test/pcgen/persistence/lst/prereq/PreStatParserTest.java
@@ -23,20 +23,21 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import pcgen.EnUsLocaleDependentTestCase;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.persistence.PersistenceLayerException;
-import pcgen.util.TestHelper;
+import pcgen.test.PCGenTestEnvironment;
 import plugin.pretokens.parser.PreStatParser;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.Test;
 
 
+@ExtendWith(PCGenTestEnvironment.class)
 class PreStatParserTest extends EnUsLocaleDependentTestCase
 {
 
 	@BeforeEach
 	void setUp()
 	{
-		TestHelper.loadPlugins();
 	}
 
 	

--- a/code/src/test/pcgen/util/TestHelper.java
+++ b/code/src/test/pcgen/util/TestHelper.java
@@ -156,23 +156,6 @@ public final class TestHelper
 	}
 
 	/**
-	 * No-op: plugin loading runs once via the static initializer. The method
-	 * is retained because many test classes invoke it explicitly to document
-	 * their dependency on plugins being loaded.
-	 */
-	/**
-	 * @deprecated Plugins are now loaded automatically once per JVM by the
-	 * {@code PCGenTestEnvironment} JUnit 5 extension (auto-discovered via
-	 * {@code META-INF/services}). Existing call sites can simply delete the
-	 * call; this stub is kept only to avoid touching every test in one
-	 * patch.
-	 */
-	@Deprecated
-	public static void loadPlugins()
-	{
-	}
-
-	/**
 	 * Get the field related to a name
 	 * @param aClass The class to search for the field
 	 * @param fieldName the field to search for

--- a/code/src/test/pcgen/util/TestHelper.java
+++ b/code/src/test/pcgen/util/TestHelper.java
@@ -55,7 +55,6 @@ import pcgen.core.spell.Spell;
 import pcgen.io.ExportHandler;
 import pcgen.persistence.CampaignFileLoader;
 import pcgen.persistence.GameModeFileLoader;
-import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.AbilityLoader;
 import pcgen.persistence.lst.CampaignSourceEntry;
 import pcgen.persistence.lst.GenericLoader;
@@ -68,13 +67,10 @@ import pcgen.system.PCGenTask;
 import pcgen.system.PropertyContextFactory;
 import plugin.lsttokens.testsupport.BuildUtilities;
 
-import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.lang.reflect.Field;
@@ -159,7 +155,7 @@ public final class TestHelper
 	 * @param cls The class the try is for.
 	 * @return The CampaignSourceEntry.
 	 */
-	public static CampaignSourceEntry createSource(Class cls)
+	public static CampaignSourceEntry createSource(Class<?> cls)
 	{
 		final CampaignSourceEntry source;
 		try
@@ -206,7 +202,7 @@ public final class TestHelper
 						return f;
 					}
 				}
-				if (!"Object".equals(clazz.getName()))
+				if (clazz != Object.class)
 				{
 					clazz = clazz.getSuperclass();
 				} else
@@ -455,7 +451,8 @@ public final class TestHelper
 	/**
 	 * Checks to see if this PC has the weapon proficiency key aKey
 	 *
-	 * @param aKey
+	 * @param pc the PlayerCharacter to check
+	 * @param aKey the WeaponProf key to look up
 	 * @return boolean
 	 */
 	public static boolean hasWeaponProfKeyed(PlayerCharacter pc,
@@ -479,13 +476,11 @@ public final class TestHelper
 		// Read in config.ini and override the pcc location if it exists
 		try (var lines = Files.lines(Path.of("config.ini")))
 		{
-			var pccFilesPath = lines
+			return lines
 					.filter(line -> line.startsWith("pccFilesPath="))
 					.map(line -> line.substring(13))
 					.findFirst()
 					.orElse(pccLoc);
-
-			return pccFilesPath;
 		} catch (IOException e)
 		{
 			// Ignore, see method comment
@@ -511,7 +506,7 @@ public final class TestHelper
 			bw.write("settingsPath=" + configFolder + "\r\n");
 			if (pccLoc != null)
 			{
-				LOG.info("Using PCC Location of '" + pccLoc + "'.");
+				LOG.log(Level.INFO, "Using PCC Location of ''{0}''.", pccLoc);
 				bw.write("pccFilesPath=" + pccLoc + "\r\n");
 			}
 			bw.write("customPath=testsuite\\\\customdata\r\n");
@@ -522,7 +517,7 @@ public final class TestHelper
 	{
 		String configFolder = "testsuite";
 		String pccLoc = TestHelper.findDataFolder();
-		LOG.info("Got data folder of " + pccLoc);
+		LOG.log(Level.INFO, "Got data folder of {0}", pccLoc);
 		try
 		{
 			TestHelper.createDummySettingsFile(testConfigFile, configFolder,
@@ -562,7 +557,7 @@ public final class TestHelper
 	}
 
 	public static PCClass parsePCClassText(String classPCCText,
-										   CampaignSourceEntry source) throws PersistenceLayerException
+										   CampaignSourceEntry source)
 	{
 		PCClassLoader pcClassLoader = new PCClassLoader();
 		PCClass reconstClass = null;
@@ -572,7 +567,7 @@ public final class TestHelper
 			String line = tok.nextToken();
 			if (!StringUtils.isBlank(line))
 			{
-				LOG.info("Processing line:'" + line + "'.");
+				LOG.log(Level.INFO, "Processing line:''{0}''.", line);
 				reconstClass =
 						pcClassLoader.parseLine(Globals.getContext(),
 								reconstClass, line, source);

--- a/code/src/test/pcgen/util/TestHelper.java
+++ b/code/src/test/pcgen/util/TestHelper.java
@@ -21,7 +21,6 @@
 package pcgen.util;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.SystemUtils;
 import pcgen.base.lang.UnreachableError;
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.enumeration.ListKey;
@@ -53,18 +52,13 @@ import pcgen.core.bonus.Bonus;
 import pcgen.core.bonus.BonusObj;
 import pcgen.core.spell.Spell;
 import pcgen.io.ExportHandler;
-import pcgen.persistence.CampaignFileLoader;
 import pcgen.persistence.GameModeFileLoader;
-import pcgen.persistence.lst.AbilityLoader;
 import pcgen.persistence.lst.CampaignSourceEntry;
 import pcgen.persistence.lst.GenericLoader;
 import pcgen.persistence.lst.LstObjectFileLoader;
 import pcgen.persistence.lst.PCClassLoader;
 import pcgen.rules.context.LoadContext;
-import pcgen.system.ConfigurationSettings;
 import pcgen.system.Main;
-import pcgen.system.PCGenTask;
-import pcgen.system.PropertyContextFactory;
 import plugin.lsttokens.testsupport.BuildUtilities;
 
 import java.io.BufferedWriter;
@@ -97,8 +91,6 @@ public final class TestHelper
 	}
 
 	private static final LstObjectFileLoader<Equipment> eqLoader = new GenericLoader<>(Equipment.class);
-	private static final LstObjectFileLoader<Ability> abLoader = new AbilityLoader();
-	private static CampaignSourceEntry source;
 
 	private TestHelper()
 	{
@@ -283,53 +275,6 @@ public final class TestHelper
 		return anAbility;
 	}
 
-	/**
-	 * Make an ability
-	 *
-	 * @param input the Ability source string to parse and create the ability from
-	 * @return true if OK
-	 */
-	public static boolean makeAbilityFromString(final String input)
-	{
-		try
-		{
-			if (source == null)
-			{
-				try
-				{
-					source = new CampaignSourceEntry(new Campaign(),
-							new URI("file:/" + TestHelper.class.getName() + ".java"));
-				} catch (URISyntaxException e)
-				{
-					throw new UnreachableError(e);
-				}
-			}
-
-			abLoader.parseLine(Globals.getContext(), null, input, source);
-			return true;
-		} catch (Exception e)
-		{
-			Logging.errorPrint(e.getLocalizedMessage());
-		}
-		return false;
-	}
-
-
-	/**
-	 * Set the important info about a WeaponProf
-	 * @param name The weaponprof name
-	 * @param type The type info ("." separated)
-	 * @return The weapon prof (which has also been added to global storage
-	 */
-	public static WeaponProf makeWeaponProf(final String name, final String type)
-	{
-		final WeaponProf aWpnProf = new WeaponProf();
-		aWpnProf.setName(name);
-		aWpnProf.put(StringKey.KEY_NAME, ("KEY_" + name));
-		addType(aWpnProf, type);
-		Globals.getContext().getReferenceContext().importObject(aWpnProf);
-		return aWpnProf;
-	}
 
 	/**
 	 * Set the important info about a Race
@@ -511,33 +456,6 @@ public final class TestHelper
 			}
 			bw.write("customPath=testsuite\\\\customdata\r\n");
 		}
-	}
-
-	public static void loadGameModes(String testConfigFile)
-	{
-		String configFolder = "testsuite";
-		String pccLoc = TestHelper.findDataFolder();
-		LOG.log(Level.INFO, "Got data folder of {0}", pccLoc);
-		try
-		{
-			TestHelper.createDummySettingsFile(testConfigFile, configFolder,
-					pccLoc);
-		} catch (IOException e)
-		{
-			Logging.errorPrint("DataTest.loadGameModes failed", e);
-		}
-
-		PropertyContextFactory configFactory =
-				new PropertyContextFactory(SystemUtils.USER_DIR);
-		configFactory.registerAndLoadPropertyContext(ConfigurationSettings
-				.getInstance(testConfigFile));
-		Main.loadProperties(false);
-		PCGenTask loadPluginTask = Main.createLoadPluginTask();
-		loadPluginTask.run();
-		GameModeFileLoader gameModeFileLoader = new GameModeFileLoader();
-		gameModeFileLoader.run();
-		CampaignFileLoader campaignFileLoader = new CampaignFileLoader();
-		campaignFileLoader.run();
 	}
 
 	public static ChronicleEntry buildChronicleEntry(boolean visible, String campaign, String date,

--- a/code/src/test/pcgen/util/TestHelper.java
+++ b/code/src/test/pcgen/util/TestHelper.java
@@ -58,7 +58,6 @@ import pcgen.persistence.lst.GenericLoader;
 import pcgen.persistence.lst.LstObjectFileLoader;
 import pcgen.persistence.lst.PCClassLoader;
 import pcgen.rules.context.LoadContext;
-import pcgen.system.Main;
 import plugin.lsttokens.testsupport.BuildUtilities;
 
 import java.io.BufferedWriter;
@@ -84,11 +83,6 @@ import java.util.logging.Level;
 public final class TestHelper
 {
 	private static final Logger LOG = Logger.getLogger(TestHelper.class.getName());
-
-	static
-	{
-		Main.createLoadPluginTask().run();
-	}
 
 	private static final LstObjectFileLoader<Equipment> eqLoader = new GenericLoader<>(Equipment.class);
 
@@ -166,11 +160,16 @@ public final class TestHelper
 	 * is retained because many test classes invoke it explicitly to document
 	 * their dependency on plugins being loaded.
 	 */
+	/**
+	 * @deprecated Plugins are now loaded automatically once per JVM by the
+	 * {@code PCGenTestEnvironment} JUnit 5 extension (auto-discovered via
+	 * {@code META-INF/services}). Existing call sites can simply delete the
+	 * call; this stub is kept only to avoid touching every test in one
+	 * patch.
+	 */
+	@Deprecated
 	public static void loadPlugins()
 	{
-		// Intentionally empty. Calling this method is enough — the call
-		// references TestHelper, which triggers the class's static
-		// initializer (where the actual plugin load happens).
 	}
 
 	/**

--- a/code/src/test/pcgen/util/TestHelper.java
+++ b/code/src/test/pcgen/util/TestHelper.java
@@ -95,7 +95,11 @@ public final class TestHelper
 {
 	private static final Logger LOG = Logger.getLogger(TestHelper.class.getName());
 
-	private static boolean loaded = false;
+	static
+	{
+		Main.createLoadPluginTask().run();
+	}
+
 	private static final LstObjectFileLoader<Equipment> eqLoader = new GenericLoader<>(Equipment.class);
 	private static final LstObjectFileLoader<Ability> abLoader = new AbilityLoader();
 	private static CampaignSourceEntry source;
@@ -138,7 +142,6 @@ public final class TestHelper
 	 */
 	public static boolean makeEquipment(final String input)
 	{
-		loadPlugins();
 		try
 		{
 			final CampaignSourceEntry source = createSource(TestHelper.class);
@@ -171,15 +174,15 @@ public final class TestHelper
 	}
 
 	/**
-	 * Load the plugins
+	 * No-op: plugin loading runs once via the static initializer. The method
+	 * is retained because many test classes invoke it explicitly to document
+	 * their dependency on plugins being loaded.
 	 */
 	public static void loadPlugins()
 	{
-		if (!loaded)
-		{
-			pcgen.system.Main.createLoadPluginTask().run();
-			loaded = true;
-		}
+		// Intentionally empty. Calling this method is enough — the call
+		// references TestHelper, which triggers the class's static
+		// initializer (where the actual plugin load happens).
 	}
 
 	/**
@@ -292,8 +295,6 @@ public final class TestHelper
 	 */
 	public static boolean makeAbilityFromString(final String input)
 	{
-		loadPlugins();
-
 		try
 		{
 			if (source == null)

--- a/code/src/test/plugin/exporttokens/AttackTokenTest.java
+++ b/code/src/test/plugin/exporttokens/AttackTokenTest.java
@@ -17,7 +17,7 @@
  */
 package plugin.exporttokens;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.base.FormulaFactory;
@@ -80,12 +80,11 @@ public class AttackTokenTest extends AbstractCharacterTestCase
 	@Test
 	public void testBase()
 	{
-		assertEquals("Total melee attack no bonus", "+2", new AttackToken()
-			.getToken("ATTACK.MELEE.TOTAL", getCharacter(), null));
+		assertEquals("+2", new AttackToken()
+			.getToken("ATTACK.MELEE.TOTAL", getCharacter(), null), "Total melee attack no bonus");
 
-		assertEquals("Total melee attack no bonus short", "+2",
-			new AttackToken().getToken("ATTACK.MELEE.TOTAL.SHORT",
-				getCharacter(), null));
+		assertEquals("+2", new AttackToken().getToken("ATTACK.MELEE.TOTAL.SHORT",
+				getCharacter(), null), "Total melee attack no bonus short");
 	}
 
 	/**
@@ -97,12 +96,11 @@ public class AttackTokenTest extends AbstractCharacterTestCase
 		getCharacter().incrementClassLevel(1, myClass, true);
 		getCharacter().calcActiveBonuses();
 
-		assertEquals("Total melee attack no bonus", "+8/+3", new AttackToken()
-			.getToken("ATTACK.MELEE.TOTAL", getCharacter(), null));
+		assertEquals("+8/+3", new AttackToken()
+			.getToken("ATTACK.MELEE.TOTAL", getCharacter(), null), "Total melee attack no bonus");
 
-		assertEquals("Total melee attack no bonus short", "+8",
-			new AttackToken().getToken("ATTACK.MELEE.TOTAL.SHORT",
-				getCharacter(), null));
+		assertEquals("+8", new AttackToken().getToken("ATTACK.MELEE.TOTAL.SHORT",
+				getCharacter(), null), "Total melee attack no bonus short");
 	}
 
 }

--- a/code/src/test/plugin/exporttokens/CampaignHistoryTokenTest.java
+++ b/code/src/test/plugin/exporttokens/CampaignHistoryTokenTest.java
@@ -17,7 +17,7 @@
  */
 package plugin.exporttokens;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static pcgen.util.TestHelper.evaluateToken;
 
 import java.io.IOException;
@@ -69,25 +69,16 @@ public class CampaignHistoryTokenTest  extends AbstractCharacterTestCase
 	{
 		FileAccess.setCurrentOutputFilter("xml");
 		PlayerCharacter character = getCharacter();
-		assertEquals("Field Campaign", visibleEntry.getCampaign(),
-			evaluateToken("CAMPAIGNHISTORY.0.CAMPAIGN", character));
-		assertEquals("Field ADVENTURE", visibleEntry.getAdventure(),
-			evaluateToken("CAMPAIGNHISTORY.0.ADVENture", character));
-		assertEquals("Field PARTY", visibleEntry.getParty(),
-			evaluateToken("CAMPAIGNHISTORY.0.PARTY", character));
-		assertEquals("Field DATE", visibleEntry.getDate(),
-			evaluateToken("CAMPAIGNHISTORY.0.DATE", character));
-		assertEquals("Field XP", visibleEntry.getXpField(),
-			Integer.parseInt(evaluateToken("CAMPAIGNHISTORY.0.XP", character)));
-		assertEquals("Field GM", visibleEntry.getGmField(),
-			evaluateToken("CAMPAIGNHISTORY.0.GM", character));
-		assertEquals("Field Text", visibleEntry.getChronicle(),
-			evaluateToken("CAMPAIGNHISTORY.0.TEXT", character));
-		assertEquals("Default field", visibleEntry.getChronicle(),
-			evaluateToken("CAMPAIGNHISTORY.0", character));
+		assertEquals(visibleEntry.getCampaign(), evaluateToken("CAMPAIGNHISTORY.0.CAMPAIGN", character), "Field Campaign");
+		assertEquals(visibleEntry.getAdventure(), evaluateToken("CAMPAIGNHISTORY.0.ADVENture", character), "Field ADVENTURE");
+		assertEquals(visibleEntry.getParty(), evaluateToken("CAMPAIGNHISTORY.0.PARTY", character), "Field PARTY");
+		assertEquals(visibleEntry.getDate(), evaluateToken("CAMPAIGNHISTORY.0.DATE", character), "Field DATE");
+		assertEquals(visibleEntry.getXpField(), Integer.parseInt(evaluateToken("CAMPAIGNHISTORY.0.XP", character)), "Field XP");
+		assertEquals(visibleEntry.getGmField(), evaluateToken("CAMPAIGNHISTORY.0.GM", character), "Field GM");
+		assertEquals(visibleEntry.getChronicle(), evaluateToken("CAMPAIGNHISTORY.0.TEXT", character), "Field Text");
+		assertEquals(visibleEntry.getChronicle(), evaluateToken("CAMPAIGNHISTORY.0", character), "Default field");
 
-		assertEquals("Invalid field", "",
-			evaluateToken("CAMPAIGNHISTORY.0.LALALA", character));
+		assertEquals("", evaluateToken("CAMPAIGNHISTORY.0.LALALA", character), "Invalid field");
 	}
 
 
@@ -96,27 +87,18 @@ public class CampaignHistoryTokenTest  extends AbstractCharacterTestCase
 	{
 		FileAccess.setCurrentOutputFilter("xml");
 		PlayerCharacter character = getCharacter();
-		assertEquals("Default visibility", visibleEntry.getAdventure(),
-			evaluateToken("CAMPAIGNHISTORY.0.ADVENTURE", character));
-		assertEquals("Default visibility", "",
-			evaluateToken("CAMPAIGNHISTORY.1.ADVENTURE", character));
+		assertEquals(visibleEntry.getAdventure(), evaluateToken("CAMPAIGNHISTORY.0.ADVENTURE", character), "Default visibility");
+		assertEquals("", evaluateToken("CAMPAIGNHISTORY.1.ADVENTURE", character), "Default visibility");
 
-		assertEquals("Hidden visibility", hiddenEntry.getAdventure(),
-			evaluateToken("CAMPAIGNHISTORY.HIDDEN.0.ADVENTURE", character));
-		assertEquals("Hidden visibility", "",
-			evaluateToken("CAMPAIGNHISTORY.HIDDEN.1.ADVENTURE", character));
+		assertEquals(hiddenEntry.getAdventure(), evaluateToken("CAMPAIGNHISTORY.HIDDEN.0.ADVENTURE", character), "Hidden visibility");
+		assertEquals("", evaluateToken("CAMPAIGNHISTORY.HIDDEN.1.ADVENTURE", character), "Hidden visibility");
 
-		assertEquals("All visibility", visibleEntry.getAdventure(),
-			evaluateToken("CAMPAIGNHISTORY.ALL.0.ADVENTURE", character));
-		assertEquals("All visibility", hiddenEntry.getAdventure(),
-			evaluateToken("CAMPAIGNHISTORY.ALL.1.ADVENTURE", character));
+		assertEquals(visibleEntry.getAdventure(), evaluateToken("CAMPAIGNHISTORY.ALL.0.ADVENTURE", character), "All visibility");
+		assertEquals(hiddenEntry.getAdventure(), evaluateToken("CAMPAIGNHISTORY.ALL.1.ADVENTURE", character), "All visibility");
 
-		assertEquals("Visible visibility", visibleEntry.getAdventure(),
-			evaluateToken("CAMPAIGNHISTORY.VISIBLE.0.ADVENTURE", character));
-		assertEquals("Visible visibility", "",
-			evaluateToken("CAMPAIGNHISTORY.VISIBLE.1.ADVENTURE", character));
+		assertEquals(visibleEntry.getAdventure(), evaluateToken("CAMPAIGNHISTORY.VISIBLE.0.ADVENTURE", character), "Visible visibility");
+		assertEquals("", evaluateToken("CAMPAIGNHISTORY.VISIBLE.1.ADVENTURE", character), "Visible visibility");
 
-		assertEquals("Invalid visibility", "",
-			evaluateToken("CAMPAIGNHISTORY.LALALA.0.ADVENTURE", character));
+		assertEquals("", evaluateToken("CAMPAIGNHISTORY.LALALA.0.ADVENTURE", character), "Invalid visibility");
 	}
 }

--- a/code/src/test/plugin/exporttokens/SkillSitTokenTest.java
+++ b/code/src/test/plugin/exporttokens/SkillSitTokenTest.java
@@ -17,7 +17,7 @@
  */
 package plugin.exporttokens;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.base.FormulaFactory;
@@ -176,69 +176,68 @@ public class SkillSitTokenTest extends AbstractCharacterTestCase
 		SkillSitToken token = new SkillSitToken();
 
 		// First test each sub token
-		assertEquals("SkillToken", "Balance", token.getToken("SKILLSIT.0",
-			character, null));
-		assertEquals("SkillToken", "DEX", token.getToken("SKILLSIT.0.ABILITY",
-			character, null));
-		assertEquals("SkillToken", "9", token.getToken("SKILLSIT.0.TOTAL",
-				character, null));
-		assertEquals("SkillToken", "3", token.getToken("SKILLSIT.0.ABMOD",
-			character, null));
-		assertEquals("SkillToken", "4.0", token.getToken("SKILLSIT.0.RANK",
-			character, null));
-		assertEquals("SkillToken", "2", token.getToken("SKILLSIT.0.MISC",
-			character, null));
-		assertEquals("SkillToken", "N", token.getToken("SKILLSIT.0.EXCLUSIVE",
-			character, null));
-		assertEquals("SkillToken", "Y", token.getToken("SKILLSIT.0.UNTRAINED",
-			character, null));
-		assertEquals("SkillToken", "9", token.getToken(
-			"SKILLSIT.0.EXCLUSIVE_TOTAL", character, null));
-		assertEquals("SkillToken", "9", token.getToken("SKILLSIT.0.TRAINED_TOTAL",
-			character, null));
-		assertEquals("SkillToken", "+2[TUMBLE|Balance] +3[STAT]", token.getToken(
-			"SKILLSIT.0.EXPLAIN", character, null));
+		assertEquals("Balance", token.getToken("SKILLSIT.0",
+			character, null), "SkillToken");
+		assertEquals("DEX", token.getToken("SKILLSIT.0.ABILITY",
+			character, null), "SkillToken");
+		assertEquals("9", token.getToken("SKILLSIT.0.TOTAL",
+				character, null), "SkillToken");
+		assertEquals("3", token.getToken("SKILLSIT.0.ABMOD",
+			character, null), "SkillToken");
+		assertEquals("4.0", token.getToken("SKILLSIT.0.RANK",
+			character, null), "SkillToken");
+		assertEquals("2", token.getToken("SKILLSIT.0.MISC",
+			character, null), "SkillToken");
+		assertEquals("N", token.getToken("SKILLSIT.0.EXCLUSIVE",
+			character, null), "SkillToken");
+		assertEquals("Y", token.getToken("SKILLSIT.0.UNTRAINED",
+			character, null), "SkillToken");
+		assertEquals("9", token.getToken(
+			"SKILLSIT.0.EXCLUSIVE_TOTAL", character, null), "SkillToken");
+		assertEquals("9", token.getToken("SKILLSIT.0.TRAINED_TOTAL",
+			character, null), "SkillToken");
+		assertEquals("+2[TUMBLE|Balance] +3[STAT]", token.getToken(
+			"SKILLSIT.0.EXPLAIN", character, null), "SkillToken");
 
 		// Test the indexed retrieval
-		assertEquals("SkillToken", "Balance (On a Ball)", token.getToken("SKILLSIT.1",
-			character, null));
-		assertEquals("SkillToken", "DEX", token.getToken("SKILLSIT.1.ABILITY",
-			character, null));
-		assertEquals("SkillToken", "11", token.getToken("SKILLSIT.1.TOTAL",
-				character, null));
-		assertEquals("SkillToken", "3", token.getToken("SKILLSIT.1.ABMOD",
-			character, null));
-		assertEquals("SkillToken", "4.0", token.getToken("SKILLSIT.1.RANK",
-			character, null));
-		assertEquals("SkillToken", "4", token.getToken("SKILLSIT.1.MISC",
-			character, null));
-		assertEquals("SkillToken", "N", token.getToken("SKILLSIT.1.EXCLUSIVE",
-			character, null));
-		assertEquals("SkillToken", "Y", token.getToken("SKILLSIT.1.UNTRAINED",
-			character, null));
-		assertEquals("SkillToken", "11", token.getToken(
-			"SKILLSIT.1.EXCLUSIVE_TOTAL", character, null));
-		assertEquals("SkillToken", "11", token.getToken("SKILLSIT.1.TRAINED_TOTAL",
-			character, null));
-		assertEquals("SkillToken", "+2[TUMBLE|Balance] +3[STAT] situational: +2[KNOWLEDGE (RELIGION)]", token.getToken(
-			"SKILLSIT.1.EXPLAIN", character, null));
+		assertEquals("Balance (On a Ball)", token.getToken("SKILLSIT.1",
+			character, null), "SkillToken");
+		assertEquals("DEX", token.getToken("SKILLSIT.1.ABILITY",
+			character, null), "SkillToken");
+		assertEquals("11", token.getToken("SKILLSIT.1.TOTAL",
+				character, null), "SkillToken");
+		assertEquals("3", token.getToken("SKILLSIT.1.ABMOD",
+			character, null), "SkillToken");
+		assertEquals("4.0", token.getToken("SKILLSIT.1.RANK",
+			character, null), "SkillToken");
+		assertEquals("4", token.getToken("SKILLSIT.1.MISC",
+			character, null), "SkillToken");
+		assertEquals("N", token.getToken("SKILLSIT.1.EXCLUSIVE",
+			character, null), "SkillToken");
+		assertEquals("Y", token.getToken("SKILLSIT.1.UNTRAINED",
+			character, null), "SkillToken");
+		assertEquals("11", token.getToken(
+			"SKILLSIT.1.EXCLUSIVE_TOTAL", character, null), "SkillToken");
+		assertEquals("11", token.getToken("SKILLSIT.1.TRAINED_TOTAL",
+			character, null), "SkillToken");
+		assertEquals("+2[TUMBLE|Balance] +3[STAT] situational: +2[KNOWLEDGE (RELIGION)]", token.getToken(
+			"SKILLSIT.1.EXPLAIN", character, null), "SkillToken");
 
 		
-		assertEquals("SkillToken", "KNOWLEDGE (ARCANA)", token.getToken("SKILLSIT.2",
-			character, null));
-		assertEquals("SkillToken", "KNOWLEDGE (RELIGION)", token.getToken("SKILLSIT.3",
-			character, null));
-		assertEquals("SkillToken", "Tumble", token.getToken("SKILLSIT.4",
-			character, null));
+		assertEquals("KNOWLEDGE (ARCANA)", token.getToken("SKILLSIT.2",
+			character, null), "SkillToken");
+		assertEquals("KNOWLEDGE (RELIGION)", token.getToken("SKILLSIT.3",
+			character, null), "SkillToken");
+		assertEquals("Tumble", token.getToken("SKILLSIT.4",
+			character, null), "SkillToken");
 		//Alphabetical!
-		assertEquals("SkillToken", "Tumble (On Hot Concrete)", token.getToken("SKILLSIT.5",
-			character, null));
+		assertEquals("Tumble (On Hot Concrete)", token.getToken("SKILLSIT.5",
+			character, null), "SkillToken");
 
 		// Test the named retrieval
-		assertEquals("SkillToken", "Tumble", token.getToken("SKILLSIT.TUMBLE",
-			character, null));
-		assertEquals("SkillToken", "Tumble (On Hot Concrete)",
-			token.getToken("SKILLSIT.TUMBLE=On Hot Concrete", character, null));
+		assertEquals("Tumble", token.getToken("SKILLSIT.TUMBLE",
+			character, null), "SkillToken");
+		assertEquals("Tumble (On Hot Concrete)", token.getToken("SKILLSIT.TUMBLE=On Hot Concrete", character, null), "SkillToken");
 	}
 
 	@Override

--- a/code/src/test/plugin/exporttokens/SkillTokenTest.java
+++ b/code/src/test/plugin/exporttokens/SkillTokenTest.java
@@ -17,7 +17,7 @@
  */
 package plugin.exporttokens;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.base.FormulaFactory;
@@ -168,36 +168,36 @@ public class SkillTokenTest extends AbstractCharacterTestCase
 		SkillToken token = new SkillToken();
 
 		// First test each sub token
-		assertEquals("SkillToken", "Balance", token.getToken("SKILL.0",
-			character, null));
-		assertEquals("SkillToken", "DEX", token.getToken("SKILL.0.ABILITY",
-			character, null));
-		assertEquals("SkillToken", "9", token.getToken("SKILL.0.TOTAL",
-				character, null));
-		assertEquals("SkillToken", "3", token.getToken("SKILL.0.ABMOD",
-			character, null));
-		assertEquals("SkillToken", "4.0", token.getToken("SKILL.0.RANK",
-			character, null));
-		assertEquals("SkillToken", "2", token.getToken("SKILL.0.MISC",
-			character, null));
-		assertEquals("SkillToken", "N", token.getToken("SKILL.0.EXCLUSIVE",
-			character, null));
-		assertEquals("SkillToken", "Y", token.getToken("SKILL.0.UNTRAINED",
-			character, null));
-		assertEquals("SkillToken", "9", token.getToken(
-			"SKILL.0.EXCLUSIVE_TOTAL", character, null));
-		assertEquals("SkillToken", "9", token.getToken("SKILL.0.TRAINED_TOTAL",
-			character, null));
-		assertEquals("SkillToken", "+2[TUMBLE|Balance] +3[STAT]", token.getToken(
-			"SKILL.0.EXPLAIN", character, null));
+		assertEquals("Balance", token.getToken("SKILL.0",
+			character, null), "SkillToken");
+		assertEquals("DEX", token.getToken("SKILL.0.ABILITY",
+			character, null), "SkillToken");
+		assertEquals("9", token.getToken("SKILL.0.TOTAL",
+				character, null), "SkillToken");
+		assertEquals("3", token.getToken("SKILL.0.ABMOD",
+			character, null), "SkillToken");
+		assertEquals("4.0", token.getToken("SKILL.0.RANK",
+			character, null), "SkillToken");
+		assertEquals("2", token.getToken("SKILL.0.MISC",
+			character, null), "SkillToken");
+		assertEquals("N", token.getToken("SKILL.0.EXCLUSIVE",
+			character, null), "SkillToken");
+		assertEquals("Y", token.getToken("SKILL.0.UNTRAINED",
+			character, null), "SkillToken");
+		assertEquals("9", token.getToken(
+			"SKILL.0.EXCLUSIVE_TOTAL", character, null), "SkillToken");
+		assertEquals("9", token.getToken("SKILL.0.TRAINED_TOTAL",
+			character, null), "SkillToken");
+		assertEquals("+2[TUMBLE|Balance] +3[STAT]", token.getToken(
+			"SKILL.0.EXPLAIN", character, null), "SkillToken");
 
 		// Test the indexed retrieval
-		assertEquals("SkillToken", "Tumble", token.getToken("SKILL.3",
-			character, null));
+		assertEquals("Tumble", token.getToken("SKILL.3",
+			character, null), "SkillToken");
 
 		// Test the named retrieval
-		assertEquals("SkillToken", "Tumble", token.getToken("SKILL.TUMBLE",
-			character, null));
+		assertEquals("Tumble", token.getToken("SKILL.TUMBLE",
+			character, null), "SkillToken");
 	}
 
 	/**
@@ -211,8 +211,8 @@ public class SkillTokenTest extends AbstractCharacterTestCase
 		SkillToken token = new SkillLevelToken();
 
 		// First test each sub token
-		assertEquals("SKILLLEVEL.1.TOTAL", "6", token.getToken(
-			"SKILLLEVEL.1.TOTAL", character, null));
+		assertEquals("6", token.getToken(
+			"SKILLLEVEL.1.TOTAL", character, null), "SKILLLEVEL.1.TOTAL");
 	}
 
 	/**
@@ -226,10 +226,10 @@ public class SkillTokenTest extends AbstractCharacterTestCase
 		SkillToken token = new SkillSubsetToken();
 
 		// First test each sub token
-		assertEquals("SkillSubsetToken", "KNOWLEDGE (RELIGION)", token
-			.getToken("SKILLSUBSET.1.KNOWLEDGE.NAME", character, null));
-		assertEquals("SkillSubsetToken", "8.0", token.getToken(
-			"SKILLSUBSET.0.KNOWLEDGE.RANK", character, null));
+		assertEquals("KNOWLEDGE (RELIGION)", token
+			.getToken("SKILLSUBSET.1.KNOWLEDGE.NAME", character, null), "SkillSubsetToken");
+		assertEquals("8.0", token.getToken(
+			"SKILLSUBSET.0.KNOWLEDGE.RANK", character, null), "SkillSubsetToken");
 	}
 
 	/**
@@ -243,10 +243,10 @@ public class SkillTokenTest extends AbstractCharacterTestCase
 		SkillToken token = new SkillTypeToken();
 
 		// First test each sub token
-		assertEquals("SkillTypeToken", "Balance", token.getToken(
-			"SKILLTYPE.0.DEX.NAME", character, null));
-		assertEquals("SkillTypeToken", "10", token.getToken(
-			"SKILLTYPE.1.DEX.TOTAL", character, null));
+		assertEquals("Balance", token.getToken(
+			"SKILLTYPE.0.DEX.NAME", character, null), "SkillTypeToken");
+		assertEquals("10", token.getToken(
+			"SKILLTYPE.1.DEX.TOTAL", character, null), "SkillTypeToken");
 	}
 
 	@Override

--- a/code/src/test/plugin/exporttokens/SpellListTokenTest.java
+++ b/code/src/test/plugin/exporttokens/SpellListTokenTest.java
@@ -17,7 +17,7 @@
  */
 package plugin.exporttokens;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -126,10 +126,10 @@ public class SpellListTokenTest extends AbstractCharacterTestCase
 
 		SpellListBookToken token = new SpellListBookToken();
 		// TODO: These don't work yet, so skip them to avoid false errors.
-//		assertEquals("SpellListBookToken(1lv TA)", "", token.getToken(
-//			"SPELLLISTBOOK.0.1", character, null));
-//		assertEquals("SpellListBookToken(1lv TD)", "TestDivine", token
-//			.getToken("SPELLLISTBOOK.1.1", character, null));
+//		assertEquals("", token.getToken(
+//			"SPELLLISTBOOK.0.1", character, null), "SpellListBookToken(1lv TA)");
+//		assertEquals("TestDivine", token
+//			.getToken("SPELLLISTBOOK.1.1", character, null), "SpellListBookToken(1lv TD)");
 	}
 
 	/**
@@ -146,8 +146,8 @@ public class SpellListTokenTest extends AbstractCharacterTestCase
 		character.incrementClassLevel(1, arcaneClass, true);
 
 		SpellListCastToken token = new SpellListCastToken();
-		assertEquals("testSpellListCastToken(1lv TA)", "2", token.getToken(
-			"SPELLLISTCAST.0.1", character, null));
+		assertEquals("2", token.getToken(
+			"SPELLLISTCAST.0.1", character, null), "testSpellListCastToken(1lv TA)");
 	}
 
 	/**
@@ -163,10 +163,10 @@ public class SpellListTokenTest extends AbstractCharacterTestCase
 		character.incrementClassLevel(1, divineClass, true);
 
 		SpellListClassToken token = new SpellListClassToken();
-		assertEquals("testSpellListClassToken(1lv TA)", "TestArcane", token
-			.getToken("SPELLLISTCLASS.0", character, null));
-		assertEquals("testSpellListClassToken(1lv TD)", "TestDivine", token
-			.getToken("SPELLLISTCLASS.1", character, null));
+		assertEquals("TestArcane", token
+			.getToken("SPELLLISTCLASS.0", character, null), "testSpellListClassToken(1lv TA)");
+		assertEquals("TestDivine", token
+			.getToken("SPELLLISTCLASS.1", character, null), "testSpellListClassToken(1lv TD)");
 	}
 
 	/**
@@ -182,10 +182,10 @@ public class SpellListTokenTest extends AbstractCharacterTestCase
 		character.incrementClassLevel(1, divineClass, true);
 
 		SpellListDcStatToken token = new SpellListDcStatToken();
-		assertEquals("testSpellListDcStatToken(1lv TA)", "CHA", token.getToken(
-			"SPELLLISTDCSTAT.0.1", character, null));
-		assertEquals("testSpellListDcStatToken(1lv TD)", "WIS", token.getToken(
-			"SPELLLISTDCSTAT.1.1", character, null));
+		assertEquals("CHA", token.getToken(
+			"SPELLLISTDCSTAT.0.1", character, null), "testSpellListDcStatToken(1lv TA)");
+		assertEquals("WIS", token.getToken(
+			"SPELLLISTDCSTAT.1.1", character, null), "testSpellListDcStatToken(1lv TD)");
 	}
 
 	/**
@@ -203,10 +203,10 @@ public class SpellListTokenTest extends AbstractCharacterTestCase
 		character.calcActiveBonuses();
 
 		SpellListDcToken token = new SpellListDcToken();
-		assertEquals("SpellListDcToken(1lv TA)", "12", token.getToken(
-			"SPELLLISTDC.0.0", character, null));
-		assertEquals("SpellListDcToken(1lv TA)", "15", token.getToken(
-			"SPELLLISTDC.0.3", character, null));
+		assertEquals("12", token.getToken(
+			"SPELLLISTDC.0.0", character, null), "SpellListDcToken(1lv TA)");
+		assertEquals("15", token.getToken(
+			"SPELLLISTDC.0.3", character, null), "SpellListDcToken(1lv TA)");
 	}
 
 	/**
@@ -233,9 +233,9 @@ public class SpellListTokenTest extends AbstractCharacterTestCase
 		character.incrementClassLevel(1, divineClass, true);
 
 		SpellListTypeToken token = new SpellListTypeToken();
-		assertEquals("testSpellListTypeToken(1lv TA)", "Arcane", token
-			.getToken("SPELLLISTTYPE.0.1", character, null));
-		assertEquals("testSpellListTypeToken(1lv TD)", "Divine", token
-			.getToken("SPELLLISTTYPE.1.1", character, null));
+		assertEquals("Arcane", token
+			.getToken("SPELLLISTTYPE.0.1", character, null), "testSpellListTypeToken(1lv TA)");
+		assertEquals("Divine", token
+			.getToken("SPELLLISTTYPE.1.1", character, null), "testSpellListTypeToken(1lv TD)");
 	}
 }

--- a/code/src/test/plugin/jepcommands/CountCommandTest.java
+++ b/code/src/test/plugin/jepcommands/CountCommandTest.java
@@ -19,7 +19,7 @@ package plugin.jepcommands;
 
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.enumeration.ObjectKey;

--- a/code/src/test/plugin/jepcommands/CountDistinctCommandTest.java
+++ b/code/src/test/plugin/jepcommands/CountDistinctCommandTest.java
@@ -19,7 +19,7 @@ package plugin.jepcommands;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.closeTo;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import pcgen.AbstractCharacterTestCase;
 import pcgen.cdom.enumeration.ObjectKey;

--- a/code/src/testResources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/code/src/testResources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+pcgen.test.PCGenTestEnvironment

--- a/code/src/testResources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/code/src/testResources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,1 +1,0 @@
-pcgen.test.PCGenTestEnvironment

--- a/code/src/testResources/junit-platform.properties
+++ b/code/src/testResources/junit-platform.properties
@@ -1,0 +1,4 @@
+# Auto-detect JUnit 5 extensions registered via
+# META-INF/services/org.junit.jupiter.api.extension.Extension.
+# Used by PCGenTestEnvironment to install plugin loading once per JVM.
+junit.jupiter.extensions.autodetection.enabled=true

--- a/code/src/testResources/junit-platform.properties
+++ b/code/src/testResources/junit-platform.properties
@@ -1,4 +1,0 @@
-# Auto-detect JUnit 5 extensions registered via
-# META-INF/services/org.junit.jupiter.api.extension.Extension.
-# Used by PCGenTestEnvironment to install plugin loading once per JVM.
-junit.jupiter.extensions.autodetection.enabled=true

--- a/code/src/testcommon/pcgen/test/PCGenTestEnvironment.java
+++ b/code/src/testcommon/pcgen/test/PCGenTestEnvironment.java
@@ -15,9 +15,8 @@ import pcgen.system.Main;
 
 /**
  * JUnit 5 extension that loads PCGen plugins exactly once per JVM, before
- * any test class that opts in runs. Replaces the lazy
- * {@code TestHelper.loadPlugins()} pattern: opted-in test classes no
- * longer need to remember to call it from their setup hooks.
+ * any test class that opts in runs. Replaces the boilerplate of every
+ * test having to remember to load plugins from its setup hook.
  *
  * <p>This is opt-in (NOT auto-discovered). Plugin loading populates the
  * global {@code PluginFunctionLibrary}, which any newly constructed

--- a/code/src/testcommon/pcgen/test/PCGenTestEnvironment.java
+++ b/code/src/testcommon/pcgen/test/PCGenTestEnvironment.java
@@ -47,7 +47,7 @@ public final class PCGenTestEnvironment implements BeforeAllCallback
 	public void beforeAll(ExtensionContext context)
 	{
 		// getRoot() ensures one entry across the whole JVM, not one per test class.
-		context.getRoot().getStore(NAMESPACE).getOrComputeIfAbsent(LOADED_KEY, k -> {
+		context.getRoot().getStore(NAMESPACE).computeIfAbsent(LOADED_KEY, k -> {
 			Main.createLoadPluginTask().run();
 			return Boolean.TRUE;
 		});

--- a/code/src/testcommon/pcgen/test/PCGenTestEnvironment.java
+++ b/code/src/testcommon/pcgen/test/PCGenTestEnvironment.java
@@ -15,18 +15,28 @@ import pcgen.system.Main;
 
 /**
  * JUnit 5 extension that loads PCGen plugins exactly once per JVM, before
- * any test class runs. Replaces the lazy {@code TestHelper.loadPlugins()}
- * pattern: tests no longer need to remember to call it.
+ * any test class that opts in runs. Replaces the lazy
+ * {@code TestHelper.loadPlugins()} pattern: opted-in test classes no
+ * longer need to remember to call it from their setup hooks.
  *
- * <p>Auto-registered via
- * {@code META-INF/services/org.junit.jupiter.api.extension.Extension}
- * combined with {@code junit.jupiter.extensions.autodetection.enabled=true}.
+ * <p>This is opt-in (NOT auto-discovered). Plugin loading populates the
+ * global {@code PluginFunctionLibrary}, which any newly constructed
+ * {@code VariableContext} reads from at construction time — so tests
+ * that build a {@code VariableContext} expecting an empty function
+ * library (e.g. {@code SetSolverManagerTest}) must NOT have plugins
+ * loaded. Per-class opt-in keeps that boundary explicit.
+ *
+ * <p>Usage: annotate the test class with
+ * {@code @ExtendWith(PCGenTestEnvironment.class)}. Most test classes
+ * inherit this from {@code AbstractCharacterTestCase} or
+ * {@code AbstractJunit5CharacterTestCase} and don't need to add it
+ * themselves.
  *
  * <p>This extension does NOT call {@link Main#loadProperties} or run
- * GameModeFileLoader / CampaignFileLoader — those need a settings file that
- * most tests don't provide. Tests that load real game data (DataTest,
- * DataLoadTest) still drive that sequence themselves; everything else
- * just needs plugins registered with the various factories.
+ * GameModeFileLoader / CampaignFileLoader — those need a settings file
+ * that most tests don't provide. Tests that load real game data
+ * (DataTest, DataLoadTest) drive that sequence themselves; everything
+ * else just needs plugins registered with the various factories.
  */
 public final class PCGenTestEnvironment implements BeforeAllCallback
 {

--- a/code/src/testcommon/pcgen/test/PCGenTestEnvironment.java
+++ b/code/src/testcommon/pcgen/test/PCGenTestEnvironment.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 the PCGen Project. Author: Vest <Vest@users.noreply.github.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+package pcgen.test;
+
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import pcgen.system.Main;
+
+/**
+ * JUnit 5 extension that loads PCGen plugins exactly once per JVM, before
+ * any test class runs. Replaces the lazy {@code TestHelper.loadPlugins()}
+ * pattern: tests no longer need to remember to call it.
+ *
+ * <p>Auto-registered via
+ * {@code META-INF/services/org.junit.jupiter.api.extension.Extension}
+ * combined with {@code junit.jupiter.extensions.autodetection.enabled=true}.
+ *
+ * <p>This extension does NOT call {@link Main#loadProperties} or run
+ * GameModeFileLoader / CampaignFileLoader — those need a settings file that
+ * most tests don't provide. Tests that load real game data (DataTest,
+ * DataLoadTest) still drive that sequence themselves; everything else
+ * just needs plugins registered with the various factories.
+ */
+public final class PCGenTestEnvironment implements BeforeAllCallback
+{
+	private static final ExtensionContext.Namespace NAMESPACE =
+			ExtensionContext.Namespace.create(PCGenTestEnvironment.class);
+	private static final String LOADED_KEY = "plugins-loaded";
+
+	@Override
+	public void beforeAll(ExtensionContext context)
+	{
+		// getRoot() ensures one entry across the whole JVM, not one per test class.
+		context.getRoot().getStore(NAMESPACE).getOrComputeIfAbsent(LOADED_KEY, k -> {
+			Main.createLoadPluginTask().run();
+			return Boolean.TRUE;
+		});
+	}
+}

--- a/code/src/utest/pcgen/cdom/base/FormulaFactoryTest.java
+++ b/code/src/utest/pcgen/cdom/base/FormulaFactoryTest.java
@@ -1,6 +1,6 @@
 package pcgen.cdom.base;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import pcgen.base.format.ArrayFormatManager;
 import pcgen.base.formatmanager.FormatUtilities;

--- a/code/src/utest/pcgen/persistence/RecursiveFileFinderTest.java
+++ b/code/src/utest/pcgen/persistence/RecursiveFileFinderTest.java
@@ -8,7 +8,7 @@ import java.util.List;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import pcgen.system.ConfigurationSettings;
 
 public class RecursiveFileFinderTest {

--- a/code/src/utest/plugin/lsttokens/FollowersLstTest.java
+++ b/code/src/utest/plugin/lsttokens/FollowersLstTest.java
@@ -18,7 +18,7 @@
 package plugin.lsttokens;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.list.CompanionList;

--- a/code/src/utest/plugin/lsttokens/VisionLstTest.java
+++ b/code/src/utest/plugin/lsttokens/VisionLstTest.java
@@ -18,7 +18,7 @@
 package plugin.lsttokens;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URISyntaxException;
 


### PR DESCRIPTION
## Summary

Replace the manual `TestHelper.loadPlugins()` boilerplate with a proper JUnit 5 lifecycle hook. Originally tried a static initializer (early commits on this branch); that turned out to load plugins at JVM class-load time, **before** test setup — which broke `:datatest` (settings-file race) and `:test` (TestFX tearDown trying deep reflection without `--add-opens`). Rewrote using a `BeforeAllCallback` extension instead. Also keeps the orthogonal cleanups from the original PR: dead-method removal and `parsePCClassText` deduplication.

The PR also finishes the long-pending JUnit 4 → 6 migration (last three commits) — the `getOrComputeIfAbsent` deprecation warning that surfaced while building this branch is what kicked it off.

**OK to squash**, but the commit history is split into logical groups if reviewers prefer to keep them.

### 1. JUnit 5 extension (`PCGenTestEnvironment`)

- New `code/src/testcommon/pcgen/test/PCGenTestEnvironment.java` — a `BeforeAllCallback` that runs `Main.createLoadPluginTask().run()` exactly once per JVM, keyed via `ExtensionContext.Store.GLOBAL`.
- **Opt-in** via `@ExtendWith(PCGenTestEnvironment.class)`, NOT auto-discovered. Auto-discovery would force plugin loading on tests like `SetSolverManagerTest.setUp` that explicitly assume an empty `PluginFunctionLibrary` (its `addFunction(getOther)` collides with the entry that plugin loading puts in the singleton). The original `loadPlugins()` was opt-in too — each test that wanted plugins called it explicitly. The annotation preserves that boundary while removing the boilerplate.
- Applied to `AbstractCharacterTestCase` and `AbstractJunit5CharacterTestCase`. The annotation propagates to ~114 subclasses automatically.
- Applied directly to the 10 standalone test classes that previously called `TestHelper.loadPlugins()`.
- `TestHelper.loadPlugins()` and the static initializer that briefly replaced it are both deleted. No call sites remain.

### 2. `Main.runBootstrapTasks()`

The 4-step bootstrap sequence (`createLoadPluginTask` → `GameModeFileLoader` → `CampaignFileLoader`, run via `PCGenTaskExecutor`) was duplicated verbatim in `startupWithGUI()`, `startupWithoutGUI()`, **and** open-coded twice more in `DataTest.loadGameModes()` / `DataLoadTest.loadGameModes()`. Pulled into one `Main.runBootstrapTasks(PCGenTaskListener…)` helper. All four call sites now use it. Eliminates the risk of one of them drifting out of order — the bug we just hit when the static-initializer attempt loaded plugins before `Main.loadProperties()`.

### 3. TestFX/JavaFX 25 fix

Separately, `:test` was crashing with `InaccessibleObjectException: module javafx.graphics does not "opens" com.sun.javafx.application` from TestFX's `cleanupParameters` (which uses `setAccessible(true)` on a private static field). The existing `--add-exports` flag in `build.gradle:684` wasn't enough — `setAccessible` needs `--add-opens`. Changed `--add-exports` → `--add-opens` for `com.sun.javafx.application`. The other three `--add-exports` flags in the JVM-arg block stay as-is (they're for Monocle and JavaFX logging, which only need export-level access).

### 4. `--stacktrace` on every CI gradle invocation

Costs nothing on green builds (only fires on failure). This session needed two separate diagnostic commits — one for the TestFX `InaccessibleObjectException`, one for the static-initializer-induced JVM exit — purely because Gradle's default output for a crashed test JVM is `non-zero exit value 1` with no further detail, plus a hint to use `--stacktrace`. Make that the next step happen automatically.

### 5. Original cleanup work (kept from earlier in the PR)

These were done before the static-initializer attempt and are unrelated to it. Worth keeping:

- **Dead-method removal in `TestHelper`**: `makeAbilityFromString`, `makeWeaponProf`, `loadGameModes(String)` — zero callers anywhere in the tree, last real users removed years ago (2014, 2009, 2018 respectively). Recoverable from git via `git log -S` if anyone needs them.
- **`parsePCClassText` dedup**: `PCClassTest` and `AddClassSkillsTest` carried near-identical 17-line copies. Both now route through the canonical `TestHelper.parsePCClassText`. -62/+5 lines net.
- **IDE-flagged warnings**: 4 unused imports, an unthrown `throws`, raw-type → parameterized `Class<?>`, string-based class-walk replaced by identity compare, redundant local inlined, parameterized log calls, missing Javadoc filled in.

### 6. JUnit 4 → 6 migration (final three commits)

The BOM was already on `org.junit:junit-bom:6.1.0`, but several pieces of test scaffolding still referenced JUnit 3/4 APIs. The build comment claiming "~870 legacy tests" was stale by years — actual count of pure-JUnit-4 files at the start of this work was 1, plus 86 hybrid files using `org.junit.Assert.*` static imports.

- **Deprecated APIs in test scaffolding** (`aca6bc17a5`): `ExtensionContext.Store#getOrComputeIfAbsent` was deprecated in JUnit 6.0 in favor of `#computeIfAbsent` (mirrors `java.util.Map`) — `PCGenTestEnvironment` swapped over. `AbstractFormulaTestCase` and `TestUtilities` dropped `junit.framework.TestCase.fail` for Jupiter `Assertions.fail`. `RecursiveFileFinderTest` swapped `org.junit.Test` for the Jupiter `@Test`.

- **Bulk `Assert` → `Assertions` rewrite** (`efeb5e11a5`): 86 files, 1054 message-arg position swaps. JUnit 4's `assertEquals(message, expected, actual)` becomes Jupiter's `assertEquals(expected, actual, message)`. The trap is that mass-rewriting the imports alone would compile cleanly because Jupiter's `assertEquals(Object, Object, String)` overload silently matches the old shape with `message` interpreted as `expected` and vice versa — every failure message would be wrong, but the test class would still pass when assertions hold. The script (paren-balanced parser, top-level comma split) only swaps when the first arg is a string literal and the arity matches the JUnit-4 leading-message shape (3+ for `assertEquals`/`assertSame`/`assertNotSame`/`assertArrayEquals`, 2 for the rest). Nine cases where the leading message was a `+`-concatenation expression rather than a literal were caught by the compiler (the `assertTrue(BooleanSupplier, ...)` overload doesn't accept a String first arg) and fixed by hand in `PreRaceTest` and `EquipmentSetFacadeImplTest`.

- **Drop the dead deps** (`ac6034694c`): `junit:junit:4.13.2` and `junit-vintage-engine` come out of both `build.gradle` files. Stale comment removed.

## Test plan

- [x] `./gradlew :test :itest :datatest :slowtest` — all four green locally before the JUnit 6 commits (`:slowtest` ~11 min, others a couple minutes total).
- [x] Reviewed the test-result XMLs under `build/test-results/{test,itest,datatest,slowtest}/` — no failures, no errors, no skipped tests beyond the existing baseline.
- [x] After the JUnit 6 commits: `compileTestJava`, `compileSlowtestJava`, `compileItestJava` all clean; `:test`, `:itest`, and a representative `:slowtest` set (`StatListTest`, `PrereqHandlerTest`, `PObjectTest`, `PreRaceTest`) green.
- [ ] Full `:slowtest` and `:datatest` re-run after the JUnit 6 commits — the migration is mechanical but worth confirming end-to-end.
- [ ] CI green on this PR's `Build PCGen with Gradle` workflow.