### PR TITLE
Fix jpackage app crash from missing requires java.logging in merged module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ import org.apache.tools.ant.filters.FixCrLfFilter
 import org.apache.tools.ant.taskdefs.condition.Os
 
 import de.undercouch.gradle.tasks.download.Download
+import org.beryx.jlink.data.JdepsUsage
 
 /**
  * Plugins without versions are ones that are bundled with Gradle at the version
@@ -310,9 +311,14 @@ jlink {
                'freemarker', 'argparse4j', 'xmlunit', 'controlsfx',
                'annotations', 'spotbugs', 'xmlresolver')
 
+    // Resolve packages → modules with the JDK's jdeps; the plugin's default
+    // resolver silently misses JDK modules on some distros (e.g. Temurin 25).
+    useJdeps.set(JdepsUsage.exclusively)
+
     mergedModule {
         additive = true
-        // List only modules NOT auto-derived by jlink — duplicates fail compilation (jlink plugin >= 4.0.1).
+        // jdeps already derives the JDK modules our merged jars reference;
+        // list only modules it cannot derive (loaded reflectively / via SPI).
         requires 'java.naming'
         requires 'java.scripting'
         requires 'java.management'


### PR DESCRIPTION
## Summary

- Switch the `org.beryx.jlink` plugin to use the JDK's own `jdeps` tool (`useJdeps = 'exclusively'`) when synthesizing `module-info.java` for the merged module, instead of the plugin's built-in package→module resolver.
- Fixes a silent runtime failure where `PcGen.app` crashes at startup on macOS when built with certain JDK distributions.

## The bug

When the app was built with Temurin 25 on macOS, launching the bundle failed before `main()` ran:

```
Exception in thread "main" java.lang.IllegalAccessError:
  class freemarker.log._JULLoggerFactory (in module net.sourceforge.pcgen.merged.module)
  cannot access class java.util.logging.Logger (in module java.logging)
  because module net.sourceforge.pcgen.merged.module does not read module java.logging
    at .../freemarker.log._JULLoggerFactory.getLogger
    at .../freemarker.template.Configuration.<clinit>
    at pcgen.io.ExportUtilities.getObjectWrapper
    at pcgen.system.PCGenPropBundle.<clinit>
    at pcgen.system.CommandLineArguments.getParser
    at pcgen.system.Main.<clinit>
Failed to launch JVM
```

## Root cause

With the default `useJdeps = 'no'`, the jlink plugin uses its own resolver to map packages to modules. On Temurin 25 the resolver silently fails to find JDK modules — the `createMergedModule` log shows:

```
Cannot find module exporting java.logging (used by the merged module)
Cannot find module exporting java.io ...
Cannot find module exporting java.lang ...
Cannot find module exporting java.util ...
Cannot find module exporting java.util.regex (required by spring-core-7.0.7.jar)
...
```

Those messages are only logged at `info` level; the build keeps going and writes `module-info.java` for `net.sourceforge.pcgen.merged.module` with the missing `requires` directives elided. At runtime freemarker's `_JULLoggerFactory` then can't access `java.util.logging.Logger`.

SapMachine 25 happens to resolve those packages correctly, which is why the same source built fine on some machines and produced a broken bundle on others.

## Fix

Use `jdeps` (`useJdeps = 'exclusively'`). It ships with every conforming JDK 9+, reads the JDK's actual `jrt:` filesystem, and reliably maps packages → modules across vendors (Temurin, SapMachine, Liberica, Zulu, Corretto, Oracle).

After the fix, `javap` on the merged module shows the previously missing requires:

```
open module net.sourceforge.pcgen.merged.module {
  requires java.logging;
  requires java.sql;
  requires java.prefs;
  requires java.xml;
  requires java.desktop;
  requires jdk.jfr;
  requires jdk.unsupported;
  requires jdk.xml.dom;
  requires java.compiler;
  ...
}
```

If `jdeps` ever fails on a future JDK, `'exclusively'` makes the build fail loudly at `createMergedModule` instead of silently producing a broken app.

### Why not just list the missing modules in `mergedModule { ... }`?

The plugin appends user-supplied `requires` verbatim after the auto-derived ones with no dedup. On JDKs where derivation succeeds, listing `java.logging` again would cause `javac` to reject the synthesized `module-info.java` with duplicate-requires errors. The pre-existing comment ("List only modules NOT auto-derived by jlink — duplicates fail compilation") was preserving that constraint. `useJdeps = 'exclusively'` removes the dependency on the homegrown probe entirely, which is the durable fix.

## Test plan

- [x] `./gradlew createMergedModule` — succeeds; merged jar contains `requires java.logging` (verified with `javap`).
- [x] `./gradlew jpackageImage` — succeeds, no warnings about missing modules.
- [x] `build/jpackage/PcGen.app/Contents/MacOS/PcGen --help` — runs to completion, exits 0 (previously crashed at `PCGenPropBundle.<clinit>`).
- [ ] CI build green on Linux / Windows / macOS.
- [ ] Confirm fix on the originally affected setup (Temurin 25 / macOS).