### PR TITLE
Remove unused GMGen randomname i18n keys

### DIFF
--- a/code/src/resources/pcgen/lang/LanguageBundle.properties
+++ b/code/src/resources/pcgen/lang/LanguageBundle.properties
@@ -2952,9 +2952,6 @@ in_plugin_overland_scaleConverter=Scale Converter
 in_plugin_overland_total=Total: 
 in_plugin_overland_travelTime=Travel Time
 
-in_plugin_randomname_name=Random Name
-in_mn_plugin_randomname_name=R
-
 in_plugin_encounter_name=Encounter
 in_mn_plugin_encounter_name=E
 in_plugin_encounter_targetEL=Target EL

--- a/code/src/resources/pcgen/lang/LanguageBundle_es.properties
+++ b/code/src/resources/pcgen/lang/LanguageBundle_es.properties
@@ -2941,9 +2941,6 @@ in_plugin_overland_scaleConverter=Conversor de Escala
 in_plugin_overland_total=Total:
 in_plugin_overland_travelTime=Tiempo de Viaje
 
-in_plugin_randomname_name=Generador de Nombres
-in_mn_plugin_randomname_name=A
-
 in_plugin_encounter_name=Crear Encuentros
 in_mn_plugin_encounter_name=E
 in_plugin_encounter_targetEL=Target EL

--- a/code/src/resources/pcgen/lang/LanguageBundle_fr.properties
+++ b/code/src/resources/pcgen/lang/LanguageBundle_fr.properties
@@ -2863,9 +2863,6 @@ in_plugin_overland_scaleConverter=Convertisseur d’échelle
 in_plugin_overland_total=Total : 
 in_plugin_overland_travelTime=Temps de trajet
 
-in_plugin_randomname_name=Générateur de nom
-in_mn_plugin_randomname_name=n
-
 in_plugin_encounter_name=Rencontre
 in_mn_plugin_encounter_name=e
 in_plugin_encounter_targetEL=NR cible

--- a/code/src/resources/pcgen/lang/LanguageBundle_it.properties
+++ b/code/src/resources/pcgen/lang/LanguageBundle_it.properties
@@ -2690,9 +2690,6 @@ in_plugin_overland_scaleConverter=Convertitore di Scala
 in_plugin_overland_total=Totale: 
 in_plugin_overland_travelTime=Tempo di Viaggio
 
-in_plugin_randomname_name=Nome Casuale
-in_mn_plugin_randomname_name=N
-
 in_plugin_network_name=Rete
 in_mn_plugin_network_name=t
 

--- a/code/src/testResources/pcgen/lang/cleaned.properties
+++ b/code/src/testResources/pcgen/lang/cleaned.properties
@@ -2670,9 +2670,6 @@ in_lstConvErrorsFound=Caution! {0} errors were found in the data being converted
 # Mnemonic for in_plugin_overland_name
 
 
-in_plugin_randomname_name=Random Name
-in_mn_plugin_randomname_name=R
-
 
 #CoreView Labels
 in_mnuToolsCoreView = View Character Hierarchy


### PR DESCRIPTION
## Summary

Delete two i18n keys that became dead weight after #7566:

- `in_plugin_randomname_name` — *"Random Name"* / *"Generador de Nombres"* / etc.
- `in_mn_plugin_randomname_name` — single-letter mnemonic.

Both were only ever referenced from `plugin/doomsdaybook/RandomNamePlugin.java`, the GMGen plugin wrapper that advertised the "Random Names" tab name and mnemonic to GMGen's plugin host:

```java
private static final String IN_NAME    = "in_plugin_randomname_name";
private static final String IN_NAME_MN = "in_mn_plugin_randomname_name";
...
LanguageBundle.getString(RandomNamePlugin.IN_NAME);
LanguageBundle.getMnemonic(RandomNamePlugin.IN_NAME_MN);
```

#7566 (*Random-name dialog: rewrite from Swing to JavaFX*) deleted that wrapper as its first commit ("Remove dead RandomNamePlugin GMGen wrapper"). The live path is now `RandomNameDialog` → `RandomNamePanelController` + `RandomNamePanel.fxml` in core — no plugin tab label, no plugin-style mnemonic, no replacement key needed.

The `_plugin_` namespace was specific to GMGen plugin self-identification; core dialogs don't follow that convention.

## Verification

- `code/src/test/pcgen/gui2/ScanForUnusedIl8nKeysTest` flagged the keys as unused after #7566 (visible in the `cleaned.properties` / `unused.properties` snapshots that drift on the working tree after the rewrite).
- Manual grep across `*.java`, `*.fxml`, `*.lst`, and other `*.properties` (excluding the bundle files themselves and the test snapshots): no references.
- Removed from the four locale bundles that still carried them — `LanguageBundle.properties` (en), `_es`, `_fr`, `_it`. `_de`, `_ja`, `_pt` already lacked them.
- Regenerated `cleaned.properties` via `./gradlew slowtest --tests pcgen.gui2.ScanForUnusedIl8nKeysTest`. `unused.properties` is unchanged because the keys are now simply absent from the source bundle.

## Test plan

- [x] `slowtest --tests pcgen.gui2.ScanForUnusedIl8nKeysTest` passes; snapshots up to date.
- [x] Random-name dialog still functional (manually opened from the Summary tab).
- [ ] CI green on master merge.