### PR TITLE
Build cleanup: distribution / plugins / release.gradle drive-by fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -368,6 +368,21 @@ jlink {
 // Package up other files with the main program after jpackage creates the image
 tasks.named("jpackageImage") {
     dependsOn tasks.named("jlink")
+
+    // Finder lazily writes .DS_Store into directories it has previewed; if one
+    // appears under build/jpackage between the plugin listing the dir and
+    // recursively deleting it, the rmtree fails with "New files were found".
+    // Sweep them out first.
+    def jpackageDir = layout.buildDirectory.dir("jpackage")
+    doFirst {
+        def root = jpackageDir.get().asFile.toPath()
+        if (java.nio.file.Files.exists(root)) {
+            java.nio.file.Files.walk(root).withCloseable { stream ->
+                stream.filter { it.fileName.toString() == ".DS_Store" }
+                      .forEach { java.nio.file.Files.deleteIfExists(it) }
+            }
+        }
+    }
 }
 
 tasks.named("jlink") {

--- a/code/gradle/distribution.gradle
+++ b/code/gradle/distribution.gradle
@@ -102,7 +102,13 @@ tasks.named("run") {
 tasks.named("installDist") {
     def installLibDir = layout.buildDirectory.dir("install/pcgen/lib")
     doLast {
-        installLibDir.get().asFile.listFiles()?.findAll { it.name.startsWith('javafx-') }?.each { it.delete() }
+        def libDir = installLibDir.get().asFile
+        def javafxLibs = libDir.listFiles({ File f -> f.name.startsWith("javafx-") } as java.io.FileFilter)
+        javafxLibs?.each { f ->
+            if (!f.delete()) {
+                throw new GradleException("Failed to delete ${f}")
+            }
+        }
     }
 }
 

--- a/code/gradle/distribution.gradle
+++ b/code/gradle/distribution.gradle
@@ -97,7 +97,9 @@ tasks.named("installDist") {
     def installLibDir = layout.buildDirectory.dir("install/pcgen/lib")
     doLast {
         def libDir = installLibDir.get().asFile
-        def javafxLibs = libDir.listFiles({ File f -> f.name.startsWith("javafx-") } as java.io.FileFilter)
+        def javafxLibs = libDir.listFiles({ File f ->
+            f.name.startsWith("javafx-") || f.name.startsWith("javafx.")
+        } as java.io.FileFilter)
         javafxLibs?.each { f ->
             if (!f.delete()) {
                 throw new GradleException("Failed to delete ${f}")

--- a/code/gradle/distribution.gradle
+++ b/code/gradle/distribution.gradle
@@ -48,12 +48,6 @@ ext {
         }
         from('code') {
             include 'LICENSE'
-
-            eachFile { file ->
-                if(file.getName().endsWith(".sh")) {
-                    file.setMode(0755)
-                }
-            }
         }
     }
 

--- a/code/gradle/plugins.gradle
+++ b/code/gradle/plugins.gradle
@@ -19,7 +19,7 @@ def createJarTask = {taskName, archiveName, description, includePattern ->
     tasks.register(taskName, Jar) {
         this.description = description
         group = PLUGINS_GROUP
-        dependsOn tasks.named("compileJava")
+        dependsOn tasks.named("classes")
 
         archiveFileName = archiveName
         manifest {

--- a/code/gradle/release.gradle
+++ b/code/gradle/release.gradle
@@ -20,7 +20,6 @@
  */
 
 apply from: "code/gradle/releaseUtils.groovy"
-apply plugin: 'java'
 
 ext {
     // Work out the path to the release notes for our current version.

--- a/code/src/java/plugin/exporttokens/manifest.mf
+++ b/code/src/java/plugin/exporttokens/manifest.mf
@@ -1,1 +1,0 @@
-Class-Path: lib/pcgen.jar

--- a/code/src/java/plugin/lsttokens/manifest.mf
+++ b/code/src/java/plugin/lsttokens/manifest.mf
@@ -1,1 +1,0 @@
-Class-Path: lib/pcgen.jar


### PR DESCRIPTION
## Summary

Seven small, independent cleanups to the Gradle build files. Each commit stands alone and was verified with `./gradlew installDist` and `./gradlew jpackageImage`.

- **distribution.gradle** — `installDist`'s JavaFX cleanup now throws on delete failure instead of silently swallowing it (and is config-cache safe: uses `File.listFiles` + `java.io.FileFilter` instead of `project.delete(fileTree(...))` at execution time).
- **distribution.gradle** — also delete dot-named JavaFX jars (`javafx.graphics.jar`) in addition to the dash-named Maven form (`javafx-graphics-*.jar`). The application plugin emits the dot form, so the previous filter never matched.
- **distribution.gradle** — drop the dead `.sh` chmod hook in `programScriptImage`. The `eachFile { setMode 0755 }` block targeted shell scripts, but the `from('code')` spec only includes `LICENSE`. The block was unreachable and used the deprecated `setMode` API.
- **plugins.gradle** — depend on the `classes` aggregator instead of `compileJava` so resource processing is also wired in.
- **release.gradle** — drop redundant `apply plugin: 'java'`. The application plugin (already applied) transitively applies java.
- **build.gradle** — sweep `.DS_Store` files before `jpackageImage` runs its `rmtree` of `build/jpackage`. macOS Finder lazily writes `.DS_Store` into previewed directories; if one appears between the plugin listing the dir and recursively deleting it, the rmtree fails with \"New files were found\".
- Removed two orphan `manifest.mf` fragments under `code/src/java/plugin/` that contained only `Class-Path: lib/pcgen.jar` and weren't referenced from any task.

## Notes

- This is cleanup-only. It does **not** include the freemarker `IllegalAccessError` fix on packaged apps under JEP 493 / Temurin 25 — that lives in #7583.
- Overlap with #7583: if #7583 merges first, this branch needs a rebase. Specifically, `code/gradle/plugins.gradle` — keep #7583's typed `createJarTask` parameters (`String taskName, String archiveName, ...`) when resolving the conflict; the typed form is strictly an improvement.

## Test plan

- [x] `./gradlew clean installDist` succeeds; resulting `build/install/pcgen/lib/` contains no `javafx-*` or `javafx.*` jars
- [x] `./gradlew jpackageImage` succeeds, including a planted `.DS_Store` under `build/jpackage/` to prove the doFirst sweep
- [x] `./gradlew jarAllPlugins` produces the eleven plugin jars under `plugins/`
- [ ] CI green