### PR TITLE
Build/test cleanup: drop duplicated test JVM args, refresh stale Javadoc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -697,19 +697,18 @@ tasks.named("test", Test) {
     useJUnitPlatform()
     maxParallelForks = parallelTestForks
     // TestFX/Monocle setup — only the unit test source set has TestFX-based tests.
+    // Other JavaFX/Monocle args (testfx.*, prism.order, --add-exports for
+    // com.sun.javafx.util / com.sun.javafx.logging, --add-opens for
+    // com.sun.glass.ui) are applied to every Test by the
+    // tasks.withType(Test).configureEach block below; only the
+    // com.sun.javafx.application open is unique here, since withType
+    // has --add-exports (not --add-opens) for that package.
     jvmArgs += [
-            '-Dtestfx.robot=glass',
-            '-Dtestfx.headless=true',
-            '-Dprism.order=sw',
             // Workaround for TestFX modularity issue. https://github.com/TestFX/TestFX/issues/638
             // --add-opens (not --add-exports) is required: TestFX's @AfterEach cleanup
             // does setAccessible(true) on a private field of ParametersImpl, which is
             // deep reflection — exports alone aren't enough.
             '--add-opens', 'javafx.graphics/com.sun.javafx.application=ALL-UNNAMED',
-            // Required for Monocle.
-            '--add-exports', 'javafx.graphics/com.sun.javafx.util=ALL-UNNAMED',
-            '--add-exports', 'javafx.base/com.sun.javafx.logging=ALL-UNNAMED',
-            '--add-opens', 'javafx.graphics/com.sun.glass.ui=ALL-UNNAMED',
     ]
 }
 

--- a/code/src/test/plugin/PluginBuildTest.java
+++ b/code/src/test/plugin/PluginBuildTest.java
@@ -39,9 +39,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * {@code PluginBuildTest} verifies that the pluginbuild.xml file has all
- * required data. As a result this unit test is a bit different in structure to
- * a normal test.
+ * {@code PluginBuildTest} verifies that every plugin source file under
+ * {@code code/src/java/plugin/<category>/} is packaged into the matching
+ * {@code <category>plugins.jar} produced by {@code code/gradle/plugins.gradle}.
+ * As a result this unit test is a bit different in structure to a normal test.
  */
 class PluginBuildTest
 {


### PR DESCRIPTION
## Summary

- **build.gradle**: drop six duplicated JVM args from the `tasks.named("test", Test)` block — they are already applied to every Test by the `tasks.withType(Test).configureEach` block (`-Dtestfx.robot=glass`, `-Dtestfx.headless=true`, `-Dprism.order=sw`, `--add-exports` for `javafx.graphics/com.sun.javafx.util` and `javafx.base/com.sun.javafx.logging`, `--add-opens javafx.graphics/com.sun.glass.ui`). Each was landing on the test JVM command line twice. Kept `--add-opens javafx.graphics/com.sun.javafx.application` because `withType` has `--add-exports` (not `--add-opens`) for that package, and TestFX's `@AfterEach` cleanup uses `setAccessible(true)` deep reflection on `ParametersImpl`.
- **PluginBuildTest.java**: refresh stale class Javadoc — it still referenced the deleted Ant `pluginbuild.xml`. Updated to describe what the test actually does (every `plugin/<category>/` source file is packaged into the matching `<category>plugins.jar`).

## Test plan

- [x] `./gradlew help` — build script parses
- [x] `./gradlew compileTestJava` — clean compile
- [x] `./gradlew :test --tests pcgen.gui3.dialog.AboutDialogTest` — TestFX test still passes (confirms the kept `--add-opens` is sufficient for ParametersImpl deep reflection)