### PR TITLE
Fix #7338: SEVERE log on shutdown when skill table re-sorts after close

### DIFF
--- a/code/src/java/pcgen/gui2/facade/CharacterLevelsFacadeImpl.java
+++ b/code/src/java/pcgen/gui2/facade/CharacterLevelsFacadeImpl.java
@@ -66,6 +66,16 @@ import org.jetbrains.annotations.Nullable;
 public class CharacterLevelsFacadeImpl extends AbstractListFacade<CharacterLevelFacade>
 		implements CharacterLevelsFacade, DataFacetChangeListener<CharID, Skill>, BonusChangeListener
 {
+	/**
+	 * After {@link #closeCharacter()}, {@code theCharacter} is set to this
+	 * placeholder rather than {@code null} so UI events that fire mid-teardown
+	 * (e.g. row re-sort triggered by DelegatingDataSet.detachDelegates) can
+	 * read empty-but-valid state instead of NPE-ing or producing SEVERE log
+	 * noise from downstream null-guards. Mirrors the same pattern in
+	 * {@link CharacterFacadeImpl}.
+	 */
+	private static final PlayerCharacter CLOSED_PC = new PlayerCharacter();
+
 	private PlayerCharacter theCharacter;
 	private CharacterDisplay charDisplay;
 
@@ -110,7 +120,7 @@ public class CharacterLevelsFacadeImpl extends AbstractListFacade<CharacterLevel
 		{
 			bcf.removeBonusChangeListener(this, "SKILLRANK", skillFacade.getKeyName().toUpperCase());
 		}
-		theCharacter = null;
+		theCharacter = CLOSED_PC;
 		charDisplay = null;
 		charID = null;
 	}

--- a/code/src/test/pcgen/gui2/facade/CharacterLevelsFacadeImplTest.java
+++ b/code/src/test/pcgen/gui2/facade/CharacterLevelsFacadeImplTest.java
@@ -20,10 +20,17 @@ package pcgen.gui2.facade;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 
 import pcgen.AbstractJunit5CharacterTestCase;
 import pcgen.cdom.enumeration.ObjectKey;
@@ -39,6 +46,7 @@ import pcgen.core.Skill;
 import pcgen.core.XPTable;
 import pcgen.core.pclevelinfo.PCLevelInfo;
 import pcgen.facade.core.CharacterLevelFacade;
+import pcgen.facade.core.CharacterLevelsFacade.SkillBreakdown;
 import pcgen.facade.core.DataSetFacade;
 import pcgen.facade.core.UIDelegate;
 import pcgen.persistence.lst.CampaignSourceEntry;
@@ -470,6 +478,84 @@ public class CharacterLevelsFacadeImplTest extends AbstractJunit5CharacterTestCa
 			charLvlsFI.findNextLevelForSkill(spellcraftSkill,
 				charLvlsFI.getElementAt(16), 0.0f), "Any level for removing rank of spellcraft"
 		);
+	}
+
+	/**
+	 * Reproduces bug #7338: on macOS Cmd-Q shutdown, an exception is logged because
+	 * {@link CharacterLevelsFacadeImpl#getSkillBreakdown} is reached <em>after</em>
+	 * {@link CharacterLevelsFacadeImpl#closeCharacter} has nulled out the underlying
+	 * PlayerCharacter.
+	 *
+	 * The shutdown order in CharacterFacadeImpl#closeCharacter is:
+	 *   1. charLevelsFacade.closeCharacter()  // nulls theCharacter here
+	 *   2. dataSet.detachDelegates()          // fires list-change events, refilter,
+	 *                                         //   re-sort, comparator pulls skill data
+	 *
+	 * The comparator path lands in {@link CharacterLevelsFacadeImpl#getSkillBreakdown},
+	 * which calls {@code SkillRankControl.getTotalRank(theCharacter, skill)} with a
+	 * null character. That is null-guarded and returns 0, but it logs a SEVERE entry
+	 * with a stack trace. The bug is the noisy log on every shutdown.
+	 *
+	 * This test calls getSkillBreakdown after closeCharacter and asserts that no
+	 * SEVERE log record is produced.
+	 */
+	@Test
+	public void testGetSkillBreakdownAfterCloseCharacterDoesNotLogError()
+	{
+		setGameSkillRankData(false);
+
+		PlayerCharacter pc = getCharacter();
+		pc.incrementClassLevel(1, fighterClass);
+
+		CharacterLevelsFacadeImpl charLvlsFI =
+				new CharacterLevelsFacadeImpl(pc, delegate,
+					todoManager, dataSetFacade, null);
+		CharacterLevelFacade level = charLvlsFI.getElementAt(0);
+		assertNotNull(level, "Test setup: level 0 should exist");
+
+		List<LogRecord> severeRecords = new ArrayList<>();
+		Handler captor = new Handler()
+		{
+			@Override
+			public void publish(LogRecord record)
+			{
+				if (record.getLevel().intValue() >= Level.SEVERE.intValue())
+				{
+					severeRecords.add(record);
+				}
+			}
+
+			@Override
+			public void flush()
+			{
+			}
+
+			@Override
+			public void close()
+			{
+			}
+		};
+		Logger rootLogger = Logger.getLogger("");
+		rootLogger.addHandler(captor);
+		try
+		{
+			charLvlsFI.closeCharacter();
+
+			// Mirrors the post-close UI path: TreeViewTableModel re-sorts, the row
+			// comparator calls SkillTreeViewModel.getData -> getSkillBreakdown.
+			SkillBreakdown sb =
+					charLvlsFI.getSkillBreakdown(level, climbSkill);
+			assertNotNull(sb, "SkillBreakdown should not be null after close");
+		}
+		finally
+		{
+			rootLogger.removeHandler(captor);
+		}
+
+		assertTrue(severeRecords.isEmpty(),
+				"getSkillBreakdown after closeCharacter must not log SEVERE records, "
+						+ "but produced: " + severeRecords.stream()
+						.map(LogRecord::getMessage).toList());
 	}
 
 	private static void setGameSkillRankData(boolean crossClassCostTwo)


### PR DESCRIPTION
## Summary

Fixes #7338 — on macOS Cmd-Q shutdown (and any path that calls `closeAllCharacters` while the Skill tab is mounted), `SkillRankControl.getTotalRank` is invoked with a null `PlayerCharacter`, producing a noisy SEVERE log with stack trace. The shutdown completes correctly; the user just sees a scary trace in the log.

## Root cause

`CharacterFacadeImpl.closeCharacter` already documents the relevant invariant explicitly:

```java
/*
 * Unfortunately, a dummy rather than null is necessary because the UI
 * does model swaps and such that do not pause events in the UI so that
 * it is trying to update things that do not exist
 */
theCharacter = DUMMY_PC;
```

`CharacterLevelsFacadeImpl.closeCharacter` did not follow the same pattern — it assigned `theCharacter = null`. During teardown, `dataSet.detachDelegates()` fires list-change events that propagate up to the skill tree's row comparator (`RowComparator.compare` → `SkillTreeViewModel.getData` → `CharacterLevelsFacadeImpl.getSkillBreakdown` → `SkillRankControl.getTotalRank(null, skill)`). The null guard at `SkillRankControl.java:64-67` swallows the NPE but emits a SEVERE record with a `new Throwable()` for diagnostics — that's the ticket symptom.

## Fix

Mirror the parent facade's pattern: introduce a static placeholder `CLOSED_PC` and assign it instead of null. Empty-but-valid PC state lets mid-teardown UI events read sane defaults without triggering downstream null-guard logging.

Two-line behavioral change, scoped to `CharacterLevelsFacadeImpl`. Does not modify `CharacterFacadeImpl` or any other facade.

## Test plan

- [x] Added `CharacterLevelsFacadeImplTest#testGetSkillBreakdownAfterCloseCharacterDoesNotLogError` — installs a JUL `Handler` capturing SEVERE records, calls `closeCharacter()`, then `getSkillBreakdown(level, skill)` (the exact path on the bug's stack trace), and asserts no SEVERE record was emitted.
- [x] On master without the fix the test fails with the verbatim ticket stack trace (`Asked to get total rank for null character ... at SkillRankControl.getTotalRank(SkillRankControl.java:66) at CharacterLevelsFacadeImpl.getSkillBreakdown(CharacterLevelsFacadeImpl.java:394)`).
- [x] After the fix the test passes; the three pre-existing tests in the class also still pass (`./gradlew :slowtest --tests 'pcgen.gui2.facade.CharacterLevelsFacadeImplTest'`).
- [ ] Manual smoke test: load a character on macOS, hit ⌘Q, confirm clean shutdown log — should be done by a reviewer with macOS access (I can't reproduce the exact event ordering without GUI access in this environment, but the test reproduces the precise call chain reported).

cc @Azhrei — would you mind retrying the macOS Cmd-Q repro on this branch when you get a chance? The unit test reproduces the same `getTotalRank` SEVERE log via the same call chain you reported, and stops emitting it after this change.