### PR TITLE
Add nightly build workflow and overhaul manual release workflow

### DIFF
--- a/.github/workflows/gradle-nightly.yml
+++ b/.github/workflows/gradle-nightly.yml
@@ -1,0 +1,271 @@
+name: Nightly Build
+
+# Runs daily at 02:00 UTC. Skips the build entirely if there have been
+# zero new commits on master in the last 24 hours (so no PRs merged and no
+# direct commits = no nightly release). When changes are present, builds
+# full release artifacts for all four supported platforms and publishes
+# them as a GitHub pre-release tagged v<base>-NIGHTLY.<YYYYMMDD>.
+#
+# The base version comes from gradle.properties with any existing
+# -SNAPSHOT suffix stripped, e.g. 6.09.08-SNAPSHOT -> base 6.09.08 ->
+# nightly version 6.09.08-NIGHTLY.20260615.
+#
+# The workflow keeps the seven most recent nightly pre-releases; older
+# nightly releases and their underlying git tags are deleted automatically
+# at the end of every successful run.
+
+on:
+  schedule:
+    # Daily at 02:00 UTC. Approx 14:00 NZDT / 21:00 ET / 18:00 PT.
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  # Never run two nightly builds in parallel; never cancel one in flight,
+  # so we don't end up with a half-published release.
+  group: nightly
+  cancel-in-progress: false
+
+jobs:
+  check_changes:
+    name: Check for changes
+    runs-on: ubuntu-latest
+    outputs:
+      should_build: ${{ steps.detect.outputs.should_build }}
+      nightly_version: ${{ steps.detect.outputs.nightly_version }}
+      tag_name: ${{ steps.detect.outputs.tag_name }}
+      commit_sha: ${{ steps.detect.outputs.commit_sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: master
+
+      - name: Detect changes and compute nightly version
+        id: detect
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          NEW_COMMITS=$(git rev-list --count --since='24 hours ago' HEAD)
+          COMMIT_SHA=$(git rev-parse HEAD)
+          SHORT_SHA=$(git rev-parse --short HEAD)
+
+          echo "Commits in the last 24h on master: ${NEW_COMMITS}"
+          echo "HEAD: ${COMMIT_SHA} (${SHORT_SHA})"
+
+          if [ "${NEW_COMMITS}" -eq 0 ]; then
+            echo "::notice::No new commits on master in the last 24h, skipping nightly build."
+            echo "should_build=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          BASE_VERSION=$(grep '^version=' gradle.properties | head -1 | cut -d'=' -f2 | tr -d '[:space:]')
+          BASE_VERSION="${BASE_VERSION%-SNAPSHOT}"
+          BUILD_DATE=$(date -u +%Y%m%d)
+          NIGHTLY_VERSION="${BASE_VERSION}-NIGHTLY.${BUILD_DATE}"
+          TAG_NAME="v${NIGHTLY_VERSION}"
+
+          echo "Base version:    ${BASE_VERSION}"
+          echo "Nightly version: ${NIGHTLY_VERSION}"
+          echo "Tag name:        ${TAG_NAME}"
+
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG_NAME}" > /dev/null 2>&1; then
+            echo "::warning::Tag '${TAG_NAME}' already exists on the remote, skipping nightly build."
+            echo "should_build=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          {
+            echo "should_build=true"
+            echo "nightly_version=${NIGHTLY_VERSION}"
+            echo "tag_name=${TAG_NAME}"
+            echo "commit_sha=${COMMIT_SHA}"
+          } >> "${GITHUB_OUTPUT}"
+
+  create_release:
+    name: Create nightly pre-release
+    needs: check_changes
+    if: needs.check_changes.outputs.should_build == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.check_changes.outputs.commit_sha }}
+
+      - name: Create and push nightly tag
+        env:
+          TAG_NAME: ${{ needs.check_changes.outputs.tag_name }}
+          COMMIT_SHA: ${{ needs.check_changes.outputs.commit_sha }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${TAG_NAME}" -m "Nightly build of ${COMMIT_SHA}"
+          git push origin "${TAG_NAME}"
+          echo "Tagged ${COMMIT_SHA} as ${TAG_NAME}."
+
+      - name: Create GitHub pre-release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.check_changes.outputs.tag_name }}
+          name: ${{ needs.check_changes.outputs.tag_name }}
+          target_commitish: ${{ needs.check_changes.outputs.commit_sha }}
+          draft: false
+          prerelease: true
+          generate_release_notes: false
+          body: |
+            Automated nightly build of `master` at commit
+            ${{ needs.check_changes.outputs.commit_sha }}.
+
+            > ⚠️ Nightly builds are unstable, automated snapshots intended for
+            > testing only. They are not suitable for production use.
+
+  build_release:
+    name: Build nightly (${{ matrix.release_suffix }})
+    needs: [check_changes, create_release]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            release_suffix: ubuntu
+          - os: ubuntu-24.04-arm
+            release_suffix: ubuntu-arm
+          - os: macos-latest
+            release_suffix: mac
+          - os: windows-latest
+            release_suffix: windows
+          # windows-arm removed - no GitHub-hosted runner available yet
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.check_changes.outputs.tag_name }}
+
+      - name: Patch gradle.properties with nightly version
+        shell: bash
+        env:
+          NIGHTLY_VERSION: ${{ needs.check_changes.outputs.nightly_version }}
+        run: |
+          set -euo pipefail
+          echo "Patching gradle.properties version to ${NIGHTLY_VERSION}"
+          sed -i.bak "s/^version=.*/version=${NIGHTLY_VERSION}/" gradle.properties
+          rm -f gradle.properties.bak
+          grep '^version=' gradle.properties
+
+      - name: Patch PCGenProp.properties with nightly version and build date
+        shell: bash
+        env:
+          NIGHTLY_VERSION: ${{ needs.check_changes.outputs.nightly_version }}
+        run: |
+          set -euo pipefail
+          PROPS_FILE="code/src/resources/pcgen/system/prop/PCGenProp.properties"
+          RELEASE_DATE=$(date -u +%Y-%m-%d)
+
+          echo "Setting VersionNumber=${NIGHTLY_VERSION} and ReleaseDate=${RELEASE_DATE} in ${PROPS_FILE}"
+          sed -i.bak "s/^VersionNumber=.*/VersionNumber=${NIGHTLY_VERSION}/" "${PROPS_FILE}"
+          sed -i.bak "s/^ReleaseDate=.*/ReleaseDate=${RELEASE_DATE}/" "${PROPS_FILE}"
+          rm -f "${PROPS_FILE}.bak"
+
+          grep -E '^(VersionNumber|ReleaseDate)=' "${PROPS_FILE}"
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+
+      # setup-gradle@v4 is the canonical Gradle cache for GitHub Actions.
+      # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-disabled: false
+          cache-read-only: false
+          cache-overwrite-existing: true
+
+      # Cache the host-platform JDK and JavaFX jmod archives downloaded by
+      # the downloadJdk / downloadJfxMods tasks. Filenames are stamped with
+      # ${hostOs}_${hostArch}, so each runner OS gets its own cache bucket
+      # via the runner-keyed actions/cache key. These are pinned by
+      # javaVersion (gradle.properties) and the URL templates (build.gradle),
+      # so keying on those file hashes invalidates correctly when we bump
+      # the JDK or JavaFX version. We cache only the archives (.tar.gz / .zip)
+      # and let Gradle re-extract them each run via its own up-to-date checks.
+      - name: Cache downloaded JDK and JavaFX archives
+        uses: actions/cache@v4
+        with:
+          path: |
+            jdks/jdk_*.tar.gz
+            jdks/jdk_*.zip
+            jdks/jfx_jmods_*.zip
+          key: jdks-${{ hashFiles('gradle.properties', 'build.gradle') }}
+          restore-keys: |
+            jdks-
+
+      - name: Build, test, and assemble nightly release artifacts
+        run: ./gradlew build compileSlowtest datatest pfinttest pcgenRelease --stacktrace
+
+      - name: Upload nightly artifacts as workflow artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.release_suffix }}-nightly
+          path: ${{ github.workspace }}/build/release/*
+          if-no-files-found: error
+
+      - name: Attach nightly artifacts to GitHub pre-release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.check_changes.outputs.tag_name }}
+          files: ${{ github.workspace }}/build/release/*
+          fail_on_unmatched_files: true
+
+  cleanup_old_nightlies:
+    name: Cleanup old nightlies
+    needs: build_release
+    if: needs.build_release.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Delete nightly releases older than the most recent 7
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          KEEP: 7
+        run: |
+          set -euo pipefail
+
+          # List all releases (json), filter to nightly pre-releases, sort
+          # by createdAt descending, keep the most recent ${KEEP}, delete
+          # the rest. Failures here must not fail the whole nightly run
+          # (handled by the `|| true` on the delete loop below).
+          mapfile -t TAGS_TO_DELETE < <(
+            gh release list --limit 200 \
+              --json tagName,createdAt,isPrerelease \
+              --jq '[
+                .[]
+                | select(.isPrerelease)
+                | select(.tagName | test("^v.*-NIGHTLY\\."))
+              ] | sort_by(.createdAt) | reverse | .['"${KEEP}"':] | .[].tagName'
+          )
+
+          if [ "${#TAGS_TO_DELETE[@]}" -eq 0 ]; then
+            echo "No old nightly releases to delete (keeping the most recent ${KEEP})."
+            exit 0
+          fi
+
+          echo "Deleting ${#TAGS_TO_DELETE[@]} old nightly release(s):"
+          printf ' - %s\n' "${TAGS_TO_DELETE[@]}"
+
+          for tag in "${TAGS_TO_DELETE[@]}"; do
+            if ! gh release delete "${tag}" --yes --cleanup-tag; then
+              echo "::warning::Failed to delete nightly release ${tag}."
+            fi
+          done

--- a/.github/workflows/gradle-release-manual.yml
+++ b/.github/workflows/gradle-release-manual.yml
@@ -1,14 +1,45 @@
-name: Create Release with Manual Tag
+name: Manual Release
+
+# Manual full release workflow. The operator triggers this workflow with
+# a release version (e.g. 6.09.08, or 6.09.08.RC1 for a release
+# candidate). The workflow then:
+#
+#   1. prepare_release:
+#      - Validates the version string and verifies the tag is free.
+#      - Commits the version bump to gradle.properties on the dispatched
+#        branch.
+#      - Tags the release commit v<release_version> and creates a GitHub
+#        Release at that tag (optionally marked as a pre-release).
+#
+#   2. build_release (matrix across the four supported platforms):
+#      - Checks out the release tag and runs the full build + tests +
+#        pcgenRelease, uploading native installers and portable zips to
+#        the GitHub Release.
+#
+#   3. bump_to_next_dev (only if every platform built successfully):
+#      - Bumps the version on the dispatched branch to the next dev cycle
+#        via `./gradlew updateVersionToNext` (which appends -SNAPSHOT),
+#        and commits the change so the source tree is ready for further
+#        development.
+#
+# Note on the bump rule: updateVersionToNext (see
+# code/gradle/releaseUtils.groovy::updateVersion) increments the trailing
+# numeric token of the version. For 6.09.08 this yields 6.09.09-SNAPSHOT.
+# For 6.09.08.RC1 it yields 6.09.08.RC2-SNAPSHOT. Operators promoting a
+# final release should therefore pass the final version (e.g. 6.09.08),
+# not the RC tag.
 
 on:
   workflow_dispatch:
     inputs:
-      tag_name:
-        description: 'Tag name for the release (e.g., v6.09.08 for production, v6.09.08-SNAPSHOT for nightly, v6.09.08.RC1 for release candidate). The tag will be created on the selected branch.'
+      release_version:
+        description: >
+          Release version, without the leading "v" or any -SNAPSHOT suffix.
+          Examples: 6.09.08 (final), 6.09.08.RC1 (release candidate).
         required: true
         type: string
       prerelease:
-        description: 'Mark as a pre-release (use for nightly builds and RCs)'
+        description: 'Mark the GitHub Release as a pre-release (use for RCs).'
         required: false
         type: boolean
         default: false
@@ -16,17 +47,46 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  # Never run two manual releases at once on the same branch, and never
+  # cancel one in flight: a half-completed release leaves the source
+  # branch and tags in an inconsistent state.
+  group: manual-release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
-  create_release:
-    name: Create Release
+  prepare_release:
+    name: Prepare release
     runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.tag.outputs.tag_name }}
+      release_sha: ${{ steps.tag.outputs.release_sha }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - name: Create and push tag
+      - name: Validate release version
         env:
-          TAG_NAME: ${{ inputs.tag_name }}
+          RELEASE_VERSION: ${{ inputs.release_version }}
         run: |
+          set -euo pipefail
+          if ! [[ "${RELEASE_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(\.[A-Za-z0-9]+)?$ ]]; then
+            echo "::error::release_version '${RELEASE_VERSION}' is not a valid release version."
+            echo ""
+            echo "Expected format: MAJOR.MINOR.PATCH or MAJOR.MINOR.PATCH.QUALIFIER"
+            echo "Examples: 6.09.08, 6.09.08.RC1"
+            echo "Do NOT include a leading 'v' or a -SNAPSHOT suffix."
+            exit 1
+          fi
+          echo "Release version '${RELEASE_VERSION}' is valid."
+
+      - name: Verify tag does not already exist
+        env:
+          RELEASE_VERSION: ${{ inputs.release_version }}
+        run: |
+          set -euo pipefail
+          TAG_NAME="v${RELEASE_VERSION}"
           if git ls-remote --exit-code --tags origin "refs/tags/${TAG_NAME}" > /dev/null 2>&1; then
             echo "::error::Tag '${TAG_NAME}' already exists on the remote."
             echo ""
@@ -34,7 +94,7 @@ jobs:
             echo " HOW TO FIX"
             echo "========================================="
             echo ""
-            echo "If you want to re-release this tag, delete it first:"
+            echo "If you want to re-release this version, delete the tag first:"
             echo "  git tag -d ${TAG_NAME}"
             echo "  git push origin :refs/tags/${TAG_NAME}"
             echo ""
@@ -42,76 +102,65 @@ jobs:
             echo "========================================="
             exit 1
           fi
+          echo "Tag '${TAG_NAME}' is available."
+
+      - name: Configure git identity
+        run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag "${TAG_NAME}"
-          git push origin "${TAG_NAME}"
-          echo "✅ Tag '${TAG_NAME}' created and pushed from $(git rev-parse --short HEAD) on branch ${GITHUB_REF_NAME}."
 
-      - name: Update gradle.properties with release version
+      - name: Commit release version to gradle.properties
         env:
-          TAG_NAME: ${{ inputs.tag_name }}
+          RELEASE_VERSION: ${{ inputs.release_version }}
         run: |
-          VERSION="${TAG_NAME#v}"
-          echo "Updating gradle.properties version to ${VERSION}"
-          sed -i "s/^version=.*/version=${VERSION}/" gradle.properties
-          echo "Updated gradle.properties:"
+          set -euo pipefail
+          echo "Updating gradle.properties version to ${RELEASE_VERSION}"
+          sed -i.bak "s/^version=.*/version=${RELEASE_VERSION}/" gradle.properties
+          rm -f gradle.properties.bak
           grep '^version=' gradle.properties
 
-      - name: Validate tag matches gradle.properties version
-        env:
-          TAG_NAME: ${{ inputs.tag_name }}
-        run: |
-          GRADLE_VERSION=$(grep '^version=' gradle.properties | head -1 | cut -d'=' -f2 | tr -d '[:space:]')
-          EXPECTED_TAG="v${GRADLE_VERSION}"
-
-          echo "Tag name:                ${TAG_NAME}"
-          echo "gradle.properties version: ${GRADLE_VERSION}"
-          echo "Expected tag:            ${EXPECTED_TAG}"
-          echo ""
-
-          if [ "${TAG_NAME}" != "${EXPECTED_TAG}" ]; then
-            echo "::error::Tag '${TAG_NAME}' does not match gradle.properties version '${GRADLE_VERSION}'."
-            echo ""
-            echo "========================================="
-            echo " HOW TO FIX"
-            echo "========================================="
-            echo ""
-            echo "Option 1: Update gradle.properties to match the tag"
-            echo "  - Edit gradle.properties and set: version=${TAG_NAME#v}"
-            echo "  - Commit, push, then re-tag:"
-            echo "    git tag -d ${TAG_NAME}"
-            echo "    git push origin :refs/tags/${TAG_NAME}"
-            echo "    git tag ${TAG_NAME}"
-            echo "    git push origin ${TAG_NAME}"
-            echo ""
-            echo "Option 2: Create the correct tag for the current version"
-            echo "  - git tag ${EXPECTED_TAG}"
-            echo "  - git push origin ${EXPECTED_TAG}"
-            echo "  - Then trigger this workflow with tag: ${EXPECTED_TAG}"
-            echo ""
-            echo "Option 3: Manual dispatch with the correct tag"
-            echo "  - Go to Actions > 'Create Release with Manual Tag' > Run workflow"
-            echo "  - Enter tag_name: ${EXPECTED_TAG}"
-            echo "========================================="
-            exit 1
+          git add gradle.properties
+          # No-op safe: if nothing changed (re-run after partial failure)
+          # we still want the commit step to be idempotent.
+          if git diff --cached --quiet; then
+            echo "gradle.properties already at ${RELEASE_VERSION}, skipping commit."
+          else
+            git commit -m "Release v${RELEASE_VERSION}"
+            git push origin "HEAD:${GITHUB_REF_NAME}"
           fi
 
-          echo "✅ Tag matches gradle.properties version."
+      - name: Tag release commit and create GitHub Release
+        id: tag
+        env:
+          RELEASE_VERSION: ${{ inputs.release_version }}
+        run: |
+          set -euo pipefail
+          TAG_NAME="v${RELEASE_VERSION}"
+          RELEASE_SHA=$(git rev-parse HEAD)
 
-      - name: Create Release
-        id: create_release
+          git tag -a "${TAG_NAME}" -m "Release ${TAG_NAME}"
+          git push origin "${TAG_NAME}"
+
+          {
+            echo "tag_name=${TAG_NAME}"
+            echo "release_sha=${RELEASE_SHA}"
+          } >> "${GITHUB_OUTPUT}"
+
+          echo "Tagged ${RELEASE_SHA} as ${TAG_NAME}."
+
+      - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ inputs.tag_name }}
-          name: ${{ inputs.tag_name }}
+          tag_name: ${{ steps.tag.outputs.tag_name }}
+          name: ${{ steps.tag.outputs.tag_name }}
+          target_commitish: ${{ steps.tag.outputs.release_sha }}
           draft: false
-          prerelease: ${{ inputs.prerelease || false }}
+          prerelease: ${{ inputs.prerelease }}
           generate_release_notes: false
 
   build_release:
-    name: Build Release
-    needs: create_release
+    name: Build release (${{ matrix.release_suffix }})
+    needs: prepare_release
     strategy:
       fail-fast: false
       matrix:
@@ -130,21 +179,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          ref: ${{ needs.prepare_release.outputs.tag_name }}
 
-      - name: Checkout tag
-        run: git checkout "refs/tags/${{ inputs.tag_name }}"
-
-      - name: Update gradle.properties with release version
+      - name: Update PCGenProp.properties with release version and date
         shell: bash
+        env:
+          RELEASE_VERSION: ${{ inputs.release_version }}
         run: |
-          TAG_NAME="${{ inputs.tag_name }}"
-          VERSION="${TAG_NAME#v}"
-          echo "Updating gradle.properties version to ${VERSION}"
-          sed -i.bak "s/^version=.*/version=${VERSION}/" gradle.properties
-          rm -f gradle.properties.bak
-          echo "Updated gradle.properties:"
-          grep '^version=' gradle.properties
+          set -euo pipefail
+          PROPS_FILE="code/src/resources/pcgen/system/prop/PCGenProp.properties"
+          RELEASE_DATE=$(date -u +%Y-%m-%d)
+
+          echo "Setting VersionNumber=${RELEASE_VERSION} and ReleaseDate=${RELEASE_DATE} in ${PROPS_FILE}"
+          sed -i.bak "s/^VersionNumber=.*/VersionNumber=${RELEASE_VERSION}/" "${PROPS_FILE}"
+          sed -i.bak "s/^ReleaseDate=.*/ReleaseDate=${RELEASE_DATE}/" "${PROPS_FILE}"
+          rm -f "${PROPS_FILE}.bak"
+
+          grep -E '^(VersionNumber|ReleaseDate)=' "${PROPS_FILE}"
 
       - name: Set up JDK 25
         uses: actions/setup-java@v4
@@ -193,6 +244,72 @@ jobs:
       - name: Attach release artifacts to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ inputs.tag_name }}
+          tag_name: ${{ needs.prepare_release.outputs.tag_name }}
           files: ${{ github.workspace }}/build/release/*
           fail_on_unmatched_files: true
+
+  bump_to_next_dev:
+    name: Bump version to next dev cycle
+    needs: [prepare_release, build_release]
+    if: success()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref_name }}
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-disabled: false
+          cache-read-only: true
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump version via Gradle and commit
+        run: |
+          set -euo pipefail
+
+          OLD_VERSION=$(grep '^version=' gradle.properties | head -1 | cut -d'=' -f2 | tr -d '[:space:]')
+          echo "Current version: ${OLD_VERSION}"
+
+          # Delegates to releaseUtils.groovy::updateVersion: increments the
+          # trailing numeric segment (zero-padded to 2 digits) and appends
+          # -SNAPSHOT. The Groovy helper writes the new value into
+          # gradle.properties directly.
+          ./gradlew --no-daemon --no-configuration-cache updateVersionToNext
+
+          NEW_VERSION=$(grep '^version=' gradle.properties | head -1 | cut -d'=' -f2 | tr -d '[:space:]')
+          echo "New version:     ${NEW_VERSION}"
+
+          if [ "${OLD_VERSION}" = "${NEW_VERSION}" ]; then
+            echo "::error::updateVersionToNext did not change the version (${OLD_VERSION})."
+            exit 1
+          fi
+
+          git add gradle.properties
+          if git diff --cached --quiet; then
+            echo "::error::No changes staged after updateVersionToNext."
+            exit 1
+          fi
+
+          git commit -m "Bump version to v${NEW_VERSION} for next dev cycle"
+          git push origin "HEAD:${GITHUB_REF_NAME}"
+
+          {
+            echo "## Next dev cycle"
+            echo ""
+            echo "- Previous version: \`${OLD_VERSION}\`"
+            echo "- New dev version:  \`${NEW_VERSION}\`"
+            echo "- Branch:           \`${GITHUB_REF_NAME}\`"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/gradle-release-manual.yml
+++ b/.github/workflows/gradle-release-manual.yml
@@ -25,7 +25,7 @@ name: Manual Release
 # Note on the bump rule: updateVersionToNext (see
 # code/gradle/releaseUtils.groovy::updateVersion) increments the trailing
 # numeric token of the version. For 6.09.08 this yields 6.09.09-SNAPSHOT.
-# For 6.09.08.RC1 it yields 6.09.08.RC2-SNAPSHOT. Operators promoting a
+# For 6.09.08.RC1 it yields 6.09.08.RC02-SNAPSHOT. Operators promoting a
 # final release should therefore pass the final version (e.g. 6.09.08),
 # not the RC tag.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Key entry point: `pcgen.system.Main` (code/src/java/pcgen/system/Main.java)
 - installers/ … installer assets (mac/win/linux), release notes
 - PCGen-base/, PCGen-Formula/ … separate Gradle builds for base/formula modules (consumed as Maven dependencies)
 - Root Gradle files: build.gradle, settings.gradle, gradle.properties, gradlew*
-- CI: `.github/workflows/gradle-test.yml`, `gradle-release.yml`, `gradle-release-manual.yml`, `codeql-analysis.yml`
+- CI: `.github/workflows/gradle-test.yml`, `gradle-nightly.yml`, `gradle-release.yml`, `gradle-release-manual.yml`, `codeql-analysis.yml`
 
 ## Essential Commands
 
@@ -122,16 +122,17 @@ Conventions/gotchas observed:
 ## Build/Release Flow
 
 - For releases, see `code/gradle/release.gradle` and CI workflows:
-  - `.github/workflows/gradle-release.yml` — triggered on tag push `v*.*.*` or manual dispatch with existing tag
-  - `.github/workflows/gradle-release-manual.yml` — manual dispatch that creates a new tag on the selected branch
-- Both release workflows validate that the tag matches `gradle.properties` version.
+  - `.github/workflows/gradle-release.yml` — triggered on tag push `v*.*.*` or manual dispatch with existing tag (validates tag vs `gradle.properties`).
+  - `.github/workflows/gradle-release-manual.yml` — manual dispatch that takes a release version, commits the bump to `gradle.properties` on the dispatched branch, tags + builds across all platforms, then commits the next `-SNAPSHOT` dev version back to the same branch on success.
+  - `.github/workflows/gradle-nightly.yml` — scheduled daily; skips if no commits to `master` in the last 24h; otherwise publishes a pre-release tagged `v<base>-NIGHTLY.<YYYYMMDD>` with all four platform builds and prunes nightlies older than the most recent 7.
 - Release tasks:
   - `prepareRelease` (build; version handling via `releaseUtils.groovy`)
   - `pcgenRelease` (prepareRelease + assembleArtifacts + checksum)
   - `pcgenReleaseOfficial` (pcgenRelease + updateVersionRelease)
+  - `updateVersionToNext` (Groovy helper in `releaseUtils.groovy` that bumps the trailing numeric segment by 1, zero-padded to two digits, and appends `-SNAPSHOT`; used by the manual release workflow's post-build bump step).
 - Artifacts collected into build/release; jpackage produces platform installers under build/jpackage.
 - Release CI builds on: ubuntu-latest (x64), ubuntu-24.04-arm, macos-latest, windows-latest.
-- CI updates `PCGenProp.properties` with version number and release date at build time.
+- CI updates `PCGenProp.properties` with version number and release date at build time (per-platform, in-memory, never committed).
 
 ## Data and Outputsheets
 
@@ -152,9 +153,19 @@ Conventions/gotchas observed:
 - **gradle-release.yml** (tag push `v*.*.*` or workflow_dispatch with existing tag):
   - Validates tag vs gradle.properties version
   - Creates GitHub release, builds on 4 platforms, attaches artifacts
-- **gradle-release-manual.yml** (workflow_dispatch — creates tag then releases):
-  - Creates and pushes a new tag on the current branch
-  - Updates gradle.properties to match, then delegates to same build matrix
+- **gradle-release-manual.yml** (workflow_dispatch — full release pipeline with version management):
+  - Inputs: `release_version` (e.g. `6.09.08`; no `v` prefix, no `-SNAPSHOT`) and `prerelease` boolean.
+  - `prepare_release`: validates the version, ensures the tag is free, commits `version=<release_version>` to `gradle.properties` on the dispatched branch via `github-actions[bot]`, tags the commit, and creates the GitHub Release.
+  - `build_release`: 4-platform matrix mirroring `gradle-release.yml`; checks out the new tag and runs `./gradlew build compileSlowtest datatest pfinttest pcgenRelease`, uploading artifacts to the Release.
+  - `bump_to_next_dev` (only if every matrix job passed): runs `./gradlew --no-daemon --no-configuration-cache updateVersionToNext` and commits the new `-SNAPSHOT` version back to the dispatched branch so the source tree is ready for further development.
+  - Concurrency: `manual-release-${{ github.ref }}`, no cancel-in-progress (avoid partial publish).
+- **gradle-nightly.yml** (schedule `0 2 * * *` + workflow_dispatch):
+  - `check_changes`: counts commits on `master` in the last 24h via `git rev-list --count --since='24 hours ago' HEAD`; on zero commits, the workflow short-circuits and the build/cleanup jobs are skipped.
+  - When changes are present, derives `<base>` from `gradle.properties` (stripping any `-SNAPSHOT`), computes `nightly_version=<base>-NIGHTLY.<YYYYMMDD>` (UTC), and treats the tag `v<nightly_version>` as the release identifier.
+  - `create_release`: creates and pushes the tag, then creates a GitHub pre-release at that tag.
+  - `build_release`: 4-platform matrix; checks out the tag, in-memory patches `gradle.properties` and `PCGenProp.properties` to the nightly version, runs the same full build + tests as the manual release, and attaches artifacts to the pre-release.
+  - `cleanup_old_nightlies`: keeps the most recent 7 nightly pre-releases (`v*-NIGHTLY.*` matching) and deletes older ones together with their git tags via `gh release delete <tag> --yes --cleanup-tag`. Failures are warnings, not workflow-fatal.
+  - Concurrency: group `nightly`, no cancel-in-progress.
 
 ## How to Add/Modify Code
 
@@ -192,7 +203,9 @@ Conventions/gotchas observed:
 | Plugin jar building             | code/gradle/plugins.gradle                                  |
 | Reporting (quality)             | code/gradle/reporting.gradle                                |
 | CI test workflow                | .github/workflows/gradle-test.yml                           |
-| CI release workflow             | .github/workflows/gradle-release.yml                        |
+| CI release workflow (tag)       | .github/workflows/gradle-release.yml                        |
+| CI release workflow (manual)    | .github/workflows/gradle-release-manual.yml                 |
+| CI nightly workflow             | .github/workflows/gradle-nightly.yml                        |
 
 ## Local Run Examples
 


### PR DESCRIPTION
## Summary

Adds two GitHub Actions workflows for automated releases.

### 1. `gradle-nightly.yml` (new)

Daily scheduled workflow that produces full release artifacts for all four supported platforms whenever `master` has received new commits in the previous 24 hours.

- **Trigger:** cron `0 2 * * *` (02:00 UTC daily) + `workflow_dispatch` for ad-hoc runs.
- **Change detection:** `git rev-list --count --since='24 hours ago' HEAD` on `master`. Zero commits → short-circuits and skips the build entirely.
- **Versioning:** `<base>-NIGHTLY.<YYYYMMDD>` where `<base>` is the `gradle.properties` version with any `-SNAPSHOT` suffix stripped (e.g. `6.09.08-NIGHTLY.20260615`).
- **Publishing:** GitHub **pre-release** tagged `v<nightly_version>` with all 4 platform artifacts attached.
- **Retention:** keeps the seven most recent nightly pre-releases; deletes older releases **and** their underlying git tags via `gh release delete --cleanup-tag`.

### 2. `gradle-release-manual.yml` (replaces existing)

Owns the full release lifecycle from version bump to next-dev bump.

- **Trigger:** `workflow_dispatch` only.
- **Inputs:**
  - `release_version` — e.g. `6.09.08` or `6.09.08.RC1`. Validated against `^\d+\.\d+\.\d+(\.[A-Za-z0-9]+)?$`. No `v` prefix, no `-SNAPSHOT` suffix.
  - `prerelease` — boolean (default `false`), useful for RCs.
- **Jobs:**
  1. `prepare_release` — validates the version, verifies the tag is free, commits the `gradle.properties` bump to the dispatched branch as `github-actions[bot]`, tags the commit, and creates the GitHub Release.
  2. `build_release` — 4-platform matrix mirroring `gradle-release.yml`; checks out the new tag and runs `./gradlew build compileSlowtest datatest pfinttest pcgenRelease --stacktrace`, uploading artifacts to the Release.
  3. `bump_to_next_dev` — only runs when every matrix job succeeded. Invokes `./gradlew --no-daemon --no-configuration-cache updateVersionToNext` (reuses the existing Groovy helper in `code/gradle/releaseUtils.groovy`) and commits the new `-SNAPSHOT` version back to the dispatched branch so the source tree is ready for further development.

### Untouched

`gradle-release.yml` (tag-push path), `gradle-test.yml`, `codeql-analysis.yml`, and all Gradle build logic.

## Validation

- `actionlint 1.7.12` + `shellcheck 0.11.0` integration — 0 findings on all 5 workflows.
- All YAML files parse cleanly.
- `updateVersionToNext` confirmed reachable from the top-level build (`build.gradle:853` applies `code/gradle/release.gradle`).
- Cannot smoke-test the workflows end-to-end without a real run; first CI run will exercise them.

## Caveats

- **Version bump rule:** `updateVersion` in `releaseUtils.groovy` bumps the trailing numeric token via regex `(\d+)([^\d]*$)`. So `6.09.08` → `6.09.09-SNAPSHOT` (patch bump), but `6.09.08.RC1` → `6.09.08.RC02-SNAPSHOT` (RC bump, not patch bump). Operators promoting a final release should pass the final version (e.g. `6.09.08`), not an RC tag. The workflow input help text documents this.
- **Branch protection:** if `master` requires PR review, direct pushes from `github-actions[bot]` (in both `prepare_release` and `bump_to_next_dev`) will fail. We can switch the bump step to open a PR instead if the first real run reveals this.
- **jpackage `appVersion`** already strips `-SNAPSHOT` and non-numeric suffixes (`build.gradle:349`), so the nightly suffix doesn't break installer naming — no installer-side changes needed.
- **Same-day collision:** manually dispatching the nightly workflow twice on the same UTC day will fail the second run at "tag already exists". Acceptable given the schedule fires once per day.

## Test plan

Once merged:
1. Trigger `gradle-nightly.yml` via `workflow_dispatch` to validate the happy path without waiting for cron.
2. Trigger `gradle-release-manual.yml` with an RC version (e.g. the next `.RC` candidate, with `prerelease: true`) to validate the full pipeline end-to-end.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>