### PR TITLE
ci: run Gradle build on master pushes to populate Actions cache

### DIFF
--- a/.github/workflows/gradle-test.yml
+++ b/.github/workflows/gradle-test.yml
@@ -5,6 +5,8 @@ name: Build PCGen with Gradle
 
 on:
   pull_request:
+  push:
+    branches: [master]
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

The repo's GitHub Actions cache list at https://github.com/PCGen/pcgen/actions/caches has been empty — `active_caches_count: 0` — which means every PR build does a clean dependency download (~3-4 min wasted at the top of every run).

Root cause: `gradle/actions/setup-gradle@v4` only writes to the cache from jobs running on the default branch. PR jobs run with `cache-read-only: true`. From a recent PR build log:

```
cache-read-only: true
…
Gradle User Home cache not found. Will initialize empty.
…
Cache is read-only: will not save state for use in subsequent builds.
```

Since `gradle-test.yml` only triggered on `pull_request:`, no job ever ran on master, so nothing ever populated the cache.

This PR adds `push: branches: [master]` so master commits populate the Gradle cache. PR builds remain read-only and now have something to read.

## Test plan

- [ ] Merge to master
- [ ] Confirm a `Build PCGen with Gradle` run is triggered by the merge commit
- [ ] Confirm cache entries appear at https://github.com/PCGen/pcgen/actions/caches after that run
- [ ] Confirm the next PR build logs `Gradle User Home cache restored …` instead of `cache not found`