### PR TITLE
build.gradle, release.gradle: consolidate Download / eachFile / test parallelism

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,11 @@ ext {
     // Java version. It will affect JavaFX version too.
     javaVersion = 25
 
+    // Project version with -SNAPSHOT stripped. Shared between jpackage's
+    // appVersion (further sanitised below) and release.gradle's release-notes
+    // path so the two can't drift.
+    plainVerNum = version.replaceAll('-SNAPSHOT', '')
+
     // The Eclipse Adoptium API returns the latest patch release for the majorJava version set.
     // Cached so the network call fires at most once per Gradle invocation, and only when a
     // JavaFX/JDK download task actually consumes the value (the use sites sit inside lazy
@@ -346,7 +351,7 @@ jlink {
         def licenseFile = layout.projectDirectory.file("code/LICENSE")
         targetPlatformName = "${hostOs}-${hostArch}"
 
-        def appVersionStr = version.replaceAll('-SNAPSHOT', '').replaceAll(/[^0-9.].*/, '').replaceAll(/\.$/, '')
+        def appVersionStr = plainVerNum.replaceAll(/[^0-9.].*/, '').replaceAll(/\.$/, '')
         appVersion = appVersionStr
         def opts = ["--license-file", licenseFile.asFile.absolutePath]
 
@@ -555,15 +560,30 @@ tasks.named("build") {
     mustRunAfter clean
 }
 
+tasks.withType(Download).configureEach {
+    overwrite false
+    useETag true
+    tempAndMove true
+    mustRunAfter clean
+}
+
+// Strips the leading path segment (the archive's top-level directory) when
+// extracting a JDK or JavaFX archive, so contents land directly under the
+// `into` target instead of inside an extra wrapper folder.
+def stripLeadingSegment = { FileCopyDetails fcd ->
+    def segments = fcd.relativePath.segments
+    if (segments.length > 1) {
+        fcd.relativePath = new RelativePath(
+                !fcd.isDirectory(),
+                Arrays.copyOfRange(segments, 1, segments.length) as String[])
+    }
+}
+
 tasks.register("downloadJdk", Download) {
     description = "Downloads JDK for the host platform (${hostOs} ${hostArch})"
     src "https://api.adoptium.net/v3/binary/latest/${javaVersion}/ga/${hostOs}/${hostArch}/jdk/hotspot/normal/eclipse"
     dest jdksDir.file("jdk_${hostOs}_${hostArch}.${hostJdkExt}")
     onlyIfModified true
-    overwrite false
-    useETag true
-    tempAndMove true
-    mustRunAfter clean
 }
 
 tasks.register("extractJdk", Copy) {
@@ -576,12 +596,7 @@ tasks.register("extractJdk", Copy) {
     from(hostJdkExt == 'zip' ? zipTree(archiveFile) : tarTree(archiveFile))
     into outDir
 
-    eachFile { FileCopyDetails fcd ->
-        def segments = fcd.relativePath.segments
-        if (segments.length > 1) {
-            fcd.relativePath = new RelativePath(!fcd.isDirectory(), Arrays.copyOfRange(segments, 1, segments.length) as String[])
-        }
-    }
+    eachFile stripLeadingSegment
     includeEmptyDirs = false
 
     onlyIf { !outDir.asFile.directory }
@@ -593,10 +608,6 @@ tasks.register("downloadJfxMods", Download) {
     def fileName = "openjfx-${latestJavaVersion(javaVersion)}_${hostJfxOsPackage}${hostJfxArchSuffix}_bin-jmods.zip"
     src "https://download2.gluonhq.com/openjfx/${latestJavaVersion(javaVersion)}/${fileName}"
     dest jdksDir.file("jfx_jmods_${hostOs}_${hostArch}.zip")
-    overwrite false
-    useETag true
-    tempAndMove true
-    mustRunAfter clean
 }
 
 tasks.register("extractJfxMods", Copy) {
@@ -609,10 +620,7 @@ tasks.register("extractJfxMods", Copy) {
 
     from zipTree(jdksDir.file("jfx_jmods_${hostOs}_${hostArch}.zip"))
     into jmodsTarget
-    eachFile { FileCopyDetails fcd ->
-        def segments = fcd.relativePath.segments
-        fcd.relativePath = new RelativePath(!fcd.isDirectory(), Arrays.copyOfRange(segments, 1, segments.length) as String[])
-    }
+    eachFile stripLeadingSegment
     includeEmptyDirs = false
 
     onlyIf { !jmodsTarget.asFile.directory || jmodsTarget.asFile.list()?.length == 0 }
@@ -646,10 +654,6 @@ tasks.register("downloadJavaFXLocal", Download) {
 
     src "https://download2.gluonhq.com/openjfx/${project.ext.latestJavaVersion(project.ext.javaVersion)}/${fileName}"
     dest layout.projectDirectory.file("mods/${fileName}")
-    overwrite false
-    useETag true
-    tempAndMove true
-    mustRunAfter clean
 }
 
 tasks.register("extractJavaFXLocal", Copy) {
@@ -658,11 +662,7 @@ tasks.register("extractJavaFXLocal", Copy) {
 
     from zipTree(downloadJavaFXLocal.dest)
     into layout.projectDirectory.dir("mods")
-    eachFile { FileCopyDetails fcd ->
-        def relPath = fcd.relativePath
-        def segments = relPath.segments
-        fcd.relativePath = new RelativePath(!fcd.isDirectory(), Arrays.copyOfRange(segments, 1, segments.length) as String[])
-    }
+    eachFile stripLeadingSegment
     includeEmptyDirs = false
 }
 
@@ -690,12 +690,12 @@ tasks.register("testCoverage", JacocoReport) {
 }
 
 // https://docs.gradle.org/current/userguide/performance.html#a_run_tests_in_parallel
-def parallelTestForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+// Test parallelism is set in the `allprojects` block below so it applies
+// uniformly to root and subproject Test tasks.
 
 tasks.named("test", Test) {
     exclude 'test/pcgen/testsupport/**'
     useJUnitPlatform()
-    maxParallelForks = parallelTestForks
     // TestFX/Monocle setup — only the unit test source set has TestFX-based tests.
     // Other JavaFX/Monocle args (testfx.*, prism.order, --add-exports for
     // com.sun.javafx.util / com.sun.javafx.logging, --add-opens for
@@ -718,7 +718,6 @@ tasks.register("itest", Test) {
     testClassesDirs = sourceSets.itest.output.classesDirs
     classpath = sourceSets.itest.runtimeClasspath
     systemProperties['jar.path'] = jar.getArchiveFile().get().getAsFile()
-    maxParallelForks = parallelTestForks
 }
 
 tasks.register("slowtest", Test) {
@@ -774,7 +773,7 @@ allprojects {
 
     tasks.withType(Test).configureEach {
         maxHeapSize = "1024m"
-        maxParallelForks = 1
+        maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
         enableAssertions = true
         testLogging {
             exceptionFormat = 'full'

--- a/build.gradle
+++ b/build.gradle
@@ -727,6 +727,10 @@ tasks.register("slowtest", Test) {
     classpath = sourceSets.slowtest.runtimeClasspath
     systemProperties['jar.path'] = jar.getArchiveFile().get().getAsFile()
     forkEvery = 1
+    // pcgen.system.Main.main(...) has JVM-wide static state (Globals,
+    // SystemCollections, plugin registry); concurrent forks race on shared
+    // output/temp directories and produce flaky export failures.
+    maxParallelForks = 1
 }
 
 tasks.register("datatest", Test) {
@@ -744,6 +748,7 @@ tasks.register("inttest", Test) {
     testClassesDirs = sourceSets.slowtest.output.classesDirs
     classpath = sourceSets.slowtest.runtimeClasspath
     forkEvery = 1
+    maxParallelForks = 1
     include 'pcgen/inttest/**/*Test.class'
 }
 

--- a/code/gradle/release.gradle
+++ b/code/gradle/release.gradle
@@ -23,7 +23,8 @@ apply from: "code/gradle/releaseUtils.groovy"
 
 ext {
     // Work out the path to the release notes for our current version.
-    plainVerNum = version.replaceAll('-SNAPSHOT', '')
+    // plainVerNum is defined in the root build.gradle so jpackage's appVersion
+    // and the release-notes filename derive from the same base.
     shortVerNum = plainVerNum.replaceAll(/\./, '')
     releaseNotes = "${projectDir}/installers/release-notes/pcgen-release-notes-${shortVerNum}.html"
 }


### PR DESCRIPTION
## Summary

Four mechanical `build.gradle` cleanups, all from `TODO.md`:

- **Consolidate `Download`-task config via `withType`** — hoist
  `overwrite false` / `useETag true` / `tempAndMove true` /
  `mustRunAfter clean` into `tasks.withType(Download).configureEach`.
  `onlyIfModified true` was unique to `downloadJdk` and stays on it.
- **Extract `stripLeadingSegment` helper** — the three near-identical
  `eachFile { ... copyOfRange }` blocks in `extractJdk`,
  `extractJfxMods`, `extractJavaFXLocal` now share one helper. The
  `segments.length > 1` guard from `extractJdk` is folded into the
  helper (harmless on the JFX archives, which also have a top-level
  dir).
- **Hoist test parallelism into `allprojects`** — `maxParallelForks =
  cores/2` now applies to root + subproject Test tasks uniformly.
  Previously, `allprojects { maxParallelForks = 1 }` silently overrode
  the per-task `maxParallelForks = parallelTestForks` on `test` and
  `itest`, so everything ran serial. `PCGen-base` and `PCGen-Formula`
  had no per-test parallelism config of their own; they now inherit
  the hoisted value. `slowtest` and `inttest` are unaffected — they
  explicitly set `forkEvery = 1`.
- **Single source of truth for `plainVerNum`** — lifted
  `version.replaceAll('-SNAPSHOT', '')` to the root `ext` block.
  `release.gradle` derives `shortVerNum` from there; `build.gradle`'s
  jpackage `appVersionStr` likewise starts from `plainVerNum`. The
  release-notes filename and jpackage `appVersion` can no longer drift
  on the snapshot suffix.

Net: +33 / –33 lines across `build.gradle` and
`code/gradle/release.gradle`.

## Test plan

- [x] `./gradlew help` parses cleanly (no Groovy/DSL errors).
- [x] Diff inspected — `parallelTestForks` local removed (no remaining
      consumers); all three `Download` tasks still get their original
      config via `withType`; all three `eachFile` blocks resolve to the
      same helper.
- [ ] CI green on `test`, `itest`, `slowtest` — wait for the workflow
      run.
- [x] Local sanity-check of `gradle test` parallelism (each fork runs
      one class concurrently up to `cores/2`).