### PR TITLE
Drop controlsfx dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -210,7 +210,6 @@ dependencies {
     implementation 'org.scijava:jep:2.4.2'
     implementation 'org.freemarker:freemarker:2.3.34'
     implementation 'net.sourceforge.argparse4j:argparse4j:0.9.0'
-    implementation 'org.controlsfx:controlsfx:11.2.3'
     implementation project(':PCGen-base')
     implementation project(':PCGen-Formula')
 
@@ -281,7 +280,7 @@ jlink {
     addExtraDependencies('javafx')
     forceMerge('jep', 'fop', 'Saxon-HE',
                'commons-lang3', 'spring',
-               'freemarker', 'argparse4j', 'xmlunit', 'controlsfx',
+               'freemarker', 'argparse4j', 'xmlunit',
                'annotations', 'spotbugs', 'xmlresolver')
 
     // Resolve packages → modules with the JDK's jdeps; the plugin's default

--- a/code/src/java/module-info.java
+++ b/code/src/java/module-info.java
@@ -25,7 +25,6 @@ module pcgen {
     requires org.apache.commons.lang3;
     requires freemarker;
     requires net.sourceforge.argparse4j;
-    requires org.controlsfx.controls;
     requires org.apache.xmlgraphics.fop.core;
     requires org.apache.xmlgraphics.fop.events;
     requires org.apache.xmlgraphics.commons;

--- a/code/src/java/pcgen/gui2/util/JDynamicTable.java
+++ b/code/src/java/pcgen/gui2/util/JDynamicTable.java
@@ -34,11 +34,11 @@ import pcgen.gui3.GuiUtility;
 
 import javafx.embed.swing.JFXPanel;
 import javafx.event.ActionEvent;
+import javafx.event.EventHandler;
 import javafx.scene.control.Button;
 import javafx.scene.control.CheckMenuItem;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.MenuItem;
-import org.controlsfx.control.action.Action;
 
 public class JDynamicTable extends JTableEx
 {
@@ -172,7 +172,7 @@ public class JDynamicTable extends JTableEx
 		}
 	}
 
-	private final class MenuAction extends Action
+	private final class MenuAction implements EventHandler<ActionEvent>
 	{
 
 		private boolean visible;
@@ -180,13 +180,12 @@ public class JDynamicTable extends JTableEx
 
 		private MenuAction(TableColumn column, boolean visible)
 		{
-			super(column.getHeaderValue().toString());
-			super.setEventHandler(this::actionPerformed);
 			this.visible = visible;
 			this.column = column;
 		}
 
-		public void actionPerformed(ActionEvent e)
+		@Override
+		public void handle(ActionEvent e)
 		{
 			visible = !visible;
 			dynamicColumnModel.setVisible(column, visible);

--- a/code/src/java/pcgen/gui2/util/JTreeViewTable.java
+++ b/code/src/java/pcgen/gui2/util/JTreeViewTable.java
@@ -55,6 +55,7 @@ import pcgen.util.ListMap;
 
 import javafx.embed.swing.JFXPanel;
 import javafx.event.ActionEvent;
+import javafx.event.EventHandler;
 import javafx.scene.control.Button;
 import javafx.scene.control.CheckMenuItem;
 import javafx.scene.control.ContextMenu;
@@ -62,7 +63,6 @@ import javafx.scene.control.MenuItem;
 import javafx.scene.control.RadioMenuItem;
 import javafx.scene.control.SeparatorMenuItem;
 import javafx.scene.control.ToggleGroup;
-import org.controlsfx.control.action.Action;
 
 /**
  * JTreeViewTable is a subclass of JTreeTable that uses a TreeViewModel instead
@@ -122,7 +122,7 @@ public class JTreeViewTable<T> extends JTreeTable
 		CheckMenuItem item = new CheckMenuItem();
 		boolean visible = dynamicColumnModel.isVisible(column);
 			item.setSelected(visible);
-		Action menuAction = new MenuAction(column, visible);
+		MenuAction menuAction = new MenuAction(column, visible);
 		item.setText(menuAction.getText());
 		item.setOnAction(menuAction);
 		return item;
@@ -479,7 +479,22 @@ public class JTreeViewTable<T> extends JTreeTable
 
 	}
 
-	private final class MenuAction extends Action
+	private abstract static class NamedAction implements EventHandler<ActionEvent>
+	{
+		private final String text;
+
+		NamedAction(String text)
+		{
+			this.text = text;
+		}
+
+		String getText()
+		{
+			return text;
+		}
+	}
+
+	private final class MenuAction extends NamedAction
 	{
 
 		private boolean visible;
@@ -488,19 +503,19 @@ public class JTreeViewTable<T> extends JTreeTable
 		private MenuAction(TableColumn column, boolean visible)
 		{
 			super(column.getHeaderValue().toString());
-			super.setEventHandler(this::actionPerformed);
 			this.visible = visible;
 			this.column = column;
 		}
 
-		public void actionPerformed(ActionEvent e)
+		@Override
+		public void handle(ActionEvent e)
 		{
 			dynamicColumnModel.setVisible(column, visible = !visible);
 		}
 
 	}
 
-	private final class ChangeViewAction extends Action
+	private final class ChangeViewAction extends NamedAction
 	{
 
 		private final TreeView<? super T> view;
@@ -508,11 +523,11 @@ public class JTreeViewTable<T> extends JTreeTable
 		ChangeViewAction(TreeView<? super T> view)
 		{
 			super(view.getViewName());
-			super.setEventHandler(this::actionPerformed);
 			this.view = view;
 		}
 
-		public void actionPerformed(ActionEvent e)
+		@Override
+		public void handle(ActionEvent e)
 		{
 			setTreeView(view);
 		}


### PR DESCRIPTION
## Summary

- ControlsFX was used only as a base class for three private inner classes in `JDynamicTable` / `JTreeViewTable`. Only `getText()` and the `EventHandler<ActionEvent>` surface were ever consumed — none of the controlsfx menu/toolbar/property machinery.
- Replaced with a small private `NamedAction` base (text + handler) in `JTreeViewTable`. `JDynamicTable` drops the unused text entirely (it was set on the `Action` but never read — the `CheckMenuItem` had no label either way).
- Removed `org.controlsfx:controlsfx:11.2.3` from `build.gradle`, its `forceMerge` entry under `jlink`, and `requires org.controlsfx.controls;` from `module-info.java`.

## Test plan

- [x] `./gradlew compileJava` and `./gradlew compileTestJava` pass
- [x] Manually exercised both code paths via the corner-button popup on the Skills tab tree-view table:
  - Switched tree views (Type/Name → Name) — `ChangeViewAction.handle()` fires, table re-organizes correctly
  - Toggled column visibility checkboxes — `MenuAction.handle()` fires, columns hide/show correctly
  - Radio/checkbox labels render correctly — `getText()` works on both inner classes