### PR TITLE
Fix Skills tab NPE during character close repaint

### DIFF
--- a/code/src/java/pcgen/gui2/tabs/skill/SkillTreeViewModel.java
+++ b/code/src/java/pcgen/gui2/tabs/skill/SkillTreeViewModel.java
@@ -150,7 +150,7 @@ public class SkillTreeViewModel
 					case 3 -> levels.getSkillCost(level, obj) == SkillCost.CLASS
 							? LanguageBundle.getString("in_yes") //$NON-NLS-1$
 							: LanguageBundle.getString("in_no"); //$NON-NLS-1$
-					case 4 -> levels.getSkillCost(level, obj).getCost();
+					case 4 -> levels.getSkillCost(level, obj) == null ? null : levels.getSkillCost(level, obj).getCost();
 					case 5 -> character.getInfoFactory().getDescription(obj);
 					case 6 -> obj.getSource();
 					default -> null;


### PR DESCRIPTION
## Summary

- `CharacterLevelsFacade.getSkillCost()` can return `null` while the EDT paints a stale Skills cell after character teardown has begun. Reproduces by hitting Cmd-Q with an unsaved character: the modal "Save changes?" `JOptionPane` keeps the EDT pumping paint events while the character model is being torn down on a non-EDT thread.
- The "Skill Cost" column at `SkillTreeViewModel.java:153` calls `levels.getSkillCost(level, obj).getCost()` without a null check and NPEs.
- Mirrors the existing empty-selection branch (`case 3, 5 -> null` at line 137): a missing skill cost renders as `null` for that cell.

## Stack trace

```
java.lang.NullPointerException: Cannot invoke "pcgen.cdom.enumeration.SkillCost.getCost()"
        because the return value of "pcgen.facade.core.CharacterLevelsFacade.getSkillCost(...)" is null
    at pcgen.gui2.tabs.skill.SkillTreeViewModel.getData(SkillTreeViewModel.java:153)
    at pcgen.gui2.util.treeview.TreeViewTableModel$TreeViewNode.getValueAt(...)
    at javax.swing.JTable.prepareRenderer(...)
    ...
    at javax.swing.JOptionPane.showOptionDialog(...)
    at pcgen.gui2.PCGenFrame.closeAllCharacters(PCGenFrame.java:688)
```

## Test plan

- [x] `./gradlew compileJava` passes
- [ ] Manual: load a source, open a new character, switch to the Skills tab, hit Cmd-Q → "Save changes?" dialog appears without NPEs in the log