### PR TITLE
PMD cleanup: drop redundant `implements` on prereq Pre*Tester / Pre*Parser

### DIFF
--- a/code/src/java/pcgen/persistence/lst/prereq/AbstractPrerequisiteListParser.java
+++ b/code/src/java/pcgen/persistence/lst/prereq/AbstractPrerequisiteListParser.java
@@ -37,7 +37,6 @@ import org.apache.commons.lang3.StringUtils;
  * Abstract PRE parser, provides common parsing for many PRE tokens.
  */
 public abstract class AbstractPrerequisiteListParser extends AbstractPrerequisiteParser
-		implements PrerequisiteParserInterface
 {
 
 	protected void convertKeysToSubKeys(Prerequisite prereq, String kind)

--- a/code/src/java/plugin/pretokens/parser/PreAbilityParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreAbilityParser.java
@@ -23,14 +23,13 @@ import java.util.List;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteListParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 import pcgen.system.LanguageBundle;
 import pcgen.util.Logging;
 
 /**
  * A prerequisite parser class that handles the parsing of pre ability tokens.
  */
-public class PreAbilityParser extends AbstractPrerequisiteListParser implements PrerequisiteParserInterface
+public class PreAbilityParser extends AbstractPrerequisiteListParser
 {
 	private static final String CATEGORY = "CATEGORY.";
 	private static final String CATEGORY_EQUALS = "CATEGORY=";

--- a/code/src/java/plugin/pretokens/parser/PreAgeSetParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreAgeSetParser.java
@@ -19,13 +19,12 @@ package plugin.pretokens.parser;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteListParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 import pcgen.util.Logging;
 
 /**
  * A prerequisite parser class that handles the parsing of pre age set tokens.
  */
-public class PreAgeSetParser extends AbstractPrerequisiteListParser implements PrerequisiteParserInterface
+public class PreAgeSetParser extends AbstractPrerequisiteListParser
 {
 
 	/**

--- a/code/src/java/plugin/pretokens/parser/PreAlignParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreAlignParser.java
@@ -25,12 +25,11 @@ import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteOperator;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre align tokens.
  */
-public class PreAlignParser extends AbstractPrerequisiteParser implements PrerequisiteParserInterface
+public class PreAlignParser extends AbstractPrerequisiteParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreArmorProfParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreArmorProfParser.java
@@ -23,12 +23,11 @@
 package plugin.pretokens.parser;
 
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteListParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre armourprof tokens.
  */
-public class PreArmorProfParser extends AbstractPrerequisiteListParser implements PrerequisiteParserInterface
+public class PreArmorProfParser extends AbstractPrerequisiteListParser
 {
 
 	/**

--- a/code/src/java/plugin/pretokens/parser/PreAttackParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreAttackParser.java
@@ -21,13 +21,12 @@ package plugin.pretokens.parser;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 import pcgen.util.Logging;
 
 /**
  * A prerequisite parser class that handles the parsing of pre attack tokens.
  */
-public class PreAttackParser extends AbstractPrerequisiteParser implements PrerequisiteParserInterface
+public class PreAttackParser extends AbstractPrerequisiteParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreBaseSizeParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreBaseSizeParser.java
@@ -25,13 +25,12 @@ import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteException;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 import pcgen.rules.context.LoadContext;
 
 /**
  * A prerequisite parser class that handles the parsing of pre base size tokens.
  */
-public class PreBaseSizeParser extends AbstractPrerequisiteParser implements PrerequisiteParserInterface
+public class PreBaseSizeParser extends AbstractPrerequisiteParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreCSkillParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreCSkillParser.java
@@ -21,12 +21,11 @@ package plugin.pretokens.parser;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteListParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre CSkill tokens.
  */
-public class PreCSkillParser extends AbstractPrerequisiteListParser implements PrerequisiteParserInterface
+public class PreCSkillParser extends AbstractPrerequisiteListParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreCampaignParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreCampaignParser.java
@@ -20,12 +20,11 @@ package plugin.pretokens.parser;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteListParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre CAMPAIGN tokens.
  */
-public class PreCampaignParser extends AbstractPrerequisiteListParser implements PrerequisiteParserInterface
+public class PreCampaignParser extends AbstractPrerequisiteListParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreCharactertypeParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreCharactertypeParser.java
@@ -19,12 +19,11 @@
 package plugin.pretokens.parser;
 
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteListParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre charactertype tokens.
  */
-public class PreCharactertypeParser extends AbstractPrerequisiteListParser implements PrerequisiteParserInterface
+public class PreCharactertypeParser extends AbstractPrerequisiteListParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreCityParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreCityParser.java
@@ -19,12 +19,11 @@
 package plugin.pretokens.parser;
 
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteSimpleParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre city tokens.
  */
-public class PreCityParser extends AbstractPrerequisiteSimpleParser implements PrerequisiteParserInterface
+public class PreCityParser extends AbstractPrerequisiteSimpleParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreClassLevelMaxParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreClassLevelMaxParser.java
@@ -22,13 +22,12 @@ import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteOperator;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteListParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 import pcgen.util.Logging;
 
 /**
  * A prerequisite parser class that handles the parsing of pre class level max tokens.
  */
-public class PreClassLevelMaxParser extends AbstractPrerequisiteListParser implements PrerequisiteParserInterface
+public class PreClassLevelMaxParser extends AbstractPrerequisiteListParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreClassParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreClassParser.java
@@ -19,12 +19,11 @@
 package plugin.pretokens.parser;
 
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteListParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre class tokens.
  */
-public class PreClassParser extends AbstractPrerequisiteListParser implements PrerequisiteParserInterface
+public class PreClassParser extends AbstractPrerequisiteListParser
 {
 	/**
 	 * Returns a Array of the kings of PRE tags this class parses, 

--- a/code/src/java/plugin/pretokens/parser/PreDamageReductionParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreDamageReductionParser.java
@@ -24,12 +24,11 @@ import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteOperator;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre damage reduction tokens.
  */
-public class PreDamageReductionParser extends AbstractPrerequisiteParser implements PrerequisiteParserInterface
+public class PreDamageReductionParser extends AbstractPrerequisiteParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreDeityAlignParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreDeityAlignParser.java
@@ -24,12 +24,11 @@ import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteOperator;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre deity align tokens.
  */
-public class PreDeityAlignParser extends AbstractPrerequisiteParser implements PrerequisiteParserInterface
+public class PreDeityAlignParser extends AbstractPrerequisiteParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreDeityDomainParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreDeityDomainParser.java
@@ -19,12 +19,11 @@
 package plugin.pretokens.parser;
 
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteListParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre deity domain tokens.
  */
-public class PreDeityDomainParser extends AbstractPrerequisiteListParser implements PrerequisiteParserInterface
+public class PreDeityDomainParser extends AbstractPrerequisiteListParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreDeityParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreDeityParser.java
@@ -21,14 +21,13 @@ package plugin.pretokens.parser;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteListParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * {@code PreDeityParser} parses PREDEITY prerequisites. It handles both
  * new (PREDEITY:1,Odin) and old (PREDEITY:Odin) format syntax along with the
  * hasdeity syntax (PREDEITY:Y or PREDEITY:No). 
  */
-public class PreDeityParser extends AbstractPrerequisiteListParser implements PrerequisiteParserInterface
+public class PreDeityParser extends AbstractPrerequisiteListParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreDomainParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreDomainParser.java
@@ -18,12 +18,11 @@
 package plugin.pretokens.parser;
 
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteListParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre domain tokens.
  */
-public class PreDomainParser extends AbstractPrerequisiteListParser implements PrerequisiteParserInterface
+public class PreDomainParser extends AbstractPrerequisiteListParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreEquipBothParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreEquipBothParser.java
@@ -18,12 +18,11 @@
 package plugin.pretokens.parser;
 
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteListParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre equip both tokens.
  */
-public class PreEquipBothParser extends AbstractPrerequisiteListParser implements PrerequisiteParserInterface
+public class PreEquipBothParser extends AbstractPrerequisiteListParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreEquipPrimaryParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreEquipPrimaryParser.java
@@ -18,12 +18,11 @@
 package plugin.pretokens.parser;
 
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteListParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre equip primary tokens.
  */
-public class PreEquipPrimaryParser extends AbstractPrerequisiteListParser implements PrerequisiteParserInterface
+public class PreEquipPrimaryParser extends AbstractPrerequisiteListParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreEquipSecondaryParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreEquipSecondaryParser.java
@@ -18,12 +18,11 @@
 package plugin.pretokens.parser;
 
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteListParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre equip secondary tokens.
  */
-public class PreEquipSecondaryParser extends AbstractPrerequisiteListParser implements PrerequisiteParserInterface
+public class PreEquipSecondaryParser extends AbstractPrerequisiteListParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreEquipTwoWeaponParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreEquipTwoWeaponParser.java
@@ -18,9 +18,8 @@
 package plugin.pretokens.parser;
 
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteListParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
-public class PreEquipTwoWeaponParser extends AbstractPrerequisiteListParser implements PrerequisiteParserInterface
+public class PreEquipTwoWeaponParser extends AbstractPrerequisiteListParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreGenderParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreGenderParser.java
@@ -21,12 +21,11 @@ import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteOperator;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteSimpleParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre gender tokens.
  */
-public class PreGenderParser extends AbstractPrerequisiteSimpleParser implements PrerequisiteParserInterface
+public class PreGenderParser extends AbstractPrerequisiteSimpleParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreHDParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreHDParser.java
@@ -23,13 +23,12 @@ import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteOperator;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 import pcgen.util.Logging;
 
 /**
  * A prerequisite parser class that handles the parsing of pre HD tokens.
  */
-public class PreHDParser extends AbstractPrerequisiteParser implements PrerequisiteParserInterface
+public class PreHDParser extends AbstractPrerequisiteParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreHPParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreHPParser.java
@@ -21,12 +21,11 @@ import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteOperator;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre HP tokens.
  */
-public class PreHPParser extends AbstractPrerequisiteParser implements PrerequisiteParserInterface
+public class PreHPParser extends AbstractPrerequisiteParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreHandsParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreHandsParser.java
@@ -24,12 +24,11 @@ import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteException;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre hands tokens.
  */
-public class PreHandsParser extends AbstractPrerequisiteParser implements PrerequisiteParserInterface
+public class PreHandsParser extends AbstractPrerequisiteParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreItemParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreItemParser.java
@@ -18,12 +18,11 @@
 package plugin.pretokens.parser;
 
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteListParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre item tokens.
  */
-public class PreItemParser extends AbstractPrerequisiteListParser implements PrerequisiteParserInterface
+public class PreItemParser extends AbstractPrerequisiteListParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreKitParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreKitParser.java
@@ -18,12 +18,11 @@
 package plugin.pretokens.parser;
 
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteListParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre kit tokens.
  */
-public class PreKitParser extends AbstractPrerequisiteListParser implements PrerequisiteParserInterface
+public class PreKitParser extends AbstractPrerequisiteListParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreLanguageParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreLanguageParser.java
@@ -20,12 +20,11 @@ package plugin.pretokens.parser;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteListParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre language tokens.
  */
-public class PreLanguageParser extends AbstractPrerequisiteListParser implements PrerequisiteParserInterface
+public class PreLanguageParser extends AbstractPrerequisiteListParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreLegsParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreLegsParser.java
@@ -24,12 +24,11 @@ import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteException;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre legs tokens.
  */
-public class PreLegsParser extends AbstractPrerequisiteParser implements PrerequisiteParserInterface
+public class PreLegsParser extends AbstractPrerequisiteParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreLevelMaxParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreLevelMaxParser.java
@@ -21,12 +21,11 @@ import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteOperator;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteIntegerParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre level max tokens.
  */
-public class PreLevelMaxParser extends AbstractPrerequisiteIntegerParser implements PrerequisiteParserInterface
+public class PreLevelMaxParser extends AbstractPrerequisiteIntegerParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreMoveParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreMoveParser.java
@@ -21,12 +21,11 @@
 package plugin.pretokens.parser;
 
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteListParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre move tokens.
  */
-public class PreMoveParser extends AbstractPrerequisiteListParser implements PrerequisiteParserInterface
+public class PreMoveParser extends AbstractPrerequisiteListParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreMultParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreMultParser.java
@@ -25,10 +25,9 @@ import pcgen.core.prereq.PrerequisiteOperator;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteParser;
 import pcgen.persistence.lst.prereq.PreParserFactory;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 import pcgen.util.Logging;
 
-public class PreMultParser extends AbstractPrerequisiteParser implements PrerequisiteParserInterface
+public class PreMultParser extends AbstractPrerequisiteParser
 {
 	@Override
 	public String[] kindsHandled()

--- a/code/src/java/plugin/pretokens/parser/PrePCLevelParser.java
+++ b/code/src/java/plugin/pretokens/parser/PrePCLevelParser.java
@@ -21,12 +21,11 @@ import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteOperator;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre PC Level tokens.
  */
-public class PrePCLevelParser extends AbstractPrerequisiteParser implements PrerequisiteParserInterface
+public class PrePCLevelParser extends AbstractPrerequisiteParser
 {
 
 	//TODO created tests

--- a/code/src/java/plugin/pretokens/parser/PrePointBuyMethodParser.java
+++ b/code/src/java/plugin/pretokens/parser/PrePointBuyMethodParser.java
@@ -18,12 +18,11 @@
 package plugin.pretokens.parser;
 
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteListParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre point buy method tokens.
  */
-public class PrePointBuyMethodParser extends AbstractPrerequisiteListParser implements PrerequisiteParserInterface
+public class PrePointBuyMethodParser extends AbstractPrerequisiteListParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreRaceParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreRaceParser.java
@@ -20,12 +20,11 @@ package plugin.pretokens.parser;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteListParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre reach tokens.
  */
-public class PreRaceParser extends AbstractPrerequisiteListParser implements PrerequisiteParserInterface
+public class PreRaceParser extends AbstractPrerequisiteListParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreReachParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreReachParser.java
@@ -24,12 +24,11 @@ import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteException;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre reach tokens.
  */
-public class PreReachParser extends AbstractPrerequisiteParser implements PrerequisiteParserInterface
+public class PreReachParser extends AbstractPrerequisiteParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreRegionParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreRegionParser.java
@@ -18,12 +18,11 @@
 package plugin.pretokens.parser;
 
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteSimpleParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre region tokens.
  */
-public class PreRegionParser extends AbstractPrerequisiteSimpleParser implements PrerequisiteParserInterface
+public class PreRegionParser extends AbstractPrerequisiteSimpleParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreRuleParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreRuleParser.java
@@ -20,12 +20,11 @@ package plugin.pretokens.parser;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteListParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre rule tokens.
  */
-public class PreRuleParser extends AbstractPrerequisiteListParser implements PrerequisiteParserInterface
+public class PreRuleParser extends AbstractPrerequisiteListParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreShieldProfParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreShieldProfParser.java
@@ -18,12 +18,11 @@
 package plugin.pretokens.parser;
 
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteListParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre shield prof tokens.
  */
-public class PreShieldProfParser extends AbstractPrerequisiteListParser implements PrerequisiteParserInterface
+public class PreShieldProfParser extends AbstractPrerequisiteListParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreSizeParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreSizeParser.java
@@ -24,13 +24,12 @@ import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteException;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 import pcgen.rules.context.LoadContext;
 
 /**
  * A prerequisite parser class that handles the parsing of pre size tokens.
  */
-public class PreSizeParser extends AbstractPrerequisiteParser implements PrerequisiteParserInterface
+public class PreSizeParser extends AbstractPrerequisiteParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreSkillParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreSkillParser.java
@@ -20,12 +20,11 @@ package plugin.pretokens.parser;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteListParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre skill tokens.
  */
-public class PreSkillParser extends AbstractPrerequisiteListParser implements PrerequisiteParserInterface
+public class PreSkillParser extends AbstractPrerequisiteListParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreSkillSitParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreSkillSitParser.java
@@ -23,10 +23,9 @@ import java.util.List;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteListParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 import pcgen.util.Logging;
 
-public class PreSkillSitParser extends AbstractPrerequisiteListParser implements PrerequisiteParserInterface
+public class PreSkillSitParser extends AbstractPrerequisiteListParser
 {
 	@Override
 	public String[] kindsHandled()

--- a/code/src/java/plugin/pretokens/parser/PreSkillTotalParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreSkillTotalParser.java
@@ -20,12 +20,11 @@ package plugin.pretokens.parser;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre skill total tokens.
  */
-public class PreSkillTotalParser extends AbstractPrerequisiteParser implements PrerequisiteParserInterface
+public class PreSkillTotalParser extends AbstractPrerequisiteParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreSpecialAbilityParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreSpecialAbilityParser.java
@@ -18,12 +18,11 @@
 package plugin.pretokens.parser;
 
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteListParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre special ability tokens.
  */
-public class PreSpecialAbilityParser extends AbstractPrerequisiteListParser implements PrerequisiteParserInterface
+public class PreSpecialAbilityParser extends AbstractPrerequisiteListParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreSpellBookParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreSpellBookParser.java
@@ -18,12 +18,11 @@
 package plugin.pretokens.parser;
 
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteSimpleParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre spell booktokens.
  */
-public class PreSpellBookParser extends AbstractPrerequisiteSimpleParser implements PrerequisiteParserInterface
+public class PreSpellBookParser extends AbstractPrerequisiteSimpleParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreSpellCastParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreSpellCastParser.java
@@ -23,12 +23,11 @@ import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteOperator;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre spell cast tokens.
  */
-public class PreSpellCastParser extends AbstractPrerequisiteParser implements PrerequisiteParserInterface
+public class PreSpellCastParser extends AbstractPrerequisiteParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreSpellDescriptorParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreSpellDescriptorParser.java
@@ -18,12 +18,11 @@
 package plugin.pretokens.parser;
 
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteListParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre spell descriptor tokens.
  */
-public class PreSpellDescriptorParser extends AbstractPrerequisiteListParser implements PrerequisiteParserInterface
+public class PreSpellDescriptorParser extends AbstractPrerequisiteListParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreSpellParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreSpellParser.java
@@ -18,12 +18,11 @@
 package plugin.pretokens.parser;
 
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteListParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre Spell tokens.
  */
-public class PreSpellParser extends AbstractPrerequisiteListParser implements PrerequisiteParserInterface
+public class PreSpellParser extends AbstractPrerequisiteListParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreSpellResistanceParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreSpellResistanceParser.java
@@ -21,12 +21,11 @@ import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteException;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteIntegerParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre spell resistance tokens.
  */
-public class PreSpellResistanceParser extends AbstractPrerequisiteIntegerParser implements PrerequisiteParserInterface
+public class PreSpellResistanceParser extends AbstractPrerequisiteIntegerParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreSpellSchoolParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreSpellSchoolParser.java
@@ -18,12 +18,11 @@
 package plugin.pretokens.parser;
 
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteListParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre spell school tokens.
  */
-public class PreSpellSchoolParser extends AbstractPrerequisiteListParser implements PrerequisiteParserInterface
+public class PreSpellSchoolParser extends AbstractPrerequisiteListParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreSpellSchoolSubParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreSpellSchoolSubParser.java
@@ -18,12 +18,11 @@
 package plugin.pretokens.parser;
 
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteListParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre spell school sub tokens.
  */
-public class PreSpellSchoolSubParser extends AbstractPrerequisiteListParser implements PrerequisiteParserInterface
+public class PreSpellSchoolSubParser extends AbstractPrerequisiteListParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreSpellTypeParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreSpellTypeParser.java
@@ -20,12 +20,11 @@ package plugin.pretokens.parser;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteListParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre spell tokens.
  */
-public class PreSpellTypeParser extends AbstractPrerequisiteListParser implements PrerequisiteParserInterface
+public class PreSpellTypeParser extends AbstractPrerequisiteListParser
 {
 	@Override
 	protected boolean requiresValue()

--- a/code/src/java/plugin/pretokens/parser/PreStatParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreStatParser.java
@@ -23,13 +23,12 @@ import pcgen.core.prereq.PrerequisiteException;
 import pcgen.core.prereq.PrerequisiteOperator;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 import pcgen.util.Logging;
 
 /**
  * A prerequisite parser class that handles the parsing of pre stat tokens.
  */
-public class PreStatParser extends AbstractPrerequisiteParser implements PrerequisiteParserInterface
+public class PreStatParser extends AbstractPrerequisiteParser
 {
 
 	/**

--- a/code/src/java/plugin/pretokens/parser/PreSubClassParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreSubClassParser.java
@@ -18,12 +18,11 @@
 package plugin.pretokens.parser;
 
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteListParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre sub-class tokens.
  */
-public class PreSubClassParser extends AbstractPrerequisiteListParser implements PrerequisiteParserInterface
+public class PreSubClassParser extends AbstractPrerequisiteListParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreTemplateParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreTemplateParser.java
@@ -18,12 +18,11 @@
 package plugin.pretokens.parser;
 
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteListParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre template tokens.
  */
-public class PreTemplateParser extends AbstractPrerequisiteListParser implements PrerequisiteParserInterface
+public class PreTemplateParser extends AbstractPrerequisiteListParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreTextParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreTextParser.java
@@ -20,12 +20,11 @@ package plugin.pretokens.parser;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre text tokens.
  */
-public class PreTextParser extends AbstractPrerequisiteParser implements PrerequisiteParserInterface
+public class PreTextParser extends AbstractPrerequisiteParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreTotalABParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreTotalABParser.java
@@ -20,13 +20,12 @@ package plugin.pretokens.parser;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 import pcgen.util.Logging;
 
 /**
  * A prerequisite parser class that handles the parsing of pre attack tokens.
  */
-public class PreTotalABParser extends AbstractPrerequisiteParser implements PrerequisiteParserInterface
+public class PreTotalABParser extends AbstractPrerequisiteParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreTypeParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreTypeParser.java
@@ -10,12 +10,11 @@ import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteOperator;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre type tokens.
  */
-public class PreTypeParser extends AbstractPrerequisiteParser implements PrerequisiteParserInterface
+public class PreTypeParser extends AbstractPrerequisiteParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreUnarmedAttackParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreUnarmedAttackParser.java
@@ -18,12 +18,11 @@
 package plugin.pretokens.parser;
 
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteIntegerParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre unarmed attack tokens.
  */
-public class PreUnarmedAttackParser extends AbstractPrerequisiteIntegerParser implements PrerequisiteParserInterface
+public class PreUnarmedAttackParser extends AbstractPrerequisiteIntegerParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreVariableParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreVariableParser.java
@@ -22,12 +22,11 @@ import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteException;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre variable tokens.
  */
-public class PreVariableParser extends AbstractPrerequisiteParser implements PrerequisiteParserInterface
+public class PreVariableParser extends AbstractPrerequisiteParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreVisionParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreVisionParser.java
@@ -20,13 +20,12 @@ package plugin.pretokens.parser;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.persistence.PersistenceLayerException;
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteListParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 import pcgen.util.Logging;
 
 /**
  * A prerequisite parser class that handles the parsing of pre vision tokens.
  */
-public class PreVisionParser extends AbstractPrerequisiteListParser implements PrerequisiteParserInterface
+public class PreVisionParser extends AbstractPrerequisiteListParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/parser/PreWieldParser.java
+++ b/code/src/java/plugin/pretokens/parser/PreWieldParser.java
@@ -18,12 +18,11 @@
 package plugin.pretokens.parser;
 
 import pcgen.persistence.lst.prereq.AbstractPrerequisiteListParser;
-import pcgen.persistence.lst.prereq.PrerequisiteParserInterface;
 
 /**
  * A prerequisite parser class that handles the parsing of pre wield tokens.
  */
-public class PreWieldParser extends AbstractPrerequisiteListParser implements PrerequisiteParserInterface
+public class PreWieldParser extends AbstractPrerequisiteListParser
 {
 	/**
 	 * Get the type of prerequisite handled by this token.

--- a/code/src/java/plugin/pretokens/test/PreAbilityTester.java
+++ b/code/src/java/plugin/pretokens/test/PreAbilityTester.java
@@ -23,7 +23,6 @@ import pcgen.core.PlayerCharacter;
 import pcgen.core.prereq.AbstractPrerequisiteTest;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteException;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.core.prereq.PrerequisiteUtilities;
 import pcgen.system.LanguageBundle;
 
@@ -31,7 +30,7 @@ import pcgen.system.LanguageBundle;
  * {@code PreAbilityParser} tests whether a character passes ability
  * prereqs.
  */
-public class PreAbilityTester extends AbstractPrerequisiteTest implements PrerequisiteTest
+public class PreAbilityTester extends AbstractPrerequisiteTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreAgeSetTester.java
+++ b/code/src/java/plugin/pretokens/test/PreAgeSetTester.java
@@ -20,10 +20,9 @@ import pcgen.core.display.CharacterDisplay;
 import pcgen.core.prereq.AbstractDisplayPrereqTest;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteException;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.system.LanguageBundle;
 
-public class PreAgeSetTester extends AbstractDisplayPrereqTest implements PrerequisiteTest
+public class PreAgeSetTester extends AbstractDisplayPrereqTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreAlignTester.java
+++ b/code/src/java/plugin/pretokens/test/PreAlignTester.java
@@ -32,13 +32,12 @@ import pcgen.core.prereq.AbstractPrerequisiteTest;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteException;
 import pcgen.core.prereq.PrerequisiteOperator;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.output.channel.ChannelUtilities;
 import pcgen.output.channel.compat.AlignmentCompat;
 import pcgen.system.LanguageBundle;
 import pcgen.util.Logging;
 
-public class PreAlignTester extends AbstractPrerequisiteTest implements PrerequisiteTest
+public class PreAlignTester extends AbstractPrerequisiteTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreArmorProfTester.java
+++ b/code/src/java/plugin/pretokens/test/PreArmorProfTester.java
@@ -27,14 +27,13 @@ import pcgen.core.display.CharacterDisplay;
 import pcgen.core.prereq.AbstractDisplayPrereqTest;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteException;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.system.LanguageBundle;
 
 /**
  * {@code PreArmorProfTester} does the testing of armor proficiency
  * prerequisites. 
  */
-public class PreArmorProfTester extends AbstractDisplayPrereqTest implements PrerequisiteTest
+public class PreArmorProfTester extends AbstractDisplayPrereqTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreArmorTypeTester.java
+++ b/code/src/java/plugin/pretokens/test/PreArmorTypeTester.java
@@ -26,12 +26,11 @@ import pcgen.core.Equipment;
 import pcgen.core.display.CharacterDisplay;
 import pcgen.core.prereq.AbstractDisplayPrereqTest;
 import pcgen.core.prereq.Prerequisite;
-import pcgen.core.prereq.PrerequisiteTest;
 
 /**
  * Prerequisite test the type of a piece of armour.
  */
-public class PreArmorTypeTester extends AbstractDisplayPrereqTest implements PrerequisiteTest
+public class PreArmorTypeTester extends AbstractDisplayPrereqTest
 {
 
 	// TODO All the equipment related PRE tag code should be refactored into a

--- a/code/src/java/plugin/pretokens/test/PreAttackTester.java
+++ b/code/src/java/plugin/pretokens/test/PreAttackTester.java
@@ -23,13 +23,12 @@ import pcgen.core.PlayerCharacter;
 import pcgen.core.prereq.AbstractPrerequisiteTest;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteException;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.system.LanguageBundle;
 
 /**
  * Prerequisite test the type of a piece of armour.
  */
-public class PreAttackTester extends AbstractPrerequisiteTest implements PrerequisiteTest
+public class PreAttackTester extends AbstractPrerequisiteTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreBaseSizeTester.java
+++ b/code/src/java/plugin/pretokens/test/PreBaseSizeTester.java
@@ -25,10 +25,9 @@ import pcgen.core.PlayerCharacter;
 import pcgen.core.SizeAdjustment;
 import pcgen.core.prereq.AbstractPrerequisiteTest;
 import pcgen.core.prereq.Prerequisite;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.rules.context.AbstractReferenceContext;
 
-public class PreBaseSizeTester extends AbstractPrerequisiteTest implements PrerequisiteTest
+public class PreBaseSizeTester extends AbstractPrerequisiteTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreBirthPlaceTester.java
+++ b/code/src/java/plugin/pretokens/test/PreBirthPlaceTester.java
@@ -23,9 +23,8 @@ import pcgen.cdom.enumeration.PCStringKey;
 import pcgen.core.display.CharacterDisplay;
 import pcgen.core.prereq.AbstractDisplayPrereqTest;
 import pcgen.core.prereq.Prerequisite;
-import pcgen.core.prereq.PrerequisiteTest;
 
-public class PreBirthPlaceTester extends AbstractDisplayPrereqTest implements PrerequisiteTest
+public class PreBirthPlaceTester extends AbstractDisplayPrereqTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreCampaignTester.java
+++ b/code/src/java/plugin/pretokens/test/PreCampaignTester.java
@@ -32,7 +32,6 @@ import pcgen.core.prereq.AbstractDisplayPrereqTest;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteException;
 import pcgen.core.prereq.PrerequisiteOperator;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.persistence.PersistenceManager;
 import pcgen.system.LanguageBundle;
 import pcgen.util.Logging;
@@ -43,7 +42,7 @@ import pcgen.util.Logging;
  * 
  * 
  */
-public class PreCampaignTester extends AbstractDisplayPrereqTest implements PrerequisiteTest
+public class PreCampaignTester extends AbstractDisplayPrereqTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreCharactertypeTester.java
+++ b/code/src/java/plugin/pretokens/test/PreCharactertypeTester.java
@@ -23,10 +23,9 @@ import pcgen.cdom.util.CControl;
 import pcgen.core.display.CharacterDisplay;
 import pcgen.core.prereq.AbstractDisplayPrereqTest;
 import pcgen.core.prereq.Prerequisite;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.output.channel.ChannelUtilities;
 
-public class PreCharactertypeTester extends AbstractDisplayPrereqTest implements PrerequisiteTest
+public class PreCharactertypeTester extends AbstractDisplayPrereqTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreCheckBaseTester.java
+++ b/code/src/java/plugin/pretokens/test/PreCheckBaseTester.java
@@ -23,9 +23,8 @@ import pcgen.core.PCCheck;
 import pcgen.core.PlayerCharacter;
 import pcgen.core.prereq.AbstractPrerequisiteTest;
 import pcgen.core.prereq.Prerequisite;
-import pcgen.core.prereq.PrerequisiteTest;
 
-public class PreCheckBaseTester extends AbstractPrerequisiteTest implements PrerequisiteTest
+public class PreCheckBaseTester extends AbstractPrerequisiteTest
 {
 
 	/**

--- a/code/src/java/plugin/pretokens/test/PreCheckTester.java
+++ b/code/src/java/plugin/pretokens/test/PreCheckTester.java
@@ -10,12 +10,11 @@ import pcgen.core.PCCheck;
 import pcgen.core.PlayerCharacter;
 import pcgen.core.prereq.AbstractPrerequisiteTest;
 import pcgen.core.prereq.Prerequisite;
-import pcgen.core.prereq.PrerequisiteTest;
 
 /**
  * Prerequisite test that the character has a non-zero value for a given check.
  */
-public class PreCheckTester extends AbstractPrerequisiteTest implements PrerequisiteTest
+public class PreCheckTester extends AbstractPrerequisiteTest
 {
 
 	/** Constructor. */

--- a/code/src/java/plugin/pretokens/test/PreCityTester.java
+++ b/code/src/java/plugin/pretokens/test/PreCityTester.java
@@ -23,9 +23,8 @@ import pcgen.cdom.enumeration.PCStringKey;
 import pcgen.core.display.CharacterDisplay;
 import pcgen.core.prereq.AbstractDisplayPrereqTest;
 import pcgen.core.prereq.Prerequisite;
-import pcgen.core.prereq.PrerequisiteTest;
 
-public class PreCityTester extends AbstractDisplayPrereqTest implements PrerequisiteTest
+public class PreCityTester extends AbstractDisplayPrereqTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreClassTester.java
+++ b/code/src/java/plugin/pretokens/test/PreClassTester.java
@@ -13,7 +13,6 @@ import pcgen.core.PlayerCharacter;
 import pcgen.core.display.CharacterDisplay;
 import pcgen.core.prereq.AbstractPrerequisiteTest;
 import pcgen.core.prereq.Prerequisite;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.system.LanguageBundle;
 import pcgen.util.Logging;
 
@@ -22,7 +21,7 @@ import pcgen.util.Logging;
  * To change the template for this generated type comment go to
  * Window - Preferences - Java - Code Generation - Code and Comments
  */
-public class PreClassTester extends AbstractPrerequisiteTest implements PrerequisiteTest
+public class PreClassTester extends AbstractPrerequisiteTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreDamageReductionTester.java
+++ b/code/src/java/plugin/pretokens/test/PreDamageReductionTester.java
@@ -22,9 +22,8 @@ import pcgen.cdom.base.CDOMObject;
 import pcgen.core.display.CharacterDisplay;
 import pcgen.core.prereq.AbstractDisplayPrereqTest;
 import pcgen.core.prereq.Prerequisite;
-import pcgen.core.prereq.PrerequisiteTest;
 
-public class PreDamageReductionTester extends AbstractDisplayPrereqTest implements PrerequisiteTest
+public class PreDamageReductionTester extends AbstractDisplayPrereqTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreDeityAlignTester.java
+++ b/code/src/java/plugin/pretokens/test/PreDeityAlignTester.java
@@ -14,7 +14,6 @@ import pcgen.core.PCAlignment;
 import pcgen.core.PlayerCharacter;
 import pcgen.core.prereq.AbstractPrerequisiteTest;
 import pcgen.core.prereq.Prerequisite;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.output.channel.ChannelUtilities;
 import pcgen.system.LanguageBundle;
 import pcgen.util.Logging;
@@ -22,7 +21,7 @@ import pcgen.util.Logging;
 /**
  * Prerequisite test that the character has a deity with the correct alignment.
  */
-public class PreDeityAlignTester extends AbstractPrerequisiteTest implements PrerequisiteTest
+public class PreDeityAlignTester extends AbstractPrerequisiteTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreDeityDomainTester.java
+++ b/code/src/java/plugin/pretokens/test/PreDeityDomainTester.java
@@ -26,11 +26,10 @@ import pcgen.core.Globals;
 import pcgen.core.display.CharacterDisplay;
 import pcgen.core.prereq.AbstractDisplayPrereqTest;
 import pcgen.core.prereq.Prerequisite;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.output.channel.ChannelUtilities;
 import pcgen.system.LanguageBundle;
 
-public class PreDeityDomainTester extends AbstractDisplayPrereqTest implements PrerequisiteTest
+public class PreDeityDomainTester extends AbstractDisplayPrereqTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreDeityTester.java
+++ b/code/src/java/plugin/pretokens/test/PreDeityTester.java
@@ -18,7 +18,6 @@ import pcgen.core.prereq.AbstractDisplayPrereqTest;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteException;
 import pcgen.core.prereq.PrerequisiteOperator;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.output.channel.ChannelUtilities;
 import pcgen.system.LanguageBundle;
 
@@ -27,7 +26,7 @@ import pcgen.system.LanguageBundle;
  * To change the template for this generated type comment go to
  * Window - Preferences - Java - Code Generation - Code and Comments
  */
-public class PreDeityTester extends AbstractDisplayPrereqTest implements PrerequisiteTest
+public class PreDeityTester extends AbstractDisplayPrereqTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreEquipBothTester.java
+++ b/code/src/java/plugin/pretokens/test/PreEquipBothTester.java
@@ -24,9 +24,8 @@ import pcgen.core.PlayerCharacter;
 import pcgen.core.prereq.PreEquippedTester;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteException;
-import pcgen.core.prereq.PrerequisiteTest;
 
-public class PreEquipBothTester extends PreEquippedTester implements PrerequisiteTest
+public class PreEquipBothTester extends PreEquippedTester
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreEquipPrimaryTester.java
+++ b/code/src/java/plugin/pretokens/test/PreEquipPrimaryTester.java
@@ -24,9 +24,8 @@ import pcgen.core.PlayerCharacter;
 import pcgen.core.prereq.PreEquippedTester;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteException;
-import pcgen.core.prereq.PrerequisiteTest;
 
-public class PreEquipPrimaryTester extends PreEquippedTester implements PrerequisiteTest
+public class PreEquipPrimaryTester extends PreEquippedTester
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreEquipSecondaryTester.java
+++ b/code/src/java/plugin/pretokens/test/PreEquipSecondaryTester.java
@@ -24,9 +24,8 @@ import pcgen.core.PlayerCharacter;
 import pcgen.core.prereq.PreEquippedTester;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteException;
-import pcgen.core.prereq.PrerequisiteTest;
 
-public class PreEquipSecondaryTester extends PreEquippedTester implements PrerequisiteTest
+public class PreEquipSecondaryTester extends PreEquippedTester
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreEquipTester.java
+++ b/code/src/java/plugin/pretokens/test/PreEquipTester.java
@@ -29,10 +29,9 @@ import pcgen.core.display.CharacterDisplay;
 import pcgen.core.prereq.AbstractPrerequisiteTest;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteException;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.system.LanguageBundle;
 
-public class PreEquipTester extends AbstractPrerequisiteTest implements PrerequisiteTest
+public class PreEquipTester extends AbstractPrerequisiteTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreEquipTwoWeaponTester.java
+++ b/code/src/java/plugin/pretokens/test/PreEquipTwoWeaponTester.java
@@ -24,9 +24,8 @@ import pcgen.core.PlayerCharacter;
 import pcgen.core.prereq.PreEquippedTester;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteException;
-import pcgen.core.prereq.PrerequisiteTest;
 
-public class PreEquipTwoWeaponTester extends PreEquippedTester implements PrerequisiteTest
+public class PreEquipTwoWeaponTester extends PreEquippedTester
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreFactSetTester.java
+++ b/code/src/java/plugin/pretokens/test/PreFactSetTester.java
@@ -28,14 +28,13 @@ import pcgen.core.prereq.AbstractPrerequisiteTest;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteException;
 import pcgen.core.prereq.PrerequisiteOperator;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.output.publish.OutputDB;
 import pcgen.system.LanguageBundle;
 
 /**
  * The Class {@code PreFactTester} is responsible for testing FACT values on an object.
  */
-public class PreFactSetTester extends AbstractPrerequisiteTest implements PrerequisiteTest
+public class PreFactSetTester extends AbstractPrerequisiteTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreFactTester.java
+++ b/code/src/java/plugin/pretokens/test/PreFactTester.java
@@ -26,14 +26,13 @@ import pcgen.core.prereq.AbstractPrerequisiteTest;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteException;
 import pcgen.core.prereq.PrerequisiteOperator;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.output.publish.OutputDB;
 import pcgen.system.LanguageBundle;
 
 /**
  * The Class {@code PreFactTester} is responsible for testing FACT values on an object.
  */
-public class PreFactTester extends AbstractPrerequisiteTest implements PrerequisiteTest
+public class PreFactTester extends AbstractPrerequisiteTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreGenderTester.java
+++ b/code/src/java/plugin/pretokens/test/PreGenderTester.java
@@ -23,9 +23,8 @@ import pcgen.core.PlayerCharacter;
 import pcgen.core.prereq.AbstractPrerequisiteTest;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteOperator;
-import pcgen.core.prereq.PrerequisiteTest;
 
-public class PreGenderTester extends AbstractPrerequisiteTest implements PrerequisiteTest
+public class PreGenderTester extends AbstractPrerequisiteTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreHDTester.java
+++ b/code/src/java/plugin/pretokens/test/PreHDTester.java
@@ -24,10 +24,9 @@ import pcgen.core.display.CharacterDisplay;
 import pcgen.core.prereq.AbstractDisplayPrereqTest;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteException;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.system.LanguageBundle;
 
-public class PreHDTester extends AbstractDisplayPrereqTest implements PrerequisiteTest
+public class PreHDTester extends AbstractDisplayPrereqTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreHPTester.java
+++ b/code/src/java/plugin/pretokens/test/PreHPTester.java
@@ -24,10 +24,9 @@ import pcgen.core.PlayerCharacter;
 import pcgen.core.prereq.AbstractPrerequisiteTest;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteException;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.system.LanguageBundle;
 
-public class PreHPTester extends AbstractPrerequisiteTest implements PrerequisiteTest
+public class PreHPTester extends AbstractPrerequisiteTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreHandsTester.java
+++ b/code/src/java/plugin/pretokens/test/PreHandsTester.java
@@ -25,10 +25,9 @@ import pcgen.core.PlayerCharacter;
 import pcgen.core.prereq.AbstractPrerequisiteTest;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteException;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.system.LanguageBundle;
 
-public class PreHandsTester extends AbstractPrerequisiteTest implements PrerequisiteTest
+public class PreHandsTester extends AbstractPrerequisiteTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreHasDeityTester.java
+++ b/code/src/java/plugin/pretokens/test/PreHasDeityTester.java
@@ -30,10 +30,9 @@ import pcgen.core.display.CharacterDisplay;
 import pcgen.core.prereq.AbstractDisplayPrereqTest;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteOperator;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.output.channel.ChannelUtilities;
 
-public class PreHasDeityTester extends AbstractDisplayPrereqTest implements PrerequisiteTest
+public class PreHasDeityTester extends AbstractDisplayPrereqTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreItemTester.java
+++ b/code/src/java/plugin/pretokens/test/PreItemTester.java
@@ -27,14 +27,13 @@ import pcgen.core.display.CharacterDisplay;
 import pcgen.core.prereq.AbstractDisplayPrereqTest;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteException;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.core.utils.CoreUtility;
 import pcgen.system.LanguageBundle;
 
 /**
  * Sets requirements for items a character must possess.
  */
-public class PreItemTester extends AbstractDisplayPrereqTest implements PrerequisiteTest
+public class PreItemTester extends AbstractDisplayPrereqTest
 {
 
 	// TODO Refactor this with all the equipment tests.

--- a/code/src/java/plugin/pretokens/test/PreKitTester.java
+++ b/code/src/java/plugin/pretokens/test/PreKitTester.java
@@ -24,13 +24,12 @@ import pcgen.core.display.CharacterDisplay;
 import pcgen.core.prereq.AbstractDisplayPrereqTest;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteException;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.system.LanguageBundle;
 
 /**
  * Prerequisite tester, tests for the presence of a kit.
  */
-public class PreKitTester extends AbstractDisplayPrereqTest implements PrerequisiteTest
+public class PreKitTester extends AbstractDisplayPrereqTest
 {
 
 	private static final Class<Kit> KIT_CLASS = Kit.class;

--- a/code/src/java/plugin/pretokens/test/PreLanguageTester.java
+++ b/code/src/java/plugin/pretokens/test/PreLanguageTester.java
@@ -25,10 +25,9 @@ import pcgen.core.display.CharacterDisplay;
 import pcgen.core.prereq.AbstractDisplayPrereqTest;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteException;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.system.LanguageBundle;
 
-public class PreLanguageTester extends AbstractDisplayPrereqTest implements PrerequisiteTest
+public class PreLanguageTester extends AbstractDisplayPrereqTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreLegsTester.java
+++ b/code/src/java/plugin/pretokens/test/PreLegsTester.java
@@ -23,10 +23,9 @@ import pcgen.core.display.CharacterDisplay;
 import pcgen.core.prereq.AbstractDisplayPrereqTest;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteException;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.system.LanguageBundle;
 
-public class PreLegsTester extends AbstractDisplayPrereqTest implements PrerequisiteTest
+public class PreLegsTester extends AbstractDisplayPrereqTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreLevelMaxTester.java
+++ b/code/src/java/plugin/pretokens/test/PreLevelMaxTester.java
@@ -22,10 +22,9 @@ import pcgen.cdom.base.CDOMObject;
 import pcgen.core.display.CharacterDisplay;
 import pcgen.core.prereq.AbstractDisplayPrereqTest;
 import pcgen.core.prereq.Prerequisite;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.system.LanguageBundle;
 
-public class PreLevelMaxTester extends AbstractDisplayPrereqTest implements PrerequisiteTest
+public class PreLevelMaxTester extends AbstractDisplayPrereqTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreLevelTester.java
+++ b/code/src/java/plugin/pretokens/test/PreLevelTester.java
@@ -22,9 +22,8 @@ import pcgen.cdom.base.CDOMObject;
 import pcgen.core.display.CharacterDisplay;
 import pcgen.core.prereq.AbstractDisplayPrereqTest;
 import pcgen.core.prereq.Prerequisite;
-import pcgen.core.prereq.PrerequisiteTest;
 
-public class PreLevelTester extends AbstractDisplayPrereqTest implements PrerequisiteTest
+public class PreLevelTester extends AbstractDisplayPrereqTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreMultTester.java
+++ b/code/src/java/plugin/pretokens/test/PreMultTester.java
@@ -32,7 +32,7 @@ import pcgen.util.Logging;
 
 import org.apache.commons.lang3.StringUtils;
 
-public class PreMultTester extends AbstractPrerequisiteTest implements PrerequisiteTest
+public class PreMultTester extends AbstractPrerequisiteTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PrePCLevelTester.java
+++ b/code/src/java/plugin/pretokens/test/PrePCLevelTester.java
@@ -19,9 +19,8 @@ import pcgen.cdom.base.CDOMObject;
 import pcgen.core.display.CharacterDisplay;
 import pcgen.core.prereq.AbstractDisplayPrereqTest;
 import pcgen.core.prereq.Prerequisite;
-import pcgen.core.prereq.PrerequisiteTest;
 
-public class PrePCLevelTester extends AbstractDisplayPrereqTest implements PrerequisiteTest
+public class PrePCLevelTester extends AbstractDisplayPrereqTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PrePointBuyMethodTester.java
+++ b/code/src/java/plugin/pretokens/test/PrePointBuyMethodTester.java
@@ -23,13 +23,12 @@ import pcgen.core.SettingsHandler;
 import pcgen.core.display.CharacterDisplay;
 import pcgen.core.prereq.AbstractDisplayPrereqTest;
 import pcgen.core.prereq.Prerequisite;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.system.LanguageBundle;
 
 /**
  * {@code PrePointBuyMethod}.
  */
-public class PrePointBuyMethodTester extends AbstractDisplayPrereqTest implements PrerequisiteTest
+public class PrePointBuyMethodTester extends AbstractDisplayPrereqTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreRaceTester.java
+++ b/code/src/java/plugin/pretokens/test/PreRaceTester.java
@@ -33,9 +33,8 @@ import pcgen.core.Race;
 import pcgen.core.display.CharacterDisplay;
 import pcgen.core.prereq.AbstractDisplayPrereqTest;
 import pcgen.core.prereq.Prerequisite;
-import pcgen.core.prereq.PrerequisiteTest;
 
-public class PreRaceTester extends AbstractDisplayPrereqTest implements PrerequisiteTest
+public class PreRaceTester extends AbstractDisplayPrereqTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreReachTester.java
+++ b/code/src/java/plugin/pretokens/test/PreReachTester.java
@@ -25,10 +25,9 @@ import pcgen.core.display.CharacterDisplay;
 import pcgen.core.prereq.AbstractDisplayPrereqTest;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteException;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.system.LanguageBundle;
 
-public class PreReachTester extends AbstractDisplayPrereqTest implements PrerequisiteTest
+public class PreReachTester extends AbstractDisplayPrereqTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreRegionTester.java
+++ b/code/src/java/plugin/pretokens/test/PreRegionTester.java
@@ -25,10 +25,9 @@ import pcgen.core.prereq.AbstractDisplayPrereqTest;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteException;
 import pcgen.core.prereq.PrerequisiteOperator;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.system.LanguageBundle;
 
-public class PreRegionTester extends AbstractDisplayPrereqTest implements PrerequisiteTest
+public class PreRegionTester extends AbstractDisplayPrereqTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreRuleTester.java
+++ b/code/src/java/plugin/pretokens/test/PreRuleTester.java
@@ -27,7 +27,7 @@ import pcgen.core.prereq.PrerequisiteException;
 import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.core.prereq.PrerequisiteTestFactory;
 
-public class PreRuleTester extends AbstractPrerequisiteTest implements PrerequisiteTest
+public class PreRuleTester extends AbstractPrerequisiteTest
 {
 
 	/**

--- a/code/src/java/plugin/pretokens/test/PreShieldProfTester.java
+++ b/code/src/java/plugin/pretokens/test/PreShieldProfTester.java
@@ -26,9 +26,8 @@ import pcgen.core.ShieldProf;
 import pcgen.core.display.CharacterDisplay;
 import pcgen.core.prereq.AbstractDisplayPrereqTest;
 import pcgen.core.prereq.Prerequisite;
-import pcgen.core.prereq.PrerequisiteTest;
 
-public class PreShieldProfTester extends AbstractDisplayPrereqTest implements PrerequisiteTest
+public class PreShieldProfTester extends AbstractDisplayPrereqTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreSizeTester.java
+++ b/code/src/java/plugin/pretokens/test/PreSizeTester.java
@@ -26,10 +26,9 @@ import pcgen.core.PlayerCharacter;
 import pcgen.core.SizeAdjustment;
 import pcgen.core.prereq.AbstractPrerequisiteTest;
 import pcgen.core.prereq.Prerequisite;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.rules.context.AbstractReferenceContext;
 
-public class PreSizeTester extends AbstractPrerequisiteTest implements PrerequisiteTest
+public class PreSizeTester extends AbstractPrerequisiteTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreSkillMultTester.java
+++ b/code/src/java/plugin/pretokens/test/PreSkillMultTester.java
@@ -25,10 +25,9 @@ import pcgen.core.analysis.SkillRankControl;
 import pcgen.core.display.CharacterDisplay;
 import pcgen.core.prereq.AbstractPrerequisiteTest;
 import pcgen.core.prereq.Prerequisite;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.system.LanguageBundle;
 
-public class PreSkillMultTester extends AbstractPrerequisiteTest implements PrerequisiteTest
+public class PreSkillMultTester extends AbstractPrerequisiteTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreSkillSitTester.java
+++ b/code/src/java/plugin/pretokens/test/PreSkillSitTester.java
@@ -32,10 +32,9 @@ import pcgen.core.display.CharacterDisplay;
 import pcgen.core.prereq.AbstractPrerequisiteTest;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteOperator;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.system.LanguageBundle;
 
-public class PreSkillSitTester extends AbstractPrerequisiteTest implements PrerequisiteTest
+public class PreSkillSitTester extends AbstractPrerequisiteTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreSkillTester.java
+++ b/code/src/java/plugin/pretokens/test/PreSkillTester.java
@@ -37,10 +37,9 @@ import pcgen.core.display.CharacterDisplay;
 import pcgen.core.prereq.AbstractPrerequisiteTest;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteOperator;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.system.LanguageBundle;
 
-public class PreSkillTester extends AbstractPrerequisiteTest implements PrerequisiteTest
+public class PreSkillTester extends AbstractPrerequisiteTest
 {
 
 	@SuppressWarnings("unused")

--- a/code/src/java/plugin/pretokens/test/PreSpecialAbilityTester.java
+++ b/code/src/java/plugin/pretokens/test/PreSpecialAbilityTester.java
@@ -24,10 +24,9 @@ import pcgen.core.SpecialAbility;
 import pcgen.core.prereq.AbstractPrerequisiteTest;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteException;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.system.LanguageBundle;
 
-public class PreSpecialAbilityTester extends AbstractPrerequisiteTest implements PrerequisiteTest
+public class PreSpecialAbilityTester extends AbstractPrerequisiteTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreSpellBookTester.java
+++ b/code/src/java/plugin/pretokens/test/PreSpellBookTester.java
@@ -24,9 +24,8 @@ import pcgen.core.PCClass;
 import pcgen.core.display.CharacterDisplay;
 import pcgen.core.prereq.AbstractDisplayPrereqTest;
 import pcgen.core.prereq.Prerequisite;
-import pcgen.core.prereq.PrerequisiteTest;
 
-public class PreSpellBookTester extends AbstractDisplayPrereqTest implements PrerequisiteTest
+public class PreSpellBookTester extends AbstractDisplayPrereqTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreSpellCastMemorizeTester.java
+++ b/code/src/java/plugin/pretokens/test/PreSpellCastMemorizeTester.java
@@ -10,14 +10,13 @@ import pcgen.core.PCClass;
 import pcgen.core.display.CharacterDisplay;
 import pcgen.core.prereq.AbstractDisplayPrereqTest;
 import pcgen.core.prereq.Prerequisite;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.system.LanguageBundle;
 
 /**
  * To change the template for this generated type comment go to
  * Window - Preferences - Java - Code Generation - Code and Comments
  */
-public class PreSpellCastMemorizeTester extends AbstractDisplayPrereqTest implements PrerequisiteTest
+public class PreSpellCastMemorizeTester extends AbstractDisplayPrereqTest
 {
 
     /**

--- a/code/src/java/plugin/pretokens/test/PreSpellCastTester.java
+++ b/code/src/java/plugin/pretokens/test/PreSpellCastTester.java
@@ -23,10 +23,9 @@ import pcgen.core.PCClass;
 import pcgen.core.display.CharacterDisplay;
 import pcgen.core.prereq.AbstractDisplayPrereqTest;
 import pcgen.core.prereq.Prerequisite;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.system.LanguageBundle;
 
-public class PreSpellCastTester extends AbstractDisplayPrereqTest implements PrerequisiteTest
+public class PreSpellCastTester extends AbstractDisplayPrereqTest
 {
 
     @Override

--- a/code/src/java/plugin/pretokens/test/PreSpellDescriptorTester.java
+++ b/code/src/java/plugin/pretokens/test/PreSpellDescriptorTester.java
@@ -23,11 +23,10 @@ import pcgen.cdom.base.CDOMObject;
 import pcgen.core.PlayerCharacter;
 import pcgen.core.prereq.AbstractPrerequisiteTest;
 import pcgen.core.prereq.Prerequisite;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.core.spell.Spell;
 import pcgen.system.LanguageBundle;
 
-public class PreSpellDescriptorTester extends AbstractPrerequisiteTest implements PrerequisiteTest
+public class PreSpellDescriptorTester extends AbstractPrerequisiteTest
 {
 
     @Override

--- a/code/src/java/plugin/pretokens/test/PreSpellResistanceTester.java
+++ b/code/src/java/plugin/pretokens/test/PreSpellResistanceTester.java
@@ -22,9 +22,8 @@ import pcgen.cdom.base.CDOMObject;
 import pcgen.core.PlayerCharacter;
 import pcgen.core.prereq.AbstractPrerequisiteTest;
 import pcgen.core.prereq.Prerequisite;
-import pcgen.core.prereq.PrerequisiteTest;
 
-public class PreSpellResistanceTester extends AbstractPrerequisiteTest implements PrerequisiteTest
+public class PreSpellResistanceTester extends AbstractPrerequisiteTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreSpellSchoolSubTester.java
+++ b/code/src/java/plugin/pretokens/test/PreSpellSchoolSubTester.java
@@ -24,11 +24,10 @@ import pcgen.cdom.base.CDOMObject;
 import pcgen.core.PlayerCharacter;
 import pcgen.core.prereq.AbstractPrerequisiteTest;
 import pcgen.core.prereq.Prerequisite;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.core.spell.Spell;
 import pcgen.system.LanguageBundle;
 
-public class PreSpellSchoolSubTester extends AbstractPrerequisiteTest implements PrerequisiteTest
+public class PreSpellSchoolSubTester extends AbstractPrerequisiteTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreSpellSchoolTester.java
+++ b/code/src/java/plugin/pretokens/test/PreSpellSchoolTester.java
@@ -24,14 +24,13 @@ import pcgen.cdom.base.CDOMObject;
 import pcgen.core.PlayerCharacter;
 import pcgen.core.prereq.AbstractPrerequisiteTest;
 import pcgen.core.prereq.Prerequisite;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.core.spell.Spell;
 import pcgen.system.LanguageBundle;
 
 /**
  * Prerequisite tester, tests for the presence of a school of spellcasting.
  */
-public class PreSpellSchoolTester extends AbstractPrerequisiteTest implements PrerequisiteTest
+public class PreSpellSchoolTester extends AbstractPrerequisiteTest
 {
 
     @Override

--- a/code/src/java/plugin/pretokens/test/PreSpellTester.java
+++ b/code/src/java/plugin/pretokens/test/PreSpellTester.java
@@ -30,12 +30,11 @@ import pcgen.core.PlayerCharacter;
 import pcgen.core.display.CharacterDisplay;
 import pcgen.core.prereq.AbstractPrerequisiteTest;
 import pcgen.core.prereq.Prerequisite;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.core.spell.Spell;
 import pcgen.system.LanguageBundle;
 import pcgen.util.Logging;
 
-public class PreSpellTester extends AbstractPrerequisiteTest implements PrerequisiteTest
+public class PreSpellTester extends AbstractPrerequisiteTest
 {
 
     @Override

--- a/code/src/java/plugin/pretokens/test/PreSpellTypeTester.java
+++ b/code/src/java/plugin/pretokens/test/PreSpellTypeTester.java
@@ -22,14 +22,13 @@ import pcgen.cdom.base.CDOMObject;
 import pcgen.core.PlayerCharacter;
 import pcgen.core.prereq.AbstractPrerequisiteTest;
 import pcgen.core.prereq.Prerequisite;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.system.LanguageBundle;
 import pcgen.util.Logging;
 
 /**
  * This is used to check the characters spellcasting ability.
  */
-public class PreSpellTypeTester extends AbstractPrerequisiteTest implements PrerequisiteTest
+public class PreSpellTypeTester extends AbstractPrerequisiteTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreStatTester.java
+++ b/code/src/java/plugin/pretokens/test/PreStatTester.java
@@ -25,10 +25,9 @@ import pcgen.core.display.CharacterDisplay;
 import pcgen.core.prereq.AbstractDisplayPrereqTest;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteException;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.system.LanguageBundle;
 
-public class PreStatTester extends AbstractDisplayPrereqTest implements PrerequisiteTest
+public class PreStatTester extends AbstractDisplayPrereqTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreSubClassTester.java
+++ b/code/src/java/plugin/pretokens/test/PreSubClassTester.java
@@ -24,13 +24,12 @@ import pcgen.core.display.CharacterDisplay;
 import pcgen.core.prereq.AbstractDisplayPrereqTest;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteException;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.system.LanguageBundle;
 
 /**
  * Prerequisite tester, tests for the presence of a subclass.
  */
-public class PreSubClassTester extends AbstractDisplayPrereqTest implements PrerequisiteTest
+public class PreSubClassTester extends AbstractDisplayPrereqTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreTemplateTester.java
+++ b/code/src/java/plugin/pretokens/test/PreTemplateTester.java
@@ -25,13 +25,12 @@ import pcgen.core.display.CharacterDisplay;
 import pcgen.core.prereq.AbstractDisplayPrereqTest;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteException;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.system.LanguageBundle;
 
 /**
  * Prerequisite tester, tests for the presence of a template.
  */
-public class PreTemplateTester extends AbstractDisplayPrereqTest implements PrerequisiteTest
+public class PreTemplateTester extends AbstractDisplayPrereqTest
 {
 
 	private static final Class<PCTemplate> PCTEMPLATE_CLASS = PCTemplate.class;

--- a/code/src/java/plugin/pretokens/test/PreTextTester.java
+++ b/code/src/java/plugin/pretokens/test/PreTextTester.java
@@ -23,13 +23,12 @@ import pcgen.core.display.CharacterDisplay;
 import pcgen.core.prereq.AbstractDisplayPrereqTest;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteOperator;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.system.LanguageBundle;
 
 /**
  * Prerequisite tester, test for the presence of text.
  */
-public class PreTextTester extends AbstractDisplayPrereqTest implements PrerequisiteTest
+public class PreTextTester extends AbstractDisplayPrereqTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreTotalABTester.java
+++ b/code/src/java/plugin/pretokens/test/PreTotalABTester.java
@@ -23,10 +23,9 @@ import pcgen.core.PlayerCharacter;
 import pcgen.core.prereq.AbstractPrerequisiteTest;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteException;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.system.LanguageBundle;
 
-public class PreTotalABTester extends AbstractPrerequisiteTest implements PrerequisiteTest
+public class PreTotalABTester extends AbstractPrerequisiteTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreTypeTester.java
+++ b/code/src/java/plugin/pretokens/test/PreTypeTester.java
@@ -30,14 +30,13 @@ import pcgen.core.prereq.AbstractDisplayPrereqTest;
 import pcgen.core.prereq.Prerequisite;
 import pcgen.core.prereq.PrerequisiteException;
 import pcgen.core.prereq.PrerequisiteOperator;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.system.LanguageBundle;
 import pcgen.util.Logging;
 
 /**
  * Prerequisite tester, tests for the presence of a type.
  */
-public class PreTypeTester extends AbstractDisplayPrereqTest implements PrerequisiteTest
+public class PreTypeTester extends AbstractDisplayPrereqTest
 {
 
 	/**

--- a/code/src/java/plugin/pretokens/test/PreUnarmedAttackTester.java
+++ b/code/src/java/plugin/pretokens/test/PreUnarmedAttackTester.java
@@ -24,10 +24,9 @@ import pcgen.core.PlayerCharacter;
 import pcgen.core.display.CharacterDisplay;
 import pcgen.core.prereq.AbstractPrerequisiteTest;
 import pcgen.core.prereq.Prerequisite;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.system.LanguageBundle;
 
-public class PreUnarmedAttackTester extends AbstractPrerequisiteTest implements PrerequisiteTest
+public class PreUnarmedAttackTester extends AbstractPrerequisiteTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreVariableTester.java
+++ b/code/src/java/plugin/pretokens/test/PreVariableTester.java
@@ -32,7 +32,7 @@ import pcgen.core.utils.CoreUtility;
 /**
  * Prerequisite test for the presence of a variable.
  */
-public class PreVariableTester extends AbstractPrerequisiteTest implements PrerequisiteTest
+public class PreVariableTester extends AbstractPrerequisiteTest
 {
 
 	/**

--- a/code/src/java/plugin/pretokens/test/PreVisionTester.java
+++ b/code/src/java/plugin/pretokens/test/PreVisionTester.java
@@ -23,14 +23,13 @@ import pcgen.core.Vision;
 import pcgen.core.display.CharacterDisplay;
 import pcgen.core.prereq.AbstractDisplayPrereqTest;
 import pcgen.core.prereq.Prerequisite;
-import pcgen.core.prereq.PrerequisiteTest;
 import pcgen.util.enumeration.VisionType;
 
 /**
  *
  * Checks a characters vision..
  */
-public class PreVisionTester extends AbstractDisplayPrereqTest implements PrerequisiteTest
+public class PreVisionTester extends AbstractDisplayPrereqTest
 {
 
 	@Override

--- a/code/src/java/plugin/pretokens/test/PreWieldTester.java
+++ b/code/src/java/plugin/pretokens/test/PreWieldTester.java
@@ -20,9 +20,8 @@ import pcgen.core.Equipment;
 import pcgen.core.display.CharacterDisplay;
 import pcgen.core.prereq.AbstractDisplayPrereqTest;
 import pcgen.core.prereq.Prerequisite;
-import pcgen.core.prereq.PrerequisiteTest;
 
-public class PreWieldTester extends AbstractDisplayPrereqTest implements PrerequisiteTest
+public class PreWieldTester extends AbstractDisplayPrereqTest
 {
 
 	@Override


### PR DESCRIPTION
## Summary

- Drop redundant `implements PrerequisiteTest` / `implements PrerequisiteParserInterface` declarations from 131 `Pre*Tester` / `Pre*Parser` classes — the interface is already provided by their abstract parent (`AbstractPrerequisiteTest` / `AbstractDisplayPrereqTest` / `PreEquippedTester` / `AbstractPrerequisiteParser` family).
- Drop the now-unused imports where the class no longer references the type elsewhere; keep them where it does (e.g. `PreMultTester` uses `PrerequisiteTest` as a local-variable type).
- Clears 131 of the 166 `UnnecessaryInterfaceDeclaration` PMD violations (total PMD count 801 → 670). The remaining 35 are non-prereq cases (mid-list interfaces, generics, inner classes) — left for a follow-up.

No behavioural change: every removed `implements` is supplied by an ancestor on the existing extends chain, so the type identity is unchanged.

## Test plan

- [x] `./gradlew checkstyleMain` — passes (Allman brace style preserved)
- [x] `./gradlew compileJava compileTestJava compileItestJava` — clean
- [x] `./gradlew test` — passes
- [x] `./gradlew itest` — passes (this is the LST-token integration suite that exercises the touched classes)
- [x] `./gradlew pmdMain` — `UnnecessaryInterfaceDeclaration` count: 166 → 35