### PR TITLE
PMD cleanup: drop misleading `public` from members of non-public nested types

### DIFF
--- a/code/src/java/pcgen/cdom/choiceset/CollectionToAbilitySelection.java
+++ b/code/src/java/pcgen/cdom/choiceset/CollectionToAbilitySelection.java
@@ -308,18 +308,18 @@ public class CollectionToAbilitySelection implements PrimitiveChoiceSet<AbilityS
 		private final Ability ability;
 		private final String choice;
 
-		public AbilityWithChoice(Ability a, String c)
+		AbilityWithChoice(Ability a, String c)
 		{
 			ability = a;
 			choice = c;
 		}
 
-		public Ability getAbility()
+		Ability getAbility()
 		{
 			return ability;
 		}
 
-		public String getChoice()
+		String getChoice()
 		{
 			return choice;
 		}

--- a/code/src/java/pcgen/cdom/facet/AgeSetKitFacet.java
+++ b/code/src/java/pcgen/cdom/facet/AgeSetKitFacet.java
@@ -174,12 +174,12 @@ public class AgeSetKitFacet extends AbstractStorageFacet<CharID> implements Data
 
 		private HashMapToList<AgeSet, Kit> kitMap = new HashMapToList<>();
 
-		public List<Kit> get(AgeSet ageSet)
+		List<Kit> get(AgeSet ageSet)
 		{
 			return kitMap.getListFor(ageSet);
 		}
 
-		public void put(AgeSet ageSet, Collection<? extends Kit> choice)
+		void put(AgeSet ageSet, Collection<? extends Kit> choice)
 		{
 			kitMap.addAllToListFor(ageSet, choice);
 		}

--- a/code/src/java/pcgen/cdom/facet/analysis/LevelFacet.java
+++ b/code/src/java/pcgen/cdom/facet/analysis/LevelFacet.java
@@ -200,8 +200,8 @@ public class LevelFacet extends AbstractStorageFacet<CharID> implements ClassLev
 	 */
 	private static class LevelCacheInfo
 	{
-		public int monsterLevels;
-		public int nonMonsterLevels;
+		int monsterLevels;
+		int nonMonsterLevels;
 
 		@Override
 		public int hashCode()

--- a/code/src/java/pcgen/cdom/facet/analysis/QualifyFacet.java
+++ b/code/src/java/pcgen/cdom/facet/analysis/QualifyFacet.java
@@ -158,7 +158,7 @@ public class QualifyFacet extends AbstractStorageFacet<CharID> implements DataFa
 		 * @param source
 		 *            The source for the Qualifier being added to this CacheInfo
 		 */
-		public void add(Qualifier q, CDOMObject source)
+		void add(Qualifier q, CDOMObject source)
 		{
 			hml.addToListFor(q.getQualifiedReference().getPersistentFormat(), q);
 			sourceMap.addToListFor(source, q);
@@ -172,7 +172,7 @@ public class QualifyFacet extends AbstractStorageFacet<CharID> implements DataFa
 		 *            The source CDOMObject for which all Qualifier objects will
 		 *            be removed from this CacheInfo
 		 */
-		public void removeAll(CDOMObject object)
+		void removeAll(CDOMObject object)
 		{
 			List<Qualifier> list = sourceMap.removeListFor(object);
 			if (list != null)
@@ -194,7 +194,7 @@ public class QualifyFacet extends AbstractStorageFacet<CharID> implements DataFa
 		 * @return true if the Player Character has been granted qualification
 		 *         for the given CDOMObject; false otherwise
 		 */
-		public boolean isQualified(Loadable qualTestObject)
+		boolean isQualified(Loadable qualTestObject)
 		{
 			ClassIdentity<? extends Loadable> identity = qualTestObject.getClassIdentity();
 			List<Qualifier> list = hml.getListFor(identity.getPersistentFormat());

--- a/code/src/java/pcgen/cdom/facet/base/AbstractItemConvertingFacet.java
+++ b/code/src/java/pcgen/cdom/facet/base/AbstractItemConvertingFacet.java
@@ -549,12 +549,12 @@ public abstract class AbstractItemConvertingFacet<S, D> extends AbstractDataFace
 		/**
 		 * The set of objects from which the converted object has been received
 		 */
-		public Set<Object> set = Collections.newSetFromMap(new IdentityHashMap<>());
+		Set<Object> set = Collections.newSetFromMap(new IdentityHashMap<>());
 
 		/**
 		 * The converted ("destination") object
 		 */
-		public D dest;
+		D dest;
 
 		@Override
 		public int hashCode()

--- a/code/src/java/pcgen/cdom/facet/fact/RegionFacet.java
+++ b/code/src/java/pcgen/cdom/facet/fact/RegionFacet.java
@@ -298,11 +298,11 @@ public class RegionFacet extends AbstractDataFacet<CharID, String>
 	 */
 	private static class RegionCacheInfo
 	{
-		public Optional<Region> cachedRegion = Optional.empty();
+		Optional<Region> cachedRegion = Optional.empty();
 
-		public Region region;
+		Region region;
 
-		public String subregion;
+		String subregion;
 
 		@Override
 		public String toString()

--- a/code/src/java/pcgen/cdom/meta/ConvertingFacetView.java
+++ b/code/src/java/pcgen/cdom/meta/ConvertingFacetView.java
@@ -81,7 +81,7 @@ public class ConvertingFacetView<S, D> implements FacetView<Object>
 		private final S source;
 		private final D destination;
 
-		public S getSource()
+		S getSource()
 		{
 			return source;
 		}

--- a/code/src/java/pcgen/core/DataSet.java
+++ b/code/src/java/pcgen/core/DataSet.java
@@ -584,7 +584,7 @@ public class DataSet implements DataSetFacade
 			return map.get(key);
 		}
 
-		public void put(AbilityCategory key, ListFacade<AbilityFacade> value)
+		void put(AbilityCategory key, ListFacade<AbilityFacade> value)
 		{
 			map.put(key, value);
 		}

--- a/code/src/java/pcgen/core/PlayerCharacter.java
+++ b/code/src/java/pcgen/core/PlayerCharacter.java
@@ -6700,7 +6700,7 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 		 *
 		 * @return bonus
 		 */
-		public int getBonus()
+		int getBonus()
 		{
 			return bonus;
 		}
@@ -6710,7 +6710,7 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 		 *
 		 * @return type
 		 */
-		public String getType()
+		String getType()
 		{
 			return type;
 		}
@@ -6720,7 +6720,7 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 		 *
 		 * @param newBonus
 		 */
-		public void setBonus(final int newBonus)
+		void setBonus(final int newBonus)
 		{
 			bonus = newBonus;
 		}

--- a/code/src/java/pcgen/core/RollingMethods.java
+++ b/code/src/java/pcgen/core/RollingMethods.java
@@ -385,7 +385,7 @@ public final class RollingMethods
 				this.rolls = rolls;
 			}
 
-			public Integer getRolls()
+			Integer getRolls()
 			{
 				return rolls;
 			}
@@ -438,7 +438,7 @@ public final class RollingMethods
 				this.rolls = rolls;
 			}
 
-			public Integer getRolls()
+			Integer getRolls()
 			{
 				return rolls;
 			}

--- a/code/src/java/pcgen/core/chooser/CDOMChooserFacadeImpl.java
+++ b/code/src/java/pcgen/core/chooser/CDOMChooserFacadeImpl.java
@@ -427,7 +427,7 @@ public class CDOMChooserFacadeImpl<T> implements ChooserFacade
 	{
 		private final CDOMObject cdomObj;
 
-		public CDOMInfoWrapper(CDOMObject cdomObj)
+		CDOMInfoWrapper(CDOMObject cdomObj)
 		{
 			this.cdomObj = cdomObj;
 
@@ -466,7 +466,7 @@ public class CDOMChooserFacadeImpl<T> implements ChooserFacade
 		/**
 		 * @return the cdomObj
 		 */
-		public CDOMObject getCdomObj()
+		CDOMObject getCdomObj()
 		{
 			return cdomObj;
 		}
@@ -484,7 +484,7 @@ public class CDOMChooserFacadeImpl<T> implements ChooserFacade
 		private final String string;
 		private final String delimiter;
 
-		public DelimitedStringInfoWrapper(String string, String delimiter)
+		DelimitedStringInfoWrapper(String string, String delimiter)
 		{
 			this.string = string;
 			this.delimiter = StringUtils.trimToNull(delimiter);

--- a/code/src/java/pcgen/core/chooser/ChooseController.java
+++ b/code/src/java/pcgen/core/chooser/ChooseController.java
@@ -21,32 +21,32 @@ import java.util.List;
 
 class ChooseController<T>
 {
-	public int getPool()
+	int getPool()
 	{
 		return 1;
 	}
 
-	public boolean isMultYes()
+	boolean isMultYes()
 	{
 		return false;
 	}
 
-	public boolean isStackYes()
+	boolean isStackYes()
 	{
 		return false;
 	}
 
-	public double getCost()
+	double getCost()
 	{
 		return 1.0;
 	}
 
-	public int getTotalChoices()
+	int getTotalChoices()
 	{
 		return 1;
 	}
 
-	public void adjustPool(List<? extends T> selected)
+	void adjustPool(List<? extends T> selected)
 	{
 		// Ignore
 	}

--- a/code/src/java/pcgen/core/kit/KitAbilities.java
+++ b/code/src/java/pcgen/core/kit/KitAbilities.java
@@ -287,10 +287,10 @@ public final class KitAbilities extends BaseKit
 
 	private static class AbilitySelection implements Comparable<AbilitySelection>
 	{
-		public final Ability ability;
-		public final String selection;
+		final Ability ability;
+		final String selection;
 
-		public AbilitySelection(Ability a, String sel)
+		AbilitySelection(Ability a, String sel)
 		{
 			ability = a;
 			selection = sel;

--- a/code/src/java/pcgen/gui2/CharacterTabs.java
+++ b/code/src/java/pcgen/gui2/CharacterTabs.java
@@ -190,7 +190,7 @@ public final class CharacterTabs extends SharedTabPane
 		private final ReferenceFacade<String> tabNameRef;
 		private final ReferenceFacade<String> nameRef;
 
-		public TabLabel(CharacterFacade character)
+		TabLabel(CharacterFacade character)
 		{
 			super(new FlowLayout(FlowLayout.CENTER, 5, 2));
 			this.character = character;
@@ -241,7 +241,7 @@ public final class CharacterTabs extends SharedTabPane
 			setOpaque(false);
 		}
 
-		public void removeListeners()
+		void removeListeners()
 		{
 			tabNameRef.removeReferenceListener(this);
 			nameRef.removeReferenceListener(this);

--- a/code/src/java/pcgen/gui2/PCGenFrame.java
+++ b/code/src/java/pcgen/gui2/PCGenFrame.java
@@ -1498,7 +1498,7 @@ public final class PCGenFrame extends JFrame implements UIDelegate, CharacterSel
 		private final SourceFileLoader loader;
 		private final SwingWorker<List<LogRecord>, List<LogRecord>> worker;
 
-		public SourceLoadWorker(SourceSelectionFacade sources, UIDelegate delegate)
+		SourceLoadWorker(SourceSelectionFacade sources, UIDelegate delegate)
 		{
 			this.sources = sources;
 			loader = new SourceFileLoader(delegate, sources.getCampaigns(), sources.getGameMode().get().getName());

--- a/code/src/java/pcgen/gui2/PCGenMenuBar.java
+++ b/code/src/java/pcgen/gui2/PCGenMenuBar.java
@@ -164,7 +164,7 @@ public final class PCGenMenuBar extends JMenuBar implements CharacterSelectionLi
 	private class FileMenu extends AbstractListMenu<File> implements ActionListener
 	{
 
-		public FileMenu()
+		FileMenu()
 		{
 			super(actionMap.get(PCGenActionMap.FILE_COMMAND));
 			add(new JMenuItem(actionMap.get(PCGenActionMap.NEW_COMMAND)));
@@ -216,7 +216,7 @@ public final class PCGenMenuBar extends JMenuBar implements CharacterSelectionLi
 	private class PartyMenu extends AbstractListMenu<File> implements ActionListener
 	{
 
-		public PartyMenu()
+		PartyMenu()
 		{
 			super(actionMap.get(PCGenActionMap.PARTY_COMMAND));
 			add(new JMenuItem(actionMap.get(PCGenActionMap.OPEN_PARTY_COMMAND)));
@@ -327,7 +327,7 @@ public final class PCGenMenuBar extends JMenuBar implements CharacterSelectionLi
 	 */
 	private class LoggingLevelMenu extends AbstractRadioListMenu<LoggingLevelWrapper>
 	{
-		public LoggingLevelMenu()
+		LoggingLevelMenu()
 		{
 			super(actionMap.get(PCGenActionMap.LOGGING_LEVEL_COMMAND));
 			DefaultListFacade<LoggingLevelWrapper> levels = new DefaultListFacade<>();
@@ -367,7 +367,7 @@ public final class PCGenMenuBar extends JMenuBar implements CharacterSelectionLi
 	{
 		private final Level level;
 
-		public LoggingLevelWrapper(Level level)
+		LoggingLevelWrapper(Level level)
 		{
 			this.level = level;
 		}
@@ -381,7 +381,7 @@ public final class PCGenMenuBar extends JMenuBar implements CharacterSelectionLi
 		/**
 		 * @return the level
 		 */
-		public Level getLevel()
+		Level getLevel()
 		{
 			return level;
 		}

--- a/code/src/java/pcgen/gui2/converter/TokenConverter.java
+++ b/code/src/java/pcgen/gui2/converter/TokenConverter.java
@@ -152,7 +152,7 @@ public final class TokenConverter
 		private TokenProcessorPlugin nextToken = null;
 		private boolean needNewToken = true;
 
-		public ConverterIterator(Class<?> cl, String key)
+		ConverterIterator(Class<?> cl, String key)
 		{
 			rootClass = cl;
 			tokenKey = key;

--- a/code/src/java/pcgen/gui2/converter/panel/SourceSelectionPanel.java
+++ b/code/src/java/pcgen/gui2/converter/panel/SourceSelectionPanel.java
@@ -74,7 +74,7 @@ public class SourceSelectionPanel extends ConvertSubPanel
 		/**
 		 * @return the file
 		 */
-		public File getFile()
+		File getFile()
 		{
 			return file;
 		}
@@ -82,7 +82,7 @@ public class SourceSelectionPanel extends ConvertSubPanel
 		/**
 		 * @param file the file to set
 		 */
-		public void setFile(File file)
+		void setFile(File file)
 		{
 			this.file = file;
 		}
@@ -90,7 +90,7 @@ public class SourceSelectionPanel extends ConvertSubPanel
 		/**
 		 * @return the title
 		 */
-		public String getTitle()
+		String getTitle()
 		{
 			return title;
 		}

--- a/code/src/java/pcgen/gui2/coreview/CoreViewFrame.java
+++ b/code/src/java/pcgen/gui2/coreview/CoreViewFrame.java
@@ -198,7 +198,7 @@ public class CoreViewFrame extends JFrame
 		private DefaultListFacade<CoreViewNodeFacade> coreViewList;
 		private final List<? extends DataViewColumn> dataColumns;
 
-		public CoreViewTreeViewModel(CharacterFacade character)
+		CoreViewTreeViewModel(CharacterFacade character)
 		{
 			this.character = character;
 
@@ -210,7 +210,7 @@ public class CoreViewFrame extends JFrame
 		/**
 		 * @param corePerspective
 		 */
-		public void setPerspective(CorePerspective corePerspective)
+		void setPerspective(CorePerspective corePerspective)
 		{
 			List<CoreViewNodeFacade> coreViewNodes = character.getCoreViewTree(corePerspective);
 			coreViewList = new DefaultListFacade<>(coreViewNodes);

--- a/code/src/java/pcgen/gui2/dialog/CharacterHPDialog.java
+++ b/code/src/java/pcgen/gui2/dialog/CharacterHPDialog.java
@@ -176,7 +176,7 @@ public final class CharacterHPDialog extends JDialog implements ActionListener
 	private class HPTableModel extends AbstractTableModel implements HitPointListener
 	{
 
-		public HPTableModel()
+		HPTableModel()
 		{
 			levels.addHitPointListener(this);
 		}
@@ -266,7 +266,7 @@ public final class CharacterHPDialog extends JDialog implements ActionListener
 
 		private final JButton button = new JButton();
 
-		public Renderer()
+		Renderer()
 		{
 			button.setMargin(new Insets(0, 0, 0, 0));
 			button.setText("Reroll");
@@ -287,7 +287,7 @@ public final class CharacterHPDialog extends JDialog implements ActionListener
 		private final JButton button = new JButton();
 		private int editingRow;
 
-		public Editor()
+		Editor()
 		{
 			button.setMargin(new Insets(0, 0, 0, 0));
 			button.setText("Reroll");

--- a/code/src/java/pcgen/gui2/dialog/PrintPreviewDialog.java
+++ b/code/src/java/pcgen/gui2/dialog/PrintPreviewDialog.java
@@ -313,7 +313,7 @@ public final class PrintPreviewDialog extends JDialog implements ActionListener
     private static class PercentEditor extends JFormattedTextField implements ComboBoxEditor, PropertyChangeListener
     {
 
-        public PercentEditor(JComboBox<Double> comboBox)
+        PercentEditor(JComboBox<Double> comboBox)
         {
             super(NumberFormat.getPercentInstance());
             addPropertyChangeListener("value", this);
@@ -353,7 +353,7 @@ public final class PrintPreviewDialog extends JDialog implements ActionListener
 
         private final URI uri;
 
-        public PreviewLoader(URI uri)
+        PreviewLoader(URI uri)
         {
             this.uri = uri;
             progressBar.setIndeterminate(true);

--- a/code/src/java/pcgen/gui2/equip/EquipCustomPanel.java
+++ b/code/src/java/pcgen/gui2/equip/EquipCustomPanel.java
@@ -307,7 +307,7 @@ public final class EquipCustomPanel extends FlippingSplitPane
 		private final CharacterFacade character;
 		private final EquipmentBuilderFacade builder2;
 
-		public EquipInfoHandler(CharacterFacade character, EquipmentBuilderFacade builder)
+		EquipInfoHandler(CharacterFacade character, EquipmentBuilderFacade builder)
 		{
 			this.character = character;
 			builder2 = builder;
@@ -338,7 +338,7 @@ public final class EquipCustomPanel extends FlippingSplitPane
 		private final EquipmentBuilderFacade builder;
 		private EquipmentModifier currObj;
 
-		public EquipModInfoHandler(CharacterFacade character, EquipmentBuilderFacade builder)
+		EquipModInfoHandler(CharacterFacade character, EquipmentBuilderFacade builder)
 		{
 			this.character = character;
 			this.builder = builder;
@@ -379,7 +379,7 @@ public final class EquipCustomPanel extends FlippingSplitPane
 
 	private class AddEqmodAction extends AbstractAction
 	{
-		public AddEqmodAction()
+		AddEqmodAction()
 		{
 			super(LanguageBundle.getString("in_eqCust_AddPrimary")); //$NON-NLS-1$
 			putValue(SMALL_ICON, Icons.Forward16.getImageIcon());
@@ -404,7 +404,7 @@ public final class EquipCustomPanel extends FlippingSplitPane
 
 	private class RemoveEqmodAction extends AbstractAction
 	{
-		public RemoveEqmodAction()
+		RemoveEqmodAction()
 		{
 			super(LanguageBundle.getString("in_eqCust_RemovePrimary")); //$NON-NLS-1$
 			putValue(SMALL_ICON, Icons.Back16.getImageIcon());
@@ -429,7 +429,7 @@ public final class EquipCustomPanel extends FlippingSplitPane
 
 	private class NameAction extends AbstractAction
 	{
-		public NameAction()
+		NameAction()
 		{
 			super(LanguageBundle.getString("in_nameLabel")); //$NON-NLS-1$
 		}
@@ -448,7 +448,7 @@ public final class EquipCustomPanel extends FlippingSplitPane
 
 	private class SPropAction extends AbstractAction
 	{
-		public SPropAction()
+		SPropAction()
 		{
 			super(LanguageBundle.getString("in_eqCust_SProp")); //$NON-NLS-1$
 		}
@@ -467,7 +467,7 @@ public final class EquipCustomPanel extends FlippingSplitPane
 
 	private class CostAction extends AbstractAction
 	{
-		public CostAction()
+		CostAction()
 		{
 			super(LanguageBundle.getString("in_igEqModelColCost")); //$NON-NLS-1$
 		}
@@ -486,7 +486,7 @@ public final class EquipCustomPanel extends FlippingSplitPane
 
 	private class WeightAction extends AbstractAction
 	{
-		public WeightAction()
+		WeightAction()
 		{
 			super(LanguageBundle.getString("in_igEqModelColWeight")); //$NON-NLS-1$
 		}
@@ -505,7 +505,7 @@ public final class EquipCustomPanel extends FlippingSplitPane
 
 	private class DamageAction extends AbstractAction
 	{
-		public DamageAction()
+		DamageAction()
 		{
 			super(LanguageBundle.getString("in_igInfoLabelTextDamage")); //$NON-NLS-1$
 		}
@@ -704,7 +704,7 @@ public final class EquipCustomPanel extends FlippingSplitPane
 
 		private final DefaultReferenceFacade<EquipmentHead> headRef;
 
-		public HeadBoxModel()
+		HeadBoxModel()
 		{
 			setListFacade(validHeads);
 			headRef = new DefaultReferenceFacade<>(currentHead);
@@ -732,7 +732,7 @@ public final class EquipCustomPanel extends FlippingSplitPane
 	private class SizeBoxModel extends CharacterComboBoxModel<SizeAdjustment>
 	{
 
-		public SizeBoxModel()
+		SizeBoxModel()
 		{
 			setListFacade(character.getDataSet().getSizes());
 			setReference(builder.getSizeRef());

--- a/code/src/java/pcgen/gui2/facade/CharacterFacadeImpl.java
+++ b/code/src/java/pcgen/gui2/facade/CharacterFacadeImpl.java
@@ -3660,7 +3660,7 @@ public class CharacterFacadeImpl
 		 * Create a new reference based on the supplied rectangle.
 		 * @param rect
 		 */
-		public RectangleReference(Rectangle rect)
+		RectangleReference(Rectangle rect)
 		{
 			super(rect == null ? null : (Rectangle) rect.clone());
 		}

--- a/code/src/java/pcgen/gui2/facade/CompanionFacadeDelegate.java
+++ b/code/src/java/pcgen/gui2/facade/CompanionFacadeDelegate.java
@@ -99,7 +99,7 @@ public class CompanionFacadeDelegate implements CompanionFacade
 
 		private ReferenceFacade<T> delegate;
 
-		public void setDelegate(ReferenceFacade<T> newDelegate)
+		void setDelegate(ReferenceFacade<T> newDelegate)
 		{
 			if (delegate != null)
 			{

--- a/code/src/java/pcgen/gui2/facade/CompanionSupportFacadeImpl.java
+++ b/code/src/java/pcgen/gui2/facade/CompanionSupportFacadeImpl.java
@@ -466,7 +466,7 @@ public class CompanionSupportFacadeImpl implements CompanionSupportFacade, ListL
 	{
 		private final Follower follower;
 
-		public DelegateFileListener(Follower followerIn)
+		DelegateFileListener(Follower followerIn)
 		{
 			this.follower = followerIn;
 		}
@@ -486,7 +486,7 @@ public class CompanionSupportFacadeImpl implements CompanionSupportFacade, ListL
 	{
 		private final Follower follower;
 
-		public DelegateNameListener(Follower followerIn)
+		DelegateNameListener(Follower followerIn)
 		{
 			this.follower = followerIn;
 		}

--- a/code/src/java/pcgen/gui2/facade/CoreUtils.java
+++ b/code/src/java/pcgen/gui2/facade/CoreUtils.java
@@ -201,7 +201,7 @@ final class CoreUtils
 		/**
 		 * Create a new instance of CoreUtils.LocationCoreViewNode
 		 */
-		public LocationCoreViewNode(Object object)
+		LocationCoreViewNode(Object object)
 		{
 			this.object = object;
 		}

--- a/code/src/java/pcgen/gui2/facade/DelegatingDataSet.java
+++ b/code/src/java/pcgen/gui2/facade/DelegatingDataSet.java
@@ -135,7 +135,7 @@ public class DelegatingDataSet implements DataSetFacade
 
 		private final MapFacade<AbilityCategory, ListFacade<AbilityFacade>> abilitiesDelegate;
 
-		public DelegatingAbilitiesMap(MapFacade<AbilityCategory, ListFacade<AbilityFacade>> abilitiesDelegate)
+		DelegatingAbilitiesMap(MapFacade<AbilityCategory, ListFacade<AbilityFacade>> abilitiesDelegate)
 		{
 			this.abilitiesDelegate = abilitiesDelegate;
 			this.abilitiesMap = new HashMap<>();
@@ -143,7 +143,7 @@ public class DelegatingDataSet implements DataSetFacade
 			abilitiesDelegate.addMapListener(this);
 		}
 
-		public void detach()
+		void detach()
 		{
 			abilitiesDelegate.removeMapListener(this);
 			for (DelegatingListFacade<AbilityFacade> list : abilitiesMap.values())

--- a/code/src/java/pcgen/gui2/facade/TempBonusHelper.java
+++ b/code/src/java/pcgen/gui2/facade/TempBonusHelper.java
@@ -410,7 +410,7 @@ public final class TempBonusHelper
 	{
 		private final CharacterDisplay charDisplay;
 
-		public CharacterInfoFacade(CharacterDisplay charDisplay)
+		CharacterInfoFacade(CharacterDisplay charDisplay)
 		{
 			this.charDisplay = charDisplay;
 

--- a/code/src/java/pcgen/gui2/filter/FilterBar.java
+++ b/code/src/java/pcgen/gui2/filter/FilterBar.java
@@ -125,7 +125,7 @@ public class FilterBar<C, E> extends JPanel implements DisplayableFilter<C, E>
 		private boolean entered = false;
 		private boolean open = true;
 
-		public ArrowButton()
+		ArrowButton()
 		{
 			setMinimumSize(new Dimension(6, 6));
 			setPreferredSize(new Dimension(6, 6));
@@ -194,12 +194,12 @@ public class FilterBar<C, E> extends JPanel implements DisplayableFilter<C, E>
 			g.fillPolygon(xs, ys, 3);
 		}
 
-		public void setOpen(boolean open)
+		void setOpen(boolean open)
 		{
 			this.open = open;
 		}
 
-		public boolean isOpen()
+		boolean isOpen()
 		{
 			return open;
 		}
@@ -215,7 +215,7 @@ public class FilterBar<C, E> extends JPanel implements DisplayableFilter<C, E>
 	{
 		private transient Lock instanceLock = new ReentrantLock();
 
-		public FilterLayout()
+		FilterLayout()
 		{
 			super(FlowLayout.LEFT, 5, 2);
 		}

--- a/code/src/java/pcgen/gui2/filter/FilteredListFacadeTableModel.java
+++ b/code/src/java/pcgen/gui2/filter/FilteredListFacadeTableModel.java
@@ -121,7 +121,7 @@ public abstract class FilteredListFacadeTableModel<E> extends AbstractTableModel
 
 		private final E element;
 
-		public ElementRow(E element)
+		ElementRow(E element)
 		{
 			this.element = element;
 		}
@@ -139,7 +139,7 @@ public abstract class FilteredListFacadeTableModel<E> extends AbstractTableModel
 
 		private final Comparator<Row> comp;
 
-		public RowComparator(Comparator<Row> comparator)
+		RowComparator(Comparator<Row> comparator)
 		{
 			super();
 			this.comp = comparator;

--- a/code/src/java/pcgen/gui2/kits/KitPanel.java
+++ b/code/src/java/pcgen/gui2/kits/KitPanel.java
@@ -164,12 +164,12 @@ public class KitPanel extends FlippingSplitPane
 		};
 		private final CharacterFacade character;
 
-		public KitFilterHandler(CharacterFacade character)
+		KitFilterHandler(CharacterFacade character)
 		{
 			this.character = character;
 		}
 
-		public void install()
+		void install()
 		{
 			qFilterButton.setFilter(qFilter);
 		}
@@ -181,7 +181,7 @@ public class KitPanel extends FlippingSplitPane
 
 		private final CharacterFacade character;
 
-		public InfoHandler(CharacterFacade character)
+		InfoHandler(CharacterFacade character)
 		{
 			this.character = character;
 		}
@@ -222,7 +222,7 @@ public class KitPanel extends FlippingSplitPane
 
 		private final CharacterFacade character;
 
-		public AddAction(CharacterFacade character)
+		AddAction(CharacterFacade character)
 		{
 			super(LanguageBundle.getString("in_kitApply")); //$NON-NLS-1$
 			this.character = character;
@@ -256,7 +256,7 @@ public class KitPanel extends FlippingSplitPane
 		private final boolean isAvailModel;
 		private final FilteredListFacade<CharacterFacade, Kit> kits;
 
-		public KitTreeViewModel(CharacterFacade character, boolean isAvailModel)
+		KitTreeViewModel(CharacterFacade character, boolean isAvailModel)
 		{
 			this.character = character;
 			this.isAvailModel = isAvailModel;

--- a/code/src/java/pcgen/gui2/prefs/OutputPanel.java
+++ b/code/src/java/pcgen/gui2/prefs/OutputPanel.java
@@ -426,7 +426,7 @@ public final class OutputPanel extends PCGenPrefsPanel
 					}
 				};
 
-		public String getValue()
+		String getValue()
 		{
 			return switch (this)
 					{
@@ -437,7 +437,7 @@ public final class OutputPanel extends PCGenPrefsPanel
 					};
 		}
 
-		public static ExportChoices getChoice(String value)
+		static ExportChoices getChoice(String value)
 		{
 			Boolean choice = BooleanUtils.toBooleanObject(value);
 			if (choice == null)

--- a/code/src/java/pcgen/gui2/solverview/LegalScopeWrapper.java
+++ b/code/src/java/pcgen/gui2/solverview/LegalScopeWrapper.java
@@ -48,7 +48,7 @@ class LegalScopeWrapper
 	 * 
 	 * @return the ImplementedScope underlying this LegalScopeWrapper
 	 */
-	public ImplementedScope getLegalScope()
+	ImplementedScope getLegalScope()
 	{
 		return legalScope;
 	}

--- a/code/src/java/pcgen/gui2/solverview/ObjectNameDisplayer.java
+++ b/code/src/java/pcgen/gui2/solverview/ObjectNameDisplayer.java
@@ -51,7 +51,7 @@ class ObjectNameDisplayer
 	 * 
 	 * @return the VarScoped underlying this ObjectNameDisplayer
 	 */
-	public VarScoped getObject()
+	VarScoped getObject()
 	{
 		return obj;
 	}

--- a/code/src/java/pcgen/gui2/solverview/SolverViewFrame.java
+++ b/code/src/java/pcgen/gui2/solverview/SolverViewFrame.java
@@ -358,7 +358,7 @@ public final class SolverViewFrame extends JFrame
 			return false;
 		}
 
-		public void setSteps(List<ProcessStep<T>> steps)
+		void setSteps(List<ProcessStep<T>> steps)
 		{
 			this.steps = steps;
 			fireTableDataChanged();
@@ -367,8 +367,8 @@ public final class SolverViewFrame extends JFrame
 
 	private static final class PCRef
 	{
-		public String name;
-		public CharID id;
+		String name;
+		CharID id;
 
 		private PCRef(String pcname, CharID id)
 		{

--- a/code/src/java/pcgen/gui2/sources/AdvancedSourceSelectionPanel.java
+++ b/code/src/java/pcgen/gui2/sources/AdvancedSourceSelectionPanel.java
@@ -113,7 +113,7 @@ class AdvancedSourceSelectionPanel extends JPanel
 	 */
 	private final UIContext uiContext;
 	
-	public AdvancedSourceSelectionPanel(PCGenFrame frame, UIContext uiContext)
+	AdvancedSourceSelectionPanel(PCGenFrame frame, UIContext uiContext)
 	{
 		this.uiContext = Objects.requireNonNull(uiContext);
 		this.frame = frame;
@@ -268,17 +268,17 @@ class AdvancedSourceSelectionPanel extends JPanel
 		}
 	}
 
-	public GameMode getSelectedGameMode()
+	GameMode getSelectedGameMode()
 	{
 		return gameMode;
 	}
 
-	public List<Campaign> getSelectedCampaigns()
+	List<Campaign> getSelectedCampaigns()
 	{
 		return selectedCampaigns.getContents();
 	}
 
-	public void setSourceSelection(SourceSelectionFacade sources)
+	void setSourceSelection(SourceSelectionFacade sources)
 	{
 		if (sources == null || sources.getGameMode() == null)
 		{
@@ -398,7 +398,7 @@ class AdvancedSourceSelectionPanel extends JPanel
 	private class AddAction extends AbstractAction
 	{
 
-		public AddAction()
+		AddAction()
 		{
 			super(LanguageBundle.getString("in_addSelected")); //$NON-NLS-1$
 			putValue(SMALL_ICON, Icons.Forward16.getImageIcon());
@@ -442,7 +442,7 @@ class AdvancedSourceSelectionPanel extends JPanel
 	private class RemoveAction extends AbstractAction
 	{
 
-		public RemoveAction()
+		RemoveAction()
 		{
 			super(LanguageBundle.getString("in_removeSelected")); //$NON-NLS-1$
 			putValue(SMALL_ICON, Icons.Back16.getImageIcon());
@@ -470,7 +470,7 @@ class AdvancedSourceSelectionPanel extends JPanel
 	private class UnloadAllAction extends AbstractAction
 	{
 
-		public UnloadAllAction()
+		UnloadAllAction()
 		{
 			super(LanguageBundle.getString("in_src_unloadAll")); //$NON-NLS-1$
 		}
@@ -495,7 +495,7 @@ class AdvancedSourceSelectionPanel extends JPanel
 		private final List<DefaultDataViewColumn> columns;
 		private final boolean isAvailModel;
 
-		public SourceTreeViewModel()
+		SourceTreeViewModel()
 		{
 			this.model = new DefaultListFacade<>();
 			this.isAvailModel = true;
@@ -504,7 +504,7 @@ class AdvancedSourceSelectionPanel extends JPanel
 				new DefaultDataViewColumn("in_src_loaded", String.class, false));
 		}
 
-		public SourceTreeViewModel(DefaultListFacade<Campaign> model)
+		SourceTreeViewModel(DefaultListFacade<Campaign> model)
 		{
 			this.model = model;
 			this.isAvailModel = false;
@@ -562,7 +562,7 @@ class AdvancedSourceSelectionPanel extends JPanel
 			return columns;
 		}
 
-		public void setGameModel(GameMode gameMode)
+		void setGameModel(GameMode gameMode)
 		{
 			if (baseModel != null)
 			{
@@ -673,7 +673,7 @@ class AdvancedSourceSelectionPanel extends JPanel
 		 * Create a new renderer for the campaign names for a game mode. The 
 		 * names will be coloured to show if they are qualified or not.
 		 */
-		public CampaignRenderer()
+		CampaignRenderer()
 		{
 			setTextNonSelectionColor(ColorUtilty.colorToAWTColor(UIPropertyContext.getQualifiedColor()));
 		}

--- a/code/src/java/pcgen/gui2/sources/SourceSelectionDialog.java
+++ b/code/src/java/pcgen/gui2/sources/SourceSelectionDialog.java
@@ -358,7 +358,7 @@ public class SourceSelectionDialog extends JDialog implements ActionListener, Ch
 		private final InfoPane infoPane;
 		private final InfoPaneLinkAction linkAction;
 
-		public QuickSourceSelectionPanel()
+		QuickSourceSelectionPanel()
 		{
 			sourceList = new JList<>();
 			infoPane = new InfoPane(LanguageBundle.getString("in_src_info")); //$NON-NLS-1$
@@ -438,7 +438,7 @@ public class SourceSelectionDialog extends JDialog implements ActionListener, Ch
 			sourceList.addListSelectionListener(this);
 		}
 
-		public SourceSelectionFacade getSourceSelection()
+		SourceSelectionFacade getSourceSelection()
 		{
 			return (SourceSelectionFacade) sourceList.getSelectedValue();
 		}
@@ -472,7 +472,7 @@ public class SourceSelectionDialog extends JDialog implements ActionListener, Ch
 		 * responding to a user action. 
 		 * @param selection The sources selected.
 		 */
-		public void makeSourceSelected(SourceSelectionFacade selection)
+		void makeSourceSelected(SourceSelectionFacade selection)
 		{
 			advancedPanel.setSourceSelection(selection);
 			deleteButton.setEnabled(selection.isModifiable());

--- a/code/src/java/pcgen/gui2/tabs/AbilitiesInfoTab.java
+++ b/code/src/java/pcgen/gui2/tabs/AbilitiesInfoTab.java
@@ -99,7 +99,7 @@ public class AbilitiesInfoTab extends SharedTabPane implements CharacterInfoTab,
 		private String selectedTitle;
 		private final ListFacade<AbilityCategory> activeCategories;
 
-		public AbilityTabsModel(CharacterFacade character)
+		AbilityTabsModel(CharacterFacade character)
 		{
 			this.character = character;
 			this.activeCategories = character.getActiveAbilityCategories();
@@ -231,7 +231,7 @@ public class AbilitiesInfoTab extends SharedTabPane implements CharacterInfoTab,
 			//TODO: do something
 		}
 
-		public void install()
+		void install()
 		{
 			activeCategories.addListListener(this);
 			for (TabInfo tabInfo : tabs)
@@ -244,7 +244,7 @@ public class AbilitiesInfoTab extends SharedTabPane implements CharacterInfoTab,
 			isInstalled = true;
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			abilityTab.storeState(typeMap.get(selectedTitle).tabData);
 			removeChangeListener(this);
@@ -277,7 +277,7 @@ public class AbilitiesInfoTab extends SharedTabPane implements CharacterInfoTab,
 		@SuppressWarnings({"UseOfObsoleteCollectionType", "PMD.ReplaceHashtableWithMap", "serial"})
 		private final class TabInfo
 		{
-			public final String title;
+			final String title;
 			private final Hashtable<Object, Object> tabData;
 			private final DefaultListFacade<AbilityCategory> categoryList;
 			private final DefaultListFacade<AbilityCategory> fullCategoryList;

--- a/code/src/java/pcgen/gui2/tabs/AbilityChooserTab.java
+++ b/code/src/java/pcgen/gui2/tabs/AbilityChooserTab.java
@@ -171,7 +171,7 @@ public class AbilityChooserTab extends FlippingSplitPane implements StateEditabl
 	private static final class BooleanRenderer extends DefaultTableCellRenderer
 	{
 
-		public BooleanRenderer()
+		BooleanRenderer()
 		{
 			setHorizontalAlignment(SwingConstants.CENTER);
 		}
@@ -207,7 +207,7 @@ public class AbilityChooserTab extends FlippingSplitPane implements StateEditabl
 		private final String title;
 		private final DelegatingListFacade<AbilityFacade> delegate;
 
-		public AvailableAbilityTreeViewModel(CharacterFacade character, ListSelectionModel selectionModel,
+		AvailableAbilityTreeViewModel(CharacterFacade character, ListSelectionModel selectionModel,
 			String tableTitle)
 		{
 			this.character = character;
@@ -272,13 +272,13 @@ public class AbilityChooserTab extends FlippingSplitPane implements StateEditabl
 			return ret.toString();
 		}
 
-		public void install()
+		void install()
 		{
 			availableTreeViewPanel.setTreeViewModel(this);
 			selectedTreeViewPanel.getSelectionModel().addListSelectionListener(this);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			selectedTreeViewPanel.getSelectionModel().removeListSelectionListener(this);
 		}
@@ -359,14 +359,14 @@ public class AbilityChooserTab extends FlippingSplitPane implements StateEditabl
 		private String text;
 		private String title;
 
-		public InfoHandler(CharacterFacade character)
+		InfoHandler(CharacterFacade character)
 		{
 			this.character = character;
 			this.text = ""; //$NON-NLS-1$
 			this.title = LanguageBundle.getString("in_abInfo"); //$NON-NLS-1$
 		}
 
-		public void install()
+		void install()
 		{
 			availableTreeViewPanel.getSelectionModel().addListSelectionListener(this);
 			selectedTreeViewPanel.getSelectionModel().addListSelectionListener(this);
@@ -375,7 +375,7 @@ public class AbilityChooserTab extends FlippingSplitPane implements StateEditabl
 			infoPane.setText(text);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			availableTreeViewPanel.getSelectionModel().removeListSelectionListener(this);
 			selectedTreeViewPanel.getSelectionModel().removeListSelectionListener(this);
@@ -528,7 +528,7 @@ public class AbilityChooserTab extends FlippingSplitPane implements StateEditabl
 		private final CharacterFacade character;
 		private AbilityCategory abilityCat;
 
-		public AddAction(CharacterFacade character)
+		AddAction(CharacterFacade character)
 		{
 			super(LanguageBundle.getString("in_addSelected")); //$NON-NLS-1$
 			this.character = character;
@@ -563,13 +563,13 @@ public class AbilityChooserTab extends FlippingSplitPane implements StateEditabl
 			}
 		}
 
-		public void install()
+		void install()
 		{
 			availableTreeViewPanel.addActionListener(this);
 			categoryTable.getSelectionModel().addListSelectionListener(this);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			availableTreeViewPanel.removeActionListener(this);
 			categoryTable.getSelectionModel().removeListSelectionListener(this);
@@ -600,7 +600,7 @@ public class AbilityChooserTab extends FlippingSplitPane implements StateEditabl
 		private final CharacterFacade character;
 		private AbilityCategory abilityCat;
 
-		public RemoveAction(CharacterFacade character)
+		RemoveAction(CharacterFacade character)
 		{
 			super(LanguageBundle.getString("in_removeSelected")); //$NON-NLS-1$
 			this.character = character;
@@ -634,13 +634,13 @@ public class AbilityChooserTab extends FlippingSplitPane implements StateEditabl
 			}
 		}
 
-		public void install()
+		void install()
 		{
 			selectedTreeViewPanel.addActionListener(this);
 			categoryTable.getSelectionModel().addListSelectionListener(this);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			selectedTreeViewPanel.removeActionListener(this);
 			categoryTable.getSelectionModel().removeListSelectionListener(this);
@@ -679,12 +679,12 @@ public class AbilityChooserTab extends FlippingSplitPane implements StateEditabl
 		};
 		private final CharacterFacade character;
 
-		public AbilityFilterHandler(CharacterFacade character)
+		AbilityFilterHandler(CharacterFacade character)
 		{
 			this.character = character;
 		}
 
-		public void install()
+		void install()
 		{
 			qFilterButton.setFilter(qFilter);
 		}
@@ -696,12 +696,12 @@ public class AbilityChooserTab extends FlippingSplitPane implements StateEditabl
 
 		private final CategoryTableModel model;
 
-		public CategoryFilterHandler(CategoryTableModel model)
+		CategoryFilterHandler(CategoryTableModel model)
 		{
 			this.model = model;
 		}
 
-		public void install()
+		void install()
 		{
 			categoryBar.setFilterHandler(this);
 			refilter();
@@ -732,18 +732,18 @@ public class AbilityChooserTab extends FlippingSplitPane implements StateEditabl
 
 		private final CharacterFacade character;
 
-		public TreeRendererHandler(CharacterFacade character)
+		TreeRendererHandler(CharacterFacade character)
 		{
 			this.character = character;
 		}
 
-		public void install()
+		void install()
 		{
 			abilityRenderer.setCharacter(character);
 			qualifiedRenderer.setCharacter(character);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			abilityRenderer.setCharacter(null);
 			qualifiedRenderer.setCharacter(null);

--- a/code/src/java/pcgen/gui2/tabs/CharacterSheetInfoTab.java
+++ b/code/src/java/pcgen/gui2/tabs/CharacterSheetInfoTab.java
@@ -250,7 +250,7 @@ public class CharacterSheetInfoTab extends FlippingSplitPane implements Characte
 			}
 		}
 
-		public void install()
+		void install()
 		{
 			GuiAssertions.assertIsNotJavaFXThread();
 			sheetBox.setOnAction(this::onSelectedCharSheet);
@@ -280,17 +280,17 @@ public class CharacterSheetInfoTab extends FlippingSplitPane implements Characte
 
 		private final CharacterFacade character;
 
-		public CSheetHandler(CharacterFacade character)
+		CSheetHandler(CharacterFacade character)
 		{
 			this.character = character;
 		}
 
-		public void install()
+		void install()
 		{
 			csheet.setCharacter(character);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 		}
 
@@ -365,7 +365,7 @@ public class CharacterSheetInfoTab extends FlippingSplitPane implements Characte
 
 		};
 
-		public TempBonusTableModel(CharacterFacade character)
+		TempBonusTableModel(CharacterFacade character)
 		{
 			super(character);
 			setDelegate(character.getTempBonuses());
@@ -441,7 +441,7 @@ public class CharacterSheetInfoTab extends FlippingSplitPane implements Characte
 		 */
 		private static final long serialVersionUID = 5028006226606996671L;
 
-		public EquipSetTableModel(CharacterFacade character)
+		EquipSetTableModel(CharacterFacade character)
 		{
 			super(character);
 			character.getEquipmentSetRef().addReferenceListener(this);

--- a/code/src/java/pcgen/gui2/tabs/ClassInfoTab.java
+++ b/code/src/java/pcgen/gui2/tabs/ClassInfoTab.java
@@ -263,7 +263,7 @@ public class ClassInfoTab extends FlippingSplitPane implements CharacterInfoTab
 		private final CharacterFacade character;
 		private PCClass selectedClass = null;
 
-		public AddClassAction(CharacterFacade character)
+		AddClassAction(CharacterFacade character)
 		{
 			super(LanguageBundle.getString("in_cl_addlevels"));
 			this.character = character;
@@ -277,7 +277,7 @@ public class ClassInfoTab extends FlippingSplitPane implements CharacterInfoTab
 			addCharacterLevels(character, selectedClass);
 		}
 
-		public void install()
+		void install()
 		{
 			addButton.setAction(this);
 			availableTable.addActionListener(this);
@@ -285,7 +285,7 @@ public class ClassInfoTab extends FlippingSplitPane implements CharacterInfoTab
 			classTable.getSelectionModel().addListSelectionListener(this);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			availableTable.removeActionListener(this);
 			availableTable.getSelectionModel().removeListSelectionListener(this);
@@ -313,7 +313,7 @@ public class ClassInfoTab extends FlippingSplitPane implements CharacterInfoTab
 
 		private final CharacterFacade character;
 
-		public RemoveClassAction(CharacterFacade character)
+		RemoveClassAction(CharacterFacade character)
 		{
 			super(LanguageBundle.getString("in_cl_removelevels"));
 			this.character = character;
@@ -328,7 +328,7 @@ public class ClassInfoTab extends FlippingSplitPane implements CharacterInfoTab
 			character.removeCharacterLevels(1);
 		}
 
-		public void install()
+		void install()
 		{
 			removeButton.setAction(this);
 		}
@@ -373,12 +373,12 @@ public class ClassInfoTab extends FlippingSplitPane implements CharacterInfoTab
 
 		private CharacterFacade character = null;
 
-		public void setCharacter(CharacterFacade character)
+		void setCharacter(CharacterFacade character)
 		{
 			this.character = character;
 		}
 
-		public TransHandler createHandler(CharacterFacade character)
+		TransHandler createHandler(CharacterFacade character)
 		{
 			return new TransHandler(character);
 		}
@@ -388,17 +388,17 @@ public class ClassInfoTab extends FlippingSplitPane implements CharacterInfoTab
 
 			private final CharacterFacade character;
 
-			public TransHandler(CharacterFacade character)
+			TransHandler(CharacterFacade character)
 			{
 				this.character = character;
 			}
 
-			public void install()
+			void install()
 			{
 				setCharacter(character);
 			}
 
-			public void uninstall()
+			void uninstall()
 			{
 				setCharacter(null);
 			}
@@ -487,12 +487,12 @@ public class ClassInfoTab extends FlippingSplitPane implements CharacterInfoTab
 
 		private final CharacterFacade character;
 
-		public QualifiedFilterHandler(CharacterFacade character)
+		QualifiedFilterHandler(CharacterFacade character)
 		{
 			this.character = character;
 		}
 
-		public void install()
+		void install()
 		{
 			qFilterButton.setFilter(this);
 		}
@@ -519,7 +519,7 @@ public class ClassInfoTab extends FlippingSplitPane implements CharacterInfoTab
 				new DefaultListFacade<>(Arrays.asList(ClassTreeView.values()));
 		private final CharacterFacade character;
 
-		public ClassTreeViewModel(CharacterFacade character)
+		ClassTreeViewModel(CharacterFacade character)
 		{
 			this.character = character;
 		}
@@ -651,7 +651,7 @@ public class ClassInfoTab extends FlippingSplitPane implements CharacterInfoTab
 		};
 		private final CharacterLevelsFacade model;
 
-		public ClassTableModel(CharacterFacade character)
+		ClassTableModel(CharacterFacade character)
 		{
 			this.model = character.getCharacterLevelsFacade();
 			model.addListListener(this);
@@ -741,20 +741,20 @@ public class ClassInfoTab extends FlippingSplitPane implements CharacterInfoTab
 		private final CharacterFacade character;
 		private String text;
 
-		public InfoHandler(CharacterFacade character)
+		InfoHandler(CharacterFacade character)
 		{
 			this.character = character;
 			this.text = ""; //$NON-NLS-1$
 		}
 
-		public void install()
+		void install()
 		{
 			classTable.getSelectionModel().addListSelectionListener(this);
 			availableTable.getSelectionModel().addListSelectionListener(this);
 			infoPane.setText(text);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			classTable.getSelectionModel().removeListSelectionListener(this);
 			availableTable.getSelectionModel().removeListSelectionListener(this);

--- a/code/src/java/pcgen/gui2/tabs/CompanionInfoTab.java
+++ b/code/src/java/pcgen/gui2/tabs/CompanionInfoTab.java
@@ -260,12 +260,12 @@ public class CompanionInfoTab extends FlippingSplitPane implements CharacterInfo
 		private final JTree tree;
 		private List<TreePath> expandedPaths = Collections.emptyList();
 
-		public TreeExpansionHandler()
+		TreeExpansionHandler()
 		{
 			this.tree = companionsTable.getTree();
 		}
 
-		public void install()
+		void install()
 		{
 			for (TreePath path : expandedPaths)
 			{
@@ -274,7 +274,7 @@ public class CompanionInfoTab extends FlippingSplitPane implements CharacterInfo
 			tree.addTreeExpansionListener(this);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			tree.removeTreeExpansionListener(this);
 		}
@@ -308,7 +308,7 @@ public class CompanionInfoTab extends FlippingSplitPane implements CharacterInfo
 		private final ListSelectionModel selectionModel;
 		private final PCGenFrame frame;
 
-		public LoadButtonAndSheetHandler()
+		LoadButtonAndSheetHandler()
 		{
 			File sheet = Path.of(
 						ConfigurationSettings.getPreviewDir(),
@@ -319,7 +319,7 @@ public class CompanionInfoTab extends FlippingSplitPane implements CharacterInfo
 			this.frame = (PCGenFrame) JOptionPane.getFrameForComponent(CompanionInfoTab.this);
 		}
 
-		public void install()
+		void install()
 		{
 			configureButton();
 			loadButton.setAction(this);
@@ -337,7 +337,7 @@ public class CompanionInfoTab extends FlippingSplitPane implements CharacterInfo
 			sheetSupport.install();
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			selectionModel.removeListSelectionListener(this);
 			sheetSupport.uninstall();
@@ -458,7 +458,7 @@ public class CompanionInfoTab extends FlippingSplitPane implements CharacterInfo
 		private final JButton button = new JButton();
 		private final DefaultTableCellRenderer background = new DefaultTableCellRenderer();
 
-		public ButtonCellRenderer()
+		ButtonCellRenderer()
 		{
 			button.setMargin(new Insets(0, 0, 0, 0));
 
@@ -526,7 +526,7 @@ public class CompanionInfoTab extends FlippingSplitPane implements CharacterInfo
 		private final DefaultTableCellRenderer background = new DefaultTableCellRenderer();
 		private final CharacterFacade character;
 
-		public ButtonCellEditor(CharacterFacade character)
+		ButtonCellEditor(CharacterFacade character)
 		{
 			this.character = character;
 
@@ -609,12 +609,12 @@ public class CompanionInfoTab extends FlippingSplitPane implements CharacterInfo
 			implements Filter<String, CompanionStubFacade>
 	{
 
-		public FilteredCompanionList()
+		FilteredCompanionList()
 		{
 			setFilter(this);
 		}
 
-		public void setCompanionType(String type)
+		void setCompanionType(String type)
 		{
 			setContext(type);
 		}
@@ -644,7 +644,7 @@ public class CompanionInfoTab extends FlippingSplitPane implements CharacterInfo
 		private final DefaultListFacade<CompanionTreeView> treeViews =
 				new DefaultListFacade<>(Arrays.asList(CompanionTreeView.values()));
 
-		public CompanionDialog()
+		CompanionDialog()
 		{
 			super(JOptionPane.getFrameForComponent(CompanionInfoTab.this), true);
 			this.model = new FilteredCompanionList();
@@ -712,13 +712,13 @@ public class CompanionInfoTab extends FlippingSplitPane implements CharacterInfo
 			}
 		}
 
-		public void setCharacter(CharacterFacade character)
+		void setCharacter(CharacterFacade character)
 		{
 			this.character = character;
 			model.setDelegate(character.getCompanionSupport().getAvailableCompanions());
 		}
 
-		public void setCompanionType(String type)
+		void setCompanionType(String type)
 		{
 			companionType = type;
 			model.setCompanionType(type);
@@ -776,7 +776,7 @@ public class CompanionInfoTab extends FlippingSplitPane implements CharacterInfo
 		/**
 		 * @return the newCompanion
 		 */
-		public CharacterFacade getNewCompanion()
+		CharacterFacade getNewCompanion()
 		{
 			return newCompanion;
 		}
@@ -818,7 +818,7 @@ public class CompanionInfoTab extends FlippingSplitPane implements CharacterInfo
 		private final CompanionSupportFacade support;
 		private final MapFacade<String, Integer> maxMap;
 
-		public CompanionsModel(CharacterFacade character)
+		CompanionsModel(CharacterFacade character)
 		{
 			this.support = character.getCompanionSupport();
 			this.maxMap = support.getMaxCompanionsMap();
@@ -854,7 +854,7 @@ public class CompanionInfoTab extends FlippingSplitPane implements CharacterInfo
 
 			private final CompanionFacade companion;
 
-			public CompanionNode(CompanionFacade companion)
+			CompanionNode(CompanionFacade companion)
 			{
 				this.companion = companion;
 			}
@@ -882,7 +882,7 @@ public class CompanionInfoTab extends FlippingSplitPane implements CharacterInfo
 
 			private final String type;
 
-			public CompanionTypeNode(String type)
+			CompanionTypeNode(String type)
 			{
 				super(Arrays.asList(type, null));
 				this.type = type;
@@ -997,7 +997,7 @@ public class CompanionInfoTab extends FlippingSplitPane implements CharacterInfo
 			private final List<String> types;
 			private final ListFacade<? extends CompanionFacade> companions;
 
-			public RootNode()
+			RootNode()
 			{
 				this.types = new ArrayList<>();
 				this.companions = support.getCompanions();

--- a/code/src/java/pcgen/gui2/tabs/DescriptionInfoTab.java
+++ b/code/src/java/pcgen/gui2/tabs/DescriptionInfoTab.java
@@ -185,7 +185,7 @@ public class DescriptionInfoTab extends FlippingSplitPane implements CharacterIn
 		private final List<NoteInfoPane> notePaneList;
 		private final CharacterFacade character;
 
-		public NoteListHandler(CharacterFacade character, DefaultListModel<PageItem> listModel,
+		NoteListHandler(CharacterFacade character, DefaultListModel<PageItem> listModel,
 			List<NoteInfoPane> notePaneList)
 		{
 			this.character = character;
@@ -219,7 +219,7 @@ public class DescriptionInfoTab extends FlippingSplitPane implements CharacterIn
 			return notePane;
 		}
 
-		public void install()
+		void install()
 		{
 			notes.addListListener(this);
 
@@ -229,7 +229,7 @@ public class DescriptionInfoTab extends FlippingSplitPane implements CharacterIn
 			}
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			notes.removeListListener(this);
 
@@ -325,7 +325,7 @@ public class DescriptionInfoTab extends FlippingSplitPane implements CharacterIn
 		 * @param note      The note being represented.
 		 * @param page      The page to display the note.
 		 */
-		public PageItem(CharacterFacade character, NoteItem note, CharacterInfoTab page)
+		PageItem(CharacterFacade character, NoteItem note, CharacterInfoTab page)
 		{
 			this.note = note;
 			this.name = ""; //$NON-NLS-1$
@@ -341,7 +341,7 @@ public class DescriptionInfoTab extends FlippingSplitPane implements CharacterIn
 		 * @param name      The name of the page.
 		 * @param page      The pre-defined page..
 		 */
-		public PageItem(CharacterFacade character, String name, CharacterInfoTab page)
+		PageItem(CharacterFacade character, String name, CharacterInfoTab page)
 		{
 			this.note = null;
 			this.name = name;
@@ -356,12 +356,12 @@ public class DescriptionInfoTab extends FlippingSplitPane implements CharacterIn
 			return note == null ? name : note.getName();
 		}
 
-		public void storeModels()
+		void storeModels()
 		{
 			page.storeModels(data);
 		}
 
-		public void restoreModels()
+		void restoreModels()
 		{
 			page.restoreModels(data);
 		}
@@ -374,7 +374,7 @@ public class DescriptionInfoTab extends FlippingSplitPane implements CharacterIn
 		private final ListSelectionModel selectionModel;
 		private PageItem currentPage;
 
-		public PageHandler(ListSelectionModel selectionModel, PageItem currentPage)
+		PageHandler(ListSelectionModel selectionModel, PageItem currentPage)
 		{
 			this.selectionModel = selectionModel;
 			this.currentPage = currentPage;
@@ -399,7 +399,7 @@ public class DescriptionInfoTab extends FlippingSplitPane implements CharacterIn
 			pages.show(pagePanel, currentPage.id);
 		}
 
-		public void install()
+		void install()
 		{
 			selectionModel.addListSelectionListener(this);
 			currentPage.restoreModels();
@@ -407,7 +407,7 @@ public class DescriptionInfoTab extends FlippingSplitPane implements CharacterIn
 			pages.show(pagePanel, currentPage.id);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			selectionModel.removeListSelectionListener(this);
 			currentPage.storeModels();
@@ -424,7 +424,7 @@ public class DescriptionInfoTab extends FlippingSplitPane implements CharacterIn
 
 		private final CharacterFacade character;
 
-		public AddAction(CharacterFacade character)
+		AddAction(CharacterFacade character)
 		{
 			super(LanguageBundle.getString("in_descAddPage")); //$NON-NLS-1$
 			this.character = character;

--- a/code/src/java/pcgen/gui2/tabs/DomainInfoTab.java
+++ b/code/src/java/pcgen/gui2/tabs/DomainInfoTab.java
@@ -285,12 +285,12 @@ public class DomainInfoTab extends FlippingSplitPane implements CharacterInfoTab
 
 		private final CharacterFacade character;
 
-		public DomainRenderer(CharacterFacade character)
+		DomainRenderer(CharacterFacade character)
 		{
 			this.character = character;
 		}
 
-		public void install()
+		void install()
 		{
 			domainTable.setDefaultRenderer(Object.class, this);
 		}
@@ -329,19 +329,19 @@ public class DomainInfoTab extends FlippingSplitPane implements CharacterInfoTab
 		private final CharacterFacade character;
 		private String text;
 
-		public DeityInfoHandler(CharacterFacade character)
+		DeityInfoHandler(CharacterFacade character)
 		{
 			this.character = character;
 			this.text = ""; //$NON-NLS-1$
 		}
 
-		public void install()
+		void install()
 		{
 			deityTable.getSelectionModel().addListSelectionListener(this);
 			deityInfo.setText(text);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			deityTable.getSelectionModel().removeListSelectionListener(this);
 		}
@@ -372,19 +372,19 @@ public class DomainInfoTab extends FlippingSplitPane implements CharacterInfoTab
 		private final CharacterFacade character;
 		private String text;
 
-		public DomainInfoHandler(CharacterFacade character)
+		DomainInfoHandler(CharacterFacade character)
 		{
 			this.character = character;
 			this.text = ""; //$NON-NLS-1$
 		}
 
-		public void install()
+		void install()
 		{
 			domainTable.getSelectionModel().addListSelectionListener(this);
 			domainInfo.setText(text);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			domainTable.getSelectionModel().removeListSelectionListener(this);
 		}
@@ -419,7 +419,7 @@ public class DomainInfoTab extends FlippingSplitPane implements CharacterInfoTab
 
 		private final CharacterFacade character;
 
-		public SelectDeityAction(CharacterFacade character)
+		SelectDeityAction(CharacterFacade character)
 		{
 			super(LanguageBundle.getString("in_select")); //$NON-NLS-1$
 			this.character = character;
@@ -439,12 +439,12 @@ public class DomainInfoTab extends FlippingSplitPane implements CharacterInfoTab
 			}
 		}
 
-		public void install()
+		void install()
 		{
 			deityTable.addActionListener(this);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			deityTable.removeActionListener(this);
 		}
@@ -474,12 +474,12 @@ public class DomainInfoTab extends FlippingSplitPane implements CharacterInfoTab
 		};
 		private final CharacterFacade character;
 
-		public QualifiedFilterHandler(CharacterFacade character)
+		QualifiedFilterHandler(CharacterFacade character)
 		{
 			this.character = character;
 		}
 
-		public void install()
+		void install()
 		{
 			qDomainButton.setFilter(domainFilter);
 			qDeityButton.setFilter(deityFilter);
@@ -492,12 +492,12 @@ public class DomainInfoTab extends FlippingSplitPane implements CharacterInfoTab
 
 		private final DomainTableModel tableModel;
 
-		public DomainTableHandler(CharacterFacade character)
+		DomainTableHandler(CharacterFacade character)
 		{
 			tableModel = new DomainTableModel(character);
 		}
 
-		public void install()
+		void install()
 		{
 			domainFilter.setFilterHandler(this);
 			tableModel.setFilter(domainFilter);
@@ -505,7 +505,7 @@ public class DomainInfoTab extends FlippingSplitPane implements CharacterInfoTab
 			domainRowHeaderTable.setModel(tableModel);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			tableModel.setFilter(null);
 		}
@@ -535,13 +535,13 @@ public class DomainInfoTab extends FlippingSplitPane implements CharacterInfoTab
 		private final JLabel label;
 		private final ReferenceFacade<Integer> ref;
 
-		public DomainLabelHandler(CharacterFacade character, JLabel label)
+		DomainLabelHandler(CharacterFacade character, JLabel label)
 		{
 			ref = character.getRemainingDomainSelectionsRef();
 			this.label = label;
 		}
 
-		public void install()
+		void install()
 		{
 			if (ref != null)
 			{
@@ -553,7 +553,7 @@ public class DomainInfoTab extends FlippingSplitPane implements CharacterInfoTab
 			}
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			if (ref != null)
 			{
@@ -575,13 +575,13 @@ public class DomainInfoTab extends FlippingSplitPane implements CharacterInfoTab
 		private final JLabel label;
 		private final ReferenceFacade<Deity> ref;
 
-		public DeityLabelHandler(CharacterFacade character, JLabel label)
+		DeityLabelHandler(CharacterFacade character, JLabel label)
 		{
 			ref = character.getDeityRef();
 			this.label = label;
 		}
 
-		public void install()
+		void install()
 		{
 			label.setFont(FontManipulation.plain(label.getFont()));
 			if (ref == null)
@@ -604,7 +604,7 @@ public class DomainInfoTab extends FlippingSplitPane implements CharacterInfoTab
 
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			if (ref != null)
 			{
@@ -650,7 +650,7 @@ public class DomainInfoTab extends FlippingSplitPane implements CharacterInfoTab
 
 		};
 
-		public DomainTableModel(CharacterFacade character)
+		DomainTableModel(CharacterFacade character)
 		{
 			super(character);
 			if (character.isFeatureEnabled(CControl.DOMAINFEATURE))
@@ -736,7 +736,7 @@ public class DomainInfoTab extends FlippingSplitPane implements CharacterInfoTab
 		private final CharacterFacade character;
 		private final InfoFactory infoFactory;
 
-		public DeityTreeViewModel(CharacterFacade character)
+		DeityTreeViewModel(CharacterFacade character)
 		{
 			this.character = character;
 			this.infoFactory = character.getInfoFactory();
@@ -851,7 +851,7 @@ public class DomainInfoTab extends FlippingSplitPane implements CharacterInfoTab
 
 		}
 
-		public List<String> getDomainNames(Deity pobj)
+		List<String> getDomainNames(Deity pobj)
 		{
 			List<String> domains = new ArrayList<>();
 			for (CDOMReference<Domain> ref : pobj.getSafeListMods(Deity.DOMAINLIST))

--- a/code/src/java/pcgen/gui2/tabs/EquipInfoTab.java
+++ b/code/src/java/pcgen/gui2/tabs/EquipInfoTab.java
@@ -398,7 +398,7 @@ public class EquipInfoTab extends FlippingSplitPane implements CharacterInfoTab,
 
 		private final CharacterFacade character;
 
-		public AddSetAction(CharacterFacade character)
+		AddSetAction(CharacterFacade character)
 		{
 			super(LanguageBundle.getString("in_new")); //$NON-NLS-1$
 			this.character = character;
@@ -423,7 +423,7 @@ public class EquipInfoTab extends FlippingSplitPane implements CharacterInfoTab,
 
 		private final CharacterFacade character;
 
-		public RemoveSetAction(CharacterFacade character)
+		RemoveSetAction(CharacterFacade character)
 		{
 			super(LanguageBundle.getString("in_remove")); //$NON-NLS-1$
 			this.character = character;
@@ -442,7 +442,7 @@ public class EquipInfoTab extends FlippingSplitPane implements CharacterInfoTab,
 
 		private final CharacterFacade character;
 
-		public EquipSetBoxModel(CharacterFacade character)
+		EquipSetBoxModel(CharacterFacade character)
 		{
 			this.character = character;
 			setListFacade(character.getEquipmentSets());
@@ -460,7 +460,7 @@ public class EquipInfoTab extends FlippingSplitPane implements CharacterInfoTab,
 	private class ExpandAllAction extends AbstractAction
 	{
 
-		public ExpandAllAction()
+		ExpandAllAction()
 		{
 			super("+"); //$NON-NLS-1$
 			putValue(SHORT_DESCRIPTION, LanguageBundle.getString("in_expandAllTip")); //$NON-NLS-1$
@@ -481,7 +481,7 @@ public class EquipInfoTab extends FlippingSplitPane implements CharacterInfoTab,
 	private class CollapseAllAction extends AbstractAction
 	{
 
-		public CollapseAllAction()
+		CollapseAllAction()
 		{
 			super("-"); //$NON-NLS-1$
 			putValue(SHORT_DESCRIPTION, LanguageBundle.getString("in_collapseAllTip")); //$NON-NLS-1$
@@ -504,7 +504,7 @@ public class EquipInfoTab extends FlippingSplitPane implements CharacterInfoTab,
 
 		private final CharacterFacade character;
 
-		public UnequipAllAction(CharacterFacade character)
+		UnequipAllAction(CharacterFacade character)
 		{
 			super(LanguageBundle.getString("in_equipUnequipAll")); //$NON-NLS-1$
 			this.character = character;
@@ -535,14 +535,14 @@ public class EquipInfoTab extends FlippingSplitPane implements CharacterInfoTab,
 		private final ReferenceFacade<String> loadRef;
 		private final ReferenceFacade<String> limitRef;
 
-		public LabelsUpdater(CharacterFacade character)
+		LabelsUpdater(CharacterFacade character)
 		{
 			weightRef = character.getCarriedWeightRef();
 			loadRef = character.getLoadRef();
 			limitRef = character.getWeightLimitRef();
 		}
 
-		public void install()
+		void install()
 		{
 			weightLabel.setText(weightRef.get());
 			setLoadLabel(Load.getLoadType(loadRef.get()));
@@ -553,7 +553,7 @@ public class EquipInfoTab extends FlippingSplitPane implements CharacterInfoTab,
 			limitRef.addReferenceListener(this);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			weightRef.removeReferenceListener(this);
 			loadRef.removeReferenceListener(this);
@@ -586,20 +586,20 @@ public class EquipInfoTab extends FlippingSplitPane implements CharacterInfoTab,
 		private final CharacterFacade character;
 		private String text;
 
-		public EquipInfoHandler(CharacterFacade character)
+		EquipInfoHandler(CharacterFacade character)
 		{
 			this.character = character;
 			this.text = ""; //$NON-NLS-1$
 		}
 
-		public void install()
+		void install()
 		{
 			equipmentTable.getSelectionModel().addListSelectionListener(this);
 			equipmentSetTable.getSelectionModel().addListSelectionListener(this);
 			infoPane.setText(text);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			equipmentTable.getSelectionModel().removeListSelectionListener(this);
 			equipmentSetTable.getSelectionModel().removeListSelectionListener(this);
@@ -649,12 +649,12 @@ public class EquipInfoTab extends FlippingSplitPane implements CharacterInfoTab,
 
 		private final CharacterFacade character;
 
-		public EquipmentRenderer(CharacterFacade character)
+		EquipmentRenderer(CharacterFacade character)
 		{
 			this.character = character;
 		}
 
-		public void install()
+		void install()
 		{
 			equipmentTable.setDefaultRenderer(Object.class, this);
 		}
@@ -683,7 +683,7 @@ public class EquipInfoTab extends FlippingSplitPane implements CharacterInfoTab,
 		private static final DataFlavor[] FLAVORS = {EQUIP_NODE_ARRAY_FLAVOR, EQUIPMENT_ARRAY_FLAVOR};
 		private final EquipNode[] nodeArray;
 
-		public EquipNodeSelection(EquipNode[] nodeArray)
+		EquipNodeSelection(EquipNode[] nodeArray)
 		{
 			this.nodeArray = nodeArray;
 		}
@@ -726,12 +726,12 @@ public class EquipInfoTab extends FlippingSplitPane implements CharacterInfoTab,
 
 		private final CharacterFacade character;
 
-		public EquipmentTransferHandler(CharacterFacade character)
+		EquipmentTransferHandler(CharacterFacade character)
 		{
 			this.character = character;
 		}
 
-		public void install()
+		void install()
 		{
 			equipmentTable.setDragEnabled(true);
 			equipmentTable.setDropMode(DropMode.ON);
@@ -820,12 +820,12 @@ public class EquipInfoTab extends FlippingSplitPane implements CharacterInfoTab,
 
 		private final CharacterFacade character;
 
-		public EquipmentSetTransferHandler(CharacterFacade character)
+		EquipmentSetTransferHandler(CharacterFacade character)
 		{
 			this.character = character;
 		}
 
-		public void install()
+		void install()
 		{
 			equipmentSetTable.setTransferHandler(this);
 			equipmentSetTable.setDragEnabled(true);
@@ -1016,12 +1016,12 @@ public class EquipInfoTab extends FlippingSplitPane implements CharacterInfoTab,
 			popupMenu.show(e.getComponent(), e.getX(), e.getY());
 		}
 
-		public void install()
+		void install()
 		{
 			equipmentSetTable.addMouseListener(this);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			equipmentSetTable.removeMouseListener(this);
 		}

--- a/code/src/java/pcgen/gui2/tabs/InfoTabbedPane.java
+++ b/code/src/java/pcgen/gui2/tabs/InfoTabbedPane.java
@@ -334,7 +334,7 @@ public final class InfoTabbedPane extends JTabbedPane implements CharacterSelect
 		private final Queue<CharacterInfoTab> storeQueue;
 		private final Queue<Future<?>> restoreQueue;
 
-		public TabModelService()
+		TabModelService()
 		{
 			super(1, 1, 0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(), r -> {
                 Thread thread = new Thread(r);
@@ -374,7 +374,7 @@ public final class InfoTabbedPane extends JTabbedPane implements CharacterSelect
 			storeQueue.add(infoTab);
 		}
 
-		public void restoreModels(Map<CharacterInfoTab, ModelMap> states, int selectedIndex)
+		void restoreModels(Map<CharacterInfoTab, ModelMap> states, int selectedIndex)
 		{
 			CharacterInfoTab firstTab = (CharacterInfoTab) getComponentAt(selectedIndex);
 			restoreTab(firstTab, states.get(firstTab));
@@ -397,7 +397,7 @@ public final class InfoTabbedPane extends JTabbedPane implements CharacterSelect
 			}
 		}
 
-		public void storeModels(Map<CharacterInfoTab, ModelMap> states)
+		void storeModels(Map<CharacterInfoTab, ModelMap> states)
 		{
 			while (!storeQueue.isEmpty())
 			{
@@ -406,7 +406,7 @@ public final class InfoTabbedPane extends JTabbedPane implements CharacterSelect
 			}
 		}
 
-		public void cancelRestoreTasks()
+		void cancelRestoreTasks()
 		{
 			while (!restoreQueue.isEmpty())
 			{
@@ -421,7 +421,7 @@ public final class InfoTabbedPane extends JTabbedPane implements CharacterSelect
 			private final ModelMap models;
 			private boolean executed;
 
-			public RestoreModelsTask(CharacterInfoTab infoTab, ModelMap models)
+			RestoreModelsTask(CharacterInfoTab infoTab, ModelMap models)
 			{
 				this.infoTab = infoTab;
 				this.models = models;
@@ -459,7 +459,7 @@ public final class InfoTabbedPane extends JTabbedPane implements CharacterSelect
 
 		private final Component component;
 
-		public TabActionListener(Component component)
+		TabActionListener(Component component)
 		{
 			this.component = component;
 		}

--- a/code/src/java/pcgen/gui2/tabs/InventoryInfoTab.java
+++ b/code/src/java/pcgen/gui2/tabs/InventoryInfoTab.java
@@ -67,19 +67,19 @@ public class InventoryInfoTab extends JTabbedPane implements CharacterInfoTab, T
 		private final ModelMap equipModelMap;
 		private final ModelMap purchaseModelMap;
 
-		public ModelHandler(CharacterFacade character)
+		ModelHandler(CharacterFacade character)
 		{
 			equipModelMap = equipTab.createModels(character);
 			purchaseModelMap = purchaseTab.createModels(character);
 		}
 
-		public void restoreModels()
+		void restoreModels()
 		{
 			equipTab.restoreModels(equipModelMap);
 			purchaseTab.restoreModels(purchaseModelMap);
 		}
 
-		public void storeModels()
+		void storeModels()
 		{
 			equipTab.storeModels(equipModelMap);
 			purchaseTab.storeModels(purchaseModelMap);

--- a/code/src/java/pcgen/gui2/tabs/PurchaseInfoTab.java
+++ b/code/src/java/pcgen/gui2/tabs/PurchaseInfoTab.java
@@ -442,7 +442,7 @@ public class PurchaseInfoTab extends FlippingSplitPane implements CharacterInfoT
 		private final BigDecimalFieldHandler fundsHandler;
 		private final BigDecimalFieldHandler wealthHandler;
 
-		public CurrencyFieldHandler(final CharacterFacade character)
+		CurrencyFieldHandler(final CharacterFacade character)
 		{
 			/**
 			 * Handler for the Current Funds field. This listens for and
@@ -476,13 +476,13 @@ public class PurchaseInfoTab extends FlippingSplitPane implements CharacterInfoT
 			};
 		}
 
-		public void install()
+		void install()
 		{
 			fundsHandler.install();
 			wealthHandler.install();
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			fundsHandler.uninstall();
 			wealthHandler.uninstall();
@@ -494,7 +494,7 @@ public class PurchaseInfoTab extends FlippingSplitPane implements CharacterInfoT
 
 		private final CharacterFacade character;
 
-		public AddAction(CharacterFacade character)
+		AddAction(CharacterFacade character)
 		{
 			super(LanguageBundle.getString("in_ieAddEq")); //$NON-NLS-1$
 			putValue(SMALL_ICON, Icons.Forward16.getImageIcon());
@@ -522,12 +522,12 @@ public class PurchaseInfoTab extends FlippingSplitPane implements CharacterInfoT
 			}
 		}
 
-		public void install()
+		void install()
 		{
 			availableTable.addActionListener(this);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			availableTable.removeActionListener(this);
 		}
@@ -539,7 +539,7 @@ public class PurchaseInfoTab extends FlippingSplitPane implements CharacterInfoT
 
 		private final CharacterFacade character;
 
-		public AddCustomAction(CharacterFacade character)
+		AddCustomAction(CharacterFacade character)
 		{
 			super(LanguageBundle.getString("in_igAddCustom")); //$NON-NLS-1$
 			putValue(SMALL_ICON, Icons.Forward16.getImageIcon());
@@ -577,7 +577,7 @@ public class PurchaseInfoTab extends FlippingSplitPane implements CharacterInfoT
 
 		private final CharacterFacade character;
 
-		public DeleteCustomAction(CharacterFacade character)
+		DeleteCustomAction(CharacterFacade character)
 		{
 			super(LanguageBundle.getString("in_igDeleteCustom")); //$NON-NLS-1$
 			this.character = character;
@@ -606,7 +606,7 @@ public class PurchaseInfoTab extends FlippingSplitPane implements CharacterInfoT
 
 		private final CharacterFacade character;
 
-		public UseAutoResizeAction(CharacterFacade character)
+		UseAutoResizeAction(CharacterFacade character)
 		{
 			super(LanguageBundle.getString("in_igAutoResize")); //$NON-NLS-1$
 			this.character = character;
@@ -618,7 +618,7 @@ public class PurchaseInfoTab extends FlippingSplitPane implements CharacterInfoT
 			character.setAutoResize(autoResizeBox.isSelected());
 		}
 
-		public void install()
+		void install()
 		{
 			autoResizeBox.setSelected(character.isAutoResize());
 		}
@@ -651,12 +651,12 @@ public class PurchaseInfoTab extends FlippingSplitPane implements CharacterInfoT
 			}
 		}
 
-		public void install()
+		void install()
 		{
 			purchasedTable.addActionListener(this);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			purchasedTable.removeActionListener(this);
 		}
@@ -685,12 +685,12 @@ public class PurchaseInfoTab extends FlippingSplitPane implements CharacterInfoT
 			}
 		}
 
-		public void install()
+		void install()
 		{
 			purchasedTable.addActionListener(this);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			purchasedTable.removeActionListener(this);
 		}
@@ -705,7 +705,7 @@ public class PurchaseInfoTab extends FlippingSplitPane implements CharacterInfoT
 
 		private final CharacterFacade character;
 
-		public FundsAddAction(CharacterFacade character)
+		FundsAddAction(CharacterFacade character)
 		{
 			this.character = character;
 			putValue(SMALL_ICON, new SignIcon(Sign.Plus));
@@ -734,7 +734,7 @@ public class PurchaseInfoTab extends FlippingSplitPane implements CharacterInfoT
 
 		private final CharacterFacade character;
 
-		public FundsSubtractAction(CharacterFacade character)
+		FundsSubtractAction(CharacterFacade character)
 		{
 			this.character = character;
 			putValue(SMALL_ICON, new SignIcon(Sign.Minus));
@@ -763,7 +763,7 @@ public class PurchaseInfoTab extends FlippingSplitPane implements CharacterInfoT
 
 		private final CharacterFacade character;
 
-		public AllowDebtAction(CharacterFacade character)
+		AllowDebtAction(CharacterFacade character)
 		{
 			super(LanguageBundle.getString("in_igAllowDebt")); //$NON-NLS-1$
 			this.character = character;
@@ -775,7 +775,7 @@ public class PurchaseInfoTab extends FlippingSplitPane implements CharacterInfoT
 			character.setAllowDebt(allowDebt.isSelected());
 		}
 
-		public void install()
+		void install()
 		{
 			allowDebt.setSelected(character.isAllowDebt());
 		}
@@ -789,21 +789,21 @@ public class PurchaseInfoTab extends FlippingSplitPane implements CharacterInfoT
 		private String text;
 		private List<EquipmentFacade> oldList;
 
-		public EquipInfoHandler(CharacterFacade character)
+		EquipInfoHandler(CharacterFacade character)
 		{
 			this.character = character;
 			this.text = ""; //$NON-NLS-1$
 			oldList = null;
 		}
 
-		public void install()
+		void install()
 		{
 			availableTable.getSelectionModel().addListSelectionListener(this);
 			purchasedTable.getSelectionModel().addListSelectionListener(this);
 			infoPane.setText(text);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			availableTable.getSelectionModel().removeListSelectionListener(this);
 			purchasedTable.getSelectionModel().removeListSelectionListener(this);
@@ -858,12 +858,12 @@ public class PurchaseInfoTab extends FlippingSplitPane implements CharacterInfoT
 
 		private final CharacterFacade character;
 
-		public CurrencyLabelHandler(CharacterFacade character)
+		CurrencyLabelHandler(CharacterFacade character)
 		{
 			this.character = character;
 		}
 
-		public void install()
+		void install()
 		{
 			String currencyDisplay = character.getDataSet().getGameMode().getCurrencyDisplay();
 			for (JLabel label : currencyLabels)
@@ -888,7 +888,7 @@ public class PurchaseInfoTab extends FlippingSplitPane implements CharacterInfoT
 		private final CharacterFacade character;
 		private final ListFacade<EquipmentFacade> equipmentList;
 
-		public AvailableTreeViewModel(CharacterFacade character)
+		AvailableTreeViewModel(CharacterFacade character)
 		{
 			this.character = character;
 			this.equipmentList = character.getDataSet().getEquipment();
@@ -961,7 +961,7 @@ public class PurchaseInfoTab extends FlippingSplitPane implements CharacterInfoT
 		{
 		}
 
-		public void install()
+		void install()
 		{
 			availableTable.setTreeViewModel(this);
 		}
@@ -981,7 +981,7 @@ public class PurchaseInfoTab extends FlippingSplitPane implements CharacterInfoT
 		private final CharacterFacade character;
 		private final EquipmentListFacade equipmentList;
 
-		public PurchasedTreeViewModel(CharacterFacade character)
+		PurchasedTreeViewModel(CharacterFacade character)
 		{
 			this.character = character;
 			this.equipmentList = character.getPurchasedEquipment();
@@ -1151,12 +1151,12 @@ public class PurchaseInfoTab extends FlippingSplitPane implements CharacterInfoT
 
 		private final CharacterFacade character;
 
-		public EquipmentFilterHandler(CharacterFacade character)
+		EquipmentFilterHandler(CharacterFacade character)
 		{
 			this.character = character;
 		}
 
-		public void install()
+		void install()
 		{
 			availableTable.setContext(character);
 		}
@@ -1168,12 +1168,12 @@ public class PurchaseInfoTab extends FlippingSplitPane implements CharacterInfoT
 
 		private final CharacterFacade character;
 
-		public EquipmentTransferHandler(CharacterFacade character)
+		EquipmentTransferHandler(CharacterFacade character)
 		{
 			this.character = character;
 		}
 
-		public void install()
+		void install()
 		{
 			availableTable.setDragEnabled(true);
 			availableTable.setDropMode(DropMode.ON);
@@ -1309,12 +1309,12 @@ public class PurchaseInfoTab extends FlippingSplitPane implements CharacterInfoT
 			popupMenu.show(e.getComponent(), e.getX(), e.getY());
 		}
 
-		public void install()
+		void install()
 		{
 			availableTable.addMouseListener(this);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			availableTable.removeMouseListener(this);
 		}
@@ -1452,12 +1452,12 @@ public class PurchaseInfoTab extends FlippingSplitPane implements CharacterInfoT
 			popupMenu.show(e.getComponent(), e.getX(), e.getY());
 		}
 
-		public void install()
+		void install()
 		{
 			purchasedTable.addMouseListener(this);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			purchasedTable.removeMouseListener(this);
 		}
@@ -1470,7 +1470,7 @@ public class PurchaseInfoTab extends FlippingSplitPane implements CharacterInfoT
 	private class SellNumMenuItem extends JMenuItem implements ActionListener
 	{
 
-		public static final int SELL_ALL_QUANTITY = -5;
+		static final int SELL_ALL_QUANTITY = -5;
 		private final int quantity;
 		private final CharacterFacade character;
 		private final List<EquipmentFacade> targets;

--- a/code/src/java/pcgen/gui2/tabs/RaceInfoTab.java
+++ b/code/src/java/pcgen/gui2/tabs/RaceInfoTab.java
@@ -201,14 +201,14 @@ public final class RaceInfoTab extends FlippingSplitPane implements CharacterInf
 			this.text = ""; //$NON-NLS-1$
 		}
 
-		public void install()
+		void install()
 		{
 			raceTable.getSelectionModel().addListSelectionListener(this);
 			selectedTable.getSelectionModel().addListSelectionListener(this);
 			infoPane.setText(text);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			raceTable.getSelectionModel().removeListSelectionListener(this);
 			selectedTable.getSelectionModel().removeListSelectionListener(this);
@@ -273,13 +273,13 @@ public final class RaceInfoTab extends FlippingSplitPane implements CharacterInf
 			}
 		}
 
-		public void install()
+		void install()
 		{
 			raceTable.addActionListener(this);
 			selectRaceButton.setAction(this);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			raceTable.removeActionListener(this);
 		}
@@ -304,13 +304,13 @@ public final class RaceInfoTab extends FlippingSplitPane implements CharacterInf
 			character.setRace(null);
 		}
 
-		public void install()
+		void install()
 		{
 			selectedTable.addActionListener(this);
 			removeButton.setAction(this);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			selectedTable.removeActionListener(this);
 		}
@@ -331,7 +331,7 @@ public final class RaceInfoTab extends FlippingSplitPane implements CharacterInf
 			this.infoFactory = character.getInfoFactory();
 		}
 
-		public void install()
+		void install()
 		{
 			noRacialHdFilterButton.setFilter(this);
 		}
@@ -358,7 +358,7 @@ public final class RaceInfoTab extends FlippingSplitPane implements CharacterInf
 			this.character = character;
 		}
 
-		public void install()
+		void install()
 		{
 			qFilterButton.setFilter(this);
 		}
@@ -387,7 +387,7 @@ public final class RaceInfoTab extends FlippingSplitPane implements CharacterInf
 			selectedModel = new RaceTreeViewModel(character, false, selectedView);
 		}
 
-		public void install()
+		void install()
 		{
 			raceTable.setTreeViewModel(availableModel);
 			selectedTable.setTreeViewModel(selectedModel);

--- a/code/src/java/pcgen/gui2/tabs/SkillInfoTab.java
+++ b/code/src/java/pcgen/gui2/tabs/SkillInfoTab.java
@@ -238,19 +238,19 @@ public class SkillInfoTab extends FlippingSplitPane implements CharacterInfoTab,
 
 		private final HtmlSheetSupport support;
 
-		public SkillSheetHandler(CharacterFacade character)
+		SkillSheetHandler(CharacterFacade character)
 		{
 			String sheet = character.getDataSet().getGameMode().getInfoSheetSkill();
 			support = new HtmlSheetSupport(character, htmlPane, sheet);
 			character.getCharacterLevelsFacade().addSkillBonusListener(this);
 		}
 
-		public void install()
+		void install()
 		{
 			support.install();
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			support.uninstall();
 		}
@@ -270,13 +270,13 @@ public class SkillInfoTab extends FlippingSplitPane implements CharacterInfoTab,
 		private final CharacterLevelsFacade levels;
 		private final ListSelectionModel model;
 
-		public LevelSelectionHandler(CharacterFacade character, ListSelectionModel model)
+		LevelSelectionHandler(CharacterFacade character, ListSelectionModel model)
 		{
 			this.levels = character.getCharacterLevelsFacade();
 			this.model = model;
 		}
 
-		public void install()
+		void install()
 		{
 			levels.addSkillPointListener(this);
 			levels.addListListener(this);
@@ -284,7 +284,7 @@ public class SkillInfoTab extends FlippingSplitPane implements CharacterInfoTab,
 			updateSelectedIndex(false);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			levels.removeSkillPointListener(this);
 			levels.removeListListener(this);
@@ -414,14 +414,14 @@ public class SkillInfoTab extends FlippingSplitPane implements CharacterInfoTab,
 		private final CharacterFacade character;
 		private boolean installed = false;
 
-		public FilterHandler(CharacterFacade character, ListSelectionModel model)
+		FilterHandler(CharacterFacade character, ListSelectionModel model)
 		{
 			this.character = character;
 			this.model = model;
 			model.addListSelectionListener(this);
 		}
 
-		public void install()
+		void install()
 		{
 			installed = true;
 			cFilterButton.setFilter(cFilter);
@@ -429,7 +429,7 @@ public class SkillInfoTab extends FlippingSplitPane implements CharacterInfoTab,
 			skillTable.setContext(character);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			installed = false;
 		}
@@ -453,7 +453,7 @@ public class SkillInfoTab extends FlippingSplitPane implements CharacterInfoTab,
 		private ListSelectionModel listModel;
 		private CharacterFacade character;
 
-		public SkillRankSpinnerEditor(CharacterFacade character, ListSelectionModel listModel)
+		SkillRankSpinnerEditor(CharacterFacade character, ListSelectionModel listModel)
 		{
 			this(new SkillRankSpinnerModel(character));
 			this.listModel = listModel;
@@ -529,7 +529,7 @@ public class SkillInfoTab extends FlippingSplitPane implements CharacterInfoTab,
 		private CharacterLevelFacade level;
 		private Skill skill;
 
-		public SkillRankSpinnerModel(CharacterFacade character)
+		SkillRankSpinnerModel(CharacterFacade character)
 		{
 			this.character = character;
 		}
@@ -540,7 +540,7 @@ public class SkillInfoTab extends FlippingSplitPane implements CharacterInfoTab,
 			return character.getCharacterLevelsFacade().getSkillRanks(level, skill);
 		}
 
-		public void configureModel(Skill sk, CharacterLevelFacade charLevel)
+		void configureModel(Skill sk, CharacterLevelFacade charLevel)
 		{
 			this.skill = sk;
 			this.level = charLevel;
@@ -556,7 +556,7 @@ public class SkillInfoTab extends FlippingSplitPane implements CharacterInfoTab,
 			}
 		}
 
-		public void setValue(Float value)
+		void setValue(Float value)
 		{
 			if (value == null)
 			{
@@ -647,19 +647,19 @@ public class SkillInfoTab extends FlippingSplitPane implements CharacterInfoTab,
 		private final CharacterFacade character;
 		private String text;
 
-		public InfoHandler(CharacterFacade character)
+		InfoHandler(CharacterFacade character)
 		{
 			this.character = character;
 			this.text = ""; //$NON-NLS-1$
 		}
 
-		public void install()
+		void install()
 		{
 			skillTable.getSelectionModel().addListSelectionListener(this);
 			infoPane.setText(text);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			skillTable.getSelectionModel().removeListSelectionListener(this);
 		}
@@ -691,7 +691,7 @@ public class SkillInfoTab extends FlippingSplitPane implements CharacterInfoTab,
 		private final SkillSheetHandler skillSheetHandler;
 		private final ComboBoxModel model;
 
-		public SkillFilterHandler(CharacterFacade character, SkillSheetHandler skillSheetHandler)
+		SkillFilterHandler(CharacterFacade character, SkillSheetHandler skillSheetHandler)
 		{
 			this.character = character;
 			this.skillSheetHandler = skillSheetHandler;
@@ -704,7 +704,7 @@ public class SkillInfoTab extends FlippingSplitPane implements CharacterInfoTab,
 			model.addListDataListener(this);
 		}
 
-		public void install()
+		void install()
 		{
 			skillFilterBox.setModel(model);
 		}

--- a/code/src/java/pcgen/gui2/tabs/SpellsInfoTab.java
+++ b/code/src/java/pcgen/gui2/tabs/SpellsInfoTab.java
@@ -73,21 +73,21 @@ public class SpellsInfoTab extends JTabbedPane implements CharacterInfoTab, Todo
 		private final ModelMap preparedTabMap;
 		private final ModelMap booksTabMap;
 
-		public ModelHandler(CharacterFacade character)
+		ModelHandler(CharacterFacade character)
 		{
 			this.knownTabMap = knownTab.createModels(character);
 			this.preparedTabMap = preparedTab.createModels(character);
 			this.booksTabMap = booksTab.createModels(character);
 		}
 
-		public void restoreModels()
+		void restoreModels()
 		{
 			knownTab.restoreModels(knownTabMap);
 			preparedTab.restoreModels(preparedTabMap);
 			booksTab.restoreModels(booksTabMap);
 		}
 
-		public void storeModels()
+		void storeModels()
 		{
 			knownTab.storeModels(knownTabMap);
 			preparedTab.storeModels(preparedTabMap);

--- a/code/src/java/pcgen/gui2/tabs/SummaryInfoTab.java
+++ b/code/src/java/pcgen/gui2/tabs/SummaryInfoTab.java
@@ -841,7 +841,7 @@ public class SummaryInfoTab extends JPanel implements CharacterInfoTab, TodoHand
 			};
 		}
 
-		public void install()
+		void install()
 		{
 			charNameHandler.install();
 			playerNameHandler.install();
@@ -855,7 +855,7 @@ public class SummaryInfoTab extends JPanel implements CharacterInfoTab, TodoHand
 			modTotalHandler.install();
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			charNameHandler.uninstall();
 			playerNameHandler.uninstall();
@@ -1000,7 +1000,7 @@ public class SummaryInfoTab extends JPanel implements CharacterInfoTab, TodoHand
 			classModel = new FacadeComboBoxModel<>(dataset.getClasses(), null);
 		}
 
-		public void install()
+		void install()
 		{
 			characterTypeComboBox.setModel(characterTypeModel);
 			genderComboBox.setModel(genderModel);
@@ -1027,7 +1027,7 @@ public class SummaryInfoTab extends JPanel implements CharacterInfoTab, TodoHand
 			xpTableComboBox.setModel(xpTableModel);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			raceComboBox.removeFocusListener(raceModel);
 		}
@@ -1043,13 +1043,13 @@ public class SummaryInfoTab extends JPanel implements CharacterInfoTab, TodoHand
 			this.character = character;
 		}
 
-		public void install()
+		void install()
 		{
 			infoBoxRenderer.setCharacter(character);
 			classBoxRenderer.setCharacter(character);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			infoBoxRenderer.setCharacter(null);
 			classBoxRenderer.setCharacter(null);
@@ -1061,7 +1061,7 @@ public class SummaryInfoTab extends JPanel implements CharacterInfoTab, TodoHand
 
 		protected CharacterFacade character;
 
-		public void setCharacter(CharacterFacade character)
+		void setCharacter(CharacterFacade character)
 		{
 			this.character = character;
 		}
@@ -1142,14 +1142,14 @@ public class SummaryInfoTab extends JPanel implements CharacterInfoTab, TodoHand
 			putValue(NAME, LanguageBundle.getString("in_edit")); //$NON-NLS-1$
 		}
 
-		public void install()
+		void install()
 		{
 			hpButton.setAction(this);
 			totalHPLabel.setText(ref.get().toString());
 			ref.addReferenceListener(this);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			ref.removeReferenceListener(this);
 		}
@@ -1221,7 +1221,7 @@ public class SummaryInfoTab extends JPanel implements CharacterInfoTab, TodoHand
 		 * Attach the handler to the screen button. e.g. When the character is
 		 * made active.
 		 */
-		public void install()
+		void install()
 		{
 			// Listen to the total levels
 			character.getCharacterLevelsFacade().addListListener(this);
@@ -1234,7 +1234,7 @@ public class SummaryInfoTab extends JPanel implements CharacterInfoTab, TodoHand
 		 * Detach the handler from the on screen button. e.g. when the character
 		 * is no longer being displayed.
 		 */
-		public void uninstall()
+		void uninstall()
 		{
 			character.getCharacterLevelsFacade().removeListListener(this);
 			character.getRollMethodRef().removeReferenceListener(this);
@@ -1249,7 +1249,7 @@ public class SummaryInfoTab extends JPanel implements CharacterInfoTab, TodoHand
 		/**
 		 * Update the state of the button.
 		 */
-		public void update()
+		void update()
 		{
 			setEnabled(character.isStatRollEnabled());
 		}
@@ -1367,7 +1367,7 @@ public class SummaryInfoTab extends JPanel implements CharacterInfoTab, TodoHand
 			}
 		}
 
-		public void install()
+		void install()
 		{
 			CharacterLevelsFacade characterLevelsFacade = character.getCharacterLevelsFacade();
 			int maxLvl = characterLevelsFacade.getSize();
@@ -1503,7 +1503,7 @@ public class SummaryInfoTab extends JPanel implements CharacterInfoTab, TodoHand
 		 * Attach the handler to the on-screen field. e.g. When the character is
 		 * made active.
 		 */
-		public void install()
+		void install()
 		{
 			reference.addReferenceListener(this);
 			label.setText(reference.get());
@@ -1513,7 +1513,7 @@ public class SummaryInfoTab extends JPanel implements CharacterInfoTab, TodoHand
 		 * Detach the handler from the on-screen field. e.g. when the character
 		 * is no longer being displayed.
 		 */
-		public void uninstall()
+		void uninstall()
 		{
 			reference.removeReferenceListener(this);
 		}
@@ -1554,7 +1554,7 @@ public class SummaryInfoTab extends JPanel implements CharacterInfoTab, TodoHand
 		 * Attach the handler to the on-screen field. e.g. When the character is
 		 * made active.
 		 */
-		public void install()
+		void install()
 		{
 			character.getTodoList().addListListener(this);
 			todoPane.addHyperlinkListener(this);
@@ -1566,7 +1566,7 @@ public class SummaryInfoTab extends JPanel implements CharacterInfoTab, TodoHand
 		 * Detach the handler from the on-screen field. e.g. when the character
 		 * is no longer being displayed.
 		 */
-		public void uninstall()
+		void uninstall()
 		{
 			todoPane.removeHyperlinkListener(this);
 			character.getTodoList().removeListListener(this);

--- a/code/src/java/pcgen/gui2/tabs/TempBonusInfoTab.java
+++ b/code/src/java/pcgen/gui2/tabs/TempBonusInfoTab.java
@@ -223,20 +223,20 @@ public class TempBonusInfoTab extends FlippingSplitPane implements CharacterInfo
 		private final CharacterFacade character;
 		private String text;
 
-		public InfoHandler(CharacterFacade character)
+		InfoHandler(CharacterFacade character)
 		{
 			this.character = character;
 			this.text = ""; //$NON-NLS-1$
 		}
 
-		public void install()
+		void install()
 		{
 			availableTable.getSelectionModel().addListSelectionListener(this);
 			selectedTable.getSelectionModel().addListSelectionListener(this);
 			infoPane.setText(text);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			availableTable.getSelectionModel().removeListSelectionListener(this);
 			selectedTable.getSelectionModel().removeListSelectionListener(this);
@@ -284,7 +284,7 @@ public class TempBonusInfoTab extends FlippingSplitPane implements CharacterInfo
 
 		private final CharacterFacade character;
 
-		public AddAction(CharacterFacade character)
+		AddAction(CharacterFacade character)
 		{
 			super(LanguageBundle.getString("in_itmInitCompAppBonTitle")); //$NON-NLS-1$
 			this.character = character;
@@ -305,13 +305,13 @@ public class TempBonusInfoTab extends FlippingSplitPane implements CharacterInfo
 			}
 		}
 
-		public void install()
+		void install()
 		{
 			availableTable.addActionListener(this);
 			addButton.setAction(this);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			availableTable.removeActionListener(this);
 		}
@@ -328,7 +328,7 @@ public class TempBonusInfoTab extends FlippingSplitPane implements CharacterInfo
 
 		private final CharacterFacade character;
 
-		public RemoveAction(CharacterFacade character)
+		RemoveAction(CharacterFacade character)
 		{
 			super(LanguageBundle.getString("in_itmInitCompRemoveButTitle")); //$NON-NLS-1$
 			this.character = character;
@@ -349,13 +349,13 @@ public class TempBonusInfoTab extends FlippingSplitPane implements CharacterInfo
 			}
 		}
 
-		public void install()
+		void install()
 		{
 			selectedTable.addActionListener(this);
 			removeButton.setAction(this);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			selectedTable.removeActionListener(this);
 		}
@@ -368,13 +368,13 @@ public class TempBonusInfoTab extends FlippingSplitPane implements CharacterInfo
 		private final TempBonusTreeViewModel availableModel;
 		private final TempBonusTreeViewModel selectedModel;
 
-		public TreeViewModelHandler(CharacterFacade character)
+		TreeViewModelHandler(CharacterFacade character)
 		{
 			availableModel = new TempBonusTreeViewModel(character, true);
 			selectedModel = new TempBonusTreeViewModel(character, false);
 		}
 
-		public void install()
+		void install()
 		{
 			availableModel.install();
 			availableTable.setTreeViewModel(availableModel);
@@ -395,7 +395,7 @@ public class TempBonusInfoTab extends FlippingSplitPane implements CharacterInfo
 		private final boolean isAvailModel;
 		private final FilteredListFacade<CharacterFacade, TempBonusFacade> tempBonuses;
 
-		public TempBonusTreeViewModel(CharacterFacade character, boolean isAvailModel)
+		TempBonusTreeViewModel(CharacterFacade character, boolean isAvailModel)
 		{
 			this.character = character;
 			this.infoFactory = character.getInfoFactory();
@@ -422,7 +422,7 @@ public class TempBonusInfoTab extends FlippingSplitPane implements CharacterInfo
 			}
 		}
 
-		public void install()
+		void install()
 		{
 			for (TempBonusTreeView tbTreeView : TempBonusTreeView.values())
 			{
@@ -542,7 +542,7 @@ public class TempBonusInfoTab extends FlippingSplitPane implements CharacterInfo
 		/**
 		 * @param factory The InfoFactory for the character ebing displayed.
 		 */
-		public void setInfoFactory(InfoFactory factory)
+		void setInfoFactory(InfoFactory factory)
 		{
 			this.infoFactory = factory;
 		}

--- a/code/src/java/pcgen/gui2/tabs/TemplateInfoTab.java
+++ b/code/src/java/pcgen/gui2/tabs/TemplateInfoTab.java
@@ -182,20 +182,20 @@ public class TemplateInfoTab extends FlippingSplitPane implements CharacterInfoT
 		private final CharacterFacade character;
 		private String text;
 
-		public InfoHandler(CharacterFacade character)
+		InfoHandler(CharacterFacade character)
 		{
 			this.character = character;
 			this.text = ""; //$NON-NLS-1$
 		}
 
-		public void install()
+		void install()
 		{
 			availableTable.getSelectionModel().addListSelectionListener(this);
 			selectedTable.getSelectionModel().addListSelectionListener(this);
 			infoPane.setText(text);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			availableTable.getSelectionModel().removeListSelectionListener(this);
 			selectedTable.getSelectionModel().removeListSelectionListener(this);
@@ -238,7 +238,7 @@ public class TemplateInfoTab extends FlippingSplitPane implements CharacterInfoT
 
 		private final CharacterFacade character;
 
-		public AddAction(CharacterFacade character)
+		AddAction(CharacterFacade character)
 		{
 			super(LanguageBundle.getString("in_irAddTemplate")); //$NON-NLS-1$
 			this.character = character;
@@ -259,13 +259,13 @@ public class TemplateInfoTab extends FlippingSplitPane implements CharacterInfoT
 			}
 		}
 
-		public void install()
+		void install()
 		{
 			availableTable.addActionListener(this);
 			addButton.setAction(this);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			availableTable.removeActionListener(this);
 		}
@@ -277,7 +277,7 @@ public class TemplateInfoTab extends FlippingSplitPane implements CharacterInfoT
 
 		private final CharacterFacade character;
 
-		public RemoveAction(CharacterFacade character)
+		RemoveAction(CharacterFacade character)
 		{
 			super(LanguageBundle.getString("in_irRemoveTemplate")); //$NON-NLS-1$
 			this.character = character;
@@ -298,13 +298,13 @@ public class TemplateInfoTab extends FlippingSplitPane implements CharacterInfoT
 			}
 		}
 
-		public void install()
+		void install()
 		{
 			selectedTable.addActionListener(this);
 			removeButton.setAction(this);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			selectedTable.removeActionListener(this);
 		}
@@ -325,12 +325,12 @@ public class TemplateInfoTab extends FlippingSplitPane implements CharacterInfoT
 		};
 		private final CharacterFacade character;
 
-		public QualifiedFilterHandler(CharacterFacade character)
+		QualifiedFilterHandler(CharacterFacade character)
 		{
 			this.character = character;
 		}
 
-		public void install()
+		void install()
 		{
 			qFilterButton.setFilter(qFilter);
 		}
@@ -345,7 +345,7 @@ public class TemplateInfoTab extends FlippingSplitPane implements CharacterInfoT
 		private final TemplateTreeViewModel availTreeView;
 		private final TemplateTreeViewModel selTreeView;
 
-		public TreeViewModelHandler(CharacterFacade character)
+		TreeViewModelHandler(CharacterFacade character)
 		{
 			availDataView = new TemplateDataView(character, true);
 			selDataView = new TemplateDataView(character, false);
@@ -353,13 +353,13 @@ public class TemplateInfoTab extends FlippingSplitPane implements CharacterInfoT
 			selTreeView = new TemplateTreeViewModel(character, false, selDataView);
 		}
 
-		public void install()
+		void install()
 		{
 			availableTable.setTreeViewModel(availTreeView);
 			selectedTable.setTreeViewModel(selTreeView);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 		}
 	}
@@ -371,7 +371,7 @@ public class TemplateInfoTab extends FlippingSplitPane implements CharacterInfoT
 		private final InfoFactory infoFactory;
 		private final boolean isAvailModel;
 
-		public TemplateDataView(CharacterFacade character, boolean isAvailModel)
+		TemplateDataView(CharacterFacade character, boolean isAvailModel)
 		{
 			this.infoFactory = character.getInfoFactory();
 			this.isAvailModel = isAvailModel;
@@ -432,7 +432,7 @@ public class TemplateInfoTab extends FlippingSplitPane implements CharacterInfoT
 		private final TemplateDataView dataView;
 		private final FilteredListFacade<CharacterFacade, PCTemplate> templates;
 
-		public TemplateTreeViewModel(CharacterFacade character, boolean isAvailModel, TemplateDataView dataView)
+		TemplateTreeViewModel(CharacterFacade character, boolean isAvailModel, TemplateDataView dataView)
 		{
 			this.character = character;
 			this.isAvailModel = isAvailModel;

--- a/code/src/java/pcgen/gui2/tabs/ability/AbilityTreeTableModel.java
+++ b/code/src/java/pcgen/gui2/tabs/ability/AbilityTreeTableModel.java
@@ -131,7 +131,7 @@ public class AbilityTreeTableModel extends AbstractTreeTableModel implements Sor
 
 		private final ListFacade<AbilityCategory> cats;
 
-		public RootTreeTableNode(ListFacade<AbilityCategory> cats)
+		RootTreeTableNode(ListFacade<AbilityCategory> cats)
 		{
 			super(Collections.singletonList(new Object()));
 			this.cats = new SortedListFacade<>(Comparators.toStringIgnoreCaseComparator(), cats);
@@ -179,7 +179,7 @@ public class AbilityTreeTableModel extends AbstractTreeTableModel implements Sor
 
 		private final ListFacade<AbilityFacade> abilities;
 
-		public CategoryTreeTableNode(AbilityCategory category)
+		CategoryTreeTableNode(AbilityCategory category)
 		{
 			setUserObject(category);
 			setValues(Collections.singletonList(category));

--- a/code/src/java/pcgen/gui2/tabs/ability/AbilityTreeViews.java
+++ b/code/src/java/pcgen/gui2/tabs/ability/AbilityTreeViews.java
@@ -118,7 +118,7 @@ public final class AbilityTreeViews
 
 		private final DataSetFacade dataset;
 
-		public PreReqTreeView(DataSetFacade dataset)
+		PreReqTreeView(DataSetFacade dataset)
 		{
 			this.dataset = dataset;
 		}

--- a/code/src/java/pcgen/gui2/tabs/bio/BioItem.java
+++ b/code/src/java/pcgen/gui2/tabs/bio/BioItem.java
@@ -65,7 +65,7 @@ abstract class BioItem
 		label.setHorizontalAlignment(SwingConstants.RIGHT);
 	}
 
-	public void addComponents(JPanel panel)
+	void addComponents(JPanel panel)
 	{
 		GridBagConstraints gbc = new GridBagConstraints();
 		gbc.anchor = GridBagConstraints.PAGE_START;
@@ -135,7 +135,7 @@ abstract class BioItem
 		this.trailinglabel = Optional.of(new JLabel(text));
 	}
 
-	public void setVisible(boolean visible)
+	void setVisible(boolean visible)
 	{
 		label.setVisible(visible);
 		combobox.ifPresent(box -> box.setVisible(visible));
@@ -146,7 +146,7 @@ abstract class BioItem
 	/**
 	 * Installs this BioItem by attaching itself to the buttons.
 	 */
-	public void install()
+	void install()
 	{
 		textFieldHandler.ifPresent(ManagedField::install);
 	}
@@ -154,7 +154,7 @@ abstract class BioItem
 	/**
 	 * Uninstalls this BioItem by removing its listeners from the buttons.
 	 */
-	public void uninstall()
+	void uninstall()
 	{
 		textFieldHandler.ifPresent(ManagedField::uninstall);
 	}

--- a/code/src/java/pcgen/gui2/tabs/bio/BiographyInfoPane.java
+++ b/code/src/java/pcgen/gui2/tabs/bio/BiographyInfoPane.java
@@ -139,7 +139,7 @@ public final class BiographyInfoPane extends JPanel implements CharacterInfoTab
 
 		private final List<BioItem> bioItems = new ArrayList<>();
 
-		public ItemHandler(CharacterFacade character)
+		ItemHandler(CharacterFacade character)
 		{
 			bioItems.add(new NameItem(character));
 			bioItems.add(new PlayerNameItem(character));
@@ -180,7 +180,7 @@ public final class BiographyInfoPane extends JPanel implements CharacterInfoTab
 			bioItems.add(new BiographyFieldBioItem(BiographyField.CATCH_PHRASE, PCStringKey.CATCHPHRASE, character));
 		}
 
-		public void install()
+		void install()
 		{
 			itemsPanel.removeAll();
 
@@ -194,7 +194,7 @@ public final class BiographyInfoPane extends JPanel implements CharacterInfoTab
 			detailsScroll.invalidate();
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			bioItems.forEach(BioItem::uninstall);
 		}
@@ -203,7 +203,7 @@ public final class BiographyInfoPane extends JPanel implements CharacterInfoTab
 	private static class NameItem extends BioItem
 	{
 
-		public NameItem(final CharacterFacade character)
+		NameItem(final CharacterFacade character)
 		{
 			super("in_nameLabel", BiographyField.NAME, character); //$NON-NLS-1$
 			setTextFieldHandler(new TextFieldHandler(new JTextField(30), character.getNameRef())
@@ -223,7 +223,7 @@ public final class BiographyInfoPane extends JPanel implements CharacterInfoTab
 	private static class PlayerNameItem extends BioItem
 	{
 
-		public PlayerNameItem(final CharacterFacade character)
+		PlayerNameItem(final CharacterFacade character)
 		{
 			super("in_player", BiographyField.PLAYERNAME, character); //$NON-NLS-1$
 			setTextFieldHandler(new TextFieldHandler(new JTextField(), character.getPlayersNameRef())
@@ -245,7 +245,7 @@ public final class BiographyInfoPane extends JPanel implements CharacterInfoTab
 
 		private final CharacterComboBoxModel<Gender> genderModel;
 
-		public GenderItem(final CharacterFacade character)
+		GenderItem(final CharacterFacade character)
 		{
 			super("in_gender", BiographyField.GENDER, character); //$NON-NLS-1$
 			genderModel = new CharacterComboBoxModel<>()
@@ -277,7 +277,7 @@ public final class BiographyInfoPane extends JPanel implements CharacterInfoTab
 
 		private final CharacterComboBoxModel<Handed> handsModel;
 
-		public HandedItem(final CharacterFacade character)
+		HandedItem(final CharacterFacade character)
 		{
 			super("in_handString", BiographyField.HANDED, character); //$NON-NLS-1$
 			handsModel = new CharacterComboBoxModel<>()
@@ -307,7 +307,7 @@ public final class BiographyInfoPane extends JPanel implements CharacterInfoTab
 	private static class AlignmentItem extends BioItem
 	{
 
-		public AlignmentItem(final CharacterFacade character)
+		AlignmentItem(final CharacterFacade character)
 		{
 			super("in_alignString", BiographyField.ALIGNMENT, character); //$NON-NLS-1$
 			CharacterComboBoxModel<PCAlignment> alignmentModel = new CharacterComboBoxModel<>()
@@ -330,7 +330,7 @@ public final class BiographyInfoPane extends JPanel implements CharacterInfoTab
 	private static class DeityItem extends BioItem
 	{
 
-		public DeityItem(final CharacterFacade character)
+		DeityItem(final CharacterFacade character)
 		{
 			super("in_deity", BiographyField.DEITY, character); //$NON-NLS-1$
 			CharacterComboBoxModel<Deity> deityModel = new CharacterComboBoxModel<>()
@@ -353,7 +353,7 @@ public final class BiographyInfoPane extends JPanel implements CharacterInfoTab
 	private static class AgeItem extends BioItem
 	{
 
-		public AgeItem(final CharacterFacade character)
+		AgeItem(final CharacterFacade character)
 		{
 			super("in_age", BiographyField.AGE, character); //$NON-NLS-1$
 			CharacterComboBoxModel<String> ageModel = new CharacterComboBoxModel<>()
@@ -386,7 +386,7 @@ public final class BiographyInfoPane extends JPanel implements CharacterInfoTab
 	private static class SkinColorItem extends BioItem
 	{
 
-		public SkinColorItem(final CharacterFacade character)
+		SkinColorItem(final CharacterFacade character)
 		{
 			super("in_appSkintoneColor", BiographyField.SKIN_TONE, character); //$NON-NLS-1$
 			setTextFieldHandler(new TextFieldHandler(new JTextField(), character.getSkinColorRef())
@@ -406,7 +406,7 @@ public final class BiographyInfoPane extends JPanel implements CharacterInfoTab
 	private static class HairColorItem extends BioItem
 	{
 
-		public HairColorItem(final CharacterFacade character)
+		HairColorItem(final CharacterFacade character)
 		{
 			super("in_appHairColor", BiographyField.HAIR_COLOR, character); //$NON-NLS-1$
 			setTextFieldHandler(new TextFieldHandler(new JTextField(), character.getHairColorRef())
@@ -426,7 +426,7 @@ public final class BiographyInfoPane extends JPanel implements CharacterInfoTab
 	private static class EyeColorItem extends BioItem
 	{
 
-		public EyeColorItem(final CharacterFacade character)
+		EyeColorItem(final CharacterFacade character)
 		{
 			super("in_appEyeColor", BiographyField.EYE_COLOR, character); //$NON-NLS-1$
 			setTextFieldHandler(new TextFieldHandler(new JTextField(), character.getEyeColorRef())
@@ -448,7 +448,7 @@ public final class BiographyInfoPane extends JPanel implements CharacterInfoTab
 
 		private WriteableReferenceFacade<Number> heightRef;
 
-		public HeightItem(final CharacterFacade character)
+		HeightItem(final CharacterFacade character)
 		{
 			super("in_height", BiographyField.HEIGHT, character); //$NON-NLS-1$
 			setTrailingLabel(character.getDataSet().getGameMode().getHeightUnit());
@@ -466,7 +466,7 @@ public final class BiographyInfoPane extends JPanel implements CharacterInfoTab
 	private static class WeightItem extends BioItem
 	{
 
-		public WeightItem(final CharacterFacade character)
+		WeightItem(final CharacterFacade character)
 		{
 			super("in_weight", BiographyField.WEIGHT, character); //$NON-NLS-1$
 			setTrailingLabel(character.getDataSet().getGameMode().getWeightUnit());
@@ -487,7 +487,7 @@ public final class BiographyInfoPane extends JPanel implements CharacterInfoTab
 	private static class RegionItem extends BioItem
 	{
 
-		public RegionItem(final CharacterFacade character)
+		RegionItem(final CharacterFacade character)
 		{
 			super("in_region", BiographyField.REGION, character); //$NON-NLS-1$
 			final JTextField regionField = new JTextField();
@@ -514,7 +514,7 @@ public final class BiographyInfoPane extends JPanel implements CharacterInfoTab
 	private static class BiographyFieldBioItem extends BioItem
 	{
 
-		public BiographyFieldBioItem(BiographyField field, PCStringKey attribute, CharacterFacade character)
+		BiographyFieldBioItem(BiographyField field, PCStringKey attribute, CharacterFacade character)
 		{
 			super(field.getIl8nKey(), field, character);
 			setTextFieldHandler(

--- a/code/src/java/pcgen/gui2/tabs/bio/CampaignHistoryInfoPane.java
+++ b/code/src/java/pcgen/gui2/tabs/bio/CampaignHistoryInfoPane.java
@@ -169,7 +169,7 @@ public class CampaignHistoryInfoPane extends JPanel implements CharacterInfoTab
 		private final List<ChroniclePane> chronicles;
 		private final DescriptionFacade descFacade;
 
-		public ChronicleHandler(CharacterFacade character)
+		ChronicleHandler(CharacterFacade character)
 		{
 			descFacade = character.getDescriptionFacade();
 			chronicles = new ArrayList<>();
@@ -192,7 +192,7 @@ public class CampaignHistoryInfoPane extends JPanel implements CharacterInfoTab
 		 * Installs this ChronicleHandler by attaching itself to the buttons and changes
 		 * the components of the chroniclesPane to the ones contained in this handler.
 		 */
-		public void install()
+		void install()
 		{
 			addButton.addActionListener(this);
 			allButton.addActionListener(this);
@@ -212,7 +212,7 @@ public class CampaignHistoryInfoPane extends JPanel implements CharacterInfoTab
 		/**
 		 * Uninstalls this ChronicleHandler by removing its listeners from the buttons.
 		 */
-		public void uninstall()
+		void uninstall()
 		{
 			addButton.removeActionListener(this);
 			allButton.removeActionListener(this);
@@ -256,7 +256,7 @@ public class CampaignHistoryInfoPane extends JPanel implements CharacterInfoTab
 		/**
 		 * Deletes a chronicle from this character and updates the display
 		 */
-		public void deleteChroniclePane(ChroniclePane pane, ChronicleEntry entry)
+		void deleteChroniclePane(ChroniclePane pane, ChronicleEntry entry)
 		{
 			descFacade.removeChronicleEntry(entry);
 			chroniclesPane.remove(pane);
@@ -300,14 +300,14 @@ public class CampaignHistoryInfoPane extends JPanel implements CharacterInfoTab
 		 * only for components that want to know the size of a ChroniclePane without fully
 		 * initializing it.
 		 */
-		public ChroniclePane()
+		ChroniclePane()
 		{
 			super(new GridBagLayout());
 			setBorder(BorderFactory.createEmptyBorder(2, 0, 5, 5));
 			initComponents();
 		}
 
-		public ChroniclePane(ChronicleHandler handler, final ChronicleEntry entry)
+		ChroniclePane(ChronicleHandler handler, final ChronicleEntry entry)
 		{
 			this();
 			this.handler = handler;
@@ -330,7 +330,7 @@ public class CampaignHistoryInfoPane extends JPanel implements CharacterInfoTab
 			deleteButton.addActionListener(this);
 		}
 
-		public void setSelected(boolean select)
+		void setSelected(boolean select)
 		{
 			checkBox.setSelected(select);
 			entry.setOutputEntry(select);
@@ -507,7 +507,7 @@ public class CampaignHistoryInfoPane extends JPanel implements CharacterInfoTab
 
 		private final ChroniclePane dummyPane = new ChroniclePane();
 
-		public ChroniclesPane()
+		ChroniclesPane()
 		{
 			setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
 		}

--- a/code/src/java/pcgen/gui2/tabs/bio/NoteInfoPane.java
+++ b/code/src/java/pcgen/gui2/tabs/bio/NoteInfoPane.java
@@ -128,7 +128,7 @@ public class NoteInfoPane extends JPanel implements CharacterInfoTab
 
 		private final DescriptionFacade descFacade;
 
-		public NoteHandler(CharacterFacade character)
+		NoteHandler(CharacterFacade character)
 		{
 			descFacade = character.getDescriptionFacade();
 			noteField.setText(note.getValue());

--- a/code/src/java/pcgen/gui2/tabs/bio/PortraitInfoPane.java
+++ b/code/src/java/pcgen/gui2/tabs/bio/PortraitInfoPane.java
@@ -206,7 +206,7 @@ public class PortraitInfoPane extends JScrollPane implements CharacterInfoTab
 		private boolean movingRect = false;
 		private Point cropOffset = null;
 
-		public PortraitHandler(CharacterFacade character)
+		PortraitHandler(CharacterFacade character)
 		{
 			this.character = character;
 			cropRect = character.getThumbnailCropRef().get();
@@ -216,7 +216,7 @@ public class PortraitInfoPane extends JScrollPane implements CharacterInfoTab
 			}
 		}
 
-		public void install()
+		void install()
 		{
 			setPortrait(character.getPortraitRef().get());
 			portraitPane.setCropRectangle(cropRect);
@@ -230,7 +230,7 @@ public class PortraitInfoPane extends JScrollPane implements CharacterInfoTab
 			zoomSlider.addChangeListener(this);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			character.getPortraitRef().removeReferenceListener(this);
 			character.getThumbnailCropRef().removeReferenceListener(this);

--- a/code/src/java/pcgen/gui2/tabs/bio/PortraitPane.java
+++ b/code/src/java/pcgen/gui2/tabs/bio/PortraitPane.java
@@ -36,19 +36,19 @@ class PortraitPane extends JComponent
 	private BufferedImage portrait;
 	private Rectangle cropRect;
 
-	public PortraitPane()
+	PortraitPane()
 	{
 		this.setBorder(BorderFactory.createLineBorder(Color.BLACK));
 	}
 
-	public void setPortraitImage(BufferedImage portrait)
+	void setPortraitImage(BufferedImage portrait)
 	{
 		this.portrait = portrait;
 		scale = MAX_PORTRAIT_HEIGHT / (float) portrait.getHeight();
 		repaint();
 	}
 
-	public void setCropRectangle(Rectangle newCropRect)
+	void setCropRectangle(Rectangle newCropRect)
 	{
 		this.cropRect = new Rectangle(newCropRect);
 		repaint();

--- a/code/src/java/pcgen/gui2/tabs/bio/ThumbnailPane.java
+++ b/code/src/java/pcgen/gui2/tabs/bio/ThumbnailPane.java
@@ -36,19 +36,19 @@ class ThumbnailPane extends JComponent
 	private BufferedImage portrait;
 	private Rectangle cropRect;
 
-	public ThumbnailPane()
+	ThumbnailPane()
 	{
 		this.setDoubleBuffered(true);
 		this.setBorder(BorderFactory.createLineBorder(Color.BLACK));
 	}
 
-	public void setPortraitImage(BufferedImage portrait)
+	void setPortraitImage(BufferedImage portrait)
 	{
 		this.portrait = portrait;
 		refreshImage();
 	}
 
-	public void setCropRectangle(Rectangle cropRect)
+	void setCropRectangle(Rectangle cropRect)
 	{
 		this.cropRect = new Rectangle(cropRect);
 		refreshImage();

--- a/code/src/java/pcgen/gui2/tabs/equip/EquipmentModels.java
+++ b/code/src/java/pcgen/gui2/tabs/equip/EquipmentModels.java
@@ -247,7 +247,7 @@ public class EquipmentModels
 	private class EquipViewHandler extends AbstractAction
 	{
 
-		public void install()
+		void install()
 		{
 			equipViewBox.setAction(this);
 			equipViewBox.setSelectedItem(selectedView);
@@ -285,7 +285,7 @@ public class EquipmentModels
 	private static class EquippedTableModel extends EquipmentTableModel implements ReferenceListener<EquipmentSetFacade>
 	{
 
-		public EquippedTableModel(CharacterFacade character)
+		EquippedTableModel(CharacterFacade character)
 		{
 			super(character);
 			ReferenceFacade<EquipmentSetFacade> ref = character.getEquipmentSetRef();
@@ -306,7 +306,7 @@ public class EquipmentModels
 	private static class EquippedTableRootModel extends EquipmentTableModel implements ReferenceListener<EquipmentSetFacade>
 	{
 
-		public EquippedTableRootModel(CharacterFacade character)
+		EquippedTableRootModel(CharacterFacade character)
 		{
 			super(character);
 			ReferenceFacade<EquipmentSetFacade> ref = character.getEquipmentSetRef();
@@ -329,7 +329,7 @@ public class EquipmentModels
 	private class UnequipAction extends AbstractAction
 	{
 
-		public UnequipAction()
+		UnequipAction()
 		{
 			super(LanguageBundle.getString("in_equipUnequipSel")); //$NON-NLS-1$
 			this.putValue(SMALL_ICON, Icons.Back16.getImageIcon());
@@ -402,12 +402,12 @@ public class EquipmentModels
 			}
 		}
 
-		public void install()
+		void install()
 		{
 			equipmentSetTable.addActionListener(this);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			equipmentSetTable.removeActionListener(this);
 		}
@@ -560,7 +560,7 @@ public class EquipmentModels
 		private JSpinner spinner = new JSpinner();
 		private final EquipmentListFacade equipmentList;
 
-		public SpinnerEditor(EquipmentListFacade equipmentList)
+		SpinnerEditor(EquipmentListFacade equipmentList)
 		{
 			this.equipmentList = equipmentList;
 			spinner.addChangeListener(this);
@@ -617,7 +617,7 @@ public class EquipmentModels
 		private JComboBox comboBox = null;
 		private MapToList<EquipmentFacade, EquipNode> equipMap;
 
-		public ComboEditor(MapToList<EquipmentFacade, EquipNode> equipMap)
+		ComboEditor(MapToList<EquipmentFacade, EquipNode> equipMap)
 		{
 			this.equipMap = equipMap;
 		}
@@ -654,7 +654,7 @@ public class EquipmentModels
 	private class MoveUpAction extends AbstractAction
 	{
 
-		public MoveUpAction()
+		MoveUpAction()
 		{
 			super(LanguageBundle.getString("in_equipMoveUpMenuCommand")); //$NON-NLS-1$
 			this.putValue(SMALL_ICON, Icons.Up16.getImageIcon());
@@ -675,12 +675,12 @@ public class EquipmentModels
 			}
 		}
 
-		public void install()
+		void install()
 		{
 			equipmentSetTable.addActionListener(this);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			equipmentSetTable.removeActionListener(this);
 		}
@@ -690,7 +690,7 @@ public class EquipmentModels
 	private class MoveDownAction extends AbstractAction
 	{
 
-		public MoveDownAction()
+		MoveDownAction()
 		{
 			super(LanguageBundle.getString("in_equipMoveDownMenuCommand")); //$NON-NLS-1$
 			this.putValue(SMALL_ICON, Icons.Down16.getImageIcon());
@@ -711,12 +711,12 @@ public class EquipmentModels
 			}
 		}
 
-		public void install()
+		void install()
 		{
 			equipmentSetTable.addActionListener(this);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			equipmentSetTable.removeActionListener(this);
 		}

--- a/code/src/java/pcgen/gui2/tabs/skill/SkillPointTableModel.java
+++ b/code/src/java/pcgen/gui2/tabs/skill/SkillPointTableModel.java
@@ -186,7 +186,7 @@ public class SkillPointTableModel extends AbstractTableModel
 		/**
 		 *  Create a new BoldNumberRenderer instance.
 		 */
-		public BoldNumberRenderer()
+		BoldNumberRenderer()
 		{
 			setHorizontalAlignment(SwingConstants.CENTER);
 		}

--- a/code/src/java/pcgen/gui2/tabs/spells/ClassInfoHandler.java
+++ b/code/src/java/pcgen/gui2/tabs/spells/ClassInfoHandler.java
@@ -37,7 +37,7 @@ class ClassInfoHandler implements ListSelectionListener
 	private final InfoPane classPane;
 	private String text;
 
-	public ClassInfoHandler(CharacterFacade character, JTreeViewTable<?> table1, JTreeViewTable<?> table2,
+	ClassInfoHandler(CharacterFacade character, JTreeViewTable<?> table1, JTreeViewTable<?> table2,
 		InfoPane classPane)
 	{
 		this.character = character;
@@ -47,14 +47,14 @@ class ClassInfoHandler implements ListSelectionListener
 		this.text = ""; //$NON-NLS-1$
 	}
 
-	public void install()
+	void install()
 	{
 		availableTable.getSelectionModel().addListSelectionListener(this);
 		selectedTable.getSelectionModel().addListSelectionListener(this);
 		classPane.setText(text);
 	}
 
-	public void uninstall()
+	void uninstall()
 	{
 		availableTable.getSelectionModel().removeListSelectionListener(this);
 		selectedTable.getSelectionModel().removeListSelectionListener(this);

--- a/code/src/java/pcgen/gui2/tabs/spells/SpellBooksTab.java
+++ b/code/src/java/pcgen/gui2/tabs/spells/SpellBooksTab.java
@@ -245,7 +245,7 @@ public class SpellBooksTab extends FlippingSplitPane implements CharacterInfoTab
 
 		private final SpellSupportFacade spellSupport;
 
-		public SpellBookModel(CharacterFacade character)
+		SpellBookModel(CharacterFacade character)
 		{
 			this.spellSupport = character.getSpellSupport();
 			setListFacade(spellSupport.getSpellbooks());
@@ -264,7 +264,7 @@ public class SpellBooksTab extends FlippingSplitPane implements CharacterInfoTab
 
 		private final CharacterFacade character;
 
-		public AddSpellAction(CharacterFacade character)
+		AddSpellAction(CharacterFacade character)
 		{
 			this.character = character;
 			putValue(SMALL_ICON, Icons.Forward16.getImageIcon());
@@ -284,13 +284,13 @@ public class SpellBooksTab extends FlippingSplitPane implements CharacterInfoTab
 			}
 		}
 
-		public void install()
+		void install()
 		{
 			availableTable.addActionListener(this);
 			addButton.setAction(this);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			availableTable.removeActionListener(this);
 		}
@@ -302,7 +302,7 @@ public class SpellBooksTab extends FlippingSplitPane implements CharacterInfoTab
 
 		private final CharacterFacade character;
 
-		public RemoveSpellAction(CharacterFacade character)
+		RemoveSpellAction(CharacterFacade character)
 		{
 			this.character = character;
 			putValue(SMALL_ICON, Icons.Back16.getImageIcon());
@@ -321,13 +321,13 @@ public class SpellBooksTab extends FlippingSplitPane implements CharacterInfoTab
 			}
 		}
 
-		public void install()
+		void install()
 		{
 			selectedTable.addActionListener(this);
 			removeButton.setAction(this);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			selectedTable.removeActionListener(this);
 		}
@@ -341,7 +341,7 @@ public class SpellBooksTab extends FlippingSplitPane implements CharacterInfoTab
 		private final SpellTreeViewModel selectedModel;
 		private final CharacterFacade character;
 
-		public TreeViewModelHandler(CharacterFacade character)
+		TreeViewModelHandler(CharacterFacade character)
 		{
 			this.character = character;
 			availableModel = new SpellTreeViewModel(character.getSpellSupport().getKnownSpellNodes(), false,
@@ -350,14 +350,14 @@ public class SpellBooksTab extends FlippingSplitPane implements CharacterInfoTab
 				"SpellBooksSel", character.getInfoFactory());
 		}
 
-		public void install()
+		void install()
 		{
 			spellRenderer.setCharacter(character);
 			availableTable.setTreeViewModel(availableModel);
 			selectedTable.setTreeViewModel(selectedModel);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			spellRenderer.setCharacter(null);
 		}
@@ -369,12 +369,12 @@ public class SpellBooksTab extends FlippingSplitPane implements CharacterInfoTab
 
 		private final CharacterFacade character;
 
-		public SpellFilterHandler(CharacterFacade character)
+		SpellFilterHandler(CharacterFacade character)
 		{
 			this.character = character;
 		}
 
-		public void install()
+		void install()
 		{
 			qFilterButton.setFilter(this);
 		}

--- a/code/src/java/pcgen/gui2/tabs/spells/SpellInfoHandler.java
+++ b/code/src/java/pcgen/gui2/tabs/spells/SpellInfoHandler.java
@@ -38,7 +38,7 @@ class SpellInfoHandler implements ListSelectionListener
 	private final InfoPane spellsPane;
 	private String currText;
 
-	public SpellInfoHandler(CharacterFacade character, JTreeViewTable<?> table1, JTreeViewTable<?> table2,
+	SpellInfoHandler(CharacterFacade character, JTreeViewTable<?> table1, JTreeViewTable<?> table2,
 		InfoPane spellsPane)
 	{
 		this.spellsPane = spellsPane;
@@ -48,14 +48,14 @@ class SpellInfoHandler implements ListSelectionListener
 		this.currText = ""; //$NON-NLS-1$
 	}
 
-	public void install()
+	void install()
 	{
 		availableTable.getSelectionModel().addListSelectionListener(this);
 		selectedTable.getSelectionModel().addListSelectionListener(this);
 		spellsPane.setText(currText);
 	}
 
-	public void uninstall()
+	void uninstall()
 	{
 		availableTable.getSelectionModel().removeListSelectionListener(this);
 		selectedTable.getSelectionModel().removeListSelectionListener(this);

--- a/code/src/java/pcgen/gui2/tabs/spells/SpellNodeDataView.java
+++ b/code/src/java/pcgen/gui2/tabs/spells/SpellNodeDataView.java
@@ -39,7 +39,7 @@ class SpellNodeDataView implements DataView<SuperNode>
 	private final String prefsKey;
 	private final InfoFactory infoFactory;
 
-	public SpellNodeDataView(boolean initiallyVisible, String prefsKey, InfoFactory infoFactory)
+	SpellNodeDataView(boolean initiallyVisible, String prefsKey, InfoFactory infoFactory)
 	{
 		super();
 		this.prefsKey = prefsKey;

--- a/code/src/java/pcgen/gui2/tabs/spells/SpellsKnownTab.java
+++ b/code/src/java/pcgen/gui2/tabs/spells/SpellsKnownTab.java
@@ -255,7 +255,7 @@ public class SpellsKnownTab extends FlippingSplitPane implements CharacterInfoTa
 
 		private final CharacterFacade character;
 
-		public AddSpellAction(CharacterFacade character)
+		AddSpellAction(CharacterFacade character)
 		{
 			this.character = character;
 			putValue(SMALL_ICON, Icons.Forward16.getImageIcon());
@@ -274,13 +274,13 @@ public class SpellsKnownTab extends FlippingSplitPane implements CharacterInfoTa
 			}
 		}
 
-		public void install()
+		void install()
 		{
 			availableTable.addActionListener(this);
 			addButton.setAction(this);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			availableTable.removeActionListener(this);
 		}
@@ -292,7 +292,7 @@ public class SpellsKnownTab extends FlippingSplitPane implements CharacterInfoTa
 
 		private final CharacterFacade character;
 
-		public RemoveSpellAction(CharacterFacade character)
+		RemoveSpellAction(CharacterFacade character)
 		{
 			this.character = character;
 			putValue(SMALL_ICON, Icons.Back16.getImageIcon());
@@ -311,13 +311,13 @@ public class SpellsKnownTab extends FlippingSplitPane implements CharacterInfoTa
 			}
 		}
 
-		public void install()
+		void install()
 		{
 			selectedTable.addActionListener(this);
 			removeButton.setAction(this);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			selectedTable.removeActionListener(this);
 		}
@@ -329,7 +329,7 @@ public class SpellsKnownTab extends FlippingSplitPane implements CharacterInfoTa
 
 		private final CharacterFacade character;
 
-		public AutoAddSpellsAction(CharacterFacade character)
+		AutoAddSpellsAction(CharacterFacade character)
 		{
 			super(LanguageBundle.getString("InfoSpells.autoload"));
 			this.character = character;
@@ -341,7 +341,7 @@ public class SpellsKnownTab extends FlippingSplitPane implements CharacterInfoTa
 			character.getSpellSupport().setAutoSpells(autoKnownBox.isSelected());
 		}
 
-		public void install()
+		void install()
 		{
 			autoKnownBox.setAction(this);
 			autoKnownBox.setSelected(character.getSpellSupport().isAutoSpells());
@@ -354,7 +354,7 @@ public class SpellsKnownTab extends FlippingSplitPane implements CharacterInfoTa
 
 		private final CharacterFacade character;
 
-		public UseHigherSlotsAction(CharacterFacade character)
+		UseHigherSlotsAction(CharacterFacade character)
 		{
 			super(LanguageBundle.getString("InfoKnownSpells.canUseHigherSlots"));
 			this.character = character;
@@ -366,7 +366,7 @@ public class SpellsKnownTab extends FlippingSplitPane implements CharacterInfoTa
 			character.getSpellSupport().setUseHigherKnownSlots(slotsBox.isSelected());
 		}
 
-		public void install()
+		void install()
 		{
 			slotsBox.setAction(this);
 			slotsBox.setSelected(character.getSpellSupport().isUseHigherKnownSlots());
@@ -379,7 +379,7 @@ public class SpellsKnownTab extends FlippingSplitPane implements CharacterInfoTa
 
 		private final CharacterFacade character;
 
-		public PreviewSpellsAction(CharacterFacade character)
+		PreviewSpellsAction(CharacterFacade character)
 		{
 			this.character = character;
 			putValue(SMALL_ICON, Icons.PrintPreview16.getImageIcon());
@@ -398,7 +398,7 @@ public class SpellsKnownTab extends FlippingSplitPane implements CharacterInfoTa
 
 		private final CharacterFacade character;
 
-		public ExportSpellsAction(CharacterFacade character)
+		ExportSpellsAction(CharacterFacade character)
 		{
 			this.character = character;
 			putValue(SMALL_ICON, Icons.Print16.getImageIcon());
@@ -419,7 +419,7 @@ public class SpellsKnownTab extends FlippingSplitPane implements CharacterInfoTa
 		private final SpellTreeViewModel selectedModel;
 		private final CharacterFacade character;
 
-		public TreeViewModelHandler(CharacterFacade character)
+		TreeViewModelHandler(CharacterFacade character)
 		{
 			this.character = character;
 			availableModel = new SpellTreeViewModel(character.getSpellSupport().getAvailableSpellNodes(), false,
@@ -428,14 +428,14 @@ public class SpellsKnownTab extends FlippingSplitPane implements CharacterInfoTa
 				"SpellsKnownSel", character.getInfoFactory());
 		}
 
-		public void install()
+		void install()
 		{
 			spellRenderer.setCharacter(character);
 			availableTable.setTreeViewModel(availableModel);
 			selectedTable.setTreeViewModel(selectedModel);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			spellRenderer.setCharacter(null);
 		}
@@ -447,12 +447,12 @@ public class SpellsKnownTab extends FlippingSplitPane implements CharacterInfoTa
 
 		private final CharacterFacade character;
 
-		public SpellFilterHandler(CharacterFacade character)
+		SpellFilterHandler(CharacterFacade character)
 		{
 			this.character = character;
 		}
 
-		public void install()
+		void install()
 		{
 			qFilterButton.setFilter(this);
 		}

--- a/code/src/java/pcgen/gui2/tabs/spells/SpellsPreparedTab.java
+++ b/code/src/java/pcgen/gui2/tabs/spells/SpellsPreparedTab.java
@@ -282,7 +282,7 @@ public class SpellsPreparedTab extends FlippingSplitPane implements CharacterInf
 
 		private CharacterFacade character;
 
-		public AddMMSpellAction(CharacterFacade character)
+		AddMMSpellAction(CharacterFacade character)
 		{
 			this.character = character;
 			String label = character.getDataSet().getGameMode().getAddWithMetamagicMessage();
@@ -315,7 +315,7 @@ public class SpellsPreparedTab extends FlippingSplitPane implements CharacterInf
 
 		private CharacterFacade character;
 
-		public AddSpellAction(CharacterFacade character)
+		AddSpellAction(CharacterFacade character)
 		{
 			this.character = character;
 			putValue(SMALL_ICON, Icons.Forward16.getImageIcon());
@@ -335,13 +335,13 @@ public class SpellsPreparedTab extends FlippingSplitPane implements CharacterInf
 			}
 		}
 
-		public void install()
+		void install()
 		{
 			availableTable.addActionListener(this);
 			addSpellButton.setAction(this);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			availableTable.removeActionListener(this);
 		}
@@ -353,7 +353,7 @@ public class SpellsPreparedTab extends FlippingSplitPane implements CharacterInf
 
 		private CharacterFacade character;
 
-		public RemoveSpellAction(CharacterFacade character)
+		RemoveSpellAction(CharacterFacade character)
 		{
 			this.character = character;
 			putValue(SMALL_ICON, Icons.Back16.getImageIcon());
@@ -372,13 +372,13 @@ public class SpellsPreparedTab extends FlippingSplitPane implements CharacterInf
 			}
 		}
 
-		public void install()
+		void install()
 		{
 			selectedTable.addActionListener(this);
 			removeSpellButton.setAction(this);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			selectedTable.removeActionListener(this);
 		}
@@ -390,7 +390,7 @@ public class SpellsPreparedTab extends FlippingSplitPane implements CharacterInf
 
 		private CharacterFacade character;
 
-		public UseHigherSlotsAction(CharacterFacade character)
+		UseHigherSlotsAction(CharacterFacade character)
 		{
 			super(LanguageBundle.getString("InfoPreparedSpells.canUseHigherSlots"));
 			this.character = character;
@@ -402,7 +402,7 @@ public class SpellsPreparedTab extends FlippingSplitPane implements CharacterInf
 			character.getSpellSupport().setUseHigherPreppedSlots(slotsBox.isSelected());
 		}
 
-		public void install()
+		void install()
 		{
 			slotsBox.setAction(this);
 			slotsBox.setSelected(character.getSpellSupport().isUseHigherPreppedSlots());
@@ -415,7 +415,7 @@ public class SpellsPreparedTab extends FlippingSplitPane implements CharacterInf
 
 		private CharacterFacade character;
 
-		public AddSpellListAction(CharacterFacade character)
+		AddSpellListAction(CharacterFacade character)
 		{
 			super(LanguageBundle.getString("InfoSpells.add"));
 			this.character = character;
@@ -434,7 +434,7 @@ public class SpellsPreparedTab extends FlippingSplitPane implements CharacterInf
 
 		private CharacterFacade character;
 
-		public RemoveSpellListAction(CharacterFacade character)
+		RemoveSpellListAction(CharacterFacade character)
 		{
 			super(LanguageBundle.getString("InfoSpells.delete"));
 			this.character = character;
@@ -455,7 +455,7 @@ public class SpellsPreparedTab extends FlippingSplitPane implements CharacterInf
 		private SpellTreeViewModel selectedModel;
 		private CharacterFacade character;
 
-		public TreeViewModelHandler(CharacterFacade character)
+		TreeViewModelHandler(CharacterFacade character)
 		{
 			this.character = character;
 			availableModel = new SpellTreeViewModel(character.getSpellSupport().getKnownSpellNodes(), false,
@@ -464,14 +464,14 @@ public class SpellsPreparedTab extends FlippingSplitPane implements CharacterInf
 				"SpellsPrepSel", character.getInfoFactory());
 		}
 
-		public void install()
+		void install()
 		{
 			spellRenderer.setCharacter(character);
 			availableTable.setTreeViewModel(availableModel);
 			selectedTable.setTreeViewModel(selectedModel);
 		}
 
-		public void uninstall()
+		void uninstall()
 		{
 			spellRenderer.setCharacter(null);
 		}
@@ -483,12 +483,12 @@ public class SpellsPreparedTab extends FlippingSplitPane implements CharacterInf
 
 		private final CharacterFacade character;
 
-		public SpellFilterHandler(CharacterFacade character)
+		SpellFilterHandler(CharacterFacade character)
 		{
 			this.character = character;
 		}
 
-		public void install()
+		void install()
 		{
 			qFilterButton.setFilter(this);
 		}

--- a/code/src/java/pcgen/gui2/tabs/summary/ClassLevelTableModel.java
+++ b/code/src/java/pcgen/gui2/tabs/summary/ClassLevelTableModel.java
@@ -261,7 +261,7 @@ public class ClassLevelTableModel extends AbstractTableModel implements ListList
 		private JButton addLevelButton = Utilities.createSignButton(Sign.Plus);
 		private JButton removeLevelButton = Utilities.createSignButton(Sign.Minus);
 
-		public Editor()
+		Editor()
 		{
 			super();
 			cellPanel.setLayout(new BoxLayout(cellPanel, BoxLayout.X_AXIS));

--- a/code/src/java/pcgen/gui2/tabs/summary/LanguageTableModel.java
+++ b/code/src/java/pcgen/gui2/tabs/summary/LanguageTableModel.java
@@ -202,7 +202,7 @@ public class LanguageTableModel extends AbstractTableModel implements ListListen
 		private JLabel addLabel = new JLabel();
 		private JLabel cellLabel = new JLabel();
 
-		public Editor()
+		Editor()
 		{
 			cellPanel.setLayout(cardLayout);
 			cellPanel.setOpaque(true);
@@ -309,7 +309,7 @@ public class LanguageTableModel extends AbstractTableModel implements ListListen
 		private JButton removeButton = Utilities.createSignButton(Sign.Minus);
 		private JLabel addLabel = new JLabel();
 
-		public Renderer()
+		Renderer()
 		{
 			setLayout(cardLayout);
 			Box box = Box.createHorizontalBox();

--- a/code/src/java/pcgen/gui2/tabs/summary/StatTableModel.java
+++ b/code/src/java/pcgen/gui2/tabs/summary/StatTableModel.java
@@ -215,7 +215,7 @@ public class StatTableModel extends AbstractTableModel implements ReferenceListe
 	private static class FixedHeaderCellRenderer extends JLabel implements TableCellRenderer
 	{
 
-		public FixedHeaderCellRenderer(String text)
+		FixedHeaderCellRenderer(String text)
 		{
 			setText(text);
 			setBorder(BorderFactory.createEmptyBorder(2, 5, 2, 10));
@@ -240,7 +240,7 @@ public class StatTableModel extends AbstractTableModel implements ReferenceListe
 
 		private DecimalFormat formatter = PrettyIntegerFormat.getFormat();
 
-		public ModRenderer()
+		ModRenderer()
 		{
 			setHorizontalAlignment(SwingConstants.RIGHT);
 			setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 7));
@@ -286,7 +286,7 @@ public class StatTableModel extends AbstractTableModel implements ReferenceListe
 		/**
 		 * Create a new ValueRenderer instance.
 		 */
-		public ValueRenderer()
+		ValueRenderer()
 		{
 			setHorizontalAlignment(SwingConstants.RIGHT);
 			setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 7));

--- a/code/src/java/pcgen/gui2/tools/FlippingSplitPane.java
+++ b/code/src/java/pcgen/gui2/tools/FlippingSplitPane.java
@@ -441,7 +441,7 @@ public class FlippingSplitPane extends JSplitPane
 		 */
 		private boolean locked = false;
 
-		public LockAction()
+		LockAction()
 		{
 			configureProps();
 		}
@@ -465,7 +465,7 @@ public class FlippingSplitPane extends JSplitPane
 			setLocked(!locked);
 		}
 
-		public boolean isLocked()
+		boolean isLocked()
 		{
 			return locked;
 		}
@@ -479,7 +479,7 @@ public class FlippingSplitPane extends JSplitPane
 		 *
 		 * @see #isLocked
 		 */
-		public void setLocked(boolean locked)
+		void setLocked(boolean locked)
 		{
 			if (this.locked == locked)
 			{

--- a/code/src/java/pcgen/gui2/util/JTreeTable.java
+++ b/code/src/java/pcgen/gui2/util/JTreeTable.java
@@ -268,7 +268,7 @@ public class JTreeTable extends JTableEx
 		 * not be guaranteed the tree will have finished processing
 		 * the event before us.
 		 **/
-		public void setTreeTableModel(TreeTableModel model)
+		void setTreeTableModel(TreeTableModel model)
 		{
 			if (treeTableModel != null)
 			{
@@ -467,7 +467,7 @@ public class JTreeTable extends JTableEx
 		private int visibleRow;
 		private DefaultTableCellRenderer tableCellRenderer;
 
-		public TreeTableCellRenderer()
+		TreeTableCellRenderer()
 		{
 			this.tableCellRenderer = new DefaultTableCellRenderer()
 			{

--- a/code/src/java/pcgen/gui2/util/treeview/TreeViewTableModel.java
+++ b/code/src/java/pcgen/gui2/util/treeview/TreeViewTableModel.java
@@ -252,7 +252,7 @@ public class TreeViewTableModel<E> extends AbstractTreeTableModel implements Sor
 
 		private final int level;
 
-		public TreeViewNode(Vector<TreeViewPath<? super E>> paths)
+		TreeViewNode(Vector<TreeViewPath<? super E>> paths)
 		{
 			this(0, null, paths);
 		}
@@ -323,7 +323,7 @@ public class TreeViewTableModel<E> extends AbstractTreeTableModel implements Sor
 			}
 		}
 
-		public void removeTreeViewPath(TreeViewPath<? super E> path)
+		void removeTreeViewPath(TreeViewPath<? super E> path)
 		{
 			if (!loadedChildren)
 			{
@@ -360,7 +360,7 @@ public class TreeViewTableModel<E> extends AbstractTreeTableModel implements Sor
 			}
 		}
 
-		public void insertTreeViewPath(TreeViewPath<? super E> path)
+		void insertTreeViewPath(TreeViewPath<? super E> path)
 		{
 			//			Logging.errorPrint("adding: "+path);
 			if (!loadedChildren)
@@ -445,7 +445,7 @@ public class TreeViewTableModel<E> extends AbstractTreeTableModel implements Sor
 
 		private Comparator<Row> mostRecentComparator = null;
 
-		public void setComparator(Comparator<Row> comparator)
+		void setComparator(Comparator<Row> comparator)
 		{
 			this.mostRecentComparator = comparator;
 		}

--- a/code/src/java/pcgen/gui3/preferences/EquipmentPreferencesModel.java
+++ b/code/src/java/pcgen/gui3/preferences/EquipmentPreferencesModel.java
@@ -34,8 +34,8 @@ final class EquipmentPreferencesModel
 			this.max = max;
 		}
 
-		public final int min;
-		public final int max;
+		final int min;
+		final int max;
 	}
 
 	private final IntegerProperty maxPotionLevel = new SimpleIntegerProperty();

--- a/code/src/java/pcgen/gui3/preferences/PCGenPreferencesModel.java
+++ b/code/src/java/pcgen/gui3/preferences/PCGenPreferencesModel.java
@@ -46,7 +46,7 @@ public final class PCGenPreferencesModel
 	{
 		private final String title;
 
-		public EmptyPrefPanel(String title, JFXPanel innerPanel)
+		EmptyPrefPanel(String title, JFXPanel innerPanel)
 		{
 			this.title = title;
 			this.add(innerPanel);

--- a/code/src/java/pcgen/io/Cache.java
+++ b/code/src/java/pcgen/io/Cache.java
@@ -49,7 +49,7 @@ final class Cache
 	 * @param key
 	 * @return True if the map contains the key
 	 */
-	public boolean containsKey(final String key)
+	boolean containsKey(final String key)
 	{
 		return map.containsKey(key);
 	}
@@ -59,7 +59,7 @@ final class Cache
 	 * @param key
 	 * @return List
 	 */
-	public List<String> get(String key)
+	List<String> get(String key)
 	{
 		return map.get(key);
 	}
@@ -69,7 +69,7 @@ final class Cache
 	 * @param key
 	 * @param value
 	 */
-	public void put(String key, String value)
+	void put(String key, String value)
 	{
 		if (map.containsKey(key))
 		{

--- a/code/src/java/pcgen/io/EntityEncoder.java
+++ b/code/src/java/pcgen/io/EntityEncoder.java
@@ -196,7 +196,7 @@ final class EntityMap
 	 * @param key
 	 * @return value
 	 */
-	public String get(String key)
+	String get(String key)
 	{
 		final String value = map.get(key);
 
@@ -209,7 +209,7 @@ final class EntityMap
 	 * @param key
 	 * @param value
 	 */
-	public void put(String key, String value)
+	void put(String key, String value)
 	{
 		map.put(key, value);
 		map.put(value, key);

--- a/code/src/java/pcgen/io/ExportHandler.java
+++ b/code/src/java/pcgen/io/ExportHandler.java
@@ -3311,7 +3311,7 @@ public abstract class ExportHandler
 		 * Return true if we have more tokens
 		 * @return true if we have
 		 */
-		public boolean hasMoreTokens()
+		boolean hasMoreTokens()
 		{
 			return (!_forThisString.isEmpty());
 		}
@@ -3320,7 +3320,7 @@ public abstract class ExportHandler
 		 * Return the next token
 		 * @return next token
 		 */
-		public String nextToken()
+		String nextToken()
 		{
 			String aString;
 
@@ -3405,17 +3405,17 @@ public abstract class ExportHandler
 			}
 		}
 
-		public Integer min()
+		Integer min()
 		{
 			return cMin;
 		}
 
-		public Integer max()
+		Integer max()
 		{
 			return cMax;
 		}
 
-		public Integer step()
+		Integer step()
 		{
 			return cStep;
 		}

--- a/code/src/java/pcgen/io/FORNode.java
+++ b/code/src/java/pcgen/io/FORNode.java
@@ -57,7 +57,7 @@ final class FORNode
 	 * Add a child
 	 * @param child
 	 */
-	public void addChild(Object child)
+	void addChild(Object child)
 	{
 		children.add(child);
 	}
@@ -66,7 +66,7 @@ final class FORNode
 	 * Return the children of this node
 	 * @return the children of this node
 	 */
-	public List<?> children()
+	List<?> children()
 	{
 		return children;
 	}
@@ -75,7 +75,7 @@ final class FORNode
 	 * Return TRUE if exists
 	 * @return TRUE if exists
 	 */
-	public boolean exists()
+	boolean exists()
 	{
 		return exists;
 	}
@@ -84,7 +84,7 @@ final class FORNode
 	 * Return max
 	 * @return max
 	 */
-	public String max()
+	String max()
 	{
 		return max;
 	}
@@ -93,7 +93,7 @@ final class FORNode
 	 * Return min
 	 * @return min
 	 */
-	public String min()
+	String min()
 	{
 		return min;
 	}
@@ -102,7 +102,7 @@ final class FORNode
 	 * Return step
 	 * @return step
 	 */
-	public String step()
+	String step()
 	{
 		return step;
 	}
@@ -111,7 +111,7 @@ final class FORNode
 	 * Return var
 	 * @return var
 	 */
-	public String var()
+	String var()
 	{
 		return var;
 	}

--- a/code/src/java/pcgen/io/IIFNode.java
+++ b/code/src/java/pcgen/io/IIFNode.java
@@ -43,7 +43,7 @@ class IIFNode
 	 * Add a 'true' child to the tree
 	 * @param child
 	 */
-	public void addTrueChild(Object child)
+	void addTrueChild(Object child)
 	{
 		trueChildren.add(child);
 	}
@@ -52,7 +52,7 @@ class IIFNode
 	 * List the nodes that are truly children
 	 * @return the nodes that are truly children
 	 */
-	public final List<?> trueChildren()
+	final List<?> trueChildren()
 	{
 		return Collections.unmodifiableList(trueChildren);
 	}
@@ -61,7 +61,7 @@ class IIFNode
 	 * Add a false child
 	 * @param child
 	 */
-	public void addFalseChild(final Object child)
+	void addFalseChild(final Object child)
 	{
 		falseChildren.add(child);
 	}
@@ -70,7 +70,7 @@ class IIFNode
 	 * Returns an expression for the node
 	 * @return an expression for the node
 	 */
-	public final String expr()
+	final String expr()
 	{
 		return expr;
 	}
@@ -79,7 +79,7 @@ class IIFNode
 	 * List the false children
 	 * @return the false children
 	 */
-	public final List<?> falseChildren()
+	final List<?> falseChildren()
 	{
 		return Collections.unmodifiableList(falseChildren);
 	}

--- a/code/src/java/pcgen/io/PCGParseException.java
+++ b/code/src/java/pcgen/io/PCGParseException.java
@@ -49,7 +49,7 @@ final class PCGParseException extends Exception
 	/**
 	 * @return error line
 	 */
-	public String getLine()
+	String getLine()
 	{
 		return errorLine;
 	}
@@ -66,7 +66,7 @@ final class PCGParseException extends Exception
 	/**
 	 * @return error method
 	 */
-	public String getMethod()
+	String getMethod()
 	{
 		return errorMethod;
 	}

--- a/code/src/java/pcgen/io/PCGVer2Parser.java
+++ b/code/src/java/pcgen/io/PCGVer2Parser.java
@@ -5347,7 +5347,7 @@ final class PCGVer2Parser implements PCGParser
 		 * list for the element.
 		 * @return A {@code List} of children
 		 */
-		public List<PCGElement> getChildren()
+		List<PCGElement> getChildren()
 		{
 			if (children == null)
 			{
@@ -5825,7 +5825,7 @@ final class PCGVer2Parser implements PCGParser
 	 * This method should NOT be called outside of file i/o routines!
 	 * @param aSource the source to be set
 	 **/
-	public ClassSource getDomainSource(String aSource)
+	ClassSource getDomainSource(String aSource)
 	{
 		final StringTokenizer aTok = new StringTokenizer(aSource, "|", false);
 
@@ -5865,7 +5865,7 @@ final class PCGVer2Parser implements PCGParser
 		}
 	}
 
-	public PCAlignment getNoAlignment()
+	PCAlignment getNoAlignment()
 	{
 		return Globals.getContext().getReferenceContext().silentlyGetConstructedCDOMObject(PCAlignment.class,
 			Constants.NONE);

--- a/code/src/java/pcgen/rules/context/AbstractListContext.java
+++ b/code/src/java/pcgen/rules/context/AbstractListContext.java
@@ -590,10 +590,10 @@ public abstract class AbstractListContext
 
 	private static class OwnerURI
 	{
-		public final CDOMObject owner;
-		public final URI source;
+		final CDOMObject owner;
+		final URI source;
 
-		public OwnerURI(URI sourceURI, CDOMObject cdo)
+		OwnerURI(URI sourceURI, CDOMObject cdo)
 		{
 			source = sourceURI;
 			owner = cdo;

--- a/code/src/java/pcgen/rules/context/EditorObjectContext.java
+++ b/code/src/java/pcgen/rules/context/EditorObjectContext.java
@@ -23,7 +23,7 @@ class EditorObjectContext extends AbstractObjectContext
 {
 	private final TrackingObjectCommitStrategy commit = new TrackingObjectCommitStrategy();
 
-	public void purge(CDOMObject cdo)
+	void purge(CDOMObject cdo)
 	{
 		commit.purge(cdo);
 	}

--- a/code/src/java/pcgen/rules/context/EditorReferenceContext.java
+++ b/code/src/java/pcgen/rules/context/EditorReferenceContext.java
@@ -88,7 +88,7 @@ final class EditorReferenceContext extends RuntimeReferenceContext
 		return true;
 	}
 
-	public void purge(CDOMObject cdo)
+	void purge(CDOMObject cdo)
 	{
 		super.forget(cdo);
 	}
@@ -99,7 +99,7 @@ final class EditorReferenceContext extends RuntimeReferenceContext
 	 * 
 	 * @return A new EditorReferenceContext
 	 */
-	public static EditorReferenceContext createEditorReferenceContext()
+	static EditorReferenceContext createEditorReferenceContext()
 	{
 		EditorReferenceContext context = new EditorReferenceContext();
 		context.initialize();

--- a/code/src/java/pcgen/rules/context/ListChanges.java
+++ b/code/src/java/pcgen/rules/context/ListChanges.java
@@ -37,7 +37,7 @@ class ListChanges<T extends CDOMObject> implements AssociatedChanges<CDOMReferen
 	private final CDOMReference<? extends CDOMList<T>> list;
 	private final boolean clear;
 
-	public ListChanges(String token, CDOMObject added, CDOMObject removed, CDOMReference<? extends CDOMList<T>> listref,
+	ListChanges(String token, CDOMObject added, CDOMObject removed, CDOMReference<? extends CDOMList<T>> listref,
 		boolean globallyCleared)
 	{
 		tokenName = token;
@@ -53,7 +53,7 @@ class ListChanges<T extends CDOMObject> implements AssociatedChanges<CDOMReferen
 		return clear;
 	}
 
-	public boolean isEmpty()
+	boolean isEmpty()
 	{
 		/*
 		 * TODO This lies because it doesn't analyze tokenName
@@ -82,7 +82,7 @@ class ListChanges<T extends CDOMObject> implements AssociatedChanges<CDOMReferen
 		return set;
 	}
 
-	public boolean hasAddedItems()
+	boolean hasAddedItems()
 	{
 		/*
 		 * TODO This lies because it doesn't analyze tokenName
@@ -115,7 +115,7 @@ class ListChanges<T extends CDOMObject> implements AssociatedChanges<CDOMReferen
 		return set;
 	}
 
-	public boolean hasRemovedItems()
+	boolean hasRemovedItems()
 	{
 		/*
 		 * TODO This lies because it doesn't analyze tokenName

--- a/code/src/java/pcgen/rules/context/LoadContextInst.java
+++ b/code/src/java/pcgen/rules/context/LoadContextInst.java
@@ -108,7 +108,7 @@ abstract class LoadContextInst implements LoadContext
 		FacetInitialization.initialize();
 	}
 
-	public LoadContextInst(AbstractReferenceContext rc, AbstractListContext lc, AbstractObjectContext oc)
+	LoadContextInst(AbstractReferenceContext rc, AbstractListContext lc, AbstractObjectContext oc)
 	{
 		Objects.requireNonNull(rc, "ReferenceContext cannot be null");
 		Objects.requireNonNull(lc, "ListContext cannot be null");
@@ -175,7 +175,7 @@ abstract class LoadContextInst implements LoadContext
 	/*
 	 * Get the type of context we're running in (either Editor or Runtime)
 	 */
-	public abstract String getContextType();
+	abstract String getContextType();
 
 	@Override
 	public AbstractObjectContext getObjectContext()
@@ -603,7 +603,7 @@ abstract class LoadContextInst implements LoadContext
 		/**
 		 * Constructs a new LoadContext derived from the given LoadContext
 		 */
-		public DerivedLoadContext(LoadContext parent, PCGenScope scope)
+		DerivedLoadContext(LoadContext parent, PCGenScope scope)
 		{
 			this.derivedScope = scope;
 			this.parent = parent;

--- a/code/src/java/pcgen/rules/persistence/TableLoader.java
+++ b/code/src/java/pcgen/rules/persistence/TableLoader.java
@@ -218,7 +218,7 @@ public class TableLoader extends LstLineFileLoader
 		 *            The underlying Table to which the column names should be
 		 *            assigned
 		 */
-		public ImportColumnNames(DataTable table)
+		ImportColumnNames(DataTable table)
 		{
 			t = table;
 		}
@@ -289,7 +289,7 @@ public class TableLoader extends LstLineFileLoader
 		 *            assigned
 		 * @param columnNames
 		 */
-		public ImportColumnFormats(DataTable table, List<String> columnNames)
+		ImportColumnFormats(DataTable table, List<String> columnNames)
 		{
 			t = table;
 			this.columnNames = columnNames;
@@ -380,7 +380,7 @@ public class TableLoader extends LstLineFileLoader
 		 * @param table
 		 *            The underlying Table to which the data will be loaded
 		 */
-		public ImportData(DataTable table)
+		ImportData(DataTable table)
 		{
 			t = table;
 		}

--- a/code/src/java/pcgen/rules/persistence/TokenLibrary.java
+++ b/code/src/java/pcgen/rules/persistence/TokenLibrary.java
@@ -413,7 +413,7 @@ public final class TokenLibrary implements PluginLoader
 		private Class<?> stopClass;
 		private final Iterator<TokenFamily> subIterator;
 
-		public AbstractTokenIterator(Class<C> cl, String key)
+		AbstractTokenIterator(Class<C> cl, String key)
 		{
 			rootClass = cl;
 			subIterator = TOKEN_FAMILIES.iterator();
@@ -478,7 +478,7 @@ public final class TokenLibrary implements PluginLoader
 			extends TokenLibrary.AbstractTokenIterator<C, T>
 	{
 
-		public TokenIterator(Class<C> cl, String key)
+		TokenIterator(Class<C> cl, String key)
 		{
 			super(cl, key);
 		}
@@ -496,7 +496,7 @@ public final class TokenLibrary implements PluginLoader
 
 		private final String subTokenKey;
 
-		public SubTokenIterator(Class<C> cl, String key, String subKey)
+		SubTokenIterator(Class<C> cl, String key, String subKey)
 		{
 			super(cl, key);
 			subTokenKey = subKey;
@@ -514,7 +514,7 @@ public final class TokenLibrary implements PluginLoader
 			extends TokenLibrary.AbstractTokenIterator<C, T>
 	{
 
-		public QualifierTokenIterator(Class<C> cl, String key)
+		QualifierTokenIterator(Class<C> cl, String key)
 		{
 			super(cl, key);
 		}
@@ -551,7 +551,7 @@ public final class TokenLibrary implements PluginLoader
 			extends TokenLibrary.AbstractTokenIterator<C, T>
 	{
 
-		public PrimitiveTokenIterator(Class<C> cl, String key)
+		PrimitiveTokenIterator(Class<C> cl, String key)
 		{
 			super(cl, key);
 		}
@@ -588,7 +588,7 @@ public final class TokenLibrary implements PluginLoader
 			extends TokenLibrary.AbstractTokenIterator<C, T>
 	{
 
-		public ModifierIterator(Class<C> cl, String key)
+		ModifierIterator(Class<C> cl, String key)
 		{
 			super(cl, key);
 		}
@@ -619,7 +619,7 @@ public final class TokenLibrary implements PluginLoader
 	static class PreTokenIterator extends TokenLibrary.AbstractTokenIterator<CDOMObject, PrerequisiteParserInterface>
 	{
 
-		public PreTokenIterator(String key)
+		PreTokenIterator(String key)
 		{
 			super(CDOMOBJECT_CLASS, key);
 		}

--- a/code/src/java/pcgen/rules/persistence/token/AbstractRestrictedSpellPrimitive.java
+++ b/code/src/java/pcgen/rules/persistence/token/AbstractRestrictedSpellPrimitive.java
@@ -100,18 +100,18 @@ public abstract class AbstractRestrictedSpellPrimitive implements PrimitiveToken
 
 	private static class Restriction
 	{
-		public final Formula minLevel;
-		public final Formula maxLevel;
-		public final Boolean knownRequired;
+		final Formula minLevel;
+		final Formula maxLevel;
+		final Boolean knownRequired;
 
-		public Restriction(Formula levelMin, Formula levelMax, Boolean known)
+		Restriction(Formula levelMin, Formula levelMax, Boolean known)
 		{
 			minLevel = levelMin;
 			maxLevel = levelMax;
 			knownRequired = known;
 		}
 
-		public String getLSTformat()
+		String getLSTformat()
 		{
 			StringBuilder sb = new StringBuilder();
 			if (knownRequired != null)

--- a/code/src/java/pcgen/system/LegacySettings.java
+++ b/code/src/java/pcgen/system/LegacySettings.java
@@ -44,7 +44,7 @@ final class LegacySettings extends PropertyContext
 	/**
 	 * @return The singleton LegacySettings instance.
 	 */
-	public static LegacySettings getInstance()
+	static LegacySettings getInstance()
 	{
 		return INSTANCE;
 	}

--- a/code/src/java/pcgen/system/PluginClassLoader.java
+++ b/code/src/java/pcgen/system/PluginClassLoader.java
@@ -156,7 +156,7 @@ class PluginClassLoader extends PCGenTask
 		loadPlugins();
 	}
 
-	public void loadPlugins()
+	void loadPlugins()
 	{
 		findJarFiles(pluginDir);
 		setMaximum(jarFiles.size());

--- a/code/src/java/pcgen/util/CollectionMaps.java
+++ b/code/src/java/pcgen/util/CollectionMaps.java
@@ -66,7 +66,7 @@ public final class CollectionMaps
 		private final Class<C> collectionClass;
 
 		@SuppressWarnings("unchecked")
-		public BasicListMap(Class<? extends Map> mapClass, Class<C> collectionClass)
+		BasicListMap(Class<? extends Map> mapClass, Class<C> collectionClass)
 			throws InstantiationException, IllegalAccessException
 		{
 			this.map = mapClass.newInstance();
@@ -184,7 +184,7 @@ public final class CollectionMaps
 		private final Class<C> collectionClass;
 
 		@SuppressWarnings("unchecked")
-		public BasicCollectionMap(Class<? extends Map> mapClass, Class<C> collectionClass)
+		BasicCollectionMap(Class<? extends Map> mapClass, Class<C> collectionClass)
 			throws InstantiationException, IllegalAccessException
 		{
 			this.map = mapClass.newInstance();

--- a/code/src/java/pcgen/util/JepCountType.java
+++ b/code/src/java/pcgen/util/JepCountType.java
@@ -347,7 +347,7 @@ public abstract class JepCountType
 	{
 		String type;
 
-		public TypeFilter(String typ)
+		TypeFilter(String typ)
 		{
 			type = typ;
 		}
@@ -364,7 +364,7 @@ public abstract class JepCountType
 	{
 		String type;
 
-		public TypeExclusionFilter(String typ)
+		TypeExclusionFilter(String typ)
 		{
 			type = typ;
 		}
@@ -390,7 +390,7 @@ public abstract class JepCountType
 	{
 		Nature nature;
 
-		public NatureFilter(Nature n)
+		NatureFilter(Nature n)
 		{
 			nature = n;
 		}

--- a/code/src/java/pcgen/util/Logging.java
+++ b/code/src/java/pcgen/util/Logging.java
@@ -654,8 +654,8 @@ public final class Logging
 
 	private static final class QueuedMessage
 	{
-		public final Level level;
-		public final String message;
+		final Level level;
+		final String message;
 		private final StackTraceElement[] stackTrace;
 
 		private QueuedMessage(Level lvl, String msg)

--- a/code/src/java/pcgen/util/WeightedCollection.java
+++ b/code/src/java/pcgen/util/WeightedCollection.java
@@ -466,7 +466,7 @@ public class WeightedCollection<E> extends AbstractCollection<E>
 		 * 
 		 * @return The object this item wraps
 		 */
-		public T getElement()
+		T getElement()
 		{
 			return theElement;
 		}
@@ -476,7 +476,7 @@ public class WeightedCollection<E> extends AbstractCollection<E>
 		 * 
 		 * @return The weight of this item
 		 */
-		public int getWeight()
+		int getWeight()
 		{
 			return theWeight;
 		}

--- a/code/src/java/plugin/grouping/AllGroupingToken.java
+++ b/code/src/java/plugin/grouping/AllGroupingToken.java
@@ -99,12 +99,12 @@ public class AllGroupingToken<T extends Loadable> implements GroupingDefinition<
 		 *            The GroupingInfo used to determine the format of objects contained
 		 *            by this AllGrouping
 		 */
-		public AllGrouping(GroupingInfo<T> groupingInfo)
+		AllGrouping(GroupingInfo<T> groupingInfo)
 		{
 			this.groupingInfo = Objects.requireNonNull(groupingInfo);
 		}
 
-		public void setChild(GroupingCollection<?> childCollection)
+		void setChild(GroupingCollection<?> childCollection)
 		{
 			childGrouping = childCollection;
 		}

--- a/code/src/java/plugin/grouping/GroupGroupingToken.java
+++ b/code/src/java/plugin/grouping/GroupGroupingToken.java
@@ -97,7 +97,7 @@ public class GroupGroupingToken<T extends Loadable> implements GroupingDefinitio
 		 *            The GroupingInfo used to determine the format and GROUP: of objects
 		 *            contained by this GroupGrouping
 		 */
-		public GroupGrouping(GroupingInfo<T> info)
+		GroupGrouping(GroupingInfo<T> info)
 		{
 			this.groupingInfo = Objects.requireNonNull(info);
 			String value = info.getValue();
@@ -107,7 +107,7 @@ public class GroupGroupingToken<T extends Loadable> implements GroupingDefinitio
 			}
 		}
 
-		public void setChild(GroupingCollection<?> childCollection)
+		void setChild(GroupingCollection<?> childCollection)
 		{
 			childGrouping = childCollection;
 		}

--- a/code/src/java/plugin/grouping/KeyGroupingToken.java
+++ b/code/src/java/plugin/grouping/KeyGroupingToken.java
@@ -94,7 +94,7 @@ public class KeyGroupingToken<T extends Loadable & PCGenScoped> implements Group
 		 *            The GroupingInfo used to determine the format and KEY of objects
 		 *            contained by this KeyGrouping
 		 */
-		public KeyGrouping(GroupingInfo<T> info)
+		KeyGrouping(GroupingInfo<T> info)
 		{
 			String value = info.getValue();
 			if ((value == null) || value.isEmpty())
@@ -104,7 +104,7 @@ public class KeyGroupingToken<T extends Loadable & PCGenScoped> implements Group
 			this.groupingInfo = Objects.requireNonNull(info);
 		}
 
-		public void setChild(GroupingCollection<?> childCollection)
+		void setChild(GroupingCollection<?> childCollection)
 		{
 			childGrouping = childCollection;
 		}

--- a/code/src/java/plugin/modifier/set/AddModifierFactory.java
+++ b/code/src/java/plugin/modifier/set/AddModifierFactory.java
@@ -222,7 +222,7 @@ public class AddModifierFactory<T> implements ModifierFactory<T[]>
 		 * 
 		 * @return The FormatManager for this AddArrayModifier
 		 */
-		public FormatManager<T[]> getFormatManager()
+		FormatManager<T[]> getFormatManager()
 		{
 			return fmtManager;
 		}

--- a/code/src/java/plugin/modifier/set/SetModifierFactory.java
+++ b/code/src/java/plugin/modifier/set/SetModifierFactory.java
@@ -203,7 +203,7 @@ public class SetModifierFactory<T> extends AbstractFixedSetModifierFactory<T[]>
 		 * 
 		 * @return The FormatManager for this SetArrayModifier
 		 */
-		public FormatManager<T[]> getFormatManager()
+		FormatManager<T[]> getFormatManager()
 		{
 			return fmtManager;
 		}


### PR DESCRIPTION
## Summary

When a nested type is `private` or package-private, declaring its members `public` is misleading — the effective visibility is bounded by the enclosing type, not by the keyword. PMD's `PublicMemberInNonPublicType` rule flagged 560 such members; this PR strips the redundant `public` from 549 of them across 106 files.

PMD already exempts `@Override` methods and inherited interface methods, so every flagged `public` was genuinely strippable, with one caveat:

PMD treats `protected` nested types in public outer classes the same as package-private, but those types are reachable across packages via subclassing. Four such types
- `AbstractCNASEnforcingFacet.SourcedCNAS`
- `SpellListToken.SpellListTokenParams`
- `AbstractListMenu.CheckBoxMenuItem`
- `JTreeViewTable.CornerButtonPopupMenu`

are accessed cross-package by their subclasses (and would fail to compile if their `public` members were narrowed). The 11 PMD violations on these four types are left as-is.

## Stats

- **Before**: 801 PMD violations total, 560 `PublicMemberInNonPublicType`.
- **After**: 252 PMD violations total, 11 `PublicMemberInNonPublicType` (the 4 false positives above).
- Hotspots cleaned: `pcgen/gui2/tabs/**` (Swing-era listener Actions, field handlers, install/uninstall lifecycle methods on private inner classes).

## Test plan

- [x] `./gradlew checkstyleMain` — passes
- [x] `./gradlew compileJava compileTestJava compileItestJava` — clean
- [x] `./gradlew test` — passes
- [x] `./gradlew itest` — passes
- [x] `./gradlew pmdMain` — `PublicMemberInNonPublicType` count: 560 → 11