### PR TITLE
PMD tiny cleanups + Files.newBufferedWriter sweep

### DIFF
--- a/code/src/java/pcgen/cdom/base/CDOMObject.java
+++ b/code/src/java/pcgen/cdom/base/CDOMObject.java
@@ -1233,6 +1233,7 @@ public abstract class CDOMObject extends ConcretePrereqObject
 		return this;
 	}
 
+	@Override
 	public Optional<String> getLocalScopeName()
 	{
 		//I don't have one

--- a/code/src/java/pcgen/cdom/inst/Dynamic.java
+++ b/code/src/java/pcgen/cdom/inst/Dynamic.java
@@ -138,6 +138,7 @@ public class Dynamic
 		return this;
 	}
 
+	@Override
 	public Optional<String> getLocalScopeName()
 	{
 		return Optional.of("PC." + category.getKeyName());

--- a/code/src/java/pcgen/core/CustomData.java
+++ b/code/src/java/pcgen/core/CustomData.java
@@ -24,12 +24,12 @@ import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -415,7 +415,7 @@ public final class CustomData
     {
         try
         {
-            return new BufferedWriter(new OutputStreamWriter(new FileOutputStream(path), "UTF-8"));
+            return Files.newBufferedWriter(Path.of(path), StandardCharsets.UTF_8);
         } catch (IOException e)
         {
             Logging.errorPrint("Could not get a writer to write to " + path

--- a/code/src/java/pcgen/gui2/converter/LSTConverter.java
+++ b/code/src/java/pcgen/gui2/converter/LSTConverter.java
@@ -17,14 +17,12 @@
  */
 package pcgen.gui2.converter;
 
-import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -226,9 +224,7 @@ public class LSTConverter extends Observable
 					changeLogWriter.append("\nProcessing ").append(String.valueOf(in)).append("\n");
 					load(uri, loader)
 							.ifPresent((String result) -> {
-								try (Writer out = new BufferedWriter(new OutputStreamWriter(
-										new FileOutputStream(outFile),
-										StandardCharsets.UTF_8)))
+								try (Writer out = Files.newBufferedWriter(outFile.toPath(), StandardCharsets.UTF_8))
 								{
 									out.write(result);
 								} catch (IOException e)

--- a/code/src/java/pcgen/gui2/facade/CharacterFacadeImpl.java
+++ b/code/src/java/pcgen/gui2/facade/CharacterFacadeImpl.java
@@ -1244,19 +1244,17 @@ public class CharacterFacadeImpl
 		for (PCClass aClass : classList)
 		{
 			AlignmentCompat.setCurrentAlignment(theCharacter.getCharID(), newAlign);
+			if (!theCharacter.isQualified(aClass))
 			{
-				if (!theCharacter.isQualified(aClass))
+				if (aClass.containsKey(ObjectKey.EX_CLASS))
 				{
-					if (aClass.containsKey(ObjectKey.EX_CLASS))
+					if (!unqualified.isEmpty())
 					{
-						if (!unqualified.isEmpty())
-						{
-							unqualified.append(", "); //$NON-NLS-1$
-						}
-
-						unqualified.append(aClass.getKeyName());
-						exclassList.add(aClass);
+						unqualified.append(", "); //$NON-NLS-1$
 					}
+
+					unqualified.append(aClass.getKeyName());
+					exclassList.add(aClass);
 				}
 			}
 		}

--- a/code/src/java/pcgen/gui2/tabs/ClassInfoTab.java
+++ b/code/src/java/pcgen/gui2/tabs/ClassInfoTab.java
@@ -157,13 +157,11 @@ public class ClassInfoTab extends FlippingSplitPane implements CharacterInfoTab
 			box.setBorder(new EmptyBorder(0, 0, 5, 0));
 			selPanel.add(box, BorderLayout.SOUTH);
 		}
-		{
-			classTable.setDragEnabled(true);
-			classTable.setTransferHandler(classTransferHandler);
+		classTable.setDragEnabled(true);
+		classTable.setTransferHandler(classTransferHandler);
 
-			availableTable.setDragEnabled(true);
-			availableTable.setTransferHandler(classTransferHandler);
-		}
+		availableTable.setDragEnabled(true);
+		availableTable.setTransferHandler(classTransferHandler);
 		initListeners();
 
 		topPane.setRightComponent(selPanel);

--- a/code/src/java/pcgen/gui2/tabs/PurchaseInfoTab.java
+++ b/code/src/java/pcgen/gui2/tabs/PurchaseInfoTab.java
@@ -229,10 +229,9 @@ public class PurchaseInfoTab extends FlippingSplitPane implements CharacterInfoT
 			initMoneyPanel(panel);
 			splitPane.setLeftComponent(panel);
 		}
-		{// Bottom Right Panel
-			infoPane.setTitle(LanguageBundle.getString("in_igEqInfo")); //$NON-NLS-1$
-			splitPane.setRightComponent(infoPane);
-		}
+		// Bottom Right Panel
+		infoPane.setTitle(LanguageBundle.getString("in_igEqInfo")); //$NON-NLS-1$
+		splitPane.setRightComponent(infoPane);
 		splitPane.setResizeWeight(0.25);
 		setResizeWeight(1);
 		setBottomComponent(splitPane);

--- a/code/src/java/pcgen/gui3/preloader/PCGenPreloader.java
+++ b/code/src/java/pcgen/gui3/preloader/PCGenPreloader.java
@@ -101,7 +101,7 @@ public class PCGenPreloader implements PCGenTaskListener, Controllable<PCGenPrel
 	public void done()
 	{
 		GuiAssertions.assertIsNotJavaFXThread();
-		Platform.runLater(() -> primaryStage.close());
+		Platform.runLater(primaryStage::close);
 	}
 
 	/**

--- a/code/src/java/pcgen/io/PCGVer2Creator.java
+++ b/code/src/java/pcgen/io/PCGVer2Creator.java
@@ -950,17 +950,11 @@ public final class PCGVer2Creator
 
 			int sp = pcl.getSkillPointsGained(thePC);
 
-			//if (sp != 0)
-			{
-				buffer.append('|').append(IOConstants.TAG_SKILLPOINTSGAINED).append(':').append(sp);
-			}
+			buffer.append('|').append(IOConstants.TAG_SKILLPOINTSGAINED).append(':').append(sp);
 
 			sp = pcl.getSkillPointsRemaining();
 
-			//if (sp != 0)
-			{
-				buffer.append('|').append(IOConstants.TAG_SKILLPOINTSREMAINING).append(':').append(sp);
-			}
+			buffer.append('|').append(IOConstants.TAG_SKILLPOINTSREMAINING).append(':').append(sp);
 
 			buffer.append(IOConstants.LINE_SEP);
 		}

--- a/code/src/java/pcgen/persistence/lst/CampaignOutput.java
+++ b/code/src/java/pcgen/persistence/lst/CampaignOutput.java
@@ -20,9 +20,9 @@ package pcgen.persistence.lst;
 
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Collection;
 import java.util.List;
 
@@ -55,7 +55,7 @@ public final class CampaignOutput
         final File outFile = new File(
                 ConfigurationSettings.getPccFilesDir() + File.separator + campaign.getSafe(StringKey.DESTINATION));
 
-        try (BufferedWriter out = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(outFile), "UTF-8")))
+        try (BufferedWriter out = Files.newBufferedWriter(outFile.toPath(), StandardCharsets.UTF_8))
         {
 
             List<String> commentList = campaign.getListFor(ListKey.COMMENT);

--- a/code/src/java/pcgen/system/BatchExporter.java
+++ b/code/src/java/pcgen/system/BatchExporter.java
@@ -266,11 +266,7 @@ public class BatchExporter
 	 */
 	public static boolean exportCharacterToNonPDF(CharacterFacade character, File outFile, File templateFile)
 	{
-		try (BufferedWriter bw = new BufferedWriter(
-				new OutputStreamWriter(
-						new FileOutputStream(outFile),
-					StandardCharsets.UTF_8)
-		))
+		try (BufferedWriter bw = Files.newBufferedWriter(outFile.toPath(), StandardCharsets.UTF_8))
 		{
 			character.export(ExportHandler.createExportHandler(templateFile), bw);
 			character.setDefaultOutputSheet(false, templateFile);
@@ -384,7 +380,7 @@ public class BatchExporter
 	 */
 	public static boolean exportPartyToNonPDF(PartyFacade party, File outFile, File templateFile)
 	{
-		try (BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(outFile), StandardCharsets.UTF_8)))
+		try (BufferedWriter bw = Files.newBufferedWriter(outFile.toPath(), StandardCharsets.UTF_8))
 		{
 			party.export(ExportHandler.createExportHandler(templateFile), bw);
 			return true;


### PR DESCRIPTION
## Summary

- **10 PMD violations cleared** across 5 rules: `MissingOverride` (×2), `UseStandardCharsets` (×2), `LambdaCanBeMethodReference` (×1), `UnnecessaryBlock` (×5).
- **Drive-by**: replaced the `new BufferedWriter(new OutputStreamWriter(new FileOutputStream(file), charset))` stack with `Files.newBufferedWriter(path, charset)` at four file-output sites (`CampaignOutput`, `CustomData`, `BatchExporter` ×2, `LSTConverter`). Same semantics (`CREATE` + `TRUNCATE_EXISTING` + `WRITE`), one call instead of three nested constructors. Sites that wrap an existing `OutputStream` (no file path) keep the wrapper stack — `Files.newBufferedWriter` only takes a `Path`.

11 files, +29 / −46.

## Test plan

- [x] `./gradlew checkstyleMain` — passes
- [x] `./gradlew compileJava compileTestJava compileItestJava` — clean
- [x] `./gradlew pmdMain` — total 801 → 791 (10 cleared)