### PR TITLE
ci: split build and integration-tests into parallel jobs

### DIFF
--- a/.github/workflows/gradle-test.yml
+++ b/.github/workflows/gradle-test.yml
@@ -1,5 +1,9 @@
-# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
+# This workflow builds PCGen with Gradle. The `build` and `integration-tests`
+# jobs run in parallel — they share the Gradle build cache via setup-gradle@v4
+# but otherwise compile their inputs independently. Splitting the previous
+# single-job sequence (`./gradlew build` then `./gradlew itest datatest slowtest`)
+# shaves the ~4 min compile/spotbugs/unit-test phase off the critical path of
+# the ~16 min slow-test phase.
 
 name: Build PCGen with Gradle
 
@@ -10,7 +14,7 @@ on:
 
 jobs:
   build:
-
+    name: Build, unit tests, and static analysis
     runs-on: ubuntu-latest
     permissions:
       checks: write
@@ -33,23 +37,15 @@ jobs:
       - name: Build with Gradle Wrapper
         run: ./gradlew build --stacktrace
 
-      - name: Run integration, data, and slow tests
-        run: ./gradlew itest datatest slowtest --stacktrace
-
-      - name: Publish Test Results
+      - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
         with:
+          check_name: 'Unit Test Results'
           files: |
-            build/test-results/**/*.xml
-            build/test-results/**/*.trx
-            build/test-results/**/*.json
+            build/test-results/test/**/*.xml
             PCGen-base/build/test-results/**/*.xml
-            PCGen-base/build/test-results/**/*.trx
-            PCGen-base/build/test-results/**/*.json
             PCGen-Formula/build/test-results/**/*.xml
-            PCGen-Formula/build/test-results/**/*.trx
-            PCGen-Formula/build/test-results/**/*.json
 
       - name: Run Coverage
         run: ./gradlew testCoverage --stacktrace
@@ -75,3 +71,34 @@ jobs:
         run: |
           echo "Total coverage ${{ steps.jacoco.outputs.coverage-overall }}"
           echo "Changed Files coverage ${{ steps.jacoco.outputs.coverage-changed-files }}"
+
+  integration-tests:
+    name: Integration, data, and slow tests
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Run integration, data, and slow tests
+        run: ./gradlew itest datatest slowtest --stacktrace
+
+      - name: Publish Integration Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          check_name: 'Integration Test Results'
+          files: |
+            build/test-results/itest/**/*.xml
+            build/test-results/slowtest/**/*.xml

--- a/build.gradle
+++ b/build.gradle
@@ -726,10 +726,6 @@ tasks.register("slowtest", Test) {
     classpath = sourceSets.slowtest.runtimeClasspath
     systemProperties['jar.path'] = jar.getArchiveFile().get().getAsFile()
     forkEvery = 1
-    // pcgen.system.Main.main(...) has JVM-wide static state (Globals,
-    // SystemCollections, plugin registry); concurrent forks race on shared
-    // output/temp directories and produce flaky export failures.
-    maxParallelForks = 1
 }
 
 tasks.register("datatest", Test) {
@@ -747,7 +743,6 @@ tasks.register("inttest", Test) {
     testClassesDirs = sourceSets.slowtest.output.classesDirs
     classpath = sourceSets.slowtest.runtimeClasspath
     forkEvery = 1
-    maxParallelForks = 1
     include 'pcgen/inttest/**/*Test.class'
 }
 

--- a/code/src/slowtest/pcgen/inttest/PcgenFtlTestCase.java
+++ b/code/src/slowtest/pcgen/inttest/PcgenFtlTestCase.java
@@ -75,12 +75,11 @@ public abstract class PcgenFtlTestCase
 	 * Run the test.
 	 *
 	 * @param character The PC
-	 * @param mode      The game mode
 	 * @throws IOException Signals that an I/O exception has occurred.
 	 */
-	public void runTest(String character, String mode) throws IOException
+	public void runTest(String character) throws IOException
 	{
-		LOG.info("RUNTEST with the character: " + character + " and the game mode: " + mode);
+		LOG.info("RUNTEST with the character: " + character);
 		String characterFileName = character + ".xml";
 		String characterPCFileName = character + ".pcg";
 		Path inputFolder = Paths.get("code/testsuite/PCGfiles");

--- a/code/src/slowtest/pcgen/inttest/PcgenFtlTestCase.java
+++ b/code/src/slowtest/pcgen/inttest/PcgenFtlTestCase.java
@@ -19,6 +19,7 @@ package pcgen.inttest;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
 import org.xmlunit.builder.DiffBuilder;
 import org.xmlunit.builder.Input;
 import org.xmlunit.diff.Diff;
@@ -27,9 +28,10 @@ import pcgen.system.Main;
 import pcgen.util.GracefulExit;
 import pcgen.util.TestHelper;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.text.MessageFormat;
 import java.util.Locale;
 import java.util.logging.Logger;
@@ -47,6 +49,14 @@ public abstract class PcgenFtlTestCase
 	private static final Logger LOG = Logger.getLogger(PcgenFtlTestCase.class.getName());
 
 	private static final String TEST_CONFIG_FILE = "config.ini.junit";
+
+	/**
+	 * JUnit-managed per-test temp directory. Holds {@code config.ini.junit}, the {@code settingsPath}
+	 * directory and the export output. Per-test isolation lets parallel forks run without
+	 * racing on a shared {@code config.ini.junit} in the project root.
+	 */
+	@TempDir
+	Path tempDir;
 
 	@BeforeEach
 	public void setUp()
@@ -68,42 +78,43 @@ public abstract class PcgenFtlTestCase
 	 * @param mode      The game mode
 	 * @throws IOException Signals that an I/O exception has occurred.
 	 */
-	public static void runTest(String character, String mode) throws IOException
+	public void runTest(String character, String mode) throws IOException
 	{
 		LOG.info("RUNTEST with the character: " + character + " and the game mode: " + mode);
-		// Delete the old generated output for this test
 		String characterFileName = character + ".xml";
 		String characterPCFileName = character + ".pcg";
-		var inputFolder = new File("code/testsuite/PCGfiles");
-		var outputFolder = new File("code/testsuite/output");
-		var csheetsFolder = new File("code/testsuite/csheets");
-		outputFolder.mkdirs();
+		Path inputFolder = Paths.get("code/testsuite/PCGfiles");
+		Path csheetsFolder = Paths.get("code/testsuite/csheets");
 
-		var inputFile = new File(inputFolder, characterPCFileName);
-		var outputFile = new File(outputFolder, characterFileName);
-		var expectedFile = new File(csheetsFolder, characterFileName);
+		Path settingsDir = Files.createDirectories(tempDir.resolve("testsuite"));
+		Path outputDir = Files.createDirectories(tempDir.resolve("output"));
+		Path configFile = tempDir.resolve(TEST_CONFIG_FILE);
+
+		Path inputFile = inputFolder.resolve(characterPCFileName);
+		Path outputFile = outputDir.resolve(characterFileName);
+		Path expectedFile = csheetsFolder.resolve(characterFileName);
 
 		String pccLoc = TestHelper.findDataFolder();
 
 		/*
 		 * Override the pcc location, game mode and several other properties in the options.ini file
 		 */
-		String configFolder = "testsuite";
-		TestHelper.createDummySettingsFile(TEST_CONFIG_FILE, configFolder, pccLoc);
+		TestHelper.createDummySettingsFile(configFile.toString(), settingsDir.toString(), pccLoc);
 
 		GracefulExit.registerExitFunction((int status) ->
 				assertEquals(0, status,
 						MessageFormat.format("The export of {0} failed with an error: {1}.", character, status)));
 
-		Main.main("--character", inputFile.getCanonicalPath(),
+		Main.main("--character", inputFile.toString(),
 				"--exportsheet", "code/testsuite/base-xml.ftl",
-				"--outputfile", outputFile.getCanonicalPath(),
+				"--outputfile", outputFile.toString(),
+				"--settingsdir", tempDir.toString(),
 				"--configfilename", TEST_CONFIG_FILE);
 
 		// the XML of the expected result
-		var expected = Files.readString(expectedFile.toPath());
+		var expected = Files.readString(expectedFile);
 		// the XML of the actual result
-		var actual = Files.readString(outputFile.toPath());
+		var actual = Files.readString(outputFile);
 
 		LOG.info(() -> MessageFormat.format("Comparing the expected ({0}) and actual ({1}) results",
 				expectedFile, outputFile));

--- a/code/src/slowtest/pcgen/inttest/game_35e/pcGenGUIAliceTest.java
+++ b/code/src/slowtest/pcgen/inttest/game_35e/pcGenGUIAliceTest.java
@@ -14,6 +14,6 @@ public class pcGenGUIAliceTest extends PcgenFtlTestCase
 	@Test
 	public void testCode() throws Exception
 	{
-		runTest("35e_Alice", "35e");
+		runTest("35e_Alice");
 	}
 }

--- a/code/src/slowtest/pcgen/inttest/game_35e/pcGenGUIBardTest.java
+++ b/code/src/slowtest/pcgen/inttest/game_35e/pcGenGUIBardTest.java
@@ -15,6 +15,6 @@ public class pcGenGUIBardTest extends PcgenFtlTestCase
 	@Test
 	public void testCode() throws Exception
 	{
-		runTest("35e_Bard", "35e");
+		runTest("35e_Bard");
 	}
 }

--- a/code/src/slowtest/pcgen/inttest/game_35e/pcGenGUIBobTest.java
+++ b/code/src/slowtest/pcgen/inttest/game_35e/pcGenGUIBobTest.java
@@ -14,6 +14,6 @@ public class pcGenGUIBobTest extends PcgenFtlTestCase
 	@Test
 	public void testCode() throws Exception
 	{
-		runTest("35e_Bob", "35e");
+		runTest("35e_Bob");
 	}
 }

--- a/code/src/slowtest/pcgen/inttest/game_35e/pcGenGUICharlieTest.java
+++ b/code/src/slowtest/pcgen/inttest/game_35e/pcGenGUICharlieTest.java
@@ -15,6 +15,6 @@ public class pcGenGUICharlieTest extends PcgenFtlTestCase
 	@Test
 	public void testCode() throws Exception
 	{
-		runTest("35e_Charlie", "35e");
+		runTest("35e_Charlie");
 	}
 }

--- a/code/src/slowtest/pcgen/inttest/game_35e/pcGenGUICloudGiantTest.java
+++ b/code/src/slowtest/pcgen/inttest/game_35e/pcGenGUICloudGiantTest.java
@@ -16,7 +16,7 @@ public class pcGenGUICloudGiantTest extends PcgenFtlTestCase
 	@Test
 	public void testCloudGiantHalfDragon() throws IOException
 	{
-		runTest("35e_CloudGiantHalfDragon", "35e");
+		runTest("35e_CloudGiantHalfDragon");
 	}
 
 }

--- a/code/src/slowtest/pcgen/inttest/game_35e/pcGenGUIDaveTest.java
+++ b/code/src/slowtest/pcgen/inttest/game_35e/pcGenGUIDaveTest.java
@@ -13,6 +13,6 @@ public class pcGenGUIDaveTest extends PcgenFtlTestCase
 	@Test
 	public void testCode() throws Exception
 	{
-		runTest("35e_Dave", "35e");
+		runTest("35e_Dave");
 	}
 }

--- a/code/src/slowtest/pcgen/inttest/game_35e/pcGenGUIEveTest.java
+++ b/code/src/slowtest/pcgen/inttest/game_35e/pcGenGUIEveTest.java
@@ -14,6 +14,6 @@ public class pcGenGUIEveTest extends PcgenFtlTestCase
 	@Test
 	public void testCode() throws Exception
 	{
-		runTest("35e_Eve", "35e");
+		runTest("35e_Eve");
 	}
 }

--- a/code/src/slowtest/pcgen/inttest/game_35e/pcGenGUIFranTest.java
+++ b/code/src/slowtest/pcgen/inttest/game_35e/pcGenGUIFranTest.java
@@ -14,6 +14,6 @@ public class pcGenGUIFranTest extends PcgenFtlTestCase
 	@Test
 	public void testCode() throws Exception
 	{
-		runTest("35e_Fran", "35e");
+		runTest("35e_Fran");
 	}
 }

--- a/code/src/slowtest/pcgen/inttest/game_35e/pcGenGUIGordonTest.java
+++ b/code/src/slowtest/pcgen/inttest/game_35e/pcGenGUIGordonTest.java
@@ -14,6 +14,6 @@ public class pcGenGUIGordonTest extends PcgenFtlTestCase
 	@Test
 	public void testCode() throws Exception
 	{
-		runTest("35e_Gordon", "35e");
+		runTest("35e_Gordon");
 	}
 }

--- a/code/src/slowtest/pcgen/inttest/game_35e/pcGenGUIHaroldTest.java
+++ b/code/src/slowtest/pcgen/inttest/game_35e/pcGenGUIHaroldTest.java
@@ -14,6 +14,6 @@ public class pcGenGUIHaroldTest extends PcgenFtlTestCase
 	@Test
 	public void testCode() throws Exception
 	{
-		runTest("35e_Harold", "35e");
+		runTest("35e_Harold");
 	}
 }

--- a/code/src/slowtest/pcgen/inttest/game_35e/pcGenGUIIvanTest.java
+++ b/code/src/slowtest/pcgen/inttest/game_35e/pcGenGUIIvanTest.java
@@ -14,6 +14,6 @@ public class pcGenGUIIvanTest extends PcgenFtlTestCase
 	@Test
 	public void testCode() throws Exception
 	{
-		runTest("35e_Ivan", "35e");
+		runTest("35e_Ivan");
 	}
 }

--- a/code/src/slowtest/pcgen/inttest/game_35e/pcGenGUIJangoTest.java
+++ b/code/src/slowtest/pcgen/inttest/game_35e/pcGenGUIJangoTest.java
@@ -13,6 +13,6 @@ public class pcGenGUIJangoTest extends PcgenFtlTestCase
 	@Test
 	public void testJango() throws Exception
 	{
-		runTest("35e_Jango", "35e");
+		runTest("35e_Jango");
 	}
 }

--- a/code/src/slowtest/pcgen/inttest/game_35e/pcGenGUIJimDopTest.java
+++ b/code/src/slowtest/pcgen/inttest/game_35e/pcGenGUIJimDopTest.java
@@ -15,6 +15,6 @@ public class pcGenGUIJimDopTest extends PcgenFtlTestCase
 	@Test
 	public void testJimDop() throws Exception
 	{
-		runTest("35e_JimDop", "35e");
+		runTest("35e_JimDop");
 	}
 }

--- a/code/src/slowtest/pcgen/inttest/game_35e/pcGenGUILaurenTest.java
+++ b/code/src/slowtest/pcgen/inttest/game_35e/pcGenGUILaurenTest.java
@@ -13,6 +13,6 @@ public class pcGenGUILaurenTest extends PcgenFtlTestCase
 	@Test
 	public void testLauren() throws Exception
 	{
-		runTest("35e_Lauren", "35e");
+		runTest("35e_Lauren");
 	}
 }

--- a/code/src/slowtest/pcgen/inttest/game_35e/pcGenGUIMalloryTest.java
+++ b/code/src/slowtest/pcgen/inttest/game_35e/pcGenGUIMalloryTest.java
@@ -13,6 +13,6 @@ public class pcGenGUIMalloryTest extends PcgenFtlTestCase
 	@Test
 	public void testMallory() throws Exception
 	{
-		runTest("35e_Mallory", "35e");
+		runTest("35e_Mallory");
 	}
 }

--- a/code/src/slowtest/pcgen/inttest/game_35e/pcGenGUIQPsiCrystalTest.java
+++ b/code/src/slowtest/pcgen/inttest/game_35e/pcGenGUIQPsiCrystalTest.java
@@ -14,6 +14,6 @@ public class pcGenGUIQPsiCrystalTest extends PcgenFtlTestCase
 	@Test
 	public void testQPsiCrystal() throws Exception
 	{
-		runTest("35e_Q-PsiCrystal", "35e");
+		runTest("35e_Q-PsiCrystal");
 	}
 }

--- a/code/src/slowtest/pcgen/inttest/game_35e/pcGenGUIQuasvinTest.java
+++ b/code/src/slowtest/pcgen/inttest/game_35e/pcGenGUIQuasvinTest.java
@@ -14,6 +14,6 @@ public class pcGenGUIQuasvinTest extends PcgenFtlTestCase
 	@Test
 	public void testQuasvin() throws Exception
 	{
-		runTest("35e_Quasvin", "35e");
+		runTest("35e_Quasvin");
 	}
 }

--- a/code/src/slowtest/pcgen/inttest/game_3e/pcGenGUIBarJackTest.java
+++ b/code/src/slowtest/pcgen/inttest/game_3e/pcGenGUIBarJackTest.java
@@ -31,6 +31,6 @@ public class pcGenGUIBarJackTest extends PcgenFtlTestCase
 	@Test
 	public void testBarJack() throws Exception
 	{
-		runTest("3e_BarJack", "3e");
+		runTest("3e_BarJack");
 	}
 }

--- a/code/src/slowtest/pcgen/inttest/game_3e/pcGenGUIBrdJoeTest.java
+++ b/code/src/slowtest/pcgen/inttest/game_3e/pcGenGUIBrdJoeTest.java
@@ -31,7 +31,7 @@ public class pcGenGUIBrdJoeTest extends PcgenFtlTestCase
 	@Test
 	public void testBrdJoe() throws Exception
 	{
-		runTest("3e_BrdJoe", "3e");
+		runTest("3e_BrdJoe");
 	}
 
 }

--- a/code/src/slowtest/pcgen/inttest/game_3e/pcGenGUICleElfTest.java
+++ b/code/src/slowtest/pcgen/inttest/game_3e/pcGenGUICleElfTest.java
@@ -31,6 +31,6 @@ public class pcGenGUICleElfTest extends PcgenFtlTestCase
 	@Test
 	public void testCleElf() throws Exception
 	{
-		runTest("3e_CleElf", "3e");
+		runTest("3e_CleElf");
 	}
 }

--- a/code/src/slowtest/pcgen/inttest/game_3e/pcGenGUIFigFaeTest.java
+++ b/code/src/slowtest/pcgen/inttest/game_3e/pcGenGUIFigFaeTest.java
@@ -33,6 +33,6 @@ public class pcGenGUIFigFaeTest extends PcgenFtlTestCase
 	@Test
 	public void testFigFae() throws Exception
 	{
-		runTest("3e_FigFae", "3e");
+		runTest("3e_FigFae");
 	}
 }

--- a/code/src/slowtest/pcgen/inttest/game_3e/pcGenGUIMonKeeTest.java
+++ b/code/src/slowtest/pcgen/inttest/game_3e/pcGenGUIMonKeeTest.java
@@ -31,6 +31,6 @@ public class pcGenGUIMonKeeTest extends PcgenFtlTestCase
 	@Test
 	public void testMonKee() throws Exception
 	{
-		runTest("3e_MonKee", "3e");
+		runTest("3e_MonKee");
 	}
 }

--- a/code/src/slowtest/pcgen/inttest/game_3e/pcGenGUISWizSamTest.java
+++ b/code/src/slowtest/pcgen/inttest/game_3e/pcGenGUISWizSamTest.java
@@ -34,6 +34,6 @@ public class pcGenGUISWizSamTest extends PcgenFtlTestCase
 	@Test
 	public void testSWizSam() throws IOException
 	{
-		runTest("3e_SWizSam", "3e");
+		runTest("3e_SWizSam");
 	}
 }

--- a/code/src/slowtest/pcgen/inttest/game_3e/pcGenGUIWizSharTest.java
+++ b/code/src/slowtest/pcgen/inttest/game_3e/pcGenGUIWizSharTest.java
@@ -33,7 +33,7 @@ public class pcGenGUIWizSharTest extends PcgenFtlTestCase
 	@Test
 	public void testWizShar() throws IOException
 	{
-		runTest("3e_WizShar", "3e");
+		runTest("3e_WizShar");
 	}
 
 }

--- a/code/src/slowtest/pcgen/inttest/game_modern/pcGenGUIElwoodTest.java
+++ b/code/src/slowtest/pcgen/inttest/game_modern/pcGenGUIElwoodTest.java
@@ -33,6 +33,6 @@ public class pcGenGUIElwoodTest extends PcgenFtlTestCase
 	@Test
 	public void testElwood() throws Exception
 	{
-		runTest("msrd_Elwood", "Modern");
+		runTest("msrd_Elwood");
 	}
 }

--- a/code/src/slowtest/pcgen/inttest/game_modern/pcGenGUIIlyanaTest.java
+++ b/code/src/slowtest/pcgen/inttest/game_modern/pcGenGUIIlyanaTest.java
@@ -32,6 +32,6 @@ public class pcGenGUIIlyanaTest extends PcgenFtlTestCase
 	@Test
 	public void testIlyana() throws Exception
 	{
-		runTest("msrd_Ilyana", "Modern");
+		runTest("msrd_Ilyana");
 	}
 }

--- a/code/src/slowtest/pcgen/inttest/game_pathfinder/pcGenGUIPfrpgClericTest.java
+++ b/code/src/slowtest/pcgen/inttest/game_pathfinder/pcGenGUIPfrpgClericTest.java
@@ -16,6 +16,6 @@ public class pcGenGUIPfrpgClericTest extends PcgenFtlTestCase
 	@Test
 	public void testCode() throws Exception
 	{
-		runTest("pf_Cleric", "Pathfinder_RPG");
+		runTest("pf_Cleric");
 	}
 }

--- a/code/src/slowtest/pcgen/inttest/game_pathfinder/pcGenGUIPfrpgGoldielocksTest.java
+++ b/code/src/slowtest/pcgen/inttest/game_pathfinder/pcGenGUIPfrpgGoldielocksTest.java
@@ -17,6 +17,6 @@ public class pcGenGUIPfrpgGoldielocksTest extends PcgenFtlTestCase
 	@Test
 	public void testCode() throws IOException
 	{
-		runTest("pf_goldielocks", "Pathfinder_RPG");
+		runTest("pf_goldielocks");
 	}
 }

--- a/code/src/slowtest/pcgen/inttest/game_pathfinder/pcGenGUIPfrpgPaladinTest.java
+++ b/code/src/slowtest/pcgen/inttest/game_pathfinder/pcGenGUIPfrpgPaladinTest.java
@@ -30,6 +30,6 @@ public class pcGenGUIPfrpgPaladinTest extends PcgenFtlTestCase
 	@Test
 	public void testCode() throws Exception
 	{
-		runTest("pf_Paladin", "Pathfinder_RPG");
+		runTest("pf_Paladin");
 	}
 }

--- a/code/src/slowtest/pcgen/inttest/game_pathfinder/pcGenGUIPfrpgRogueTest.java
+++ b/code/src/slowtest/pcgen/inttest/game_pathfinder/pcGenGUIPfrpgRogueTest.java
@@ -30,6 +30,6 @@ public class pcGenGUIPfrpgRogueTest extends PcgenFtlTestCase
 	@Test
 	public void testCode() throws Exception
 	{
-		runTest("pf_Rogue", "Pathfinder_RPG");
+		runTest("pf_Rogue");
 	}
 }

--- a/code/src/slowtest/pcgen/inttest/game_starfinder/pcGenGUISFmechanicTest.java
+++ b/code/src/slowtest/pcgen/inttest/game_starfinder/pcGenGUISFmechanicTest.java
@@ -17,6 +17,6 @@ public class pcGenGUISFmechanicTest extends PcgenFtlTestCase
 	@Test
 	public void testCode() throws IOException
 	{
-		runTest("sf_mechanic", "Starfinder");
+		runTest("sf_mechanic");
 	}
 }

--- a/code/src/slowtest/pcgen/inttest/game_starfinder/pcGenGUISFsoldierTest.java
+++ b/code/src/slowtest/pcgen/inttest/game_starfinder/pcGenGUISFsoldierTest.java
@@ -17,6 +17,6 @@ public class pcGenGUISFsoldierTest extends PcgenFtlTestCase
 	@Test
 	public void testCode() throws IOException
 	{
-		runTest("sf_soldier", "Starfinder");
+		runTest("sf_soldier");
 	}
 }

--- a/code/src/slowtest/pcgen/persistence/lst/DataLoadTest.java
+++ b/code/src/slowtest/pcgen/persistence/lst/DataLoadTest.java
@@ -21,8 +21,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -52,8 +53,7 @@ import pcgen.util.Logging;
 import pcgen.util.TestHelper;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.SystemUtils;
-import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -65,20 +65,20 @@ public class DataLoadTest implements PCGenTaskListener
 	/** The name of our dummy config file. */
 	private static final String TEST_CONFIG_FILE = "config.ini.junit";
 
+	/**
+	 * Per-class temp directory holding the dummy {@code config.ini.junit} and the
+	 * {@code settingsPath} folder. Per-class isolation lets parallel forks within
+	 * {@code :datatest} (DataTest + DataLoadTest) run without racing on a shared
+	 * config file in the project root.
+	 */
+	@TempDir
+	static Path tempDir;
+
 	private Collection<LogRecord> errors = new ArrayList<>();
 
 
 	/**
-	 * Tidy up the config file we created. 
-	 */
-	@AfterAll
-	static void afterClass()
-	{
-		new File(TEST_CONFIG_FILE).delete();
-	}
-
-	/**
-	 * Build the list of sources to be checked. Also initialises the plugins and 
+	 * Build the list of sources to be checked. Also initializes the plugins and
 	 * loads the game mode and campaign files.
 	 */
 	public static Stream<Object[]> data()
@@ -144,10 +144,12 @@ public class DataLoadTest implements PCGenTaskListener
 	{
 		String pccLoc = TestHelper.findDataFolder();
 		System.out.println("Got data folder of " + pccLoc);
+		Path settingsDir = tempDir.resolve("testsuite");
+		Path configFile = tempDir.resolve(TEST_CONFIG_FILE);
 		try
 		{
-			String configFolder = "testsuite";
-			TestHelper.createDummySettingsFile(TEST_CONFIG_FILE, configFolder,
+			Files.createDirectories(settingsDir);
+			TestHelper.createDummySettingsFile(configFile.toString(), settingsDir.toString(),
 				pccLoc);
 		}
 		catch (IOException e)
@@ -156,7 +158,7 @@ public class DataLoadTest implements PCGenTaskListener
 		}
 
 		PropertyContextFactory configFactory =
-				new PropertyContextFactory(SystemUtils.USER_DIR);
+				new PropertyContextFactory(tempDir.toString());
 		configFactory.registerAndLoadPropertyContext(ConfigurationSettings
 			.getInstance(TEST_CONFIG_FILE));
 		Main.loadProperties(false);

--- a/code/src/slowtest/pcgen/persistence/lst/DataTest.java
+++ b/code/src/slowtest/pcgen/persistence/lst/DataTest.java
@@ -48,10 +48,9 @@ import pcgen.system.PropertyContextFactory;
 import pcgen.util.Logging;
 import pcgen.util.TestHelper;
 
-import org.apache.commons.lang3.SystemUtils;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * The Class {@code DataTest} checks the data files for known issues.
@@ -62,21 +61,21 @@ class DataTest
 	private static final String TEST_CONFIG_FILE = "config.ini.junit";
 
 	/**
+	 * Per-class temp directory holding the dummy {@code config.ini.junit} and the
+	 * {@code settingsPath} folder. Per-class isolation lets parallel forks within
+	 * {@code :datatest} (DataTest + DataLoadTest) run without racing on a shared
+	 * config file in the project root.
+	 */
+	@TempDir
+	static Path tempDir;
+
+	/**
 	 * Initialise the plugins and load the game mode and campaign files.
 	 */
 	@BeforeAll
 	static void onceOnly()
 	{
 		loadGameModes();
-	}
-
-	/**
-	 * Tidy up the config file we created.
-	 */
-	@AfterAll
-	static void afterClass()
-	{
-		new File(TEST_CONFIG_FILE).delete();
 	}
 
 	/**
@@ -269,10 +268,12 @@ class DataTest
 	{
 		String pccLoc = TestHelper.findDataFolder();
 		System.out.println("Got data folder of " + pccLoc);
+		Path settingsDir = tempDir.resolve("testsuite");
+		Path configFile = tempDir.resolve(TEST_CONFIG_FILE);
 		try
 		{
-			String configFolder = "testsuite";
-			TestHelper.createDummySettingsFile(TEST_CONFIG_FILE, configFolder,
+			Files.createDirectories(settingsDir);
+			TestHelper.createDummySettingsFile(configFile.toString(), settingsDir.toString(),
 				pccLoc);
 		}
 		catch (IOException e)
@@ -280,7 +281,7 @@ class DataTest
 			Logging.errorPrint("DataTest.loadGameModes failed", e);
 		}
 
-		PropertyContextFactory configFactory = new PropertyContextFactory(SystemUtils.USER_DIR);
+		PropertyContextFactory configFactory = new PropertyContextFactory(tempDir.toString());
 		configFactory.registerAndLoadPropertyContext(ConfigurationSettings.getInstance(TEST_CONFIG_FILE));
 		Main.loadProperties(false);
 		Main.runBootstrapTasks();

--- a/code/src/slowtest/pcgen/persistence/lst/DataTest.java
+++ b/code/src/slowtest/pcgen/persistence/lst/DataTest.java
@@ -32,7 +32,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
+import java.util.logging.Level;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -48,6 +48,7 @@ import pcgen.system.PropertyContextFactory;
 import pcgen.util.Logging;
 import pcgen.util.TestHelper;
 
+import freemarker.template.TemplateException;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -87,7 +88,7 @@ class DataTest
 	public void pathLengthTest()
 	{
 		String dataPath = ConfigurationSettings.getPccFilesDir();
-		System.out.println("Got datapath of " + new File(dataPath).getAbsolutePath());
+		Logging.log(Level.INFO, "Got datapath of " + new File(dataPath).getAbsolutePath());
 
 		Collection<String> allowedNames =
 				new HashSet<>(Arrays.asList(
@@ -118,7 +119,7 @@ class DataTest
 
 		// Output the list
 		Collections.sort(longPaths);
-		longPaths.forEach(System.out::println);
+		longPaths.forEach(p -> Logging.log(Level.INFO, p));
 
 		// Flag any change for the worse.
 		assertEquals(
@@ -127,9 +128,11 @@ class DataTest
 
 	/**
 	 * Produce the variable report in html and csv formats.
-	 * @throws Exception if the report fails.
+	 *
+	 * @throws IOException        if writing a report file fails.
+	 * @throws TemplateException  if rendering the FreeMarker template fails.
 	 */
-	public void produceVariableReport() throws Exception
+	public void produceVariableReport() throws IOException, TemplateException
 	{
 		Map<ReportFormat, String> reportNameMap =
 				new EnumMap<>(ReportFormat.class);
@@ -138,9 +141,8 @@ class DataTest
 		VariableReport vReport = new VariableReport();
 		vReport.runReport(reportNameMap);
 
-		reportNameMap.entrySet().stream().map(repType -> "Variable report in " + repType.getKey()
-				+ " format output to "
-				+ new File(repType.getValue()).getAbsolutePath()).forEach(System.out::println);
+		reportNameMap.forEach((fmt, name) -> Logging.log(Level.INFO,
+				"Variable report in " + fmt + " format output to " + new File(name).getAbsolutePath()));
 	}
 
 	/**
@@ -215,10 +217,8 @@ class DataTest
 		                         .map(srcRelPath -> srcRelPath + "\r\n")
 		                         .collect(Collectors.joining());
 
-		// Flag any missing files
-		// TODO Revert back to the below
+		// Flag any orphan files
 		assertEquals("", report, "Some data files are orphaned.");
-		//assertEquals("pathfinder_2e/core_rulebook/c_skills_situation.lst", report, "Some data files are orphaned.");
 	}
 
 	/**
@@ -235,7 +235,7 @@ class DataTest
 			return walk.filter(Files::isRegularFile)
 			           .map(Path::toFile)
 			           .filter(f -> exts.contains(extensionOf(f.getName())))
-			           .collect(Collectors.toList());
+			           .toList();
 		}
 		catch (IOException e)
 		{
@@ -254,10 +254,10 @@ class DataTest
 		List<CampaignSourceEntry> cseList =
 				new ArrayList<>();
 		CampaignLoader.OBJECT_FILE_LISTKEY.stream()
-		      .map((Function<ListKey, List>) campaign::getSafeListFor)
+		      .map(campaign::getSafeListFor)
 		      .forEach(cseList::addAll);
 		CampaignLoader.OTHER_FILE_LISTKEY.stream()
-		      .map((Function<ListKey, List>) campaign::getSafeListFor)
+		      .map(campaign::getSafeListFor)
 		      .forEach(cseList::addAll);
 		cseList.addAll(campaign.getSafeListFor(ListKey.FILE_PCC));
 		return cseList;
@@ -267,7 +267,7 @@ class DataTest
 	private static void loadGameModes()
 	{
 		String pccLoc = TestHelper.findDataFolder();
-		System.out.println("Got data folder of " + pccLoc);
+		Logging.log(Level.INFO, "Got data folder of " + pccLoc);
 		Path settingsDir = tempDir.resolve("testsuite");
 		Path configFile = tempDir.resolve(TEST_CONFIG_FILE);
 		try

--- a/code/src/slowtest/plugin/PluginBuildTest.java
+++ b/code/src/slowtest/plugin/PluginBuildTest.java
@@ -30,6 +30,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.stream.Collectors;
@@ -49,9 +50,39 @@ class PluginBuildTest
 	private static final String JAVA_EXT = ".java";
 	private static final String CLASS_EXT = ".class";
 
+	private static final Path PLUGIN_SOURCE_ROOT = Paths.get("code/src/java/plugin");
+
 	@BeforeEach
 	void setUp()
 	{
+	}
+
+	/**
+	 * Catches a new {@code code/src/java/plugin/&lt;category&gt;/} directory that was added
+	 * without a matching jar entry being wired into {@code code/gradle/plugins.gradle}
+	 * (and thus a matching test method here). The set below must stay in sync with the
+	 * {@code createJarTask("...", "...plugins.jar", ..., "plugin/&lt;category&gt;/**\/*.class")}
+	 * calls in {@code plugins.gradle}.
+	 */
+	@Test
+	public void everyPluginPackageHasACorrespondingJar() throws IOException
+	{
+		Set<String> packagedCategories = Set.of(
+				"bonustokens", "converter", "exporttokens", "function",
+				"grouping", "jepcommands", "lsttokens", "modifier",
+				"pretokens", "primitive", "qualifier"
+		);
+		try (Stream<Path> stream = Files.list(PLUGIN_SOURCE_ROOT))
+		{
+			Set<String> uncovered = stream
+					.filter(Files::isDirectory)
+					.map(p -> p.getFileName().toString())
+					.filter(n -> !packagedCategories.contains(n))
+					.collect(Collectors.toCollection(TreeSet::new));
+			assertTrue(uncovered.isEmpty(),
+					"New plugin package(s) under " + PLUGIN_SOURCE_ROOT
+							+ " without a jar entry in plugins.gradle: " + uncovered);
+		}
 	}
 
 	/**
@@ -177,6 +208,9 @@ class PluginBuildTest
 
 	private void checkPluginJar(Path jar, Path sourceFolder) throws IOException
 	{
+		String expectedJarPrefix = PLUGIN_SOURCE_ROOT.getParent().relativize(sourceFolder)
+				.toString().replace(File.separatorChar, '/') + '/';
+
 		try (Stream<Path> stream = Files.walk(sourceFolder)) {
 			var javaPlugins = stream
 					.filter(Files::isRegularFile)
@@ -187,9 +221,19 @@ class PluginBuildTest
 					.collect(Collectors.toSet());
 
 			try (JarFile jarFile = new JarFile(jar.toFile())) {
-				var res = jarFile.stream()
+				Set<String> classEntries = jarFile.stream()
 						.map(JarEntry::getRealName)
 						.filter(s -> s.endsWith(CLASS_EXT))
+						.collect(Collectors.toSet());
+
+				Set<String> foreign = classEntries.stream()
+						.filter(s -> s.startsWith("plugin/") && !s.startsWith(expectedJarPrefix))
+						.collect(Collectors.toCollection(TreeSet::new));
+				assertTrue(foreign.isEmpty(),
+						"Jar " + jar + " contains classes outside the expected " + expectedJarPrefix
+								+ " sub-package: " + foreign);
+
+				var res = classEntries.stream()
 						.map(s -> s.substring(s.lastIndexOf('/') + 1)) // trim everything before the last '/'
 						.map(s -> s.substring(0, s.length() - CLASS_EXT.length()))   // trim the class extension
 						.collect(Collectors.toSet());


### PR DESCRIPTION
> **Stacked on top of #7603.** PR #7603 fixes the cross-fork race in PcgenFtlTestCase. Without it, master's slowtest is flaky under any cores/2 parallelism, including this PR's own CI runs. Once #7603 merges, rebasing this branch onto master leaves only the workflow-yaml diff.

## Summary

- Split the single sequential CI job into two jobs that run in parallel: `build` (compile + plugin jars + spotbugs + unit `:test` + coverage) and `integration-tests` (`itest` + `datatest` + `slowtest`).
- Both share the Gradle dependency cache via `setup-gradle@v4`. `slowtest` does not depend on `:test` or `:spotbugs*` (verified with `./gradlew slowtest --dry-run`), so the integration-tests job re-pays only ~30 s of `code` + `slowtest` compile, against ~4 min saved on the critical path.
- Each job runs its own `publish-unit-test-result-action` with a disjoint file glob, so the two checks show only their own results instead of one job blocking on the other's reports.

## Why

Today the wall clock is `build (~4 min) → itest+datatest+slowtest (~16 min) ≈ 20 min`. Static analysis on master sources has nothing to do with whether the slow character-export tests pass; running them back-to-back in one job just sums the time. Expected wall clock after this split: `max(~5 min, ~16 min) ≈ 16 min` today, dropping to `max(~5 min, ~7-8 min) ≈ 8 min` once #7603 lands and slowtest can use cores/2 parallelism without racing.

## Test plan
- [ ] CI run on this PR shows two jobs (`build`, `integration-tests`) running in parallel.
- [ ] Both jobs succeed.
- [ ] Two separate test-result checks appear on the PR (`Unit Test Results`, `Integration Test Results`).
- [ ] Coverage comment is posted from the `build` job.
- [ ] Wall-clock is meaningfully shorter than the previous sequential run for the same commit.