### PR TITLE
Fix macOS portable .app being unlaunchable after unzip

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,8 @@
 
 import groovy.json.JsonSlurper
 
+import java.nio.file.Files
+
 import org.apache.tools.ant.filters.FixCrLfFilter
 import org.apache.tools.ant.taskdefs.condition.Os
 
@@ -384,10 +386,10 @@ tasks.named("jpackageImage") {
     def jpackageDir = layout.buildDirectory.dir("jpackage")
     doFirst {
         def root = jpackageDir.get().asFile.toPath()
-        if (java.nio.file.Files.exists(root)) {
-            java.nio.file.Files.walk(root).withCloseable { stream ->
+        if (Files.exists(root)) {
+            Files.walk(root).withCloseable { stream ->
                 stream.filter { it.fileName.toString() == ".DS_Store" }
-                      .forEach { java.nio.file.Files.deleteIfExists(it) }
+                      .forEach { Files.deleteIfExists(it) }
             }
         }
     }
@@ -463,14 +465,34 @@ if (Os.isFamily(Os.FAMILY_MAC)) {
 
 // Portable zip: same self-contained app the installer ships, but as an
 // unzip-and-run archive. Source folder is whatever fullJpackage produces.
-tasks.register("portableZip", Zip) {
-    dependsOn tasks.named("fullJpackage")
-    def appDir = (hostOs == "mac") ? "PcGen.app" : "PcGen"
-    from(layout.buildDirectory.dir("jpackage/${appDir}")) {
-        into appDir
+//
+// On macOS the bundle is packed with `ditto -c -k --keepParent` rather than
+// Gradle's Zip task: ditto preserves the 0755 exec bits on
+// Contents/MacOS/MacDirLauncher and Contents/MacOS/PcGen, plus symlinks,
+// xattrs, and code signatures. Plain Zip strips POSIX modes, leaving the
+// .app non-launchable after unzip ("application can't be opened").
+if (hostOs == "mac") {
+    tasks.register("portableZip", Exec) {
+        dependsOn tasks.named("fullJpackage")
+        def archive = layout.buildDirectory.file(
+                "jpackage/pcgen-${version}-${hostOs}-${hostArch}-portable.zip")
+        def appBundle = layout.buildDirectory.dir("jpackage/PcGen.app")
+        inputs.dir(appBundle)
+        outputs.file(archive)
+        // ditto -c -k overwrites an existing archive silently; no pre-delete needed.
+        commandLine "ditto", "-c", "-k", "--keepParent",
+                appBundle.get().asFile.absolutePath,
+                archive.get().asFile.absolutePath
     }
-    archiveFileName = "pcgen-${version}-${hostOs}-${hostArch}-portable.zip"
-    destinationDirectory = layout.buildDirectory.dir("jpackage")
+} else {
+    tasks.register("portableZip", Zip) {
+        dependsOn tasks.named("fullJpackage")
+        from(layout.buildDirectory.dir("jpackage/PcGen")) {
+            into "PcGen"
+        }
+        archiveFileName = "pcgen-${version}-${hostOs}-${hostArch}-portable.zip"
+        destinationDirectory = layout.buildDirectory.dir("jpackage")
+    }
 }
 
 // Create the Data Convertor JAR.


### PR DESCRIPTION
## Summary

The macOS nightly artifact (`pcgen-*-mac-*-portable.zip`) ships a `.app` bundle that cannot be launched after extraction. Double-clicking it gives the generic "The application \"PcGen.app\" can't be opened" Finder dialog.

## Root cause

`build.gradle:466` uses Gradle's built-in `Zip` task to pack the bundle. Plain ZIP strips POSIX file modes from archive entries, so on extraction:

- `PcGen.app/Contents/MacOS/MacDirLauncher` (the bash shim that `cd`s into `Contents/app` and execs the real binary) loses its `0755` mode.
- `PcGen.app/Contents/MacOS/PcGen` (the Mach-O launched by jpackage) loses it too.

macOS refuses to launch a bundle whose `CFBundleExecutable` isn't executable, hence the dialog. Verified locally with the latest nightly: both files arrived as `-rw-r--r--` with `Feb 1 1980` timestamps (the ZIP epoch default).

## Fix

Use `ditto -c -k --keepParent` for the macOS branch instead of `Zip`. `ditto` is Apple's canonical archiver for `.app` bundles — it preserves Unix modes, symlinks, extended attributes, and code-signature metadata that plain ZIP discards. Linux/Windows continue to use Gradle's `Zip` task; their executables don't depend on a Unix exec bit.

## Verification

Locally on macOS arm64, after the fix:

```
$ unzip -Z build/jpackage/pcgen-*-mac-*-portable.zip 'PcGen.app/Contents/MacOS/*'
-rwxr-xr-x  2.1 unx   223936 bX defN 26-Jun-17 22:44 PcGen.app/Contents/MacOS/PcGen
-rwxr-xr-x  2.1 unx       57 bX defN 26-Jun-17 22:45 PcGen.app/Contents/MacOS/MacDirLauncher
```

- Exec bits preserved (`-rwxr-xr-x`)
- Real timestamps, not 1980
- `_CodeSignature/` block intact (matters once builds start being signed)

Extracting with `ditto -x -k` round-trips cleanly and the bundle launches.

## Notes

- Gatekeeper will still reject unsigned nightlies (`source=no usable signature`); that's a separate Apple Developer ID notarisation issue, not packaging. Users currently work around it with `xattr -dr com.apple.quarantine`.
- `Files.deleteIfExists` is used in `doFirst` rather than `project.delete` because the latter trips the Gradle configuration cache (`Invocation of 'delete' references a Gradle script object from a Groovy closure at execution time`).