### PR TITLE
WieldCategory tokens: replace 14-year-old auto-gen TODO with rationale

### DIFF
--- a/code/src/java/plugin/lsttokens/gamemode/wieldcategory/DownToken.java
+++ b/code/src/java/plugin/lsttokens/gamemode/wieldcategory/DownToken.java
@@ -70,7 +70,9 @@ public class DownToken extends AbstractTokenWithSeparator<WieldCategory> impleme
 	@Override
 	public String[] unparse(LoadContext context, WieldCategory wc)
 	{
-		// TODO Auto-generated method stub
+		// Gamemode WieldCategory data is read by WieldCategoryLoader and is
+		// not written back through the CDOM unparse pipeline; this token
+		// family is also superseded by CControl.WIELDCAT + WCSTEPSFORMULA.
 		return null;
 	}
 

--- a/code/src/java/plugin/lsttokens/gamemode/wieldcategory/FinessableToken.java
+++ b/code/src/java/plugin/lsttokens/gamemode/wieldcategory/FinessableToken.java
@@ -64,7 +64,9 @@ public class FinessableToken extends AbstractNonEmptyToken<WieldCategory> implem
 	@Override
 	public String[] unparse(LoadContext context, WieldCategory wc)
 	{
-		// TODO Auto-generated method stub
+		// Gamemode WieldCategory data is read by WieldCategoryLoader and is
+		// not written back through the CDOM unparse pipeline; this token
+		// family is also superseded by CControl.WIELDCAT + WCSTEPSFORMULA.
 		return null;
 	}
 

--- a/code/src/java/plugin/lsttokens/gamemode/wieldcategory/HandsToken.java
+++ b/code/src/java/plugin/lsttokens/gamemode/wieldcategory/HandsToken.java
@@ -63,7 +63,9 @@ public class HandsToken extends AbstractNonEmptyToken<WieldCategory> implements 
 	@Override
 	public String[] unparse(LoadContext context, WieldCategory wc)
 	{
-		// TODO Auto-generated method stub
+		// Gamemode WieldCategory data is read by WieldCategoryLoader and is
+		// not written back through the CDOM unparse pipeline; this token
+		// family is also superseded by CControl.WIELDCAT + WCSTEPSFORMULA.
 		return null;
 	}
 

--- a/code/src/java/plugin/lsttokens/gamemode/wieldcategory/SizediffToken.java
+++ b/code/src/java/plugin/lsttokens/gamemode/wieldcategory/SizediffToken.java
@@ -57,7 +57,9 @@ public class SizediffToken extends AbstractNonEmptyToken<WieldCategory> implemen
 	@Override
 	public String[] unparse(LoadContext context, WieldCategory wc)
 	{
-		// TODO Auto-generated method stub
+		// Gamemode WieldCategory data is read by WieldCategoryLoader and is
+		// not written back through the CDOM unparse pipeline; this token
+		// family is also superseded by CControl.WIELDCAT + WCSTEPSFORMULA.
 		return null;
 	}
 

--- a/code/src/java/plugin/lsttokens/gamemode/wieldcategory/UpToken.java
+++ b/code/src/java/plugin/lsttokens/gamemode/wieldcategory/UpToken.java
@@ -70,7 +70,9 @@ public class UpToken extends AbstractTokenWithSeparator<WieldCategory> implement
 	@Override
 	public String[] unparse(LoadContext context, WieldCategory wc)
 	{
-		// TODO Auto-generated method stub
+		// Gamemode WieldCategory data is read by WieldCategoryLoader and is
+		// not written back through the CDOM unparse pipeline; this token
+		// family is also superseded by CControl.WIELDCAT + WCSTEPSFORMULA.
 		return null;
 	}
 


### PR DESCRIPTION
## Summary

- All five gamemode wieldcategory tokens (`UP`, `DOWN`, `HANDS`, `SIZEDIFF`, `FINESSABLE`) carried `// TODO Auto-generated method stub` above an unimplemented `unparse()` returning `null`.
- Replaced with a 3-line comment documenting why `null` is correct: gamemode `WieldCategory` data is read by `WieldCategoryLoader` from `miscinfo.lst` and is never written back through the CDOM unparse pipeline. The token family is also superseded by `CControl.WIELDCAT` + `WCSTEPSFORMULA` (NEWTAG-624, `dae6184136`).
- No behavior change. `compileJava` clean.

## Why document instead of implement

The IDE-generated stubs date back to commit 299066c22d (2010, *"Wield Category update to new token style"*) — boilerplate produced when the tokens migrated to `CDOMPrimaryToken` and never filled in because no consumer of `unparse()` exists for these tokens. The PCGen wiki page *Formula Parser Conversion - Data* lists this token shape under data being phased out by the formula parser, reinforcing the deprecation framing.

Implementing `unparse` would require adding an accessor for `WieldCategory.wcSteps` plus tests for code paths nothing currently exercises, on a token family slated to disappear. Documenting the intent matches reality with no maintenance surface.

## Test plan

- [x] `./gradlew compileJava` — green
- [x] CI green