### PR TITLE
Gradle cleanups: explicit plugin category names + dedupe buildTimestamp

### DIFF
--- a/code/gradle/autobuild.gradle
+++ b/code/gradle/autobuild.gradle
@@ -1,11 +1,11 @@
-import java.time.LocalDateTime
-
 /*
  * PCGen autobuild generation tasks. This file specifies the way in which the
  * autobuild site is generated and the outputs from other tasks that are to be
  * deployed with the site.
  *
  * Usage: ./gradlew deployAutobuild
+ *
+ * Note: buildTimestamp is defined in distribution.gradle (applied first).
  */
 ext {
     if (System.env.BUILD_NUMBER) {
@@ -13,8 +13,6 @@ ext {
     } else {
         destAutobuildDir = layout.buildDirectory.dir("autobuilds").get()
     }
-
-    buildTimestamp = LocalDateTime.now(Clock.systemUTC())
 }
 
 tasks.register("copyDocs", Sync) {

--- a/code/gradle/plugins.gradle
+++ b/code/gradle/plugins.gradle
@@ -12,7 +12,7 @@ tasks.register("cleanPlugins", Delete) {
     delete fileTree(dir: pluginsDir, include: "*.jar")
 }
 
-def createJarTask = {String taskName, String archiveName, String description, String includePattern ->
+def createJarTask = {String taskName, String archiveName, String categoryName, String description, String includePattern ->
     tasks.register(taskName, Jar) {
         this.description = description
         group = PLUGINS_GROUP
@@ -21,7 +21,7 @@ def createJarTask = {String taskName, String archiveName, String description, St
         archiveFileName = archiveName
         manifest {
             attributes(
-                    "Implementation-Title": "PCGen ${taskName.replace('jar', '').toLowerCase()} plugins",
+                    "Implementation-Title": "PCGen ${categoryName} plugins",
                     "Implementation-Version": project.version,
                     "Class-Path": "lib/pcgen.jar"
             )
@@ -35,17 +35,17 @@ def createJarTask = {String taskName, String archiveName, String description, St
     }
 }
 
-createJarTask("jarExportPlugins", "exportplugins.jar", "Build (Link) Export Token plugin jar files", "plugin/exporttokens/**/*.class")
-createJarTask("jarBonusPlugins", "bonusplugins.jar", "Build (Link) plugin Bonus Token jar files", "plugin/bonustokens/**/*.class")
-createJarTask("jarLstPlugins", "lstplugins.jar", "Build (Link) plugin LST Token jar files", "plugin/lsttokens/**/*.class")
-createJarTask("jarPrePlugins", "preplugins.jar", "Build (Link) Prereq Token plugin jar files", "plugin/pretokens/**/*.class")
-createJarTask("jarConverterPlugins", "converterplugins.jar", "Build (Link) Converter plugin jar files", "plugin/converter/**/*.class")
-createJarTask("jarModifierPlugins", "modifierplugins.jar", "Build (Link) Lst Modifier Token plugin jar files", "plugin/modifier/**/*.class")
-createJarTask("jarPrimitivePlugins", "primitiveplugins.jar", "Build (Link) Lst Primitive Token plugin jar files", "plugin/primitive/**/*.class")
-createJarTask("jarQualifierPlugins", "qualifierplugins.jar", "Build (Link) Lst Compatibility Token plugin jar files", "plugin/qualifier/**/*.class")
-createJarTask("jarFunctionPlugins", "functionplugins.jar", "Build (Link) Custom Function jar files", "plugin/function/**/*.class")
-createJarTask("jarGroupingPlugins", "groupingplugins.jar", "Build (Link) Grouping plugin jar files", "plugin/grouping/**/*.class")
-createJarTask("jarJepCommandsPlugins", "jepcommandsplugins.jar", "Build (Link) Jep Command plugin jar files", "plugin/jepcommands/**/*.class")
+createJarTask("jarExportPlugins", "exportplugins.jar", "export", "Build (Link) Export Token plugin jar files", "plugin/exporttokens/**/*.class")
+createJarTask("jarBonusPlugins", "bonusplugins.jar", "bonus", "Build (Link) plugin Bonus Token jar files", "plugin/bonustokens/**/*.class")
+createJarTask("jarLstPlugins", "lstplugins.jar", "LST", "Build (Link) plugin LST Token jar files", "plugin/lsttokens/**/*.class")
+createJarTask("jarPrePlugins", "preplugins.jar", "prereq", "Build (Link) Prereq Token plugin jar files", "plugin/pretokens/**/*.class")
+createJarTask("jarConverterPlugins", "converterplugins.jar", "converter", "Build (Link) Converter plugin jar files", "plugin/converter/**/*.class")
+createJarTask("jarModifierPlugins", "modifierplugins.jar", "modifier", "Build (Link) Lst Modifier Token plugin jar files", "plugin/modifier/**/*.class")
+createJarTask("jarPrimitivePlugins", "primitiveplugins.jar", "primitive", "Build (Link) Lst Primitive Token plugin jar files", "plugin/primitive/**/*.class")
+createJarTask("jarQualifierPlugins", "qualifierplugins.jar", "qualifier", "Build (Link) Lst Compatibility Token plugin jar files", "plugin/qualifier/**/*.class")
+createJarTask("jarFunctionPlugins", "functionplugins.jar", "function", "Build (Link) Custom Function jar files", "plugin/function/**/*.class")
+createJarTask("jarGroupingPlugins", "groupingplugins.jar", "grouping", "Build (Link) Grouping plugin jar files", "plugin/grouping/**/*.class")
+createJarTask("jarJepCommandsPlugins", "jepcommandsplugins.jar", "JEP command", "Build (Link) Jep Command plugin jar files", "plugin/jepcommands/**/*.class")
 
 tasks.register("jarAllPlugins") {
     description = "Create the plugin jars"


### PR DESCRIPTION
## Summary

Two small, independent gradle cleanups picked up from `TODO.md`:

- **`plugins.gradle`**: `createJarTask` now takes an explicit category-name parameter instead of mangling it out of the task name with `taskName.replace('jar', '').toLowerCase()`. Removes a redundant manifest title ("PCGen exportplugins plugins" → "PCGen export plugins") and a fragile string substitution. `Implementation-Title` is not read by any code in the project, so the wording change is cosmetic.
- **`autobuild.gradle`**: drops the duplicate `buildTimestamp = LocalDateTime.now(...)` assignment. The same `ext` property was also defined in `distribution.gradle:13`, applied first by `build.gradle`. Two clocks ticking seconds apart on a slow runner could disagree. `buildTimestamp` is still consumed by `autobuild.gradle`'s `copySite` task via the inherited ext property.

## Test plan

- [x] `./gradlew jarLstPlugins jarExportPlugins jarPrePlugins jarJepCommandsPlugins` — manifests inspected; titles read "PCGen LST plugins", "PCGen export plugins", "PCGen prereq plugins", "PCGen JEP command plugins".
- [x] `./gradlew tasks --all` — autobuild tasks (`copyDocs`, `copySite`, `deployAutobuild`) still register cleanly after dropping the duplicate `buildTimestamp`.
- [x] No code references `Implementation-Title` in `code/src/java/` or `code/src/test/`.