### PR TITLE
Fix Domains tab showing object/prereq debug text instead of domain names (#6978)

### DIFF
--- a/code/src/java/pcgen/core/QualifiedObject.java
+++ b/code/src/java/pcgen/core/QualifiedObject.java
@@ -108,11 +108,7 @@ public class QualifiedObject<T> extends ConcretePrereqObject implements Qualifyi
 	@Override
 	public String toString()
 	{
-		// TODO Auto-generated method stub
-		return "Object:"
-				+ theObject.toString()
-				+ ", Prereq:"
-				+ getPrerequisiteList().toString();
+		return theObject == null ? "" : theObject.toString();
 	}
 
 	@Override

--- a/code/src/test/pcgen/core/QualifiedObjectTest.java
+++ b/code/src/test/pcgen/core/QualifiedObjectTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 (C) Vest <Vest@users.noreply.github.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards against regression of issue #6978, where the Domains tab rendered
+ * QualifiedObject's debug-format toString instead of the wrapped object's name.
+ */
+class QualifiedObjectTest
+{
+	@Test
+	void toStringDelegatesToWrappedObject()
+	{
+		assertEquals("Air", new QualifiedObject<>("Air").toString());
+	}
+
+	@Test
+	void toStringReturnsEmptyStringForNullWrappedObject()
+	{
+		assertEquals("", new QualifiedObject<>(null).toString());
+	}
+}


### PR DESCRIPTION
## Summary

- Fixes #6978: the Domains tab listed entries like `Object:Air, Prereq:[<prereq operator="GTEQ" operand="1" ...>]` instead of the domain name.
- Root cause: `QualifiedObject.toString()` was a leftover auto-generated debug stub (`"Object:" + theObject + ", Prereq:" + getPrerequisiteList()`). `DomainInfoTab.DomainRenderer` is a `DefaultTableCellRenderer`, which falls back to `value.toString()` for the cell text, so the debug string was rendered directly. The same path also broke `SearchFilterPanel`, which matches search input against `element.toString()`.
- Fix: delegate `QualifiedObject.toString()` to the wrapped object (returning `""` when the wrapped object is `null`). Domain inherits `CDOMObject.toString()` which returns the display name, so the cell now shows "Air", "Animal", … and search starts matching domain names again.
- No callers in `code/src/java` or `code/src/test` rely on the previous debug-format output (verified by search), so this is a safe behavior change.

## Test plan

- [x] New unit test `pcgen.core.QualifiedObjectTest` covers delegation and the null-wrapped case (`./gradlew :test --tests pcgen.core.QualifiedObjectTest` passes).
- [x] Manual: launch PCGen, load *SRD 3.5 for Players*, hit **New**, open the **Domains** tab, and confirm the right-hand list shows plain domain names (Air, Animal, Artifice, …) and that the **Search** field filters by name.