### PR TITLE
build.gradle: drop stale forceMerge entries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -273,8 +273,7 @@ jlink {
     addExtraDependencies('javafx')
     forceMerge('jep', 'fop', 'Saxon-HE',
                'commons-lang3', 'spring',
-               'freemarker', 'argparse4j', 'xmlunit',
-               'annotations', 'spotbugs', 'xmlresolver')
+               'freemarker', 'argparse4j', 'xmlresolver')
 
     // Resolve packages → modules with the JDK's jdeps; the plugin's default
     // resolver silently misses JDK modules on some distros (e.g. Temurin 25).


### PR DESCRIPTION
## Summary

Three of the eleven entries in the badass-jlink-plugin `forceMerge(...)` call in `build.gradle` no longer correspond to anything on `runtimeClasspath`:

- **`xmlunit`** — moved to `testImplementation` in `2c15a069f1`
- **`spotbugs`** — `com.github.spotbugs:spotbugs-annotations` is `compileOnly`
- **`annotations`** — `org.jetbrains:annotations` is `compileOnly`

None of these jars reach `build/jlinkbase/jlinkjars/`, so the substring match in `forceMerge` was finding nothing for them. The list now contains only jars that are actually present in the merge staging dir at jlink time: `jep`, `fop`, `Saxon-HE`, `commons-lang3`, `spring`, `freemarker`, `argparse4j`, `xmlresolver`.

Pure cleanup — no behaviour change.

## Test plan

- [x] `./gradlew clean jlink` — BUILD SUCCESSFUL locally on macOS aarch64 (Temurin 25 JEP 493 JDK).
- [x] Verified `build/jlinkbase/jlinkjars/` contains no `xmlunit-*.jar`, `spotbugs-annotations-*.jar`, or `annotations-*.jar` before and after the change.