### PR TITLE
UserChooseInformation: make immutable, drop setTitle

### DIFF
--- a/code/src/java/pcgen/cdom/base/UserChooseInformation.java
+++ b/code/src/java/pcgen/cdom/base/UserChooseInformation.java
@@ -20,6 +20,7 @@ package pcgen.cdom.base;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import pcgen.cdom.enumeration.AssociationListKey;
 import pcgen.cdom.enumeration.GroupingState;
@@ -30,15 +31,27 @@ import pcgen.rules.context.LoadContext;
 
 import org.jetbrains.annotations.NotNull;
 
-public class UserChooseInformation implements ChooseInformation<String>, Chooser<String>
+public final class UserChooseInformation implements ChooseInformation<String>, Chooser<String>
 {
 
 	public static final String UCI_NAME = "User Input";
 
+	private static final String DEFAULT_TITLE = "Provide User Input";
+
 	/**
-	 * The title (presented to the user) of this ChoiceSet
+	 * The title (presented to the user) of this ChoiceSet.
 	 */
-	private String title = null;
+	private final String title;
+
+	public UserChooseInformation()
+	{
+		this(DEFAULT_TITLE);
+	}
+
+	public UserChooseInformation(String title)
+	{
+		this.title = Objects.requireNonNullElse(title, DEFAULT_TITLE);
+	}
 
 	@Override
 	public Class<String> getReferenceClass()
@@ -79,7 +92,7 @@ public class UserChooseInformation implements ChooseInformation<String>, Chooser
 	@Override
 	public String getTitle()
 	{
-		return title == null ? "Provide User Input" : title;
+		return title;
 	}
 
 	@Override
@@ -162,11 +175,6 @@ public class UserChooseInformation implements ChooseInformation<String>, Chooser
 	public String encodeChoice(String choice)
 	{
 		return choice;
-	}
-
-	public void setTitle(String chooseTitle)
-	{
-		title = chooseTitle;
 	}
 
 	private static AssociationListKey<String> getListKey()

--- a/code/src/java/plugin/lsttokens/choose/UserInputToken.java
+++ b/code/src/java/plugin/lsttokens/choose/UserInputToken.java
@@ -50,7 +50,7 @@ public class UserInputToken implements CDOMSecondaryToken<CDOMObject>
 	@Override
 	public ParseResult parseToken(LoadContext context, CDOMObject obj, String value)
 	{
-		UserChooseInformation ci = new UserChooseInformation();
+		String title;
 		if (value != null)
 		{
 			int pipeLoc = value.indexOf('|');
@@ -84,18 +84,18 @@ public class UserInputToken implements CDOMSecondaryToken<CDOMObject>
 				return new ParseResult.Fail("CHOOSE:" + getTokenName() + " in " + obj.getClass() + ' '
 					+ obj.getKeyName() + " had invalid arguments: " + value);
 			}
-			String title = titleString.substring(6);
+			title = titleString.substring(6);
 			if (title.startsWith("\""))
 			{
 				title = title.substring(1, title.length() - 1);
 			}
-			ci.setTitle(title);
 		}
 		else
 		{
-			ci.setTitle(getDefaultTitle());
+			// No args - legal
+			title = getDefaultTitle();
 		}
-		// No args - legal
+		UserChooseInformation ci = new UserChooseInformation(title);
 		context.getObjectContext().put(obj, ObjectKey.CHOOSE_INFO, ci);
 		return ParseResult.SUCCESS;
 	}


### PR DESCRIPTION
Pass the title via constructor; drop the post-construction setter and the null-default branch in `getTitle()`. The sole caller (`UserInputToken.parseToken`) computes the title up-front and now constructs once.

Makes the class `final` and the `title` field `final`. Eliminates the EI_EXPOSE_REP2 hazard on this `Chooser<String>` implementation: all eight `Chooser<T>` implementations in the codebase are now state-free or constructor-injected only.

## What this looks like

Before:

```java
public class UserChooseInformation ... {
    private String title = null;

    public String getTitle() {
        return title == null ? "Provide User Input" : title;
    }

    public void setTitle(String chooseTitle) {
        title = chooseTitle;
    }
}
```

After:

```java
public final class UserChooseInformation ... {
    private static final String DEFAULT_TITLE = "Provide User Input";
    private final String title;

    public UserChooseInformation() { this(DEFAULT_TITLE); }

    public UserChooseInformation(String title) {
        this.title = Objects.requireNonNullElse(title, DEFAULT_TITLE);
    }

    public String getTitle() { return title; }
}
```

`UserInputToken.parseToken` collapses two `setTitle(...)` branches into a single up-front `title` local and one `new UserChooseInformation(title)` call.

## Verification

- `./gradlew compileJava` clean.
- `:test --tests "plugin.lsttokens.choose.*" --tests "pcgen.cdom.base.*"` — 2149 tests, 0 failures.

## Scope note

Standalone refactor — independent of the other two SpotBugs PRs (#TBD EI suppression, #TBD IMPROPER_UNICODE rewrite).