### PR TITLE
spotbugs_ignore: suppress EI_EXPOSE_REP/REP2 in cdom + output

### DIFF
--- a/code/standards/spotbugs_ignore.xml
+++ b/code/standards/spotbugs_ignore.xml
@@ -38,6 +38,18 @@
     <Bug pattern="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR" />
   </Match>
   <Match>
+    <!-- CDOM is intentionally wired by shared reference: Spring-injected
+         facet singletons, identity-based domain references (CNAbility,
+         ClassSource, Selection, …), and lazy CDOMRef resolvers. Defensive
+         copy is wrong here - it would either break identity equality or
+         clone long-lived collaborators. -->
+    <Or>
+      <Package name="~pcgen[.]cdom.*"/>
+      <Package name="~pcgen[.]output.*"/>
+    </Or>
+    <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2"/>
+  </Match>
+  <Match>
     <Class name="~.*\.*Test"/>
 
     <Not>


### PR DESCRIPTION
The CDOM layer is wired by shared reference by design. The 359 EI_EXPOSE_REP / EI_EXPOSE_REP2 findings under `pcgen.cdom.*` and `pcgen.output.*` break into three shapes, all of which the SpotBugs detector is technically correct about but architecturally wrong to "fix":

- **Spring-injected facet singletons** (~240 of 359). Setter-injected at boot; defensive-copying a long-lived collaborator is incoherent.
- **Identity-based references in helper/event classes** (CNAbility, ClassSource, Selection, *ChangeEvent, …). Hold direct references to domain objects (Ability, PCClass, Spell, …) by design — `equals`/`hashCode` rely on it, cloning would break the identity invariant.
- **`CDOMRef*`** (~38 findings). Lazy "resolve once, then read" lifecycle managed by the reference context, not by the holder.

In every case the flagged "fix" (defensive copy) is wrong. The warning is correct in general but does not apply to this design.

## Filter rule

```xml
<Match>
  <!-- CDOM is intentionally wired by shared reference: Spring-injected
       facet singletons, identity-based domain references (CNAbility,
       ClassSource, Selection, …), and lazy CDOMRef resolvers. Defensive
       copy is wrong here - it would either break identity equality or
       clone long-lived collaborators. -->
  <Or>
    <Package name="~pcgen[.]cdom.*"/>
    <Package name="~pcgen[.]output.*"/>
  </Or>
  <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2"/>
</Match>
```

## SpotBugs count impact

| | Before | After |
|---|---:|---:|
| Total findings | 470 | 111 |
| EI_EXPOSE_REP* | 359 | 0 |
| Other (real candidates) | 111 | 111 |

The remaining 111 are substantive: `IMPROPER_UNICODE` (25 — addressed in a sibling PR), `CT_CONSTRUCTOR_THROW` (29), `SE_BAD_FIELD` (10), real correctness findings (`FE_FLOATING_POINT_EQUALITY` ×2, `ES_COMPARING_STRINGS_WITH_EQ` ×2), etc.

## Why filter rule and not `@SuppressFBWarnings` per field

Three identity-by-design architectural patterns, ~300 affected fields. A filter rule states the project-level decision once, in one place, with rationale. Per-field annotations would scatter the same rationale 300 times.

## Why not `@Immutable` on the relevant interfaces

SpotBugs's `MutableClasses` utility *does* respect `@Immutable` (any annotation whose binary name ends in `/Immutable;`). But:
- `spotbugs-annotations` doesn't ship `@Immutable`. Would require adding `jsr305` or `jcip-annotations` (both defunct).
- It would only suppress findings where the *field's declared type* is annotated. ~2 of the 359 findings are on fields typed `Chooser<T>`; the rest are on mutable types that the JCIP `@Immutable` claim genuinely doesn't fit (facets carry change-support, caches, listener lists).

## TODO at `reporting.gradle:31` stays

`// TODO fix the outstanding bugs and then remove the ignoreFailures` is now substantively closer to actionable, but per established convention the TODO stays until all real findings are resolved.

## Scope note

Standalone — independent of the `UserChooseInformation` immutability PR and the IMPROPER_UNICODE rewrite PR.