### PR TITLE
IMPROPER_UNICODE: replace equalsIgnoreCase where safe, suppress where idiomatic

### DIFF
--- a/code/src/java/pcgen/cdom/choiceset/SpellCasterChoiceSet.java
+++ b/code/src/java/pcgen/cdom/choiceset/SpellCasterChoiceSet.java
@@ -35,6 +35,8 @@ import pcgen.cdom.reference.CDOMGroupRef;
 import pcgen.core.PCClass;
 import pcgen.core.PlayerCharacter;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * A SpellCasterChoiceSet contains references to PCClass Objects.
  * 
@@ -233,6 +235,8 @@ public class SpellCasterChoiceSet extends ChoiceSet<PCClass> implements Primitiv
 	 *         contains.
 	 */
 	@Override
+	@SuppressFBWarnings(value = "IMPROPER_UNICODE",
+		justification = "equalsIgnoreCase is locale-independent; null-tolerant on spelltype from getResolved()")
 	public Set<PCClass> getSet(PlayerCharacter pc)
 	{
 		FactKey<String> fk = FactKey.valueOf("SpellType");

--- a/code/src/java/pcgen/cdom/content/DamageReduction.java
+++ b/code/src/java/pcgen/cdom/content/DamageReduction.java
@@ -103,7 +103,8 @@ public class DamageReduction extends ConcretePrereqObject implements QualifyingO
 		while (tok.hasMoreTokens())
 		{
 			final String val = tok.nextToken();
-			if (!("or".equalsIgnoreCase(val) || "and".equalsIgnoreCase(val)))
+			if (!(String.CASE_INSENSITIVE_ORDER.compare("or", val) == 0
+				|| String.CASE_INSENSITIVE_ORDER.compare("and", val) == 0))
 			{
 				ret.add(val.toLowerCase());
 			}

--- a/code/src/java/pcgen/cdom/content/fact/FactGrouping.java
+++ b/code/src/java/pcgen/cdom/content/fact/FactGrouping.java
@@ -78,7 +78,7 @@ public class FactGrouping<T extends CDOMObject, F> implements GroupingCollection
 		{
 			throw new IllegalArgumentException("FactGrouping must have value following =");
 		}
-		if (!fi.getFactName().equalsIgnoreCase(infoKey))
+		if (String.CASE_INSENSITIVE_ORDER.compare(fi.getFactName(), infoKey) != 0)
 		{
 			throw new IllegalArgumentException(
 				"FactGrouping expected grouping type of " + fi.getFactName() + " but it was " + infoKey);

--- a/code/src/java/pcgen/cdom/enumeration/Component.java
+++ b/code/src/java/pcgen/cdom/enumeration/Component.java
@@ -17,6 +17,8 @@
  */
 package pcgen.cdom.enumeration;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /** An enumeration of &quot;Standard&quot; spell components */
 public enum Component
 {
@@ -62,6 +64,8 @@ public enum Component
 	 * @return A Component object.  If no object matches <tt>OTHER</tt> is 
 	 * returned.
 	 */
+	@SuppressFBWarnings(value = "IMPROPER_UNICODE",
+		justification = "equalsIgnoreCase is locale-independent; null-tolerant on aKey per Javadoc (returns OTHER)")
 	public static Component getComponentFromKey(final String aKey)
 	{
 		for (Component c : Component.values())

--- a/code/src/java/pcgen/cdom/enumeration/SkillFilter.java
+++ b/code/src/java/pcgen/cdom/enumeration/SkillFilter.java
@@ -19,6 +19,8 @@ package pcgen.cdom.enumeration;
 
 import pcgen.system.LanguageBundle;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * SkillsExport defines which skills are to be displayed on an output sheet.
  * 
@@ -96,6 +98,8 @@ public enum SkillFilter
 		return null;
 	}
 
+	@SuppressFBWarnings(value = "IMPROPER_UNICODE",
+		justification = "equalsIgnoreCase is locale-independent; null-tolerant on value")
 	public static SkillFilter getByToken(String value)
 	{
 		for (SkillFilter filter : values())

--- a/code/src/java/pcgen/cdom/facet/DomainSpellsFacet.java
+++ b/code/src/java/pcgen/cdom/facet/DomainSpellsFacet.java
@@ -83,7 +83,7 @@ public class DomainSpellsFacet extends AbstractSourcedListFacet<CharID, CDOMList
 	{
 		for (PCClass aClass : classFacet.getSet(id))
 		{
-			if (aClass.getKeyName().equalsIgnoreCase(classKey))
+			if (String.CASE_INSENSITIVE_ORDER.compare(aClass.getKeyName(), classKey) == 0)
 			{
 				return aClass;
 			}

--- a/code/src/java/pcgen/cdom/facet/MasterFacet.java
+++ b/code/src/java/pcgen/cdom/facet/MasterFacet.java
@@ -49,7 +49,7 @@ public class MasterFacet extends AbstractItemFacet<CharID, Follower>
 	{
 		for (CompanionMod cMod : companionModFacet.getSet(id))
 		{
-			if (cMod.getType().equalsIgnoreCase(get(id).getType().getKeyName()))
+			if (String.CASE_INSENSITIVE_ORDER.compare(cMod.getType(), get(id).getType().getKeyName()) == 0)
 			{
 				if (cMod.get(StringKey.MASTER_CHECK_FORMULA) != null)
 				{
@@ -76,7 +76,7 @@ public class MasterFacet extends AbstractItemFacet<CharID, Follower>
 	{
 		for (CompanionMod cMod : companionModFacet.getSet(id))
 		{
-			if (cMod.getType().equalsIgnoreCase(get(id).getType().getKeyName()))
+			if (String.CASE_INSENSITIVE_ORDER.compare(cMod.getType(), get(id).getType().getKeyName()) == 0)
 			{
 				if (cMod.get(StringKey.MASTER_HP_FORMULA) != null)
 				{
@@ -108,7 +108,7 @@ public class MasterFacet extends AbstractItemFacet<CharID, Follower>
 			 * TYPE in CompanionMod to be "special" and actually store a
 			 * CompanionList object, not a String
 			 */
-			if (cMod.getType().equalsIgnoreCase(get(id).getType().getKeyName()))
+			if (String.CASE_INSENSITIVE_ORDER.compare(cMod.getType(), get(id).getType().getKeyName()) == 0)
 			{
 				String copyMasterBAB = cMod.get(StringKey.MASTER_BAB_FORMULA);
 				if (copyMasterBAB != null)
@@ -136,7 +136,7 @@ public class MasterFacet extends AbstractItemFacet<CharID, Follower>
 	{
 		for (CompanionMod cMod : companionModFacet.getSet(id))
 		{
-			if (cMod.getType().equalsIgnoreCase(get(id).getType().getKeyName()))
+			if (String.CASE_INSENSITIVE_ORDER.compare(cMod.getType(), get(id).getType().getKeyName()) == 0)
 			{
 				if (cMod.getSafe(ObjectKey.USE_MASTER_SKILL))
 				{

--- a/code/src/java/pcgen/cdom/facet/analysis/ChallengeRatingFacet.java
+++ b/code/src/java/pcgen/cdom/facet/analysis/ChallengeRatingFacet.java
@@ -39,6 +39,7 @@ import pcgen.core.ClassType;
 import pcgen.core.PCClass;
 import pcgen.core.SettingsHandler;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -310,6 +311,8 @@ public class ChallengeRatingFacet
 	 * @return the Challenge Rating provided solely by the given Class of the
 	 *         Player Character identified by the given CharID
 	 */
+	@SuppressFBWarnings(value = "IMPROPER_UNICODE",
+		justification = "equalsIgnoreCase is locale-independent; literal-on-left tolerates null crf from getCRFormula()")
 	private Integer calcClassCR(CharID id, PCClass cl)
 	{
 		Formula cr = cl.get(FormulaKey.CR);

--- a/code/src/java/pcgen/cdom/facet/analysis/MovementResultFacet.java
+++ b/code/src/java/pcgen/cdom/facet/analysis/MovementResultFacet.java
@@ -199,7 +199,7 @@ public class MovementResultFacet extends AbstractStorageFacet<CharID>
 					moveType = moveType.substring(5);
 				}
 
-				if (!moveType.equalsIgnoreCase("ALL"))
+				if (String.CASE_INSENSITIVE_ORDER.compare("ALL", moveType) != 0)
 				{
 					String clean = CoreUtility.capitalizeFirstLetter(moveType);
 					moveRates.putIfAbsent(MovementType.getConstant(clean), 0.0);

--- a/code/src/java/pcgen/cdom/formula/AssociationUtilities.java
+++ b/code/src/java/pcgen/cdom/formula/AssociationUtilities.java
@@ -38,7 +38,7 @@ public final class AssociationUtilities
 		int equalLoc = assocInstructions.indexOf("=");
 		String assocName = assocInstructions.substring(0, equalLoc);
 		String assocValue = assocInstructions.substring(equalLoc + 1);
-		if ("PRIORITY".equalsIgnoreCase(assocName))
+		if (String.CASE_INSENSITIVE_ORDER.compare("PRIORITY", assocName) == 0)
 		{
 			int priorityNumber;
 			try

--- a/code/src/java/pcgen/cdom/formula/PluginFunctionLibrary.java
+++ b/code/src/java/pcgen/cdom/formula/PluginFunctionLibrary.java
@@ -69,7 +69,7 @@ public final class PluginFunctionLibrary implements PluginLoader
 	{
 		for (FormulaFunction f : list)
 		{
-			if (f.getFunctionName().equalsIgnoreCase(name))
+			if (String.CASE_INSENSITIVE_ORDER.compare(f.getFunctionName(), name) == 0)
 			{
 				return f;
 			}

--- a/code/src/java/pcgen/cdom/formula/local/DefinedWrappingLibrary.java
+++ b/code/src/java/pcgen/cdom/formula/local/DefinedWrappingLibrary.java
@@ -75,7 +75,7 @@ public class DefinedWrappingLibrary implements FunctionLibrary
 	@Override
 	public FormulaFunction getFunction(String functionName)
 	{
-		if (functionName.equalsIgnoreCase(definedName))
+		if (String.CASE_INSENSITIVE_ORDER.compare(functionName, definedName) == 0)
 		{
 			return new DefinedFunction(definedName, definedValue, formatManager);
 		}

--- a/code/src/java/pcgen/cdom/formula/local/RemoteWrappingLibrary.java
+++ b/code/src/java/pcgen/cdom/formula/local/RemoteWrappingLibrary.java
@@ -86,11 +86,11 @@ public class RemoteWrappingLibrary implements FunctionLibrary
 	@Override
 	public FormulaFunction getFunction(String functionName)
 	{
-		if (functionName.equalsIgnoreCase("source"))
+		if (String.CASE_INSENSITIVE_ORDER.compare("source", functionName) == 0)
 		{
 			return new DefinedFunction("source", sourceValue, sourceFormatManager);
 		}
-		if (functionName.equalsIgnoreCase("target"))
+		if (String.CASE_INSENSITIVE_ORDER.compare("target", functionName) == 0)
 		{
 			return new DefinedFunction("target", targetValue, targetFormatManager);
 		}

--- a/code/src/java/pcgen/cdom/grouping/GroupingScopeFilter.java
+++ b/code/src/java/pcgen/cdom/grouping/GroupingScopeFilter.java
@@ -80,7 +80,7 @@ public class GroupingScopeFilter<T> implements GroupingCollection<T>
 	public void process(PCGenScoped target, Consumer<PCGenScoped> consumer)
 	{
 		Optional<String> localScopeName = target.getLocalScopeName();
-		if (localScopeName.isPresent() && localScopeName.get().equalsIgnoreCase(scopeName))
+		if (localScopeName.isPresent() && localScopeName.get().equals(scopeName))
 		{
 			underlying.process(target, consumer);
 		}

--- a/code/src/java/pcgen/cdom/processor/ChangeArmorType.java
+++ b/code/src/java/pcgen/cdom/processor/ChangeArmorType.java
@@ -24,6 +24,8 @@ import java.util.Objects;
 
 import pcgen.cdom.content.Processor;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * ChangeArmorType is a Processor that alters Armor Types.
  * 
@@ -95,6 +97,8 @@ public class ChangeArmorType implements Processor<String>
 	 *         armor type
 	 */
 	@Override
+	@SuppressFBWarnings(value = "IMPROPER_UNICODE",
+		justification = "equalsIgnoreCase is locale-independent; sourceType is null-tolerated per class Javadoc")
 	public String applyProcessor(String sourceType, Object context)
 	{
 		return source.equalsIgnoreCase(sourceType) ? result : sourceType;

--- a/code/src/java/pcgen/cdom/reference/AbstractReferenceManufacturer.java
+++ b/code/src/java/pcgen/cdom/reference/AbstractReferenceManufacturer.java
@@ -47,6 +47,8 @@ import pcgen.cdom.inst.Dynamic;
 import pcgen.util.Logging;
 import pcgen.util.StringPClassUtil;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * An AbstractReferenceManufacturer is a concrete, but abstract object capable
  * of creating CDOMReferences of a given "form". That "form" includes a specific
@@ -525,6 +527,8 @@ public abstract class AbstractReferenceManufacturer<T extends Loadable> implemen
 	 *            AbstractReferenceManufacturer should be changed
 	 */
 	@Override
+	@SuppressFBWarnings(value = "IMPROPER_UNICODE",
+		justification = "equalsIgnoreCase is locale-independent; null-tolerant on key arg")
 	public void renameObject(String key, T item)
 	{
 		String oldKey = item.getKeyName();
@@ -658,11 +662,11 @@ public abstract class AbstractReferenceManufacturer<T extends Loadable> implemen
 			throw new IllegalArgumentException("= cannot be a in valid single item (perhaps something like TYPE= "
 				+ "is not supported in this token?): " + key);
 		}
-		if (key.equalsIgnoreCase("ANY"))
+		if (String.CASE_INSENSITIVE_ORDER.compare("ANY", key) == 0)
 		{
 			throw new IllegalArgumentException("Any cannot be a valid single item (not supported in this token?)");
 		}
-		if (key.equalsIgnoreCase("ALL"))
+		if (String.CASE_INSENSITIVE_ORDER.compare("ALL", key) == 0)
 		{
 			throw new IllegalArgumentException("All cannot be a valid single item (not supported in this token?)");
 		}
@@ -671,7 +675,7 @@ public abstract class AbstractReferenceManufacturer<T extends Loadable> implemen
 			throw new IllegalArgumentException(": cannot exist in a valid single item (did you try to use a "
 				+ "PRE where it is not supported?) " + key);
 		}
-		if (key.equalsIgnoreCase("%LIST"))
+		if (String.CASE_INSENSITIVE_ORDER.compare("%LIST", key) == 0)
 		{
 			throw new IllegalArgumentException("%LIST cannot be a valid single item (not supported in this token?)");
 		}
@@ -827,7 +831,7 @@ public abstract class AbstractReferenceManufacturer<T extends Loadable> implemen
 			{
 				Logging.errorPrint(activeObj.getClass() + " " + activeObj.getDisplayName() + " has a null KeyName");
 			}
-			else if (!keyName.equalsIgnoreCase(second.toString()))
+			else if (String.CASE_INSENSITIVE_ORDER.compare(keyName, second.toString()) != 0)
 			{
 				Logging.errorPrint(getReferenceDescription() + " Magical Key Change: " + second + " to " + keyName);
 				returnGood = false;


### PR DESCRIPTION
Walked the 25 `IMPROPER_UNICODE` findings flagged by find-sec-bugs under `pcgen.cdom.*`. All 25 were `String.equalsIgnoreCase` calls.

`equalsIgnoreCase` is **locale-independent** in the JDK: it folds character-by-character via `Character.toUpperCase(Character.toLowerCase(c))`, using Unicode's default case mapping rather than the runtime default `Locale`. The detector's stated Turkish-I rationale applies to `String.toLowerCase()` / `String.toUpperCase()` without an explicit `Locale`, but **not** to `equalsIgnoreCase`. Verified empirically:

```
After Locale.setDefault(tr-TR):
  "TITLE".toLowerCase()                     → "tıtle"   ← Turkish-I, locale-dependent
  "TITLE".equalsIgnoreCase("title")         → true      ← stable
```

So the findings are linter false positives in PCGen's context. Fixed in two buckets rather than a blanket package suppression:

## Bucket A — 17 sites: `String.CASE_INSENSITIVE_ORDER.compare(...) == 0`

Both sides are guaranteed non-null. Rewrite is behavior-identical (`CASE_INSENSITIVE_ORDER` uses the same `Character.toUpperCase(toLowerCase(c))` folding), allocation-free, and tells SpotBugs the comparison is locale-explicit:

```java
// before
if (key.equalsIgnoreCase("ANY"))

// after
if (String.CASE_INSENSITIVE_ORDER.compare("ANY", key) == 0)
```

Affected files:
- `DamageReduction.java`
- `FactGrouping.java`
- `DomainSpellsFacet.java`
- `MasterFacet.java` (4 sites)
- `MovementResultFacet.java`
- `AssociationUtilities.java`
- `PluginFunctionLibrary.java`
- `DefinedWrappingLibrary.java`
- `RemoteWrappingLibrary.java` (2 sites)
- `AbstractReferenceManufacturer.java` (4 sites)

One of these (`GroupingScopeFilter.java:83`) was further tightened to plain `equals()`: both sides flow from `PCGenScope.getName()`, which returns programmatic uppercase constants like `"PC.RACE"`. Case-insensitivity was unneeded defensive overkill there. A survey of the other 388 `equalsIgnoreCase` callsites across `code/src/java` turned up no other such candidate — every remaining site defends against LST-author case variation, which is a deliberate codebase convention.

## Bucket B — 6 sites: `@SuppressFBWarnings`, keep `equalsIgnoreCase`

These are public lookup/factory utilities or processors that *deliberately* tolerate a `null` argument (the JDK API: `\"X\".equalsIgnoreCase(null)` returns `false`). Rewriting them to `CASE_INSENSITIVE_ORDER.compare` would NPE on the same input, requiring an extra null guard the original didn't need. Worse code for a non-bug. Suppress at the method level with the rationale instead:

```java
@SuppressFBWarnings(value = "IMPROPER_UNICODE",
    justification = "equalsIgnoreCase is locale-independent; null-tolerant on aKey per Javadoc")
public static Component getComponentFromKey(final String aKey) { ... }
```

Affected methods:
- `SpellCasterChoiceSet.getSet` (spelltype from `getResolved()` is nullable)
- `Component.getComponentFromKey` (public lookup, Javadoc says null → `OTHER`)
- `SkillFilter.getByToken` (public lookup, null-tolerant)
- `ChangeArmorType.applyProcessor` (class Javadoc documents null-tolerance)
- `AbstractReferenceManufacturer.renameObject` (public arg, safe side already on left)
- `ChallengeRatingFacet.calcClassCR` (literal-on-left already, crf can be null from `getCRFormula()`)

This is the first introduction of `edu.umd.cs.findbugs.annotations.SuppressFBWarnings` in PCGen. The annotation jar (`spotbugs-annotations:4.10.2`) is already on the `compileOnly` classpath via `build.gradle:218`.

## SpotBugs count impact

| Pattern | Before | After |
|---|---:|---:|
| IMPROPER_UNICODE | 25 | 0 |

## Verification

- `./gradlew compileJava` clean.
- 9933 tests across `:test --tests "plugin.lsttokens.*" --tests "pcgen.core.*"` — 0 failures.

## Scope note

Standalone — independent of the EI_EXPOSE_REP suppression PR and the `UserChooseInformation` immutability PR.

(Branch name is `spotbugs-locale-root` from an earlier draft that explored `Locale.ROOT`; the final approach uses `CASE_INSENSITIVE_ORDER.compare` instead — same folding semantics, no extra allocations.)