### PR TITLE
CDOM: mark 20 leaf classes final to clear CT_CONSTRUCTOR_THROW

### DIFF
--- a/code/src/java/pcgen/cdom/base/BasicClassIdentity.java
+++ b/code/src/java/pcgen/cdom/base/BasicClassIdentity.java
@@ -26,7 +26,7 @@ import java.util.Objects;
  * @param <T>
  *            The Format (Class) of the object represented by this ClassIdentity.
  */
-public class BasicClassIdentity<T> implements ClassIdentity<T>
+public final class BasicClassIdentity<T> implements ClassIdentity<T>
 {
 
 	/**

--- a/code/src/java/pcgen/cdom/base/SpellLevelChooseInformation.java
+++ b/code/src/java/pcgen/cdom/base/SpellLevelChooseInformation.java
@@ -44,7 +44,7 @@ import org.jetbrains.annotations.NotNull;
  * file when saved. Thus, encoding and decoding (to a 'persistent' string)
  * methods are provided.
  */
-public class SpellLevelChooseInformation implements ChooseInformation<SpellLevel>
+public final class SpellLevelChooseInformation implements ChooseInformation<SpellLevel>
 {
 
 	private final List<SpellLevelInfo> info;

--- a/code/src/java/pcgen/cdom/choiceset/AbilityRefChoiceSet.java
+++ b/code/src/java/pcgen/cdom/choiceset/AbilityRefChoiceSet.java
@@ -55,7 +55,7 @@ import pcgen.output.channel.ChannelUtilities;
  * AbilityRefChoiceSet. The contents of a AbilityRefChoiceSet is fixed, and will
  * not vary by the PlayerCharacter used to resolve the AbilityRefChoiceSet.
  */
-public class AbilityRefChoiceSet implements PrimitiveChoiceSet<CNAbilitySelection>
+public final class AbilityRefChoiceSet implements PrimitiveChoiceSet<CNAbilitySelection>
 {
 
 	/**

--- a/code/src/java/pcgen/cdom/choiceset/CompoundAndChoiceSet.java
+++ b/code/src/java/pcgen/cdom/choiceset/CompoundAndChoiceSet.java
@@ -40,7 +40,7 @@ import pcgen.util.Logging;
  *            The Class of the underlying objects contained by this
  *            CompoundAndChoiceSet
  */
-public class CompoundAndChoiceSet<T> implements PrimitiveChoiceSet<T>
+public final class CompoundAndChoiceSet<T> implements PrimitiveChoiceSet<T>
 {
 
 	/**

--- a/code/src/java/pcgen/cdom/choiceset/CompoundOrChoiceSet.java
+++ b/code/src/java/pcgen/cdom/choiceset/CompoundOrChoiceSet.java
@@ -41,7 +41,7 @@ import pcgen.util.Logging;
  *            The Class of the underlying objects contained by this
  *            CompoundOrChoiceSet
  */
-public class CompoundOrChoiceSet<T> implements PrimitiveChoiceSet<T>
+public final class CompoundOrChoiceSet<T> implements PrimitiveChoiceSet<T>
 {
 
 	/**

--- a/code/src/java/pcgen/cdom/choiceset/ReferenceChoiceSet.java
+++ b/code/src/java/pcgen/cdom/choiceset/ReferenceChoiceSet.java
@@ -43,7 +43,7 @@ import pcgen.core.PlayerCharacter;
  * @param <T>
  *            The class of object this ReferenceChoiceSet contains.
  */
-public class ReferenceChoiceSet<T> implements PrimitiveChoiceSet<T>
+public final class ReferenceChoiceSet<T> implements PrimitiveChoiceSet<T>
 {
 
 	/**

--- a/code/src/java/pcgen/cdom/choiceset/SimpleChoiceSet.java
+++ b/code/src/java/pcgen/cdom/choiceset/SimpleChoiceSet.java
@@ -43,7 +43,7 @@ import pcgen.core.PlayerCharacter;
  * @param <T>
  *            The class of object this SimpleChoiceSet contains.
  */
-public class SimpleChoiceSet<T> implements PrimitiveChoiceSet<T>
+public final class SimpleChoiceSet<T> implements PrimitiveChoiceSet<T>
 {
 
 	/**

--- a/code/src/java/pcgen/cdom/choiceset/SpellReferenceChoiceSet.java
+++ b/code/src/java/pcgen/cdom/choiceset/SpellReferenceChoiceSet.java
@@ -54,7 +54,7 @@ import pcgen.util.Logging;
  * correct for DomainSpellList references having a "DOMAIN." prefix in order to
  * distinguish them from ClassSpellList references/names
  */
-public class SpellReferenceChoiceSet implements PrimitiveChoiceSet<CDOMListObject<Spell>>
+public final class SpellReferenceChoiceSet implements PrimitiveChoiceSet<CDOMListObject<Spell>>
 {
 	/**
 	 * The underlying Set of CDOMReferences that contain the CDOMListObjects in

--- a/code/src/java/pcgen/cdom/content/ChallengeRating.java
+++ b/code/src/java/pcgen/cdom/content/ChallengeRating.java
@@ -26,7 +26,7 @@ import pcgen.core.SettingsHandler;
  * A ChallengeRating is intended to be a type-safe wrapper for an Formula
  * serving as a challenge rating
  */
-public class ChallengeRating extends ConcretePrereqObject
+public final class ChallengeRating extends ConcretePrereqObject
 {
 
 	/**

--- a/code/src/java/pcgen/cdom/content/HitDie.java
+++ b/code/src/java/pcgen/cdom/content/HitDie.java
@@ -27,7 +27,7 @@ import pcgen.util.Logging;
  * HitDie also provides other methods to support additional features for
  * establish the sequence of HitDie objects.
  */
-public class HitDie extends ConcretePrereqObject implements Comparable<HitDie>
+public final class HitDie extends ConcretePrereqObject implements Comparable<HitDie>
 {
 
 	/**

--- a/code/src/java/pcgen/cdom/content/KnownSpellIdentifier.java
+++ b/code/src/java/pcgen/cdom/content/KnownSpellIdentifier.java
@@ -34,7 +34,7 @@ import pcgen.core.spell.Spell;
  * A KnownSpellIdentifier is an object that identifies Spell objects that are
  * known at a specific spell level. The Spell objects are stored by reference.
  */
-public class KnownSpellIdentifier extends ConcretePrereqObject
+public final class KnownSpellIdentifier extends ConcretePrereqObject
 {
 
 	/**

--- a/code/src/java/pcgen/cdom/content/LevelExchange.java
+++ b/code/src/java/pcgen/cdom/content/LevelExchange.java
@@ -27,7 +27,7 @@ import pcgen.core.PCClass;
  * A LevelExchange is a storage container identifying the level exchange that
  * can take place when a given class is taken.
  */
-public class LevelExchange extends ConcretePrereqObject
+public final class LevelExchange extends ConcretePrereqObject
 {
 
 	/**

--- a/code/src/java/pcgen/cdom/content/fact/FactGroup.java
+++ b/code/src/java/pcgen/cdom/content/fact/FactGroup.java
@@ -37,7 +37,7 @@ import pcgen.rules.context.LoadContext;
  * @param <F>
  *            The Type of the Fact being checked in this FactGroup
  */
-public class FactGroup<T extends CDOMObject, F> implements ObjectContainer<T>
+public final class FactGroup<T extends CDOMObject, F> implements ObjectContainer<T>
 {
 
 	/**

--- a/code/src/java/pcgen/cdom/content/fact/FactGrouping.java
+++ b/code/src/java/pcgen/cdom/content/fact/FactGrouping.java
@@ -33,7 +33,7 @@ import pcgen.cdom.grouping.GroupingInfo;
  * @param <F>
  *            The Type of the Fact being checked in this FactGrouping
  */
-public class FactGrouping<T extends CDOMObject, F> implements GroupingCollection<T>
+public final class FactGrouping<T extends CDOMObject, F> implements GroupingCollection<T>
 {
 
 	/**

--- a/code/src/java/pcgen/cdom/content/factset/FactSetGroup.java
+++ b/code/src/java/pcgen/cdom/content/factset/FactSetGroup.java
@@ -37,7 +37,7 @@ import pcgen.rules.context.LoadContext;
  * @param <F>
  *            The Type of the FactSet being checked in this FactSetGroup
  */
-public class FactSetGroup<T extends CDOMObject, F> implements ObjectContainer<T>
+public final class FactSetGroup<T extends CDOMObject, F> implements ObjectContainer<T>
 {
 
 	/**

--- a/code/src/java/pcgen/cdom/primitive/CompoundAndPrimitive.java
+++ b/code/src/java/pcgen/cdom/primitive/CompoundAndPrimitive.java
@@ -30,7 +30,7 @@ import pcgen.cdom.enumeration.GroupingState;
 import pcgen.core.PlayerCharacter;
 import pcgen.util.Logging;
 
-public class CompoundAndPrimitive<T> implements PrimitiveCollection<T>
+public final class CompoundAndPrimitive<T> implements PrimitiveCollection<T>
 {
 
 	private final Class<? super T> refClass;

--- a/code/src/java/pcgen/cdom/primitive/CompoundOrPrimitive.java
+++ b/code/src/java/pcgen/cdom/primitive/CompoundOrPrimitive.java
@@ -31,7 +31,7 @@ import pcgen.cdom.enumeration.GroupingState;
 import pcgen.core.PlayerCharacter;
 import pcgen.util.Logging;
 
-public class CompoundOrPrimitive<T> implements PrimitiveCollection<T>
+public final class CompoundOrPrimitive<T> implements PrimitiveCollection<T>
 {
 
 	private final Class<? super T> refClass;

--- a/code/src/java/pcgen/cdom/processor/HitDieStep.java
+++ b/code/src/java/pcgen/cdom/processor/HitDieStep.java
@@ -29,7 +29,7 @@ import pcgen.cdom.content.Processor;
  * during construction, the object constructing this HitDieStep is expected to
  * understand if it is setting an upper or lower bound.
  */
-public class HitDieStep implements Processor<HitDie>
+public final class HitDieStep implements Processor<HitDie>
 {
 
 	/**

--- a/code/src/java/pcgen/cdom/reference/PatternMatchingReference.java
+++ b/code/src/java/pcgen/cdom/reference/PatternMatchingReference.java
@@ -38,7 +38,7 @@ import pcgen.cdom.enumeration.GroupingState;
  * @param <T>
  *            The class of object underlying this PatternMatchingReference.
  */
-public class PatternMatchingReference<T extends Loadable> extends CDOMReference<T>
+public final class PatternMatchingReference<T extends Loadable> extends CDOMReference<T>
 {
 
 	/**

--- a/code/src/java/pcgen/cdom/reference/TransparentFactory.java
+++ b/code/src/java/pcgen/cdom/reference/TransparentFactory.java
@@ -39,7 +39,7 @@ import pcgen.cdom.base.Loadable;
  * @param <T>
  *            The type of object managed by this TransparentFactory
  */
-public class TransparentFactory<T extends Loadable> implements ManufacturableFactory<T>
+public final class TransparentFactory<T extends Loadable> implements ManufacturableFactory<T>
 {
 
 	/**


### PR DESCRIPTION
SpotBugs flags constructors that throw exceptions when the class is not final, since a malicious subclass could observe a partially-constructed instance via finalize(). All 20 classes are leaf classes (no extenders in code/src/java or code/src/test), so marking them final is safe and clears the SpotBugs findings without any behavior change.

Verified locally:
- compileJava: BUILD SUCCESSFUL
- tests (pcgen.cdom.*, plugin.lsttokens.choose.*): 4495 tests, 0 failures, 0 errors
- spotbugsMain delta: 470 -> 446 total (-24); all 20 target classes now have 0 CT_CONSTRUCTOR_THROW findings; 5 CT_CONSTRUCTOR_THROW remain in other classes (unchanged baseline)