### PR TITLE
SpotBugs correctness: fix 9 findings in CDOM (FE/ES/NP/EQ)

### DIFF
--- a/code/src/java/pcgen/cdom/base/CategorizedAbilitySelectionChooseInformation.java
+++ b/code/src/java/pcgen/cdom/base/CategorizedAbilitySelectionChooseInformation.java
@@ -21,11 +21,15 @@ import pcgen.cdom.choiceset.CollectionToAbilitySelection;
 import pcgen.cdom.content.AbilitySelection;
 import pcgen.core.AbilityCategory;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * CategorizedAbilitySelectionChooseInformation
- * 
- * 
+ *
+ *
  */
+@SuppressFBWarnings(value = "EQ_DOESNT_OVERRIDE_EQUALS",
+	justification = "casChoiceSet aliases the parent's pcs field; parent equals already compares it")
 public class CategorizedAbilitySelectionChooseInformation extends BasicChooseInformation<AbilitySelection>
 {
 

--- a/code/src/java/pcgen/cdom/base/ChoiceSet.java
+++ b/code/src/java/pcgen/cdom/base/ChoiceSet.java
@@ -30,6 +30,8 @@ import pcgen.cdom.reference.CDOMSingleRef;
 import pcgen.core.AbilityCategory;
 import pcgen.core.PlayerCharacter;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * A ChoiceSet is a named container of a Collection of objects (stored in a
  * PrimitiveChoiceSet).
@@ -216,6 +218,8 @@ public class ChoiceSet<T> extends ConcretePrereqObject implements SelectableSet<
 		return false;
 	}
 
+	@SuppressFBWarnings(value = "EQ_DOESNT_OVERRIDE_EQUALS",
+		justification = "arcs aliases the parent's pcs field; parent equals already compares it")
 	public static class AbilityChoiceSet extends ChoiceSet<CNAbilitySelection>
 	{
 

--- a/code/src/java/pcgen/cdom/base/ConcretePersistentTransitionChoice.java
+++ b/code/src/java/pcgen/cdom/base/ConcretePersistentTransitionChoice.java
@@ -24,17 +24,21 @@ import pcgen.cdom.enumeration.AssociationListKey;
 import pcgen.core.PlayerCharacter;
 import pcgen.rules.context.LoadContext;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * This is a transitional class from PCGen 5.15+ to the final CDOM core. It is
  * provided as convenience to hold a set of choices and the number of choices
  * allowed, prior to final implementation of the new choice system.
- * 
+ *
  * This is a TransitionChoice that is designed to be stored in a PlayerCharacter
  * file when saved. Thus, encoding and decoding (to a 'persistent' string)
  * methods are provided.
- * 
+ *
  * @param <T>
  */
+@SuppressFBWarnings(value = "EQ_DOESNT_OVERRIDE_EQUALS",
+	justification = "choiceActor is a mutable encoding strategy, not identity; parent equals over choices+count is sufficient")
 public class ConcretePersistentTransitionChoice<T> extends ConcreteTransitionChoice<T>
 		implements PersistentTransitionChoice<T>
 {

--- a/code/src/java/pcgen/cdom/choiceset/CollectionToAbilitySelection.java
+++ b/code/src/java/pcgen/cdom/choiceset/CollectionToAbilitySelection.java
@@ -339,14 +339,7 @@ public class CollectionToAbilitySelection implements PrimitiveChoiceSet<AbilityS
 			}
 			if (o instanceof AbilityWithChoice other)
 			{
-				if (choice == null)
-				{
-					if (other.choice != null)
-					{
-						return false;
-					}
-				}
-				return ability.equals(other.ability) && ((choice == other.choice) || choice.equals(other.choice));
+				return ability.equals(other.ability) && Objects.equals(choice, other.choice);
 			}
 			return false;
 		}

--- a/code/src/java/pcgen/cdom/content/AbilitySelection.java
+++ b/code/src/java/pcgen/cdom/content/AbilitySelection.java
@@ -19,6 +19,7 @@ package pcgen.cdom.content;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.StringTokenizer;
 
 import pcgen.cdom.base.CDOMObject;
@@ -211,7 +212,7 @@ public class AbilitySelection extends Selection<Ability, String> implements Comp
 		}
 		String selection = getSelection();
 		String oselection = o.getSelection();
-		if (selection == oselection)
+		if (Objects.equals(selection, oselection))
 		{
 			return 0;
 		}

--- a/code/src/java/pcgen/cdom/facet/BonusSkillRankChangeFacet.java
+++ b/code/src/java/pcgen/cdom/facet/BonusSkillRankChangeFacet.java
@@ -69,7 +69,7 @@ public class BonusSkillRankChangeFacet extends AbstractStorageFacet<CharID>
 			}
 
 			Double oldValue = map.get(s);
-			if ((oldValue == null) || (newValue != oldValue))
+			if ((oldValue == null) || (Double.compare(newValue, oldValue) != 0))
 			{
 				map.put(s, newValue);
 				support.fireSkillRankChange(id, s, oldValue, newValue);

--- a/code/src/java/pcgen/cdom/facet/TotalSkillRankFacet.java
+++ b/code/src/java/pcgen/cdom/facet/TotalSkillRankFacet.java
@@ -64,7 +64,7 @@ public class TotalSkillRankFacet extends AbstractStorageFacet<CharID>
 		Objects.requireNonNull(rank, "Rank cannot be null");
 		Map<Skill, Double> map = getConstructingInfo(id);
 		Double currentRank = map.get(sk);
-		boolean isNew = (currentRank == null) || (rank.doubleValue() != currentRank.doubleValue());
+		boolean isNew = (currentRank == null) || (Double.compare(rank, currentRank) != 0);
 		if (isNew)
 		{
 			map.put(sk, rank);

--- a/code/src/java/pcgen/cdom/inst/AbstractCategory.java
+++ b/code/src/java/pcgen/cdom/inst/AbstractCategory.java
@@ -193,6 +193,10 @@ public abstract class AbstractCategory<T extends Categorized<T>> implements Cate
 	@Override
 	public boolean equals(Object o)
 	{
+		if (o == null)
+		{
+			return false;
+		}
 		if (getClass().equals(o.getClass()))
 		{
 			AbstractCategory<?> other = (AbstractCategory<?>) o;

--- a/code/src/java/pcgen/cdom/list/CompanionList.java
+++ b/code/src/java/pcgen/cdom/list/CompanionList.java
@@ -97,6 +97,10 @@ public class CompanionList extends CDOMListObject<Race> implements Category<Comp
 	@Override
 	public boolean equals(Object o)
 	{
+		if (o == null)
+		{
+			return false;
+		}
 		if (getClass().equals(o.getClass()))
 		{
 			CompanionList other = (CompanionList) o;

--- a/code/src/test/pcgen/cdom/facet/BonusSkillRankChangeFacetTest.java
+++ b/code/src/test/pcgen/cdom/facet/BonusSkillRankChangeFacetTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2026 (C) Vest <Vest@users.noreply.github.com>
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.cdom.facet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.ref.WeakReference;
+import java.util.HashMap;
+import java.util.Map;
+
+import pcgen.cdom.enumeration.CharID;
+import pcgen.cdom.enumeration.DataSetID;
+import pcgen.cdom.facet.BonusSkillRankChangeFacet.SkillRankChangeEvent;
+import pcgen.cdom.facet.BonusSkillRankChangeFacet.SkillRankChangeListener;
+import pcgen.core.Globals;
+import pcgen.core.SettingsHandler;
+import pcgen.core.Skill;
+import pcgen.rules.context.AbstractReferenceContext;
+import pcgen.rules.context.LoadContext;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the Double.compare semantics in BonusSkillRankChangeFacet.reset()
+ * after the SpotBugs FE_FLOATING_POINT_EQUALITY fix (PR #7628).
+ */
+public class BonusSkillRankChangeFacetTest
+{
+	private static LoadContext context;
+	private static Skill skill;
+
+	private CharID id;
+	private final BonusSkillRankChangeFacet facet = new BonusSkillRankChangeFacet();
+	private final SRListener listener = new SRListener();
+	/** Backing values returned by the in-test BonusCheckingFacet. */
+	private Map<String, Double> bonusValues;
+
+	private static final class SRListener implements SkillRankChangeListener
+	{
+		int eventCount;
+		SkillRankChangeEvent lastEvent;
+
+		@Override
+		public void bonusChange(SkillRankChangeEvent event)
+		{
+			eventCount++;
+			lastEvent = event;
+		}
+	}
+
+	@BeforeAll
+	static void staticSetUp()
+	{
+		SettingsHandler.getGameAsProperty().get().clearLoadContext();
+		context = Globals.getContext();
+		AbstractReferenceContext ref = context.getReferenceContext();
+		FacetLibrary.getFacet(LoadContextFacet.class).set(context.getDataSetID(),
+			new WeakReference<>(context));
+		skill = new Skill();
+		skill.setName("TestSkill");
+		ref.importObject(skill);
+	}
+
+	@BeforeEach
+	void setUp()
+	{
+		DataSetID cid = context.getDataSetID();
+		id = CharID.getID(cid);
+		bonusValues = new HashMap<>();
+		facet.addSkillRankChangeListener(listener);
+		facet.setBonusCheckingFacet(new BonusCheckingFacet()
+		{
+			@Override
+			public double getBonus(CharID charID, String bonusType, String bonusName)
+			{
+				return bonusValues.getOrDefault(bonusType + "." + bonusName, 0.0d);
+			}
+		});
+	}
+
+	/** First reset fires once; second reset with same value does not refire. */
+	@Test
+	public void sameValueDoesNotRefire()
+	{
+		bonusValues.put("SKILLRANK." + skill.getKeyName(), 3.0d);
+
+		facet.reset(id);
+		assertEquals(1, listener.eventCount, "first reset should fire one event");
+		assertEquals(3.0d, listener.lastEvent.getNewVal().doubleValue(), 0.0001);
+
+		facet.reset(id);
+		assertEquals(1, listener.eventCount, "same-value reset should not refire");
+	}
+
+	/** Reset with a changed value fires a new event with old/new values. */
+	@Test
+	public void changedValueFiresAgain()
+	{
+		bonusValues.put("SKILLRANK." + skill.getKeyName(), 3.0d);
+		facet.reset(id);
+		assertEquals(1, listener.eventCount);
+
+		bonusValues.put("SKILLRANK." + skill.getKeyName(), 5.0d);
+		facet.reset(id);
+		assertEquals(2, listener.eventCount, "changed value should fire a new event");
+		assertEquals(3.0d, listener.lastEvent.getOldVal().doubleValue(), 0.0001);
+		assertEquals(5.0d, listener.lastEvent.getNewVal().doubleValue(), 0.0001);
+	}
+}

--- a/code/src/test/pcgen/cdom/facet/TotalSkillRankFacetTest.java
+++ b/code/src/test/pcgen/cdom/facet/TotalSkillRankFacetTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 (C) Vest <Vest@users.noreply.github.com>
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.cdom.facet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import pcgen.cdom.enumeration.CharID;
+import pcgen.cdom.enumeration.DataSetID;
+import pcgen.cdom.facet.event.AssociationChangeEvent;
+import pcgen.cdom.facet.event.AssociationChangeListener;
+import pcgen.core.Skill;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the Double.compare semantics in TotalSkillRankFacet.set()
+ * after the SpotBugs FE_FLOATING_POINT_EQUALITY fix (PR #7628).
+ */
+public class TotalSkillRankFacetTest
+{
+	private CharID id;
+	private final TotalSkillRankFacet facet = new TotalSkillRankFacet();
+	private final ACListener listener = new ACListener();
+	private Skill skill;
+
+	private static final class ACListener implements AssociationChangeListener
+	{
+		int eventCount;
+		AssociationChangeEvent lastEvent;
+
+		@Override
+		public void bonusChange(AssociationChangeEvent event)
+		{
+			eventCount++;
+			lastEvent = event;
+		}
+	}
+
+	@BeforeEach
+	void setUp()
+	{
+		DataSetID cid = DataSetID.getID();
+		id = CharID.getID(cid);
+		facet.addAssociationChangeListener(listener);
+		skill = new Skill();
+		skill.setName("TestSkill");
+	}
+
+	/** Setting the same Double value twice stores once and fires once. */
+	@Test
+	public void sameValueIsNotReapplied()
+	{
+		facet.set(id, skill, 3.0d);
+		assertEquals(1, listener.eventCount, "first set should fire");
+		assertEquals(3.0d, facet.get(id, skill), 0.0001);
+
+		facet.set(id, skill, 3.0d);
+		assertEquals(1, listener.eventCount, "same-value set should not refire");
+	}
+
+	/** Setting a different Double value fires again with old/new values. */
+	@Test
+	public void changedValueIsReapplied()
+	{
+		facet.set(id, skill, 3.0d);
+		assertEquals(1, listener.eventCount);
+
+		facet.set(id, skill, 5.0d);
+		assertEquals(2, listener.eventCount, "changed value should fire a new event");
+		assertEquals(5.0d, facet.get(id, skill), 0.0001);
+		assertEquals(3.0d, listener.lastEvent.getOldVal().doubleValue(), 0.0001);
+		assertEquals(5.0d, listener.lastEvent.getNewVal().doubleValue(), 0.0001);
+	}
+}

--- a/code/src/test/pcgen/cdom/inst/AbstractCategoryEqualsNullTest.java
+++ b/code/src/test/pcgen/cdom/inst/AbstractCategoryEqualsNullTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 (C) Vest <Vest@users.noreply.github.com>
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.cdom.inst;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the equals(null) contract for AbstractCategory subclasses
+ * after the SpotBugs NP_EQUALS fix (PR #7628).
+ */
+public class AbstractCategoryEqualsNullTest
+{
+
+	/** equals(null) returns false instead of throwing NPE. */
+	@Test
+	public void equalsNullReturnsFalseNotNPE()
+	{
+		DynamicCategory category = new DynamicCategory();
+		category.setName("Movement");
+		assertFalse(category.equals(null));
+	}
+}

--- a/code/src/test/pcgen/cdom/list/CompanionListEqualsNullTest.java
+++ b/code/src/test/pcgen/cdom/list/CompanionListEqualsNullTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 (C) Vest <Vest@users.noreply.github.com>
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.cdom.list;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the equals(null) contract for CompanionList after the
+ * SpotBugs NP_EQUALS fix (PR #7628).
+ */
+public class CompanionListEqualsNullTest
+{
+
+	/** equals(null) returns false instead of throwing NPE. */
+	@Test
+	public void equalsNullReturnsFalseNotNPE()
+	{
+		CompanionList list = new CompanionList();
+		list.setName("Test");
+		assertFalse(list.equals(null));
+	}
+}


### PR DESCRIPTION
Fixes 9 SpotBugs correctness findings in CDOM:

- **FE_FLOATING_POINT_EQUALITY** (2): `BonusSkillRankChangeFacet.reset`, `TotalSkillRankFacet.set`. Replace `newValue != oldValue` on double/Double with `Double.compare(...) != 0` so the facets fire change events iff the value actually changed (handles NaN and signed-zero correctly).
- **ES_COMPARING_STRINGS_WITH_EQ** (2): `CollectionToAbilitySelection.AbilityWithChoice.equals` and `AbilitySelection.compareTo`. Replace `String == String` with `Objects.equals`, which keeps the identity fast-path and handles null safely.
- **NP_EQUALS_SHOULD_HANDLE_NULL_ARGUMENT** (2): `AbstractCategory.equals`, `CompanionList.equals`. Both started with `getClass().equals(o.getClass())` which NPEs on `equals(null)`; added the required leading null check.
- **EQ_DOESNT_OVERRIDE_EQUALS** (3): `CategorizedAbilitySelectionChooseInformation`, `ChoiceSet.AbilityChoiceSet`, `ConcretePersistentTransitionChoice`. In each case the subclass adds a field that does not affect equality (either it aliases a parent field already compared, or it's a mutable strategy that would break hashCode stability). Suppressed via `@SuppressFBWarnings` with one-line rationale, following the convention from a7cd6c15.

### Verification

- `./gradlew compileJava` — clean.
- `./gradlew :test --tests "pcgen.cdom.*" --tests "plugin.lsttokens.choose.*"` — 2349 + 2146 tests, 0 failures.
- SpotBugs delta: 470 → 461 (the 9 specific findings are gone, no new findings).

