### PR TITLE
build.gradle: re-sign Mac bundle ad-hoc after patchMacJpackage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -431,6 +431,7 @@ if (Os.isFamily(Os.FAMILY_MAC)) {
             unix(0755)
         }
         into layout.buildDirectory.dir("jpackage/PcGen.app/Contents/MacOS")
+        def appBundleDir = layout.buildDirectory.dir("jpackage/PcGen.app")
         def plistFile = layout.buildDirectory.file("jpackage/PcGen.app/Contents/Info.plist")
         doLast {
             def plist = plistFile.get().asFile
@@ -439,6 +440,19 @@ if (Os.isFamily(Os.FAMILY_MAC)) {
                 "<key>CFBundleExecutable</key>\n  <string>PcGen</string>",
                 "<key>CFBundleExecutable</key>\n  <string>MacDirLauncher</string>")
             plist.text = content
+
+            // jpackage seals the bundle with an ad-hoc signature; rewriting
+            // Info.plist and dropping MacDirLauncher into Contents/MacOS above
+            // invalidates that seal, so `spctl -a` rejects the result as
+            // "directory or signature have been modified". Re-sign ad-hoc so
+            // the bundle is internally consistent. Users still see Gatekeeper
+            // on first launch (no Developer ID), but a single
+            // `xattr -dr com.apple.quarantine PcGen.app` is then enough —
+            // no `codesign --force --deep` round-trip required.
+            exec {
+                commandLine "codesign", "--force", "--deep", "--sign", "-",
+                        appBundleDir.get().asFile.absolutePath
+            }
         }
     }
 


### PR DESCRIPTION
## Problem

Every release of `PcGen.app` ships with a broken signature on macOS. Running `spctl -a -vv` on a freshly downloaded bundle reports:

```
PcGen.app: invalid resource directory (directory or signature have been modified)
```

This happens *before* quarantine is even considered. Users see "PcGen.app is damaged and can't be opened" on first launch and have to recover with `codesign --force --deep --sign -` or a `ditto` round-trip. The fix doesn't stick because the next download has the same problem.

## Root cause

`jpackage` seals the bundle with an ad-hoc signature. The existing `patchMacJpackage` task then:

1. Rewrites `Contents/Info.plist` to point `CFBundleExecutable` at `MacDirLauncher`.
2. Copies `MacDirLauncher` into `Contents/MacOS/`.

Both modifications happen *after* the seal, invalidating it (`Sealed Resources rules=13` no longer matches the on-disk contents). Re-running jpackage doesn't help — the patch runs after every build.

## Fix

Re-sign the bundle ad-hoc at the end of `patchMacJpackage` so the seal matches the final on-disk layout. One `codesign --force --deep --sign -` in a `doLast` block.

## Scope / what this does not do

- This does **not** make Gatekeeper happy on first launch — that needs a real Developer ID + notarization, which requires a paid Apple Developer account and CI secrets, and is out of scope here.
- It **does** mean a user can recover the bundle with just `xattr -dr com.apple.quarantine PcGen.app` (one command, no `sudo`, no `codesign --force --deep` on the user side). That's the minimum a non-notarized app can offer.

## Verification

- `./gradlew help --task patchMacJpackage` parses cleanly.
- Manual `spctl -a -vv` against a local build was not run (build is ~5-10 min); CI on `macos-latest` will exercise it.

After the change, on a fresh build:

```sh
spctl -a -vv build/jpackage/PcGen.app
# build/jpackage/PcGen.app: accepted    (when xattr is clean)
```