### PR TITLE
Name native installers like the portable zip (version + OS/arch)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,7 @@ Conventions/gotchas observed:
   - `pcgenReleaseOfficial` (pcgenRelease + updateVersionRelease)
   - `updateVersionToNext` (Groovy helper in `releaseUtils.groovy` that bumps the trailing numeric segment by 1, zero-padded to two digits, and appends `-SNAPSHOT`; used by the manual release workflow's post-build bump step).
 - Artifacts collected into build/release; jpackage produces platform installers under build/jpackage.
+- **Artifact filename convention**: `assembleArtifacts` (`code/gradle/release.gradle`) renames the native installers it copies into `build/release` to mirror the portable zip — `pcgen-<version>-<hostOs>-<hostArch>.<ext>` (e.g. `pcgen-6.09.08.RC1-NIGHTLY.20260624-mac-aarch64.dmg`, `pcgen-6.09.08-windows-x64.exe`, `pcgen-6.09.08-linux-x64.deb`). This is a **filename-only** change: jpackage's *internal* `appVersion` is still the sanitised numeric version (`build.gradle:353`, e.g. `6.09.08`) because dmg/exe/deb require a strictly numeric version. The rename relies on `project.ext.hostOs`/`project.ext.hostArch` published in `build.gradle` (the local `def`s aren't visible to the separately-applied `release.gradle`). Workflows upload `build/release/*` (wildcard), so no workflow changes are needed when this convention changes.
 - Release CI builds on: ubuntu-latest (x64), ubuntu-24.04-arm, macos-latest, windows-latest.
 - CI updates `PCGenProp.properties` with version number and release date at build time (per-platform, in-memory, never committed).
 

--- a/build.gradle
+++ b/build.gradle
@@ -277,6 +277,11 @@ def hostArch = supportedHostArch[rawHostArch]
 if (hostArch == null) {
     throw new GradleException("Unsupported host arch: '${rawHostArch}'. Supported: ${supportedHostArch.keySet().join(", ")}")
 }
+// Publish the host tokens so release.gradle (a separately-applied script) can
+// build installer filenames that match the portable zip
+// (pcgen-<version>-<hostOs>-<hostArch>.<ext>).
+project.ext.hostOs = hostOs
+project.ext.hostArch = hostArch
 def hostJdkExt = (hostOs == "windows") ? "zip" : "tar.gz"
 def hostJfxOsPackage = (hostOs == "mac") ? "osx" : hostOs
 def hostJfxArchSuffix = "-${hostArch}"

--- a/code/gradle/release.gradle
+++ b/code/gradle/release.gradle
@@ -43,6 +43,20 @@ tasks.register("assembleArtifacts", Copy) {
     description = "Create the release artifacts and get them into the release folder."
     into releaseDir
 
+    // jpackage names native installers with its sanitised numeric appVersion and
+    // no platform suffix (e.g. pcgen-6.09.08.dmg), which drops the full version
+    // qualifier (e.g. -NIGHTLY.<date>) and the OS/arch. Rename them on the way in
+    // so they mirror the portable zip: pcgen-<version>-<hostOs>-<hostArch>.<ext>.
+    // The installer's *internal* version is untouched (still the numeric
+    // appVersion). Locals keep the closure configuration-cache safe.
+    def fullVersion = version.toString()
+    def osToken = hostOs
+    def archToken = hostArch
+    rename { String name ->
+        def matcher = name =~ /\.(dmg|exe|msi|deb|rpm)$/
+        matcher.find() ? "pcgen-${fullVersion}-${osToken}-${archToken}.${matcher.group(1)}" : name
+    }
+
     from(layout.buildDirectory.dir("libs")){
         include 'pcgen*-sources.jar'
     }


### PR DESCRIPTION
## Summary

`jpackage` names the native installers using its **sanitised numeric** `appVersion` with no platform suffix — e.g. `pcgen-6.09.08.dmg`. For **nightly** builds the human-readable version (`6.09.08.RC1-NIGHTLY.20260624`) is stripped down to `6.09.08`, so the installer:

- loses the `-NIGHTLY.<date>` qualifier (it looks like an official `6.09.08` release), and
- carries no OS/arch.

Meanwhile the **portable zip** is already named `pcgen-<version>-<os>-<arch>-portable.zip`, so the two artifact types are inconsistent.

This renames the native installers (`.dmg`/`.exe`/`.deb`, plus `.msi`/`.rpm` defensively) as `assembleArtifacts` copies them into `build/release`, so they mirror the portable zip:

| Build | Before | After |
|---|---|---|
| Nightly | `pcgen-6.09.08.dmg` | `pcgen-6.09.08.RC1-NIGHTLY.20260624-mac-aarch64.dmg` |
| Official | `pcgen-6.09.08.dmg` | `pcgen-6.09.08-mac-aarch64.dmg` |

**This is a filename-only change.** jpackage's *internal* `appVersion` stays the sanitised numeric value (`6.09.08`) — native installer formats (dmg/exe/deb) require a strictly numeric version — so installers still install correctly. Only the downloadable filename changes.

## Changes

- **`build.gradle`** — publish `project.ext.hostOs` / `project.ext.hostArch` so the separately-applied `release.gradle` can read them (the local `def`s aren't visible there).
- **`code/gradle/release.gradle`** — add a configuration-cache-safe `rename {}` to `assembleArtifacts` that rewrites `*.dmg/.exe/.msi/.deb/.rpm` → `pcgen-<version>-<hostOs>-<hostArch>.<ext>`; the portable zip and sources jar pass through untouched.
- **`AGENTS.md`** — document the convention.

## Scope & compatibility

- Applies to **all** builds (nightly, release, release-manual). The `.dmg`/`.exe` carried no arch before, so adding `-<os>-<arch>` also future-proofs against filename collisions if a second arch per OS is ever added.
- **No workflow changes needed** — all three workflows upload `build/release/*` by wildcard.
- The `.deb` becomes hyphenated (`pcgen-<version>-linux-<arch>.deb`) instead of Debian's `name_version_arch.deb`; fine for standalone GitHub release assets (revisit only if an apt repo is introduced).

## Testing

- Transform logic checked against representative filenames (dmg/exe/deb + portable zip + sources jar): installers renamed, zip/jar untouched.
- `./gradlew :assembleArtifacts --dry-run` configures cleanly; the `ext` host tokens resolve in `release.gradle` (config cache is only disabled by the pre-existing `:buildDashboard` task, unrelated to this change).
- A standalone Gradle `Copy` exercising the exact `rename {}` closure produced the expected filenames at runtime.
