### PR TITLE
SpotBugs concurrency: holder-idiom singleton + volatile flag

### DIFF
--- a/code/src/java/pcgen/cdom/formula/PluginFunctionLibrary.java
+++ b/code/src/java/pcgen/cdom/formula/PluginFunctionLibrary.java
@@ -28,28 +28,28 @@ import pcgen.util.Logging;
 public final class PluginFunctionLibrary implements PluginLoader
 {
 
-	private static PluginFunctionLibrary instance = null;
-
-	private List<FormulaFunction> list = new ArrayList<>();
+	private final List<FormulaFunction> list = new ArrayList<>();
 
 	private PluginFunctionLibrary()
 	{
-		// Don't instantiate utility class
+		// Singleton; use getInstance().
+	}
+
+	/** Lazy holder — JVM class-init guarantees single, thread-safe publication. */
+	private static final class Holder
+	{
+		static final PluginFunctionLibrary INSTANCE = new PluginFunctionLibrary();
 	}
 
 	public static PluginFunctionLibrary getInstance()
 	{
-		if (instance == null)
-		{
-			instance = new PluginFunctionLibrary();
-		}
-		return instance;
+		return Holder.INSTANCE;
 	}
 
 	@Override
-	public void loadPlugin(Class<?> clazz) throws Exception
+	public void loadPlugin(Class<?> clazz) throws ReflectiveOperationException
 	{
-		Object token = clazz.newInstance();
+		Object token = clazz.getDeclaredConstructor().newInstance();
 		if (token instanceof FormulaFunction tok)
 		{
 			FormulaFunction existing = existingFunction(tok.getFunctionName());
@@ -90,10 +90,7 @@ public final class PluginFunctionLibrary implements PluginLoader
 
 	public static void clear()
 	{
-		if (instance != null)
-		{
-			instance.list.clear();
-		}
+		Holder.INSTANCE.list.clear();
 	}
 
 }

--- a/code/src/java/pcgen/cdom/reference/AbstractReferenceManufacturer.java
+++ b/code/src/java/pcgen/cdom/reference/AbstractReferenceManufacturer.java
@@ -66,7 +66,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 public abstract class AbstractReferenceManufacturer<T extends Loadable> implements ReferenceManufacturer<T>
 {
 
-	private boolean isResolved = false;
+	private volatile boolean isResolved = false;
 
 	private final ManufacturableFactory<T> factory;
 

--- a/code/src/test/pcgen/cdom/formula/PluginFunctionLibraryTest.java
+++ b/code/src/test/pcgen/cdom/formula/PluginFunctionLibraryTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2026 (C) Vest <Vest@users.noreply.github.com>
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.cdom.formula;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+
+import pcgen.base.formula.base.DependencyManager;
+import pcgen.base.formula.base.EvaluationManager;
+import pcgen.base.formula.base.FormulaFunction;
+import pcgen.base.formula.base.FormulaSemantics;
+import pcgen.base.formula.parse.Node;
+import pcgen.base.formula.visitor.DependencyVisitor;
+import pcgen.base.formula.visitor.EvaluateVisitor;
+import pcgen.base.formula.visitor.SemanticsVisitor;
+import pcgen.base.formula.visitor.StaticVisitor;
+import pcgen.base.util.FormatManager;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the singleton + plugin-load contract of {@link PluginFunctionLibrary}.
+ *
+ * Single-threaded behavioural coverage; thread-safety of the holder idiom used
+ * by {@link PluginFunctionLibrary#getInstance()} is a JVM-spec guarantee
+ * (class initialisation is single-threaded and publishes a happens-before edge),
+ * not testable from a single-threaded JUnit run.
+ */
+public class PluginFunctionLibraryTest
+{
+
+	@Test
+	public void getInstanceReturnsSameSingleton()
+	{
+		PluginFunctionLibrary first = PluginFunctionLibrary.getInstance();
+		assertNotNull(first);
+		assertSame(first, PluginFunctionLibrary.getInstance());
+	}
+
+	@Test
+	public void pluginClassesIsFormulaFunction()
+	{
+		assertArrayEquals(new Class<?>[]{FormulaFunction.class},
+			PluginFunctionLibrary.getInstance().getPluginClasses());
+	}
+
+	@Test
+	public void loadPluginRegistersFormulaFunction() throws Exception
+	{
+		PluginFunctionLibrary lib = PluginFunctionLibrary.getInstance();
+		int before = lib.getFunctions().size();
+		lib.loadPlugin(TestFunctionAlpha.class);
+		List<FormulaFunction> after = lib.getFunctions();
+		assertEquals(before + 1, after.size());
+		assertTrue(after.stream().anyMatch(TestFunctionAlpha.class::isInstance));
+	}
+
+	@Test
+	public void loadPluginIgnoresNonFormulaFunctionClass() throws Exception
+	{
+		PluginFunctionLibrary lib = PluginFunctionLibrary.getInstance();
+		int before = lib.getFunctions().size();
+		lib.loadPlugin(NotAFormulaFunction.class);
+		assertEquals(before, lib.getFunctions().size());
+	}
+
+	@Test
+	public void loadPluginRejectsDuplicateByNameButDoesNotThrow() throws Exception
+	{
+		PluginFunctionLibrary lib = PluginFunctionLibrary.getInstance();
+		lib.loadPlugin(TestFunctionBeta.class);
+		int afterFirst = lib.getFunctions().size();
+		// Same getFunctionName(), different class — second registration is dropped (logged, not thrown).
+		lib.loadPlugin(TestFunctionBetaDuplicate.class);
+		assertEquals(afterFirst, lib.getFunctions().size());
+	}
+
+	@Test
+	public void loadPluginRejectsNonInstantiableClass()
+	{
+		PluginFunctionLibrary lib = PluginFunctionLibrary.getInstance();
+		// PrivateCtorFunction has no accessible no-arg constructor; reflection must fail
+		// with a checked ReflectiveOperationException (we don't depend on the exact subtype).
+		assertThrows(ReflectiveOperationException.class,
+			() -> lib.loadPlugin(PrivateCtorFunction.class));
+	}
+
+	@Test
+	public void getFunctionsReturnsUnmodifiableView()
+	{
+		List<FormulaFunction> functions = PluginFunctionLibrary.getInstance().getFunctions();
+		assertThrows(UnsupportedOperationException.class,
+			() -> functions.add(new TestFunctionAlpha()));
+	}
+
+	// ── Test fixtures ────────────────────────────────────────────────────────
+
+	/**
+	 * Stub FormulaFunction; concrete subclasses just override {@link #getFunctionName()}.
+	 * All other methods return harmless values — none of them are exercised here.
+	 */
+	private abstract static class StubFunction implements FormulaFunction
+	{
+		@Override
+		public Boolean isStatic(StaticVisitor visitor, Node[] args)
+		{
+			return Boolean.TRUE;
+		}
+
+		@Override
+		public FormatManager<?> allowArgs(SemanticsVisitor visitor, Node[] args, FormulaSemantics semantics)
+		{
+			return null;
+		}
+
+		@Override
+		public Object evaluate(EvaluateVisitor visitor, Node[] args, EvaluationManager manager)
+		{
+			return Integer.valueOf(0);
+		}
+
+		@Override
+		public Optional<FormatManager<?>> getDependencies(DependencyVisitor visitor,
+			DependencyManager manager, Node[] args)
+		{
+			return Optional.empty();
+		}
+	}
+
+	public static class TestFunctionAlpha extends StubFunction
+	{
+		@Override
+		public String getFunctionName()
+		{
+			return "PluginFunctionLibraryTest_Alpha";
+		}
+	}
+
+	public static class TestFunctionBeta extends StubFunction
+	{
+		@Override
+		public String getFunctionName()
+		{
+			return "PluginFunctionLibraryTest_Beta";
+		}
+	}
+
+	/** Same getFunctionName() as TestFunctionBeta — must be rejected as duplicate. */
+	public static class TestFunctionBetaDuplicate extends StubFunction
+	{
+		@Override
+		public String getFunctionName()
+		{
+			return "PluginFunctionLibraryTest_Beta";
+		}
+	}
+
+	/** Not a FormulaFunction — loadPlugin must silently ignore. */
+	public static class NotAFormulaFunction
+	{
+	}
+
+	/** No accessible no-arg constructor — loadPlugin must throw a ReflectiveOperationException. */
+	public static class PrivateCtorFunction extends StubFunction
+	{
+		private PrivateCtorFunction()
+		{
+		}
+
+		@Override
+		public String getFunctionName()
+		{
+			return "PluginFunctionLibraryTest_Private";
+		}
+	}
+}


### PR DESCRIPTION
Four SpotBugs concurrency findings in two files — all real thread-safety concerns.

## Fixes

### `AT_STALE_THREAD_WRITE_OF_PRIMITIVE` — `AbstractReferenceManufacturer.java:69`

`isResolved` was a plain `boolean`, set by the data-load thread in `resolveReferences()` and then read on the variable-binding hot paths (lines 693, 1253) from other threads. Two real failure modes:

1. The reader could keep observing a cached `false` indefinitely on memory architectures with weak ordering.
2. Worse: a reader that *does* observe `true` could still see a half-populated `active` map — the `isResolved = true` write isn't ordered with respect to the prior map writes.

Marked the field `volatile`. The write-once / read-many access pattern doesn't need full `synchronized`; `volatile` gives both visibility and the happens-before edge that orders the prior writes to `active` before any reader who sees `true`.

### `LI_LAZY_INIT_STATIC` + `SING_SINGLETON_GETTER_NOT_SYNCHRONIZED` — `PluginFunctionLibrary.getInstance()`

Classic broken double-init pattern:

```java
private static PluginFunctionLibrary instance = null;
public static PluginFunctionLibrary getInstance() {
    if (instance == null) {                              // ← unsafe read
        instance = new PluginFunctionLibrary();          // ← two threads can both pass
    }
    return instance;
}
```

Replaced with the **Initialization-on-Demand Holder Idiom**:

```java
private static final class Holder {
    static final PluginFunctionLibrary INSTANCE = new PluginFunctionLibrary();
}
public static PluginFunctionLibrary getInstance() {
    return Holder.INSTANCE;
}
```

JVM class-init guarantees the `Holder` is initialised exactly once, lazily on first `getInstance()` call, and publishes a happens-before edge for `INSTANCE`. No `synchronized`, no `volatile`, no allocation overhead. The `instance` static field is gone; the `list` field can now be `final`.

### `THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION` — `PluginFunctionLibrary.loadPlugin`

Narrowed `throws Exception` to `throws ReflectiveOperationException`, which is what `clazz.getDeclaredConstructor().newInstance()` actually throws (covers `NoSuchMethodException`, `InstantiationException`, `IllegalAccessException`, `InvocationTargetException`). Also replaced the deprecated `clazz.newInstance()` with `getDeclaredConstructor().newInstance()`. The impl signature can legally narrow the interface's `throws Exception`.

## Why not `Spring` / `LazyConstant` for the singleton?

Discussed during planning:

- **Spring** is the wiring mechanism for the facet graph (~232 beans) but `PluginFunctionLibrary` is a `PluginLoader`, not a facet — sits next to `PrerequisiteTestFactory.getInstance()`, `PJEP.getJepPluginLoader()`, etc., none of which are Spring beans. Plugin loaders register during `Main.bootstrap` *before* most Spring consumers come up. Adopting Spring here would mean either flipping bootstrap order for one outlier, or doing a project-wide refactor of all `PluginLoader.getInstance()` singletons — out of scope for a SpotBugs fix.
- **`LazyConstant`** (JEP 526, preview in JDK 26) is the JDK's eventual answer but **still preview**, requires `--enable-preview` on every JVM in the toolchain, and the two advantages it brings over the holder idiom (JIT constant-folding, retry-on-init-failure) don't apply here — `getInstance()` is called twice in the codebase against a no-op constructor. The holder idiom is the idiomatic Java answer that's been in *Effective Java* since 1998 and is JVM-spec thread-safe without any preview flag.

## Tests

New `PluginFunctionLibraryTest` (7 tests) pinning:
- Singleton identity (`getInstance()` returns same ref).
- `getPluginClasses()` returns `{ FormulaFunction.class }`.
- `loadPlugin` registers a `FormulaFunction`.
- `loadPlugin` silently ignores non-`FormulaFunction` classes.
- `loadPlugin` rejects duplicate names without throwing.
- `loadPlugin` propagates `ReflectiveOperationException` on a class with no accessible no-arg constructor.
- `getFunctions()` returns an unmodifiable view.

The `volatile` fix is a memory-model property and is **not testable from a single-threaded JUnit run** — writing a stress test that's reliable enough for CI would be more work than the fix and would essentially be testing the JVM spec. Behavioural regression is covered transitively by 2965 `itest` cases that load real data through `AbstractReferenceManufacturer.resolveReferences()`. This is called out in the test class Javadoc.

## Verification

- `./gradlew compileJava` → BUILD SUCCESSFUL
- Scoped `:test --tests "pcgen.cdom.*" --tests "plugin.lsttokens.*"` → **12075 tests, 0 failures**
- `./gradlew :itest` → **2965 tests, 0 failures**
- `./gradlew spotbugsMain` → 4 targeted findings cleared, 0 new findings introduced. Total dropped from 76 → 72.

## Scope note

Standalone — independent of the still-open #7627 (`mark-cdom-classes-final`) and the merged #7624–#7628. Branched off latest `origin/master`.