### PR TITLE
spotbugs: suppress 4 design-intentional findings

### DIFF
--- a/code/src/java/pcgen/cdom/base/FormulaFactory.java
+++ b/code/src/java/pcgen/cdom/base/FormulaFactory.java
@@ -33,6 +33,8 @@ import pcgen.base.util.FormatManager;
 import pcgen.core.Equipment;
 import pcgen.core.PlayerCharacter;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * FormulaFactory is a utility class which creates Formula objects based on the
  * input provided
@@ -324,6 +326,8 @@ public final class FormulaFactory
 	 *            The expression to be interpreted by the formula parser
 	 * @return The NEPFormula representing the given expression
 	 */
+	@SuppressFBWarnings(value = "DCN_NULLPOINTER_EXCEPTION",
+		justification = "NPE is a deliberate signal that the expression is not a simple constant; control falls through to the slower parse path")
 	public static <T> NEPFormula<T> getNEPFormulaFor(FormatManager<T> fmtManager, String expression)
 	{
 		if (expression == null || expression.isEmpty())

--- a/code/src/java/pcgen/cdom/facet/StatValueFacet.java
+++ b/code/src/java/pcgen/cdom/facet/StatValueFacet.java
@@ -35,6 +35,8 @@ import pcgen.core.Globals;
 import pcgen.core.PCStat;
 import pcgen.output.channel.ChannelUtilities;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * StatValueFacet stores the values of PCStat objects (such as Strength is 18) for a
  * Player Character.
@@ -201,6 +203,8 @@ public class StatValueFacet extends AbstractScopeFacet<CharID, PCStat, Number>
 		return ControlUtilities.getControlToken(Globals.getContext(), CControl.STATINPUT);
 	}
 
+	@SuppressFBWarnings(value = "DCN_NULLPOINTER_EXCEPTION",
+		justification = "NPE is caught to translate into an IllegalArgumentException with a clearer error message when a CHANNEL is undefined")
 	private VariableID<Number> getVarID(CharID id, PCStat stat, String channelName)
 	{
 		String varName = ChannelUtilities.createVarName(channelName);

--- a/code/src/java/pcgen/cdom/facet/analysis/MovementResultFacet.java
+++ b/code/src/java/pcgen/cdom/facet/analysis/MovementResultFacet.java
@@ -50,6 +50,8 @@ import pcgen.core.SimpleMovement;
 import pcgen.core.utils.CoreUtility;
 import pcgen.util.enumeration.Load;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * MovementResultFacet stores the resulting movement of a Player Character. Note
  * that this does not store the Movement objects granted by CDOMObjects; rather
@@ -691,6 +693,8 @@ public class MovementResultFacet extends AbstractStorageFacet<CharID>
 		}
 	}
 
+	@SuppressFBWarnings(value = "SE_COMPARATOR_SHOULD_BE_SERIALIZABLE",
+		justification = "Private inner Comparator is never serialized; pcgen does not serialize facet runtime constructs (see spotbugs_ignore.xml SE_BAD_FIELD rule)")
 	private class MoveSorter implements Comparator<NamedValue>
 	{
 

--- a/code/src/java/pcgen/cdom/reference/TransparentFactory.java
+++ b/code/src/java/pcgen/cdom/reference/TransparentFactory.java
@@ -24,6 +24,8 @@ import pcgen.base.lang.UnreachableError;
 import pcgen.cdom.base.ClassIdentity;
 import pcgen.cdom.base.Loadable;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * A TransparentFactory is a ManufacturableFactory that produces Transparent CDOMReference
  * objects. These are CDOMReferences that it will not be reasonable to directly resolve -
@@ -56,6 +58,8 @@ public class TransparentFactory<T extends Loadable> implements ManufacturableFac
 	/**
 	 * Constructs a new TransparentFactory that will process objects of the given Class
 	 */
+	@SuppressFBWarnings(value = "REFLC_REFLECTION_MAY_INCREASE_ACCESSIBILITY_OF_CLASS",
+		justification = "Reflection on refClass is the documented purpose of TransparentFactory: it builds references to CDOM types resolved by name from LST data")
 	public TransparentFactory(String formatRepresentation, Class<T> objClass)
 	{
 		this.formatRepresentation = Objects.requireNonNull(formatRepresentation);


### PR DESCRIPTION
Adds `@SuppressFBWarnings` with one-line rationale to four design-intentional findings:

1. **DCN_NULLPOINTER_EXCEPTION** @ `FormulaFactory.getNEPFormulaFor`
   NPE is a deliberate signal that the expression is not a simple constant; control falls through to the slower parse path.
2. **DCN_NULLPOINTER_EXCEPTION** @ `StatValueFacet.getVarID`
   NPE is caught to translate into an `IllegalArgumentException` with a clearer error message when a CHANNEL is undefined.
3. **SE_COMPARATOR_SHOULD_BE_SERIALIZABLE** @ `MovementResultFacet$MoveSorter`
   Private inner Comparator is never serialized; pcgen does not serialize facet runtime constructs (see `spotbugs_ignore.xml` SE_BAD_FIELD rule).
4. **REFLC_REFLECTION_MAY_INCREASE_ACCESSIBILITY_OF_CLASS** @ `TransparentFactory.<init>`
   Reflection on `refClass` is the documented purpose of `TransparentFactory`: it builds references to CDOM types resolved by name from LST data.

SpotBugs delta verified:
- DCN_NULLPOINTER_EXCEPTION: 2 -> 0 (drop 2)
- SE_COMPARATOR_SHOULD_BE_SERIALIZABLE: 1 -> 0 (drop 1)
- REFLC_REFLECTION_MAY_INCREASE_ACCESSIBILITY_OF_CLASS: 2 -> 1 (drop 1)
- No new findings introduced.

Scoped tests: `./gradlew :test --tests "pcgen.cdom.*"` -> 2355 tests, 0 failures.