### PR TITLE
CDOM: mark CNAbility + CNAbilitySelection final (CT_CONSTRUCTOR_THROW)

### DIFF
--- a/code/src/java/pcgen/cdom/content/CNAbility.java
+++ b/code/src/java/pcgen/cdom/content/CNAbility.java
@@ -38,7 +38,7 @@ import pcgen.core.Ability;
 /**
  * An CNAbility represents an "unresolved" (categorized) Ability &amp; Nature.
  */
-public class CNAbility extends ConcretePrereqObject
+public final class CNAbility extends ConcretePrereqObject
 		implements QualifyingObject, Comparable<CNAbility>, ChooseDriver, Reducible
 {
 

--- a/code/src/java/pcgen/cdom/helper/CNAbilitySelection.java
+++ b/code/src/java/pcgen/cdom/helper/CNAbilitySelection.java
@@ -33,7 +33,7 @@ import pcgen.core.AbilityCategory;
 import pcgen.core.SettingsHandler;
 import pcgen.rules.context.LoadContext;
 
-public class CNAbilitySelection extends ConcretePrereqObject implements QualifyingObject, Reducible
+public final class CNAbilitySelection extends ConcretePrereqObject implements QualifyingObject, Reducible
 {
 
 	private final CNAbility cna;


### PR DESCRIPTION
Same shape as PR #7627, which marked 20 leaf classes final to silence SpotBugs CT_CONSTRUCTOR_THROW. These two classes escaped that PR's net.

Verified via grep that no subclasses exist in `code/src/{java,test,itest,slowtest}`; the only matches for "extends CNAbility" / "extends CNAbilitySelection" are `<? extends ...>` generic wildcards, not class inheritance.

SpotBugs XML delta confirms exactly 3 CT_CONSTRUCTOR_THROW findings cleared (CNAbility one constructor, CNAbilitySelection two constructors), 0 new findings.