### PR TITLE
LoadContextFacet: helper kills 7 redundant NP_NULL findings

### DIFF
--- a/code/src/java/pcgen/cdom/facet/LoadContextFacet.java
+++ b/code/src/java/pcgen/cdom/facet/LoadContextFacet.java
@@ -16,6 +16,7 @@
 package pcgen.cdom.facet;
 
 import java.lang.ref.WeakReference;
+import java.util.Objects;
 
 import pcgen.cdom.base.DataSetInitializedFacet;
 import pcgen.cdom.enumeration.DataSetID;
@@ -37,6 +38,23 @@ public class LoadContextFacet extends AbstractItemFacet<DataSetID, WeakReference
 	public synchronized void initialize(LoadContext context)
 	{
 		set(context.getDataSetID(), new WeakReference<>(context));
+	}
+
+	/**
+	 * Returns the LoadContext for the given DataSetID, centralising the
+	 * WeakReference unwrap that is otherwise repeated at every call site.
+	 *
+	 * <p>The LoadContext is registered during data load (see
+	 * {@link #initialize(LoadContext)}) and the post-init invariant of this
+	 * facet is that it is always present, so a missing value indicates a
+	 * programming error rather than a recoverable condition.</p>
+	 */
+	public LoadContext getLoadContext(DataSetID dsID)
+	{
+		WeakReference<LoadContext> ref = Objects.requireNonNull(get(dsID),
+			() -> "No LoadContext registered for DataSetID " + dsID);
+		return Objects.requireNonNull(ref.get(),
+			() -> "LoadContext for DataSetID " + dsID + " has been garbage-collected");
 	}
 
 	/**

--- a/code/src/java/pcgen/cdom/facet/SolverManagerFacet.java
+++ b/code/src/java/pcgen/cdom/facet/SolverManagerFacet.java
@@ -50,7 +50,7 @@ public class SolverManagerFacet extends AbstractItemFacet<CharID, SolverManager>
 	public <T> boolean addModifier(CharID id, VarModifier<T> vm, VarScoped thisValue, Modifier<T> modifier,
 		ScopeInstance source)
 	{
-		VariableContext varContext = loadContextFacet.get(id.getDatasetID()).get().getVariableContext();
+		VariableContext varContext = loadContextFacet.getLoadContext(id.getDatasetID()).getVariableContext();
 		ScopeInstance scope = resolveScope(id, vm, thisValue, varContext);
 		VariableID<T> varID = (VariableID<T>) varContext.getVariableID(scope, vm.getVarName());
 		SolverManager sm = get(id);
@@ -65,7 +65,7 @@ public class SolverManagerFacet extends AbstractItemFacet<CharID, SolverManager>
 	public <T> void removeModifier(CharID id, VarModifier<T> vm, VarScoped thisValue, Modifier<T> modifier,
 		ScopeInstance source)
 	{
-		VariableContext varContext = loadContextFacet.get(id.getDatasetID()).get().getVariableContext();
+		VariableContext varContext = loadContextFacet.getLoadContext(id.getDatasetID()).getVariableContext();
 		ScopeInstance scope = resolveScope(id, vm, thisValue, varContext);
 		VariableID<T> varID = (VariableID<T>) varContext.getVariableID(scope, vm.getVarName());
 		SolverManager sm = get(id);

--- a/code/src/java/pcgen/cdom/facet/VariableStoreFacet.java
+++ b/code/src/java/pcgen/cdom/facet/VariableStoreFacet.java
@@ -40,7 +40,7 @@ public class VariableStoreFacet extends AbstractItemFacet<CharID, MonitorableVar
 		T value = get(id).get(varID);
 		if (value == null)
 		{
-			return loadContextFacet.get(id.getDatasetID()).get().getVariableContext()
+			return loadContextFacet.getLoadContext(id.getDatasetID()).getVariableContext()
 				.getDefaultValue(varID.getFormatManager());
 		}
 		return value;

--- a/code/src/java/pcgen/cdom/facet/model/SizeFacet.java
+++ b/code/src/java/pcgen/cdom/facet/model/SizeFacet.java
@@ -83,7 +83,7 @@ public class SizeFacet extends AbstractDataFacet<CharID, SizeAdjustment>
 	public int racialSizeInt(CharID id)
 	{
 		String baseSizeControl = ControlUtilities.getControlToken(
-			loadContextFacet.get(id.getDatasetID()).get(), CControl.BASESIZE);
+			loadContextFacet.getLoadContext(id.getDatasetID()), CControl.BASESIZE);
 		if (baseSizeControl != null)
 		{
 			SizeAdjustment baseSize = (SizeAdjustment) resultFacet
@@ -104,7 +104,7 @@ public class SizeFacet extends AbstractDataFacet<CharID, SizeAdjustment>
 	private int calcRacialSizeInt(CharID id)
 	{
 		String baseSizeControl = ControlUtilities.getControlToken(
-			loadContextFacet.get(id.getDatasetID()).get(), CControl.BASESIZE);
+			loadContextFacet.getLoadContext(id.getDatasetID()), CControl.BASESIZE);
 		if (baseSizeControl != null)
 		{
 			SizeAdjustment baseSize = (SizeAdjustment) resultFacet

--- a/code/src/java/pcgen/cdom/formula/VariableUtilities.java
+++ b/code/src/java/pcgen/cdom/formula/VariableUtilities.java
@@ -32,6 +32,8 @@ import pcgen.cdom.facet.event.DataFacetChangeListener;
 import pcgen.rules.context.LoadContext;
 import pcgen.rules.context.VariableContext;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * VariableUtilities are a class for monitoring events on variables.
  */
@@ -73,7 +75,7 @@ public final class VariableUtilities
 	{
 		ScopeInstance globalInstance = SCOPE_FACET.getGlobalScope(id);
 		VariableContext varContext =
-				LOAD_CONTEXT_FACET.get(id.getDatasetID()).get().getVariableContext();
+				LOAD_CONTEXT_FACET.getLoadContext(id.getDatasetID()).getVariableContext();
         return (VariableID<T>) varContext.getVariableID(globalInstance, variableName);
 	}
 
@@ -158,7 +160,7 @@ public final class VariableUtilities
 	public static <T> VariableID<T> getLocalVariableID(CharID id,
 		ScopeInstance scopeInst, String name)
 	{
-		LoadContext loadContext = LOAD_CONTEXT_FACET.get(id.getDatasetID()).get();
+		LoadContext loadContext = LOAD_CONTEXT_FACET.getLoadContext(id.getDatasetID());
 		return (VariableID<T>) loadContext.getVariableContext().getVariableID(scopeInst, name);
 	}
 
@@ -175,6 +177,8 @@ public final class VariableUtilities
 	 *            The name of the variable for which the VariableID should be returned
 	 * @return The VariableID for the variable with the given name on the given object
 	 */
+	@SuppressFBWarnings(value = "BC_UNCONFIRMED_CAST",
+		justification = "VarScoped instances in pcgen are always PCGenScoped (PCGenScoped extends VarScoped)")
 	public static <T> VariableID<T> getLocalVariableID(CharID id, VarScoped owner,
 		String name)
 	{


### PR DESCRIPTION
## Why

Seven SpotBugs `NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE` findings all
trace back to the same idiom

```java
loadContextFacet.get(dsId).get()
```

where the outer `.get(...)` returns `WeakReference<LoadContext>` and
the inner `.get()` unwraps it. Both calls are
`@CheckForNull`-annotated, so SpotBugs flags every call site even
though the post-init invariant of `LoadContextFacet` is that a
`LoadContext` is always registered. These are artefacts of two chained
nullable returns, not real bugs.

## What

Add `LoadContextFacet.getLoadContext(DataSetID)` that centralises the
unwrap chain in one place with one `Objects.requireNonNull` per step.
`requireNonNull` is preferred over a `@SuppressFBWarnings` suppression
because a missing or garbage-collected `LoadContext` is a programming
error rather than a recoverable condition, and the
`NullPointerException` with a descriptive message is more informative
for the caller than the NPE that the inlined idiom would otherwise
raise on the next method invocation.

Refactors 7 callsites to use the helper:
- `SolverManagerFacet.addModifier` / `removeModifier`
- `VariableStoreFacet.getValue`
- `SizeFacet.racialSizeInt` / `calcRacialSizeInt`
- `VariableUtilities.getGlobalVariableID` / `getLocalVariableID(CharID, ScopeInstance, String)`

## Why is `LoadContext` wrapped in `WeakReference` at all?

This wrapping was introduced by Tom Parker in 2018 (`76dbd8f727`,
"Local Functions") and isn't touched by this PR — the helper preserves
it. But it's worth explaining since reviewers may ask "won't GC just
handle this?"

The facet storage backend (`AbstractStorageFacet.CACHE`) is a
**`WeakHashMap`** keyed by `PCGenIdentifier` (here `DataSetID`):

```java
// AbstractStorageFacet.java:77
private static final DoubleKeyMap<PCGenIdentifier, Class<?>, Object> CACHE =
        new DoubleKeyMap<>(WeakHashMap.class, HashMap.class);
```

A `WeakHashMap` only drops an entry once its **key** becomes weakly
reachable — i.e. no strong references to that key exist anywhere,
including from the entry's own value. But a `LoadContext` strongly
references its `DataSetID` via `context.getDataSetID()`. If
`LoadContextFacet` stored the `LoadContext` directly:

```
WeakHashMap<DataSetID, LoadContext>
   ↑                        ↓
   └── DataSetID ←── LoadContext (strong)
```

…the entry's value would forever pin the key alive, the `WeakHashMap`
would never reclaim the entry, and every old `LoadContext` would
survive every data reload. Textbook `WeakHashMap`-cycle leak.

Wrapping the value in `WeakReference<LoadContext>` cuts that strong
back-edge: when external strong references to a particular
`LoadContext` go away (e.g. `GameMode.context` is reassigned during
reload), it becomes weakly reachable, GC collects it, the `DataSetID`
back-reference disappears, the key becomes weakly reachable, and the
`WeakHashMap` entry is finally removed.

So the `WeakReference` isn't general GC paranoia — it's the standard
fix for a known `WeakHashMap` value→key cycle, and the helper
preserves it.

## Bonus

Method-level `@SuppressFBWarnings("BC_UNCONFIRMED_CAST")` on
`VariableUtilities.getLocalVariableID(CharID, VarScoped, String)`:
all `VarScoped` implementations in pcgen are `PCGenScoped`
(`PCGenScoped extends VarScoped`), so the cast is safe.

## SpotBugs delta

- `NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE`: 8 -> 1 (-7)
- `BC_UNCONFIRMED_CAST`: 3 -> 2 (-1)
- No new findings introduced anywhere.

## Tests

- `./gradlew compileJava` -> BUILD SUCCESSFUL
- `./gradlew :test --tests "pcgen.cdom.facet.*" --tests "pcgen.cdom.formula.*"` -> 0 failures