### PR TITLE
Region/Type: add value-equals; DisplayLocation: suppress identity-equals

### DIFF
--- a/code/src/java/pcgen/cdom/enumeration/DisplayLocation.java
+++ b/code/src/java/pcgen/cdom/enumeration/DisplayLocation.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Objects;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import pcgen.base.enumeration.TypeSafeConstant;
 import pcgen.base.util.CaseInsensitiveMap;
 
@@ -155,15 +156,11 @@ public final class DisplayLocation implements TypeSafeConstant, Comparable<Displ
 	}
 
 	@Override
+	@SuppressFBWarnings(value = "EQ_COMPARETO_USE_OBJECT_EQUALS",
+		justification = "Singleton-by-construction via getConstant intern map; "
+			+ "no .equals() callers, not used as a collection key. Identity equality is correct here.")
 	public int compareTo(DisplayLocation type)
 	{
-		/*
-		 * Note: Some tools will report a problem here because Type implements
-		 * compareTo, but does not implement custom implementations of hashCode
-		 * or equals(). Because this is intended as a TypeSafeConstant, and Type
-		 * has a private constructor, it is unnecessary to implement a custom
-		 * hashCode or equals.
-		 */
 		return fieldName.compareTo(type.fieldName);
 	}
 	

--- a/code/src/java/pcgen/cdom/enumeration/Region.java
+++ b/code/src/java/pcgen/cdom/enumeration/Region.java
@@ -29,10 +29,15 @@ import pcgen.base.util.CaseInsensitiveMap;
 import pcgen.cdom.base.Constants;
 
 /**
- * 
  * This Class is a Type Safe Constant. It is designed to hold Regions in a
  * type-safe fashion, so that they can be quickly compared and use less memory
  * when identical Regions exist in two CDOMObjects.
+ *
+ * <p>{@code equals} and {@code hashCode} are case-insensitive on
+ * {@code fieldName} to match {@link #compareTo} (Comparable contract) and to
+ * support use as a {@code HashMap} key — see {@code BioSet}'s
+ * {@code DoubleKeyMap<Optional<Region>, …>} and the {@code .equals()} calls
+ * in {@code RegionFacet.matchesRegion}.</p>
  */
 public final class Region implements TypeSafeConstant, Comparable<Region>
 {

--- a/code/src/java/pcgen/cdom/enumeration/Region.java
+++ b/code/src/java/pcgen/cdom/enumeration/Region.java
@@ -20,6 +20,7 @@ package pcgen.cdom.enumeration;
 import java.lang.reflect.Field;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Locale;
 import java.util.Objects;
 
 import pcgen.base.enumeration.TypeSafeConstant;
@@ -36,22 +37,19 @@ import pcgen.cdom.base.Constants;
 public final class Region implements TypeSafeConstant, Comparable<Region>
 {
 	/**
-	 * This Map contains the mappings from Strings to the Type Safe Constant
-	 */
-	private static CaseInsensitiveMap<Region> typeMap;
-
-	/**
 	 * This is used to provide a unique ordinal to each constant in this class
 	 */
-	private static int ordinalCount;
+	private static int ordinalCount = 0;
 
 	/**
 	 * A "None" region for universal use.
-	 *
-	 * Declared after the mutable counters above so the constructor sees a
-	 * defined `ordinalCount` — silences SpotBugs SI_INSTANCE_BEFORE_FINALS_ASSIGNED.
 	 */
 	public static final Region NONE = new Region(Constants.NONE);
+
+	/**
+	 * This Map contains the mappings from Strings to the Type Safe Constant
+	 */
+	private static CaseInsensitiveMap<Region> typeMap;
 
 	/**
 	 * The name of this Constant
@@ -199,14 +197,20 @@ public final class Region implements TypeSafeConstant, Comparable<Region>
 	@Override
 	public int compareTo(Region region)
 	{
-		/*
-		 * Note: Some tools will report a problem here because Region implements
-		 * compareTo, but does not implement custom implementations of hashCode
-		 * or equals(). Because this is intended as a TypeSafeConstant, and Type
-		 * has a private constructor, it is unnecessary to implement a custom
-		 * hashCode or equals.
-		 */
 		return fieldName.compareToIgnoreCase(region.fieldName);
+	}
+
+	@Override
+	public boolean equals(Object o)
+	{
+		return o instanceof Region other
+			&& String.CASE_INSENSITIVE_ORDER.compare(fieldName, other.fieldName) == 0;
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return fieldName.toLowerCase(Locale.ROOT).hashCode();
 	}
 
 }

--- a/code/src/java/pcgen/cdom/enumeration/Type.java
+++ b/code/src/java/pcgen/cdom/enumeration/Type.java
@@ -28,10 +28,15 @@ import pcgen.base.util.CaseInsensitiveMap;
 import pcgen.cdom.base.Constants;
 
 /**
- * 
  * This Class is a Type Safe Constant. It is designed to hold Types in a
  * type-safe fashion, so that they can be quickly compared and use less memory
  * when identical Types exist in two CDOMObjects.
+ *
+ * <p>{@code equals} and {@code hashCode} are value-based on {@code fieldName}
+ * (case-sensitive, matching {@link #compareTo}). Type is used as a
+ * {@code HashSet}/{@code HashMap} key across the codebase (DataSet, GameMode,
+ * BodyStructure, spell/skill lists, …); the value-equals contract holds even
+ * when an instance is constructed outside the {@link #getConstant} intern map.</p>
  */
 public final class Type implements TypeSafeConstant, Comparable<Type>
 {

--- a/code/src/java/pcgen/cdom/enumeration/Type.java
+++ b/code/src/java/pcgen/cdom/enumeration/Type.java
@@ -213,14 +213,19 @@ public final class Type implements TypeSafeConstant, Comparable<Type>
 	@Override
 	public int compareTo(Type type)
 	{
-		/*
-		 * Note: Some tools will report a problem here because Type implements
-		 * compareTo, but does not implement custom implementations of hashCode
-		 * or equals(). Because this is intended as a TypeSafeConstant, and Type
-		 * has a private constructor, it is unnecessary to implement a custom
-		 * hashCode or equals.
-		 */
 		return fieldName.compareTo(type.fieldName);
+	}
+
+	@Override
+	public boolean equals(Object o)
+	{
+		return o instanceof Type other && fieldName.equals(other.fieldName);
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return fieldName.hashCode();
 	}
 
 	public static void buildMap()


### PR DESCRIPTION
## Summary

Fixes **3 EQ_COMPARETO_USE_OBJECT_EQUALS** and **1 SI_INSTANCE_BEFORE_FINALS_ASSIGNED** findings from SpotBugs in `pcgen.cdom.enumeration`. All three classes (`Region`, `Type`, `DisplayLocation`) implement `Comparable` without overriding `equals`/`hashCode`. Two of them are used as collection keys in production code; the third is not. Fix per case.

## Changes

### Region.java (used as collection key)
- **Added** value-based `equals` and `hashCode` matching the existing case-insensitive `compareTo`.
- `equals` uses `String.CASE_INSENSITIVE_ORDER.compare(...) == 0` (per PR #7626 convention) so the find-sec-bugs IMPROPER_UNICODE rule stays clean.
- `hashCode` folds via `toLowerCase(Locale.ROOT)` for a stable, locale-independent hash consistent with equals.
- **Rearranged** `private static int ordinalCount = 0` above the `NONE` declaration to silence `SI_INSTANCE_BEFORE_FINALS_ASSIGNED` (JLS default-initialises `int` to 0 anyway; pure static-layout cleanup).

**Why safe:** `Region` is used as `Optional<Region>` key in `BioSet.ageMap` / `BioSet.userMap` (`DoubleKeyMap`/`TripleKeyMapToList`) and `.equals()` is called directly in `RegionFacet.matchesRegion`. The `getConstant` intern map already made two `getConstant(name)` calls return the same instance, so the new equals/hashCode strengthens but does not change behaviour for any existing call site.

### Type.java (used as collection key)
- **Added** value-based `equals` and `hashCode` matching the existing case-sensitive `compareTo`.
- `Type` is used as `HashSet<Type>` / `HashMap<Type, ...>` in 8 production files.
- Since `TYPE_MAP` is a `CaseInsensitiveMap`, two distinct `Type` instances with fieldNames differing only in case cannot exist, so case-sensitive equals correctly matches compareTo.

### DisplayLocation.java (not used as collection key)
- **Suppress** with method-level `@SuppressFBWarnings("EQ_COMPARETO_USE_OBJECT_EQUALS")` on `compareTo`.
- Justification: singleton-by-construction via `getConstant` intern map; no `.equals()` callers, not used as a collection key. Identity equality is correct here.

## Verification

- `./gradlew compileJava`: BUILD SUCCESSFUL
- Scoped tests (`pcgen.cdom.enumeration.*`, `pcgen.cdom.facet.*`, `pcgen.cdom.facet.fact.*`, `pcgen.core.*`): **2528 tests, 0 failures, 0 errors**.
- SpotBugs delta (XML report, total `<BugInstance>` rows):
  - Before: 77
  - After: 73
  - **EQ_COMPARETO_USE_OBJECT_EQUALS: 3 -> 0** (Region, Type, DisplayLocation)
  - **SI_INSTANCE_BEFORE_FINALS_ASSIGNED: 1 -> 0** (Region.NONE)
  - **No new findings introduced.**
