### PR TITLE
spotbugs: suppress 6 design-intentional cast/CT findings

### DIFF
--- a/code/src/java/pcgen/cdom/base/ConcretePersistentTransitionChoice.java
+++ b/code/src/java/pcgen/cdom/base/ConcretePersistentTransitionChoice.java
@@ -79,6 +79,8 @@ public class ConcretePersistentTransitionChoice<T> extends ConcreteTransitionCho
 	 *             if the given ChoiceActor is not a PersistentChoiceActor
 	 */
 	@Override
+	@SuppressFBWarnings(value = "BC_UNCONFIRMED_CAST",
+		justification = "API contract documents @throws ClassCastException for non-PersistentChoiceActor; the cast is the contract")
 	public void setChoiceActor(ChoiceActor<T> actor)
 	{
 		choiceActor = (PersistentChoiceActor<T>) actor;

--- a/code/src/java/pcgen/cdom/content/fact/FactGrouping.java
+++ b/code/src/java/pcgen/cdom/content/fact/FactGrouping.java
@@ -24,6 +24,8 @@ import pcgen.cdom.formula.PCGenScoped;
 import pcgen.cdom.grouping.GroupingCollection;
 import pcgen.cdom.grouping.GroupingInfo;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * A FactGrouping is a GroupingCollection that contains objects of a specific type (e.g.
  * Skill) that contain a specific value in a given FACT
@@ -116,6 +118,8 @@ public class FactGrouping<T extends CDOMObject, F> implements GroupingCollection
 	}
 
 	@Override
+	@SuppressFBWarnings(value = "BC_UNCONFIRMED_CAST",
+		justification = "Only CDOMObject can have facts (per in-code comment); type system can't express this constraint as PCGenScoped is the wider interface")
 	public void process(PCGenScoped o, Consumer<PCGenScoped> consumer)
 	{
 		//Cast can not fail (as only CDOMObject can have facts)

--- a/code/src/java/pcgen/cdom/facet/LevelInfoFacet.java
+++ b/code/src/java/pcgen/cdom/facet/LevelInfoFacet.java
@@ -25,6 +25,8 @@ import pcgen.cdom.enumeration.CharID;
 import pcgen.cdom.facet.base.AbstractListFacet;
 import pcgen.core.pclevelinfo.PCLevelInfo;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * LevelInfoFacet stores the PCLevelInfo objects contained in a Player
  * Character. These store information about a specific Level (such as stat
@@ -58,6 +60,8 @@ public class LevelInfoFacet extends AbstractListFacet<CharID, PCLevelInfo>
 	 * @return The object in this LevelInfoFacet for the Player Character
 	 *         represented by the given CharID and location.
 	 */
+	@SuppressFBWarnings(value = "BC_UNCONFIRMED_CAST_OF_RETURN_VALUE",
+		justification = "Facet's own cache; getComponentSet() always returns ArrayList<PCLevelInfo>")
 	public PCLevelInfo get(CharID id, int location)
 	{
 		List<PCLevelInfo> componentSet = (List<PCLevelInfo>) getCachedSet(id);

--- a/code/src/java/pcgen/cdom/facet/analysis/UnencumberedArmorFacet.java
+++ b/code/src/java/pcgen/cdom/facet/analysis/UnencumberedArmorFacet.java
@@ -30,6 +30,8 @@ import pcgen.cdom.facet.event.DataFacetChangeEvent;
 import pcgen.cdom.facet.event.DataFacetChangeListener;
 import pcgen.util.enumeration.Load;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * UnencumberedArmorFacet is a Facet that tracks the Load objects for
  * Unencumbered Armor that have been locked on a Player Character.
@@ -111,6 +113,8 @@ public class UnencumberedArmorFacet extends AbstractSourcedListFacet<CharID, Loa
 	 * @return The best Load value to avoid encumberance from Armor for the
 	 *         Player Character identified by the given CharID.
 	 */
+	@SuppressFBWarnings(value = "BC_UNCONFIRMED_CAST_OF_RETURN_VALUE",
+		justification = "Facet's own cache; getComponentMap() always returns TreeMap<Load, Set<Object>>")
 	public Load getBestLoad(CharID id)
 	{
 		TreeMap<Load, Set<Object>> map = (TreeMap<Load, Set<Object>>) getCachedMap(id);

--- a/code/src/java/pcgen/cdom/facet/analysis/UnencumberedLoadFacet.java
+++ b/code/src/java/pcgen/cdom/facet/analysis/UnencumberedLoadFacet.java
@@ -30,6 +30,8 @@ import pcgen.cdom.facet.event.DataFacetChangeEvent;
 import pcgen.cdom.facet.event.DataFacetChangeListener;
 import pcgen.util.enumeration.Load;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * UnencumberedLoadFacet is a Facet that tracks the Load objects for
  * Unencumbered movement that have been locked on a Player Character.
@@ -111,6 +113,8 @@ public class UnencumberedLoadFacet extends AbstractSourcedListFacet<CharID, Load
 	 * @return The best Load value to avoid encumberance from Load for the
 	 *         Player Character identified by the given CharID.
 	 */
+	@SuppressFBWarnings(value = "BC_UNCONFIRMED_CAST_OF_RETURN_VALUE",
+		justification = "Facet's own cache; getComponentMap() always returns TreeMap<Load, Set<Object>>")
 	public Load getBestLoad(CharID id)
 	{
 		TreeMap<Load, Set<Object>> map = (TreeMap<Load, Set<Object>>) getCachedMap(id);

--- a/code/src/java/pcgen/cdom/reference/AbstractReferenceManufacturer.java
+++ b/code/src/java/pcgen/cdom/reference/AbstractReferenceManufacturer.java
@@ -171,8 +171,10 @@ public abstract class AbstractReferenceManufacturer<T extends Loadable> implemen
 	 * @throws IllegalArgumentException
 	 *             if the given Class is null or the given Class does not have a
 	 *             public, zero argument constructor
-	 * 
+	 *
 	 */
+	@SuppressFBWarnings(value = "CT_CONSTRUCTOR_THROW",
+		justification = "Abstract class; ManufacturableFactory is required and Objects.requireNonNull is the lightest defense against an unusable instance")
 	public AbstractReferenceManufacturer(ManufacturableFactory<T> fac)
 	{
 		if (fac == null)


### PR DESCRIPTION
Add method/constructor-level `@SuppressFBWarnings` with one-line justifications for casts and constructor-throws that are intentional by design.

## Suppressions

| # | Finding | Location | Justification |
|---|---------|----------|---------------|
| 1 | BC_UNCONFIRMED_CAST | `ConcretePersistentTransitionChoice.setChoiceActor` | API contract documents `@throws ClassCastException` for non-PersistentChoiceActor; the cast is the contract |
| 2 | BC_UNCONFIRMED_CAST | `FactGrouping.process` | Only CDOMObject can have facts (per in-code comment); type system can't express this constraint as PCGenScoped is the wider interface |
| 3 | BC_UNCONFIRMED_CAST_OF_RETURN_VALUE | `LevelInfoFacet.get` | Facet's own cache; `getComponentSet()` always returns `ArrayList<PCLevelInfo>` |
| 4 | BC_UNCONFIRMED_CAST_OF_RETURN_VALUE | `UnencumberedArmorFacet.getBestLoad` | Facet's own cache; `getComponentMap()` always returns `TreeMap<Load, Set<Object>>` |
| 5 | BC_UNCONFIRMED_CAST_OF_RETURN_VALUE | `UnencumberedLoadFacet.getBestLoad` | Facet's own cache; `getComponentMap()` always returns `TreeMap<Load, Set<Object>>` |
| 6 | CT_CONSTRUCTOR_THROW | `AbstractReferenceManufacturer` constructor | Abstract class; ManufacturableFactory is required and `Objects.requireNonNull` is the lightest defense against an unusable instance |

## SpotBugs delta (XML-verified)

- BC_UNCONFIRMED_CAST: 3 -> 1 (-2; the third occurrence in VariableUtilities is handled in a separate PR)
- BC_UNCONFIRMED_CAST_OF_RETURN_VALUE: 3 -> 0 (-3)
- CT_CONSTRUCTOR_THROW: 29 -> 28 (-1)
- Total: -6, no new findings

## Validation

- `./gradlew compileJava` -> BUILD SUCCESSFUL
- `./gradlew :test --tests "pcgen.cdom.*"` -> 2355 tests, 0 failures