### PR TITLE
PMD: remove redundant 'implements' (UnnecessaryInterfaceDeclaration)

### DIFF
--- a/code/src/java/pcgen/cdom/base/CDOMObject.java
+++ b/code/src/java/pcgen/cdom/base/CDOMObject.java
@@ -67,8 +67,7 @@ import pcgen.core.analysis.BonusActivation;
 import pcgen.core.bonus.BonusObj;
 
 public abstract class CDOMObject extends ConcretePrereqObject
-		implements Cloneable, BonusContainer, Loadable, Reducible, PCGenScoped, VarHolder,
-		VarContainer
+		implements BonusContainer, Loadable, Reducible, PCGenScoped, VarHolder
 {
 
 	public static final Comparator<CDOMObject> P_OBJECT_COMP =

--- a/code/src/java/pcgen/cdom/enumeration/SubClassCategory.java
+++ b/code/src/java/pcgen/cdom/enumeration/SubClassCategory.java
@@ -30,7 +30,7 @@ import pcgen.core.SubClass;
  * 
  * This Class is a Type Safe Constant.
  */
-public final class SubClassCategory extends AbstractCategory<SubClass> implements TypeSafeConstant, Category<SubClass>
+public final class SubClassCategory extends AbstractCategory<SubClass> implements TypeSafeConstant
 {
 
 	/**

--- a/code/src/java/pcgen/cdom/formula/VariableWrapper.java
+++ b/code/src/java/pcgen/cdom/formula/VariableWrapper.java
@@ -30,7 +30,7 @@ import pcgen.facade.util.ReferenceFacade;
  *            The Format of the information contained in this VariableWrapper
  */
 public final class VariableWrapper<T> extends AbstractReferenceFacade<T>
-		implements VariableListener<T>, ReferenceFacade<T>
+		implements VariableListener<T>
 {
 
 	/**

--- a/code/src/java/pcgen/cdom/inst/Dynamic.java
+++ b/code/src/java/pcgen/cdom/inst/Dynamic.java
@@ -40,7 +40,7 @@ import pcgen.cdom.helper.VarHolderSupport;
  * framework for use in a data driven system.
  */
 public class Dynamic
-		implements Loadable, VarHolder, VarContainer, PCGenScoped, Categorized<Dynamic>
+		implements VarHolder, PCGenScoped, Categorized<Dynamic>
 {
 
 	/**

--- a/code/src/java/pcgen/cdom/inst/PCClassLevel.java
+++ b/code/src/java/pcgen/cdom/inst/PCClassLevel.java
@@ -24,7 +24,7 @@ import pcgen.cdom.enumeration.StringKey;
  * A PCClassLevel is a CDOMObject that represents items gained in a specific
  * level of a PCClass.
  */
-public final class PCClassLevel extends CDOMObject implements Cloneable
+public final class PCClassLevel extends CDOMObject
 {
 
 	@Override

--- a/code/src/java/pcgen/cdom/reference/CDOMGroupRef.java
+++ b/code/src/java/pcgen/cdom/reference/CDOMGroupRef.java
@@ -28,7 +28,7 @@ import pcgen.cdom.base.CDOMReference;
  * @param <T>
  *            The Class of the underlying objects contained by this CDOMGroupRef
  */
-public abstract class CDOMGroupRef<T> extends CDOMReference<T> implements ObjectContainer<T>
+public abstract class CDOMGroupRef<T> extends CDOMReference<T>
 {
 
 	/**

--- a/code/src/java/pcgen/cdom/reference/SimpleReferenceManufacturer.java
+++ b/code/src/java/pcgen/cdom/reference/SimpleReferenceManufacturer.java
@@ -28,7 +28,6 @@ import pcgen.cdom.base.Loadable;
  *            manufacture
  */
 public class SimpleReferenceManufacturer<T extends Loadable> extends AbstractReferenceManufacturer<T>
-		implements ReferenceManufacturer<T>
 {
 	/**
 	 * Constructs a new SimpleReferenceManufacturer that will construct or

--- a/code/src/java/pcgen/core/Ability.java
+++ b/code/src/java/pcgen/core/Ability.java
@@ -38,7 +38,7 @@ import pcgen.persistence.lst.output.prereq.PrerequisiteWriter;
  *
  */
 @SuppressWarnings("serial")
-public final class Ability extends PObject implements Categorized<Ability>, AbilityFacade, Cloneable
+public final class Ability extends PObject implements Categorized<Ability>, AbilityFacade
 {
 	/**
 	 * Get the category of this ability

--- a/code/src/java/pcgen/core/AbilityCategory.java
+++ b/code/src/java/pcgen/core/AbilityCategory.java
@@ -67,7 +67,7 @@ import pcgen.util.enumeration.Visibility;
  * 
  */
 public class AbilityCategory
-		implements Category<Ability>, Loadable, ManufacturableFactory<Ability>
+		implements Category<Ability>, ManufacturableFactory<Ability>
 {
 	private static final ClassIdentity<AbilityCategory> IDENTITY =
 			BasicClassIdentity.getIdentity(AbilityCategory.class);

--- a/code/src/java/pcgen/core/ArmorProf.java
+++ b/code/src/java/pcgen/core/ArmorProf.java
@@ -20,7 +20,7 @@ package pcgen.core;
 
 import pcgen.cdom.base.Ungranted;
 
-public final class ArmorProf extends PObject implements Comparable<Object>, Ungranted
+public final class ArmorProf extends PObject implements Ungranted
 {
 	/**
 	 * Compares keyName only

--- a/code/src/java/pcgen/core/Equipment.java
+++ b/code/src/java/pcgen/core/Equipment.java
@@ -100,7 +100,7 @@ import org.apache.commons.lang3.StringUtils;
  * Represents Equipment for a PC.
  */
 public final class Equipment extends PObject
-		implements Serializable, Comparable<Object>, VariableContainer, EquipmentFacade, PCGenScoped
+		implements Serializable, VariableContainer, EquipmentFacade
 {
 
 	private static final long serialVersionUID = 1;

--- a/code/src/java/pcgen/core/EquipmentModifier.java
+++ b/code/src/java/pcgen/core/EquipmentModifier.java
@@ -45,7 +45,7 @@ import pcgen.util.Delta;
 /**
  * Definition and games rules for an equipment modifier.
  */
-public final class EquipmentModifier extends PObject implements Comparable<Object>, Cloneable
+public final class EquipmentModifier extends PObject
 {
 	private static final String PERCENT_CHOICE_PATTERN = Pattern.quote(Constants.LST_PERCENT_CHOICE);
 	private static final Formula CHOICE_FORMULA = FormulaFactory.getFormulaFor("%CHOICE");

--- a/code/src/java/pcgen/core/Language.java
+++ b/code/src/java/pcgen/core/Language.java
@@ -28,7 +28,7 @@ import pcgen.core.utils.ShowMessageDelegate;
 /**
  * {@code Language}.
  */
-public final class Language extends PObject implements Comparable<Object>, Ungranted, Cloneable
+public final class Language extends PObject implements Ungranted
 {
 	public static final CDOMReference<LanguageList> STARTING_LIST;
 

--- a/code/src/java/pcgen/core/PCCheck.java
+++ b/code/src/java/pcgen/core/PCCheck.java
@@ -24,7 +24,7 @@ import pcgen.cdom.base.NonInteractive;
 import pcgen.cdom.base.SortKeyRequired;
 import pcgen.cdom.enumeration.StringKey;
 
-public final class PCCheck extends PObject implements NonInteractive, SortKeyRequired, VarScoped
+public final class PCCheck extends PObject implements NonInteractive, SortKeyRequired
 {
 	@Override
 	public Optional<String> getLocalScopeName()

--- a/code/src/java/pcgen/core/PCClass.java
+++ b/code/src/java/pcgen/core/PCClass.java
@@ -81,7 +81,7 @@ import pcgen.util.enumeration.AttackType;
 import org.apache.commons.lang3.StringUtils;
 
 
-public class PCClass extends PObject implements InfoFacade, Cloneable
+public class PCClass extends PObject implements InfoFacade
 {
 
 	public static final CDOMReference<DomainList> ALLOWED_DOMAINS;

--- a/code/src/java/pcgen/core/PCStat.java
+++ b/code/src/java/pcgen/core/PCStat.java
@@ -25,7 +25,7 @@ import pcgen.cdom.base.SortKeyRequired;
 import pcgen.cdom.enumeration.StringKey;
 
 public final class PCStat extends PObject
-		implements NonInteractive, SortKeyRequired, VarScoped
+		implements NonInteractive, SortKeyRequired
 {
 	/*
 	 * This is what the UI displays for the CHOOSE:PCSTAT.

--- a/code/src/java/pcgen/core/PObject.java
+++ b/code/src/java/pcgen/core/PObject.java
@@ -45,7 +45,7 @@ import pcgen.system.PCGenSettings;
  * This is the base class for several objects in the PCGen database.
  */
 public class PObject extends CDOMObject
-		implements Cloneable, Serializable, Comparable<Object>, KeyedListContainer, QualifyingObject
+		implements Serializable, Comparable<Object>, KeyedListContainer, QualifyingObject
 {
 
 	private HiddenTypeFacet hiddenTypeFacet = FacetLibrary.getFacet(HiddenTypeFacet.class);

--- a/code/src/java/pcgen/core/ShieldProf.java
+++ b/code/src/java/pcgen/core/ShieldProf.java
@@ -25,7 +25,7 @@ import pcgen.cdom.base.Ungranted;
  *
  * DO NOT DELETE (waiting for use)
  */
-public final class ShieldProf extends PObject implements Comparable<Object>, Ungranted
+public final class ShieldProf extends PObject implements Ungranted
 {
 	/**
 	 * Compares keyName only

--- a/code/src/java/pcgen/core/SizeAdjustment.java
+++ b/code/src/java/pcgen/core/SizeAdjustment.java
@@ -29,7 +29,7 @@ import pcgen.core.bonus.BonusObj;
  * {@code SizeAdjustment}.
  *
  */
-public final class SizeAdjustment extends PObject implements VarScoped
+public final class SizeAdjustment extends PObject
 {
 	/**
 	 * Activates (checks PrereqToUse) and returns list of BonusObj's

--- a/code/src/java/pcgen/core/Skill.java
+++ b/code/src/java/pcgen/core/Skill.java
@@ -39,7 +39,7 @@ import pcgen.core.bonus.BonusObj;
  * {@code Skill}.
  * 
  */
-public final class Skill extends PObject implements ChooseDriver, VarScoped
+public final class Skill extends PObject implements ChooseDriver
 {
 	public String getKeyStatAbb()
 	{

--- a/code/src/java/pcgen/core/TextProperty.java
+++ b/code/src/java/pcgen/core/TextProperty.java
@@ -27,7 +27,7 @@ import pcgen.cdom.base.CDOMObject;
  * {@code TextProperty}.
  *
  */
-public abstract class TextProperty extends PObject implements Serializable, Comparable<Object>
+public abstract class TextProperty extends PObject implements Serializable
 {
 	/** Constructor */
 	public TextProperty()

--- a/code/src/java/pcgen/core/WeaponProf.java
+++ b/code/src/java/pcgen/core/WeaponProf.java
@@ -24,7 +24,7 @@ import pcgen.cdom.base.Ungranted;
  * {@code WeaponProf}.
  * 
  */
-public final class WeaponProf extends PObject implements Comparable<Object>, Ungranted
+public final class WeaponProf extends PObject implements Ungranted
 {
 	/**
 	 * Compares keyName only.

--- a/code/src/java/pcgen/core/bonus/BonusObj.java
+++ b/code/src/java/pcgen/core/bonus/BonusObj.java
@@ -38,7 +38,7 @@ import pcgen.rules.context.LoadContext;
  * {@code BonusObj}
  *
  **/
-public abstract class BonusObj extends ConcretePrereqObject implements Serializable, Cloneable, QualifyingObject
+public abstract class BonusObj extends ConcretePrereqObject implements Serializable, QualifyingObject
 {
 	private List<Object> bonusInfo = new ArrayList<>();
 	private Map<String, String> dependMap = new HashMap<>();

--- a/code/src/java/pcgen/gui2/tabs/AbilityChooserTab.java
+++ b/code/src/java/pcgen/gui2/tabs/AbilityChooserTab.java
@@ -196,7 +196,7 @@ public class AbilityChooserTab extends FlippingSplitPane implements StateEditabl
 	}
 
 	private class AvailableAbilityTreeViewModel extends CachedDataView<AbilityFacade>
-			implements TreeViewModel<AbilityFacade>, ListSelectionListener, DataView<AbilityFacade>
+			implements TreeViewModel<AbilityFacade>, ListSelectionListener
 	{
 
 		private final ListFacade<? extends TreeView<AbilityFacade>> treeviews;

--- a/code/src/java/pcgen/gui2/tabs/CompanionInfoTab.java
+++ b/code/src/java/pcgen/gui2/tabs/CompanionInfoTab.java
@@ -812,7 +812,7 @@ public class CompanionInfoTab extends FlippingSplitPane implements CharacterInfo
 
 	}
 
-	private static class CompanionsModel extends AbstractTreeTableModel implements TreeTableModel
+	private static class CompanionsModel extends AbstractTreeTableModel
 	{
 
 		private final CompanionSupportFacade support;

--- a/code/src/java/pcgen/gui2/tabs/PurchaseInfoTab.java
+++ b/code/src/java/pcgen/gui2/tabs/PurchaseInfoTab.java
@@ -874,7 +874,7 @@ public class PurchaseInfoTab extends FlippingSplitPane implements CharacterInfoT
 	}
 
 	private class AvailableTreeViewModel extends CachedDataView<EquipmentFacade>
-			implements TreeViewModel<EquipmentFacade>, DataView<EquipmentFacade>
+			implements TreeViewModel<EquipmentFacade>
 	{
 
 		private final ListFacade<? extends TreeView<EquipmentFacade>> treeviews =

--- a/code/src/java/pcgen/gui2/tabs/equip/EquipmentModels.java
+++ b/code/src/java/pcgen/gui2/tabs/equip/EquipmentModels.java
@@ -282,7 +282,7 @@ public class EquipmentModels
 
 	}
 
-	private static class EquippedTableModel extends EquipmentTableModel implements ReferenceListener<EquipmentSetFacade>
+	private static class EquippedTableModel extends EquipmentTableModel
 	{
 
 		EquippedTableModel(CharacterFacade character)
@@ -303,7 +303,7 @@ public class EquipmentModels
 
 	}
 
-	private static class EquippedTableRootModel extends EquipmentTableModel implements ReferenceListener<EquipmentSetFacade>
+	private static class EquippedTableRootModel extends EquipmentTableModel
 	{
 
 		EquippedTableRootModel(CharacterFacade character)

--- a/code/src/java/pcgen/rules/context/AbstractListContext.java
+++ b/code/src/java/pcgen/rules/context/AbstractListContext.java
@@ -303,7 +303,7 @@ public abstract class AbstractListContext
 
 		private URI extractURI;
 
-		protected static class CDOMShell extends CDOMObject implements Cloneable
+		protected static class CDOMShell extends CDOMObject
 		{
 			@Override
 			public CDOMShell clone() throws CloneNotSupportedException

--- a/code/src/java/pcgen/rules/persistence/token/CDOMSecondaryToken.java
+++ b/code/src/java/pcgen/rules/persistence/token/CDOMSecondaryToken.java
@@ -19,7 +19,7 @@ package pcgen.rules.persistence.token;
 
 import pcgen.rules.context.LoadContext;
 
-public interface CDOMSecondaryToken<T> extends CDOMToken<T>, CDOMSubToken<T>
+public interface CDOMSecondaryToken<T> extends CDOMSubToken<T>
 {
 	public String[] unparse(LoadContext context, T obj);
 }


### PR DESCRIPTION
## What

Removes redundant `implements` clauses across 29 files in `code/src/java`, flagged by PMD's `UnnecessaryInterfaceDeclaration` rule. Each removed interface is already provided by a supertype in the inheritance chain.

## Why

PMD's `pmdMain` task reports these as violations. The declarations are pure noise — they don't change semantics (the marker / contract is still inherited) and they obscure which interfaces the class actually adds.

## Scope

| Cluster | Sites |
|---|---:|
| Originally flagged by PMD | 32 |
| Cascaded after fixing parent classes (`CDOMObject`, `AbstractCategory` no longer shadowed by subclass declarations) | 3 |
| **Total** | **35** |

Removed markers include: `Cloneable`, `Comparable<Object>`, `Serializable`, `VarScoped`, `VarContainer`, `Loadable`, `ObjectContainer<T>`, `Category<T>`, `ReferenceFacade<T>`, `DataView<T>`, `ReferenceListener<T>`, `TreeTableModel`, `CDOMToken<T>`, `PCGenScoped`, `ReferenceManufacturer<T>` — all guaranteed by the supertype.

## Verification

- `./gradlew compileJava compileTestJava compileItestJava compileSlowtestJava` — all green
- `./gradlew pmdMain` — `UnnecessaryInterfaceDeclaration` count: **22 → 0**; overall PMD count: **110 → 75**

## Notes

- `Cloneable` is a marker interface, so the explicit declaration on a concrete class was a (mild) self-documenting hint. Removing it is correct per the rule and the supertype keeps the marker.
- Scope-limited to one rule. Other PMD clusters (`VariableDeclarationUsageDistance`, `PublicMemberInNonPublicType`, `OverridingThreadRun`, `AvoidUsingVolatile`) are untouched.
- `code/gradle/reporting.gradle` still has `pmd { ignoreFailures = true }`, so CI gating is unchanged; this PR just reduces the noise floor.
