### PR TITLE
Fail gracefully when data sources are missing or malformed

### DIFF
--- a/code/src/java/pcgen/core/Globals.java
+++ b/code/src/java/pcgen/core/Globals.java
@@ -127,7 +127,11 @@ public final class Globals
 		final Campaign campaign = getCampaignKeyedSilently(aKey);
 		if (campaign == null)
 		{
-			Logging.errorPrint("Could not find campaign: " + aKey);
+			Logging.errorPrint("Could not find campaign: " + aKey
+				+ " - no loaded .pcc file declares CAMPAIGN:" + aKey + "."
+				+ " If this is third-party (non-OGL) data, install the .pcc into the"
+				+ " vendor data dir (" + PCGenSettings.getVendorDataDir()
+				+ ") or homebrew data dir (" + PCGenSettings.getHomebrewDataDir() + ").");
 		}
 
 		return campaign;

--- a/code/src/java/pcgen/core/PlayerCharacter.java
+++ b/code/src/java/pcgen/core/PlayerCharacter.java
@@ -228,6 +228,7 @@ import pcgen.core.analysis.BonusCalc;
 import pcgen.core.analysis.ChooseActivation;
 import pcgen.core.analysis.DomainApplication;
 import pcgen.core.analysis.RaceUtilities;
+import pcgen.core.analysis.SizeUtilities;
 import pcgen.core.analysis.SkillModifier;
 import pcgen.core.analysis.SkillRankControl;
 import pcgen.core.analysis.SpellCountCalc;
@@ -542,6 +543,20 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 	public PlayerCharacter(Collection<Campaign> loadedCampaigns)
 	{
 		LoadContext context = Globals.getContext();
+		// Fail fast on a half-loaded dataset: without a SizeAdjustment flagged
+		// ISDEFAULTSIZE:YES, damage scaling, equipment sizing and the size facet
+		// would all NPE deep in facet wiring.
+		if (SizeUtilities.getDefaultSizeAdjustment() == null)
+		{
+			String gameModeName = SettingsHandler.getGameAsProperty().get().getName();
+			Logging.errorPrint("Game mode '" + gameModeName
+				+ "' has no default size: no SizeAdjustment was loaded with ISDEFAULTSIZE:YES."
+				+ " Sizes are typically defined in a *__sizes.lst file inside the gamemode's"
+				+ " Core Rules data source (e.g. data/pathfinder/.../core_essentials/ce__sizes.lst)."
+				+ " Exactly one size in that file must be flagged ISDEFAULTSIZE:YES.");
+			throw new IllegalStateException("Game mode '" + gameModeName
+				+ "' has no default size. Check earlier log errors for the missing data source.");
+		}
 		id = CharID.getID(context.getDataSetID());
 		AbstractReferenceContext refContext = context.getReferenceContext();
 		controller = refContext.constructNowIfNecessary(CodeControl.class, "Controller");

--- a/code/src/java/pcgen/persistence/lst/LstObjectFileLoader.java
+++ b/code/src/java/pcgen/persistence/lst/LstObjectFileLoader.java
@@ -27,6 +27,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Observable;
+import java.util.Optional;
 import java.util.Set;
 
 import pcgen.cdom.base.CDOMObject;
@@ -281,7 +282,15 @@ public abstract class LstObjectFileLoader<T extends CDOMObject> extends Observab
 		String aString;
 		try
 		{
-			aString = LstFileLoader.readFromURI(uri).get();
+			// readFromURI returns Optional.empty() when it logs a non-fatal IO/decode error
+			// (e.g. a non-UTF-8 .lst). Skip the file rather than aborting the whole load.
+			Optional<String> read = LstFileLoader.readFromURI(uri);
+			if (read.isEmpty())
+			{
+				setChanged();
+				return;
+			}
+			aString = read.get();
 		}
 		catch (PersistenceLayerException ple)
 		{

--- a/code/src/java/pcgen/system/CharacterManager.java
+++ b/code/src/java/pcgen/system/CharacterManager.java
@@ -84,6 +84,14 @@ public final class CharacterManager
 	 */
 	public static CharacterFacade createNewCharacter(UIDelegate delegate, DataSetFacade dataset)
 	{
+		if (dataset == null)
+		{
+			Logging.errorPrint("Unable to create character: data sources failed to load (see earlier errors)");
+			delegate.showErrorMessage(LanguageBundle.getString("in_cmCreateErrorTitle"),
+				LanguageBundle.getFormattedString("in_cmCreateErrorMessage",
+					"data sources failed to load - see earlier errors in the log"));
+			return null;
+		}
 		@SuppressWarnings("rawtypes")
 		List campaigns = ListFacades.wrap(dataset.getCampaigns());
 		try
@@ -169,6 +177,14 @@ public final class CharacterManager
     private static PlayerCharacter openPcInternal(File file, UIDelegate delegate, DataSetFacade dataset,
 		boolean blockLoadedMessage)
 	{
+		if (dataset == null)
+		{
+			Logging.errorPrint("Unable to load character " + file + ": data sources failed to load (see earlier errors)");
+			delegate.showErrorMessage(LanguageBundle.getString("in_cmLoadErrorTitle"),
+				LanguageBundle.getFormattedString("in_cmLoadErrorMessage",
+					file, "data sources failed to load - see earlier errors in the log"));
+			return null;
+		}
 		@SuppressWarnings("rawtypes")
 		List campaigns = ListFacades.wrap(dataset.getCampaigns());
 		try


### PR DESCRIPTION
## Problem

Loading a character against a partially-loaded or malformed data set produces obscure NPEs deep in facet wiring. Three real-world failure modes I hit while loading an existing `.pcg` whose campaigns weren't installed:

1. **NPE in `SizeFacet.calcRacialSizeInt:118`** — when no `SizeAdjustment` is loaded with `ISDEFAULTSIZE:YES`, the facet dereferences a `null` deep in the constructor's facet chain (20+ frames).
2. **`NoSuchElementException` in `LstObjectFileLoader.loadLstFile:284`** — when a `.lst` isn't valid UTF-8, `LstFileLoader.readFromURI` correctly logs SEVERE and returns `Optional.empty()`, but the caller's blind `.get()` aborts the entire source load.
3. **NPE on `dataset.getCampaigns()` in `CharacterManager.openPcInternal:173`** — when the source load aborted (per #2), the PCGenFrame lambda still calls `openCharacter` with a null `DataSetFacade`, and the dereference happens outside the existing `try/catch`.

## Fix

**Three NPE → actionable error replacements** (commit 1):

- `PlayerCharacter.<init>` fails fast with `IllegalStateException` when `getDefaultSizeAdjustment()` returns null. The constructor logs a SEVERE diagnostic with concrete guidance on where size definitions live (`*__sizes.lst` in the gamemode's Core Rules data source, e.g. `data/pathfinder/.../core_essentials/ce__sizes.lst`), then throws. The throw is caught by `CharacterManager`'s existing handler and surfaced as a localized dialog. No more 23-frame stack trace.
- `LstObjectFileLoader.loadLstFile` now respects the `Optional` contract: if `readFromURI` returns empty (because it logged and skipped a non-UTF-8 / IO-failed file), the loader continues with the next file instead of aborting.
- `CharacterManager.openPcInternal` and `createNewCharacter` null-guard their `DataSetFacade` parameter before dereferencing it, logging and showing a localized "data sources failed to load - see earlier errors" dialog.

**One diagnostic upgrade** (commit 2):

- `Globals.getCampaignKeyed` now tells the user *what* failed (no `.pcc` declares `CAMPAIGN:<key>`) and *where to install it* (the vendor data dir or homebrew data dir paths — printed concretely).

## Before / After

Before, loading a `.pcg` whose campaigns weren't installed produced:

```
SEVERE  Globals:130  Could not find campaign: Dungeons & Dragons - Core Books
... (×14, no further information)
SEVERE  CharacterManager:208 Unable to load character /path/to/Alejandro.pcg
java.lang.NullPointerException: Cannot invoke "pcgen.core.SizeAdjustment.get(...)"
because the return value of "...getDefaultSizeAdjustment()" is null
    at pcgen.cdom.facet.model.SizeFacet.calcRacialSizeInt(SizeFacet.java:118)
    ... 22 more frames ...
```

After, the same `.pcg` produces:

```
SEVERE  Globals:130  Could not find campaign: Dungeons & Dragons - Core Books - no
    loaded .pcc file declares CAMPAIGN:Dungeons & Dragons - Core Books. If this
    is third-party (non-OGL) data, install the .pcc into the vendor data dir
    (/Users/.../vendordata) or homebrew data dir (/Users/.../homebrewdata).
SEVERE  PlayerCharacter:552  Game mode '35e' has no default size: no SizeAdjustment
    was loaded with ISDEFAULTSIZE:YES. Sizes are typically defined in a *__sizes.lst
    file inside the gamemode's Core Rules data source (e.g.
    data/pathfinder/.../core_essentials/ce__sizes.lst). Exactly one size in that
    file must be flagged ISDEFAULTSIZE:YES.
```

Dialog: *"Game mode '35e' has no default size. Check earlier log errors for the missing data source."*

After installing the missing campaigns, the same character loads successfully.

## Risk

Low. None of the four files have behavior changes on the happy path:

- `Globals.getCampaignKeyed` — log-message-only change, still returns `null` for misses.
- `LstObjectFileLoader` — only the empty-Optional branch changes (previously threw, now skips file; the file was already skipped upstream in `readFromURI`).
- `CharacterManager` — only the `dataset == null` branch is new.
- `PlayerCharacter` — only fires when `getDefaultSizeAdjustment()` returns `null`, which is itself a "broken-data" state the engine cannot proceed against.

`./gradlew :test --tests "pcgen.cdom.facet.model.SizeFacetTest"` passes (happy-path coverage of the modified file).

## Notes

- The fail-fast at `PlayerCharacter.<init>` is the primary fix. The other three changes are defense-in-depth + diagnostic polish that surfaced while tracking down the same end-user symptom.
- No new behavior on existing tests; no `ISDEFAULTSIZE` semantics changed.
- Five other call sites of `getDefaultSizeAdjustment()` still deref unguarded (`SizeFacet.racialSizeInt:98`, `UnarmedDamageFacet.getUDamForRace:116`, `PCClass:770`, `ObjectKey.BASESIZE/SIZE.getDefault`, `FormulaKey.SIZE.getDefault`). The fail-fast in `PlayerCharacter.<init>` makes them unreachable from a valid PC, but tightening them is a reasonable follow-up.
