### PR TITLE
Fix character chooser opening in non-writable Program Files folder

### DIFF
--- a/code/src/java/pcgen/gui2/PCGenFrame.java
+++ b/code/src/java/pcgen/gui2/PCGenFrame.java
@@ -100,6 +100,7 @@ import pcgen.system.Main;
 import pcgen.system.PCGenPropBundle;
 import pcgen.system.PCGenSettings;
 import pcgen.system.PropertyContext;
+import pcgen.system.PropertyContextFactory;
 import pcgen.util.Logging;
 import pcgen.util.chooser.ChooserFactory;
 import pcgen.util.chooser.RandomChooser;
@@ -823,11 +824,7 @@ public final class PCGenFrame extends JFrame implements UIDelegate, CharacterSel
 	boolean showSaveCharacterChooser(CharacterFacade character)
 	{
 		PCGenSettings context = PCGenSettings.getInstance();
-		String parentPath = lastCharacterPath;
-		if (parentPath == null)
-		{
-			parentPath = context.getProperty(PCGenSettings.PCG_SAVE_PATH);
-		}
+		String parentPath = resolveCharacterChooserDir(context);
 
 		FileChooser fileChooser = new FileChooser();
 		fileChooser.setTitle("Save PCGen Character File");
@@ -881,6 +878,7 @@ public final class PCGenFrame extends JFrame implements UIDelegate, CharacterSel
 				}
 
 				lastCharacterPath = file.getParent();
+				rememberCharacterChooserDir(lastCharacterPath);
 				return true;
 			}
 			catch (Exception e)
@@ -926,12 +924,8 @@ public final class PCGenFrame extends JFrame implements UIDelegate, CharacterSel
 	public void showOpenCharacterChooser()
 	{
 		GuiAssertions.assertIsNotJavaFXThread();
-		PropertyContext context = PCGenSettings.getInstance();
-		String path = lastCharacterPath;
-		if (path == null)
-		{
-			path = context.getProperty(PCGenSettings.PCG_SAVE_PATH);
-		}
+		PCGenSettings context = PCGenSettings.getInstance();
+		String path = resolveCharacterChooserDir(context);
 
 		FileChooser fileChooser = new FileChooser();
 		fileChooser.setTitle("Open PCGen Character");
@@ -948,8 +942,42 @@ public final class PCGenFrame extends JFrame implements UIDelegate, CharacterSel
 		if (file != null)
 		{
 			lastCharacterPath = file.getAbsoluteFile().getParent();
+			rememberCharacterChooserDir(lastCharacterPath);
 			loadCharacterFromFile(file);
 		}
+	}
+
+	/**
+	 * Persists the last-used character folder to {@code options.ini} so it
+	 * survives a clean shutdown — and immediately flushes it so it also
+	 * survives an abrupt exit (window close from a desktop manager, crash).
+	 * Note: a forced kill (Ctrl-C, SIGKILL) before this point cannot be
+	 * caught, so the most recent folder may still be lost in that case.
+	 */
+	private static void rememberCharacterChooserDir(String dir)
+	{
+		PCGenSettings.getInstance().setProperty(PCGenSettings.LAST_CHARACTER_PATH, dir);
+		PropertyContextFactory.getDefaultFactory().savePropertyContexts();
+	}
+
+	/**
+	 * Resolve the initial folder for the character Open/Save chooser, in order:
+	 * the in-session {@code lastCharacterPath}; the persisted
+	 * {@link PCGenSettings#LAST_CHARACTER_PATH} from prior runs; the user's
+	 * configured {@link PCGenSettings#PCG_SAVE_PATH} default.
+	 */
+	private String resolveCharacterChooserDir(PropertyContext context)
+	{
+		String path = lastCharacterPath;
+		if (path == null || path.isEmpty())
+		{
+			path = context.getProperty(PCGenSettings.LAST_CHARACTER_PATH);
+		}
+		if (path == null || path.isEmpty())
+		{
+			path = context.getProperty(PCGenSettings.PCG_SAVE_PATH);
+		}
+		return path;
 	}
 
 	void showOpenPartyChooser()

--- a/code/src/java/pcgen/gui2/PCGenFrame.java
+++ b/code/src/java/pcgen/gui2/PCGenFrame.java
@@ -824,7 +824,7 @@ public final class PCGenFrame extends JFrame implements UIDelegate, CharacterSel
 	boolean showSaveCharacterChooser(CharacterFacade character)
 	{
 		PCGenSettings context = PCGenSettings.getInstance();
-		String parentPath = resolveCharacterChooserDir(context);
+		String parentPath = resolveCharacterChooserDir(lastCharacterPath, context);
 
 		FileChooser fileChooser = new FileChooser();
 		fileChooser.setTitle("Save PCGen Character File");
@@ -925,7 +925,7 @@ public final class PCGenFrame extends JFrame implements UIDelegate, CharacterSel
 	{
 		GuiAssertions.assertIsNotJavaFXThread();
 		PCGenSettings context = PCGenSettings.getInstance();
-		String path = resolveCharacterChooserDir(context);
+		String path = resolveCharacterChooserDir(lastCharacterPath, context);
 
 		FileChooser fileChooser = new FileChooser();
 		fileChooser.setTitle("Open PCGen Character");
@@ -962,13 +962,13 @@ public final class PCGenFrame extends JFrame implements UIDelegate, CharacterSel
 
 	/**
 	 * Resolve the initial folder for the character Open/Save chooser, in order:
-	 * the in-session {@code lastCharacterPath}; the persisted
+	 * the in-session {@code lastInSessionPath}; the persisted
 	 * {@link PCGenSettings#LAST_CHARACTER_PATH} from prior runs; the user's
 	 * configured {@link PCGenSettings#PCG_SAVE_PATH} default.
 	 */
-	private String resolveCharacterChooserDir(PropertyContext context)
+	static String resolveCharacterChooserDir(String lastInSessionPath, PropertyContext context)
 	{
-		String path = lastCharacterPath;
+		String path = lastInSessionPath;
 		if (path == null || path.isEmpty())
 		{
 			path = context.getProperty(PCGenSettings.LAST_CHARACTER_PATH);

--- a/code/src/java/pcgen/system/PCGenSettings.java
+++ b/code/src/java/pcgen/system/PCGenSettings.java
@@ -61,6 +61,8 @@ public final class PCGenSettings extends PropertyContext
 	public static final String PCP_SAVE_PATH = "pcgen.files.parties";
 	public static final String CHAR_PORTRAITS_PATH = "pcgen.files.portaits";
 	public static final String BACKUP_PCG_PATH = "pcgen.files.characters.backup";
+	/** Last folder used in the character Open/Save chooser; remembers across launches. */
+	public static final String LAST_CHARACTER_PATH = "pcgen.files.characters.lastUsed";
 	public static final String SELECTED_SPELL_SHEET_PATH = "pcgen.files.selectedSpellOutputSheet";
 	public static final String RECENT_CHARACTERS = "recentCharacters";
 	public static final String RECENT_PARTIES = "recentParties";
@@ -84,18 +86,37 @@ public final class PCGenSettings extends PropertyContext
 	private PCGenSettings()
 	{
 		super("options.ini");
-		setProperty(PCG_SAVE_PATH,
-			(ConfigurationSettings.getUserDir() + "/characters").replace('/', File.separatorChar));
-		setProperty(PCP_SAVE_PATH,
-			(ConfigurationSettings.getUserDir() + "/characters").replace('/', File.separatorChar));
-		setProperty(CHAR_PORTRAITS_PATH,
-			(ConfigurationSettings.getUserDir() + "/characters").replace('/', File.separatorChar));
-		setProperty(BACKUP_PCG_PATH,
-			(ConfigurationSettings.getUserDir() + "/characters").replace('/', File.separatorChar));
+		String defaultCharsDir = defaultCharactersDir();
+		setProperty(PCG_SAVE_PATH, defaultCharsDir);
+		setProperty(PCP_SAVE_PATH, defaultCharsDir);
+		setProperty(CHAR_PORTRAITS_PATH, defaultCharsDir);
+		setProperty(BACKUP_PCG_PATH, defaultCharsDir);
 		setProperty(VENDOR_DATA_DIR, "@vendordata");
 		setProperty(HOMEBREW_DATA_DIR, "@homebrewdata");
 		setProperty(CUSTOM_DATA_DIR, "@data/customsources".replace('/', File.separatorChar));
 		OutputDB.registerBooleanPreference(OPTION_SHOW_OUTPUT_NAME_FOR_OTHER_ITEMS, false);
+	}
+
+	/**
+	 * Default characters/portraits/backups dir, rooted in the user's home so it
+	 * stays writable when PCGen is installed under Program Files.
+	 */
+	static String defaultCharactersDir()
+	{
+		String root = SystemUtils.USER_HOME;
+		if (SystemUtils.IS_OS_WINDOWS)
+		{
+			String userProfile = System.getenv("USERPROFILE");
+			if (userProfile != null && !userProfile.isEmpty())
+			{
+				File documents = new File(userProfile, "Documents");
+				if (documents.isDirectory())
+				{
+					root = documents.getAbsolutePath();
+				}
+			}
+		}
+		return root + File.separator + "PCGen" + File.separator + "characters";
 	}
 
 	@Override

--- a/code/src/test/pcgen/gui2/PCGenFrameResolveCharacterChooserDirTest.java
+++ b/code/src/test/pcgen/gui2/PCGenFrameResolveCharacterChooserDirTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 Vest <Vest@users.noreply.github.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ */
+package pcgen.gui2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import pcgen.system.PCGenSettings;
+import pcgen.system.PropertyContext;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the fallback order of {@link PCGenFrame#resolveCharacterChooserDir}:
+ * in-session path → persisted LAST_CHARACTER_PATH → configured PCG_SAVE_PATH.
+ */
+class PCGenFrameResolveCharacterChooserDirTest
+{
+	private static final String IN_SESSION = "/session/path";
+	private static final String LAST_USED = "/persisted/path";
+	private static final String DEFAULT_PCG = "/default/path";
+
+	@Test
+	void inSessionPathWinsWhenSet()
+	{
+		PropertyContext ctx = new TestContext();
+		ctx.setProperty(PCGenSettings.LAST_CHARACTER_PATH, LAST_USED);
+		ctx.setProperty(PCGenSettings.PCG_SAVE_PATH, DEFAULT_PCG);
+
+		assertEquals(IN_SESSION, PCGenFrame.resolveCharacterChooserDir(IN_SESSION, ctx));
+	}
+
+	@Test
+	void persistedPathWinsWhenInSessionIsNull()
+	{
+		PropertyContext ctx = new TestContext();
+		ctx.setProperty(PCGenSettings.LAST_CHARACTER_PATH, LAST_USED);
+		ctx.setProperty(PCGenSettings.PCG_SAVE_PATH, DEFAULT_PCG);
+
+		assertEquals(LAST_USED, PCGenFrame.resolveCharacterChooserDir(null, ctx));
+	}
+
+	@Test
+	void persistedPathWinsWhenInSessionIsEmpty()
+	{
+		PropertyContext ctx = new TestContext();
+		ctx.setProperty(PCGenSettings.LAST_CHARACTER_PATH, LAST_USED);
+		ctx.setProperty(PCGenSettings.PCG_SAVE_PATH, DEFAULT_PCG);
+
+		assertEquals(LAST_USED, PCGenFrame.resolveCharacterChooserDir("", ctx));
+	}
+
+	@Test
+	void defaultPathIsUsedWhenNothingElseSet()
+	{
+		PropertyContext ctx = new TestContext();
+		ctx.setProperty(PCGenSettings.PCG_SAVE_PATH, DEFAULT_PCG);
+
+		assertEquals(DEFAULT_PCG, PCGenFrame.resolveCharacterChooserDir(null, ctx));
+	}
+
+	/** Plain {@link PropertyContext} so the test doesn't touch the singleton. */
+	private static final class TestContext extends PropertyContext
+	{
+		TestContext()
+		{
+			super("test-options.ini");
+		}
+	}
+}

--- a/code/src/test/pcgen/system/PCGenSettingsTest.java
+++ b/code/src/test/pcgen/system/PCGenSettingsTest.java
@@ -13,16 +13,20 @@
  */
 package pcgen.system;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
+import java.nio.file.Path;
 
 import org.apache.commons.lang3.SystemUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
- * Verifies that the default character/portraits/backup directory is rooted in
- * the user's home rather than {@code user.dir}.
+ * Tests the writable default and the round-trip persistence of
+ * {@link PCGenSettings#LAST_CHARACTER_PATH}.
  */
 class PCGenSettingsTest
 {
@@ -45,7 +49,41 @@ class PCGenSettingsTest
 		String dir = PCGenSettings.defaultCharactersDir();
 		String installRootedDefault = SystemUtils.USER_DIR + File.separator + "characters";
 
-		assertTrue(!dir.equals(installRootedDefault),
-				"Default characters dir must not equal user.dir/characters but was: " + dir);
+		assertNotEquals(installRootedDefault, dir,
+				"Default characters dir must not equal user.dir/characters");
+	}
+
+	/**
+	 * Locks the durability claim: {@code LAST_CHARACTER_PATH} written in one
+	 * "session" is read back in the next via {@code options.ini}.
+	 */
+	@Test
+	void lastCharacterPathRoundTripsViaOptionsIni(@TempDir Path settingsDir)
+	{
+		String chosenFolder = "/some/folder/the/user/picked";
+
+		// Session 1: write the property and flush options.ini to the temp dir.
+		PropertyContextFactory factory1 = new PropertyContextFactory(settingsDir.toString());
+		TestableSettings session1 = new TestableSettings();
+		factory1.registerAndLoadPropertyContext(session1);
+		session1.setProperty(PCGenSettings.LAST_CHARACTER_PATH, chosenFolder);
+		factory1.savePropertyContexts();
+
+		// Session 2: a fresh factory + context reads the same file back.
+		PropertyContextFactory factory2 = new PropertyContextFactory(settingsDir.toString());
+		TestableSettings session2 = new TestableSettings();
+		factory2.registerAndLoadPropertyContext(session2);
+
+		assertEquals(chosenFolder, session2.getProperty(PCGenSettings.LAST_CHARACTER_PATH),
+				"Persisted folder must survive a save+load cycle through options.ini");
+	}
+
+	/** Plain {@link PropertyContext} so we don't touch the {@code PCGenSettings} singleton. */
+	private static final class TestableSettings extends PropertyContext
+	{
+		TestableSettings()
+		{
+			super("options.ini");
+		}
 	}
 }

--- a/code/src/test/pcgen/system/PCGenSettingsTest.java
+++ b/code/src/test/pcgen/system/PCGenSettingsTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 Vest <Vest@users.noreply.github.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ */
+package pcgen.system;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+
+import org.apache.commons.lang3.SystemUtils;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that the default character/portraits/backup directory is rooted in
+ * the user's home rather than {@code user.dir}.
+ */
+class PCGenSettingsTest
+{
+	@Test
+	void defaultCharactersDirIsRootedInUserHome()
+	{
+		String dir = PCGenSettings.defaultCharactersDir();
+
+		assertTrue(dir.startsWith(SystemUtils.USER_HOME),
+				"Expected default characters dir to live under USER_HOME but was: " + dir);
+		assertTrue(dir.endsWith(File.separator + "PCGen" + File.separator + "characters"),
+				"Expected default characters dir to end with PCGen/characters but was: " + dir);
+	}
+
+	@Test
+	void defaultCharactersDirIsNotInsideInstallDir()
+	{
+		// USER_DIR is the JVM working directory; under Program Files installs it is the
+		// install root, which is not user-writable. The fix decouples the default from it.
+		String dir = PCGenSettings.defaultCharactersDir();
+		String installRootedDefault = SystemUtils.USER_DIR + File.separator + "characters";
+
+		assertTrue(!dir.equals(installRootedDefault),
+				"Default characters dir must not equal user.dir/characters but was: " + dir);
+	}
+}


### PR DESCRIPTION
## Summary

Two related fixes for character file load/save UX.

### 1. Default folder no longer lands in Program Files

`PCGenSettings` seeded `PCG_SAVE_PATH`, `PCP_SAVE_PATH`, `CHAR_PORTRAITS_PATH` and `BACKUP_PCG_PATH` from `ConfigurationSettings.getUserDir()`, which is `System.getProperty("user.dir")` — the JVM working directory. For a default jpackage `.exe` install on Windows, that resolves to `C:\Program Files\PcGen\…`, which is not user-writable. Saving a character from there triggers UAC / VirtualStore redirection (or fails outright).

The four properties now seed from a new helper `PCGenSettings.defaultCharactersDir()`:

- Windows: `%USERPROFILE%\Documents\PCGen\characters` if `Documents` exists, otherwise `USER_HOME\PCGen\characters`.
- macOS / Linux / other: `USER_HOME/PCGen/characters`.

Read-only `@`-prefixed resources (`@data`, `@system`, `@outputsheets`, `@vendordata`, `@homebrewdata`, `@docs`, `@plugins`, `@preview`) are untouched — they correctly anchor on the install tree via `user.dir`.

### 2. Open/Save chooser remembers the last-used folder across launches

`PCGenFrame` kept `lastCharacterPath` in an instance field only — it died with the JVM, so the chooser reset to the configured default on every launch. A new property `pcgen.files.characters.lastUsed` (constant `PCGenSettings.LAST_CHARACTER_PATH`) now captures the parent folder of the last file successfully opened or saved.

Resolution order for the chooser's initial folder is now:

1. In-session `lastCharacterPath` (this session's most recent pick).
2. Persisted `LAST_CHARACTER_PATH` (most recent pick from any prior session).
3. Configured `PCG_SAVE_PATH` (the user's preference in **Preferences → Locations**).

The user's preference is never overwritten — it stays the final fallback.

### When the `LAST_CHARACTER_PATH` value gets written to `options.ini`

Only when the application is closed gracefully — i.e. **right after a successful Open / Save dialog**, via `PropertyContextFactory.savePropertyContexts()`. This covers:

- Normal File → Exit / Cmd-Q / window close (calls `Main.shutdown`).
- The window manager closing the app cleanly.

It does **not** cover:

- `Ctrl-C` in a terminal-launched gradle run (SIGINT before the write).
- `kill -9` / `SIGKILL`.
- OS crash, power loss.

In those forced-termination cases the most recent folder choice may be lost. That's an existing limitation of PCGen's settings layer (settings are only flushed on clean shutdown today). Doing the write immediately after a successful chooser pick is what bounds the loss window to "since the last open/save action."

## Migration

None. Existing users have these properties already written to `options.ini`; the new seeding only affects fresh installs or users who delete `options.ini`. The new `LAST_CHARACTER_PATH` key starts empty and populates the first time a user picks a file.

## Test Plan

Automated:

- [x] `./gradlew compileJava compileTestJava` passes.
- [x] `./gradlew :test --tests pcgen.system.PCGenSettingsTest` — new `PCGenSettingsTest` (2 tests) passes:
  - `defaultCharactersDirIsRootedInUserHome` — locks the `USER_HOME` rooting.
  - `defaultCharactersDirIsNotInsideInstallDir` — locks the regression: default ≠ `user.dir/characters`.

Manual (recommended on Windows):

1. Delete `options.ini` from the settings dir (e.g. `~/Library/Preferences/pcgen/options.ini` on macOS; the chosen settings dir on Windows).
2. Launch PCGen via the installer-built `.exe` (or `./gradlew run`).
3. **File → Open Character** — verify the dialog opens at `<USER_HOME>/PCGen/characters` (or Windows `Documents\PCGen\characters`).
4. Navigate elsewhere, open any `.pcg` file.
5. **File → Exit** (clean exit).
6. Confirm `options.ini` now contains `pcgen.files.characters.lastUsed=<the folder you browsed to>`.
7. Re-launch PCGen, **File → Open Character** — verify the dialog opens at that remembered folder.