### PR TITLE
Fix Pathfinder csheet fixtures after Favored Class Bonus visibility change

### DIFF
--- a/code/testsuite/csheets/pf_Cleric.xml
+++ b/code/testsuite/csheets/pf_Cleric.xml
@@ -2125,6 +2125,28 @@ BIO
 	<ability_objects>
 		<!-- Visible Normal "Special Ability" Ability Objects -->
 		<ability_object>
+			<name>Bonus Hit Point</name>
+			<description></description>
+			<type>FAVOREDCLASSBONUS.SPECIALQUALITY</type>
+			<associated></associated>
+			<count>1</count>
+			<auto>F</auto>
+			<hidden>F</hidden>
+			<virtual>F</virtual>
+			<category>Special Ability</category>
+		</ability_object>
+		<ability_object>
+			<name>Bonus Skill Rank (Knowledge (Planes), Knowledge (Religion))</name>
+			<description></description>
+			<type>FAVOREDCLASSBONUS.SPECIALQUALITY</type>
+			<associated>Knowledge (Planes),Knowledge (Religion)</associated>
+			<count>2</count>
+			<auto>F</auto>
+			<hidden>F</hidden>
+			<virtual>F</virtual>
+			<category>Special Ability</category>
+		</ability_object>
+		<ability_object>
 			<name>Channel Positive Energy</name>
 			<description>You can unleash a wave of positive energy. You must choose to deal 2d6 points of positive energy damage to undead creatures or to heal living creatures of 2d6 points of damage. Creatures that take damage from channeled energy receive a DC 16 Will save to halve the damage. You can use this ability 6 times per day.</description>
 			<type>CLERICCLASSFEATURES.SUPERNATURAL.SPECIALATTACK.CHANNELENERGYSELECTION.CHANNELENERGY.CHANNEL ENERGY.CHANNEL ENERGY POSITIVE.CHANNEL POSITIVE ENERGY</type>
@@ -2254,28 +2276,6 @@ BIO
 			<type>ABILITYBONUS</type>
 			<associated></associated>
 			<count>0</count>
-			<auto>F</auto>
-			<hidden>T</hidden>
-			<virtual>F</virtual>
-			<category>Special Ability</category>
-		</ability_object>
-		<ability_object>
-			<name>Bonus Hit Point</name>
-			<description></description>
-			<type>FAVOREDCLASSBONUS</type>
-			<associated></associated>
-			<count>1</count>
-			<auto>F</auto>
-			<hidden>T</hidden>
-			<virtual>F</virtual>
-			<category>Special Ability</category>
-		</ability_object>
-		<ability_object>
-			<name>Bonus Skill Rank (Knowledge (Planes), Knowledge (Religion))</name>
-			<description></description>
-			<type>FAVOREDCLASSBONUS</type>
-			<associated>Knowledge (Planes),Knowledge (Religion)</associated>
-			<count>2</count>
 			<auto>F</auto>
 			<hidden>T</hidden>
 			<virtual>F</virtual>

--- a/code/testsuite/csheets/pf_Paladin.xml
+++ b/code/testsuite/csheets/pf_Paladin.xml
@@ -3174,6 +3174,17 @@ BIO
 			<category>Special Ability</category>
 		</ability_object>
 		<ability_object>
+			<name>Bonus Skill Rank (Diplomacy, Diplomacy, Diplomacy, Diplomacy)</name>
+			<description></description>
+			<type>FAVOREDCLASSBONUS.SPECIALQUALITY</type>
+			<associated>Diplomacy,Diplomacy,Diplomacy,Diplomacy</associated>
+			<count>4</count>
+			<auto>F</auto>
+			<hidden>F</hidden>
+			<virtual>F</virtual>
+			<category>Special Ability</category>
+		</ability_object>
+		<ability_object>
 			<name>Celestial Spirit</name>
 			<description>Your divine bond allows you to enhance your weapon as a standard action by calling upon the aid of a celestial spirit for 6 minutes. When called, the spirit causes the weapon to shed light as a torch. This spirit grants the weapon a +1 enhancement bonus. This bonus can be added to the weapon, stacking with existing weapon bonuses to a maximum of +5, or it can be used to add any of the following weapon properties: defending, flaming, keen, merciful (+1), axiomatic, disruption, flaming burst, holy (+2), speed (+3), and brilliant energy (+4). Adding these properties consumes an amount of bonus equal to the property&#39;s cost. These bonuses are added to any properties the weapon already has, but duplicate abilities do not stack. If the weapon is not magical, at least a +1 enhancement bonus must be added before any other properties can be added. The bonus and properties granted by the spirit are determined when the spirit is called and cannot be changed until the spirit is called again. The celestial spirit imparts no bonuses if the weapon is held by anyone other than you but resumes giving bonuses if returned to you. These bonuses apply to only one end of a double weapon. You can use this ability 1 times per day. If a weapon bonded with a celestial spirit is destroyed, you lose the use of this ability for 30 days, or until you gain a level, whichever comes first. During this 30-day period, you take a -1 penalty on attack and weapon damage rolls.</description>
 			<type>PALADINCLASSFEATURES.SPECIALQUALITY.SPELLLIKE.DIVINEBOND.DIVINE BOND</type>
@@ -3357,17 +3368,6 @@ BIO
 			<type>ABILITYBONUS</type>
 			<associated></associated>
 			<count>0</count>
-			<auto>F</auto>
-			<hidden>T</hidden>
-			<virtual>F</virtual>
-			<category>Special Ability</category>
-		</ability_object>
-		<ability_object>
-			<name>Bonus Skill Rank (Diplomacy, Diplomacy, Diplomacy, Diplomacy)</name>
-			<description></description>
-			<type>FAVOREDCLASSBONUS</type>
-			<associated>Diplomacy,Diplomacy,Diplomacy,Diplomacy</associated>
-			<count>4</count>
 			<auto>F</auto>
 			<hidden>T</hidden>
 			<virtual>F</virtual>

--- a/code/testsuite/csheets/pf_Rogue.xml
+++ b/code/testsuite/csheets/pf_Rogue.xml
@@ -3803,6 +3803,28 @@ BIO
 	<ability_objects>
 		<!-- Visible Normal "Special Ability" Ability Objects -->
 		<ability_object>
+			<name>Bonus Hit Point (6x)</name>
+			<description></description>
+			<type>FAVOREDCLASSBONUS.SPECIALQUALITY</type>
+			<associated>,,,,,</associated>
+			<count>6</count>
+			<auto>F</auto>
+			<hidden>F</hidden>
+			<virtual>F</virtual>
+			<category>Special Ability</category>
+		</ability_object>
+		<ability_object>
+			<name>Bonus Skill Rank (Handle Animal, Knowledge (Dungeoneering), Knowledge (Engineering), Knowledge (Geography), Knowledge (Local), Sense Motive)</name>
+			<description></description>
+			<type>FAVOREDCLASSBONUS.SPECIALQUALITY</type>
+			<associated>Handle Animal,Knowledge (Dungeoneering),Knowledge (Engineering),Knowledge (Geography),Knowledge (Local),Sense Motive</associated>
+			<count>6</count>
+			<auto>F</auto>
+			<hidden>F</hidden>
+			<virtual>F</virtual>
+			<category>Special Ability</category>
+		</ability_object>
+		<ability_object>
 			<name>Brigand</name>
 			<description>You hail from the River Kingdoms or the more lawless reaches of Brevoy. Life has been hard for you. Perhaps your parents and siblings were crooks and con artists, or maybe your rough, lonely life lead you to fall in with thieves and worse. You know how to ambush travelers, bully traders, avoid the law, and camp where no one might find you. Recently, you&#39;ve run into some trouble, either with the law or with other bandits, and you&#39;re looking to get away to somewhere no one would ever think to look for you. An expedition into the rugged wilderness seems like a perfect way to lie low until the trouble blows over. You gain a +1 trait bonus on Bluff, Diplomacy, Intimidate, and Sense Motive checks when dealing with brigands, thieves, bandits, and their ilk.</description>
 			<type>TRAIT.CAMPAIGNTRAIT</type>
@@ -4024,28 +4046,6 @@ BIO
 			<category>Special Ability</category>
 		</ability_object>
 		<!-- Hidden Normal "Special Ability" Ability Objects -->
-		<ability_object>
-			<name>Bonus Hit Point (6x)</name>
-			<description></description>
-			<type>FAVOREDCLASSBONUS</type>
-			<associated>,,,,,</associated>
-			<count>6</count>
-			<auto>F</auto>
-			<hidden>T</hidden>
-			<virtual>F</virtual>
-			<category>Special Ability</category>
-		</ability_object>
-		<ability_object>
-			<name>Bonus Skill Rank (Handle Animal, Knowledge (Dungeoneering), Knowledge (Engineering), Knowledge (Geography), Knowledge (Local), Sense Motive)</name>
-			<description></description>
-			<type>FAVOREDCLASSBONUS</type>
-			<associated>Handle Animal,Knowledge (Dungeoneering),Knowledge (Engineering),Knowledge (Geography),Knowledge (Local),Sense Motive</associated>
-			<count>6</count>
-			<auto>F</auto>
-			<hidden>T</hidden>
-			<virtual>F</virtual>
-			<category>Special Ability</category>
-		</ability_object>
 		<ability_object>
 			<name>Improved Evasion</name>
 			<description>This works like Evasion, except that while you still take no damage on a successful Reflex saving throw against attacks, you henceforth take only half damage on a failed save. If you are helpless, you do not gain the benefit of Improved Evasion.</description>


### PR DESCRIPTION
Fixes the Pathfinder inttest failures on master ([Cleric / Paladin / Rogue](https://github.com/PCGen/pcgen/commit/1439ee6e43bcc7313717e765acc90ef6ca805221/checks)) introduced by #7658.

### What broke

Commit 1439ee6e43 (PR #7658, issue #7478) is a **legitimate data fix** — it makes Favored Class Bonuses display on the character sheet, as the user requested. In `data/pathfinder/paizo/roleplaying_game/core_rulebook/cr_abilities_class.lst` it:

- drops `VISIBLE:DISPLAY` from `Bonus Hit Point` and `Bonus Skill Rank` (i.e. `DISPLAY_ONLY` → `DEFAULT`, so those abilities now appear in exports as well as in the GUI), and
- adds `.SpecialQuality` to their `TYPE`.

What the PR **didn't** touch is the character-sheet integration-test fixtures. So on master, `pcGenGUIPfrpgClericTest`, `pcGenGUIPfrpgPaladinTest`, and `pcGenGUIPfrpgRogueTest` all fail with:

```
Expected text value 'Channel Positive Energy' but was 'Bonus Hit Point'
Expected text value 'Brigand' but was 'Bonus Hit Point (6x)'
Expected text value 'Celestial Spirit' but was 'Bonus Skill Rank (Diplomacy, Diplomacy, Diplomacy, Diplomacy)'
```

The `<ability_object>` blocks for the Favored Class Bonuses correctly moved from the "Hidden Normal" section to the "Visible Normal Special Ability" section in the produced XML, but the expected XMLs still had them at the bottom with the old type.

### Fix

Regenerated the three csheet fixtures from the actual test output so they reflect the new correct behaviour:

- `pf_Cleric.xml`, `pf_Paladin.xml`, `pf_Rogue.xml`
- moved the Favored Class Bonus `<ability_object>` entries from the Hidden section to the Visible Normal Special Ability section,
- updated `<type>` from `FAVOREDCLASSBONUS` to `FAVOREDCLASSBONUS.SPECIALQUALITY`,
- flipped `<hidden>T</hidden>` to `<hidden>F</hidden>`.

Nothing else changed in the XMLs.

### Verified locally

- `./gradlew slowtest --tests …pcGenGUIPfrpgClericTest --tests …PaladinTest --tests …RogueTest --rerun-tasks` → all 3 pass
- `./gradlew pfinttest --rerun-tasks` (full Pathfinder inttest suite) → **BUILD SUCCESSFUL**
- `./gradlew slowtest --rerun-tasks` (all 5 game modes + data tests) → **BUILD SUCCESSFUL in 7m 25s**