### PR TITLE
lsttokens tests: report empty-override suppressions as skipped, not absent

### DIFF
--- a/code/src/test/plugin/lsttokens/AddTokenTest.java
+++ b/code/src/test/plugin/lsttokens/AddTokenTest.java
@@ -31,6 +31,7 @@ import plugin.lsttokens.testsupport.AbstractGlobalTokenTestCase;
 import plugin.lsttokens.testsupport.CDOMTokenLoader;
 import plugin.lsttokens.testsupport.ConsolidationRule;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 public class AddTokenTest extends AbstractGlobalTokenTestCase
 {
@@ -147,9 +148,10 @@ public class AddTokenTest extends AbstractGlobalTokenTestCase
 	}
 
 	@Override
+	@Test
+	@Disabled("Can't be done, nothing ever unparses")
 	public void testOverwrite()
 	{
-		// Can't be done, nothing ever unparses
 	}
 
 }

--- a/code/src/test/plugin/lsttokens/PreTokenTest.java
+++ b/code/src/test/plugin/lsttokens/PreTokenTest.java
@@ -29,6 +29,7 @@ import plugin.lsttokens.testsupport.AbstractGlobalTokenTestCase;
 import plugin.lsttokens.testsupport.CDOMTokenLoader;
 import plugin.lsttokens.testsupport.ConsolidationRule;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 public class PreTokenTest extends AbstractGlobalTokenTestCase
 {
@@ -102,9 +103,10 @@ public class PreTokenTest extends AbstractGlobalTokenTestCase
 	}
 
 	@Override
+	@Test
+	@Disabled("Can't be done, nothing ever unparses")
 	public void testOverwrite()
 	{
-		//Can't be done, nothing ever unparses
 	}
 
 }

--- a/code/src/test/plugin/lsttokens/choose/SchoolsTokenTest.java
+++ b/code/src/test/plugin/lsttokens/choose/SchoolsTokenTest.java
@@ -38,6 +38,7 @@ import plugin.lsttokens.testsupport.CDOMTokenLoader;
 import plugin.lsttokens.testsupport.TokenRegistration;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 public class SchoolsTokenTest extends AbstractChooseTokenTestCase
@@ -177,15 +178,17 @@ public class SchoolsTokenTest extends AbstractChooseTokenTestCase
 	}
 
 	@Override
+	@Test
+	@Disabled("Must ignore due to 5.16 syntax")
 	public void testInvalidInputOnlySubToken()
 	{
-		// Must ignore due to 5.16 syntax
 	}
 
 	@Override
+	@Test
+	@Disabled("Must ignore due to 5.16 syntax")
 	public void testInvalidInputOnlySubTokenPipe()
 	{
-		// Must ignore due to 5.16 syntax
 	}
 
 	@Override
@@ -195,33 +198,38 @@ public class SchoolsTokenTest extends AbstractChooseTokenTestCase
 	}
 
 	@Override
+	@Test
+	@Disabled("SpellSchool doesn't have a RM")
 	public void testUnparseIllegalAllItem()
 	{
-		//Ignore since SpellSchool doesn't have a RM
 	}
 
 	@Override
+	@Test
+	@Disabled("SpellSchool doesn't have a RM")
 	public void testUnparseIllegalAllType()
 	{
-		//Ignore since SpellSchool doesn't have a RM
 	}
 
 	@Override
+	@Test
+	@Disabled("SpellSchool doesn't have a RM")
 	public void testUnparseIllegalItemAll()
 	{
-		//Ignore since SpellSchool doesn't have a RM
 	}
 
 	@Override
+	@Test
+	@Disabled("SpellSchool doesn't have a RM")
 	public void testUnparseIllegalTypeAll()
 	{
-		//Ignore since SpellSchool doesn't have a RM
 	}
 
 	@Override
+	@Test
+	@Disabled("SpellSchool doesn't have a RM")
 	public void testUnparseLegal()
 	{
-		//Ignore since SpellSchool doesn't have a RM
 	}
 
 	@Override

--- a/code/src/test/plugin/lsttokens/equipmentmodifier/ItypeTokenTest.java
+++ b/code/src/test/plugin/lsttokens/equipmentmodifier/ItypeTokenTest.java
@@ -29,6 +29,7 @@ import plugin.lsttokens.testsupport.AbstractTypeSafeListTestCase;
 import plugin.lsttokens.testsupport.CDOMTokenLoader;
 import plugin.lsttokens.testsupport.ConsolidationRule;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 public class ItypeTokenTest extends
@@ -92,13 +93,16 @@ public class ItypeTokenTest extends
 		return true;
 	}
 
-	//TODO 514 behavior, to be changed after 5.16?
 	@Override
+	@Test
+	@Disabled("514 behavior, to be changed after 5.16?")
 	public void testReplacementInputs()
 	{
 	}
 
 	@Override
+	@Test
+	@Disabled("514 behavior, to be changed after 5.16?")
 	public void testReplacementInputsTwo()
 	{
 	}


### PR DESCRIPTION
## Summary

Concrete lst-token test classes overrode inherited `@Test` methods with an **empty body plus a code comment** to mean "this scenario doesn't apply here" — for example:

```java
@Override
public void testOverwrite()
{
    // Can't be done, nothing ever unparses
}
```

The intent was to suppress the parent's test. What actually happens under JUnit 5 is subtly worse than expected: **Jupiter drops the parent's `@Test` when the subclass overrides it without re-declaring `@Test`** (docs: [*"Such methods are inherited unless overridden."*](https://docs.junit.org/current/user-guide/#writing-tests-annotations-inheritance)). So the previous state was neither a passing test nor a reported skip — the test was simply absent from the report. A reader of the subclass could not tell whether the parent's test was still running or being suppressed.

## Fix

Re-declare `@Test` on the override alongside `@Disabled("<reason>")`. The reason string moves out of an invisible code comment into JUnit test metadata, and each suppressed test is now **reported as skipped** with its rationale instead of silently dropped.

## Methods touched (11 total)

| File | Method(s) | Reason |
|---|---|---|
| `AddTokenTest` | `testOverwrite` | "Can't be done, nothing ever unparses" |
| `PreTokenTest` | `testOverwrite` | "Can't be done, nothing ever unparses" |
| `SchoolsTokenTest` | `testInvalidInputOnlySubToken`, `testInvalidInputOnlySubTokenPipe` | "Must ignore due to 5.16 syntax" |
| `SchoolsTokenTest` | `testUnparseIllegalAllItem`, `…AllType`, `…ItemAll`, `…TypeAll`, `…Legal` | "SpellSchool doesn't have a RM" |
| `ItypeTokenTest` | `testReplacementInputs`, `testReplacementInputsTwo` | "514 behavior, to be changed after 5.16?" |

`ItypeTokenTest.testReplacementInputsTwo` was carrying the same anti-pattern **without any comment at all** — folded in here because the fix is identical.

## Verification

`./gradlew :test --tests "plugin.lsttokens.*"` (aggregated across all suites in the package tree):

|  | Before | After |
|---|---|---|
| tests | 2399 | **2410** |
| skipped | 0 | **11** |
| failures | 0 | 0 |
| errors | 0 | 0 |

The 11 newly-reported skips exactly match the 11 methods annotated above — no other tests were affected.

## Diff stats

```
 4 files changed, 26 insertions(+), 10 deletions(-)
```

Pure test-metadata cleanup. No production code changed.