### PR TITLE
Require JDK 25 with an actionable pre-flight error; drop legacy 6.08 docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,36 +10,21 @@ It supports numerous game systems, most notably:
 - Starfinder
 
 # Table of Contents
-1. [Installing From Release 6.08](#installing-from-release-608)
+1. [Installing PCGen](#installing-pcgen)
 
-2. [Installing From Release 6.09 (Alpha)](#installing-from-release-609-alpha)
+2. [PCGen Needs You](#pcgen-needs-you)
 
-3. [PCGen Needs You](#pcgen-needs-you)
+3. [The Old Wiki](#the-old-wiki)
 
-4. [The Old Wiki](#the-old-wiki)
+4. [PCGen LST Tutorial](#pcgen-lst-tutorial)
 
-5. [PCGen LST Tutorial](#pcgen-lst-tutorial)
+5. [Basic Workflow](#basic-workflow)
 
-6. [Basic Workflow](#basic-workflow)
+6. [Development Setup](#development-setup)
 
-7. [Development Setup](#development-setup)
+7. [Essential Gradle Tasks](#essential-gradle-tasks)
 
-8. [Essential Gradle Tasks](#essential-gradle-tasks)
-
-# Installing From Release 6.08
-1. Install Java.
-   - JDK 11 is recommended and has long term support, later versions should also work. 10 and below are not supported.
-   - To check if you have Java installed, see [Install Java](#install-java)
-   - If you don't have it already, you can get it from [Eclipse Temurin](https://adoptium.net/temurin/releases/?version=11).
-   
-2. Download and extract the full zip file from https://github.com/PCGen/pcgen/releases/latest.
-
-3. You should now be able to run PCGen. The exact invocation depends on your operating system, but you should be able to either double-click to launch the file for your platform.
-    - Windows: `pcgen.exe` (`pcgen.bat` for command-line users)
-    - Linux: `pcgen.sh` 
-    - Mac: `pcgen.jar` (or `pcgen.dmg` if it exists)
-    
-# Installing From Release 6.09 (Alpha)
+# Installing PCGen
 > Note: Java does not need to be preinstalled with PcGen >6.09.05
 
 ## Using Zip bundle
@@ -111,8 +96,7 @@ Check the installed version with:
 
     java -version
 
-For 6.08 development you will want Java with a minimum version of 11.
-For 6.09 development you will want Java with a minimum version of 25.
+For development you will want Java with a minimum version of 25.
 You can install the latest version from [Eclipse Temurin](https://adoptium.net) regardless of your OS, please see instructions there.
 
 ### Install Git

--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,36 @@ java {
     }
 }
 
+// Replace Gradle's opaque toolchain error with an actionable message.
+gradle.taskGraph.whenReady { graph ->
+    def needsCompile = graph.allTasks.any { it instanceof JavaCompile }
+    if (!needsCompile) return
+
+    try {
+        javaToolchains.launcherFor(java.toolchain).get()
+    } catch (Exception e) {
+        throw new GradleException("""
+
+            PCGen requires JDK ${javaVersion} to build, but Gradle could not
+            find one on this machine.
+
+            Currently running: Java ${System.getProperty('java.version')}
+                               at ${System.getProperty('java.home')}
+
+            Install JDK ${javaVersion} (or newer) and either:
+              - Set JAVA_HOME to it, or
+              - Run: ./gradlew -Porg.gradle.java.installations.paths=<path-to-jdk-${javaVersion}> <task>
+
+            Verify Gradle can see it:  ./gradlew -q javaToolchains
+
+            Downloads:
+              - Adoptium Temurin: https://adoptium.net/temurin/releases/?version=${javaVersion}
+              - Azul Zulu:        https://www.azul.com/downloads/?version=java-${javaVersion}-lts
+              - SapMachine:       https://sapmachine.io/
+            """.stripIndent(), e)
+    }
+}
+
 application {
     mainClass.set('pcgen.system.Main')
 }


### PR DESCRIPTION
Improves the newcomer / drive-by-contributor experience for the JDK 25 requirement introduced in #7611. Two orthogonal but paired changes.

## Problem

A contributor testing PR #7660 on Windows 10 with an older JDK hit:

```
* Where: Build file '...\PCGen\build.gradle' line: 252
> Could not resolve all dependencies for configuration ':runtimeClasspath'.
   > Failed to calculate the value of task ':compileJava' property 'javaCompiler'.
      > Cannot find a Java installation on your machine (Windows 10 10.0 amd64)
        matching: {languageVersion=25, vendor=any vendor, implementation=vendor-specific,
        nativeImageCapable=false}. Toolchain download repositories have not been
        configured.
```

The error is accurate but opaque — it points at a build.gradle line unrelated to the actual problem, doesn't name what version is required, doesn't name what version the user *has*, and doesn't tell them where to get a matching JDK. Meanwhile the README still documents parallel 6.08 (JDK 11) and 6.09 (JDK 25) install paths, which is confusing for someone landing on master trying to figure out which one applies.

## build.gradle — pre-flight toolchain check

Installs a `gradle.taskGraph.whenReady` hook that calls `javaToolchains.launcherFor(java.toolchain).get()` before any `JavaCompile` task runs. This uses the **same resolution path** `compileJava` itself would use, so it correctly accepts every legitimate setup:

- `JAVA_HOME` pointing at JDK 25+
- Standard OS install locations Gradle auto-discovers
- `-Porg.gradle.java.installations.paths=<path>` (the friend's workaround)
- Global `~/.gradle/gradle.properties` `org.gradle.java.installations.paths`

On failure, replaces the opaque error with:

```
PCGen requires JDK 25 to build, but Gradle could not find one on this machine.

Currently running: Java 21.0.4
                   at C:\Program Files\Eclipse Adoptium\jdk-21.0.4.7-hotspot

Install JDK 25 (or newer) and either:
  - Set JAVA_HOME to it, or
  - Run: ./gradlew -Porg.gradle.java.installations.paths=<path-to-jdk-25> <task>

Verify Gradle can see it:  ./gradlew -q javaToolchains

Downloads:
  - Adoptium Temurin: https://adoptium.net/temurin/releases/?version=25
  - Azul Zulu:        https://www.azul.com/downloads/?version=java-25-lts
  - SapMachine:       https://sapmachine.io/
```

The check fires **only when a task in the graph is a `JavaCompile`**, so `./gradlew help`, `./gradlew tasks`, `./gradlew javaToolchains`, and `./gradlew --version` remain usable even without JDK 25 installed — a
newcomer can still run `./gradlew -q javaToolchains` to discover what JDKs their machine has.

Required version is sourced from `project.ext.javaVersion` (i.e. `gradle.properties`), so future bumps stay one-line changes per the README's "Bumping Java / JavaFX versions" section.

### Why not auto-download the JDK?

Auto-provisioning a JDK 25 (e.g. via the Foojay resolver plugin) would require adding a new plugin dependency, and installing the toolchain is not a build responsibility PCGen wants to take on — it's fine for it to be a prerequisite the contributor handles once. Recent commits have been moving in the opposite direction: `af1640a877 Drop controlsfx
dependency`, `e23ea79cb7 build.gradle: drop stale forceMerge entries`, etc. This PR adds no dependency; it only improves the diagnostic when the prerequisite is missing.

## README.md — drop 6.08

Current version is `6.09.08.RC1` and every recent tag is 6.09.x. The README documented 6.08 and 6.09 install paths in parallel:

- TOC entry `Installing From Release 6.08`
- Full install section recommending JDK 11
- Second install section titled `Installing From Release 6.09 (Alpha)`
- Two-line dev-Java section: "For 6.08 development you will want Java with a minimum version of 11. / For 6.09 development you will want Java with a minimum version of 25."

Removed:
- 6.08 TOC entry (renumbered subsequent entries 2–7)
- Entire 6.08 install block (12 lines)
- 6.08 dev-Java line
- "(Alpha)" qualifier on the remaining install section — master ships 6.09 as the product; the alpha framing is stale.

Kept:
- The remaining install section, renamed `Installing PCGen`
- The 6.09 dev-Java line, simplified to "For development you will want Java with a minimum version of 25."

## Verified

| Command | Result |
|---|---|
| `./gradlew help` | Build succeeds — no toolchain resolution triggered (positive path for non-compile tasks) |
| `./gradlew compileJava --dry-run` | Build succeeds — toolchain resolved via `javaToolchains.launcherFor(...)` on machine with JDK 25 (positive path for compile tasks) |

**Not verified locally:** the negative path (message renders when no JDK 25 present), because my machine has JDK 25. The logic is small and eyeballable, but if a reviewer wants end-to-end confidence, temporarily bumping `javaVersion=99` in `gradle.properties` will trigger it.

## Out of scope

- Updating `6.09.xx`-in-a-URL patterns in the remaining install instructions — that's a docs decision about tracking `/releases/latest` vs. explicit versioning, deserves its own PR.
