### PR TITLE
SpotBugs correctness: SpellCasterChoiceSet symmetry + DescriptionActor null PC

### DIFF
--- a/code/src/java/pcgen/cdom/choiceset/SpellCasterChoiceSet.java
+++ b/code/src/java/pcgen/cdom/choiceset/SpellCasterChoiceSet.java
@@ -39,12 +39,15 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * A SpellCasterChoiceSet contains references to PCClass Objects.
- * 
+ *
  * The contents of a SpellCasterChoiceSet is defined at construction of the
  * SpellCasterChoiceSet. The contents of a SpellCasterChoiceSet is fixed, and
  * will not vary by the PlayerCharacter used to resolve the
  * SpellCasterChoiceSet.
  */
+@SuppressFBWarnings(value = "EQ_DOESNT_OVERRIDE_EQUALS",
+	justification = "Parent ChoiceSet.equals compares setName + pcs; pcs here is the typePCS passed to super, "
+		+ "which captures the relevant identity. Overriding equals here would break symmetry with the parent.")
 public class SpellCasterChoiceSet extends ChoiceSet<PCClass> implements PrimitiveChoiceSet<PCClass>
 {
 
@@ -273,49 +276,11 @@ public class SpellCasterChoiceSet extends ChoiceSet<PCClass> implements Primitiv
 		return returnSet;
 	}
 
-	@Override
-	public int hashCode()
-	{
-		return (types == null ? 0 : types.hashCode() * 29) + (primitives == null ? 0 : primitives.hashCode());
-	}
-
-	@Override
-	public boolean equals(Object obj)
-	{
-		if (obj == this)
-		{
-			return true;
-		}
-		if (obj instanceof SpellCasterChoiceSet other)
-		{
-			if (types == null)
-			{
-				if (other.types != null)
-				{
-					return false;
-				}
-			}
-			else
-			{
-				if (!types.equals(other.types))
-				{
-					return false;
-				}
-			}
-			if (primitives == null)
-			{
-				return other.primitives == null;
-			}
-			return primitives.equals(other.primitives);
-		}
-		return false;
-	}
-
 	/**
 	 * Returns the GroupingState for this SpellCasterChoiceSet. The
 	 * GroupingState indicates how this SpellCasterChoiceSet can be combined
 	 * with other PrimitiveChoiceSets.
-	 * 
+	 *
 	 * @return The GroupingState for this SpellCasterChoiceSet.
 	 */
 	@Override

--- a/code/src/java/pcgen/output/actor/DescriptionActor.java
+++ b/code/src/java/pcgen/output/actor/DescriptionActor.java
@@ -69,7 +69,14 @@ public class DescriptionActor implements OutputActor<PObject>
 			return FacetLibrary.getFacet(ObjectWrapperFacet.class).wrap(id, Constants.EMPTY_STRING);
 		}
 		PlayerCharacterTrackingFacet charStore = SpringHelper.getBean(PlayerCharacterTrackingFacet.class);
-		PlayerCharacter aPC = charStore.getPC(id);
+		PlayerCharacter aPC = (charStore == null) ? null : charStore.getPC(id);
+		if (aPC == null)
+		{
+			// SpringHelper.getBean returns null when no bean is registered, and
+			// PlayerCharacterTrackingFacet.getPC documents that null may be returned
+			// in unit-test paths where no PC has been associated with the CharID.
+			return FacetLibrary.getFacet(ObjectWrapperFacet.class).wrap(id, Constants.EMPTY_STRING);
+		}
 		final StringBuilder buf = new StringBuilder(250);
 		boolean needSpace = false;
 		for (final Description desc : theBenefits)

--- a/code/src/test/pcgen/cdom/choiceset/SpellCasterChoiceSetEqualsTest.java
+++ b/code/src/test/pcgen/cdom/choiceset/SpellCasterChoiceSetEqualsTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2026 Vest <Vest@users.noreply.github.com>
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation; either version 2.1 of the License, or (at your
+ * option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.cdom.choiceset;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import pcgen.cdom.base.ChoiceSet;
+import pcgen.cdom.base.PrimitiveChoiceSet;
+import pcgen.cdom.enumeration.GroupingState;
+import pcgen.core.PCClass;
+import pcgen.core.PlayerCharacter;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression test for the SpotBugs EQ_OVERRIDING_EQUALS_NOT_SYMMETRIC finding
+ * that previously affected {@link SpellCasterChoiceSet}. Before the fix the
+ * subclass overrode {@code equals} to require {@code SpellCasterChoiceSet} on
+ * the other side, which broke symmetry with {@link ChoiceSet#equals(Object)}.
+ * The fix removes that override and inherits the parent equality.
+ */
+class SpellCasterChoiceSetEqualsTest
+{
+
+	/**
+	 * Minimal stub PrimitiveChoiceSet identified by name; equals compares names.
+	 * Suitable for use as both the parent ChoiceSet's pcs and the subclass's
+	 * typePCS so that both ChoiceSets share the same {@code pcs} reference.
+	 */
+	private static PrimitiveChoiceSet<PCClass> stubPcs(String name)
+	{
+		return new PrimitiveChoiceSet<>()
+		{
+			@Override
+			public Class<PCClass> getChoiceClass()
+			{
+				return PCClass.class;
+			}
+
+			@Override
+			public String getLSTformat(boolean useAny)
+			{
+				return name;
+			}
+
+			@Override
+			public Set<PCClass> getSet(PlayerCharacter pc)
+			{
+				return Collections.emptySet();
+			}
+
+			@Override
+			public GroupingState getGroupingState()
+			{
+				return GroupingState.ANY;
+			}
+
+			@Override
+			public boolean equals(Object o)
+			{
+				return (o instanceof PrimitiveChoiceSet<?>) && name.equals(((PrimitiveChoiceSet<?>) o).getLSTformat(true));
+			}
+
+			@Override
+			public int hashCode()
+			{
+				return name.hashCode();
+			}
+		};
+	}
+
+	@Test
+	void parentAndSpellCasterAreSymmetricWhenSharingNameAndPcs()
+	{
+		PrimitiveChoiceSet<PCClass> sharedPcs = stubPcs("CASTERS");
+
+		// Parent ChoiceSet, name + pcs only — the identity ChoiceSet.equals checks.
+		ChoiceSet<PCClass> plainSet = new ChoiceSet<>("SPELLCASTER", sharedPcs);
+
+		// SpellCasterChoiceSet that passes the same pcs to super(...) so the
+		// parent-visible identity matches.
+		SpellCasterChoiceSet casterSet =
+			new SpellCasterChoiceSet(null, List.of(), sharedPcs, null);
+
+		// Symmetry of equals: both directions must agree (used to fail).
+		assertEquals(plainSet.equals(casterSet), casterSet.equals(plainSet),
+			"ChoiceSet.equals(SpellCasterChoiceSet) must equal SpellCasterChoiceSet.equals(ChoiceSet)");
+
+		// And the parent-defined identity says they are equal.
+		assertTrue(plainSet.equals(casterSet), "parent considers them equal (same setName + pcs)");
+		assertTrue(casterSet.equals(plainSet), "subclass must agree (symmetry)");
+
+		// Objects.equals goes through the receiver-side equals; verify both routes.
+		assertEquals(Objects.equals(plainSet, casterSet), Objects.equals(casterSet, plainSet));
+
+		// hashCode contract: equal objects must hash the same.
+		assertEquals(plainSet.hashCode(), casterSet.hashCode(),
+			"equal ChoiceSet/SpellCasterChoiceSet must hash equally");
+	}
+}


### PR DESCRIPTION
Fixes two real correctness bugs surfaced during a SpotBugs investigation in the choiceset and output.actor packages.

## SpellCasterChoiceSet: symmetry / hashCode contract

The parent `ChoiceSet.equals` accepts any `ChoiceSet<?>` (pattern matching on the parent type) and compares `setName` + `pcs`. The pre-fix subclass override required the other side to be a `SpellCasterChoiceSet`, breaking symmetry:

- `parentChoiceSet.equals(spellCaster)` returned `true` when setName + pcs matched.
- `spellCaster.equals(parentChoiceSet)` returned `false` (rejected by `instanceof SpellCasterChoiceSet`).

`hashCode` was inconsistent in the same way: parent hashed `setName ^ pcs`, subclass hashed `types` and `primitives`. Equal-by-parent objects could land in different hash buckets.

The subclass's `types` / `primitives` fields are not part of identity beyond what the parent already captures via the `typePCS` passed to `super(...)`. So the right pattern (already used by the sibling `ChoiceSet.AbilityChoiceSet` in #7628 / commit a7cd6c1504) is to delete the override and inherit the parent equality. The class gets `@SuppressFBWarnings(EQ_DOESNT_OVERRIDE_EQUALS)` with the rationale.

`SpellCasterChoiceSetEqualsTest` pins the symmetry contract; it would have failed against the pre-fix override.

## DescriptionActor.process: null guard

`PlayerCharacterTrackingFacet.getPC` documents (lines 40-47) that it may return `null` in unit-test paths where no PC has been associated with the CharID. `SpringHelper.getBean` also returns `null` when no bean is registered for the requested type. Both nulls used to flow straight into `desc.getDescription(aPC, ...)`, producing an NPE downstream.

SpotBugs flagged this as `NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE` at DescriptionActor.java:71. The fix early-returns an empty wrapped string for the no-PC case, matching the existing 'no benefits' early-out a few lines above.

## SpotBugs delta

Measured with the project exclude filter (`code/standards/spotbugs_ignore.xml`, `reportLevel = LOW`), comparing the branch against its parent commit:

- `EQ_OVERRIDING_EQUALS_NOT_SYMMETRIC`: 1 -> 0 (SpellCasterChoiceSet cleared)
- `NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE`: DescriptionActor.java:71 finding removed
- No new findings introduced.

### Historical context for deleting the `equals`/`hashCode` override

For reviewers wondering why the override existed and whether removing it loses anything — traced through git history:

- **2008, commit 6f6abda (thpr):** the class was created as `SpellReferenceChoiceSet` and `implements PrimitiveChoiceSet` — it did **not** extend `ChoiceSet`. Its `equals`/`hashCode` compared its own `set` field and were correct and self-consistent, because there was no parent equality to conflict with. The override was the class's only equality logic.
- **2008, commit 93caefeff9 (thpr, ~5 months later, "ADD:SPELLCASTER token update"):** the class was refactored to `extend ChoiceSet<PCClass>` (which already defined `equals`/`hashCode` on `setName ^ pcs` with a permissive `instanceof ChoiceSet` check) and switched to `types`/`primitives` fields, but the subclass override was kept with a **strict** `instanceof SpellCasterChoiceSet` check. That is the exact commit where the asymmetry was introduced, and it has been latent ever since.

The override is now both redundant and incorrect: the `typePCS` that drives `types`/`primitives` is the same object passed to `super(...)` as the parent's `pcs`, so the parent's `setName + pcs` comparison already captures that identity. Inheriting the parent equality (as the sibling `ChoiceSet.AbilityChoiceSet` does, cleaned up the same way in #7628) loses no discriminating power — it only restores the symmetry and hashCode contracts.
