### PR TITLE
Revert "Build(deps): bump org.beryx.jlink from 4.0.2 to 4.1.0"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ plugins {
     id 'pmd'                                            // PMD for Java, configured further below
     id 'de.undercouch.download' version '5.7.0'         // Shows download percentage
     id 'com.dorongold.task-tree' version '4.0.1'        // Prints the task dependency tree
-    id 'org.beryx.jlink' version '4.1.0'               // Creates custom runtimes with jlink
+    id 'org.beryx.jlink' version '4.0.2'               // Creates custom runtimes with jlink
     id 'jacoco'                                         // Code coverage
 }
 


### PR DESCRIPTION
Reverts PCGen/pcgen#7670

I had to revert this PR, because jlink breaks our nightly builds. With help from the bot, I have a fix for Mac, but I am not sure about Linux & Windows.
The safest change for now is to revert this commit for a while.

Sorry @dependabot-bot 