### PR TITLE
Build(deps): bump org.beryx.jlink to 4.1.1-rc to fix jpackage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ plugins {
     id 'pmd'                                            // PMD for Java, configured further below
     id 'de.undercouch.download' version '5.7.0'         // Shows download percentage
     id 'com.dorongold.task-tree' version '4.0.1'        // Prints the task dependency tree
-    id 'org.beryx.jlink' version '4.0.2'               // Creates custom runtimes with jlink
+    id 'org.beryx.jlink' version '4.1.1-rc'             // Creates custom runtimes with jlink
     id 'jacoco'                                         // Code coverage
 }
 


### PR DESCRIPTION
## Why

The straight 4.0.2 → 4.1.0 bump breaks `fullJpackage`, so it was merged and reverted twice already (#7670 → #7672, #7674 → #7677). This PR bumps to the upstream fix instead of retrying the broken version.

### Root cause

jlink 4.1.0 [added](https://github.com/beryx/badass-jlink-plugin/commit/4854c9e71e9e16a9319b5b1314c7b4f778a5bcec#r194044227) a blanket `doNotTrackState` to its jpackage tasks ([beryx/badass-jlink-plugin@4854c9e7](https://github.com/beryx/badass-jlink-plugin/commit/4854c9e71e9e16a9319b5b1314c7b4f778a5bcec)), so Gradle stopped tracking the app-image output directory. PCGen layers its own `Copy` tasks (`assembleJpackageImage`, and on macOS `patchMacJpackage`) **into** that same directory. Once the plugin stopped claiming ownership of it, Gradle's stale-output cleanup treated jpackage's files as orphans and deleted the `.jpackage.xml` marker before our copy ran — which breaks the `:jpackage` step.

This only surfaces in the **nightly** build (regular CI doesn't run jpackage), which is why the earlier bumps passed PR checks but broke master and had to be reverted.

### The fix

4.1.1-rc fixes this upstream ([beryx/badass-jlink-plugin@0d4bf7ec](https://github.com/beryx/badass-jlink-plugin/commit/0d4bf7ec6cc2409807da219c132cecc76a87afa6)): it removes the `doNotTrackState` and marks the image/installer output directories `@Optional` instead. That restores the output tracking 4.0.2 had, so Gradle again knows jpackage owns the image directory and no longer deletes the marker. **No PCGen-side workaround is needed** — this PR is the version bump only.

## Testing

Verified locally on macOS / JDK 25 with the bump alone (no build-script changes):

- `./gradlew clean fullJpackage` — **succeeds**
- `.jpackage.xml` marker survives (the exact file the bug deleted)
- app bundle stays validly signed (`codesign --verify --deep --strict` passes); `pcgen-<version>.dmg` is produced
- repeated incremental rebuilds are stable

The nightly is the real regression gate here — once merged, the next nightly run exercises the full jpackage path on all platforms.

## Notes

- Pinned to `4.1.1-rc` to unblock the nightly now; swap to `4.1.1` final once released.
- Supersedes the Dependabot re-attempt #7678 (the bare 4.1.0 bump).