### PR TITLE
Implement BONUS:CASTERLEVEL|ALLSPELLS

### DIFF
--- a/code/src/java/pcgen/core/PlayerCharacter.java
+++ b/code/src/java/pcgen/core/PlayerCharacter.java
@@ -3698,6 +3698,14 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 		return variableProcessor;
 	}
 
+	/**
+	 * Computes the caster level for a spell, or a class total when {@code aSpell}
+	 * is null, applying all matching CASTERLEVEL bonuses.
+	 *
+	 * @param acs    source of a fixed caster level; read only when {@code aSpell} is non-null
+	 * @param aSpell the spell being cast; {@code null} for a class-total query, which skips all per-spell bonuses
+	 * @return the effective caster level including bonuses
+	 */
 	public int getTotalCasterLevelWithSpellBonus(CharacterSpell acs, final Spell aSpell, final String spellType,
 												 final String classOrRace, final int casterLev)
 	{
@@ -3745,9 +3753,10 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 			return tallyCasterlevelBonuses(casterLev, false, bonuses);
 		}
 
-		// BONUS:CASTERLEVEL|ALLSPELLS|x applies to every spell of every casting
-		// class (both arcane and divine), like an effective caster level boost
-		// (e.g. Orange Prism Ioun Stone).
+		// BONUS:CASTERLEVEL|ALLSPELLS|x is a property of the spell being cast (every spell qualifies) regardless of
+		// tradition, so it belongs with the TYPE/SPELL/SCHOOL group below rather than the classOrRace block above,
+		// and must stay after the aSpell == null guard: a null spell is a total-caster-level query, not a per-spell
+		// one. Applied like an effective caster level boost (e.g. Orange Prism Ioun Stone).
 		tStr = "ALLSPELLS";
 		tBonus = (int) getTotalBonusTo("CASTERLEVEL", tStr);
 		if (tBonus != 0) // Allow negative bonus to casterlevel (e.g. Moon Circlet)

--- a/code/src/java/pcgen/core/PlayerCharacter.java
+++ b/code/src/java/pcgen/core/PlayerCharacter.java
@@ -3745,6 +3745,25 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 			return tallyCasterlevelBonuses(casterLev, false, bonuses);
 		}
 
+		// BONUS:CASTERLEVEL|ALLSPELLS|x applies to every spell of every casting
+		// class (both arcane and divine), like an effective caster level boost
+		// (e.g. Orange Prism Ioun Stone).
+		tStr = "ALLSPELLS";
+		tBonus = (int) getTotalBonusTo("CASTERLEVEL", tStr);
+		if (tBonus != 0) // Allow negative bonus to casterlevel (e.g. Moon Circlet)
+		{
+			tType = getSpellBonusType("CASTERLEVEL", tStr);
+			bonuses.add(new CasterLevelSpellBonus(tBonus, tType));
+		}
+		tStr += ".RESET";
+		tBonus = (int) getTotalBonusTo("CASTERLEVEL", tStr);
+		if (tBonus > 0)
+		{
+			replaceCasterLevel = true;
+			tType = getSpellBonusType("CASTERLEVEL", tStr);
+			bonuses.add(new CasterLevelSpellBonus(tBonus, tType));
+		}
+
 		if (!spellType.equals(Constants.NONE))
 		{
 			tStr = "TYPE." + spellType;

--- a/code/src/slowtest/pcgen/core/PlayerCharacterTest.java
+++ b/code/src/slowtest/pcgen/core/PlayerCharacterTest.java
@@ -287,6 +287,72 @@ class PlayerCharacterTest extends AbstractCharacterTestCase
 	}
 
 	/**
+	 * BONUS:CASTERLEVEL|ALLSPELLS|x raises the effective caster level of every
+	 * spell of every casting class.
+	 */
+	@Test
+	void testCasterLevelAllSpellsBonus() throws Exception
+	{
+		readyToRun();
+
+		final Spell spell = new Spell();
+		spell.setName("Test Arcane Spell");
+		final CharacterSpell charSpell = new CharacterSpell(pcClass, spell);
+
+		// Without the bonus, effective caster level equals class level.
+		final PlayerCharacter baseChar = new PlayerCharacter();
+		baseChar.setRace(human);
+		baseChar.incrementClassLevel(3, pcClass, true);
+		baseChar.calcActiveBonuses();
+		final int base = baseChar.getTotalCasterLevelWithSpellBonus(charSpell, spell,
+			pcClass.getSpellType(), pcClass.getKeyName(), 3);
+		assertEquals(3, base, "Base effective caster level should equal class level");
+
+		// Grant BONUS:CASTERLEVEL|ALLSPELLS|3 via the race, then build a PC.
+		final BonusObj allSpells = Bonus.newBonus(Globals.getContext(), "CASTERLEVEL|ALLSPELLS|3");
+		human.addToListFor(ListKey.BONUS, allSpells);
+		human.ownBonuses(human);
+
+		final PlayerCharacter character = new PlayerCharacter();
+		character.setRace(human);
+		character.incrementClassLevel(3, pcClass, true);
+		character.calcActiveBonuses();
+
+		final int boosted = character.getTotalCasterLevelWithSpellBonus(charSpell, spell,
+			pcClass.getSpellType(), pcClass.getKeyName(), 3);
+		assertEquals(6, boosted,
+			"BONUS:CASTERLEVEL|ALLSPELLS|3 should add 3 to the spell's effective caster level");
+	}
+
+	/**
+	 * BONUS:CASTERLEVEL|ALLSPELLS with a negative value lowers effective caster
+	 * level (e.g. the Moon Circlet).
+	 */
+	@Test
+	void testCasterLevelAllSpellsNegativeBonus() throws Exception
+	{
+		readyToRun();
+
+		final BonusObj allSpells = Bonus.newBonus(Globals.getContext(), "CASTERLEVEL|ALLSPELLS|-2");
+		human.addToListFor(ListKey.BONUS, allSpells);
+		human.ownBonuses(human);
+
+		final PlayerCharacter character = new PlayerCharacter();
+		character.setRace(human);
+		character.incrementClassLevel(5, pcClass, true);
+		character.calcActiveBonuses();
+
+		final Spell spell = new Spell();
+		spell.setName("Test Arcane Spell Neg");
+		final CharacterSpell charSpell = new CharacterSpell(pcClass, spell);
+
+		final int result = character.getTotalCasterLevelWithSpellBonus(charSpell, spell,
+			pcClass.getSpellType(), pcClass.getKeyName(), 5);
+		assertEquals(3, result,
+			"A negative BONUS:CASTERLEVEL|ALLSPELLS should reduce the effective caster level");
+	}
+
+	/**
 	 * Test bonus monster feats where there default monster mode is off.
 	 * Note: As PCClass grants feats which do not exist, the feat pool gets 
 	 * incremented instead.

--- a/docs/listfilepages/globalfilestagpages/globalfilesbonus.html
+++ b/docs/listfilepages/globalfilestagpages/globalfilesbonus.html
@@ -751,10 +751,10 @@ innate racial spells.
    <code>BONUS:CASTERLEVEL|ALLSPELLS|1</code>
   </p>
   <p class="indent3">
-   Adds 1 to the caster level of all of the character's
-spells, for every spellcasting class (both arcane and
-divine). Use TYPE.Arcane or TYPE.Divine to affect only one
-type.
+   Adds 1 to the caster level of every spell the character
+can cast, across all spellcasting classes regardless of
+spell type. To affect only one tradition, use TYPE.x
+instead, e.g. TYPE.Arcane.
   </p>
   <p class="indent2">
    <code>BONUS:CASTERLEVEL|RACE.Gelfling|4</code>

--- a/docs/listfilepages/globalfilestagpages/globalfilesbonus.html
+++ b/docs/listfilepages/globalfilestagpages/globalfilesbonus.html
@@ -748,6 +748,15 @@ innate racial spells.
    Adds 1 to Arcane spell caster level.
   </p>
   <p class="indent2">
+   <code>BONUS:CASTERLEVEL|ALLSPELLS|1</code>
+  </p>
+  <p class="indent3">
+   Adds 1 to the caster level of all of the character's
+spells, for every spellcasting class (both arcane and
+divine). Use TYPE.Arcane or TYPE.Divine to affect only one
+type.
+  </p>
+  <p class="indent2">
    <code>BONUS:CASTERLEVEL|RACE.Gelfling|4</code>
   </p>
   <p class="indent3">

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=6.10.00.allspells
+version=6.09.08.RC1
 org.gradle.jvmargs=-Xmx4096m
 
 org.gradle.configuration-cache=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=6.09.08.RC1
+version=6.10.00.allspells
 org.gradle.jvmargs=-Xmx4096m
 
 org.gradle.configuration-cache=true


### PR DESCRIPTION
## Summary

`BONUS:CASTERLEVEL|ALLSPELLS` has been documented since 5.7.1 but was never implemented. `getTotalCasterLevelWithSpellBonus()` queried CLASS/TYPE/SPELL/SCHOOL/SUBSCHOOL/DESCRIPTOR/DOMAIN targets but never ALLSPELLS, so the bonus parsed as a legal var yet silently did nothing. DC and CONCENTRATION already honored ALLSPELLS; CASTERLEVEL did not.

## Changes

- **Fix:** add an ALLSPELLS lookup in the `aSpell != null` branch, following the SCHOOL pattern — main bonus applied on `!= 0` so negatives count (Rod of Foiled Magic, Energy Drained, Moon Circlet), plus an `ALLSPELLS.RESET` variant. The term evaluator calls this method once per casting class, so the bonus applies per class across every casting tradition, matching effective-caster-level items (Orange Prism Ioun Stone, Half-Elf Multidisciplined, Dread Lord Magical Mastery).
- **Docs:** correct the ALLSPELLS help text — it previously claimed 'both arcane and divine' and suggested `TYPE.Divine`, but Divine is not a SPELLTYPE in shipped data and the implementation is tradition-agnostic. Reworded to match the code, using `TYPE.x` (e.g. `TYPE.Arcane`) as the filter example.
- **Comments/Javadoc:** document the `aSpell` null/non-null contract and why the ALLSPELLS block is positioned after the `aSpell == null` guard.

## Tests

Adds a slowtest in `PlayerCharacterTest` covering the ALLSPELLS bonus. Purely additive: data without ALLSPELLS is unaffected, and no inttest character uses an ALLSPELLS ability, so no csheet fixtures change.