### PR TITLE
fix: honor BONUS:PCLEVEL|TYPE in caster level evaluators

### DIFF
--- a/code/src/java/pcgen/core/term/PCCasterLevelClassTermEvaluator.java
+++ b/code/src/java/pcgen/core/term/PCCasterLevelClassTermEvaluator.java
@@ -69,7 +69,15 @@ public class PCCasterLevelClassTermEvaluator extends BasePCTermEvaluator impleme
 		}
 
 		final double d1 = pc.getTotalBonusTo("PCLEVEL", varSource);
-		final int pcBonus = (int) d1;
+		int pcBonus = (int) d1;
+
+		// BONUS:PCLEVEL|TYPE.<spellType> (e.g. the "+1 Arcane Caster Level" GM
+		// Award) applies to every class of that spell type, mirroring the
+		// spells-known/per-day handling in SpellSupportForPCClass.
+		if (!spellType.equals(Constants.NONE))
+		{
+			pcBonus += (int) pc.getTotalBonusTo("PCLEVEL", "TYPE." + spellType);
+		}
 
 		// does the class have a Casterlevel?
 		final double d2 = pc.getTotalBonusTo("CASTERLEVEL", varSource);

--- a/code/src/java/pcgen/core/term/PCCasterLevelTotalTermEvaluator.java
+++ b/code/src/java/pcgen/core/term/PCCasterLevelTotalTermEvaluator.java
@@ -52,11 +52,15 @@ public class PCCasterLevelTotalTermEvaluator extends BasePCTermEvaluator impleme
 			{
 				final String classKey = pcClass.getKeyName();
 
-				final int pcBonus = (int) pc.getTotalBonusTo("PCLEVEL", classKey);
+				String spellType = pcClass.getSpellType();
+
+				int pcBonus = (int) pc.getTotalBonusTo("PCLEVEL", classKey);
+				// BONUS:PCLEVEL|TYPE.<spellType> (e.g. the "+1 Arcane Caster
+				// Level" GM Award) applies to every class of that spell type,
+				// mirroring SpellSupportForPCClass.
+				pcBonus += (int) pc.getTotalBonusTo("PCLEVEL", "TYPE." + spellType);
 				final int castBonus = (int) pc.getTotalBonusTo("CASTERLEVEL", classKey);
 				final int iClass = (castBonus == 0) ? pc.getDisplay().getLevel(pcClass) : 0;
-
-				String spellType = pcClass.getSpellType();
 
 				iLev += pc.getTotalCasterLevelWithSpellBonus(aSpell, (aSpell == null) ? null : aSpell.getSpell(),
 					spellType, classKey, iClass + pcBonus);

--- a/code/src/slowtest/pcgen/core/PlayerCharacterTest.java
+++ b/code/src/slowtest/pcgen/core/PlayerCharacterTest.java
@@ -400,6 +400,90 @@ class PlayerCharacterTest extends AbstractCharacterTestCase
 	}
 
 	/**
+	 * BONUS:CASTERLEVEL|TYPE.Arcane raises caster level ONLY, while
+	 * BONUS:PCLEVEL|TYPE.Arcane raises BOTH caster level and spell progression
+	 * (highest castable spell level), per globalfilesbonus.html. A
+	 * caster-level-only award belongs on CASTERLEVEL; the fix must nonetheless
+	 * honor PCLEVEL, which the shipped GM Award data uses.
+	 */
+	@Test
+	void testCasterLevelVsPcLevelProgression() throws Exception
+	{
+		final LoadContext context = Globals.getContext();
+
+		// An arcane caster with a fixed CASTERLEVEL of 5 (so the caster-level
+		// evaluator has a solid base) whose CAST progression grants 2nd-level
+		// spells only at class level 2 -- so cast@2 == 0 at level 1 is the
+		// observable "spell progression" signal that a +1 effective level flips.
+		final PCClass caster = new PCClass();
+		caster.setName("VerifyCaster");
+		BuildUtilities.setFact(caster, "SpellType", "Arcane");
+		context.unconditionallyProcess(caster, "SPELLSTAT", "CHA");
+		caster.put(ObjectKey.SPELLBOOK, false);
+		caster.put(ObjectKey.MEMORIZE_SPELLS, false);
+		caster.addToListFor(ListKey.BONUS, Bonus.newBonus(context, "CASTERLEVEL|VerifyCaster|5"));
+		context.unconditionallyProcess(caster.getOriginalClassLevel(1), "CAST", "3,1");
+		context.unconditionallyProcess(caster.getOriginalClassLevel(2), "CAST", "3,2,1");
+		context.getReferenceContext().importObject(caster);
+		readyToRun();
+
+		final String sbook = Globals.getDefaultSpellBook();
+		final Spell spell = new Spell();
+		spell.setName("Verify Arcane Spell");
+		final CharacterSpell charSpell = new CharacterSpell(caster, spell);
+		final PCCasterLevelClassTermEvaluator eval = new PCCasterLevelClassTermEvaluator(
+			"CASTERLEVEL.CLASS." + caster.getKeyName(), caster.getKeyName());
+
+		final int baseCl = measureCasterLevel(caster, eval, charSpell);
+		final int baseCast2 = measureCastAtLevel2(caster, sbook);
+
+		// --- CASTERLEVEL|TYPE.Arcane|1 : expect CL +1, progression UNCHANGED ---
+		final BonusObj clBonus = Bonus.newBonus(context, "CASTERLEVEL|TYPE.Arcane|1");
+		human.addToListFor(ListKey.BONUS, clBonus);
+		human.ownBonuses(human);
+		final int clCl = measureCasterLevel(caster, eval, charSpell);
+		final int clCast2 = measureCastAtLevel2(caster, sbook);
+		human.removeFromListFor(ListKey.BONUS, clBonus);
+		human.ownBonuses(human);
+
+		// --- PCLEVEL|TYPE.Arcane|1 : expect CL +1 AND progression +1 ---
+		final BonusObj pcBonus = Bonus.newBonus(context, "PCLEVEL|TYPE.Arcane|1");
+		human.addToListFor(ListKey.BONUS, pcBonus);
+		human.ownBonuses(human);
+		final int pcCl = measureCasterLevel(caster, eval, charSpell);
+		final int pcCast2 = measureCastAtLevel2(caster, sbook);
+		human.removeFromListFor(ListKey.BONUS, pcBonus);
+		human.ownBonuses(human);
+
+		// CASTERLEVEL: caster level rose by 1, spell progression did NOT change.
+		assertEquals(baseCl + 1, clCl, "CASTERLEVEL|TYPE.Arcane should raise caster level by 1");
+		assertEquals(baseCast2, clCast2, "CASTERLEVEL|TYPE.Arcane must NOT change spell progression");
+
+		// PCLEVEL: caster level rose by 1 AND spell progression increased.
+		assertEquals(baseCl + 1, pcCl, "PCLEVEL|TYPE.Arcane should raise caster level by 1");
+		assertTrue(pcCast2 > baseCast2, "PCLEVEL|TYPE.Arcane also raises spell progression");
+	}
+
+	private int measureCasterLevel(PCClass caster, PCCasterLevelClassTermEvaluator eval, CharacterSpell charSpell)
+	{
+		final PlayerCharacter pc = new PlayerCharacter();
+		pc.setRace(human);
+		pc.incrementClassLevel(1, caster, true);
+		pc.calcActiveBonuses();
+		return eval.resolve(pc, charSpell).intValue();
+	}
+
+	private int measureCastAtLevel2(PCClass caster, String sbook)
+	{
+		final PlayerCharacter pc = new PlayerCharacter();
+		pc.setRace(human);
+		pc.incrementClassLevel(1, caster, true);
+		pc.calcActiveBonuses();
+		final PCClass held = pc.getClassKeyed(caster.getKeyName());
+		return pc.getSpellSupport(held).getCastForLevel(2, sbook, true, false, pc);
+	}
+
+	/**
 	 * Test bonus monster feats where there default monster mode is off.
 	 * Note: As PCClass grants feats which do not exist, the feat pool gets
 	 * incremented instead.

--- a/code/src/slowtest/pcgen/core/PlayerCharacterTest.java
+++ b/code/src/slowtest/pcgen/core/PlayerCharacterTest.java
@@ -59,6 +59,7 @@ import pcgen.core.display.CharacterDisplay;
 import pcgen.core.pclevelinfo.PCLevelInfo;
 import pcgen.core.spell.Spell;
 import pcgen.core.system.LoadInfo;
+import pcgen.core.term.PCCasterLevelClassTermEvaluator;
 import pcgen.gui2.UIPropertyContext;
 import pcgen.io.exporttoken.StatToken;
 import pcgen.persistence.lst.SimpleLoader;
@@ -287,6 +288,7 @@ class PlayerCharacterTest extends AbstractCharacterTestCase
 	}
 
 	/**
+	/**
 	 * BONUS:CASTERLEVEL|ALLSPELLS|x raises the effective caster level of every
 	 * spell of every casting class.
 	 */
@@ -353,8 +355,53 @@ class PlayerCharacterTest extends AbstractCharacterTestCase
 	}
 
 	/**
+	 * BONUS:PCLEVEL|TYPE.Arcane raises the caster level of every Arcane
+	 * spellcasting class (e.g. the "+1 Arcane Caster Level" GM Award).
+	 */
+	@Test
+	void testCasterLevelArcaneTypeBonus() throws Exception
+	{
+		readyToRun();
+
+		// Give the (Arcane, see setUp) class a fixed caster level of 3 so the
+		// evaluator has a nonzero base to add the TYPE bonus onto.
+		final PCClass arcaneClass = new PCClass();
+		arcaneClass.setName("ArcaneTypeClass");
+		BuildUtilities.setFact(arcaneClass, "SpellType", "Arcane");
+		arcaneClass.addToListFor(ListKey.BONUS,
+			Bonus.newBonus(Globals.getContext(), "CASTERLEVEL|ArcaneTypeClass|3"));
+		Globals.getContext().getReferenceContext().importObject(arcaneClass);
+
+		final Spell spell = new Spell();
+		spell.setName("Test Arcane Spell CL");
+		final CharacterSpell charSpell = new CharacterSpell(arcaneClass, spell);
+		final PCCasterLevelClassTermEvaluator eval = new PCCasterLevelClassTermEvaluator(
+			"CASTERLEVEL.CLASS." + arcaneClass.getKeyName(), arcaneClass.getKeyName());
+
+		// Baseline: fixed caster level 3, no PCLEVEL|TYPE bonus.
+		final PlayerCharacter baseChar = new PlayerCharacter();
+		baseChar.setRace(human);
+		baseChar.incrementClassLevel(1, arcaneClass, true);
+		baseChar.calcActiveBonuses();
+		assertEquals(3, eval.resolve(baseChar, charSpell).intValue(),
+			"Baseline caster level should be the class's fixed CASTERLEVEL of 3");
+
+		// Grant BONUS:PCLEVEL|TYPE.Arcane|1 via the race.
+		human.addToListFor(ListKey.BONUS, Bonus.newBonus(Globals.getContext(), "PCLEVEL|TYPE.Arcane|1"));
+		human.ownBonuses(human);
+
+		final PlayerCharacter character = new PlayerCharacter();
+		character.setRace(human);
+		character.incrementClassLevel(1, arcaneClass, true);
+		character.calcActiveBonuses();
+
+		assertEquals(4, eval.resolve(character, charSpell).intValue(),
+			"BONUS:PCLEVEL|TYPE.Arcane|1 should raise the Arcane class's caster level by 1 (3 + 1)");
+	}
+
+	/**
 	 * Test bonus monster feats where there default monster mode is off.
-	 * Note: As PCClass grants feats which do not exist, the feat pool gets 
+	 * Note: As PCClass grants feats which do not exist, the feat pool gets
 	 * incremented instead.
 	 */
 	@Test


### PR DESCRIPTION
## Problem
The caster-level term evaluators computed the `PCLEVEL` bonus only from `PCLEVEL|<classKey>`, so `BONUS:PCLEVEL|TYPE.Arcane` / `TYPE.Divine` (the "+1 Arcane/Divine Caster Level" GM Awards in `cr_abilities.lst`) never affected caster level — even though `SpellSupportForPCClass` already honors `PCLEVEL|TYPE.<type>` for spells known and per-day. The award raised spell slots but silently left the caster level unchanged.

Per `globalfilesbonus.html`, `BONUS:PCLEVEL` "increases the spellcasting level" (both caster level **and** progression), whereas `BONUS:CASTERLEVEL` raises the caster-level number only. This fixes the caster-level half for the TYPE form.

## Fix
Add a `PCLEVEL|TYPE.<spellType>` lookup alongside the existing class-key lookup in `PCCasterLevelClassTermEvaluator` and `PCCasterLevelTotalTermEvaluator`, mirroring `SpellSupportForPCClass`. In the total evaluator the bonus is summed per class using that class's own spell type, so a mixed arcane/divine caster gets each award applied only to the matching classes. Generic across all spell types, not just Arcane/Divine.

## Tests
- `testCasterLevelArcaneTypeBonus` — reproduces the bug (caster level 3 → 4 with `PCLEVEL|TYPE.Arcane|1`)
- `testCasterLevelVsPcLevelProgression` — documents the CASTERLEVEL-vs-PCLEVEL contract from the docs

Purely additive: no test character carries a `PCLEVEL|TYPE` ability, so all csheet fixtures are unchanged.
