### PR TITLE
Resolve bundled data & settings paths from java.home (fix #7678)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -316,6 +316,9 @@ def hostJdkExt = (hostOs == "windows") ? "zip" : "tar.gz"
 def hostJfxOsPackage = (hostOs == "mac") ? "osx" : hostOs
 def hostJfxArchSuffix = "-${hostArch}"
 
+// Assets staged here (dir named "app") are fed to jpackage via --app-content.
+def jpackageStageDir = layout.buildDirectory.dir("jpackageStage/app")
+
 jlink {
     options = ['--strip-debug', '--no-header-files', '--no-man-pages']
     addExtraDependencies('javafx')
@@ -405,6 +408,9 @@ jlink {
 
         installerOptions = opts
         imageName = "PcGen"
+
+        // Embed runtime assets via --app-content so jpackage builds and signs the whole image.
+        imageOptions = ['--app-content', jpackageStageDir.get().asFile.absolutePath]
     }
 }
 
@@ -440,75 +446,26 @@ tasks.named("jlink") {
     tasks.named(taskName) { dependsOn "extractJdk" }
 }
 
+// Stage runtime assets into a PCGen-owned "app" dir; jpackage embeds them via --app-content.
 tasks.register("assembleJpackageImage", Copy) {
-    dependsOn tasks.named("jpackageImage"), tasks.named("installDist")
+    dependsOn tasks.named("installDist")
     includeEmptyDirs = false
     from layout.buildDirectory.dir("install/pcgen")
     exclude "**/*.exe"
     exclude "**/*.bat"
     exclude "pcgen"
     exclude "**/lib/**"
-    if (Os.isFamily(Os.FAMILY_MAC)) {
-        into layout.buildDirectory.dir("jpackage/PcGen.app/Contents/app")
-    } else {
-        into layout.buildDirectory.dir("jpackage/PcGen")
-    }
-    // jpackageImage wipes the output dir on rebuild; always re-copy
-    outputs.upToDateWhen { false }
+    into jpackageStageDir
 }
 
-if (Os.isFamily(Os.FAMILY_MAC)) {
-    tasks.register("patchMacJpackage", Copy) {
-        dependsOn tasks.named("assembleJpackageImage")
-        from layout.projectDirectory.dir("installers/mac-installer")
-        include "MacDirLauncher"
-        filePermissions {
-            unix(0755)
-        }
-        into layout.buildDirectory.dir("jpackage/PcGen.app/Contents/MacOS")
-        def plistFile = layout.buildDirectory.file("jpackage/PcGen.app/Contents/Info.plist")
-        doLast {
-            def plist = plistFile.get().asFile
-            def content = plist.text
-            content = content.replace(
-                "<key>CFBundleExecutable</key>\n  <string>PcGen</string>",
-                "<key>CFBundleExecutable</key>\n  <string>MacDirLauncher</string>")
-            plist.text = content
-        }
-    }
+// jpackage reads --app-content at image build, so stage the assets first.
+tasks.named("jpackageImage") {
+    dependsOn tasks.named("assembleJpackageImage")
+}
 
-    // jpackage seals the bundle with an ad-hoc signature; rewriting
-    // Info.plist and dropping MacDirLauncher into Contents/MacOS above
-    // invalidates that seal, so `spctl -a` rejects the result as
-    // "directory or signature have been modified". Re-sign ad-hoc so
-    // the bundle is internally consistent. Users still see Gatekeeper
-    // on first launch (no Developer ID), but a single
-    // `xattr -dr com.apple.quarantine PcGen.app` is then enough —
-    // no `codesign --force --deep` round-trip required.
-    tasks.register("codesignMacJpackage", Exec) {
-        dependsOn tasks.named("patchMacJpackage")
-        def appBundleDir = layout.buildDirectory.dir("jpackage/PcGen.app")
-        commandLine "codesign", "--force", "--deep", "--sign", "-",
-                appBundleDir.get().asFile.absolutePath
-    }
-
-    // jpackage packages the image at build/jpackage/PcGen.app — make sure the
-    // data folders and the patched plist+launcher are in place before it runs.
-    tasks.named("jpackage") { dependsOn tasks.named("codesignMacJpackage") }
-
-    tasks.register("fullJpackage") {
-        dependsOn tasks.named("jpackage")
-        description = "Build the native application bundle with jpackage"
-    }
-} else {
-    // Same idea for Linux/Windows: jpackage reads build/jpackage/PcGen, which
-    // assembleJpackageImage populates with /data, /plugins, /preview, /outputsheets.
-    tasks.named("jpackage") { dependsOn tasks.named("assembleJpackageImage") }
-
-    tasks.register("fullJpackage") {
-        dependsOn tasks.named("jpackage")
-        description = "Build the native application bundle with jpackage"
-    }
+tasks.register("fullJpackage") {
+    dependsOn tasks.named("jpackage")
+    description = "Build the native application bundle with jpackage"
 }
 
 // Portable zip: same self-contained app the installer ships, but as an
@@ -516,9 +473,9 @@ if (Os.isFamily(Os.FAMILY_MAC)) {
 //
 // On macOS the bundle is packed with `ditto -c -k --keepParent` rather than
 // Gradle's Zip task: ditto preserves the 0755 exec bits on
-// Contents/MacOS/MacDirLauncher and Contents/MacOS/PcGen, plus symlinks,
-// xattrs, and code signatures. Plain Zip strips POSIX modes, leaving the
-// .app non-launchable after unzip ("application can't be opened").
+// Contents/MacOS/PcGen, plus symlinks, xattrs, and code signatures. Plain Zip
+// strips POSIX modes, leaving the .app non-launchable after unzip
+// ("application can't be opened").
 if (hostOs == "mac") {
     tasks.register("portableZip", Exec) {
         dependsOn tasks.named("fullJpackage")

--- a/code/src/java/pcgen/gui3/dialog/OptionsPathDialogController.java
+++ b/code/src/java/pcgen/gui3/dialog/OptionsPathDialogController.java
@@ -104,9 +104,20 @@ public class OptionsPathDialogController
 	{
 		DirectoryChooser directoryChooser = new DirectoryChooser();
 		String modelDirectory = model.directoryProperty().getValue();
-		if (!modelDirectory.isBlank())
+		if ((modelDirectory != null) && !modelDirectory.isBlank())
 		{
-			directoryChooser.setInitialDirectory(new File(model.directoryProperty().getValue()));
+			// The prefilled path (e.g. <install>/settings) may not exist yet, and
+			// JavaFX's DirectoryChooser silently refuses to open when initialDirectory
+			// is missing. Walk up to the nearest existing ancestor. See issue #7678.
+			File dir = new File(modelDirectory);
+			while ((dir != null) && !dir.isDirectory())
+			{
+				dir = dir.getParentFile();
+			}
+			if (dir != null)
+			{
+				directoryChooser.setInitialDirectory(dir);
+			}
 		}
 
 		File dir = directoryChooser.showDialog(optionsPathDialogScene.getWindow());

--- a/code/src/java/pcgen/gui3/dialog/OptionsPathDialogController.java
+++ b/code/src/java/pcgen/gui3/dialog/OptionsPathDialogController.java
@@ -40,6 +40,9 @@ public class OptionsPathDialogController
 	private final OptionsPathDialogModel model = new OptionsPathDialogModel();
 
 	@FXML
+	private RadioButton pcgenDir;
+
+	@FXML
 	private RadioButton freedesktop;
 
 	@FXML
@@ -77,6 +80,16 @@ public class OptionsPathDialogController
 		freedesktop.setVisible(SystemUtils.IS_OS_UNIX);
 		freedesktop.setManaged(SystemUtils.IS_OS_UNIX);
 
+		// "PCGen Dir" stores settings under the install dir, which only works on a
+		// portable/dev copy — an installed app (read-only DMG or sealed /Applications
+		// bundle) cannot be written to, so saving would fail silently. Disable it when
+		// the install root is not writable.
+		if (!ConfigurationSettings.isInstallRootWritable())
+		{
+			pcgenDir.setDisable(true);
+			pcgenDir.setText(pcgenDir.getText() + " (not writable)");
+		}
+
 		directoryGroup.selectedToggleProperty().addListener((observable, _, newValue)  -> {
 			Logging.debugPrint("toggle changed " + observable);
 			if (newValue.getUserData() != null)
@@ -108,7 +121,7 @@ public class OptionsPathDialogController
 		{
 			// The prefilled path (e.g. <install>/settings) may not exist yet, and
 			// JavaFX's DirectoryChooser silently refuses to open when initialDirectory
-			// is missing. Walk up to the nearest existing ancestor. See issue #7678.
+			// is missing. Walk up to the nearest existing ancestor.
 			File dir = new File(modelDirectory);
 			while ((dir != null) && !dir.isDirectory())
 			{

--- a/code/src/java/pcgen/gui3/dialog/OptionsPathDialogController.java
+++ b/code/src/java/pcgen/gui3/dialog/OptionsPathDialogController.java
@@ -19,6 +19,7 @@
 package pcgen.gui3.dialog;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Optional;
 
 import pcgen.system.ConfigurationSettings;
@@ -116,14 +117,11 @@ public class OptionsPathDialogController
 		String modelDirectory = model.directoryProperty().getValue();
 		if ((modelDirectory != null) && !modelDirectory.isBlank())
 		{
-			// The prefilled path (e.g. <install>/settings) may not exist yet, and
-			// JavaFX's DirectoryChooser silently refuses to open when initialDirectory
-			// is missing. Start at the nearest existing ancestor instead.
-			File initialDir = ConfigurationSettings.nearestExistingDir(modelDirectory);
-			if (initialDir != null)
-			{
-				directoryChooser.setInitialDirectory(initialDir);
-			}
+			// The prefilled path (e.g. <install>/settings) may not exist yet, and JavaFX's DirectoryChooser silently
+			// refuses to open when initialDirectory is missing.
+			ConfigurationSettings.nearestExistingDir(modelDirectory)
+					.map(Path::toFile)
+					.ifPresent(directoryChooser::setInitialDirectory);
 		}
 
 		File dir = directoryChooser.showDialog(optionsPathDialogScene.getWindow());

--- a/code/src/java/pcgen/gui3/dialog/OptionsPathDialogController.java
+++ b/code/src/java/pcgen/gui3/dialog/OptionsPathDialogController.java
@@ -80,10 +80,7 @@ public class OptionsPathDialogController
 		freedesktop.setVisible(SystemUtils.IS_OS_UNIX);
 		freedesktop.setManaged(SystemUtils.IS_OS_UNIX);
 
-		// "PCGen Dir" stores settings under the install dir, which only works on a
-		// portable/dev copy — an installed app (read-only DMG or sealed /Applications
-		// bundle) cannot be written to, so saving would fail silently. Disable it when
-		// the install root is not writable.
+		// "PCGen Dir" stores settings under the install dir. If the folder isn't writable (Mac, .dmg), disable the option.
 		if (!ConfigurationSettings.isInstallRootWritable())
 		{
 			pcgenDir.setDisable(true);
@@ -121,15 +118,11 @@ public class OptionsPathDialogController
 		{
 			// The prefilled path (e.g. <install>/settings) may not exist yet, and
 			// JavaFX's DirectoryChooser silently refuses to open when initialDirectory
-			// is missing. Walk up to the nearest existing ancestor.
-			File dir = new File(modelDirectory);
-			while ((dir != null) && !dir.isDirectory())
+			// is missing. Start at the nearest existing ancestor instead.
+			File initialDir = ConfigurationSettings.nearestExistingDir(modelDirectory);
+			if (initialDir != null)
 			{
-				dir = dir.getParentFile();
-			}
-			if (dir != null)
-			{
-				directoryChooser.setInitialDirectory(dir);
+				directoryChooser.setInitialDirectory(initialDir);
 			}
 		}
 

--- a/code/src/java/pcgen/system/ConfigurationSettings.java
+++ b/code/src/java/pcgen/system/ConfigurationSettings.java
@@ -153,9 +153,9 @@ public final class ConfigurationSettings extends PropertyContext
 		return getInstance().getProperty(key);
 	}
 
-	public static Object setSystemProperty(String key, String value)
+	public static void setSystemProperty(String key, String value)
 	{
-		return getInstance().setProperty(key, value);
+		getInstance().setProperty(key, value);
 	}
 
 	private static String getDirectory(String key)

--- a/code/src/java/pcgen/system/ConfigurationSettings.java
+++ b/code/src/java/pcgen/system/ConfigurationSettings.java
@@ -180,13 +180,35 @@ public final class ConfigurationSettings extends PropertyContext
 	 * walk up from java.home and return the first ancestor — or immediate child
 	 * of an ancestor — that actually contains PCGen's data (the "data" +
 	 * "system" folders). Falls back to user.dir for dev/IDE runs where the
-	 * runtime is a full JDK elsewhere. See issue #7678.
+	 * runtime is a full JDK elsewhere.
 	 */
 	private static String getInstallRoot()
 	{
+		return installRootPath().toString();
+	}
+
+	/** The resolved install-root directory (java.home walk, else user.dir). */
+	private static Path installRootPath()
+	{
 		return findInstallRoot(SystemUtils.JAVA_HOME)
-				.map(Path::toString)
-				.orElse(SystemUtils.USER_DIR);
+				.orElseGet(() -> Path.of(SystemUtils.USER_DIR));
+	}
+
+	/**
+	 * Whether the install root is writable — true for a portable/dev copy, false
+	 * for an installed app (read-only DMG or a sealed bundle in /Applications).
+	 * Disables the "PCGen Dir" settings option, which would otherwise fail silently
+	 * at save time (mkdirs under a read-only root).
+	 */
+	public static boolean isInstallRootWritable()
+	{
+		return isWritableDir(installRootPath());
+	}
+
+	/** Package-private seam so the writability check can be unit-tested. */
+	static boolean isWritableDir(Path dir)
+	{
+		return (dir != null) && Files.isDirectory(dir) && Files.isWritable(dir);
 	}
 
 	/**
@@ -270,7 +292,7 @@ public final class ConfigurationSettings extends PropertyContext
 					return SystemUtils.USER_HOME + File.separator + '.' + APPLICATION; // $NON-NLS-1$
 				case pcgen:
 					// Install dir, resolved from java.home like @-paths — not user.dir,
-					// which is / for a packaged/Finder launch (gave "//settings"). See issue #7678.
+					// which is / for a packaged/Finder launch (gave "//settings").
 					return getInstallRoot() + File.separator + "settings"; // $NON-NLS-1$
 				case mac_user:
 					return SystemUtils.USER_HOME + "/Library/Preferences/" + APPLICATION; // $NON-NLS-1$

--- a/code/src/java/pcgen/system/ConfigurationSettings.java
+++ b/code/src/java/pcgen/system/ConfigurationSettings.java
@@ -269,7 +269,9 @@ public final class ConfigurationSettings extends PropertyContext
 				case user:
 					return SystemUtils.USER_HOME + File.separator + '.' + APPLICATION; // $NON-NLS-1$
 				case pcgen:
-					return SystemUtils.USER_DIR + File.separator + "settings"; // $NON-NLS-1$
+					// Install dir, resolved from java.home like @-paths — not user.dir,
+					// which is / for a packaged/Finder launch (gave "//settings"). See issue #7678.
+					return getInstallRoot() + File.separator + "settings"; // $NON-NLS-1$
 				case mac_user:
 					return SystemUtils.USER_HOME + "/Library/Preferences/" + APPLICATION; // $NON-NLS-1$
 				case FD_USER:

--- a/code/src/java/pcgen/system/ConfigurationSettings.java
+++ b/code/src/java/pcgen/system/ConfigurationSettings.java
@@ -19,6 +19,11 @@
 package pcgen.system;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.stream.Stream;
 
 import org.apache.commons.lang3.SystemUtils;
 
@@ -161,25 +166,69 @@ public final class ConfigurationSettings extends PropertyContext
 		return expandRelativePath(getSystemProperty(key));
 	}
 
+	/**
+	 * The directory PCGen's bundled data (@data, @plugins, …) is resolved
+	 * against. It must be found independently of the process working directory,
+	 * because a packaged (jpackage) launcher starts with an arbitrary cwd — a
+	 * Finder/double-click launch on macOS gives user.dir=/ — and PCGen is a
+	 * linked module in the bundled runtime, so it has no jar location to key off.
+	 *
+	 * The one location the JVM always reports accurately is java.home (the
+	 * runtime image). In a jpackage bundle the app payload sits next to that
+	 * runtime at an OS-specific offset (Contents/app vs lib/app vs app), so we
+	 * walk up from java.home and return the first ancestor — or immediate child
+	 * of an ancestor — that actually contains PCGen's data (the "data" +
+	 * "system" folders). Falls back to user.dir for dev/IDE runs where the
+	 * runtime is a full JDK elsewhere. See issue #7678.
+	 */
+	private static String getInstallRoot()
+	{
+		String javaHome = SystemUtils.JAVA_HOME;
+		if (javaHome == null)
+		{
+			return SystemUtils.USER_DIR;
+		}
+		return Stream.iterate(Path.of(javaHome), Objects::nonNull, Path::getParent)
+				.flatMap(dir -> Stream.concat(Stream.of(dir), listDirectories(dir)))
+				.filter(ConfigurationSettings::looksLikeInstallRoot)
+				.findFirst()
+				.map(Path::toString)
+				.orElse(SystemUtils.USER_DIR);
+	}
+
+	private static Stream<Path> listDirectories(Path dir)
+	{
+		try (Stream<Path> children = Files.list(dir))
+		{
+			// Collect eagerly: the stream must outlive this try-with-resources.
+			return children.filter(Files::isDirectory).toList().stream();
+		}
+		catch (IOException _)
+		{
+			return Stream.empty();
+		}
+	}
+
+	private static boolean looksLikeInstallRoot(Path dir)
+	{
+		return Files.isDirectory(dir.resolve("data")) && Files.isDirectory(dir.resolve("system"));
+	}
+
 	private static String expandRelativePath(String path)
 	{
-		// TODO: a dirty hack for Mac bundles only
-		if (SystemUtils.USER_DIR.endsWith("MacOS") && path.startsWith("@"))
+		if (path.startsWith("@"))
 		{
-			path = SystemUtils.USER_DIR + File.separator + ".." + File.separator + "app" + File.separator + path.substring(1);
-		}
-		else if (path.startsWith("@"))
-		{
-			path = SystemUtils.USER_DIR + File.separator + path.substring(1);
+			path = getInstallRoot() + File.separator + path.substring(1);
 		}
 		return path;
 	}
 
 	private static String unexpandRelativePath(String path)
 	{
-		if (path.startsWith(SystemUtils.USER_DIR + File.separator))
+		String root = getInstallRoot();
+		if (path.startsWith(root + File.separator))
 		{
-			path = '@' + path.substring(SystemUtils.USER_DIR.length() + 1);
+			path = '@' + path.substring(root.length() + 1);
 		}
 		return path;
 	}

--- a/code/src/java/pcgen/system/ConfigurationSettings.java
+++ b/code/src/java/pcgen/system/ConfigurationSettings.java
@@ -287,7 +287,7 @@ public final class ConfigurationSettings extends PropertyContext
 
 	public static String getSettingsDirFromFilePath(String fType)
 	{
-		if ((fType == null) || (fType.length() < 1))
+		if ((fType == null) || fType.isEmpty())
 		{
 			// make sure we have a default
 			fType = getDefaultSettingsFilesPath();
@@ -298,7 +298,7 @@ public final class ConfigurationSettings extends PropertyContext
 			//Check to see if this path is one of the standard path types
 			path = SettingsFilesPath.valueOf(fType).getSettingsDir();
 		}
-		catch (IllegalArgumentException ex)
+		catch (IllegalArgumentException _)
 		{
 			//It must be a custom filepath
 			path = fType;

--- a/code/src/java/pcgen/system/ConfigurationSettings.java
+++ b/code/src/java/pcgen/system/ConfigurationSettings.java
@@ -212,6 +212,21 @@ public final class ConfigurationSettings extends PropertyContext
 	}
 
 	/**
+	 * The nearest existing directory at or above {@code path}, or null if none
+	 * exists up the chain. Lets a directory chooser start at a real directory
+	 * when the prefilled path does not exist yet.
+	 */
+	public static File nearestExistingDir(String path)
+	{
+		File dir = (path == null) ? null : new File(path);
+		while ((dir != null) && !dir.isDirectory())
+		{
+			dir = dir.getParentFile();
+		}
+		return dir;
+	}
+
+	/**
 	 * Walk up from {@code javaHome} and return the first ancestor — or immediate
 	 * child of an ancestor — that holds PCGen's bundled data (the "data" +
 	 * "system" folders), or empty if none is found (the caller then falls back

--- a/code/src/java/pcgen/system/ConfigurationSettings.java
+++ b/code/src/java/pcgen/system/ConfigurationSettings.java
@@ -168,19 +168,9 @@ public final class ConfigurationSettings extends PropertyContext
 	}
 
 	/**
-	 * The directory PCGen's bundled data (@data, @plugins, …) is resolved
-	 * against. It must be found independently of the process working directory,
-	 * because a packaged (jpackage) launcher starts with an arbitrary cwd — a
-	 * Finder/double-click launch on macOS gives user.dir=/ — and PCGen is a
-	 * linked module in the bundled runtime, so it has no jar location to key off.
-	 *
-	 * The one location the JVM always reports accurately is java.home (the
-	 * runtime image). In a jpackage bundle the app payload sits next to that
-	 * runtime at an OS-specific offset (Contents/app vs lib/app vs app), so we
-	 * walk up from java.home and return the first ancestor — or immediate child
-	 * of an ancestor — that actually contains PCGen's data (the "data" +
-	 * "system" folders). Falls back to user.dir for dev/IDE runs where the
-	 * runtime is a full JDK elsewhere.
+	 * The directory PCGen's bundled data (@data, @plugins, …) is resolved against,
+	 * found via {@link #findInstallRoot} from java.home rather than the process
+	 * working directory (a packaged/Finder launch gives user.dir=/).
 	 */
 	private static String getInstallRoot()
 	{

--- a/code/src/java/pcgen/system/ConfigurationSettings.java
+++ b/code/src/java/pcgen/system/ConfigurationSettings.java
@@ -212,18 +212,18 @@ public final class ConfigurationSettings extends PropertyContext
 	}
 
 	/**
-	 * The nearest existing directory at or above {@code path}, or null if none
+	 * The nearest existing directory at or above {@code path}, or empty if none
 	 * exists up the chain. Lets a directory chooser start at a real directory
 	 * when the prefilled path does not exist yet.
 	 */
-	public static File nearestExistingDir(String path)
+	public static Optional<Path> nearestExistingDir(String path)
 	{
-		File dir = (path == null) ? null : new File(path);
-		while ((dir != null) && !dir.isDirectory())
+		Path dir = (path == null) ? null : Path.of(path);
+		while ((dir != null) && !Files.isDirectory(dir))
 		{
-			dir = dir.getParentFile();
+			dir = dir.getParent();
 		}
-		return dir;
+		return Optional.ofNullable(dir);
 	}
 
 	/**

--- a/code/src/java/pcgen/system/ConfigurationSettings.java
+++ b/code/src/java/pcgen/system/ConfigurationSettings.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.apache.commons.lang3.SystemUtils;
@@ -183,17 +184,28 @@ public final class ConfigurationSettings extends PropertyContext
 	 */
 	private static String getInstallRoot()
 	{
-		String javaHome = SystemUtils.JAVA_HOME;
+		return findInstallRoot(SystemUtils.JAVA_HOME)
+				.map(Path::toString)
+				.orElse(SystemUtils.USER_DIR);
+	}
+
+	/**
+	 * Walk up from {@code javaHome} and return the first ancestor — or immediate
+	 * child of an ancestor — that holds PCGen's bundled data (the "data" +
+	 * "system" folders), or empty if none is found (the caller then falls back
+	 * to user.dir). Package-private and parameterised on {@code javaHome} so it
+	 * can be exercised without touching real system properties.
+	 */
+	static Optional<Path> findInstallRoot(String javaHome)
+	{
 		if (javaHome == null)
 		{
-			return SystemUtils.USER_DIR;
+			return Optional.empty();
 		}
 		return Stream.iterate(Path.of(javaHome), Objects::nonNull, Path::getParent)
 				.flatMap(dir -> Stream.concat(Stream.of(dir), listDirectories(dir)))
 				.filter(ConfigurationSettings::looksLikeInstallRoot)
-				.findFirst()
-				.map(Path::toString)
-				.orElse(SystemUtils.USER_DIR);
+				.findFirst();
 	}
 
 	private static Stream<Path> listDirectories(Path dir)

--- a/code/src/java/pcgen/system/PCGenSettings.java
+++ b/code/src/java/pcgen/system/PCGenSettings.java
@@ -177,9 +177,9 @@ public final class PCGenSettings extends PropertyContext
 		return getInstance().getProperty(key);
 	}
 
-	private static Object setSystemProperty(String key, String value)
+	private static void setSystemProperty(String key, String value)
 	{
-		return getInstance().setProperty(key, value);
+		getInstance().setProperty(key, value);
 	}
 
 	private static String getDirectory(String key)

--- a/code/src/resources/pcgen/gui3/dialog/OptionsPathDialog.fxml
+++ b/code/src/resources/pcgen/gui3/dialog/OptionsPathDialog.fxml
@@ -22,35 +22,39 @@
 This dialog can't really be localized, since we don't yet know which locale to use.
 We could possibly rely on the system locale, but that's a bigger decision.
 -->
-<?import javafx.scene.layout.AnchorPane?><?import javafx.scene.layout.BorderPane?><?import javafx.scene.text.Text?><?import javafx.scene.control.ToggleGroup?><?import javafx.scene.control.Label?><?import javafx.scene.control.RadioButton?><?import javafx.scene.text.TextFlow?><?import java.net.URL?><?import javafx.scene.control.TextArea?><?import javafx.scene.control.TextField?><?import javafx.scene.layout.HBox?><?import javafx.scene.layout.VBox?><?import javafx.scene.control.ButtonBar?><?import javafx.scene.control.Button?><?import javafx.scene.Scene?><?import javafx.scene.layout.Region?><?import javafx.scene.layout.Pane?>
+<?import javafx.scene.layout.AnchorPane?><?import javafx.scene.layout.BorderPane?><?import javafx.scene.text.Text?><?import javafx.scene.control.ToggleGroup?><?import javafx.scene.control.Label?><?import javafx.scene.control.RadioButton?><?import javafx.scene.text.TextFlow?><?import java.net.URL?><?import javafx.scene.control.TextArea?><?import javafx.scene.control.TextField?><?import javafx.scene.layout.HBox?><?import javafx.scene.layout.VBox?><?import javafx.scene.control.ButtonBar?><?import javafx.scene.control.Button?><?import javafx.scene.Scene?><?import javafx.scene.layout.Region?><?import javafx.scene.layout.Pane?><?import javafx.geometry.Insets?>
 <Scene xmlns="http://javafx.com/javafx"
        xmlns:fx="http://javafx.com/fxml"
        fx:controller="pcgen.gui3.dialog.OptionsPathDialogController"
        fx:id="optionsPathDialogScene">
 <AnchorPane>
-    <BorderPane id="selectDirectoryPane">
+    <BorderPane id="selectDirectoryPane"
+                AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0"
+                AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
+        <padding>
+            <Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/>
+        </padding>
         <top>
             <HBox id="topRegion">
-                <Text text="Select a directory to store PCGen options in" />
+                <Label text="Select a directory to store PCGen options in" wrapText="true" HBox.hgrow="always"/>
             </HBox>
         </top>
         <center>
             <fx:define>
                 <ToggleGroup fx:id="directoryGroup" />
             </fx:define>
-            <VBox>
-            <Text text="If you have an existing options.ini file, then select the directory containing that file"/>
-                <RadioButton toggleGroup="$directoryGroup" fx:id="pcgenDir" text="PCGen Dir: This is the directory that PCGen is installed into." userData="pcgen"/>
-                <RadioButton toggleGroup="$directoryGroup" fx:id="macUserDir" text="Mac User Dir" userData="user"/>
-                <RadioButton toggleGroup="$directoryGroup" fx:id="freedesktop" text="Freedesktop configuration sub-directory: Use for most Linux/BSD" userData="FD_USER">
-                </RadioButton>
-                <RadioButton toggleGroup="$directoryGroup" fx:id="homedir" text="Home Dir: This is your home directory" userData="mac_user"/>
-                <RadioButton toggleGroup="$directoryGroup" fx:id="select" text="Select a directory to use"/>
+            <VBox spacing="6.0">
+            <Label text="If you have an existing options.ini file, then select the directory containing that file" wrapText="true"/>
+                <RadioButton toggleGroup="$directoryGroup" fx:id="pcgenDir" text="PCGen Dir: This is the directory that PCGen is installed into." userData="pcgen" wrapText="true"/>
+                <RadioButton toggleGroup="$directoryGroup" fx:id="macUserDir" text="Mac User Dir" userData="mac_user" wrapText="true"/>
+                <RadioButton toggleGroup="$directoryGroup" fx:id="freedesktop" text="Freedesktop configuration subdirectory: Use for most Linux/BSD" userData="FD_USER" wrapText="true"/>
+                <RadioButton toggleGroup="$directoryGroup" fx:id="homedir" text="Home Dir: This is your home directory" userData="user" wrapText="true"/>
+                <RadioButton toggleGroup="$directoryGroup" fx:id="select" text="Select a directory to use" wrapText="true"/>
             </VBox>
         </center>
         <bottom>
-            <VBox>
-                <HBox>
+            <VBox spacing="6.0">
+                <HBox spacing="6.0">
                     <TextField fx:id="dirSelection" editable="false" disable="true" HBox.hgrow="always"/>
                     <Button fx:id="selectButton" text="..." onAction="#doChooser" disable="true"/>
                 </HBox>

--- a/code/src/resources/pcgen/gui3/dialog/OptionsPathDialog.fxml
+++ b/code/src/resources/pcgen/gui3/dialog/OptionsPathDialog.fxml
@@ -22,7 +22,18 @@
 This dialog can't really be localized, since we don't yet know which locale to use.
 We could possibly rely on the system locale, but that's a bigger decision.
 -->
-<?import javafx.scene.layout.AnchorPane?><?import javafx.scene.layout.BorderPane?><?import javafx.scene.text.Text?><?import javafx.scene.control.ToggleGroup?><?import javafx.scene.control.Label?><?import javafx.scene.control.RadioButton?><?import javafx.scene.text.TextFlow?><?import java.net.URL?><?import javafx.scene.control.TextArea?><?import javafx.scene.control.TextField?><?import javafx.scene.layout.HBox?><?import javafx.scene.layout.VBox?><?import javafx.scene.control.ButtonBar?><?import javafx.scene.control.Button?><?import javafx.scene.Scene?><?import javafx.scene.layout.Region?><?import javafx.scene.layout.Pane?><?import javafx.geometry.Insets?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.RadioButton?>
+<?import javafx.scene.control.TextField?>
+<?import javafx.scene.control.ToggleGroup?>
+<?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.layout.BorderPane?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.VBox?>
+<?import javafx.scene.Scene?>
+<?import java.net.URL?>
 <Scene xmlns="http://javafx.com/javafx"
        xmlns:fx="http://javafx.com/fxml"
        fx:controller="pcgen.gui3.dialog.OptionsPathDialogController"

--- a/code/src/resources/pcgen/gui3/dialog/OptionsPathDialog.fxml
+++ b/code/src/resources/pcgen/gui3/dialog/OptionsPathDialog.fxml
@@ -52,7 +52,7 @@ We could possibly rely on the system locale, but that's a bigger decision.
             <VBox>
                 <HBox>
                     <TextField fx:id="dirSelection" editable="false" disable="true" HBox.hgrow="always"/>
-                    <Button fx:id="selectButton" text="..." onAction="#doChooser" />
+                    <Button fx:id="selectButton" text="..." onAction="#doChooser" disable="true"/>
                 </HBox>
                 <Button text="OK" onAction="#onConfirm" />
             </VBox>

--- a/code/src/test/pcgen/system/ConfigurationSettingsTest.java
+++ b/code/src/test/pcgen/system/ConfigurationSettingsTest.java
@@ -18,8 +18,11 @@
 package pcgen.system;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -31,7 +34,6 @@ import org.junit.jupiter.api.io.TempDir;
 /**
  * Tests {@link ConfigurationSettings#findInstallRoot(String)} — how PCGen
  * locates its bundled data from java.home across the jpackage bundle layouts.
- * See issue #7678.
  */
 class ConfigurationSettingsTest
 {
@@ -120,5 +122,31 @@ class ConfigurationSettingsTest
 		Optional<Path> found = ConfigurationSettings.findInstallRoot(javaHome.toString());
 
 		assertTrue(found.isEmpty());
+	}
+
+	@Test
+	void isWritableDir_should_beTrue_when_dirIsWritable(@TempDir Path dir)
+	{
+		// A portable/dev install root: an ordinary writable directory.
+		assertTrue(ConfigurationSettings.isWritableDir(dir));
+	}
+
+	@Test
+	void isWritableDir_should_beFalse_when_dirIsReadOnly(@TempDir Path parent) throws IOException
+	{
+		// An installed app's root (read-only DMG / sealed bundle).
+		Path readOnly = Files.createDirectory(parent.resolve("install"));
+		File asFile = readOnly.toFile();
+		assumeTrue(asFile.setWritable(false) && !Files.isWritable(readOnly),
+				"filesystem/user ignores the read-only bit (e.g. running as root)");
+
+		assertFalse(ConfigurationSettings.isWritableDir(readOnly));
+	}
+
+	@Test
+	void isWritableDir_should_beFalse_when_dirDoesNotExist(@TempDir Path parent)
+	{
+		// The install root must be an existing directory, not just a path.
+		assertFalse(ConfigurationSettings.isWritableDir(parent.resolve("missing")));
 	}
 }

--- a/code/src/test/pcgen/system/ConfigurationSettingsTest.java
+++ b/code/src/test/pcgen/system/ConfigurationSettingsTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026 Vest <Vest@users.noreply.github.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.system;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests {@link ConfigurationSettings#findInstallRoot(String)} — how PCGen
+ * locates its bundled data from java.home across the jpackage bundle layouts.
+ * See issue #7678.
+ */
+class ConfigurationSettingsTest
+{
+	/** Create dir/{data,system} so it passes the install-root marker check. */
+	private static Path makeInstallRoot(Path dir) throws IOException
+	{
+		Files.createDirectories(dir.resolve("data"));
+		Files.createDirectories(dir.resolve("system"));
+		return dir;
+	}
+
+	@Test
+	void findInstallRoot_should_findAppDir_when_macLayout(@TempDir Path bundle) throws IOException
+	{
+		// PcGen.app/Contents/{runtime/Contents/Home, app/{data,system}}
+		Path contents = Files.createDirectories(bundle.resolve("Contents"));
+		Path javaHome = Files.createDirectories(contents.resolve("runtime/Contents/Home"));
+		Path app = makeInstallRoot(contents.resolve("app"));
+
+		Optional<Path> root = ConfigurationSettings.findInstallRoot(javaHome.toString());
+
+		assertEquals(app.toRealPath(), root.orElseThrow().toRealPath());
+	}
+
+	@Test
+	void findInstallRoot_should_findAppDir_when_linuxLayout(@TempDir Path image) throws IOException
+	{
+		// PcGen/lib/{runtime, app/{data,system}}
+		Path lib = Files.createDirectories(image.resolve("lib"));
+		Path javaHome = Files.createDirectories(lib.resolve("runtime"));
+		Path app = makeInstallRoot(lib.resolve("app"));
+
+		Optional<Path> root = ConfigurationSettings.findInstallRoot(javaHome.toString());
+
+		assertEquals(app.toRealPath(), root.orElseThrow().toRealPath());
+	}
+
+	@Test
+	void findInstallRoot_should_findAppDir_when_windowsLayout(@TempDir Path image) throws IOException
+	{
+		// PcGen\{runtime, app\{data,system}}
+		Path javaHome = Files.createDirectories(image.resolve("runtime"));
+		Path app = makeInstallRoot(image.resolve("app"));
+
+		Optional<Path> root = ConfigurationSettings.findInstallRoot(javaHome.toString());
+
+		assertEquals(app.toRealPath(), root.orElseThrow().toRealPath());
+	}
+
+	@Test
+	void findInstallRoot_should_findAncestor_when_dataIsAboveJavaHome(@TempDir Path root) throws IOException
+	{
+		// data/system sit at the root, java.home is nested below (a dev-style
+		// checkout run against a JDK inside the tree)
+		makeInstallRoot(root);
+		Path javaHome = Files.createDirectories(root.resolve("nested/jdk/home"));
+
+		Optional<Path> found = ConfigurationSettings.findInstallRoot(javaHome.toString());
+
+		assertEquals(root.toRealPath(), found.orElseThrow().toRealPath());
+	}
+
+	@Test
+	void findInstallRoot_should_beEmpty_when_noDataFound(@TempDir Path javaHome)
+	{
+		// java.home with no data/system anywhere up the tree — caller falls back
+		// to user.dir.
+		Optional<Path> found = ConfigurationSettings.findInstallRoot(javaHome.toString());
+
+		assertTrue(found.isEmpty());
+	}
+
+	@Test
+	void findInstallRoot_should_beEmpty_when_javaHomeNull()
+	{
+		assertTrue(ConfigurationSettings.findInstallRoot(null).isEmpty());
+	}
+
+	@Test
+	void findInstallRoot_should_requireBothMarkers_when_onlyDataPresent(@TempDir Path app) throws IOException
+	{
+		// A lone "data" dir must not match — the marker is data AND system.
+		Files.createDirectories(app.resolve("data"));
+		Path javaHome = Files.createDirectories(app.resolve("runtime"));
+
+		Optional<Path> found = ConfigurationSettings.findInstallRoot(javaHome.toString());
+
+		assertTrue(found.isEmpty());
+	}
+}

--- a/code/src/test/pcgen/system/ConfigurationSettingsTest.java
+++ b/code/src/test/pcgen/system/ConfigurationSettingsTest.java
@@ -19,6 +19,7 @@ package pcgen.system;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -148,5 +149,32 @@ class ConfigurationSettingsTest
 	{
 		// The install root must be an existing directory, not just a path.
 		assertFalse(ConfigurationSettings.isWritableDir(parent.resolve("missing")));
+	}
+
+	@Test
+	void nearestExistingDir_should_returnItself_when_dirExists(@TempDir Path dir)
+	{
+		assertEquals(dir.toFile(), ConfigurationSettings.nearestExistingDir(dir.toString()));
+	}
+
+	@Test
+	void nearestExistingDir_should_walkUp_when_leafMissing(@TempDir Path parent)
+	{
+		// e.g. <install>/settings where "settings" has not been created yet.
+		Path missingLeaf = parent.resolve("settings");
+		assertEquals(parent.toFile(), ConfigurationSettings.nearestExistingDir(missingLeaf.toString()));
+	}
+
+	@Test
+	void nearestExistingDir_should_walkUpSeveralLevels_when_deepPathMissing(@TempDir Path parent)
+	{
+		Path deepMissing = parent.resolve("a/b/c");
+		assertEquals(parent.toFile(), ConfigurationSettings.nearestExistingDir(deepMissing.toString()));
+	}
+
+	@Test
+	void nearestExistingDir_should_beNull_when_pathIsNull()
+	{
+		assertNull(ConfigurationSettings.nearestExistingDir(null));
 	}
 }

--- a/code/src/test/pcgen/system/ConfigurationSettingsTest.java
+++ b/code/src/test/pcgen/system/ConfigurationSettingsTest.java
@@ -19,7 +19,6 @@ package pcgen.system;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -154,7 +153,7 @@ class ConfigurationSettingsTest
 	@Test
 	void nearestExistingDir_should_returnItself_when_dirExists(@TempDir Path dir)
 	{
-		assertEquals(dir.toFile(), ConfigurationSettings.nearestExistingDir(dir.toString()));
+		assertEquals(Optional.of(dir), ConfigurationSettings.nearestExistingDir(dir.toString()));
 	}
 
 	@Test
@@ -162,19 +161,19 @@ class ConfigurationSettingsTest
 	{
 		// e.g. <install>/settings where "settings" has not been created yet.
 		Path missingLeaf = parent.resolve("settings");
-		assertEquals(parent.toFile(), ConfigurationSettings.nearestExistingDir(missingLeaf.toString()));
+		assertEquals(Optional.of(parent), ConfigurationSettings.nearestExistingDir(missingLeaf.toString()));
 	}
 
 	@Test
 	void nearestExistingDir_should_walkUpSeveralLevels_when_deepPathMissing(@TempDir Path parent)
 	{
 		Path deepMissing = parent.resolve("a/b/c");
-		assertEquals(parent.toFile(), ConfigurationSettings.nearestExistingDir(deepMissing.toString()));
+		assertEquals(Optional.of(parent), ConfigurationSettings.nearestExistingDir(deepMissing.toString()));
 	}
 
 	@Test
-	void nearestExistingDir_should_beNull_when_pathIsNull()
+	void nearestExistingDir_should_beEmpty_when_pathIsNull()
 	{
-		assertNull(ConfigurationSettings.nearestExistingDir(null));
+		assertTrue(ConfigurationSettings.nearestExistingDir(null).isEmpty());
 	}
 }

--- a/installers/mac-installer/MacDirLauncher
+++ b/installers/mac-installer/MacDirLauncher
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-DIR="${0%/*}"
-cd "$DIR/../app"
-
-"$DIR/PcGen"


### PR DESCRIPTION
## Summary

Fixes PCGen's settings/data path resolution for packaged (jpackage) builds, and cleans up the "options.ini location" dialog. Resolves the root cause behind #7678: bundled data and settings were resolved against `user.dir`, which is `/` for a Finder/double-click launch.

## Changes

**Path resolution (the core fix)**
- Resolve `@`-paths (`@data`, `@plugins`, …) and the "PCGen Dir" settings path from `java.home` (walking up to the install root that holds `data/`+`system/`) instead of `user.dir`. Falls back to `user.dir` for dev/IDE runs.
- Drops the old macOS `user.dir`-ends-with-`MacOS` hack.

**Packaging**
- Embed runtime assets via jpackage `--app-content`, so jpackage builds and signs the whole image in one pass.
- Remove the now-unneeded macOS `MacDirLauncher` wrapper + `Info.plist` rewrite + ad-hoc re-sign tasks (they existed only to work around the old `user.dir` resolution).

**"options.ini location" dialog**
- Fix `//settings` shown for "PCGen Dir" (now resolves to the real install dir).
- Disable the `…` chooser button until "Select a directory" is chosen; open the chooser at the nearest existing ancestor so it no longer silently no-ops.
- Disable "PCGen Dir" when the install dir isn't writable (installed/DMG app), with a "(not writable)" hint.
- Anchor + pad + wrap the layout so the dialog resizes cleanly without truncating labels.
- Correct swapped `userData`: "Mac User Dir" and "Home Dir" mapped to each other's settings directories.

**Misc**
- Add `ConfigurationSettingsTest` covering install-root discovery across the mac/linux/windows bundle layouts and the writability check.
- Clear two pre-existing Sonar findings in `ConfigurationSettings`.

## Verification
- `./gradlew compileJava compileTestJava test` — green (incl. new `ConfigurationSettingsTest`).
- `./gradlew fullJpackage` on macOS: bundle passes `codesign --verify --deep --strict`; launcher starts with no path/data errors; assets embedded at `Contents/app`.
- Verified on the packaged bundle that "PCGen Dir" is enabled from a writable copy and disabled from a read-only DMG mount.

⚠️ Windows/Linux packaged builds were not exercised on the (macOS) dev host — please confirm `fullJpackage` on CI for those before merge.

Refs #7678.
