### PR TITLE
Friendly message on JavaFX toolkit-init failure instead of raw stack trace

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,24 +250,13 @@ You can change the Java version to whatever version is supported, and you have i
 
 #### JavaFX / graphics toolkit fails to start on Linux
 
-If PCGen exits at startup reporting that the graphical toolkit (JavaFX) could not
-load a native graphics library — for example `UnsatisfiedLinkError: no glassgtk3 in
-java.library.path` — the native library is usually present but a *system* library it
-depends on is missing.
-
-The bundled JavaFX `libglassgtk3.so` links against `libgthread-2.0.so.0`. Recent glib
-releases no longer ship that standalone stub, so the loader fails and the JVM reports
-the misleading "not in java.library.path". Install the package that provides the stub:
+If PCGen exits at startup with an error `UnsatisfiedLinkError: no glassgtk3 in java.library.path`, it means that JavaFX
+cannot find the linked file `libgthread-2.0.so.0`. To solve it, the missing package must be installed:
 
 - **openSUSE Tumbleweed:** `sudo zypper install libgthread-2_0-0`
-- **Other distributions:** install the glib package that provides `libgthread-2.0.so.0`
-  (the exact package name varies).
+- **Other distributions:** install the glib package that provides `libgthread-2.0.so.0` (the exact package name varies).
 
-Note that having GTK 3 itself installed is not enough — the missing piece is the
-transitive `libgthread` dependency.
-
-If instead the error is `Unable to open DISPLAY`, run PCGen from a graphical desktop
-session rather than a remote/SSH shell.
+If instead the error is `Unable to open DISPLAY`, run PCGen from a graphical desktop session rather than a remote/SSH shell.
 
 
 [PCGen]: https://github.com/PCGen/pcgen

--- a/README.md
+++ b/README.md
@@ -248,6 +248,27 @@ create a run configuration using Gradle and have the command be `run`. This shou
 If you want to debug in Intellij, using the `Main` configuration and run it in debug mode.
 You can change the Java version to whatever version is supported, and you have installed.
 
+#### JavaFX / graphics toolkit fails to start on Linux
+
+If PCGen exits at startup reporting that the graphical toolkit (JavaFX) could not
+load a native graphics library — for example `UnsatisfiedLinkError: no glassgtk3 in
+java.library.path` — the native library is usually present but a *system* library it
+depends on is missing.
+
+The bundled JavaFX `libglassgtk3.so` links against `libgthread-2.0.so.0`. Recent glib
+releases no longer ship that standalone stub, so the loader fails and the JVM reports
+the misleading "not in java.library.path". Install the package that provides the stub:
+
+- **openSUSE Tumbleweed:** `sudo zypper install libgthread-2_0-0`
+- **Other distributions:** install the glib package that provides `libgthread-2.0.so.0`
+  (the exact package name varies).
+
+Note that having GTK 3 itself installed is not enough — the missing piece is the
+transitive `libgthread` dependency.
+
+If instead the error is `Unable to open DISPLAY`, run PCGen from a graphical desktop
+session rather than a remote/SSH shell.
+
 
 [PCGen]: https://github.com/PCGen/pcgen
 [JIRA]: https://pcgenorg.atlassian.net

--- a/code/src/java/pcgen/gui3/GraphicsStartupError.java
+++ b/code/src/java/pcgen/gui3/GraphicsStartupError.java
@@ -80,24 +80,23 @@ public final class GraphicsStartupError
 	 */
 	public static String buildMessage(Kind kind, Throwable failure)
 	{
-		String cause = "Underlying error: " + rootMessage(failure);
-		String seeReadme = "See the Troubleshooting section of the PCGen README.";
+		String cause = rootMessage(failure);
 		return switch (kind)
 		{
-			case NATIVE_LIBRARY -> String.join("\n",
-					"PCGen's graphical toolkit (JavaFX) failed to start.",
-					"It could not load a native graphics library. This is usually a missing system package.",
-					cause,
-					"See the Troubleshooting section of the PCGen README for platform-specific fixes.");
-			case NO_DISPLAY -> String.join("\n",
-					"PCGen's graphical toolkit (JavaFX) could not open a display.",
-					"Run PCGen from a graphical desktop session, not a remote/SSH shell.",
-					cause,
-					seeReadme);
-			case GENERIC -> String.join("\n",
-					"PCGen's graphical toolkit (JavaFX) failed to start.",
-					cause,
-					seeReadme);
+			case NATIVE_LIBRARY -> """
+					PCGen's graphical toolkit (JavaFX) failed to start.
+					It could not load a native graphics library. This is usually a missing system package.
+					Underlying error: %s
+					See the Troubleshooting section of the PCGen README for platform-specific fixes.""".formatted(cause);
+			case NO_DISPLAY -> """
+					PCGen's graphical toolkit (JavaFX) could not open a display.
+					Run PCGen from a graphical desktop session, not a remote/SSH shell.
+					Underlying error: %s
+					See the Troubleshooting section of the PCGen README.""".formatted(cause);
+			case GENERIC -> """
+					PCGen's graphical toolkit (JavaFX) failed to start.
+					Underlying error: %s
+					See the Troubleshooting section of the PCGen README.""".formatted(cause);
 		};
 	}
 

--- a/code/src/java/pcgen/gui3/GraphicsStartupError.java
+++ b/code/src/java/pcgen/gui3/GraphicsStartupError.java
@@ -80,26 +80,24 @@ public final class GraphicsStartupError
 	 */
 	public static String buildMessage(Kind kind, Throwable failure)
 	{
-		String cause = rootMessage(failure);
+		String cause = "Underlying error: " + rootMessage(failure);
+		String seeReadme = "See the Troubleshooting section of the PCGen README.";
 		return switch (kind)
 		{
-			case NATIVE_LIBRARY -> """
-					PCGen's graphical toolkit (JavaFX) failed to start.
-					It could not load a native graphics library. This is usually a missing system package.
-					Underlying error:\s""" + cause + """
-
-					See the Troubleshooting section of the PCGen README for platform-specific fixes.""";
-			case NO_DISPLAY -> """
-					PCGen's graphical toolkit (JavaFX) could not open a display.
-					Run PCGen from a graphical desktop session, not a remote/SSH shell.
-					Underlying error:\s""" + cause + """
-
-					See the Troubleshooting section of the PCGen README.""";
-			case GENERIC -> """
-					PCGen's graphical toolkit (JavaFX) failed to start.
-					Underlying error:\s""" + cause + """
-
-					See the Troubleshooting section of the PCGen README.""";
+			case NATIVE_LIBRARY -> String.join("\n",
+					"PCGen's graphical toolkit (JavaFX) failed to start.",
+					"It could not load a native graphics library. This is usually a missing system package.",
+					cause,
+					"See the Troubleshooting section of the PCGen README for platform-specific fixes.");
+			case NO_DISPLAY -> String.join("\n",
+					"PCGen's graphical toolkit (JavaFX) could not open a display.",
+					"Run PCGen from a graphical desktop session, not a remote/SSH shell.",
+					cause,
+					seeReadme);
+			case GENERIC -> String.join("\n",
+					"PCGen's graphical toolkit (JavaFX) failed to start.",
+					cause,
+					seeReadme);
 		};
 	}
 

--- a/code/src/java/pcgen/gui3/GraphicsStartupError.java
+++ b/code/src/java/pcgen/gui3/GraphicsStartupError.java
@@ -85,8 +85,7 @@ public final class GraphicsStartupError
 		{
 			case NATIVE_LIBRARY -> """
 					PCGen's graphical toolkit (JavaFX) failed to start.
-					It could not load a native graphics library. This is usually a missing \
-					system package, not a PCGen problem.
+					It could not load a native graphics library. This is usually a missing system package.
 					Underlying error:\s""" + cause + """
 
 					See the Troubleshooting section of the PCGen README for platform-specific fixes.""";

--- a/code/src/java/pcgen/gui3/GraphicsStartupError.java
+++ b/code/src/java/pcgen/gui3/GraphicsStartupError.java
@@ -14,7 +14,6 @@
 package pcgen.gui3;
 
 import java.awt.GraphicsEnvironment;
-import java.util.Locale;
 
 import javax.swing.JOptionPane;
 
@@ -22,10 +21,8 @@ import pcgen.util.GracefulExit;
 import pcgen.util.Logging;
 
 /**
- * Turns a JavaFX toolkit-initialisation failure into an honest, actionable
- * message instead of the misleading raw stack trace. See the design rationale
- * in the Troubleshooting section of the README (issue: JavaFX links against
- * {@code libgthread-2.0.so.0}, which recent glib no longer ships as a stub).
+ * Turns a JavaFX toolkit-initialization failure into a user-readable message.
+ * More details are described in the Troubleshooting section of the README.
  */
 public final class GraphicsStartupError
 {

--- a/code/src/java/pcgen/gui3/GraphicsStartupError.java
+++ b/code/src/java/pcgen/gui3/GraphicsStartupError.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2026 Vest <Vest@users.noreply.github.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ */
+package pcgen.gui3;
+
+import java.awt.GraphicsEnvironment;
+import java.util.Locale;
+
+import javax.swing.JOptionPane;
+
+import pcgen.util.GracefulExit;
+import pcgen.util.Logging;
+
+/**
+ * Turns a JavaFX toolkit-initialisation failure into an honest, actionable
+ * message instead of the misleading raw stack trace. See the design rationale
+ * in the Troubleshooting section of the README (issue: JavaFX links against
+ * {@code libgthread-2.0.so.0}, which recent glib no longer ships as a stub).
+ */
+public final class GraphicsStartupError
+{
+	private GraphicsStartupError()
+	{
+	}
+
+	/**
+	 * The kind of toolkit-init failure, used to select the message.
+	 */
+	public enum Kind
+	{
+		/** A native library could not be loaded (e.g. an unsatisfiable transitive dependency). */
+		NATIVE_LIBRARY,
+		/** The libraries loaded, but no display could be opened (headless / no X or Wayland). */
+		NO_DISPLAY,
+		/** Any other toolkit-init failure. */
+		GENERIC
+	}
+
+	/**
+	 * Classifies {@code failure} by walking its cause chain.
+	 *
+	 * @param failure the throwable raised while starting the JavaFX toolkit
+	 * @return the {@link Kind} of failure
+	 */
+	public static Kind classify(Throwable failure)
+	{
+		for (Throwable t = failure; t != null; t = t.getCause())
+		{
+			if (t instanceof LinkageError)
+			{
+				return Kind.NATIVE_LIBRARY;
+			}
+			String message = t.getMessage();
+			if (message != null && message.contains("Unable to open DISPLAY"))
+			{
+				return Kind.NO_DISPLAY;
+			}
+		}
+		return Kind.GENERIC;
+	}
+
+	/**
+	 * Builds the user-facing message for a classified failure. The message is
+	 * universal (no distro-specific commands) and echoes the real underlying
+	 * cause so a knowledgeable user gets the concrete clue.
+	 *
+	 * @param kind    the classification from {@link #classify(Throwable)}
+	 * @param failure the original throwable
+	 * @return the message to log and (when not headless) show in a dialog
+	 */
+	public static String buildMessage(Kind kind, Throwable failure)
+	{
+		String cause = rootMessage(failure);
+		return switch (kind)
+		{
+			case NATIVE_LIBRARY -> """
+					PCGen's graphical toolkit (JavaFX) failed to start.
+					It could not load a native graphics library. The library is present but a \
+					system library it depends on could not be loaded. This is usually a missing \
+					system package, not a PCGen problem.
+					Underlying error:\s""" + cause + """
+
+					See the Troubleshooting section of the PCGen README for platform-specific fixes.""";
+			case NO_DISPLAY -> """
+					PCGen's graphical toolkit (JavaFX) could not open a display.
+					Run PCGen from a graphical desktop session, not a remote/SSH shell.
+					Underlying error:\s""" + cause + """
+
+					See the Troubleshooting section of the PCGen README.""";
+			case GENERIC -> """
+					PCGen's graphical toolkit (JavaFX) failed to start.
+					Underlying error:\s""" + cause + """
+
+					See the Troubleshooting section of the PCGen README.""";
+		};
+	}
+
+	/**
+	 * Reports the toolkit-init failure to the user and exits. Logs the message
+	 * (with the throwable) always; additionally shows a Swing dialog when a
+	 * display is available. Does not return.
+	 *
+	 * @param failure the throwable raised while starting the JavaFX toolkit
+	 */
+	public static void reportAndExit(Throwable failure)
+	{
+		Kind kind = classify(failure);
+		String message = buildMessage(kind, failure);
+		Logging.errorPrint(message, failure);
+		if (!GraphicsEnvironment.isHeadless())
+		{
+			JOptionPane.showMessageDialog(null, message, "PCGen", JOptionPane.ERROR_MESSAGE);
+		}
+		GracefulExit.exit(1);
+	}
+
+	private static String rootMessage(Throwable failure)
+	{
+		Throwable root = failure;
+		while (root.getCause() != null)
+		{
+			root = root.getCause();
+		}
+		String message = root.getMessage();
+		return (message != null) ? message : root.getClass().getName();
+	}
+}

--- a/code/src/java/pcgen/gui3/GraphicsStartupError.java
+++ b/code/src/java/pcgen/gui3/GraphicsStartupError.java
@@ -85,8 +85,7 @@ public final class GraphicsStartupError
 		{
 			case NATIVE_LIBRARY -> """
 					PCGen's graphical toolkit (JavaFX) failed to start.
-					It could not load a native graphics library. The library is present but a \
-					system library it depends on could not be loaded. This is usually a missing \
+					It could not load a native graphics library. This is usually a missing \
 					system package, not a PCGen problem.
 					Underlying error:\s""" + cause + """
 

--- a/code/src/java/pcgen/gui3/PanelFromResource.java
+++ b/code/src/java/pcgen/gui3/PanelFromResource.java
@@ -205,7 +205,7 @@ public class PanelFromResource<T> implements Controllable<T>
 		try
 		{
 			Platform.startup(() -> {
-				// The toolkit is considered initialised the moment this Runnable
+				// The toolkit is considered initialized the moment this Runnable
 				// is queued onto the FX application thread; we have no work to
 				// perform here ourselves.
 			});
@@ -218,9 +218,7 @@ public class PanelFromResource<T> implements Controllable<T>
 		}
 		catch (RuntimeException | LinkageError toolkitFailure)
 		{
-			// The toolkit could not start (e.g. a native library failed to load,
-			// or no display is available). Report an honest, actionable message
-			// instead of the misleading raw stack trace, then exit. Does not return.
+			// Cannot run JavaFX, report a user-friendly message
 			GraphicsStartupError.reportAndExit(toolkitFailure);
 		}
 		Platform.setImplicitExit(false);

--- a/code/src/java/pcgen/gui3/PanelFromResource.java
+++ b/code/src/java/pcgen/gui3/PanelFromResource.java
@@ -216,6 +216,13 @@ public class PanelFromResource<T> implements Controllable<T>
 					"JavaFX toolkit was already initialised before PanelFromResource bootstrap; continuing.",
 					alreadyStarted);
 		}
+		catch (RuntimeException | LinkageError toolkitFailure)
+		{
+			// The toolkit could not start (e.g. a native library failed to load,
+			// or no display is available). Report an honest, actionable message
+			// instead of the misleading raw stack trace, then exit. Does not return.
+			GraphicsStartupError.reportAndExit(toolkitFailure);
+		}
 		Platform.setImplicitExit(false);
 	}
 }

--- a/code/src/java/pcgen/gui3/namegen/RandomNameDialog.java
+++ b/code/src/java/pcgen/gui3/namegen/RandomNameDialog.java
@@ -94,15 +94,14 @@ public final class RandomNameDialog
 		JFXPanel fxPanel;
 		try
 		{
-			// First JavaFX bootstrap for the --name-generator CLI path. Guard it so
-			// a toolkit-init failure yields an honest message rather than the raw
-			// uncaught stack trace. reportAndExit does not return.
+			// First JavaFX bootstrap for the --name-generator CLI path. Guard it to intercept a message
+			// and display it in the log.
 			fxPanel = new JFXPanel();
 		}
 		catch (RuntimeException | LinkageError toolkitFailure)
 		{
 			GraphicsStartupError.reportAndExit(toolkitFailure);
-			return; // unreachable: reportAndExit exits, but satisfies definite assignment
+			return; // unreachable, because reportAndExit exits
 		}
 		dialog.setContentPane(fxPanel);
 

--- a/code/src/java/pcgen/gui3/namegen/RandomNameDialog.java
+++ b/code/src/java/pcgen/gui3/namegen/RandomNameDialog.java
@@ -25,6 +25,7 @@ import java.util.concurrent.CountDownLatch;
 import javax.swing.JDialog;
 import javax.swing.SwingUtilities;
 
+import pcgen.gui3.GraphicsStartupError;
 import pcgen.gui3.GuiAssertions;
 import pcgen.system.LanguageBundle;
 import pcgen.util.Logging;
@@ -90,7 +91,19 @@ public final class RandomNameDialog
 
 		JDialog dialog = new JDialog(owner, LanguageBundle.getString("in_rndNameTitle"),
 				Dialog.ModalityType.APPLICATION_MODAL);
-		JFXPanel fxPanel = new JFXPanel();
+		JFXPanel fxPanel;
+		try
+		{
+			// First JavaFX bootstrap for the --name-generator CLI path. Guard it so
+			// a toolkit-init failure yields an honest message rather than the raw
+			// uncaught stack trace. reportAndExit does not return.
+			fxPanel = new JFXPanel();
+		}
+		catch (RuntimeException | LinkageError toolkitFailure)
+		{
+			GraphicsStartupError.reportAndExit(toolkitFailure);
+			return; // unreachable: reportAndExit exits, but satisfies definite assignment
+		}
 		dialog.setContentPane(fxPanel);
 
 		CountDownLatch sceneReady = new CountDownLatch(1);

--- a/code/src/java/pcgen/system/Main.java
+++ b/code/src/java/pcgen/system/Main.java
@@ -40,6 +40,7 @@ import pcgen.facade.core.UIDelegate;
 import pcgen.gui2.PCGenUIManager;
 import pcgen.gui2.UIPropertyContext;
 import pcgen.gui2.converter.TokenConverter;
+import pcgen.gui3.GraphicsStartupError;
 import pcgen.gui3.PanelFromResource;
 import pcgen.gui3.namegen.RandomNameDialog;
 import pcgen.gui3.dialog.OptionsPathDialogController;
@@ -185,7 +186,17 @@ public final class Main
 		loadProperties(true);
 		initPrintPreviewFonts();
 
-		new JFXPanel();
+		try
+		{
+			// First JavaFX bootstrap on a configured install (no OptionsPathDialog
+			// shown). Guard it so a toolkit-init failure yields an honest message
+			// instead of the raw uncaught stack trace. reportAndExit does not return.
+			new JFXPanel();
+		}
+		catch (RuntimeException | LinkageError toolkitFailure)
+		{
+			GraphicsStartupError.reportAndExit(toolkitFailure);
+		}
 
 		PCGenPreloader splash = new PCGenPreloader();
 		runBootstrapTasks(splash);

--- a/code/src/java/pcgen/system/Main.java
+++ b/code/src/java/pcgen/system/Main.java
@@ -188,9 +188,7 @@ public final class Main
 
 		try
 		{
-			// First JavaFX bootstrap on a configured install (no OptionsPathDialog
-			// shown). Guard it so a toolkit-init failure yields an honest message
-			// instead of the raw uncaught stack trace. reportAndExit does not return.
+			// If JavaFX cannot be initialized, show a user-friendly message
 			new JFXPanel();
 		}
 		catch (RuntimeException | LinkageError toolkitFailure)

--- a/code/src/test/pcgen/gui3/GraphicsStartupErrorTest.java
+++ b/code/src/test/pcgen/gui3/GraphicsStartupErrorTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2026 Vest <Vest@users.noreply.github.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ */
+package pcgen.gui3;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Locale;
+
+import org.junit.jupiter.api.Test;
+
+import pcgen.gui3.GraphicsStartupError.Kind;
+
+class GraphicsStartupErrorTest
+{
+	@Test
+	void classify_should_be_native_library_when_UnsatisfiedLinkError_is_wrapped()
+	{
+		Throwable failure = new RuntimeException(new UnsatisfiedLinkError("no glassgtk3 in java.library.path"));
+		assertEquals(Kind.NATIVE_LIBRARY, GraphicsStartupError.classify(failure));
+	}
+
+	@Test
+	void classify_should_be_native_library_when_UnsatisfiedLinkError_is_nested_deep()
+	{
+		Throwable root = new UnsatisfiedLinkError("libgthread-2.0.so.0: cannot open shared object file");
+		Throwable failure = new RuntimeException("startup failed", new IllegalStateException("glass", root));
+		assertEquals(Kind.NATIVE_LIBRARY, GraphicsStartupError.classify(failure));
+	}
+
+	@Test
+	void classify_should_be_no_display_when_message_reports_unable_to_open_display()
+	{
+		Throwable failure = new UnsupportedOperationException("Unable to open DISPLAY");
+		assertEquals(Kind.NO_DISPLAY, GraphicsStartupError.classify(failure));
+	}
+
+	@Test
+	void classify_should_be_generic_for_unrelated_runtime_error()
+	{
+		Throwable failure = new RuntimeException("something else entirely");
+		assertEquals(Kind.GENERIC, GraphicsStartupError.classify(failure));
+	}
+
+	@Test
+	void buildMessage_for_native_library_should_echo_underlying_cause_and_point_to_troubleshooting()
+	{
+		Throwable failure = new RuntimeException(
+				new UnsatisfiedLinkError("libgthread-2.0.so.0: cannot open shared object file"));
+
+		String message = GraphicsStartupError.buildMessage(Kind.NATIVE_LIBRARY, failure);
+
+		assertAll(
+				() -> assertTrue(message.contains("libgthread-2.0.so.0"),
+						"message should echo the real underlying cause: " + message),
+				() -> assertTrue(message.contains("Troubleshooting"),
+						"message should point at the README Troubleshooting section: " + message));
+	}
+
+	@Test
+	void buildMessage_for_native_library_should_not_recommend_installing_gtk()
+	{
+		Throwable failure = new RuntimeException(new UnsatisfiedLinkError("no glassgtk3"));
+
+		String message = GraphicsStartupError.buildMessage(Kind.NATIVE_LIBRARY, failure)
+				.toLowerCase(Locale.ROOT);
+
+		assertFalse(message.contains("install gtk"),
+				"must not reintroduce the misleading 'install GTK' advice: " + message);
+	}
+
+	@Test
+	void buildMessage_should_separate_label_from_cause_with_a_space()
+	{
+		Throwable failure = new RuntimeException(new UnsatisfiedLinkError("no glassgtk3"));
+
+		String message = GraphicsStartupError.buildMessage(Kind.NATIVE_LIBRARY, failure);
+
+		assertTrue(message.contains("Underlying error: no glassgtk3"),
+				"label and cause must be separated by a space: " + message);
+	}
+
+	@Test
+	void buildMessage_for_no_display_should_mention_desktop_session()
+	{
+		Throwable failure = new UnsupportedOperationException("Unable to open DISPLAY");
+
+		String message = GraphicsStartupError.buildMessage(Kind.NO_DISPLAY, failure)
+				.toLowerCase(Locale.ROOT);
+
+		assertTrue(message.contains("desktop"),
+				"no-display message should advise running from a desktop session: " + message);
+	}
+}


### PR DESCRIPTION
## Problem

When JavaFX cannot start its toolkit, PCGen died with a misleading `SEVERE` stack trace, e.g.:

```
java.lang.RuntimeException: java.lang.UnsatisfiedLinkError: no glassgtk3 in java.library.path: ...
```

That message is actively misleading. On openSUSE Tumbleweed the real cause is **not** a missing `libglassgtk3.so` (it's present in the bundled JavaFX SDK) — it's an unsatisfiable *transitive* dependency: `libglassgtk3.so` links against `libgthread-2.0.so.0`, which recent glib no longer ships as a standalone stub. A user reading "no glassgtk3 in java.library.path" wrongly tries to install GTK (already installed) and gets nowhere.

This is an environmental issue, not a PCGen bug — but PCGen owns the *diagnosis*.

## What this does

Adds `GraphicsStartupError`, which turns a toolkit-init failure into an honest, actionable message:

- **Classifies** the failure (native-library / no-display / generic) by walking the cause chain.
- **Builds a distro-neutral message** that echoes the real underlying cause and points at the README Troubleshooting section. No hardcoded "install GTK".
- **Reports headless-safe:** always logs; additionally shows a Swing dialog when a display is available (Swing/AWT don't need the GTK glass layer).
- **Exits gracefully** via `GracefulExit.exit(1)`, matching the existing `Main.validateEnvironment` idiom.

Guards every JavaFX bootstrap site, all delegating to the one helper:
- `PanelFromResource.ensureToolkitInitialized` (fresh install / OptionsPathDialog)
- `Main.startupWithGUI` — `new JFXPanel()` (normal configured-install launch)
- `RandomNameDialog` — `new JFXPanel()` (`--name-generator` CLI path)

The configured-install path was found via **live testing** on openSUSE Tumbleweed: it bootstraps via `new JFXPanel()`, not `PanelFromResource`, so guarding only the latter would have left the common case uncovered.

## README

Adds a Troubleshooting entry with the openSUSE fix (`zypper install libgthread-2_0-0`) and the transitive-`libgthread` explanation.

## Testing

- Unit tests for the pure `classify` / `buildMessage` logic (8 tests).
- Live-verified on a SUSE VM: with `libgthread` removed, the friendly message replaces the raw stack trace — both in the console and as a Swing dialog on the desktop.