### PR TITLE
fix: resolve dependency configurations lazily to avoid config-cache poisoning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -279,7 +279,11 @@ jar {
         attributes 'Implementation-Title': 'PCGen',
                 'Implementation-Version': archiveVersion,
                 'Main-Class': 'pcgen.system.Main',
-                'Class-Path': configurations.runtimeClasspath.collect { " libs/${it.name} " }.join('')
+                // Resolve the classpath lazily (Provider) so a toolchain miss fails at
+                // execution, not configuration, and can't be frozen into the config cache.
+                'Class-Path': configurations.runtimeClasspath.elements.map { files ->
+                    files.collect { " libs/${it.asFile.name} " }.join('')
+                }
     }
 
     exclude 'META-INF/*.SF', 'META-INF/*.DSA', 'META-INF/*.RSA', 'META-INF/*.EC'
@@ -509,7 +513,9 @@ tasks.register("converterJar", Jar) {
         attributes 'Implementation-Title': 'PCGen Data Converter',
                    'Implementation-Version': archiveVersion,
                    'Main-Class': 'pcgen.gui2.converter.PCGenDataConvert',
-                   'Class-Path': 'pcgen.jar' + configurations.runtimeClasspath.collect { " libs/${it.name} " }.join('')
+                   'Class-Path': configurations.runtimeClasspath.elements.map { files ->
+                       'pcgen.jar' + files.collect { " libs/${it.asFile.name} " }.join('')
+                   }
     }
 
     archiveClassifier.set('batch-convert')
@@ -825,14 +831,18 @@ tasks.withType(JavaCompile).configureEach {
     options.release = project.ext.javaVersion
 
     def modsLibPath = layout.projectDirectory.dir("mods/lib").asFile.absolutePath
-    def depJars = configurations.runtimeClasspath.files.findAll {
-        !it.name.startsWith('javafx-')
-    }.collect { it.absolutePath }.join(File.pathSeparator)
-    def compileOnlyJars = configurations.compileClasspath.files.findAll {
-        it.name.contains('annotations') || it.name.contains('spotbugs')
-    }.collect { it.absolutePath }.join(File.pathSeparator)
+    // Resolve lazily: an eager read here forces the toolchain lookup, whose failure would be frozen into the config cache.
+    def runtimeFiles = configurations.runtimeClasspath.incoming.files
+    def compileFiles = configurations.compileClasspath.incoming.files
 
     doFirst {
+        def depJars = runtimeFiles.findAll {
+            !it.name.startsWith('javafx-')
+        }.collect { it.absolutePath }.join(File.pathSeparator)
+        def compileOnlyJars = compileFiles.findAll {
+            it.name.contains('annotations') || it.name.contains('spotbugs')
+        }.collect { it.absolutePath }.join(File.pathSeparator)
+
         if (name.toLowerCase().contains("test")) {
             options.compilerArgs << "--module-path" << modsLibPath
             options.compilerArgs << "--add-modules" << "javafx.controls,javafx.web,javafx.swing,javafx.fxml,javafx.graphics"


### PR DESCRIPTION
## Problem

On a machine without a JDK matching the configured toolchain (`languageVersion=25`), `./gradlew <anything>` fails with:

> Cannot find a Java installation on your machine matching: {languageVersion=25, ...}

and — critically — the failure is **stored in the configuration cache and replayed on every subsequent invocation**, even for tasks that compile nothing (e.g. `./gradlew help`). A one-time toolchain miss (or a transient environment hiccup on a fresh checkout) becomes a permanent-looking wall until the user manually wipes `.gradle/configuration-cache`.

### Root cause

Three sites resolve dependency configurations **eagerly at configuration time**, which forces the Java toolchain lookup during project configuration:

- `jar {}` manifest `Class-Path` — `configurations.runtimeClasspath.collect { }`
- `converterJar` manifest `Class-Path` — same pattern
- `JavaCompile.configureEach {}` — `configurations.runtimeClasspath.files` / `compileClasspath.files` read outside `doFirst`

Because the toolchain is resolved during configuration, its failure is part of the configuration-cache entry.

## Fix

Make the resolutions lazy so a toolchain miss surfaces at **execution** time (which Gradle does not cache) instead of configuration time:

- **jar / converterJar manifests**: build `Class-Path` from `runtimeClasspath.elements.map { }` (a lazy `Provider`).
- **`JavaCompile.configureEach`**: capture `runtimeClasspath` / `compileClasspath` via `incoming.files` (lazy `FileCollection`) and resolve inside the existing `doFirst`.

The configuration cache stays **fully enabled**; only successful configuration is cached, and the toolchain is re-probed whenever it is unavailable.

## Verification (openSUSE Tumbleweed, JDK 25 removed to force the miss)

| Test | Before | After |
|---|---|---|
| `./gradlew help` with no JDK 25 | ❌ FAILED at manifest line (config-phase poison) | ✅ **SUCCESSFUL** |
| Fail `compileJava`, then `./gradlew help` | ❌ `help` also failed (poisoned) | ✅ `help` **SUCCESSFUL**, cache reused |
| `assemble` with JDK 25, run twice | ✅ (but a transient miss would stick) | ✅ 51s → **1s** (config cache reused) |
| Configuration-cache violations | — | ✅ none reported |
