### PR TITLE
refactor: replace deprecated method calls (Strings.CI, reflection, AWT, Thread)

### DIFF
--- a/code/src/java/pcgen/core/prereq/PrerequisiteTestFactory.java
+++ b/code/src/java/pcgen/core/prereq/PrerequisiteTestFactory.java
@@ -93,7 +93,7 @@ public final class PrerequisiteTestFactory implements PluginLoader
 	@Override
 	public void loadPlugin(Class<?> clazz) throws Exception
 	{
-		register((PrerequisiteTest) clazz.newInstance());
+		register((PrerequisiteTest) clazz.getDeclaredConstructor().newInstance());
 	}
 
 	@Override

--- a/code/src/java/pcgen/gui2/converter/TokenConverter.java
+++ b/code/src/java/pcgen/gui2/converter/TokenConverter.java
@@ -75,7 +75,7 @@ public final class TokenConverter
 			@Override
 			public void loadPlugin(Class<?> clazz) throws Exception
 			{
-				addToTokenMap((TokenProcessorPlugin) clazz.newInstance());
+				addToTokenMap((TokenProcessorPlugin) clazz.getDeclaredConstructor().newInstance());
 			}
 
 			@Override

--- a/code/src/java/pcgen/gui2/filter/SearchFilterPanel.java
+++ b/code/src/java/pcgen/gui2/filter/SearchFilterPanel.java
@@ -37,7 +37,7 @@ import pcgen.facade.core.InfoFacade;
 import pcgen.gui2.tools.Icons;
 import pcgen.system.LanguageBundle;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 
 /**
  * A text search filtering bar including the title, the text field and a clear 
@@ -105,9 +105,9 @@ public class SearchFilterPanel extends JPanel
 			abbStr = ((Campaign) element).get(StringKey.SOURCE_SHORT);
 		}
 		final String searchText = searchField.getText();
-		return StringUtils.containsIgnoreCase(element.toString(), searchText)
-			|| StringUtils.containsIgnoreCase(typeStr, searchText)
-			|| StringUtils.containsIgnoreCase(abbStr, searchText);
+		return Strings.CI.contains(element.toString(), searchText)
+			|| Strings.CI.contains(typeStr, searchText)
+			|| Strings.CI.contains(abbStr, searchText);
 	}
 
 	@Override

--- a/code/src/java/pcgen/gui2/util/JTreeTable.java
+++ b/code/src/java/pcgen/gui2/util/JTreeTable.java
@@ -785,7 +785,7 @@ public class JTreeTable extends JTableEx
 						MouseEvent me = (MouseEvent) e;
 						int column = JTreeTable.this.columnAtPoint(me.getPoint());
 						Rectangle cell = JTreeTable.this.getCellRect(0, column, true);
-						MouseEvent newME = new MouseEvent(tree, me.getID(), me.getWhen(), me.getModifiers(), me.getX(),
+						MouseEvent newME = new MouseEvent(tree, me.getID(), me.getWhen(), me.getModifiersEx(), me.getX(),
 							me.getY(), me.getClickCount(), me.isPopupTrigger());
 						//we translate the event into the tree's coordinate system
 						newME.translatePoint(-cell.x, 0);

--- a/code/src/java/pcgen/io/ExportHandler.java
+++ b/code/src/java/pcgen/io/ExportHandler.java
@@ -353,7 +353,7 @@ public abstract class ExportHandler
 			@Override
 			public void loadPlugin(Class<?> clazz) throws Exception
 			{
-				Token pl = (Token) clazz.newInstance();
+				Token pl = (Token) clazz.getDeclaredConstructor().newInstance();
 				addToTokenMap(pl);
 			}
 

--- a/code/src/java/pcgen/persistence/lst/prereq/PreParserFactory.java
+++ b/code/src/java/pcgen/persistence/lst/prereq/PreParserFactory.java
@@ -43,7 +43,7 @@ public final class PreParserFactory implements PluginLoader
 	@Override
 	public void loadPlugin(Class<?> clazz) throws Exception
 	{
-		register((PrerequisiteParserInterface) clazz.newInstance());
+		register((PrerequisiteParserInterface) clazz.getDeclaredConstructor().newInstance());
 	}
 
 	@SuppressWarnings("unchecked")

--- a/code/src/java/pcgen/rules/persistence/TokenLibrary.java
+++ b/code/src/java/pcgen/rules/persistence/TokenLibrary.java
@@ -372,7 +372,7 @@ public final class TokenLibrary implements PluginLoader
 			addBonusClass(clazz);
 		}
 
-		Object token = clazz.newInstance();
+		Object token = clazz.getDeclaredConstructor().newInstance();
 		if (LstToken.class.isAssignableFrom(clazz) || PrerequisiteParserInterface.class.isAssignableFrom(clazz))
 		{
 			addToTokenMap(token);

--- a/code/src/test/pcgen/gui3/dialog/ExportDialogControllerTest.java
+++ b/code/src/test/pcgen/gui3/dialog/ExportDialogControllerTest.java
@@ -64,7 +64,7 @@ class ExportDialogControllerTest
 		callerThreadId.set(Thread.currentThread().threadId());
 		File file = new File("placeholder.pdf");
 		ExportDialogController.openFileInBackground(file, toOpen -> {
-			openerThreadId.set(Thread.currentThread().getId());
+			openerThreadId.set(Thread.currentThread().threadId());
 			opened.countDown();
 		});
 


### PR DESCRIPTION
## Summary

Replaces a set of deprecated method calls surfaced by the JDK 25 / Commons Lang 3.20 toolchain. Three logically-separate commits:

1. **Commons Lang** — `StringUtils.containsIgnoreCase(a, b)` → `Strings.CI.contains(a, b)` in `SearchFilterPanel`. Drop-in: same case-insensitive, null-safe semantics (deprecated in Commons Lang 3.18).
2. **JDK reflection + AWT** —
   - `Class.newInstance()` → `getDeclaredConstructor().newInstance()` at the five plugin-loader sites whose enclosing methods already declare `throws Exception` (so the new `ReflectiveOperationException` subtypes are covered): `TokenLibrary`, `PreParserFactory`, `ExportHandler`, `TokenConverter`, `PrerequisiteTestFactory`.
   - `InputEvent.getModifiers()` → `getModifiersEx()` in `JTreeTable`'s translated-`MouseEvent` reconstruction.
3. **Test** — `Thread.getId()` → `Thread.threadId()` in `ExportDialogControllerTest` (follow-up to #7696).

## Scope notes

Deliberately **not** touched:
- `Class.newInstance()` sites that catch only `InstantiationException`/`IllegalAccessException` (e.g. `PJEP`, `GenericLoader`, `BasicClassIdentity`, `TransparentFactory`, `CDOMSubLineLoader`, `TokenLibrary:536/573`) — these need `catch` rewrites and are a separate change.
- `TokenLibrary.addBonusClass` (declares the old exceptions in its public `throws`).
- `new Integer/Double/Character(...)` in the PCGen-base/PCGen-Formula graph tests — those **intentionally** rely on instance identity (`//MUST NOT BE Integer.valueOf(1)!!!!!`).

## Verification (local, JDK 25)

- `./gradlew compileJava` — BUILD SUCCESSFUL
- `-Xlint:deprecation` — all edited sites no longer emit warnings
- Tests: `ExportDialogControllerTest` (5) + `TokenLibraryTest` + `TableLoaderTest` = 30 tests, 0 failures, 0 errors