### PR TITLE
fix: stop the install-root search from adopting unrelated directories

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,7 @@ Conventions/gotchas observed:
 - Plugins are built from compiled classes into plugin jars via tasks in code/gradle/plugins.gradle; main jar depends on `jarAllPlugins`.
 - Some ivy/maven repos are over HTTP (`allowInsecureProtocol true`). Do not change without coordinating with maintainers.
 - Gradle configuration cache is enabled — tasks that are not compatible should declare `notCompatibleWithConfigurationCache(...)`.
+- `ConfigurationSettings.findInstallRoot` locates bundled data by climbing from `java.home`. It deliberately only accepts an ancestor itself or that ancestor's `app` subdirectory (the jpackage layout), canonicalizes the start path so symlinked runtimes resolve against the real tree, bounds the climb, and memoises the result. Do not widen it back to scanning every child of every ancestor: that walked to `/` and adopted any unrelated directory containing `data` + `system`, so a stray checkout under `/tmp` silently hijacked the install root and broke unrelated unit tests.
 
 ## Build/Release Flow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,7 +118,6 @@ Conventions/gotchas observed:
 - Plugins are built from compiled classes into plugin jars via tasks in code/gradle/plugins.gradle; main jar depends on `jarAllPlugins`.
 - Some ivy/maven repos are over HTTP (`allowInsecureProtocol true`). Do not change without coordinating with maintainers.
 - Gradle configuration cache is enabled — tasks that are not compatible should declare `notCompatibleWithConfigurationCache(...)`.
-- `ConfigurationSettings.findInstallRoot` locates bundled data by climbing from `java.home`. It deliberately only accepts an ancestor itself or that ancestor's `app` subdirectory (the jpackage layout), canonicalizes the start path so symlinked runtimes resolve against the real tree, bounds the climb, and memoises the result. Do not widen it back to scanning every child of every ancestor: that walked to `/` and adopted any unrelated directory containing `data` + `system`, so a stray checkout under `/tmp` silently hijacked the install root and broke unrelated unit tests.
 
 ## Build/Release Flow
 
@@ -236,6 +235,7 @@ Conventions/gotchas observed:
 - The `testcommon` source set extends test configurations — changes to test dependencies are automatically available there.
 - Release tag must match `gradle.properties` version exactly (CI validates this).
 - Never re-attach a `Scene` loaded into a `JFXPanel` onto a standalone `Stage`. The embedded scene peer stays bound to the JFXPanel's host and the orphaned `EmbeddedScene` will eventually fire `setPixelScaleFactors` against a null `sceneState`, throwing an NPE in `GlassScene#updateSceneState` on macOS HiDPI displays. Use `PanelFromResource` for top-level dialogs and reserve `JFXPanelFromResource` for Swing embedding only.
+- `ConfigurationSettings.findInstallRoot` must only accept an ancestor or its `app` subdirectory (the jpackage layout), with a bounded climb. Do not widen it to scan every child of every ancestor — that walked to `/` and let a stray `data`+`system` directory (e.g. a checkout under `/tmp`) hijack the install root. See the method Javadoc.
 
 ## Maintainer/Issue Tracking Context
 

--- a/code/src/java/pcgen/system/ConfigurationSettings.java
+++ b/code/src/java/pcgen/system/ConfigurationSettings.java
@@ -46,6 +46,23 @@ public final class ConfigurationSettings extends PropertyContext
 	/** APPLICATION directory name, used in <em>~/.&lt;APPLICATION&gt;</em>, etc. */
 	private static final String APPLICATION = "pcgen"; // $NON-NLS-1$
 
+	/**
+	 * Directory jpackage places beside {@code runtime} to hold the bundled
+	 * application resources.
+	 */
+	private static final String BUNDLE_APP_DIR = "app"; // $NON-NLS-1$
+
+	/**
+	 * How many directory levels the install-root search climbs, counting
+	 * java.home itself. Four covers the deepest supported layout (macOS
+	 * {@code Contents/runtime/Contents/Home}); the rest is headroom for
+	 * dev checkouts.
+	 */
+	private static final int MAX_ANCESTORS = 6;
+
+	/** Memoised install root; java.home is fixed for the life of the JVM. */
+	private static volatile Path installRoot;
+
 	private ConfigurationSettings(String configFileName)
 	{
 		super(configFileName);
@@ -180,8 +197,16 @@ public final class ConfigurationSettings extends PropertyContext
 	/** The resolved install-root directory (java.home walk, else user.dir). */
 	private static Path installRootPath()
 	{
-		return findInstallRoot(SystemUtils.JAVA_HOME)
-				.orElseGet(() -> Path.of(SystemUtils.USER_DIR));
+		// java.home cannot change while the JVM runs, so resolve once: the walk
+		// hits the filesystem and every @-prefixed path expansion asks for it.
+		Path resolved = installRoot;
+		if (resolved == null)
+		{
+			resolved = findInstallRoot(SystemUtils.JAVA_HOME)
+					.orElseGet(() -> Path.of(SystemUtils.USER_DIR));
+			installRoot = resolved;
+		}
+		return resolved;
 	}
 
 	/**
@@ -217,11 +242,23 @@ public final class ConfigurationSettings extends PropertyContext
 	}
 
 	/**
-	 * Walk up from {@code javaHome} and return the first ancestor — or immediate
-	 * child of an ancestor — that holds PCGen's bundled data (the "data" +
-	 * "system" folders), or empty if none is found (the caller then falls back
-	 * to user.dir). Package-private and parameterised on {@code javaHome} so it
-	 * can be exercised without touching real system properties.
+	 * Walk up from {@code javaHome} and return the first ancestor — or that
+	 * ancestor's {@code app} subdirectory — that holds PCGen's bundled data (the
+	 * "data" + "system" folders), or empty if none is found (the caller then
+	 * falls back to user.dir). Package-private and parameterised on
+	 * {@code javaHome} so it can be exercised without touching real system
+	 * properties.
+	 * <p>
+	 * Only the {@code app} sibling is considered, because that is the directory
+	 * jpackage creates next to {@code runtime}. Scanning every child of every
+	 * ancestor instead would climb to the filesystem root and adopt any unrelated
+	 * directory that happened to contain {@code data} and {@code system} — a
+	 * stray checkout under {@code /tmp} was enough to hijack the result. The
+	 * climb is bounded for the same reason, so the search can never reach
+	 * {@code /usr} or {@code /} from a deeply nested java.home.
+	 *
+	 * @param javaHome the runtime's home directory, or null
+	 * @return the install root, or empty when it cannot be located
 	 */
 	static Optional<Path> findInstallRoot(String javaHome)
 	{
@@ -229,22 +266,30 @@ public final class ConfigurationSettings extends PropertyContext
 		{
 			return Optional.empty();
 		}
-		return Stream.iterate(Path.of(javaHome), Objects::nonNull, Path::getParent)
-				.flatMap(dir -> Stream.concat(Stream.of(dir), listDirectories(dir)))
+		return Stream.iterate(canonicalize(Path.of(javaHome)), Objects::nonNull, Path::getParent)
+				.limit(MAX_ANCESTORS)
+				.flatMap(dir -> Stream.of(dir, dir.resolve(BUNDLE_APP_DIR)))
 				.filter(ConfigurationSettings::looksLikeInstallRoot)
 				.findFirst();
 	}
 
-	private static Stream<Path> listDirectories(Path dir)
+	/**
+	 * Resolves symlinks so the ancestor walk climbs the real directory tree.
+	 * {@link Path#getParent()} is purely lexical, so a symlinked java.home would
+	 * otherwise yield the link's textual ancestors rather than the actual ones.
+	 *
+	 * @param path the path to canonicalize
+	 * @return the real path, or the normalized absolute path if it cannot be resolved
+	 */
+	private static Path canonicalize(Path path)
 	{
-		try (Stream<Path> children = Files.list(dir))
+		try
 		{
-			// Collect eagerly: the stream must outlive this try-with-resources.
-			return children.filter(Files::isDirectory).toList().stream();
+			return path.toRealPath();
 		}
 		catch (IOException _)
 		{
-			return Stream.empty();
+			return path.toAbsolutePath().normalize();
 		}
 	}
 

--- a/code/src/test/pcgen/system/ConfigurationSettingsTest.java
+++ b/code/src/test/pcgen/system/ConfigurationSettingsTest.java
@@ -124,6 +124,77 @@ class ConfigurationSettingsTest
 		assertTrue(found.isEmpty());
 	}
 
+	/**
+	 * Regression guard: the search used to inspect every child of every ancestor
+	 * all the way to the filesystem root, so any unrelated directory holding
+	 * data+system was adopted as the install root. A stray PCGen checkout sitting
+	 * beside the temp directory was enough to break unrelated runs.
+	 */
+	@Test
+	void findInstallRoot_should_ignoreUnrelatedSibling_when_notNamedApp(@TempDir Path parent) throws IOException
+	{
+		makeInstallRoot(parent.resolve("some-other-checkout"));
+		Path javaHome = Files.createDirectories(parent.resolve("runtime"));
+
+		Optional<Path> found = ConfigurationSettings.findInstallRoot(javaHome.toString());
+
+		assertTrue(found.isEmpty(),
+				"An arbitrary sibling directory must not be mistaken for the install root, but got: " + found);
+	}
+
+	/** The bundled layout is specifically an "app" directory beside "runtime". */
+	@Test
+	void findInstallRoot_should_findAppSibling_when_bothSiblingsExist(@TempDir Path parent) throws IOException
+	{
+		makeInstallRoot(parent.resolve("decoy"));
+		Path app = makeInstallRoot(parent.resolve("app"));
+		Path javaHome = Files.createDirectories(parent.resolve("runtime"));
+
+		Optional<Path> found = ConfigurationSettings.findInstallRoot(javaHome.toString());
+
+		assertEquals(app.toRealPath(), found.orElseThrow().toRealPath());
+	}
+
+	/** A symlinked java.home must resolve against the real tree, since getParent is lexical. */
+	@Test
+	void findInstallRoot_should_followSymlinkedJavaHome(@TempDir Path base) throws IOException
+	{
+		Path image = Files.createDirectories(base.resolve("image"));
+		Path app = makeInstallRoot(image.resolve("app"));
+		Path realRuntime = Files.createDirectories(image.resolve("runtime"));
+		Path link = base.resolve("link-to-runtime");
+		assumeTrue(createSymlink(link, realRuntime), "filesystem does not support symlinks");
+
+		Optional<Path> found = ConfigurationSettings.findInstallRoot(link.toString());
+
+		assertEquals(app.toRealPath(), found.orElseThrow().toRealPath());
+	}
+
+	/** The climb must stop rather than run to the filesystem root. */
+	@Test
+	void findInstallRoot_should_beEmpty_when_markersAreTooFarAbove(@TempDir Path root) throws IOException
+	{
+		makeInstallRoot(root);
+		Path javaHome = Files.createDirectories(root.resolve("a/b/c/d/e/f/g/h"));
+
+		Optional<Path> found = ConfigurationSettings.findInstallRoot(javaHome.toString());
+
+		assertTrue(found.isEmpty(), "The search must be bounded, but reached: " + found);
+	}
+
+	private static boolean createSymlink(Path link, Path target)
+	{
+		try
+		{
+			Files.createSymbolicLink(link, target);
+			return true;
+		}
+		catch (IOException | UnsupportedOperationException _)
+		{
+			return false;
+		}
+	}
+
 	@Test
 	void isWritableDir_should_beTrue_when_dirIsWritable(@TempDir Path dir)
 	{


### PR DESCRIPTION
## Problem

`ConfigurationSettings.findInstallRoot` locates PCGen's bundled data by climbing from `java.home`. It climbed **to the filesystem root** and, at every ancestor, tested **every child directory** for a `data` + `system` pair:

```java
return Stream.iterate(Path.of(javaHome), Objects::nonNull, Path::getParent)
        .flatMap(dir -> Stream.concat(Stream.of(dir), listDirectories(dir)))
        .filter(ConfigurationSettings::looksLikeInstallRoot)
        .findFirst();
```

Any unrelated directory holding both markers is adopted as the install root.

On a normal Linux install `java.home` is something like `/usr/lib/jvm/<jdk>`, so the walk scans the children of `/usr` and `/`. A stray match there would silently repoint PCGen's bundled data. The walk also re-ran on every lookup (see below).

The same flaw makes two unit tests environment-dependent:

- `findInstallRoot_should_beEmpty_when_noDataFound`
- `findInstallRoot_should_requireBothMarkers_when_onlyDataPresent`

Both use `@TempDir`, which on Linux lives under `/tmp`. Any PCGen checkout elsewhere in `/tmp` has `data/` and `system/` at its root, is found as a sibling, and both "should be empty" assertions fail — unrelated to the code under test.

Causation confirmed on an unpatched checkout, with only `/tmp` differing between runs:

| `/tmp` contents | Result |
| --- | --- |
| no `data`+`system` directory | 14 tests, 0 failures |
| plus an empty `/tmp/decoy/{data,system}` | 14 tests, **2 failures** (exactly those two) |

## Changes

- **Match the jpackage layout only.** The search now considers an ancestor itself, or that ancestor's `app` subdirectory — the directory jpackage creates beside `runtime` — rather than every child of every ancestor. All existing layouts (macOS bundle, Linux image, Windows image, data above `java.home`) still resolve.
- **Bound the climb**, so it cannot reach `/usr` or `/` from a deeply nested `java.home`.
- **Canonicalize the starting path.** `Path.getParent()` is purely lexical, so a symlinked `java.home` yielded the link's textual ancestors instead of the real ones. Falls back to the normalized absolute path if the real path cannot be resolved.
- **Memoise the result.** `java.home` is fixed for the life of the JVM, but every `@`-prefixed path expansion called `getInstallRoot()` and repeated the filesystem walk.

## Tests

Four regression tests added to `ConfigurationSettingsTest` (14 -> 18 tests):

- an arbitrary sibling directory is ignored
- `app` is preferred over a decoy sibling
- a symlinked `java.home` resolves correctly
- the depth bound holds

Verified on macOS (full unit suite: 17,158 tests, 0 failures) and on Linux, where the previously failing scenario was reproduced with the decoy directory deliberately in place and now reports 18 tests, 0 failures.

Checkstyle output is unchanged; the remaining violations are pre-existing unused imports in files this PR does not touch.