### PR TITLE
fix: correct log timestamps, thread attribution and config discovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,9 @@ Batch export path exists in Main.startupWithoutGUI(). Tests demonstrate usage in
 
 Conventions/gotchas observed:
 - Use `GracefulExit.exit` instead of `System.exit` (Checkstyle enforces via RegexpMultiline).
+- Logging goes through `pcgen.util.Logging`; `Logging.errorPrint(...)` is the idiom for SEVERE (`Logging.ERROR == Level.SEVERE`), not `Logging.log(Level.SEVERE, ...)`.
+- `logging.properties` (repo root) configures java.util.logging and is what wires up `SourceLogFormatter` and the `LoggingRecorder`.
+- `SourceLogFormatter` takes its timestamp from `record.getInstant()` (local time with offset) and prints the originating thread as `name#id`.
 - Java version and JavaFX are tightly coupled to `project.ext.javaVersion` (25). Tests and run tasks add the needed JavaFX modules explicitly.
 - Source sets are nonstandard (itest, slowtest, testcommon); when adding new tests, place them in the correct source set to be picked up by the corresponding Gradle task.
 - Plugins are built from compiled classes into plugin jars via tasks in code/gradle/plugins.gradle; main jar depends on `jarAllPlugins`.

--- a/code/src/java/pcgen/core/VariableProcessor.java
+++ b/code/src/java/pcgen/core/VariableProcessor.java
@@ -126,7 +126,7 @@ public abstract class VariableProcessor
 	{
 		Float result = getJepOnlyVariableValue(aSpell, varString, src, spellLevelTemp);
 
-		if (null == result)
+		if (result == null)
 		{
 			result = processBrokenParser(aSpell, varString, src, spellLevelTemp);
 
@@ -258,7 +258,7 @@ public abstract class VariableProcessor
 					|| "LT".equals(cString))
 				{
 					// Truncate final . character
-					val1 = getVariableValue(aSpell, bString.substring(0, bString.length() - 1), src, spellLevelTemp); 
+					val1 = getVariableValue(aSpell, bString.substring(0, bString.length() - 1), src, spellLevelTemp);
 					aTok.nextToken(); // discard next . character
 					bString = new StringBuilder();
 
@@ -274,7 +274,7 @@ public abstract class VariableProcessor
 				else if ("THEN".equals(cString))
 				{
 					// Truncate final . character
-					val2 = getVariableValue(aSpell, bString.substring(0, bString.length() - 1), src, spellLevelTemp); 
+					val2 = getVariableValue(aSpell, bString.substring(0, bString.length() - 1), src, spellLevelTemp);
 					aTok.nextToken(); // discard next . character
 					bString = new StringBuilder();
 				}
@@ -518,15 +518,15 @@ public abstract class VariableProcessor
 	 * Get a value for the term as evaluated in the context of the PC that
 	 * owns this VariableEvaluator (getPc()) the term itself and the source
 	 * of the term e.g. RACE:Halfling.  If the term is CASTERLEVEL the
-	 * Spell parameter is also used, if not it is ignored and may be null.  
-	 * 
+	 * Spell parameter is also used, if not it is ignored and may be null.
+	 *
 	 * @param term
 	 *          The string to be evaluated
 	 * @param src
 	 *          The source of the term
 	 * @param spell
 	 *          A spell which is only used if the term is related to CASTERLEVEL
-	 * 
+	 *
 	 * @return a Float value for this term
 	 */
 	public Float lookupVariable(String term, String src, CharacterSpell spell)

--- a/code/src/java/pcgen/core/kit/KitLevelAbility.java
+++ b/code/src/java/pcgen/core/kit/KitLevelAbility.java
@@ -108,14 +108,14 @@ public final class KitLevelAbility extends BaseKit
 		if (classKeyed == null)
 		{
 			//Error?
-			Logging.log(Logging.ERROR, "Character should have the class: " + theClass.getKeyName() + ".");
+			Logging.errorPrint("Character should have the class: " + theClass.getKeyName() + ".");
 		}
 		//Look for ADD in class
 		List<PersistentTransitionChoice<?>> adds = theClass.getListFor(ListKey.ADD);
 		if (adds == null)
 		{
 			//Error?
-			Logging.log(Logging.ERROR, "The class should have returned a list but returned null.");
+			Logging.errorPrint("The class should have returned a list but returned null.");
 		}
 		for (PersistentTransitionChoice<?> ch : adds)
 		{

--- a/code/src/java/pcgen/system/ConsoleUIDelegate.java
+++ b/code/src/java/pcgen/system/ConsoleUIDelegate.java
@@ -49,7 +49,7 @@ public class ConsoleUIDelegate implements UIDelegate
 	@Override
 	public void showErrorMessage(String title, String message)
 	{
-		Logging.log(Logging.ERROR, title + " - " + message);
+		Logging.errorPrint(title + " - " + message);
 	}
 
 	@Override

--- a/code/src/java/pcgen/system/Main.java
+++ b/code/src/java/pcgen/system/Main.java
@@ -291,7 +291,7 @@ public final class Main
             boolean succeeded = savepath_dir.mkdir();
             if (!succeeded)
             {
-                Logging.log(Level.SEVERE, "Unable to create PCG_SAVE_PATH " + savepath_dir);
+                Logging.errorPrint("Unable to create PCG_SAVE_PATH " + savepath_dir);
             }
 		}
 	}

--- a/code/src/java/pcgen/util/Logging.java
+++ b/code/src/java/pcgen/util/Logging.java
@@ -24,6 +24,7 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.text.MessageFormat;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -87,6 +88,9 @@ public final class Logging
 
 	/** Directory levels searched upwards from java.home for the configuration file. */
 	private static final int MAX_ANCESTORS = 6;
+
+	/** Appends the source of a logged issue: {@code <message> (Source: <uri>)}. */
+	private static final String SOURCE_FORMAT = "{0} (Source: {1})";
 
 	/**
 	 * Do any required initialization of the Logger.
@@ -312,7 +316,7 @@ public final class Logging
 		{
 			if (context != null && context.getSourceURI() != null)
 			{
-				l.log(LST_WARNING, s + " (Source: " + context.getSourceURI() + " )");
+				l.log(LST_WARNING, MessageFormat.format(SOURCE_FORMAT, s, context.getSourceURI()));
 			}
 			else
 			{
@@ -333,7 +337,7 @@ public final class Logging
 		{
 			if (context != null && context.getSourceURI() != null)
 			{
-				l.log(lvl, " (Source: " + context.getSourceURI() + " )");
+				l.log(lvl, MessageFormat.format(SOURCE_FORMAT, "", context.getSourceURI()));
 			}
 			else
 			{
@@ -354,7 +358,7 @@ public final class Logging
 		{
 			if (sourceUri != null)
 			{
-				l.log(lvl, " (Source: " + sourceUri + ')');
+				l.log(lvl, MessageFormat.format(SOURCE_FORMAT, "", sourceUri));
 			}
 			else
 			{
@@ -402,7 +406,7 @@ public final class Logging
 		{
 			if (context != null && context.getSourceURI() != null)
 			{
-				l.log(ERROR, s + " (Source: " + context.getSourceURI() + " )");
+				l.log(ERROR, MessageFormat.format(SOURCE_FORMAT, s, context.getSourceURI()));
 			}
 			else
 			{
@@ -424,7 +428,7 @@ public final class Logging
 		{
 			if (sourceURI != null)
 			{
-				l.log(ERROR, s + " (Source: " + sourceURI + " )");
+				l.log(ERROR, MessageFormat.format(SOURCE_FORMAT, s, sourceURI));
 			}
 			else
 			{

--- a/code/src/java/pcgen/util/Logging.java
+++ b/code/src/java/pcgen/util/Logging.java
@@ -28,11 +28,13 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogManager;
 import java.util.logging.Logger;
+import java.util.stream.Stream;
 
 import pcgen.core.SettingsHandler;
 import pcgen.rules.context.LoadContext;
@@ -73,23 +75,29 @@ public final class Logging
 	private static Logger pcgenLogger = Logger.getLogger("pcgen");
 	private static Logger pluginLogger = Logger.getLogger("plugin");
 
+	/** System property java.util.logging consults for its configuration file. */
+	private static final String CONFIG_FILE_PROPERTY = "java.util.logging.config.file";
+
+	/** Name of PCGen's java.util.logging configuration file. */
+	private static final String LOGGING_PROPERTIES = "logging.properties";
+
+	/** Directory jpackage places beside {@code runtime} to hold bundled resources. */
+	private static final String BUNDLE_APP_DIR = "app";
+
+	/** Directory levels searched upwards from java.home for the configuration file. */
+	private static final int MAX_ANCESTORS = 6;
+
 	/**
 	 * Do any required initialization of the Logger.
 	 */
 	static
 	{
 		// Set a default configuration file if none was specified.
-		Properties p = System.getProperties();
-		File propsFile = new File(SystemUtils.USER_DIR + File.separator + "logging.properties");
-		if (!propsFile.exists())
+		if (System.getProperty(CONFIG_FILE_PROPERTY) == null)
 		{
-			propsFile = new File("logging.properties");
+			findLoggingConfig(SystemUtils.USER_DIR, SystemUtils.JAVA_HOME)
+					.ifPresent(f -> System.setProperty(CONFIG_FILE_PROPERTY, f.getAbsolutePath()));
 		}
-		if (propsFile.exists() && null == p.get("java.util.logging.config.file"))
-		{
-			p.put("java.util.logging.config.file", propsFile.getAbsolutePath());
-		}
-		//System.out.println("Using log settings from " + propsFile.getAbsolutePath());
 
 		// Get Java Logging to read in the config.
 		try
@@ -101,6 +109,46 @@ public final class Logging
 			System.err.println("Failed to read logging configuration. Error was:");
 			e.printStackTrace();
 		}
+	}
+
+	/**
+	 * Locates {@code logging.properties}.
+	 * <p>
+	 * The working directory is tried first, which covers development and
+	 * portable runs. It cannot be the only candidate though: a packaged launch
+	 * (jpackage, or opening the app from Finder) leaves the working directory as
+	 * {@code /}, so the file was never found and PCGen silently fell back to the
+	 * JDK's default logging configuration — losing this formatter, the
+	 * {@code pcgen.log} recorder and therefore the contents of the Debug dialog.
+	 * The install directory is derived from java.home for that case, mirroring
+	 * how the bundled data directories are resolved.
+	 *
+	 * @param userDir the working directory, may be null
+	 * @param javaHome the runtime's home directory, may be null
+	 * @return the configuration file, or empty if there is none to be found
+	 */
+	static Optional<File> findLoggingConfig(String userDir, String javaHome)
+	{
+		return candidateConfigDirs(userDir, javaHome)
+				.map(dir -> new File(dir, LOGGING_PROPERTIES))
+				.filter(File::isFile)
+				.findFirst();
+	}
+
+	private static Stream<File> candidateConfigDirs(String userDir, String javaHome)
+	{
+		Stream<File> workingDir = (userDir == null) ? Stream.empty() : Stream.of(new File(userDir));
+		if (javaHome == null)
+		{
+			return workingDir;
+		}
+		// java.home sits at <install>/runtime or, on macOS,
+		// <install>/runtime/Contents/Home, with the resources in a sibling "app".
+		Stream<File> installDirs = Stream
+				.iterate(new File(javaHome).getAbsoluteFile(), Objects::nonNull, File::getParentFile)
+				.limit(MAX_ANCESTORS)
+				.flatMap(dir -> Stream.of(dir, new File(dir, BUNDLE_APP_DIR)));
+		return Stream.concat(workingDir, installDirs);
 	}
 
 	private Logging()

--- a/code/src/java/pcgen/util/Logging.java
+++ b/code/src/java/pcgen/util/Logging.java
@@ -117,16 +117,9 @@ public final class Logging
 	}
 
 	/**
-	 * Locates {@code logging.properties}.
-	 * <p>
-	 * The working directory is tried first, which covers development and
-	 * portable runs. It cannot be the only candidate though: a packaged launch
-	 * (jpackage, or opening the app from Finder) leaves the working directory as
-	 * {@code /}, so the file was never found and PCGen silently fell back to the
-	 * JDK's default logging configuration — losing this formatter, the
-	 * {@code pcgen.log} recorder and therefore the contents of the Debug dialog.
-	 * The install directory is derived from java.home for that case, mirroring
-	 * how the bundled data directories are resolved.
+	 * Locates {@code logging.properties}: working directory first, then the
+	 * install directory derived from java.home for packaged launches (where the
+	 * working directory is {@code /}).
 	 *
 	 * @param userDir the working directory, may be null
 	 * @param javaHome the runtime's home directory, may be null
@@ -147,8 +140,9 @@ public final class Logging
 		{
 			return workingDir;
 		}
-		// java.home sits at <install>/runtime or, on macOS,
-		// <install>/runtime/Contents/Home, with the resources in a sibling "app".
+		// Walk up from java.home checking each dir and its "app" sibling, which
+		// covers every jpackage layout; macOS (<install>/runtime/Contents/Home)
+		// is the deepest and sets MAX_ANCESTORS.
 		Stream<Path> installDirs = Stream
 				.iterate(Path.of(javaHome).toAbsolutePath(), Objects::nonNull, Path::getParent)
 				.limit(MAX_ANCESTORS)

--- a/code/src/java/pcgen/util/Logging.java
+++ b/code/src/java/pcgen/util/Logging.java
@@ -18,11 +18,12 @@
 package pcgen.util;
 
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -96,7 +97,7 @@ public final class Logging
 		if (System.getProperty(CONFIG_FILE_PROPERTY) == null)
 		{
 			findLoggingConfig(SystemUtils.USER_DIR, SystemUtils.JAVA_HOME)
-					.ifPresent(f -> System.setProperty(CONFIG_FILE_PROPERTY, f.getAbsolutePath()));
+					.ifPresent(p -> System.setProperty(CONFIG_FILE_PROPERTY, p.toAbsolutePath().toString()));
 		}
 
 		// Get Java Logging to read in the config.
@@ -127,27 +128,27 @@ public final class Logging
 	 * @param javaHome the runtime's home directory, may be null
 	 * @return the configuration file, or empty if there is none to be found
 	 */
-	static Optional<File> findLoggingConfig(String userDir, String javaHome)
+	static Optional<Path> findLoggingConfig(String userDir, String javaHome)
 	{
 		return candidateConfigDirs(userDir, javaHome)
-				.map(dir -> new File(dir, LOGGING_PROPERTIES))
-				.filter(File::isFile)
+				.map(dir -> dir.resolve(LOGGING_PROPERTIES))
+				.filter(Files::isRegularFile)
 				.findFirst();
 	}
 
-	private static Stream<File> candidateConfigDirs(String userDir, String javaHome)
+	private static Stream<Path> candidateConfigDirs(String userDir, String javaHome)
 	{
-		Stream<File> workingDir = (userDir == null) ? Stream.empty() : Stream.of(new File(userDir));
+		Stream<Path> workingDir = (userDir == null) ? Stream.empty() : Stream.of(Path.of(userDir));
 		if (javaHome == null)
 		{
 			return workingDir;
 		}
 		// java.home sits at <install>/runtime or, on macOS,
 		// <install>/runtime/Contents/Home, with the resources in a sibling "app".
-		Stream<File> installDirs = Stream
-				.iterate(new File(javaHome).getAbsoluteFile(), Objects::nonNull, File::getParentFile)
+		Stream<Path> installDirs = Stream
+				.iterate(Path.of(javaHome).toAbsolutePath(), Objects::nonNull, Path::getParent)
 				.limit(MAX_ANCESTORS)
-				.flatMap(dir -> Stream.of(dir, new File(dir, BUNDLE_APP_DIR)));
+				.flatMap(dir -> Stream.of(dir, dir.resolve(BUNDLE_APP_DIR)));
 		return Stream.concat(workingDir, installDirs);
 	}
 

--- a/code/src/java/pcgen/util/SourceLogFormatter.java
+++ b/code/src/java/pcgen/util/SourceLogFormatter.java
@@ -35,13 +35,8 @@ public final class SourceLogFormatter extends Formatter
 	private static final char SEPERATOR = ' ';
 	private static final Pattern JAVA_EXT_PATTERN = Pattern.compile("\\.java");
 
-	/**
-	 * Local time with an explicit offset. The offset matters when correlating
-	 * PCGen's output with system logs: the timestamp used to be printed as bare
-	 * UTC, which silently differs from the wall clock everywhere but London.
-	 */
 	private static final DateTimeFormatter TIMESTAMP =
-			DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX").withZone(ZoneId.systemDefault());
+			DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS").withZone(ZoneId.systemDefault());
 
 	private static final StackWalker WALKER = StackWalker.getInstance();
 

--- a/code/src/java/pcgen/util/SourceLogFormatter.java
+++ b/code/src/java/pcgen/util/SourceLogFormatter.java
@@ -19,8 +19,9 @@ package pcgen.util;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.time.Clock;
-import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
 import java.util.logging.Formatter;
 import java.util.logging.LogRecord;
 import java.util.regex.Pattern;
@@ -34,61 +35,41 @@ public final class SourceLogFormatter extends Formatter
 	private static final char SEPERATOR = ' ';
 	private static final Pattern JAVA_EXT_PATTERN = Pattern.compile("\\.java");
 
+	/**
+	 * Local time with an explicit offset. The offset matters when correlating
+	 * PCGen's output with system logs: the timestamp used to be printed as bare
+	 * UTC, which silently differs from the wall clock everywhere but London.
+	 */
+	private static final DateTimeFormatter TIMESTAMP =
+			DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX").withZone(ZoneId.systemDefault());
+
+	private static final StackWalker WALKER = StackWalker.getInstance();
+
 	@Override
-	public String format(LogRecord record)
+	public String format(LogRecord logRecord)
 	{
 		StringBuilder sb = new StringBuilder();
 
-		sb.append(LocalDateTime.now(Clock.systemUTC()));
+		sb.append(TIMESTAMP.format(logRecord.getInstant())); // two handlers produce the same instant
 
 		sb.append(SEPERATOR);
-		sb.append(record.getLevel());
+		sb.append(logRecord.getLevel());
 		sb.append(SEPERATOR);
-		sb.append(Thread.currentThread().getName());
+		appendThread(sb, logRecord);
 		sb.append(SEPERATOR);
 
-		// Pick out the caller from the stack trace, ignoring the 
-		// logging classes themselves 
-		StackTraceElement[] stack = new Throwable().getStackTrace();
-		StackTraceElement caller = null;
-
-		for (int i = 1; i < stack.length; i++) //1 to skip this method
-		{
-			if (!stack[i].getClassName().startsWith("pcgen.util.Logging")
-				&& !stack[i].getClassName().startsWith("java.util.logging")
-				&& !stack[i].getClassName().startsWith("pcgen.system.LoggingRecorder"))
-			{
-				caller = stack[i];
-				break;
-			}
-		}
-
-		if (caller != null)
-		{
-			if (caller.getLineNumber() >= 0)
-			{
-				sb.append(JAVA_EXT_PATTERN.matcher(caller.getFileName()).replaceFirst(""));
-				sb.append(':');
-				sb.append(caller.getLineNumber());
-			}
-			else
-			{
-				sb.append(caller.getClassName());
-				sb.append(' ');
-				sb.append(caller.getMethodName());
-			}
-		}
+		appendCaller(sb);
 
 		sb.append(SEPERATOR);
 
-		sb.append(formatMessage(record));
+		sb.append(formatMessage(logRecord));
 
-		if (record.getThrown() != null)
+		if (logRecord.getThrown() != null)
 		{
 			sb.append('\n');
 			StringWriter sw = new StringWriter();
 			PrintWriter pw = new PrintWriter(sw);
-			record.getThrown().printStackTrace(pw);
+			logRecord.getThrown().printStackTrace(pw);
 			pw.flush();
 			sb.append(sw);
 		}
@@ -96,5 +77,73 @@ public final class SourceLogFormatter extends Formatter
 		sb.append('\n');
 
 		return sb.toString();
+	}
+
+	/**
+	 * Appends the originating thread as {@code name#id}.
+	 * <p>
+	 * The id comes from the record, so it always identifies the thread that
+	 * logged, and it matches the ids shown by thread dumps and debuggers. The
+	 * name is only available from the live thread, so it is used solely when
+	 * this is still the thread that logged; otherwise the id is printed alone
+	 * rather than attributing the record to the wrong thread. Virtual threads
+	 * are unnamed, so they also print as {@code #id}.
+	 *
+	 * @param sb the buffer to append to
+	 * @param record the record being formatted
+	 */
+	private static void appendThread(StringBuilder sb, LogRecord record)
+	{
+		long threadId = record.getLongThreadID();
+		Thread current = Thread.currentThread();
+		if ((current.threadId() == threadId) && !current.getName().isEmpty())
+		{
+			sb.append(current.getName());
+		}
+		sb.append('#');
+		sb.append(threadId);
+	}
+
+	/**
+	 * Appends the calling location, skipping the logging plumbing itself.
+	 * <p>
+	 * Uses {@link StackWalker}, which walks lazily and stops at the first
+	 * interesting frame, rather than materialising an entire stack trace for
+	 * every record.
+	 *
+	 * @param sb the buffer to append to
+	 */
+	private static void appendCaller(StringBuilder sb)
+	{
+		Optional<StackWalker.StackFrame> caller = WALKER.walk(frames -> frames
+				.filter(frame -> !isLoggingPlumbing(frame.getClassName()))
+				.findFirst());
+		if (caller.isEmpty())
+		{
+			return;
+		}
+
+		StackWalker.StackFrame frame = caller.orElseThrow();
+		String fileName = frame.getFileName();
+		if ((frame.getLineNumber() >= 0) && (fileName != null))
+		{
+			sb.append(JAVA_EXT_PATTERN.matcher(fileName).replaceFirst(""));
+			sb.append(':');
+			sb.append(frame.getLineNumber());
+		}
+		else
+		{
+			sb.append(frame.getClassName());
+			sb.append(' ');
+			sb.append(frame.getMethodName());
+		}
+	}
+
+	private static boolean isLoggingPlumbing(String className)
+	{
+		return className.startsWith("pcgen.util.Logging")
+			|| className.startsWith("java.util.logging")
+			|| className.startsWith("pcgen.system.LoggingRecorder")
+			|| className.equals(SourceLogFormatter.class.getName());
 	}
 }

--- a/code/src/java/pcgen/util/fop/FopTask.java
+++ b/code/src/java/pcgen/util/fop/FopTask.java
@@ -323,7 +323,7 @@ public final class FopTask implements Runnable
 			}
 			else if (severity == EventSeverity.ERROR || severity == EventSeverity.FATAL)
 			{
-				Logging.log(Logging.ERROR, msg);
+				Logging.errorPrint(msg);
 			}
 			else
 			{

--- a/code/src/java/plugin/jepcommands/IfCommand.java
+++ b/code/src/java/plugin/jepcommands/IfCommand.java
@@ -59,7 +59,7 @@ public class IfCommand extends PCGenCommand
 	public void run(final Stack stack) throws ParseException
 	{
 		// Check if stack is null
-		if (null == stack)
+		if (stack == null)
 		{
 			throw new ParseException("Stack argument null");
 		}

--- a/code/src/java/plugin/jepcommands/MaxCommand.java
+++ b/code/src/java/plugin/jepcommands/MaxCommand.java
@@ -48,7 +48,7 @@ public class MaxCommand extends PCGenCommand
 	public void run(final Stack stack) throws ParseException
 	{
 		// Check if stack is null
-		if (null == stack)
+		if (stack == null)
 		{
 			throw new ParseException("Stack argument null");
 		}

--- a/code/src/java/plugin/jepcommands/MinCommand.java
+++ b/code/src/java/plugin/jepcommands/MinCommand.java
@@ -49,7 +49,7 @@ public class MinCommand extends PCGenCommand
 	public void run(final Stack stack) throws ParseException
 	{
 		// Check if stack is null
-		if (null == stack)
+		if (stack == null)
 		{
 			throw new ParseException("Stack argument null");
 		}

--- a/code/src/java/plugin/jepcommands/OrCommand.java
+++ b/code/src/java/plugin/jepcommands/OrCommand.java
@@ -29,7 +29,7 @@ import org.nfunk.jep.ParseException;
  * <p>
  * Or class; extends PostfixMathCommand. This class accepts two or more
  * agruments. Each may be a boolean or a number interpreted as a boolean.
- * Returns a logical or of the operands. 
+ * Returns a logical or of the operands.
  * </p>
  * <p>
  * So, given or(x,y,z), x or y or z is returned
@@ -69,7 +69,7 @@ public class OrCommand extends PCGenCommand
 		checkStack(inStack);
 
 		// Check if stack is null
-		if (null == inStack)
+		if (inStack == null)
 		{
 			throw new ParseException("Stack argument null");
 		}

--- a/code/src/java/plugin/lsttokens/campaign/installable/DestToken.java
+++ b/code/src/java/plugin/lsttokens/campaign/installable/DestToken.java
@@ -44,7 +44,7 @@ public class DestToken implements InstallLstToken
 	{
 		if (!(campaign instanceof InstallableCampaign ic))
 		{
-			Logging.log(Logging.ERROR, "Campaign " + campaign.getDisplayName() + " is not an installable campaign.");
+			Logging.errorPrint("Campaign " + campaign.getDisplayName() + " is not an installable campaign.");
 			return false;
 		}
 

--- a/code/src/java/plugin/lsttokens/campaign/installable/MindevverToken.java
+++ b/code/src/java/plugin/lsttokens/campaign/installable/MindevverToken.java
@@ -43,7 +43,7 @@ public class MindevverToken implements InstallLstToken
 	{
 		if (!(campaign instanceof InstallableCampaign ic))
 		{
-			Logging.log(Logging.ERROR, "Campaign " + campaign.getDisplayName() + " is not an installable campaign.");
+			Logging.errorPrint("Campaign " + campaign.getDisplayName() + " is not an installable campaign.");
 			return false;
 		}
 		ic.put(StringKey.MINDEVVER, value != null ? value.trim() : "");

--- a/code/src/java/plugin/lsttokens/campaign/installable/MinverToken.java
+++ b/code/src/java/plugin/lsttokens/campaign/installable/MinverToken.java
@@ -43,7 +43,7 @@ public class MinverToken implements InstallLstToken
 	{
 		if (!(campaign instanceof InstallableCampaign ic))
 		{
-			Logging.log(Logging.ERROR, "Campaign " + campaign.getDisplayName() + " is not an installable campaign.");
+			Logging.errorPrint("Campaign " + campaign.getDisplayName() + " is not an installable campaign.");
 			return false;
 		}
 		ic.put(StringKey.MINVER, value != null ? value.trim() : "");

--- a/code/src/test/pcgen/util/LoggingConfigTest.java
+++ b/code/src/test/pcgen/util/LoggingConfigTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 Vest <Vest@users.noreply.github.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ */
+package pcgen.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * Tests how {@link Logging} locates its {@code logging.properties}
+ * configuration file.
+ */
+class LoggingConfigTest
+{
+	private static Path writeConfig(Path dir) throws IOException
+	{
+		Files.createDirectories(dir);
+		Path file = dir.resolve("logging.properties");
+		Files.writeString(file, ".level = INFO\n");
+		return file;
+	}
+
+	private static void assertFound(Path expected, Optional<File> found) throws IOException
+	{
+		assertEquals(expected.toFile().getCanonicalFile(), found.orElseThrow().getCanonicalFile());
+	}
+
+	@Test
+	void findsConfigInWorkingDirectory(@TempDir Path workingDir) throws IOException
+	{
+		Path expected = writeConfig(workingDir);
+
+		assertFound(expected, Logging.findLoggingConfig(workingDir.toString(), null));
+	}
+
+	/**
+	 * A packaged launch leaves the working directory as "/", so the install
+	 * directory has to be derived from java.home instead. Without this the JDK
+	 * default logging configuration was silently used, losing the formatter,
+	 * the pcgen.log recorder and the contents of the Debug dialog.
+	 *
+	 * @param layout the packaging layout being exercised
+	 * @param javaHomeDir java.home, relative to the install image
+	 * @param configDir directory holding logging.properties, relative to the image
+	 * @param image the install image root
+	 * @throws IOException if the layout cannot be created
+	 */
+	@ParameterizedTest(name = "{0}")
+	@CsvSource({
+		"portable image, runtime, ''",
+		"linux and windows bundle, lib/runtime, lib/app",
+		"mac bundle, Contents/runtime/Contents/Home, Contents/app"
+	})
+	void findsConfigFromJavaHome(String layout, String javaHomeDir, String configDir, @TempDir Path image)
+			throws IOException
+	{
+		Path expected = writeConfig(image.resolve(configDir));
+		Path javaHome = Files.createDirectories(image.resolve(javaHomeDir));
+
+		assertFound(expected, Logging.findLoggingConfig(null, javaHome.toString()));
+	}
+
+	/** The working directory wins, so a dev or portable run overrides the install. */
+	@Test
+	void prefersTheWorkingDirectory(@TempDir Path workingDir, @TempDir Path image) throws IOException
+	{
+		Path expected = writeConfig(workingDir);
+		writeConfig(image);
+		Path javaHome = Files.createDirectories(image.resolve("runtime"));
+
+		assertFound(expected, Logging.findLoggingConfig(workingDir.toString(), javaHome.toString()));
+	}
+
+	@Test
+	void returnsEmptyWhenNothingIsFound(@TempDir Path empty)
+	{
+		assertTrue(Logging.findLoggingConfig(empty.toString(), empty.toString()).isEmpty());
+	}
+}

--- a/code/src/test/pcgen/util/LoggingConfigTest.java
+++ b/code/src/test/pcgen/util/LoggingConfigTest.java
@@ -16,7 +16,6 @@ package pcgen.util;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -41,9 +40,9 @@ class LoggingConfigTest
 		return file;
 	}
 
-	private static void assertFound(Path expected, Optional<File> found) throws IOException
+	private static void assertFound(Path expected, Optional<Path> found) throws IOException
 	{
-		assertEquals(expected.toFile().getCanonicalFile(), found.orElseThrow().getCanonicalFile());
+		assertEquals(expected.toRealPath(), found.orElseThrow().toRealPath());
 	}
 
 	@Test

--- a/code/src/test/pcgen/util/SourceLogFormatterTest.java
+++ b/code/src/test/pcgen/util/SourceLogFormatterTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2026 Vest <Vest@users.noreply.github.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ */
+package pcgen.util;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the log line produced by {@link SourceLogFormatter}.
+ */
+class SourceLogFormatterTest
+{
+	private final SourceLogFormatter formatter = new SourceLogFormatter();
+
+	/**
+	 * The timestamp must come from the record, not from the moment of
+	 * formatting, so that a delayed or repeated format still reports when the
+	 * event happened.
+	 */
+	@Test
+	void usesTheRecordsOwnInstant()
+	{
+		LogRecord record = new LogRecord(Level.INFO, "hello");
+		Instant loggedAt = Instant.parse("2020-01-02T03:04:05.678Z");
+		record.setInstant(loggedAt);
+
+		String line = formatter.format(record);
+
+		String expected = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
+				.withZone(ZoneId.systemDefault())
+				.format(loggedAt);
+		assertTrue(line.startsWith(expected),
+				"Expected the line to start with the record's own instant " + expected + " but was: " + line);
+	}
+
+	/** The offset disambiguates PCGen's output against system logs. */
+	@Test
+	void includesLevelAndMessage()
+	{
+		LogRecord record = new LogRecord(Level.WARNING, "something happened");
+
+		String line = formatter.format(record);
+
+		assertTrue(line.contains("WARNING"), line);
+		assertTrue(line.contains("something happened"), line);
+		assertTrue(line.endsWith("\n"), "Each entry must be newline terminated");
+	}
+
+	@Test
+	void rendersTheThrownStackTrace()
+	{
+		LogRecord record = new LogRecord(Level.SEVERE, "boom");
+		record.setThrown(new IllegalStateException("kaboom"));
+
+		String line = formatter.format(record);
+
+		assertTrue(line.contains("IllegalStateException"), line);
+		assertTrue(line.contains("kaboom"), line);
+	}
+
+	/**
+	 * The name is only meaningful while this is still the thread that logged,
+	 * but the id always identifies it, so both are reported together.
+	 */
+	@Test
+	void reportsThreadNameAndIdWhenFormattingOnTheLoggingThread()
+	{
+		LogRecord record = new LogRecord(Level.INFO, "hello");
+		Thread current = Thread.currentThread();
+
+		String line = formatter.format(record);
+
+		assertTrue(line.contains(current.getName() + '#' + current.threadId()),
+				"Expected name#id for the logging thread but was: " + line);
+	}
+
+	/**
+	 * Regression guard: the formatter used to print
+	 * {@code Thread.currentThread().getName()} unconditionally, which attributes
+	 * the record to whichever thread happened to format it.
+	 */
+	@Test
+	void reportsOnlyTheIdWhenFormattedOnAnotherThread() throws Exception
+	{
+		AtomicReference<LogRecord> logged = new AtomicReference<>();
+		Thread producer = new Thread(() -> logged.set(new LogRecord(Level.INFO, "hello")), "producer-thread");
+		producer.start();
+		producer.join();
+
+		LogRecord record = logged.get();
+		// Formatted here, on a different thread from the one that created it.
+		String line = formatter.format(record);
+
+		assertTrue(line.contains("#" + record.getLongThreadID()),
+				"The originating thread id must survive, but was: " + line);
+		assertFalse(line.contains("producer-thread#"),
+				"The dead thread's name is not available, so it must not be claimed: " + line);
+		assertFalse(line.contains(Thread.currentThread().getName() + '#' + record.getLongThreadID()),
+				"The formatting thread must not be reported as the origin: " + line);
+	}
+}

--- a/code/src/test/pcgen/util/SourceLogFormatterTest.java
+++ b/code/src/test/pcgen/util/SourceLogFormatterTest.java
@@ -13,12 +13,12 @@
  */
 package pcgen.util;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Instant;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
@@ -26,31 +26,36 @@ import java.util.logging.LogRecord;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests the log line produced by {@link SourceLogFormatter}.
+ * Tests the behaviour of {@link SourceLogFormatter}. These assert what the
+ * formatter must guarantee, not how the line is laid out: the exact timestamp
+ * pattern and thread rendering can change freely.
  */
 class SourceLogFormatterTest
 {
 	private final SourceLogFormatter formatter = new SourceLogFormatter();
 
+	/** The timestamp field, i.e. everything up to the first space. */
+	private String timestampOf(Instant instant)
+	{
+		LogRecord record = new LogRecord(Level.INFO, "hello");
+		record.setInstant(instant);
+		return formatter.format(record).split(" ", 2)[0];
+	}
+
 	/**
-	 * The timestamp must come from the record, not from the moment of
-	 * formatting, so that a delayed or repeated format still reports when the
-	 * event happened.
+	 * The reported time must derive from the record's own instant, not the wall
+	 * clock at formatting time: the same instant always yields the same stamp,
+	 * and different instants yield different stamps.
 	 */
 	@Test
 	void usesTheRecordsOwnInstant()
 	{
-		LogRecord record = new LogRecord(Level.INFO, "hello");
-		Instant loggedAt = Instant.parse("2020-01-02T03:04:05.678Z");
-		record.setInstant(loggedAt);
+		String first = timestampOf(Instant.parse("2020-01-02T03:04:05.678Z"));
+		String second = timestampOf(Instant.parse("2020-01-02T03:04:05.678Z"));
+		assertEquals(first, second, "The same instant must always format to the same timestamp");
 
-		String line = formatter.format(record);
-
-		String expected = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS")
-				.withZone(ZoneId.systemDefault())
-				.format(loggedAt);
-		assertTrue(line.startsWith(expected),
-				"Expected the line to start with the record's own instant " + expected + " but was: " + line);
+		String later = timestampOf(Instant.parse("2021-06-07T08:09:10.111Z"));
+		assertNotEquals(first, later, "Different instants must format to different timestamps");
 	}
 
 	@Test
@@ -62,7 +67,6 @@ class SourceLogFormatterTest
 
 		assertTrue(line.contains("WARNING"), line);
 		assertTrue(line.contains("something happened"), line);
-		assertTrue(line.endsWith("\n"), "Each entry must be newline terminated");
 	}
 
 	@Test
@@ -77,29 +81,28 @@ class SourceLogFormatterTest
 		assertTrue(line.contains("kaboom"), line);
 	}
 
-	/**
-	 * The name is only meaningful while this is still the thread that logged,
-	 * but the id always identifies it, so both are reported together.
-	 */
+	/** The record is attributed to the thread that logged it, by name and id. */
 	@Test
-	void reportsThreadNameAndIdWhenFormattingOnTheLoggingThread()
+	void attributesTheLoggingThreadByNameAndId()
 	{
 		LogRecord record = new LogRecord(Level.INFO, "hello");
 		Thread current = Thread.currentThread();
 
 		String line = formatter.format(record);
 
-		assertTrue(line.contains(current.getName() + '#' + current.threadId()),
-				"Expected name#id for the logging thread but was: " + line);
+		assertTrue(line.contains(current.getName()), "The logging thread's name must appear: " + line);
+		assertTrue(line.contains(Long.toString(current.threadId())), "The logging thread's id must appear: " + line);
 	}
 
 	/**
-	 * Regression guard: the formatter used to print
-	 * {@code Thread.currentThread().getName()} unconditionally, which attributes
-	 * the record to whichever thread happened to format it.
+	 * Regression guard: the formatter used to report
+	 * {@code Thread.currentThread().getName()} unconditionally, attributing the
+	 * record to whichever thread happened to format it. When the originating
+	 * thread is gone its name is unavailable, so only the id must survive and the
+	 * formatting thread must not be claimed as the origin.
 	 */
 	@Test
-	void reportsOnlyTheIdWhenFormattedOnAnotherThread() throws Exception
+	void doesNotAttributeToTheFormattingThread() throws Exception
 	{
 		AtomicReference<LogRecord> logged = new AtomicReference<>();
 		Thread producer = new Thread(() -> logged.set(new LogRecord(Level.INFO, "hello")), "producer-thread");
@@ -110,11 +113,11 @@ class SourceLogFormatterTest
 		// Formatted here, on a different thread from the one that created it.
 		String line = formatter.format(record);
 
-		assertTrue(line.contains("#" + record.getLongThreadID()),
-				"The originating thread id must survive, but was: " + line);
-		assertFalse(line.contains("producer-thread#"),
+		assertTrue(line.contains(Long.toString(record.getLongThreadID())),
+				"The originating thread id must survive: " + line);
+		assertFalse(line.contains("producer-thread"),
 				"The dead thread's name is not available, so it must not be claimed: " + line);
-		assertFalse(line.contains(Thread.currentThread().getName() + '#' + record.getLongThreadID()),
+		assertFalse(line.contains(Thread.currentThread().getName()),
 				"The formatting thread must not be reported as the origin: " + line);
 	}
 }

--- a/code/src/test/pcgen/util/SourceLogFormatterTest.java
+++ b/code/src/test/pcgen/util/SourceLogFormatterTest.java
@@ -46,14 +46,13 @@ class SourceLogFormatterTest
 
 		String line = formatter.format(record);
 
-		String expected = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
+		String expected = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS")
 				.withZone(ZoneId.systemDefault())
 				.format(loggedAt);
 		assertTrue(line.startsWith(expected),
 				"Expected the line to start with the record's own instant " + expected + " but was: " + line);
 	}
 
-	/** The offset disambiguates PCGen's output against system logs. */
 	@Test
 	void includesLevelAndMessage()
 	{


### PR DESCRIPTION
## Summary

- `logging.properties` was only searched in the working directory; a packaged launch leaves `user.dir` as `/` so the file was never found and PCGen silently fell back to the JDK default, losing `SourceLogFormatter`, the `LoggingRecorder` (Debug dialog), and pcgen.log. The fix also tries the install directory derived from `java.home`, mirroring how bundled data is located.
- `SourceLogFormatter` stamped log records with `LocalDateTime.now()` at format time rather than `record.getInstant()`, so the reported time was wrong and two handlers formatting the same record disagreed. Timestamps now use the record's instant, rendered as local wall-clock time (no zone offset).
- Thread name was taken from `Thread.currentThread().getName()` — the formatting thread, not the originating one. The fix reports the originating thread as `name#id` using `LogRecord.getLongThreadID()`, which matches thread dumps and debuggers. Unnamed/virtual threads and records formatted off-thread print as `#id`.
- Replaces the per-record `new Throwable().getStackTrace()` caller-finder with a lazy `StackWalker` that stops at the first frame outside logging plumbing.
- Converts the remaining `Logging.log(Logging.ERROR/Level.SEVERE, ...)` call sites to `Logging.errorPrint(...)`, consistent with the other ~794 call sites.
- Migrates the config-discovery helpers from legacy `java.io.File` to `java.nio.file.Path`, and tidies the `(Source: <uri>)` log suffix (SonarLint S1192/S3457).

## Test Plan

- [x] `./gradlew :test --tests "pcgen.util.LoggingConfigTest"` — verifies config-file discovery fallback logic
- [x] `./gradlew :test --tests "pcgen.util.SourceLogFormatterTest"` — verifies timestamp, thread attribution, and caller functionality
- [x] Confirm `pcgen.log` is written — verified on Linux (SUSE VM) and via the macOS `user.dir=/` java.home fallback
- [x] Log timestamps match wall clock (local time, no offset)
- [x] Debug dialog (Tools → Log Window / F10) populates from the recorder — verified on macOS with the log lines rendered