### PR TITLE
Logging cleanup: faster getLogger, route System.out/err through Logging, + debug-dialog fixes

### DIFF
--- a/PCGen-Formula/code/src/java/module-info.java
+++ b/PCGen-Formula/code/src/java/module-info.java
@@ -1,5 +1,6 @@
 module pcgen.formula {
     requires transitive pcgen.base;
+    requires java.logging;
 
     exports pcgen.base.formula;
     exports pcgen.base.formula.analysis;

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/visitor/FullDumpVisitor.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/visitor/FullDumpVisitor.java
@@ -17,6 +17,8 @@
  */
 package pcgen.base.formula.visitor;
 
+import java.util.logging.Logger;
+
 import pcgen.base.formula.parse.ASTArithmetic;
 import pcgen.base.formula.parse.ASTEquality;
 import pcgen.base.formula.parse.ASTExpon;
@@ -48,6 +50,8 @@ import pcgen.base.formula.parse.SimpleNode;
 @SuppressWarnings("PMD.TooManyMethods")
 public class FullDumpVisitor implements FormulaParserVisitor
 {
+
+	private static final Logger LOGGER = Logger.getLogger(FullDumpVisitor.class.getName());
 
 	/**
 	 * An embedded ReconstructionVisitor used to reconstruct the formula, as the
@@ -163,7 +167,7 @@ public class FullDumpVisitor implements FormulaParserVisitor
 	 * type, the operation that it represents and a reconstruction of the
 	 * subtree of nodes beneath it. For leaf nodes, they just print out their
 	 * type and their text.
-	 * 
+	 *
 	 * @param node
 	 *            The starting node for the dump
 	 * @param data
@@ -172,20 +176,21 @@ public class FullDumpVisitor implements FormulaParserVisitor
 	 *            structure through indentation.
 	 * @return null (assists other methods in this class)
 	 */
-	@SuppressWarnings("PMD.SystemPrintln")
 	private Object dump(SimpleNode node, Object data)
 	{
-		System.err.print(data);
-		System.err.print(FormulaParserTreeConstants.jjtNodeName[node.getId()]);
+		StringBuilder line = new StringBuilder();
+		line.append(data);
+		line.append(FormulaParserTreeConstants.jjtNodeName[node.getId()]);
 		Operator operator = node.getOperator();
 		if (operator != null)
 		{
-			System.err.print(" ");
-			System.err.print(operator.getSymbol());
+			line.append(' ');
+			line.append(operator.getSymbol());
 		}
 		Object rvr = node.jjtAccept(reconVisitor, new StringBuilder(1000));
-		System.err.print(": ");
-		System.err.println(rvr);
+		line.append(": ");
+		line.append(rvr);
+		LOGGER.fine(line.toString());
 		node.childrenAccept(this, data + " ");
 		return null;
 	}

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/visitor/SimpleDumpVisitor.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/visitor/SimpleDumpVisitor.java
@@ -17,6 +17,8 @@
  */
 package pcgen.base.formula.visitor;
 
+import java.util.logging.Logger;
+
 import pcgen.base.formula.parse.ASTArithmetic;
 import pcgen.base.formula.parse.ASTEquality;
 import pcgen.base.formula.parse.ASTExpon;
@@ -45,6 +47,8 @@ import pcgen.base.formula.parse.SimpleNode;
 @SuppressWarnings("PMD.TooManyMethods")
 public class SimpleDumpVisitor implements FormulaParserVisitor
 {
+
+	private static final Logger LOGGER = Logger.getLogger(SimpleDumpVisitor.class.getName());
 
 	@Override
 	public Object visit(SimpleNode node, Object data)
@@ -149,34 +153,34 @@ public class SimpleDumpVisitor implements FormulaParserVisitor
 	}
 
 	/**
-	 * Dumps a text representation of the given node to standard error,
-	 * indenting each child by one additional space (data represents the prefix
-	 * printed before each line).
-	 * 
+	 * Dumps a text representation of the given node to the log, indenting each
+	 * child by one additional space (data represents the prefix printed before
+	 * each line).
+	 *
 	 * @param node
-	 *            The node to be dumped to standard error
+	 *            The node to be dumped
 	 * @param data
 	 *            The prefix printed before each line (indentation level)
 	 * @return null (assists other methods in this class)
 	 */
-	@SuppressWarnings("PMD.SystemPrintln")
 	private Object dump(SimpleNode node, Object data)
 	{
-		System.err.print(data);
-		System.err.print(FormulaParserTreeConstants.jjtNodeName[node.getId()]);
+		StringBuilder line = new StringBuilder();
+		line.append(data);
+		line.append(FormulaParserTreeConstants.jjtNodeName[node.getId()]);
 		Operator operator = node.getOperator();
 		if (operator != null)
 		{
-			System.err.print(" ");
-			System.err.print(operator);
+			line.append(' ');
+			line.append(operator);
 		}
 
 		if (node.getText() != null)
 		{
-			System.err.print(" ");
-			System.err.print(node.getText());
+			line.append(' ');
+			line.append(node.getText());
 		}
-		System.err.println();
+		LOGGER.fine(line.toString());
 		node.childrenAccept(this, data + " ");
 		return null;
 	}

--- a/code/src/java/pcgen/cdom/base/CDOMObject.java
+++ b/code/src/java/pcgen/cdom/base/CDOMObject.java
@@ -31,6 +31,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -828,43 +829,43 @@ public abstract class CDOMObject extends ConcretePrereqObject
 		{
 			return false;
 		}
-		if (integerChar == null ? cdo.integerChar != null : !integerChar.equals(cdo.integerChar))
+		if (!Objects.equals(integerChar, cdo.integerChar))
 		{
 			// System.err.println("CDOM Inequality Integer");
 			// System.err.println(integerChar + " " + cdo.integerChar);
 			return false;
 		}
-		if (stringChar == null ? cdo.stringChar != null : !stringChar.equals(cdo.stringChar))
+		if (!Objects.equals(stringChar, cdo.stringChar))
 		{
 			// System.err.println("CDOM Inequality String");
 			// System.err.println(stringChar + " " + cdo.stringChar);
 			return false;
 		}
-		if (formulaChar == null ? cdo.formulaChar != null : !formulaChar.equals(cdo.formulaChar))
+		if (!Objects.equals(formulaChar, cdo.formulaChar))
 		{
 			// System.err.println("CDOM Inequality Formula");
 			// System.err.println(formulaChar + " " + cdo.formulaChar);
 			return false;
 		}
-		if (variableChar == null ? cdo.variableChar != null : !variableChar.equals(cdo.variableChar))
+		if (!Objects.equals(variableChar, cdo.variableChar))
 		{
 			// System.err.println("CDOM Inequality Variable");
 			// System.err.println(variableChar + " " + cdo.variableChar);
 			return false;
 		}
-		if (objectChar == null ? cdo.objectChar != null : !objectChar.equals(cdo.objectChar))
+		if (!Objects.equals(objectChar, cdo.objectChar))
 		{
 			// System.err.println("CDOM Inequality Object");
 			// System.err.println(objectChar + " " + cdo.objectChar);
 			return false;
 		}
-		if (factChar == null ? cdo.factChar != null : !factChar.equals(cdo.factChar))
+		if (!Objects.equals(factChar, cdo.factChar))
 		{
 			// System.err.println("CDOM Inequality Object");
 			// System.err.println(objectChar + " " + cdo.objectChar);
 			return false;
 		}
-		if (listChar == null ? cdo.listChar != null : !listChar.equals(cdo.listChar))
+		if (!Objects.equals(listChar, cdo.listChar))
 		{
 			//			 System.err.println("CDOM Inequality List");
 			//			 System.err.println(listChar + " " + cdo.listChar);
@@ -872,11 +873,11 @@ public abstract class CDOMObject extends ConcretePrereqObject
 			//			 + cdo.listChar.getKeySet());
 			return false;
 		}
-		if (mapChar == null ? cdo.mapChar != null : !mapChar.equals(cdo.mapChar))
+		if (!Objects.equals(mapChar, cdo.mapChar))
 		{
 			return false;
 		}
-		return cdomListMods == null ? cdo.cdomListMods == null : cdomListMods.equals(cdo.cdomListMods);
+		return Objects.equals(cdomListMods, cdo.cdomListMods);
 	}
 
 	public final <T extends CDOMObject> void putToList(CDOMReference<? extends CDOMList<?>> listRef,

--- a/code/src/java/pcgen/cdom/content/ContentDefinition.java
+++ b/code/src/java/pcgen/cdom/content/ContentDefinition.java
@@ -24,6 +24,7 @@ import pcgen.cdom.base.CDOMObject;
 import pcgen.cdom.base.Loadable;
 import pcgen.cdom.enumeration.DataSetID;
 import pcgen.rules.context.LoadContext;
+import pcgen.util.Logging;
 import pcgen.util.enumeration.View;
 import pcgen.util.enumeration.Visibility;
 
@@ -98,7 +99,7 @@ public abstract class ContentDefinition<T extends CDOMObject, F> extends UserCon
 	{
 		if (name==null)
 		{
-			System.out.println("display name should not be null!");
+			Logging.errorPrint("display name should not be null!");
 			return;
 		}
 		displayName = name;

--- a/code/src/java/pcgen/cdom/content/DatasetVariable.java
+++ b/code/src/java/pcgen/cdom/content/DatasetVariable.java
@@ -22,6 +22,7 @@ import java.util.regex.Pattern;
 
 import pcgen.base.util.FormatManager;
 import pcgen.cdom.formula.scope.PCGenScope;
+import pcgen.util.Logging;
 
 /**
  * A DatasetVariable is a variable within the new formula system, as defined by
@@ -61,7 +62,7 @@ public class DatasetVariable extends UserContent
 	{
 		if (scope==null)
 		{
-			System.out.println("Scope should not be null!");
+			Logging.errorPrint("Scope should not be null!");
 			return;
 		}
 		this.scope = scope;
@@ -113,7 +114,7 @@ public class DatasetVariable extends UserContent
 	{
 		if (format==null)
 		{
-			System.out.println("format should not be null!");
+			Logging.errorPrint("format should not be null!");
 			return;
 		}
 		this.format = format;

--- a/code/src/java/pcgen/cdom/content/UserContent.java
+++ b/code/src/java/pcgen/cdom/content/UserContent.java
@@ -21,6 +21,7 @@ import java.net.URI;
 import java.util.Objects;
 
 import pcgen.cdom.base.Loadable;
+import pcgen.util.Logging;
 
 /**
  * A UserContent manages common functions for user defined content within PCGen.
@@ -49,7 +50,7 @@ public abstract class UserContent implements Loadable
 	{
 		if (name==null)
 		{
-			System.out.println("Name cannot be null!");
+			Logging.errorPrint("Name cannot be null!");
 			return;
 		}
 		this.name = name;

--- a/code/src/java/pcgen/core/PlayerCharacter.java
+++ b/code/src/java/pcgen/core/PlayerCharacter.java
@@ -5256,7 +5256,7 @@ public class PlayerCharacter implements Cloneable, VariableContainer
 				Integer hp = getHP(frompcl);
 				if (hp == null)
 				{
-					System.err.println("Did not find HP for " + fromClass + ' ' + (i + 1) + ' ' + frompcl);
+					Logging.errorPrint("Did not find HP for " + fromClass + ' ' + (i + 1) + ' ' + frompcl);
 				}
 				hpArray[i] = hp;
 			}

--- a/code/src/java/pcgen/core/utils/MessageType.java
+++ b/code/src/java/pcgen/core/utils/MessageType.java
@@ -20,24 +20,24 @@ package pcgen.core.utils;
 /**
  * Types of messages
  */
-public final class MessageType
+public enum MessageType
 {
 
-	/** Singleton instance of Information message */
-	public static final MessageType INFORMATION = new MessageType("Information"); //$NON-NLS-1$
+	/** Information message */
+	INFORMATION("Information"),
 
-	/** Singleton instance of Warning message */
-	public static final MessageType WARNING = new MessageType("Warning"); //$NON-NLS-1$
+	/** Warning message */
+	WARNING("Warning"),
 
-	/** Singleton instance of Error message */
-	public static final MessageType ERROR = new MessageType("Error"); //$NON-NLS-1$
+	/** Error message */
+	ERROR("Error"),
 
-	/** Singleton instance of Question message */
-	public static final MessageType QUESTION = new MessageType("Question"); //$NON-NLS-1$
+	/** Question message */
+	QUESTION("Question");
 
 	private final String name;
 
-	private MessageType(final String name)
+	MessageType(final String name)
 	{
 		this.name = name;
 	}
@@ -46,19 +46,6 @@ public final class MessageType
 	public String toString()
 	{
 		return name;
-	}
-
-	// Prevent subclasses from overriding Object.equals
-	@Override
-	public boolean equals(final Object that)
-	{
-		return super.equals(that);
-	}
-
-	@Override
-	public int hashCode()
-	{
-		return super.hashCode();
 	}
 
 }

--- a/code/src/java/pcgen/core/utils/ShowMessageDelegate.java
+++ b/code/src/java/pcgen/core/utils/ShowMessageDelegate.java
@@ -54,15 +54,12 @@ public final class ShowMessageDelegate extends Observable
 
 	private static Level toLoggingLevel(final MessageType messageType)
 	{
-		if (messageType == MessageType.ERROR)
-		{
-			return Logging.ERROR;
-		}
-		if (messageType == MessageType.WARNING)
-		{
-			return Logging.WARNING;
-		}
-		return Logging.INFO;
+		return switch (messageType)
+				{
+					case ERROR -> Logging.ERROR;
+					case WARNING -> Logging.WARNING;
+					case INFORMATION, QUESTION -> Logging.INFO;
+				};
 	}
 
 	/**

--- a/code/src/java/pcgen/core/utils/ShowMessageDelegate.java
+++ b/code/src/java/pcgen/core/utils/ShowMessageDelegate.java
@@ -18,6 +18,9 @@
 package pcgen.core.utils;
 
 import java.util.Observable;
+import java.util.logging.Level;
+
+import pcgen.util.Logging;
 
 /**
  * This is a facade for gui objects in the core code.
@@ -42,8 +45,24 @@ public final class ShowMessageDelegate extends Observable
 		if (INSTANCE.countObservers() == 0 && messageWrapper.getMessage() != null
 			&& !messageWrapper.getMessage().toString().isEmpty())
 		{
-			System.out.println(messageWrapper.getTitle() + ": " + messageWrapper.getMessage());
+			// No GUI is attached (headless/batch): log the message at the level
+			// matching its type so it still reaches the user and the log file.
+			Logging.log(toLoggingLevel(messageWrapper.getMessageType()),
+					messageWrapper.getTitle() + ": " + messageWrapper.getMessage());
 		}
+	}
+
+	private static Level toLoggingLevel(final MessageType messageType)
+	{
+		if (messageType == MessageType.ERROR)
+		{
+			return Logging.ERROR;
+		}
+		if (messageType == MessageType.WARNING)
+		{
+			return Logging.WARNING;
+		}
+		return Logging.INFO;
 	}
 
 	/**

--- a/code/src/java/pcgen/gui2/converter/ObjectInjector.java
+++ b/code/src/java/pcgen/gui2/converter/ObjectInjector.java
@@ -89,7 +89,7 @@ public class ObjectInjector
         File outFile = new File(getNewOutputName(uri).getParentFile(), fileName);
         if (outFile.exists())
         {
-            System.err.println("Won't overwrite: " + outFile);
+            Logging.log(Logging.WARNING, "Won't overwrite: " + outFile);
         }
         return outFile;
     }

--- a/code/src/java/pcgen/gui2/converter/panel/RunConvertPanel.java
+++ b/code/src/java/pcgen/gui2/converter/panel/RunConvertPanel.java
@@ -312,11 +312,11 @@ public class RunConvertPanel extends ConvertSubPanel implements Observer, Conver
 		{
 			final Throwable e = (Exception) arg;
 			SwingUtilities.invokeLater(() -> addMessage(e.getMessage()));
-			System.out.println("Persistence Observer: ERROR: " + e.getMessage());
+			Logging.errorPrint("Persistence Observer: ERROR: " + e.getMessage(), e);
 		}
 		else
 		{
-			System.out.println("Persistence Observer: UNKNOWN: " + arg);
+			Logging.errorPrint("Persistence Observer: UNKNOWN: " + arg);
 		}
 	}
 

--- a/code/src/java/pcgen/gui2/solverview/SolverViewFrame.java
+++ b/code/src/java/pcgen/gui2/solverview/SolverViewFrame.java
@@ -55,6 +55,7 @@ import pcgen.gui2.tools.Utility;
 import pcgen.rules.context.LoadContext;
 import pcgen.system.CharacterManager;
 import pcgen.system.LanguageBundle;
+import pcgen.util.Logging;
 
 public final class SolverViewFrame extends JFrame
 {
@@ -134,7 +135,7 @@ public final class SolverViewFrame extends JFrame
 		else
 		{
 			//TODO Update a status bar
-			System.err.println(selectedScope.getName() + " does not have a variable: " + varNameText);
+			Logging.errorPrint(selectedScope.getName() + " does not have a variable: " + varNameText);
 		}
 	}
 

--- a/code/src/java/pcgen/gui2/tabs/CharacterSheetInfoTab.java
+++ b/code/src/java/pcgen/gui2/tabs/CharacterSheetInfoTab.java
@@ -197,7 +197,7 @@ public class CharacterSheetInfoTab extends FlippingSplitPane implements Characte
 			GuiAssertions.assertIsNotJavaFXThread();
 			if (character==null)
 			{
-			    System.out.println("Not expecting a null character in CharacterSheetInfoTab BoxHandler");
+			    Logging.errorPrint("Not expecting a null character in CharacterSheetInfoTab BoxHandler");
             }
 			this.character = character;
 			// This is the model for ComboBox

--- a/code/src/java/pcgen/gui2/util/table/IntegerEditor.java
+++ b/code/src/java/pcgen/gui2/util/table/IntegerEditor.java
@@ -48,6 +48,8 @@ import javax.swing.SwingUtilities;
 import javax.swing.text.DefaultFormatterFactory;
 import javax.swing.text.NumberFormatter;
 
+import pcgen.util.Logging;
+
 /**
  * Implements a cell editor that uses a formatted text field
  * to edit Integer values.
@@ -144,7 +146,7 @@ public class IntegerEditor extends DefaultCellEditor
 			}
 			catch (ParseException exc)
 			{
-				System.err.println("getCellEditorValue: can't parse o: " + o);
+				Logging.errorPrint("getCellEditorValue: can't parse o: " + o);
 				return null;
 			}
 		}

--- a/code/src/java/pcgen/gui3/dialog/DebugDialogController.java
+++ b/code/src/java/pcgen/gui3/dialog/DebugDialogController.java
@@ -101,14 +101,18 @@ public class DebugDialogController
 			usage = MEMORY_BEAN.getNonHeapMemoryUsage();
 		}
 		final NumberFormat format = new DecimalFormat("###,###,###");
+		// getMax() is -1 when the pool has no defined maximum (common for
+		// non-heap); guard it so Max and % Used don't render as 0 / a huge
+		// negative number.
+		final long max = usage.getMax();
 		return switch (columnIndex)
 				{
 					case 0 -> (rowIndex == 0) ? "Heap" : "Non-Heap";
 					case 1 -> format.format(usage.getInit() / MEGABYTE);
 					case 2 -> format.format(usage.getUsed() / MEGABYTE);
 					case 3 -> format.format(usage.getCommitted() / MEGABYTE);
-					case 4 -> format.format(usage.getMax() / MEGABYTE);
-					case 5 -> String.valueOf(100 * (usage.getUsed() / usage.getMax()));
+					case 4 -> (max < 0) ? "n/a" : format.format(max / MEGABYTE);
+					case 5 -> (max <= 0) ? "n/a" : Math.round(100.0 * usage.getUsed() / max) + "%";
 					default -> throw new IllegalStateException("Unexpected column index: " + columnIndex);
 				};
 	}

--- a/code/src/java/pcgen/gui3/dialog/DebugDialogController.java
+++ b/code/src/java/pcgen/gui3/dialog/DebugDialogController.java
@@ -50,6 +50,16 @@ public class DebugDialogController
 {
 
 	private static final MemoryMXBean MEMORY_BEAN = ManagementFactory.getMemoryMXBean();
+
+	/** Data rows shown: heap and non-heap. */
+	private static final int MEMORY_ROWS = 2;
+
+	/** Fixed row height; keeps the table height deterministic for the maxHeight cap. */
+	private static final double ROW_HEIGHT = 24.0;
+
+	/** Allowance for the table's top/bottom borders on top of header + rows. */
+	private static final double HEADER_BORDER_PAD = 4.0;
+
 	@FXML
 	private TableView<Map<String, String>> memoryTable;
 
@@ -63,6 +73,14 @@ public class DebugDialogController
 	void initialize()
 	{
 		memoryTable.setItems(memoryTableData);
+		// Cap the table to its data rows plus the header (one row tall) so it
+		// doesn't pad with empty rows. maxHeight is derived from the row height
+		// rather than a fixed pixel total, so it adapts if the cell size changes.
+		memoryTable.setFixedCellSize(ROW_HEIGHT);
+		// Header + data rows + a small allowance for the table's borders, so the
+		// content fits exactly without a scrollbar or trailing empty rows.
+		memoryTable.maxHeightProperty()
+				.bind(memoryTable.fixedCellSizeProperty().multiply(MEMORY_ROWS + 1).add(HEADER_BORDER_PAD));
 		setMemoryTableData();
 		logText.setText(LoggingRecorder.getLogs());
 		Logging.registerHandler(new LogHandler());
@@ -72,7 +90,7 @@ public class DebugDialogController
 	{
 		// posible optimization: get the rows rather than clear and re-add
 		memoryTableData.clear();
-		for (int row = 0; row < 2; ++row)
+		for (int row = 0; row < MEMORY_ROWS; ++row)
 		{
 			Map<String, String> dataRow = new HashMap<>();
 			for (int column = 0; column < memoryTable.getColumns().size(); column++)
@@ -89,17 +107,24 @@ public class DebugDialogController
 
 	private static String getMemoryTableValue(int rowIndex, int columnIndex)
 	{
-		final long MEGABYTE = 1024 * 1024;
+		MemoryUsage usage = (rowIndex == 0) ? MEMORY_BEAN.getHeapMemoryUsage() : MEMORY_BEAN.getNonHeapMemoryUsage();
+		String label = (rowIndex == 0) ? "Heap" : "Non-Heap";
+		return formatMemoryCell(columnIndex, label, usage);
+	}
 
-		MemoryUsage usage;
-		if (rowIndex == 0)
-		{
-			usage = MEMORY_BEAN.getHeapMemoryUsage();
-		}
-		else
-		{
-			usage = MEMORY_BEAN.getNonHeapMemoryUsage();
-		}
+	/**
+	 * Formats one memory-table cell. Package-private and free of any live
+	 * {@link MemoryMXBean} access so the number handling can be unit-tested by
+	 * passing synthetic {@link MemoryUsage} values.
+	 *
+	 * @param columnIndex the column (0 label, 1 init, 2 used, 3 committed, 4 max, 5 % used)
+	 * @param label       the row label to render for column 0
+	 * @param usage       the memory usage for the row
+	 * @return the rendered cell text
+	 */
+	static String formatMemoryCell(int columnIndex, String label, MemoryUsage usage)
+	{
+		final long MEGABYTE = 1024 * 1024;
 		final NumberFormat format = new DecimalFormat("###,###,###");
 		// getMax() is -1 when the pool has no defined maximum (common for
 		// non-heap); guard it so Max and % Used don't render as 0 / a huge
@@ -107,7 +132,7 @@ public class DebugDialogController
 		final long max = usage.getMax();
 		return switch (columnIndex)
 				{
-					case 0 -> (rowIndex == 0) ? "Heap" : "Non-Heap";
+					case 0 -> label;
 					case 1 -> format.format(usage.getInit() / MEGABYTE);
 					case 2 -> format.format(usage.getUsed() / MEGABYTE);
 					case 3 -> format.format(usage.getCommitted() / MEGABYTE);
@@ -164,8 +189,11 @@ public class DebugDialogController
 	private void runGC(final ActionEvent actionEvent)
 	{
 		MEMORY_BEAN.gc();
-		Logging.log(Logging.INFO, MessageFormat.format("Memory used after manual GC, Heap: {0}, Non heap: {1}",
-				MEMORY_BEAN.getHeapMemoryUsage().getUsed(), MEMORY_BEAN.getNonHeapMemoryUsage().getUsed()));
+		setMemoryTableData();
+		final long megabyte = 1024 * 1024;
+		Logging.log(Logging.INFO, MessageFormat.format("Memory used after manual GC, Heap: {0} MB, Non heap: {1} MB",
+				MEMORY_BEAN.getHeapMemoryUsage().getUsed() / megabyte,
+				MEMORY_BEAN.getNonHeapMemoryUsage().getUsed() / megabyte));
 	}
 	void shutdown()
 	{

--- a/code/src/java/pcgen/util/Logging.java
+++ b/code/src/java/pcgen/util/Logging.java
@@ -77,6 +77,12 @@ public final class Logging
 	private static Logger pcgenLogger = Logger.getLogger("pcgen");
 	private static Logger pluginLogger = Logger.getLogger("plugin");
 
+	/** Walks the stack lazily to name loggers after the calling class. */
+	private static final StackWalker WALKER = StackWalker.getInstance();
+
+	/** This facade's own class name, skipped when inferring the caller. */
+	private static final String CLASS_NAME = Logging.class.getName();
+
 	/** System property java.util.logging consults for its configuration file. */
 	private static final String CONFIG_FILE_PROPERTY = "java.util.logging.config.file";
 
@@ -544,35 +550,17 @@ public final class Logging
 	 *
 	 * @return An instance of Logger that deals with the specified name.
 	 */
-	private static java.util.logging.Logger getLogger()
+	private static Logger getLogger()
 	{
-		StackTraceElement[] stack = new Throwable().getStackTrace();
-		StackTraceElement caller = null;
-
-		for (int i = 1; i < stack.length; i++) //1 to skip this method
-		{
-			if (!"pcgen.util.Logging".equals(stack[i].getClassName()))
-			{
-				caller = stack[i];
-				break;
-			}
-		}
-		// name The name of the logger
-		String name = (caller == null) ? "<null>" : caller.getClassName();
-
-		Logger l = null;
-		final int maxRetries = 15;
-		int retries = 0;
-		while (l == null && retries < maxRetries)
-		{
-			l = java.util.logging.Logger.getLogger(name);
-			retries++;
-		}
-		if (l == null)
-		{
-			System.err.println("Unable to get logger for " + name + " after " + retries + " atempts.");
-		}
-		return l;
+		// Walk lazily to the first frame outside this facade instead of
+		// materialising a whole stack trace on every log call.
+		String name = WALKER.walk(frames -> frames
+				.map(StackWalker.StackFrame::getClassName)
+				.filter(className -> !CLASS_NAME.equals(className))
+				.findFirst())
+				.orElse("<null>");
+		// Logger.getLogger never returns null; it creates the logger if absent.
+		return Logger.getLogger(name);
 	}
 
 	/**

--- a/code/src/java/pcgen/util/PjepPool.java
+++ b/code/src/java/pcgen/util/PjepPool.java
@@ -21,6 +21,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Stack;
 
+import pcgen.util.Logging;
+
 public final class PjepPool
 {
 	private Stack<PJEP> freeStack = new Stack<>();
@@ -77,7 +79,7 @@ public final class PjepPool
 		}
 		else
 		{
-			System.err.println("Tried to release a PJEP instance that we did not aquire...");
+			Logging.errorPrint("Tried to release a PJEP instance that we did not aquire...");
 		}
 		interp.setParent(null);
 		freeStack.push(interp);

--- a/code/src/java/pcgen/util/PjepPool.java
+++ b/code/src/java/pcgen/util/PjepPool.java
@@ -84,11 +84,4 @@ public final class PjepPool
 		interp.setParent(null);
 		freeStack.push(interp);
 	}
-
-	public synchronized void dumpStats()
-	{
-		System.out.println("PJEP Pool: ");
-		System.out.println("    Currently Unused: " + freeStack.size());
-		System.out.println("    Currently Used  : " + usedList.size());
-	}
 }

--- a/code/src/java/plugin/function/LookupFunction.java
+++ b/code/src/java/plugin/function/LookupFunction.java
@@ -43,6 +43,7 @@ import pcgen.cdom.format.table.TableFormatManager;
 import pcgen.cdom.formula.ManagerKey;
 import pcgen.rules.context.AbstractReferenceContext;
 import pcgen.rules.context.LoadContext;
+import pcgen.util.Logging;
 
 /**
  * This is a Lookup function for finding items in a DataTable.
@@ -161,7 +162,7 @@ public class LookupFunction implements FormulaFunction
 		if (!dataTable.isColumn(columnName))
 		{
 			FormatManager<?> fmt = column.getFormatManager();
-			System.out.println("Lookup called on invalid column: '" + columnName + "' is not present on table '"
+			Logging.log(Logging.WARNING, "Lookup called on invalid column: '" + columnName + "' is not present on table '"
 				+ dataTable.getName() + "' assuming default for " + fmt.getIdentifierType());
 			VariableLibrary varLib = manager.get(EvaluationManager.VARLIB);
 			return varLib.getDefault(fmt);
@@ -176,7 +177,7 @@ public class LookupFunction implements FormulaFunction
 		if (!dataTable.hasRow(lookupType, lookupValue))
 		{
 			FormatManager<?> fmt = column.getFormatManager();
-			System.out.println(
+			Logging.log(Logging.WARNING,
 				"Lookup called on invalid item: '" + lookupValue + "' is not present in the first row of table '"
 					+ dataTable.getName() + "' assuming default for " + fmt.getIdentifierType());
 			VariableLibrary varLib = manager.get(EvaluationManager.VARLIB);

--- a/code/src/java/translation/util/Tips.java
+++ b/code/src/java/translation/util/Tips.java
@@ -35,6 +35,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import pcgen.util.Logging;
+
 /**
  * This class allows the generation of a PO Template file from the tips.txt files,
  * and also generate translated tips ({@code tips_XX.txt}) from a PO file
@@ -420,30 +422,33 @@ public final class Tips
 	/* Logging methods. */
 
 	/**
-	 * Log a message to the standard output
+	 * Log an informational message.
 	 * @param string message pattern
 	 * @param o arguments
 	 * @see MessageFormat#format(String, Object...)
 	 */
-	@SuppressWarnings("UseOfSystemOutOrSystemErr")
 	private static void log(String string, Object... o)
 	{
-		System.out.println(MessageFormat.format(string, o));
+		Logging.log(Logging.INFO, MessageFormat.format(string, o));
 	}
 
 	/**
-	 * Log a message to the error output
+	 * Log an error message, including the stack trace when a cause is supplied.
 	 * @param string message pattern
+	 * @param e the cause, may be {@code null}
 	 * @param o arguments
 	 * @see MessageFormat#format(String, Object...)
 	 */
-	@SuppressWarnings({"PMD.AvoidPrintStackTrace", "UseOfSystemOutOrSystemErr"})
 	private static void logError(String string, Throwable e, Object... o)
 	{
-		System.err.println(MessageFormat.format(string, o));
-		if (e != null)
+		String message = MessageFormat.format(string, o);
+		if (e == null)
 		{
-			e.printStackTrace();
+			Logging.errorPrint(message);
+		}
+		else
+		{
+			Logging.errorPrint(message, e);
 		}
 	}
 }

--- a/code/src/resources/pcgen/gui3/dialog/DebugDialog.css
+++ b/code/src/resources/pcgen/gui3/dialog/DebugDialog.css
@@ -18,6 +18,6 @@
 
 #memoryTable {
     -fx-fixed-cell-size: 24px;
-    /* two rows + a header */
-    -fx-max-height: 72;
+    /* header + two 24px data rows; header needs ~28px or its text clips */
+    -fx-max-height: 80;
 }

--- a/code/src/resources/pcgen/gui3/dialog/DebugDialog.css
+++ b/code/src/resources/pcgen/gui3/dialog/DebugDialog.css
@@ -15,9 +15,3 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
-
-#memoryTable {
-    -fx-fixed-cell-size: 24px;
-    /* header + two 24px data rows; header needs ~28px or its text clips */
-    -fx-max-height: 80;
-}

--- a/code/src/resources/pcgen/gui3/dialog/DebugDialog.fxml
+++ b/code/src/resources/pcgen/gui3/dialog/DebugDialog.fxml
@@ -24,8 +24,8 @@
 <Scene xmlns="http://javafx.com/javafx/25.0.1"
        xmlns:fx="http://javafx.com/fxml"
        fx:controller="pcgen.gui3.dialog.DebugDialogController">
-    <VBox>
-        <BorderPane>
+    <VBox fillWidth="true">
+        <BorderPane VBox.vgrow="ALWAYS">
             <center>
                 <TextArea BorderPane.alignment="CENTER" fx:id="logText" editable="false"/>
             </center>
@@ -36,7 +36,7 @@
                         onAction="#clearLogs"/>
             </bottom>
         </BorderPane>
-        <BorderPane>
+        <BorderPane VBox.vgrow="NEVER">
             <center>
                 <TableView fx:id="memoryTable" BorderPane.alignment="CENTER" id="memoryTable">
                     <columns>

--- a/code/src/resources/pcgen/gui3/dialog/DebugDialog.fxml
+++ b/code/src/resources/pcgen/gui3/dialog/DebugDialog.fxml
@@ -39,6 +39,9 @@
         <BorderPane VBox.vgrow="NEVER">
             <center>
                 <TableView fx:id="memoryTable" BorderPane.alignment="CENTER" id="memoryTable">
+                    <columnResizePolicy>
+                        <TableView fx:constant="CONSTRAINED_RESIZE_POLICY"/>
+                    </columnResizePolicy>
                     <columns>
                         <TableColumn id="memoryType" text="">
                             <cellValueFactory>

--- a/code/src/test/pcgen/gui3/dialog/DebugDialogControllerTest.java
+++ b/code/src/test/pcgen/gui3/dialog/DebugDialogControllerTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026 (C) Vest <Vest@users.noreply.github.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+package pcgen.gui3.dialog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.lang.management.MemoryUsage;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link DebugDialogController#formatMemoryCell}. These exercise
+ * the memory-table number handling with synthetic {@link MemoryUsage} values,
+ * so no JavaFX toolkit or running application is needed.
+ */
+class DebugDialogControllerTest
+{
+	private static final long MB = 1024 * 1024;
+
+	@Test
+	@DisplayName("column 0 renders the row label verbatim")
+	void formatMemoryCell_should_returnLabel_when_column0()
+	{
+		MemoryUsage usage = new MemoryUsage(0, 0, 0, 0);
+		assertEquals("Heap", DebugDialogController.formatMemoryCell(0, "Heap", usage));
+		assertEquals("Non-Heap", DebugDialogController.formatMemoryCell(0, "Non-Heap", usage));
+	}
+
+	@Test
+	@DisplayName("columns 1-3 render init/used/committed in megabytes")
+	void formatMemoryCell_should_renderMegabytes_when_sizeColumns()
+	{
+		MemoryUsage usage = new MemoryUsage(768 * MB, 189 * MB, 240 * MB, 2048 * MB);
+		assertEquals("768", DebugDialogController.formatMemoryCell(1, "Heap", usage));
+		assertEquals("189", DebugDialogController.formatMemoryCell(2, "Heap", usage));
+		assertEquals("240", DebugDialogController.formatMemoryCell(3, "Heap", usage));
+	}
+
+	@Test
+	@DisplayName("column 4 renders max in megabytes when a maximum is defined")
+	void formatMemoryCell_should_renderMaxMegabytes_when_maxDefined()
+	{
+		MemoryUsage usage = new MemoryUsage(768 * MB, 189 * MB, 240 * MB, 2048 * MB);
+		assertEquals("2,048", DebugDialogController.formatMemoryCell(4, "Heap", usage));
+	}
+
+	@Test
+	@DisplayName("% used is rounded correctly (guards against the old integer-division-to-zero bug)")
+	void formatMemoryCell_should_roundPercent_when_maxDefined()
+	{
+		// 189 / 2048 = 9.2% -> 9%. The old "100 * (used / max)" integer math gave 0.
+		MemoryUsage usage = new MemoryUsage(768 * MB, 189 * MB, 240 * MB, 2048 * MB);
+		assertEquals("9%", DebugDialogController.formatMemoryCell(5, "Heap", usage));
+	}
+
+	@Test
+	@DisplayName("% used renders 0% and 100% at the edges")
+	void formatMemoryCell_should_handleEdges_when_percent()
+	{
+		assertEquals("0%",
+				DebugDialogController.formatMemoryCell(5, "Heap", new MemoryUsage(0, 0, 0, 1000)));
+		assertEquals("100%",
+				DebugDialogController.formatMemoryCell(5, "Heap", new MemoryUsage(0, 1000, 1000, 1000)));
+	}
+
+	@Test
+	@DisplayName("max of -1 (no defined maximum) renders 'n/a' for both Max and % Used")
+	void formatMemoryCell_should_returnNa_when_maxUndefined()
+	{
+		// Non-heap pools report getMax() == -1; the old code showed 0 for Max and
+		// a large negative number for % Used.
+		MemoryUsage usage = new MemoryUsage(7 * MB, 91 * MB, 97 * MB, -1);
+		assertEquals("n/a", DebugDialogController.formatMemoryCell(4, "Non-Heap", usage));
+		assertEquals("n/a", DebugDialogController.formatMemoryCell(5, "Non-Heap", usage));
+	}
+
+	@Test
+	@DisplayName("an unknown column index throws")
+	void formatMemoryCell_should_throw_when_unknownColumn()
+	{
+		MemoryUsage usage = new MemoryUsage(0, 0, 0, 0);
+		assertThrows(IllegalStateException.class,
+				() -> DebugDialogController.formatMemoryCell(6, "Heap", usage));
+	}
+}


### PR DESCRIPTION
## What

Started as a `Logging.getLogger()` performance fix and a `System.out`/`System.err`
misuse sweep, and grew a few adjacent cleanups found while verifying the changes in
the running app. Grouped by theme below; each bullet is its own commit.

### Logging core

- **Stop allocating a full stack trace on every log call.** `Logging.getLogger()`
  named each logger after the calling class by allocating a `Throwable` and
  materialising its **entire** stack trace on **every** log call (~443 sites), then
  walking to the first non-`Logging` frame. Replaced with `StackWalker.walk` (lazy,
  stops at the first interesting frame) — matching the idiom already used by
  `SourceLogFormatter` in the same package. Also dropped the 15× `Logger.getLogger`
  retry loop added in 2012 (CODE-1148): `Logger.getLogger(String)` never returns
  null, so the loop and its `System.err` fallback were dead code.

### System.out / System.err → logging

- **Route genuine diagnostics through `Logging`.** 13 call sites printed real
  error/warning diagnostics straight to `System.out`/`System.err`, bypassing level
  filtering, source/thread attribution and the log file (and tripping SonarLint's
  `UseOfSystemOutOrSystemErr`). Routed through `Logging.*` at the level matching the
  message's meaning (`errorPrint` for faults; `WARNING` for skip/assume-default).
- **Drop unused `PjepPool.dumpStats()`.** Printed pool sizes to `System.out` but had
  no caller since it was first added (verified via `git log -S`) — dead debug
  scaffolding, removed rather than converted.
- **Log headless `ShowMessageDelegate` messages by type.** Its no-GUI fallback
  printed every message to `System.out` regardless of severity; now routes through
  `Logging` at the level matching the `MessageType` (ERROR→SEVERE, WARNING→WARNING,
  else INFO).
- **Route `Tips`' custom logging through `Logging`.** The translator CLI tool had its
  own `log()`/`logError()` helpers reimplementing logging with `System.out`/`err` +
  a raw `printStackTrace()`. Routed through `Logging`; verified end-to-end (POT
  generation + error path) that messages log with correct level/thread/caller.
- **Log the Formula AST dump visitors via `java.util.logging`.** `FullDumpVisitor`
  and `SimpleDumpVisitor` dumped the parsed formula tree to `System.err` piecewise.
  They're useful parser-debugging tools, so keep them but route through JUL at `FINE`
  (one record per node). Uses `java.util.logging` directly rather than
  `pcgen.util.Logging`, because `PCGen-Formula` is a standalone module that must not
  depend on the main project (that would invert the module dependency); JUL is in the
  JDK and PCGen's `Logging` is a thin facade over it. Adds `requires java.logging` to
  the module descriptor.

Intentional stdout that remains: the memory/thread dumps in `Logging` and the
pre-logging bootstrap error in `Logging`'s static initialiser. Commented-out
`System.out`/`System.err` lines are left untouched.

### Supporting refactors

- **Convert `MessageType` to an enum.** It was the type-safe-enum pattern (final class
  + static singletons + hand-rolled `equals`/`hashCode`). Making it a real enum removes
  the boilerplate and lets `ShowMessageDelegate.toLoggingLevel` be a compiler-checked
  exhaustive `switch`. No caller changes.
- **Use `Objects.equals` in `CDOMObject.isCDOMEqual`.** Replace nine hand-rolled
  null-safe equality ternaries with `java.util.Objects.equals`. Behaviour-preserving;
  exercised broadly by the lst-token suites via `AbstractCDOMTokenTestCase`. The
  commented-out debug lines inside the guards are left as-is.

### Debug dialog (found while eyeballing the new log output in-app)

- **Make the dialog resizable.** Its `VBox` gave neither pane a grow constraint, so
  enlarging the window left a dead zone below the buttons. The log pane now takes the
  extra height (`VBox.vgrow=ALWAYS`).
- **Correct the memory table.** `% Used` was computed with integer division (always 0
  for the Heap row) and produced a large negative number for Non-Heap (whose
  `getMax()` is -1). Now computed in floating point; `-1` renders as `n/a` for both
  Max and % Used.
- **Refresh on GC + adaptive sizing.** The GC button ran `gc()` and logged but never
  refreshed the table. It refreshes now, and the table height is derived from the row
  height (no magic-pixel CSS) so it shows exactly its rows without empty padding or a
  scrollbar; columns use `CONSTRAINED_RESIZE_POLICY`.
- **Testability.** Extracted the memory-cell formatting into a pure, package-private
  method with no live `MemoryMXBean` access, covered by a new plain-JUnit
  `DebugDialogControllerTest` (no JavaFX / no app boot) that pins the `% Used` math and
  the `n/a` handling.

## Testing

- `compileJava` + `compileTestJava` clean (main + `PCGen-Formula`).
- Affected unit tests pass: `LoggingConfigTest` (6), `SourceLogFormatterTest` (5),
  `DebugDialogControllerTest` (7), `LookupFunctionTest` (16), `TipsTest` (4), plus
  `isCDOMEqual`-exercising token suites (59) — 0 failures.
- Ran PCGen with debug logging to confirm `getLogger` attribution (caller + thread) is
  correct under load (~322k FINER records), and ran the `Tips` POT tool end-to-end to
  confirm its converted logging works.
