### PR TITLE
Build(deps): bump JavaFX 25.0.3 -> 25.0.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,4 +12,4 @@ javaVersion=25
 
 # Full JavaFX patch version (e.g. 25.0.3). Major MUST match javaVersion above.
 # Latest release: https://gluonhq.com/products/javafx/ or https://github.com/openjdk/jfx/tags
-javafxVersion=25.0.3
+javafxVersion=25.0.4


### PR DESCRIPTION
Aligns JavaFX with the JDK, whose latest 25 GA patch (25.0.4) the Gradle toolchain already auto-resolves; the bundled runtime download also tracks latest GA. Per README's 'Patch bump' procedure this is JavaFX-only.

Verified: clean downloadJfxMods/extractJfxMods/downloadJavaFXLocal/ extractJavaFXLocal (Gluon 25.0.4 SDK + jmods resolve), then the full test suite passes, including the JavaFX/TestFX tests.