### PR TITLE
fix: restore JTreeTable expand/collapse broken by #7703

### DIFF
--- a/code/src/java/pcgen/gui2/util/JTreeTable.java
+++ b/code/src/java/pcgen/gui2/util/JTreeTable.java
@@ -786,7 +786,7 @@ public class JTreeTable extends JTableEx
 						int column = JTreeTable.this.columnAtPoint(me.getPoint());
 						Rectangle cell = JTreeTable.this.getCellRect(0, column, true);
 						MouseEvent newME = new MouseEvent(tree, me.getID(), me.getWhen(), me.getModifiersEx(), me.getX(),
-							me.getY(), me.getClickCount(), me.isPopupTrigger());
+							me.getY(), me.getClickCount(), me.isPopupTrigger(), me.getButton());
 						//we translate the event into the tree's coordinate system
 						newME.translatePoint(-cell.x, 0);
 						tree.dispatchEvent(newME);

--- a/code/src/test/pcgen/gui2/util/JTreeTableEditorEventForwardingTest.java
+++ b/code/src/test/pcgen/gui2/util/JTreeTableEditorEventForwardingTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2026 Vest <Vest@users.noreply.github.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.gui2.util;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.swing.JTree;
+import javax.swing.table.TableCellEditor;
+
+import pcgen.gui2.util.treeview.DataView;
+import pcgen.gui2.util.treeview.DataViewColumn;
+import pcgen.gui2.util.treeview.DefaultDataViewColumn;
+import pcgen.gui2.util.treeview.TreeView;
+import pcgen.gui2.util.treeview.TreeViewPath;
+import pcgen.gui2.util.treeview.TreeViewTableModel;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression test for #7703: the tree column editor re-dispatches mouse events
+ * to the embedded {@link JTree} so it can toggle expand/collapse handles. The
+ * synthetic event must preserve the source's extended modifiers and button, or
+ * BasicTreeUI stops recognising the click and the tree can no longer be expanded.
+ */
+class JTreeTableEditorEventForwardingTest
+{
+
+	@Test
+	void editorForwardsExtendedModifiersAndButtonUnchangedToTree()
+	{
+		TreeViewTableModel<String> model = new TreeViewTableModel<>(new SingleColumnDataView());
+		model.setSelectedTreeView(new FlatTreeView());
+
+		JTreeTable table = new JTreeTable(model);
+		// Give the table geometry so columnAtPoint()/getCellRect() resolve.
+		table.setSize(200, 100);
+
+		JTree tree = table.getTree();
+		AtomicReference<MouseEvent> forwarded = new AtomicReference<>();
+		tree.addMouseListener(new MouseAdapter()
+		{
+			@Override
+			public void mousePressed(MouseEvent e)
+			{
+				forwarded.set(e);
+			}
+		});
+
+		TableCellEditor editor = table.getCellEditor(0, 0);
+
+		// A plain left-button press: extended modifiers carry BUTTON1_DOWN_MASK,
+		// which is exactly the value the pre-fix code misrouted through the
+		// legacy `modifiers` constructor parameter.
+		MouseEvent press = new MouseEvent(table, MouseEvent.MOUSE_PRESSED, 0L,
+			MouseEvent.BUTTON1_DOWN_MASK, 10, 5, 1, false, MouseEvent.BUTTON1);
+
+		editor.isCellEditable(press);
+
+		MouseEvent seen = forwarded.get();
+		assertNotNull(seen, "editor should re-dispatch a mouse event to the tree");
+		assertAll(
+			() -> assertEquals(MouseEvent.BUTTON1_DOWN_MASK, seen.getModifiersEx(),
+				"extended modifiers must survive the round-trip"),
+			() -> assertEquals(MouseEvent.BUTTON1, seen.getButton(),
+				"button must survive the round-trip"),
+			() -> assertEquals(press.getID(), seen.getID(), "event id must be preserved"),
+			() -> assertEquals(press.getClickCount(), seen.getClickCount(), "click count must be preserved")
+		);
+	}
+
+	private static final class SingleColumnDataView implements DataView<String>
+	{
+		@Override
+		public Object getData(String element, int column)
+		{
+			return element;
+		}
+
+		@Override
+		public void setData(Object value, String element, int column)
+		{
+		}
+
+		@Override
+		public List<? extends DataViewColumn> getDataColumns()
+		{
+			return List.of(new DefaultDataViewColumn("Value", String.class));
+		}
+
+		@Override
+		public String getPrefsKey()
+		{
+			return "JTreeTableEditorEventForwardingTest";
+		}
+	}
+
+	private static final class FlatTreeView implements TreeView<String>
+	{
+		@Override
+		public String getViewName()
+		{
+			return "Flat";
+		}
+
+		@Override
+		public List<TreeViewPath<String>> getPaths(String pobj)
+		{
+			return List.of(new TreeViewPath<>(pobj));
+		}
+	}
+}

--- a/code/src/test/pcgen/gui2/util/JTreeTableEditorEventForwardingTest.java
+++ b/code/src/test/pcgen/gui2/util/JTreeTableEditorEventForwardingTest.java
@@ -35,19 +35,22 @@ import pcgen.gui2.util.treeview.TreeView;
 import pcgen.gui2.util.treeview.TreeViewPath;
 import pcgen.gui2.util.treeview.TreeViewTableModel;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
- * Regression test for #7703: the tree column editor re-dispatches mouse events
- * to the embedded {@link JTree} so it can toggle expand/collapse handles. The
- * synthetic event must preserve the source's extended modifiers and button, or
- * BasicTreeUI stops recognising the click and the tree can no longer be expanded.
+ * Verifies that clicking a {@link JTreeTable} row can expand or collapse it:
+ * the tree column editor must re-dispatch the mouse event to the embedded
+ * {@link JTree} with the button and extended modifiers intact, so BasicTreeUI
+ * recognises the click and toggles the node. Covers both a single click and a
+ * double click on the row.
  */
 class JTreeTableEditorEventForwardingTest
 {
 
-	@Test
-	void editorForwardsExtendedModifiersAndButtonUnchangedToTree()
+	@ParameterizedTest
+	@ValueSource(ints = {1, 2})
+	void editorForwardsClickToTreeIntact(int clickCount)
 	{
 		TreeViewTableModel<String> model = new TreeViewTableModel<>(new SingleColumnDataView());
 		model.setSelectedTreeView(new FlatTreeView());
@@ -70,10 +73,9 @@ class JTreeTableEditorEventForwardingTest
 		TableCellEditor editor = table.getCellEditor(0, 0);
 
 		// A plain left-button press: extended modifiers carry BUTTON1_DOWN_MASK,
-		// which is exactly the value the pre-fix code misrouted through the
-		// legacy `modifiers` constructor parameter.
+		// and the button is BUTTON1. Both must reach the tree for it to toggle.
 		MouseEvent press = new MouseEvent(table, MouseEvent.MOUSE_PRESSED, 0L,
-			MouseEvent.BUTTON1_DOWN_MASK, 10, 5, 1, false, MouseEvent.BUTTON1);
+			MouseEvent.BUTTON1_DOWN_MASK, 10, 5, clickCount, false, MouseEvent.BUTTON1);
 
 		editor.isCellEditable(press);
 
@@ -81,11 +83,11 @@ class JTreeTableEditorEventForwardingTest
 		assertNotNull(seen, "editor should re-dispatch a mouse event to the tree");
 		assertAll(
 			() -> assertEquals(MouseEvent.BUTTON1_DOWN_MASK, seen.getModifiersEx(),
-				"extended modifiers must survive the round-trip"),
+				"extended modifiers must reach the tree"),
 			() -> assertEquals(MouseEvent.BUTTON1, seen.getButton(),
-				"button must survive the round-trip"),
+				"button must reach the tree"),
 			() -> assertEquals(press.getID(), seen.getID(), "event id must be preserved"),
-			() -> assertEquals(press.getClickCount(), seen.getClickCount(), "click count must be preserved")
+			() -> assertEquals(clickCount, seen.getClickCount(), "click count must be preserved")
 		);
 	}
 


### PR DESCRIPTION
## Problem

After #7703, tree nodes in the **Select Sources** dialog (and every other `JTreeTable`) can no longer be expanded or collapsed with the mouse or keyboard.

## Root cause

The tree-column editor forwards a synthetic `MouseEvent` to the embedded `JTree` so it can toggle the expand/collapse handle. #7703 replaced the deprecated `getModifiers()` with `getModifiersEx()` to clear a deprecation warning, but kept the **8-arg** `MouseEvent` constructor — whose `modifiers` parameter takes *legacy* `InputEvent` bits, not extended ones.

Feeding extended bits (e.g. `BUTTON1_DOWN_MASK = 0x400`) into that legacy slot yields an event `BasicTreeUI` no longer recognises as a plain button-1 click, so the disclosure triangles stop responding.

## Fix

Switch to the **9-arg** `MouseEvent` constructor, whose `modifiers` parameter is documented to accept extended modifiers (paired with `getModifiersEx()`), and pass `me.getButton()` through. This preserves #7703's deprecation cleanup and forwards a faithful event.

```diff
-MouseEvent newME = new MouseEvent(tree, me.getID(), me.getWhen(), me.getModifiersEx(), me.getX(),
-    me.getY(), me.getClickCount(), me.isPopupTrigger());
+MouseEvent newME = new MouseEvent(tree, me.getID(), me.getWhen(), me.getModifiersEx(), me.getX(),
+    me.getY(), me.getClickCount(), me.isPopupTrigger(), me.getButton());
```

## Test

Adds `JTreeTableEditorEventForwardingTest`: it captures the event the editor re-dispatches to the tree and asserts the extended modifiers and button survive the round-trip.

- **Fails** on the old 8-arg form (`button ... expected: <1> but was: <0>` — the 8-arg constructor has no button parameter, so it collapses to `NOBUTTON`).
- **Passes** on the 9-arg form.

Runs headlessly, consistent with the project's test configuration.

## Verification

- Confirmed the regression live in the Select Sources dialog and confirmed the fix restores mouse + keyboard expansion.
- New test verified fail-on-bug / pass-on-fix; existing `JTreeTableEditingRowTest` still passes.