### PR TITLE
perf: improve performance of isType/Type.getConstant and Collator on campaign load

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -865,6 +865,7 @@ apply from: 'code/gradle/autobuild.gradle'    // depends on distribution.gradle
 apply from: 'code/gradle/reporting.gradle'
 apply from: 'code/gradle/release.gradle'
 apply from: 'code/gradle/plugins.gradle'
+apply from: 'code/gradle/benchmark.gradle'
 
 tasks.register("allTasks") {
     dependsOn build, slowtest, javadoc, allReports

--- a/code/gradle/benchmark.gradle
+++ b/code/gradle/benchmark.gradle
@@ -1,0 +1,40 @@
+/* PCGen JMH micro-benchmarks. Defines the `jmh` source set (code/src/jmh),
+ * its JMH dependencies, and the `benchmark` task that runs them. Kept separate
+ * from build.gradle as it is a developer-only concern, not part of `build`.
+ * Called from the main build.gradle file.
+ *
+ * Usage: ./gradlew benchmark
+ *        ./gradlew benchmark --args='TypeBenchmark -f 1 -wi 3 -i 5 -prof gc'
+ */
+
+sourceSets {
+    jmh {
+        java {
+            srcDirs = ['code/src/jmh']
+        }
+        compileClasspath += sourceSets.main.output + sourceSets.main.compileClasspath
+        runtimeClasspath += sourceSets.main.output + sourceSets.main.runtimeClasspath
+    }
+}
+
+// Declaring the jmh source set above auto-creates these configurations.
+dependencies {
+    jmhImplementation 'org.openjdk.jmh:jmh-core:1.37'
+    jmhAnnotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess:1.37'
+}
+
+tasks.register("benchmark", JavaExec) {
+    group = 'verification'
+    description = 'Runs the JMH micro-benchmarks (code/src/jmh).'
+    dependsOn tasks.named('jmhClasses'), extractJavaFXLocal
+    mainClass = 'org.openjdk.jmh.Main'
+    classpath = sourceSets.jmh.runtimeClasspath
+    // Benchmarks exercise main-source classes, which need JavaFX on the module
+    // path at runtime (same reason the Test.configureEach block in build.gradle
+    // adds it).
+    jvmArgs = [
+            '-Djava.awt.headless=true',
+            "--module-path", layout.projectDirectory.dir("mods/lib").toString(),
+            "--add-modules", "javafx.controls,javafx.web,javafx.swing,javafx.fxml,javafx.graphics",
+    ]
+}

--- a/code/gradle/benchmark.gradle
+++ b/code/gradle/benchmark.gradle
@@ -26,15 +26,10 @@ dependencies {
 tasks.register("benchmark", JavaExec) {
     group = 'verification'
     description = 'Runs the JMH micro-benchmarks (code/src/jmh).'
-    dependsOn tasks.named('jmhClasses'), extractJavaFXLocal
+    dependsOn tasks.named('jmhClasses')
     mainClass = 'org.openjdk.jmh.Main'
     classpath = sourceSets.jmh.runtimeClasspath
-    // Benchmarks exercise main-source classes, which need JavaFX on the module
-    // path at runtime (same reason the Test.configureEach block in build.gradle
-    // adds it).
     jvmArgs = [
             '-Djava.awt.headless=true',
-            "--module-path", layout.projectDirectory.dir("mods/lib").toString(),
-            "--add-modules", "javafx.controls,javafx.web,javafx.swing,javafx.fxml,javafx.graphics",
     ]
 }

--- a/code/src/java/pcgen/cdom/base/CDOMObject.java
+++ b/code/src/java/pcgen/cdom/base/CDOMObject.java
@@ -75,9 +75,9 @@ public abstract class CDOMObject extends ConcretePrereqObject
 
 	public static final Comparator<CDOMObject> P_OBJECT_COMP =
 			(o1, o2) -> o1.getKeyName().compareToIgnoreCase(o2.getKeyName());
+	// For single-threaded sorting it is safe and efficient to keep the Collator as a shared instance.
+	private static final Collator NAME_COLLATOR = Collator.getInstance();
 	public static final Comparator<CDOMObject> P_OBJECT_NAME_COMP = (o1, o2) -> {
-		final Collator collator = Collator.getInstance();
-
 		// Check sort keys first
 		String key1 = o1.get(StringKey.SORT_KEY);
 		if (key1 == null)
@@ -91,14 +91,14 @@ public abstract class CDOMObject extends ConcretePrereqObject
 		}
 		if (!key1.equals(key2))
 		{
-			return collator.compare(key1, key2);
+			return NAME_COLLATOR.compare(key1, key2);
 		}
 		if (!o1.getDisplayName().equals(o2.getDisplayName()))
 		{
-			return collator.compare(o1.getDisplayName(), o2.getDisplayName());
+			return NAME_COLLATOR.compare(o1.getDisplayName(), o2.getDisplayName());
 		}
 		// Fall back to keyname if the displayname is the same
-		return collator.compare(o1.getKeyName(), o2.getKeyName());
+		return NAME_COLLATOR.compare(o1.getKeyName(), o2.getKeyName());
 	};
 	/**
 	 * The source URI for this CDOMObject.

--- a/code/src/java/pcgen/cdom/base/Loadable.java
+++ b/code/src/java/pcgen/cdom/base/Loadable.java
@@ -19,8 +19,10 @@ package pcgen.cdom.base;
 
 import java.net.URI;
 
+import pcgen.cdom.enumeration.Type;
+
 /**
- * A Loadable is an object that PCGen can load from its persistent file storage (generally "LST" files). 
+ * A Loadable is an object that PCGen can load from its persistent file storage (generally "LST" files).
  */
 public interface Loadable extends Identified
 {
@@ -69,6 +71,21 @@ public interface Loadable extends Identified
 	 * @return true if the object is of the given type; false otherwise.
 	 */
 	public boolean isType(String type);
+
+	/**
+	 * Returns true if the object is of the given single {@link Type}. Fast-path
+	 * overload for callers holding an interned Type; the default delegates to
+	 * {@link #isType(String)} so implementers with special type semantics (e.g.
+	 * Equipment) stay correct without overriding.
+	 *
+	 * @param type
+	 *            The Type to check for
+	 * @return true if the object is of the given Type; false otherwise.
+	 */
+	public default boolean isType(Type type)
+	{
+		return isType(type.toString());
+	}
 
 	/**
 	 * Returns the ClassIdentity of this Loadable.

--- a/code/src/java/pcgen/cdom/list/ClassSkillList.java
+++ b/code/src/java/pcgen/cdom/list/ClassSkillList.java
@@ -34,11 +34,11 @@ import pcgen.core.Skill;
  */
 public class ClassSkillList extends CDOMListObject<Skill>
 {
-	private Set<Type> types;
+	private final Set<Type> types = new HashSet<>();
 
 	/**
 	 * Returns the Skill Class object (Skill.class)
-	 * 
+	 *
 	 * @return the Skill Class object (Skill.class)
 	 */
 	@Override
@@ -53,7 +53,7 @@ public class ClassSkillList extends CDOMListObject<Skill>
 	@Override
 	public boolean isType(String type)
 	{
-		if ((type.isEmpty()) || (types == null))
+		if (type.isEmpty())
 		{
 			return false;
 		}
@@ -75,15 +75,11 @@ public class ClassSkillList extends CDOMListObject<Skill>
 	@Override
 	public boolean isType(Type type)
 	{
-		return (types != null) && types.contains(type);
+		return types.contains(type);
 	}
 
 	public void addType(Type type)
 	{
-		if (types == null)
-		{
-			types = new HashSet<>();
-		}
 		types.add(type);
 	}
 

--- a/code/src/java/pcgen/cdom/list/ClassSkillList.java
+++ b/code/src/java/pcgen/cdom/list/ClassSkillList.java
@@ -72,6 +72,12 @@ public class ClassSkillList extends CDOMListObject<Skill>
 		return true;
 	}
 
+	@Override
+	public boolean isType(Type type)
+	{
+		return (types != null) && types.contains(type);
+	}
+
 	public void addType(Type type)
 	{
 		if (types == null)

--- a/code/src/java/pcgen/cdom/list/ClassSpellList.java
+++ b/code/src/java/pcgen/cdom/list/ClassSpellList.java
@@ -72,6 +72,12 @@ public class ClassSpellList extends CDOMListObject<Spell>
 		return true;
 	}
 
+	@Override
+	public boolean isType(Type type)
+	{
+		return (types != null) && types.contains(type);
+	}
+
 	public void addType(Type type)
 	{
 		if (types == null)

--- a/code/src/java/pcgen/cdom/list/ClassSpellList.java
+++ b/code/src/java/pcgen/cdom/list/ClassSpellList.java
@@ -34,11 +34,11 @@ import pcgen.core.spell.Spell;
  */
 public class ClassSpellList extends CDOMListObject<Spell>
 {
-	private Set<Type> types;
+	private final Set<Type> types = new HashSet<>();
 
 	/**
 	 * Returns the Spell Class object (Spell.class)
-	 * 
+	 *
 	 * @return the Spell Class object (Spell.class)
 	 */
 	@Override
@@ -53,7 +53,7 @@ public class ClassSpellList extends CDOMListObject<Spell>
 	@Override
 	public boolean isType(String type)
 	{
-		if ((type.isEmpty()) || (types == null))
+		if (type.isEmpty())
 		{
 			return false;
 		}
@@ -75,15 +75,11 @@ public class ClassSpellList extends CDOMListObject<Spell>
 	@Override
 	public boolean isType(Type type)
 	{
-		return (types != null) && types.contains(type);
+		return types.contains(type);
 	}
 
 	public void addType(Type type)
 	{
-		if (types == null)
-		{
-			types = new HashSet<>();
-		}
 		types.add(type);
 	}
 

--- a/code/src/java/pcgen/cdom/list/DomainSpellList.java
+++ b/code/src/java/pcgen/cdom/list/DomainSpellList.java
@@ -34,11 +34,11 @@ import pcgen.core.spell.Spell;
  */
 public class DomainSpellList extends CDOMListObject<Spell>
 {
-	private Set<Type> types;
+	private final Set<Type> types = new HashSet<>();
 
 	/**
 	 * Returns the Spell Class object (Spell.class)
-	 * 
+	 *
 	 * @return the Spell Class object (Spell.class)
 	 */
 	@Override
@@ -53,7 +53,7 @@ public class DomainSpellList extends CDOMListObject<Spell>
 	@Override
 	public boolean isType(String type)
 	{
-		if ((type.isEmpty()) || (types == null))
+		if (type.isEmpty())
 		{
 			return false;
 		}
@@ -74,10 +74,6 @@ public class DomainSpellList extends CDOMListObject<Spell>
 
 	public void addType(Type type)
 	{
-		if (types == null)
-		{
-			types = new HashSet<>();
-		}
 		types.add(type);
 	}
 

--- a/code/src/java/pcgen/cdom/reference/AbstractReferenceManufacturer.java
+++ b/code/src/java/pcgen/cdom/reference/AbstractReferenceManufacturer.java
@@ -21,6 +21,7 @@ import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -43,6 +44,7 @@ import pcgen.cdom.base.CDOMReference;
 import pcgen.cdom.base.ClassIdentity;
 import pcgen.cdom.base.Loadable;
 import pcgen.cdom.content.RollMethod;
+import pcgen.cdom.enumeration.Type;
 import pcgen.cdom.inst.Dynamic;
 import pcgen.util.Logging;
 import pcgen.util.StringPClassUtil;
@@ -323,6 +325,26 @@ public abstract class AbstractReferenceManufacturer<T extends Loadable> implemen
 
 	private boolean resolveGroupReferences()
 	{
+		/*
+		 * Intern each group key's tokens to Type constants once, up front, rather
+		 * than re-interning per object. getTypeReference guarantees every element
+		 * is a single, plain type token (no '.', '=', ',', '|'), so each maps to
+		 * exactly one Type.getConstant. This hoists the intern out of the
+		 * objects x groups x tokens inner loop (PObject.isType startup hot path).
+		 * isType(Type) is safe for every T: implementers with non-trivial type
+		 * semantics (e.g. Equipment) inherit Loadable's default, which delegates
+		 * back to isType(String).
+		 */
+		Map<FixedStringList, Type[]> internedKeys = new HashMap<>(typeReferences.size());
+		for (FixedStringList key : typeReferences.keySet())
+		{
+			Type[] types = new Type[key.size()];
+			for (int i = 0; i < types.length; i++)
+			{
+				types[i] = Type.getConstant(key.get(i));
+			}
+			internedKeys.put(key, types);
+		}
 		for (T obj : getAllObjects())
 		{
 			if (allRef != null)
@@ -335,7 +357,7 @@ public abstract class AbstractReferenceManufacturer<T extends Loadable> implemen
 				if (trt != null)
 				{
 					boolean typeOkay = true;
-					for (String type : me.getKey())
+					for (Type type : internedKeys.get(me.getKey()))
 					{
 						if (!obj.isType(type))
 						{

--- a/code/src/java/pcgen/cdom/reference/AbstractReferenceManufacturer.java
+++ b/code/src/java/pcgen/cdom/reference/AbstractReferenceManufacturer.java
@@ -326,14 +326,9 @@ public abstract class AbstractReferenceManufacturer<T extends Loadable> implemen
 	private boolean resolveGroupReferences()
 	{
 		/*
-		 * Intern each group key's tokens to Type constants once, up front, rather
-		 * than re-interning per object. getTypeReference guarantees every element
-		 * is a single, plain type token (no '.', '=', ',', '|'), so each maps to
-		 * exactly one Type.getConstant. This hoists the intern out of the
-		 * objects x groups x tokens inner loop (PObject.isType startup hot path).
-		 * isType(Type) is safe for every T: implementers with non-trivial type
-		 * semantics (e.g. Equipment) inherit Loadable's default, which delegates
-		 * back to isType(String).
+		 * Intern each group key's tokens to Type constants once, before the
+		 * per-object loop, so the objects x groups x tokens matching below does
+		 * cheap Type lookups instead of re-interning strings each time.
 		 */
 		Map<FixedStringList, Type[]> internedKeys = new HashMap<>(typeReferences.size());
 		for (FixedStringList key : typeReferences.keySet())

--- a/code/src/java/pcgen/core/AbilityCategory.java
+++ b/code/src/java/pcgen/core/AbilityCategory.java
@@ -755,7 +755,7 @@ public class AbilityCategory
 			{
 				for (Type type : types)
 				{
-					if (ability.isType(type.toString()))
+					if (ability.isType(type))
 					{
 						use = true;
 						break;

--- a/code/src/java/pcgen/core/PObject.java
+++ b/code/src/java/pcgen/core/PObject.java
@@ -213,6 +213,7 @@ public class PObject extends CDOMObject
 	 *            The Type to check for
 	 * @return true if this object is of the given Type; false otherwise
 	 */
+	@Override
 	public boolean isType(final Type type)
 	{
 		return containsInList(ListKey.TYPE, type);

--- a/code/src/java/pcgen/core/PObject.java
+++ b/code/src/java/pcgen/core/PObject.java
@@ -203,6 +203,21 @@ public class PObject extends CDOMObject
 		return true;
 	}
 
+	/**
+	 * Returns whether this object is of the given single {@link Type}. Fast path
+	 * for callers that already hold an interned Type: skips the uppercase,
+	 * tokenize and {@code Type.getConstant} intern that {@link #isType(String)}
+	 * must do.
+	 *
+	 * @param type
+	 *            The Type to check for
+	 * @return true if this object is of the given Type; false otherwise
+	 */
+	public boolean isType(final Type type)
+	{
+		return containsInList(ListKey.TYPE, type);
+	}
+
 	@Override
 	public String toString()
 	{

--- a/code/src/java/pcgen/util/Comparators.java
+++ b/code/src/java/pcgen/util/Comparators.java
@@ -124,18 +124,19 @@ public final class Comparators
 	private static final class TreeTableNodeComparator implements Comparator<Object>, Serializable
 	{
 
+		private static final Collator COLLATOR = Collator.getInstance();
+
 		@Override
 		public int compare(Object o1, Object o2)
 		{
 			String key1 = getSortKey(o1);
 			String key2 = getSortKey(o2);
-			final Collator collator = Collator.getInstance();
 
 			if (!key1.equals(key2))
 			{
-				return collator.compare(key1, key2);
+				return COLLATOR.compare(key1, key2);
 			}
-			return collator.compare(String.valueOf(o1), String.valueOf(o2));
+			return COLLATOR.compare(String.valueOf(o1), String.valueOf(o2));
 		}
 
 		private static String getSortKey(Object obj1)

--- a/code/src/jmh/pcgen/cdom/enumeration/SortBenchmark.java
+++ b/code/src/jmh/pcgen/cdom/enumeration/SortBenchmark.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2026 (C) Vest <Vest@users.noreply.github.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.cdom.enumeration;
+
+import java.text.Collator;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import pcgen.cdom.base.CDOMObject;
+import pcgen.core.Ability;
+
+/**
+ * Measures the cost of sorting a CDOMObject list by name. Compares the shared-
+ * Collator {@link CDOMObject#P_OBJECT_NAME_COMP} against an equivalent comparator
+ * that constructs a Collator per comparison (the prior behaviour), so the delta
+ * from hoisting Collator.getInstance() is visible within a single run.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(1)
+@State(Scope.Benchmark)
+public class SortBenchmark
+{
+
+	@Param({"200"})
+	private int size;
+
+	/** Master unsorted list, rebuilt fresh into `work` before each invocation. */
+	private List<Ability> master;
+	private List<Ability> work;
+
+	/** Prior behaviour: a fresh Collator per comparison (sort-key -> display-name). */
+	private static final Comparator<CDOMObject> PER_COMPARE_COLLATOR = (o1, o2) -> {
+		Collator collator = Collator.getInstance();
+		String key1 = o1.get(StringKey.SORT_KEY);
+		if (key1 == null)
+		{
+			key1 = o1.getDisplayName();
+		}
+		String key2 = o2.get(StringKey.SORT_KEY);
+		if (key2 == null)
+		{
+			key2 = o2.getDisplayName();
+		}
+		if (!key1.equals(key2))
+		{
+			return collator.compare(key1, key2);
+		}
+		if (!o1.getDisplayName().equals(o2.getDisplayName()))
+		{
+			return collator.compare(o1.getDisplayName(), o2.getDisplayName());
+		}
+		return collator.compare(o1.getKeyName(), o2.getKeyName());
+	};
+
+	@Setup(Level.Trial)
+	public void buildMaster()
+	{
+		master = new ArrayList<>(size);
+		// Deterministic pseudo-shuffle so the input isn't pre-sorted: multiply the
+		// index by a value coprime to `size` and wrap. Distinct display names, so
+		// the collator does real work (no equals short-circuit).
+		for (int i = 0; i < size; i++)
+		{
+			int scrambled = (int) (((long) i * 7919) % size);
+			Ability a = new Ability();
+			a.setName("Ability_" + String.format("%05d", scrambled));
+			master.add(a);
+		}
+	}
+
+	@Setup(Level.Invocation)
+	public void freshCopy()
+	{
+		work = new ArrayList<>(master);
+	}
+
+	@Benchmark
+	public List<Ability> sharedCollator()
+	{
+		work.sort(CDOMObject.P_OBJECT_NAME_COMP);
+		return work;
+	}
+
+	@Benchmark
+	public List<Ability> perCompareCollator()
+	{
+		work.sort(PER_COMPARE_COLLATOR);
+		return work;
+	}
+}

--- a/code/src/jmh/pcgen/cdom/enumeration/TypeBenchmark.java
+++ b/code/src/jmh/pcgen/cdom/enumeration/TypeBenchmark.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2026 (C) Vest <Vest@users.noreply.github.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.cdom.enumeration;
+
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import pcgen.core.Ability;
+
+/**
+ * Baseline for the {@code PObject.isType} / {@code Type.getConstant} hot path
+ * that dominates PCGen campaign-load CPU (see the startup flame graph). Re-run
+ * after optimizing that path to measure the delta.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(1)
+@State(Scope.Benchmark)
+public class TypeBenchmark
+{
+
+	/** An Ability (a plain PObject subclass) preloaded with a handful of types. */
+	private Ability ability;
+
+	/** Pre-interned Type constants, as the optimized callers already hold. */
+	private Type weapon;
+	private Type melee;
+
+	@Setup
+	public void setUp()
+	{
+		weapon = Type.getConstant("Weapon");
+		melee = Type.getConstant("Melee");
+		ability = new Ability();
+		ability.addToListFor(ListKey.TYPE, weapon);
+		ability.addToListFor(ListKey.TYPE, melee);
+		ability.addToListFor(ListKey.TYPE, Type.getConstant("Standard"));
+	}
+
+	/** Interned-name lookup: the computeIfAbsent + CaseInsensitiveString hash/equals cost. */
+	@Benchmark
+	public Type getConstant_hit()
+	{
+		return Type.getConstant("Weapon");
+	}
+
+	/** Single token: uppercase + tokenize + one getConstant + containsInList. */
+	@Benchmark
+	public boolean isType_singleToken()
+	{
+		return ability.isType("Weapon");
+	}
+
+	/** Multi token: two getConstant calls, both matching. */
+	@Benchmark
+	public boolean isType_multiToken()
+	{
+		return ability.isType("Weapon.Melee");
+	}
+
+	/** Miss: interns the name, then fails containsInList on the first token. */
+	@Benchmark
+	public boolean isType_miss()
+	{
+		return ability.isType("Nonexistent");
+	}
+
+	/** Optimized fast path: caller already holds the interned Type (single). */
+	@Benchmark
+	public boolean isTypeFast_singleToken()
+	{
+		return ability.isType(weapon);
+	}
+
+	/** Optimized fast path over two held Types (compare against isType_multiToken). */
+	@Benchmark
+	public boolean isTypeFast_multiToken()
+	{
+		return ability.isType(weapon) && ability.isType(melee);
+	}
+
+	/**
+	 * Combined path in one shot so JMH's per-benchmark fixed cost doesn't hide the
+	 * relative differences; results consumed via Blackhole to defeat DCE.
+	 */
+	@Benchmark
+	public void mixed(Blackhole bh)
+	{
+		bh.consume(ability.isType("Weapon"));
+		bh.consume(ability.isType("Weapon.Melee"));
+		bh.consume(ability.isType("Nonexistent"));
+	}
+}

--- a/code/src/jmh/pcgen/cdom/enumeration/TypeBenchmark.java
+++ b/code/src/jmh/pcgen/cdom/enumeration/TypeBenchmark.java
@@ -17,6 +17,8 @@
  */
 package pcgen.cdom.enumeration;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.openjdk.jmh.annotations.Benchmark;
@@ -54,6 +56,13 @@ public class TypeBenchmark
 	private Type weapon;
 	private Type melee;
 
+	/** A small population of objects, mimicking resolveGroupReferences' object loop. */
+	private List<Ability> population;
+
+	/** A two-token group key, as stored in a manufacturer's typeReferences. */
+	private String[] groupTokens;
+	private Type[] internedGroupTokens;
+
 	@Setup
 	public void setUp()
 	{
@@ -63,6 +72,18 @@ public class TypeBenchmark
 		ability.addToListFor(ListKey.TYPE, weapon);
 		ability.addToListFor(ListKey.TYPE, melee);
 		ability.addToListFor(ListKey.TYPE, Type.getConstant("Standard"));
+
+		groupTokens = new String[]{"Weapon", "Melee"};
+		internedGroupTokens = new Type[]{weapon, melee};
+		population = new ArrayList<>();
+		for (int i = 0; i < 50; i++)
+		{
+			Ability a = new Ability();
+			a.addToListFor(ListKey.TYPE, weapon);
+			// Half match both tokens, half fail the second — exercises both branches.
+			a.addToListFor(ListKey.TYPE, (i % 2 == 0) ? melee : Type.getConstant("Ranged"));
+			population.add(a);
+		}
 	}
 
 	/** Interned-name lookup: the computeIfAbsent + CaseInsensitiveString hash/equals cost. */
@@ -105,6 +126,60 @@ public class TypeBenchmark
 	public boolean isTypeFast_multiToken()
 	{
 		return ability.isType(weapon) && ability.isType(melee);
+	}
+
+	/**
+	 * Old resolveGroupReferences inner loop: re-intern each String token per
+	 * object via isType(String).
+	 */
+	@Benchmark
+	public int groupResolve_stringPath()
+	{
+		int matches = 0;
+		for (Ability a : population)
+		{
+			boolean ok = true;
+			for (String token : groupTokens)
+			{
+				if (!a.isType(token))
+				{
+					ok = false;
+					break;
+				}
+			}
+			if (ok)
+			{
+				matches++;
+			}
+		}
+		return matches;
+	}
+
+	/**
+	 * New resolveGroupReferences inner loop: group tokens interned once, then
+	 * isType(Type) per object.
+	 */
+	@Benchmark
+	public int groupResolve_internedTypePath()
+	{
+		int matches = 0;
+		for (Ability a : population)
+		{
+			boolean ok = true;
+			for (Type token : internedGroupTokens)
+			{
+				if (!a.isType(token))
+				{
+					ok = false;
+					break;
+				}
+			}
+			if (ok)
+			{
+				matches++;
+			}
+		}
+		return matches;
 	}
 
 	/**

--- a/code/src/test/pcgen/cdom/reference/AbstractReferenceManufacturerGroupResolutionTest.java
+++ b/code/src/test/pcgen/cdom/reference/AbstractReferenceManufacturerGroupResolutionTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2026 (C) Vest <Vest@users.noreply.github.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.cdom.reference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Set;
+
+import pcgen.cdom.base.BasicClassIdentity;
+import pcgen.cdom.enumeration.ListKey;
+import pcgen.cdom.enumeration.Type;
+import pcgen.core.Skill;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests group ("TYPE=") resolution in {@link AbstractReferenceManufacturer}
+ * (the private resolveGroupReferences path, reached via resolveReferences).
+ *
+ * These pin the input -> group-membership behaviour that the isType(Type)
+ * fast-path optimization must preserve: an object joins a TYPE group iff it is
+ * of ALL tokens in that group's key.
+ */
+class AbstractReferenceManufacturerGroupResolutionTest
+{
+
+	private SimpleReferenceManufacturer<Skill> manufacturer;
+
+	@BeforeEach
+	void setUp()
+	{
+		manufacturer = new SimpleReferenceManufacturer<>(
+				new CDOMFactory<>(BasicClassIdentity.getIdentity(Skill.class)));
+	}
+
+	/**
+	 * Constructs a Skill in the manufacturer with the given types.
+	 */
+	private Skill makeSkill(String key, String... types)
+	{
+		Skill skill = manufacturer.constructObject(key);
+		for (String type : types)
+		{
+			skill.addToListFor(ListKey.TYPE, Type.getConstant(type));
+		}
+		return skill;
+	}
+
+	@Test
+	void singleTokenGroupContainsOnlyMatchingObjects()
+	{
+		Skill weapon = makeSkill("Weapon", "Weapon");
+		Skill armor = makeSkill("Armor", "Armor");
+
+		CDOMGroupRef<Skill> weaponGroup = manufacturer.getTypeReference("Weapon");
+
+		assertTrue(manufacturer.resolveReferences(null));
+
+		assertTrue(weaponGroup.contains(weapon));
+		assertFalse(weaponGroup.contains(armor));
+		assertEquals(Set.of(weapon), Set.copyOf(weaponGroup.getContainedObjects()));
+	}
+
+	@Test
+	void multiTokenGroupRequiresAllTokens()
+	{
+		Skill both = makeSkill("Both", "Weapon", "Melee");
+		Skill weaponOnly = makeSkill("WeaponOnly", "Weapon");
+		Skill meleeOnly = makeSkill("MeleeOnly", "Melee");
+
+		// TYPE=Weapon.Melee -> only objects that are BOTH Weapon and Melee
+		CDOMGroupRef<Skill> group = manufacturer.getTypeReference("Weapon", "Melee");
+
+		assertTrue(manufacturer.resolveReferences(null));
+
+		assertTrue(group.contains(both));
+		assertFalse(group.contains(weaponOnly));
+		assertFalse(group.contains(meleeOnly));
+		assertEquals(Set.of(both), Set.copyOf(group.getContainedObjects()));
+	}
+
+	@Test
+	void matchingIsCaseInsensitive()
+	{
+		// Object declared with one casing, group requested with another.
+		Skill skill = makeSkill("Mixed", "Weapon");
+
+		CDOMGroupRef<Skill> group = manufacturer.getTypeReference("wEaPoN");
+
+		assertTrue(manufacturer.resolveReferences(null));
+
+		assertTrue(group.contains(skill),
+				"TYPE matching must be case-insensitive (Type is interned case-insensitively)");
+	}
+
+	@Test
+	void groupWithNoMatchesIsFlaggedUnconstructed()
+	{
+		makeSkill("Weapon", "Weapon");
+
+		CDOMGroupRef<Skill> group = manufacturer.getTypeReference("Nonexistent");
+
+		// A TYPE= reference that matches nothing is a dangling reference:
+		// resolution reports failure and the group gets no objects.
+		assertFalse(manufacturer.resolveReferences(null),
+				"A TYPE group matching zero objects must be reported as unconstructed");
+		assertEquals(0, group.getObjectCount());
+	}
+
+	@Test
+	void objectQualifiesForEveryGroupItMatches()
+	{
+		Skill both = makeSkill("Both", "Weapon", "Melee");
+
+		CDOMGroupRef<Skill> weaponGroup = manufacturer.getTypeReference("Weapon");
+		CDOMGroupRef<Skill> meleeGroup = manufacturer.getTypeReference("Melee");
+		CDOMGroupRef<Skill> comboGroup = manufacturer.getTypeReference("Weapon", "Melee");
+
+		assertTrue(manufacturer.resolveReferences(null));
+
+		assertTrue(weaponGroup.contains(both));
+		assertTrue(meleeGroup.contains(both));
+		assertTrue(comboGroup.contains(both));
+	}
+}


### PR DESCRIPTION
## Summary

Targeted, low-risk performance changes on the PCGen campaign-load path, driven by CPU profiling. Each is isolated, behavior-preserving, and backed by a JMH benchmark under a new code/src/jmh source set. Plus two small build/refactor tidy-ups (noted below).

## Findings (from profiling)

Campaign-load CPU showed PObject.isType(String) → Type.getConstant → CaseInsensitiveMap.computeIfAbsent as the dominant leaf, reached from two hot loops (AbilityCategory.populate and
AbstractReferenceManufacturer.resolveGroupReferences). A secondary DataSet.initLists → sortPObjectListByName tower constructed a Collator per comparison.

### Before
<img width="3626" height="686" alt="image" src="https://github.com/user-attachments/assets/3c4e5a05-82e5-4a59-be18-b5caa6d9795b" />

### After
<img width="3626" height="686" alt="image" src="https://github.com/user-attachments/assets/a7eb45d4-869a-4a2c-82c9-159d9ade3ce4" />

## Changes

### Performance
1. PObject.isType(Type) fast path — skips uppercase/tokenize/intern when the caller already holds an interned Type; used in AbilityCategory.populate. Micro-bench: single-token 25.8 → 3.0 ns, multi-token 98.6 → 7.8 ns.
2. Loadable.isType(Type) + resolveGroupReferences — default method delegating to isType(String) (so Equipment's EqMod-merged semantics are preserved by not overriding); fast overrides on PObject/ClassSkillList/ClassSpellList. Group-key tokens interned once per manufacturer instead of per object. Group-resolution loop bench: 2989 → 747 ns (~4×). See detailed walkthrough below.
3. Shared Collator in name-sort comparators (CDOMObject.P_OBJECT_NAME_COMP, Comparators.TreeTableNodeComparator). Honest note: the JDK caches Collator rules, so this is an allocation win, not CPU — -prof gc shows 1.87M → 1.32M B/op (~30% less garbage) per 200-element sort; wall time moved only ~5% (noise).

### Build / refactor (not performance)
4. Benchmark task: removed the JavaFX module path and the extractJavaFXLocal dependency — the benchmarks exercise only core data-path classes (PObject/CDOMObject/Type), which never load JavaFX, so there is no reason to pull JavaFX into the benchmark run.
5. Eager-init the `types` set in ClassSkillList/ClassSpellList/DomainSpellList (final field, empty HashSet) and drop the null checks in addType/isType. Behavior-preserving readability cleanup, not a perf change.

## How the resolveGroupReferences optimization works (change 2)

resolveGroupReferences assigns each loaded object to the "TYPE=" group references it qualifies for. It is a nested scan:

```
for each object (getAllObjects)
    for each group reference (typeReferences)
        for each type token in that group's key
            if !object.isType(token) -> object is not in this group
```

A group key is a FixedStringList such as `["Martial","Melee"]` (from a reference like `TYPE=Martial.Melee`), and its elements are plain strings.

**Before:** the inner loop called `object.isType(String)` on each string token. `isType(String)` per call uppercases the string, tokenizes on `.`, and calls `Type.getConstant(token)` to intern each piece into the shared `Type` constant. `Type.getConstant` is a `CaseInsensitiveMap` lookup (hash + case-insensitive equals). Sitting in the innermost loop, that interning ran **objects × groups × tokens** times — e.g. 5000 abilities × 20 group refs × 2 tokens = 200,000 interning calls — even though the group tokens are tiny and fixed for the whole scan.

**After:** intern each group key's tokens to `Type` constants **once**, before the object loop:

```
"Martial" -> Type.getConstant("Martial")   // done once
"Melee"   -> Type.getConstant("Melee")      // done once
```

`getTypeReference` (which builds these keys) already guarantees each element is a single, plain token — it rejects `.`, `=`, `,`, `|` — so each string maps to exactly one `Type.getConstant`, no tokenizing or edge cases. The inner loop then calls the `isType(Type)` fast path (a direct `containsInList(ListKey.TYPE, type)`), a cheap membership test instead of re-interning a string.

Net effect: `Type.getConstant` calls drop from **O(objects × groups × tokens)** to **O(groups × tokens)**. Correctness is preserved for every element type: implementers with special type semantics (notably `Equipment`, whose `isType` merges EqMod-derived types) do **not** override `isType(Type)` and inherit `Loadable`'s default, which delegates back to `isType(String)`.

## Verification

- Guardrails green: Pre{Type,ArmorType,SpellType,Charactertype}RoundRobin, PObjectTest, PreArmorTypeTest, DataSetTest; and the list-class token tests (Mon{C,CC}SkillTokenTest, spell ClassesTokenTest, Spell{known,Level}LstTest) for change 5.
- New unit test AbstractReferenceManufacturerGroupResolutionTest (5 tests) directly pins TYPE-group membership (the resolveGroupReferences path change 2 relies on): single/multi-token matching, case-insensitivity, multi-group membership, and the dangling TYPE= case.
- End-to-end: srdinttest (SRD game-mode integration tests) — 7 tests, 0 failures, confirming TYPE-group resolution is unchanged.
- Benchmarks: ./gradlew benchmark --args='TypeBenchmark ...' / 'SortBenchmark ...'.
- Not done: an end-to-end re-profile of total startup (the isType change is visible in the profiler; the Collator change won't visibly shrink CPU).

## Out of scope

Larger structural towers — LST parsing, plugin classloading, GUI bootstrap — are not addressed here.