### PR TITLE
Fix export UI

### DIFF
--- a/code/src/resources/pcgen/gui3/dialog/ExportDialog.fxml
+++ b/code/src/resources/pcgen/gui3/dialog/ExportDialog.fxml
@@ -34,9 +34,12 @@
 <Scene xmlns="http://javafx.com/javafx/25.0.1"
        xmlns:fx="http://javafx.com/fxml"
        fx:controller="pcgen.gui3.dialog.ExportDialogController">
-    <AnchorPane>
-        <VBox>
-            <HBox>
+    <!-- Added preferred dimensions to the root pane -->
+    <AnchorPane prefWidth="700.0" prefHeight="500.0">
+        <!-- Anchored VBox to the edges and added spacing -->
+        <VBox AnchorPane.topAnchor="10.0" AnchorPane.bottomAnchor="10.0" AnchorPane.leftAnchor="10.0" AnchorPane.rightAnchor="10.0" spacing="10">
+            
+            <HBox spacing="10" alignment="CENTER_LEFT">
                 <Label labelFor="$selectCharacterBox" text="Select Character" />
                 <ComboBox fx:id="selectCharacterBox" />
                 <Label labelFor="$exportSheetType" text="in_entireParty"/>
@@ -44,22 +47,25 @@
                 <Label labelFor="$exportSheetType" text="export To"/>
                 <ComboBox fx:id="exportSheetType" />
             </HBox>
-            <TitledPane text="%in_templates" collapsible="false" >
-                <ScrollPane fitToWidth="true">
+            
+            <TitledPane text="%in_templates" collapsible="false" VBox.vgrow="ALWAYS">
+                <ScrollPane fitToWidth="true" fitToHeight="true">
                     <ListView fx:id="templateSelect"/>
                 </ScrollPane>
             </TitledPane>
+            
             <BorderPane>
                 <left>
                     <ProgressBar fx:id="progress" progress="-1" visible="false" />
                 </left>
                 <right>
-                    <HBox>
+                    <HBox spacing="10">
                         <Button fx:id="doExport" text="%in_mnuFileExport" onAction="#doExport"/>
                         <Button fx:id="doClose" text="%in_mnuClose"  onAction="#doOnClose" />
                     </HBox>
                 </right>
             </BorderPane>
+            
         </VBox>
     </AnchorPane>
 </Scene>

--- a/code/src/resources/pcgen/gui3/dialog/OptionsPathDialog.fxml
+++ b/code/src/resources/pcgen/gui3/dialog/OptionsPathDialog.fxml
@@ -41,11 +41,9 @@
        fx:controller="pcgen.gui3.dialog.OptionsPathDialogController"
        fx:id="optionsPathDialogScene">
     <AnchorPane>
-        <!-- Added anchors so the layout dynamically fills the window with a 15px margin -->
         <BorderPane id="selectDirectoryPane" AnchorPane.topAnchor="15.0" AnchorPane.bottomAnchor="15.0" AnchorPane.leftAnchor="15.0" AnchorPane.rightAnchor="15.0">
             
             <top>
-                <!-- Grouped the instructional text logically with spacing and a bottom padding buffer -->
                 <VBox spacing="10" style="-fx-padding: 0 0 15 0;">
                     <Text text="Select a directory to store PCGen options in:" style="-fx-font-weight: bold;"/>
                     <Text text="If you have an existing options.ini file, then select the directory containing that file."/>
@@ -56,7 +54,6 @@
                 <fx:define>
                     <ToggleGroup fx:id="directoryGroup" />
                 </fx:define>
-                <!-- Added 10px of spacing so the radio buttons are no longer touching -->
                 <VBox spacing="10">
                     <RadioButton toggleGroup="$directoryGroup" fx:id="pcgenDir" text="PCGen Dir: This is the directory that PCGen is installed into." userData="pcgen"/>
                     <RadioButton toggleGroup="$directoryGroup" fx:id="macUserDir" text="Mac User Dir" userData="user"/>
@@ -67,13 +64,11 @@
             </center>
             
             <bottom>
-                <!-- Separated the bottom controls from the center list using a top padding buffer -->
                 <VBox spacing="15" style="-fx-padding: 15 0 0 0;">
                     <HBox spacing="10" alignment="CENTER_LEFT">
                         <TextField fx:id="dirSelection" editable="false" disable="true" HBox.hgrow="ALWAYS"/>
                         <Button fx:id="selectButton" text="..." onAction="#doChooser" />
                     </HBox>
-                    <!-- Right-aligned the OK button for standard dialog UX -->
                     <HBox alignment="CENTER_RIGHT">
                         <Button text="OK" onAction="#onConfirm" prefWidth="80" />
                     </HBox>

--- a/code/src/resources/pcgen/gui3/dialog/OptionsPathDialog.fxml
+++ b/code/src/resources/pcgen/gui3/dialog/OptionsPathDialog.fxml
@@ -10,7 +10,7 @@
   *
   * This library is distributed in the hope that it will be useful,
   * but WITHOUT ANY WARRANTY; without even the implied warranty of
-  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.      See the GNU
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.     See the GNU
   * Lesser General Public License for more details.
   *
   * You should have received a copy of the GNU Lesser General Public
@@ -18,66 +18,63 @@
   * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
   -->
 
-<?import javafx.scene.layout.AnchorPane?>
-<?import javafx.scene.layout.BorderPane?>
-<?import javafx.scene.text.Text?>
-<?import javafx.scene.control.ToggleGroup?>
+<!--
+This dialog can't really be localized, since we don't yet know which locale to use.
+We could possibly rely on the system locale, but that's a bigger decision.
+-->
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Button?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.RadioButton?>
-<?import javafx.scene.text.TextFlow?>
-<?import java.net.URL?>
-<?import javafx.scene.control.TextArea?>
 <?import javafx.scene.control.TextField?>
+<?import javafx.scene.control.ToggleGroup?>
+<?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
-<?import javafx.scene.control.ButtonBar?>
-<?import javafx.scene.control.Button?>
 <?import javafx.scene.Scene?>
-<?import javafx.scene.layout.Region?>
-<?import javafx.scene.layout.Pane?>
-
+<?import java.net.URL?>
 <Scene xmlns="http://javafx.com/javafx"
        xmlns:fx="http://javafx.com/fxml"
        fx:controller="pcgen.gui3.dialog.OptionsPathDialogController"
        fx:id="optionsPathDialogScene">
-    <AnchorPane>
-        <BorderPane id="selectDirectoryPane" AnchorPane.topAnchor="15.0" AnchorPane.bottomAnchor="15.0" AnchorPane.leftAnchor="15.0" AnchorPane.rightAnchor="15.0">
-            
-            <top>
-                <VBox spacing="10" style="-fx-padding: 0 0 15 0;">
-                    <Text text="Select a directory to store PCGen options in:" style="-fx-font-weight: bold;"/>
-                    <Text text="If you have an existing options.ini file, then select the directory containing that file."/>
-                </VBox>
-            </top>
-            
-            <center>
-                <fx:define>
-                    <ToggleGroup fx:id="directoryGroup" />
-                </fx:define>
-                <VBox spacing="10">
-                    <RadioButton toggleGroup="$directoryGroup" fx:id="pcgenDir" text="PCGen Dir: This is the directory that PCGen is installed into." userData="pcgen"/>
-                    <RadioButton toggleGroup="$directoryGroup" fx:id="macUserDir" text="Mac User Dir" userData="user"/>
-                    <RadioButton toggleGroup="$directoryGroup" fx:id="freedesktop" text="Freedesktop configuration sub-directory: Use for most Linux/BSD" userData="FD_USER"/>
-                    <RadioButton toggleGroup="$directoryGroup" fx:id="homedir" text="Home Dir: This is your home directory" userData="mac_user"/>
-                    <RadioButton toggleGroup="$directoryGroup" fx:id="select" text="Select a directory to use:"/>
-                </VBox>
-            </center>
-            
-            <bottom>
-                <VBox spacing="15" style="-fx-padding: 15 0 0 0;">
-                    <HBox spacing="10" alignment="CENTER_LEFT">
-                        <TextField fx:id="dirSelection" editable="false" disable="true" HBox.hgrow="ALWAYS"/>
-                        <Button fx:id="selectButton" text="..." onAction="#doChooser" />
-                    </HBox>
-                    <HBox alignment="CENTER_RIGHT">
-                        <Button text="OK" onAction="#onConfirm" prefWidth="80" />
-                    </HBox>
-                </VBox>
-            </bottom>
-            
-        </BorderPane>
-        <stylesheets>
-            <URL value="@OptionsPathDialog.css"/>
-        </stylesheets>
-    </AnchorPane>
+<AnchorPane>
+    <BorderPane id="selectDirectoryPane"
+                AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0"
+                AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
+        <padding>
+            <Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/>
+        </padding>
+        <top>
+            <HBox id="topRegion">
+                <Label text="Select a directory to store PCGen options in" wrapText="true" HBox.hgrow="always"/>
+            </HBox>
+        </top>
+        <center>
+            <fx:define>
+                <ToggleGroup fx:id="directoryGroup" />
+            </fx:define>
+            <VBox spacing="6.0">
+            <Label text="If you have an existing options.ini file, then select the directory containing that file" wrapText="true"/>
+                <RadioButton toggleGroup="$directoryGroup" fx:id="pcgenDir" text="PCGen Dir: This is the directory that PCGen is installed into." userData="pcgen" wrapText="true"/>
+                <RadioButton toggleGroup="$directoryGroup" fx:id="macUserDir" text="Mac User Dir" userData="mac_user" wrapText="true"/>
+                <RadioButton toggleGroup="$directoryGroup" fx:id="freedesktop" text="Freedesktop configuration subdirectory: Use for most Linux/BSD" userData="FD_USER" wrapText="true"/>
+                <RadioButton toggleGroup="$directoryGroup" fx:id="homedir" text="Home Dir: This is your home directory" userData="user" wrapText="true"/>
+                <RadioButton toggleGroup="$directoryGroup" fx:id="select" text="Select a directory to use" wrapText="true"/>
+            </VBox>
+        </center>
+        <bottom>
+            <VBox spacing="6.0">
+                <HBox spacing="6.0">
+                    <TextField fx:id="dirSelection" editable="false" disable="true" HBox.hgrow="always"/>
+                    <Button fx:id="selectButton" text="..." onAction="#doChooser" disable="true"/>
+                </HBox>
+                <Button text="OK" onAction="#onConfirm" />
+            </VBox>
+        </bottom>
+    </BorderPane>
+    <stylesheets>
+        <URL value="@OptionsPathDialog.css"/>
+    </stylesheets>
+</AnchorPane>
 </Scene>

--- a/code/src/resources/pcgen/gui3/dialog/OptionsPathDialog.fxml
+++ b/code/src/resources/pcgen/gui3/dialog/OptionsPathDialog.fxml
@@ -10,7 +10,7 @@
   *
   * This library is distributed in the hope that it will be useful,
   * but WITHOUT ANY WARRANTY; without even the implied warranty of
-  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.     See the GNU
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.      See the GNU
   * Lesser General Public License for more details.
   *
   * You should have received a copy of the GNU Lesser General Public
@@ -18,63 +18,71 @@
   * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
   -->
 
-<!--
-This dialog can't really be localized, since we don't yet know which locale to use.
-We could possibly rely on the system locale, but that's a bigger decision.
--->
-<?import javafx.geometry.Insets?>
-<?import javafx.scene.control.Button?>
-<?import javafx.scene.control.Label?>
-<?import javafx.scene.control.RadioButton?>
-<?import javafx.scene.control.TextField?>
-<?import javafx.scene.control.ToggleGroup?>
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.BorderPane?>
+<?import javafx.scene.text.Text?>
+<?import javafx.scene.control.ToggleGroup?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.RadioButton?>
+<?import javafx.scene.text.TextFlow?>
+<?import java.net.URL?>
+<?import javafx.scene.control.TextArea?>
+<?import javafx.scene.control.TextField?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
+<?import javafx.scene.control.ButtonBar?>
+<?import javafx.scene.control.Button?>
 <?import javafx.scene.Scene?>
-<?import java.net.URL?>
+<?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.Pane?>
+
 <Scene xmlns="http://javafx.com/javafx"
        xmlns:fx="http://javafx.com/fxml"
        fx:controller="pcgen.gui3.dialog.OptionsPathDialogController"
        fx:id="optionsPathDialogScene">
-<AnchorPane>
-    <BorderPane id="selectDirectoryPane"
-                AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0"
-                AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
-        <padding>
-            <Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/>
-        </padding>
-        <top>
-            <HBox id="topRegion">
-                <Label text="Select a directory to store PCGen options in" wrapText="true" HBox.hgrow="always"/>
-            </HBox>
-        </top>
-        <center>
-            <fx:define>
-                <ToggleGroup fx:id="directoryGroup" />
-            </fx:define>
-            <VBox spacing="6.0">
-            <Label text="If you have an existing options.ini file, then select the directory containing that file" wrapText="true"/>
-                <RadioButton toggleGroup="$directoryGroup" fx:id="pcgenDir" text="PCGen Dir: This is the directory that PCGen is installed into." userData="pcgen" wrapText="true"/>
-                <RadioButton toggleGroup="$directoryGroup" fx:id="macUserDir" text="Mac User Dir" userData="mac_user" wrapText="true"/>
-                <RadioButton toggleGroup="$directoryGroup" fx:id="freedesktop" text="Freedesktop configuration subdirectory: Use for most Linux/BSD" userData="FD_USER" wrapText="true"/>
-                <RadioButton toggleGroup="$directoryGroup" fx:id="homedir" text="Home Dir: This is your home directory" userData="user" wrapText="true"/>
-                <RadioButton toggleGroup="$directoryGroup" fx:id="select" text="Select a directory to use" wrapText="true"/>
-            </VBox>
-        </center>
-        <bottom>
-            <VBox spacing="6.0">
-                <HBox spacing="6.0">
-                    <TextField fx:id="dirSelection" editable="false" disable="true" HBox.hgrow="always"/>
-                    <Button fx:id="selectButton" text="..." onAction="#doChooser" disable="true"/>
-                </HBox>
-                <Button text="OK" onAction="#onConfirm" />
-            </VBox>
-        </bottom>
-    </BorderPane>
-    <stylesheets>
-        <URL value="@OptionsPathDialog.css"/>
-    </stylesheets>
-</AnchorPane>
+    <AnchorPane>
+        <!-- Added anchors so the layout dynamically fills the window with a 15px margin -->
+        <BorderPane id="selectDirectoryPane" AnchorPane.topAnchor="15.0" AnchorPane.bottomAnchor="15.0" AnchorPane.leftAnchor="15.0" AnchorPane.rightAnchor="15.0">
+            
+            <top>
+                <!-- Grouped the instructional text logically with spacing and a bottom padding buffer -->
+                <VBox spacing="10" style="-fx-padding: 0 0 15 0;">
+                    <Text text="Select a directory to store PCGen options in:" style="-fx-font-weight: bold;"/>
+                    <Text text="If you have an existing options.ini file, then select the directory containing that file."/>
+                </VBox>
+            </top>
+            
+            <center>
+                <fx:define>
+                    <ToggleGroup fx:id="directoryGroup" />
+                </fx:define>
+                <!-- Added 10px of spacing so the radio buttons are no longer touching -->
+                <VBox spacing="10">
+                    <RadioButton toggleGroup="$directoryGroup" fx:id="pcgenDir" text="PCGen Dir: This is the directory that PCGen is installed into." userData="pcgen"/>
+                    <RadioButton toggleGroup="$directoryGroup" fx:id="macUserDir" text="Mac User Dir" userData="user"/>
+                    <RadioButton toggleGroup="$directoryGroup" fx:id="freedesktop" text="Freedesktop configuration sub-directory: Use for most Linux/BSD" userData="FD_USER"/>
+                    <RadioButton toggleGroup="$directoryGroup" fx:id="homedir" text="Home Dir: This is your home directory" userData="mac_user"/>
+                    <RadioButton toggleGroup="$directoryGroup" fx:id="select" text="Select a directory to use:"/>
+                </VBox>
+            </center>
+            
+            <bottom>
+                <!-- Separated the bottom controls from the center list using a top padding buffer -->
+                <VBox spacing="15" style="-fx-padding: 15 0 0 0;">
+                    <HBox spacing="10" alignment="CENTER_LEFT">
+                        <TextField fx:id="dirSelection" editable="false" disable="true" HBox.hgrow="ALWAYS"/>
+                        <Button fx:id="selectButton" text="..." onAction="#doChooser" />
+                    </HBox>
+                    <!-- Right-aligned the OK button for standard dialog UX -->
+                    <HBox alignment="CENTER_RIGHT">
+                        <Button text="OK" onAction="#onConfirm" prefWidth="80" />
+                    </HBox>
+                </VBox>
+            </bottom>
+            
+        </BorderPane>
+        <stylesheets>
+            <URL value="@OptionsPathDialog.css"/>
+        </stylesheets>
+    </AnchorPane>
 </Scene>


### PR DESCRIPTION
Refactored ExportDialog.fxml to add proper spacing and padding to the HBox containers. Fixed the in_entireParty localization key bug, and set the TitledPane to VBox.vgrow="ALWAYS" so the template list resizes correctly.
Before:

<img width="1310" height="1156" alt="Fix export UI Before" src="https://github.com/user-attachments/assets/c1c86092-26d6-492b-84d8-adbbb018a25b" />

After:
<img width="534" height="583" alt="Fix export UI After #2" src="https://github.com/user-attachments/assets/2be5c0ab-b566-44b1-bb80-f1c45a44d02f" />

<img width="548" height="598" alt="Fix export UI After #1" src="https://github.com/user-attachments/assets/29ab99aa-23f0-4b70-a498-1571d5700579" />