### PR TITLE
test: InfoVarsLstTest for INFOVARS token (WIP — for review with LK)

### DIFF
--- a/code/src/itest/tokencontent/GlobalInfoVarsTest.java
+++ b/code/src/itest/tokencontent/GlobalInfoVarsTest.java
@@ -156,4 +156,31 @@ class GlobalInfoVarsTest extends AbstractTokenModelTest
 		assertFalse(INFOVARS_TOKEN.parseToken(context, template, "Enchant|CritMult").passed(),
 				"INFOVARS cannot reach a variable that only exists in a local (head) scope");
 	}
+
+	/**
+	 * Demonstrates the migration pattern for replacing a substitution-bearing
+	 * ASPECT/DESC with INFO/INFOVARS. Pathfinder has ~13k such tokens, e.g.
+	 *
+	 *   ASPECT:Ability Benefit|(%1 ft.)|JetSpeed
+	 *
+	 * Those %-substitutions are fed by old-formula-system DEFINE: variables, which
+	 * INFOVARS cannot read. The conversion requires (a) migrating the variable to a
+	 * new-system GLOBAL declaration, then (b) expressing the text as a MessageFormat:
+	 *
+	 *   GLOBAL:NUMBER=JetSpeed
+	 *   INFO:AbilityBenefit|({0} ft.)   INFOVARS:AbilityBenefit|JetSpeed
+	 *
+	 * This test shows that migrated form loading and resolving end-to-end. It is the
+	 * executable template for converting an ASPECT to INFOVARS (it does NOT change
+	 * shipped data — the DEFINE->GLOBAL migration is a separate data-team decision).
+	 */
+	@Test
+	void testAspectMigrationPatternToInfoVars()
+	{
+		declareGlobalVar("JetSpeed");
+		PCTemplate template = create(PCTemplate.class, "MonsterWithJet");
+		assertTrue(INFO_TOKEN.parseToken(context, template, "AbilityBenefit|({0} ft.)").passed());
+		assertTrue(INFOVARS_TOKEN.parseToken(context, template, "AbilityBenefit|JetSpeed").passed());
+		finishLoad();
+	}
 }

--- a/code/src/itest/tokencontent/GlobalInfoVarsTest.java
+++ b/code/src/itest/tokencontent/GlobalInfoVarsTest.java
@@ -101,4 +101,22 @@ class GlobalInfoVarsTest extends AbstractTokenModelTest
 		assertFalse(INFOVARS_TOKEN.parseToken(context, template, "Detail|NotDeclaredGlobally").passed(),
 				"INFOVARS must reject a variable that is not a declared global");
 	}
+
+	/**
+	 * Documents a divergence from the 2018 INFO/INFOVARS spec: the spec describes a
+	 * scoped form INFOVARS:x|SCOPE=var (with the scope prefix optional for the
+	 * default VAR scope). That grammar is NOT implemented — INFOVARS currently
+	 * accepts only bare global variable names, so a "SCOPE=var" token is treated as
+	 * a single (illegal) variable name and rejected. This test pins that boundary;
+	 * if the scoped form is ever implemented, it should be updated to expect success.
+	 */
+	@Test
+	void testInfoVarsScopedFormNotYetSupported()
+	{
+		declareGlobalVar("InfoTestVar");
+		PCTemplate template = create(PCTemplate.class, "TemplateScopedForm");
+		assertTrue(INFO_TOKEN.parseToken(context, template, "Detail|Value is {0}.").passed());
+		assertFalse(INFOVARS_TOKEN.parseToken(context, template, "Detail|VAR=InfoTestVar").passed(),
+				"The spec's scope=variable form (e.g. VAR=x) is not implemented; it must currently be rejected");
+	}
 }

--- a/code/src/itest/tokencontent/GlobalInfoVarsTest.java
+++ b/code/src/itest/tokencontent/GlobalInfoVarsTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2026 (C) Vest <Vest@users.noreply.github.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+package tokencontent;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import pcgen.cdom.content.DatasetVariable;
+import pcgen.core.PCTemplate;
+import pcgen.rules.persistence.token.CDOMToken;
+import pcgen.rules.persistence.token.ParseResult;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import plugin.lsttokens.InfoLst;
+import plugin.lsttokens.InfoVarsLst;
+import plugin.lsttokens.testsupport.TokenRegistration;
+import plugin.lsttokens.variable.GlobalToken;
+import tokenmodel.testsupport.AbstractTokenModelTest;
+import util.TestURI;
+
+/**
+ * Integration test that INFOVARS resolves a GLOBAL variable end-to-end: a
+ * variable declared with the real GLOBAL token is accepted by INFOVARS, while a
+ * variable that was never declared globally is rejected. This exercises the
+ * "INFOVARS can only reference global variables" rule against the actual formula
+ * system (not a programmatically-asserted variable).
+ */
+class GlobalInfoVarsTest extends AbstractTokenModelTest
+{
+
+	private static final GlobalToken GLOBAL_TOKEN = new GlobalToken();
+	private static final InfoLst INFO_TOKEN = new InfoLst();
+	private static final InfoVarsLst INFOVARS_TOKEN = new InfoVarsLst();
+
+	@BeforeEach
+	@Override
+	public void setUp() throws Exception
+	{
+		super.setUp();
+		TokenRegistration.register(INFO_TOKEN);
+	}
+
+	@Override
+	public CDOMToken<?> getToken()
+	{
+		// The token under test; AbstractTokenModelTest registers this automatically.
+		return INFOVARS_TOKEN;
+	}
+
+	/**
+	 * Declares a global NUMBER variable of the given name via the real GLOBAL token.
+	 */
+	private void declareGlobalVar(String varName)
+	{
+		DatasetVariable dv = new DatasetVariable();
+		ParseResult result = GLOBAL_TOKEN.parseToken(context, dv, "NUMBER=" + varName);
+		if (!result.passed())
+		{
+			result.printMessages(TestURI.getURI());
+			throw new IllegalStateException("Setup failed: could not declare global var " + varName);
+		}
+		context.getReferenceContext().importObject(dv);
+	}
+
+	@Test
+	void testInfoVarsResolvesGlobalVariable()
+	{
+		declareGlobalVar("InfoTestVar");
+		PCTemplate template = create(PCTemplate.class, "TemplateWithInfo");
+
+		// INFO with one placeholder, INFOVARS supplying a declared global variable.
+		assertTrue(INFO_TOKEN.parseToken(context, template, "Detail|Value is {0}.").passed());
+		assertTrue(INFOVARS_TOKEN.parseToken(context, template, "Detail|InfoTestVar").passed());
+
+		// Full deferred resolution (runs InfoLst.process, resolveReferences, etc.).
+		finishLoad();
+	}
+
+	@Test
+	void testInfoVarsRejectsUndeclaredVariable()
+	{
+		// No global variable declared: INFOVARS must reject the reference at parse time.
+		PCTemplate template = create(PCTemplate.class, "TemplateWithBadInfo");
+		assertTrue(INFO_TOKEN.parseToken(context, template, "Detail|Value is {0}.").passed());
+		assertFalse(INFOVARS_TOKEN.parseToken(context, template, "Detail|NotDeclaredGlobally").passed(),
+				"INFOVARS must reject a variable that is not a declared global");
+	}
+}

--- a/code/src/itest/tokencontent/GlobalInfoVarsTest.java
+++ b/code/src/itest/tokencontent/GlobalInfoVarsTest.java
@@ -31,6 +31,7 @@ import plugin.lsttokens.InfoLst;
 import plugin.lsttokens.InfoVarsLst;
 import plugin.lsttokens.testsupport.TokenRegistration;
 import plugin.lsttokens.variable.GlobalToken;
+import plugin.lsttokens.variable.LocalToken;
 import tokenmodel.testsupport.AbstractTokenModelTest;
 import util.TestURI;
 
@@ -45,6 +46,7 @@ class GlobalInfoVarsTest extends AbstractTokenModelTest
 {
 
 	private static final GlobalToken GLOBAL_TOKEN = new GlobalToken();
+	private static final LocalToken LOCAL_TOKEN = new LocalToken();
 	private static final InfoLst INFO_TOKEN = new InfoLst();
 	private static final InfoVarsLst INFOVARS_TOKEN = new InfoVarsLst();
 
@@ -74,6 +76,21 @@ class GlobalInfoVarsTest extends AbstractTokenModelTest
 		{
 			result.printMessages(TestURI.getURI());
 			throw new IllegalStateException("Setup failed: could not declare global var " + varName);
+		}
+		context.getReferenceContext().importObject(dv);
+	}
+
+	/**
+	 * Declares a NUMBER variable in the given local scope via the real LOCAL token.
+	 */
+	private void declareLocalVar(String scope, String varName)
+	{
+		DatasetVariable dv = new DatasetVariable();
+		ParseResult result = LOCAL_TOKEN.parseToken(context, dv, scope + "|NUMBER=" + varName);
+		if (!result.passed())
+		{
+			result.printMessages(TestURI.getURI());
+			throw new IllegalStateException("Setup failed: could not declare local var " + varName);
 		}
 		context.getReferenceContext().importObject(dv);
 	}
@@ -118,5 +135,25 @@ class GlobalInfoVarsTest extends AbstractTokenModelTest
 		assertTrue(INFO_TOKEN.parseToken(context, template, "Detail|Value is {0}.").passed());
 		assertFalse(INFOVARS_TOKEN.parseToken(context, template, "Detail|VAR=InfoTestVar").passed(),
 				"The spec's scope=variable form (e.g. VAR=x) is not implemented; it must currently be rejected");
+	}
+
+	/**
+	 * LegacyKing's example: a weapon's crit multiplier lives in the local
+	 * PC.EQUIPMENT.PART (head) scope. An INFO/INFOVARS on another object (e.g. a
+	 * weapon-enchantment ability) cannot pull that head-local variable, because
+	 * INFOVARS resolves against the global scope and has no per-instance selector
+	 * to say "this weapon's head". Here the variable IS declared (in the local
+	 * head scope), yet INFOVARS still rejects it — proving the limitation is the
+	 * scope, not a missing declaration.
+	 */
+	@Test
+	void testInfoVarsCannotReachLocalHeadScopeVariable()
+	{
+		// Declare CritMult in the equipment-part (weapon head) LOCAL scope.
+		declareLocalVar("PC.EQUIPMENT.PART", "CritMult");
+		PCTemplate template = create(PCTemplate.class, "WeaponEnchantAbility");
+		assertTrue(INFO_TOKEN.parseToken(context, template, "Enchant|Crit multiplier is {0}.").passed());
+		assertFalse(INFOVARS_TOKEN.parseToken(context, template, "Enchant|CritMult").passed(),
+				"INFOVARS cannot reach a variable that only exists in a local (head) scope");
 	}
 }

--- a/code/src/test/plugin/lsttokens/InfoVarsLstTest.java
+++ b/code/src/test/plugin/lsttokens/InfoVarsLstTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2026 (C) Vest <Vest@users.noreply.github.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+package plugin.lsttokens;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import pcgen.base.util.FormatManager;
+import pcgen.cdom.base.ConcretePrereqObject;
+import pcgen.cdom.formula.scope.PCGenScope;
+import pcgen.core.PCTemplate;
+import pcgen.persistence.PersistenceLayerException;
+import pcgen.rules.context.LoadContext;
+import pcgen.rules.persistence.CDOMLoader;
+import pcgen.rules.persistence.token.CDOMToken;
+import pcgen.rules.persistence.token.CDOMWriteToken;
+import plugin.lsttokens.testsupport.AbstractGlobalTokenTestCase;
+import plugin.lsttokens.testsupport.CDOMTokenLoader;
+import plugin.lsttokens.testsupport.ConsolidationRule;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the INFOVARS token. INFOVARS references variables already declared in the formula
+ * system; the variables it can resolve are global (written bare, no scope prefix), so these
+ * tests exercise bare variable names in the active scope. See INFO &amp; INFOVARS spec.
+ */
+class InfoVarsLstTest extends AbstractGlobalTokenTestCase
+{
+	static InfoVarsLst token = new InfoVarsLst();
+	static CDOMTokenLoader<PCTemplate> loader = new CDOMTokenLoader<>();
+
+	@Override
+	public CDOMLoader<PCTemplate> getLoader()
+	{
+		return loader;
+	}
+
+	@Override
+	public Class<PCTemplate> getCDOMClass()
+	{
+		return PCTemplate.class;
+	}
+
+	@Override
+	public CDOMToken<? extends ConcretePrereqObject> getReadToken()
+	{
+		return token;
+	}
+
+	@Override
+	public CDOMWriteToken<? extends ConcretePrereqObject> getWriteToken()
+	{
+		return token;
+	}
+
+	@Test
+	void testInvalidInputEmpty()
+	{
+		assertFalse(parse(""));
+		assertNoSideEffects();
+	}
+
+	@Test
+	void testInvalidInputOnlyName()
+	{
+		assertFalse(parse("InfoName"));
+		assertNoSideEffects();
+	}
+
+	@Test
+	void testInvalidInputEmptyEntry()
+	{
+		assertFalse(parse("InfoName|MyVar||OtherVar"));
+		assertNoSideEffects();
+	}
+
+	@Test
+	void testInvalidInputIllegalVarName()
+	{
+		assertFalse(parse("InfoName|NotAVariable"));
+		assertNoSideEffects();
+	}
+
+	@Test
+	void testRoundRobinSingle() throws PersistenceLayerException
+	{
+		runRoundRobin("InfoName|MyVar");
+	}
+
+	@Test
+	void testRoundRobinMultiple() throws PersistenceLayerException
+	{
+		runRoundRobin("InfoName|MyVar|OtherVar");
+	}
+
+	@Override
+	protected String getLegalValue()
+	{
+		return "InfoName|MyVar";
+	}
+
+	@Override
+	protected String getAlternateLegalValue()
+	{
+		return "InfoName|MyVar|OtherVar";
+	}
+
+	@Override
+	protected ConsolidationRule getConsolidationRule()
+	{
+		return ConsolidationRule.OVERWRITE;
+	}
+
+	@Override
+	protected void additionalSetup(LoadContext context)
+	{
+		super.additionalSetup(context);
+		FormatManager<?> formatManager = context.getReferenceContext().getFormatManager("NUMBER");
+		PCGenScope scope = context.getActiveScope();
+		context.getVariableContext().assertLegalVariableID("MyVar", scope, formatManager);
+		context.getVariableContext().assertLegalVariableID("OtherVar", scope, formatManager);
+	}
+}


### PR DESCRIPTION
**Status: draft / WIP — to be analyzed together by @Vest and LegacyKing before this is ready.**

Test-only PR adding coverage for the `INFOVARS` token. No production change: investigation confirmed what is (and isn't) implemented relative to the 2018 spec.

## What matches the spec
- **`INFO:x|y`** — info name + `java.text.MessageFormat`. ✅
- **The three load-error rules** — INFOVARS name with no INFO; INFO needs vars but none provided; var count mismatch (all in `InfoLst.process`). ✅
- **FreeMarker `*.info` accessor** (e.g. `pc.race.info.wildness`). ✅
- **"Global variables only" is enforced at parse time** — `InfoVarsLst.parseTokenWithSeparator` validates each name against the global active scope via `isLegalVariableID(getActiveScope(), name)`.

## Spec divergence (the unbuilt feature)
The 2018 spec describes a **scoped** grammar `INFOVARS:x|SCOPE=var` (scope optional for default `VAR`). **This is not implemented** — INFOVARS parses bare names only; a `SCOPE=var` token is treated as one illegal name and rejected (verified, including the default `VAR=x` form). The implementation is a **subset**: bare global names, no scope prefix. Local-scope support needs a per-instance selector INFOVARS lacks (LK flagged `getOther()` as the fitting model). Deferred.

## Can INFOVARS replace existing Pathfinder LST?
Conceptually yes (INFO/INFOVARS is meant to replace DESC/ASPECT/BENEFIT/SPROP), but **almost none is replaceable as-is today**:

| Token | PF uses | with `%` substitution |
|---|---:|---:|
| DESC | 59,808 | 9,770 |
| ASPECT | 9,024 | 2,879 |
| BENEFIT | 4,131 | 489 |

- **Static (no `%`) DESC/ASPECT/SPROP** → replaceable by plain `INFO:` now (no INFOVARS needed); the large majority, low-risk, but doesn't exercise INFOVARS.
- **`%`-substitution tokens (~13k)** are the real INFOVARS targets, but their variables are **old-system `DEFINE:` (23,458 in PF) not new-system `GLOBAL:` (14)** — INFOVARS cannot read a `DEFINE:` var, so these need a **`DEFINE:`→`GLOBAL:` migration first** (the data-team "Phase 2"). Many also embed `PRExxx` (INFO is unconditional by design) or math, or hit the local-scope wall — needing the deferred features.

**Smallest genuine conversion** (e.g. `ASPECT:Ability Benefit|(%1 ft.)|JetSpeed`): declare `GLOBAL:NUMBER=JetSpeed`, then `INFO:AbilityBenefit|({0} ft.)` + `INFOVARS:AbilityBenefit|JetSpeed`. `testAspectMigrationPatternToInfoVars` demonstrates exactly this end-to-end. (No shipped-data change here — migration is a separate decision.)

## Data usage
`INFOVARS:` appears **zero** times in shipped data (plain `INFO:` ~580 in PF core, ~1332 project-wide). The feature is greenfield — no data-regression risk, no existing INFOVARS example to copy.

## Tests added
- `InfoVarsLstTest` (unit): round-robin + invalid-input cases.
- `GlobalInfoVarsTest` (integration) — INFOVARS against the real formula system:
  - `testInfoVarsResolvesGlobalVariable`: GLOBAL-declared var referenced by INFO+INFOVARS, loads end-to-end.
  - `testInfoVarsRejectsUndeclaredVariable`: undeclared var rejected at parse.
  - `testInfoVarsScopedFormNotYetSupported`: the spec's `SCOPE=var` form is currently rejected (flip if implemented).
  - `testInfoVarsCannotReachLocalHeadScopeVariable`: LegacyKing's example — a crit multiplier in the weapon head's local `PC.EQUIPMENT.PART` scope is still rejected, because INFOVARS resolves against the global scope with no per-instance selector.
  - `testAspectMigrationPatternToInfoVars`: the ASPECT→INFOVARS conversion (GLOBAL + INFO/INFOVARS) loading end-to-end.

## How to use INFOVARS in LST today
```
# declare a global variable (in a *__variables.lst datacontrol file)
GLOBAL:NUMBER=NumFiles

# reference it (bare name — no scope prefix)
Dodge   INFO:FileCount|There are {0,number,integer} files.   INFOVARS:FileCount|NumFiles
```

Wiki reference: https://vest.github.io/pcgen-wiki/formula-system/INFO%20and%20INFOVARS.html